### PR TITLE
[MERGE][IMP] survey: enable multiple trigger questions and answers

### DIFF
--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Surveys',
-    'version': '3.5',
+    'version': '3.6',
     'category': 'Marketing/Surveys',
     'description': """
 Create beautiful surveys and visualize answers

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -270,15 +270,15 @@ class Survey(http.Controller):
             'format_date': lambda date: format_date(request.env, date)
         }
         if survey_sudo.questions_layout != 'page_per_question':
-            triggering_answer_by_question, triggered_questions_by_answer, selected_answers = answer_sudo._get_conditional_values()
+            triggering_answers_by_question, triggered_questions_by_answer, selected_answers = answer_sudo._get_conditional_values()
             data.update({
-                'triggering_answer_by_question': {
-                    question.id: triggering_answer_by_question[question].id for question in triggering_answer_by_question.keys()
-                    if triggering_answer_by_question[question]
+                'triggering_answers_by_question': {
+                    question.id: triggering_answers.ids
+                    for question, triggering_answers in triggering_answers_by_question.items() if triggering_answers
                 },
                 'triggered_questions_by_answer': {
-                    answer.id: triggered_questions_by_answer[answer].ids
-                    for answer in triggered_questions_by_answer.keys()
+                    answer.id: triggered_questions.ids
+                    for answer, triggered_questions in triggered_questions_by_answer.items()
                 },
                 'selected_answers': selected_answers.ids
             })

--- a/addons/survey/data/survey_demo_conditional.xml
+++ b/addons/survey/data/survey_demo_conditional.xml
@@ -67,9 +67,7 @@
         <field name="title">How long is the White Nile river?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug1"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug1'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p2_q1_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p2_q1"/>
@@ -96,9 +94,7 @@
         <field name="title">What is the biggest city in the world?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug1"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug1'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p2_q2_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p2_q2"/>
@@ -129,9 +125,7 @@
         <field name="title">Which is the highest volcano in Europe?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug1"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug1'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p2_q3_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p2_q3"/>
@@ -170,9 +164,7 @@
         <field name="title">When did Genghis Khan die?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug2"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug2'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p3_q1_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p3_q1"/>
@@ -198,9 +190,7 @@
         <field name="title">Who is the architect of the Great Pyramid of Giza?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug2"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug2'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p3_q2_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p3_q2"/>
@@ -231,9 +221,7 @@
         <field name="title">How many years did the 100 years war last?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug2"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug2'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p3_q3_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p3_q3"/>
@@ -272,9 +260,7 @@
         <field name="title">Who received a Nobel prize in Physics for the discovery of neutrino oscillations, which shows that neutrinos have mass?</field>
         <field name="question_type">multiple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug3"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug3'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p4_q1_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p4_q1"/>
@@ -307,9 +293,7 @@
         <field name="title">What is, approximately, the critical mass of plutonium-239?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug3"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug3'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p4_q2_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p4_q2"/>
@@ -340,9 +324,7 @@
         <field name="title">Can Humans ever directly see a photon?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug3"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug3'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p4_q3_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p4_q3"/>
@@ -354,7 +336,7 @@
         <record id="survey_demo_burger_quiz_p4_q3_sug2" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p4_q3"/>
             <field name="sequence">2</field>
-            <field name="value">No, it's to small for the human eye.</field>
+            <field name="value">No, it's too small for the human eye.</field>
         </record>
 
     <!-- Page 5 : Art & Culture -->
@@ -371,9 +353,7 @@
         <field name="title">Which Musician is not in the 27th Club?</field>
         <field name="question_type">multiple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug4"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug4'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p5_q1_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p5_q1"/>
@@ -406,9 +386,7 @@
         <field name="title">Which painting/drawing was not made by Pablo Picasso?</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug4"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug4'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p5_q2_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p5_q2"/>
@@ -443,9 +421,7 @@
         <field name="title">Which quote is from Jean-Claude Van Damme</field>
         <field name="question_type">simple_choice</field>
         <field name="constr_mandatory" eval="True"/>
-        <field name="is_conditional" eval="True"/>
-        <field name="triggering_question_id" ref="survey_demo_burger_quiz_p1_q1"/>
-        <field name="triggering_answer_id" ref="survey_demo_burger_quiz_p1_q1_sug4"/>
+        <field name="triggering_answer_ids" eval="[Command.link(ref('survey.survey_demo_burger_quiz_p1_q1_sug4'))]"/>
     </record>
         <record id="survey_demo_burger_quiz_p5_q3_sug1" model="survey.question.answer">
             <field name="question_id" ref="survey_demo_burger_quiz_p5_q3"/>
@@ -468,6 +444,112 @@
             <field name="question_id" ref="survey_demo_burger_quiz_p5_q3"/>
             <field name="sequence">4</field>
             <field name="value">I actually don't like thinking. I think people think I like to think a lot. And I don't. I do not like to think at all.</field> <!-- Kanye West -->
+        </record>
+
+    <!-- Multiple triggers -->
+    <record id="survey_demo_food_preferences" model="survey.survey">
+        <field name="title">Food Preferences</field>
+        <field name="survey_type">survey</field>
+        <field name="access_token">foodpref-eren-ces1-abcd-344ca2tgb31e</field>
+        <field name="user_id" ref="base.user_demo"/>
+        <field name="access_mode">public</field>
+        <field name="questions_layout">one_page</field>
+        <field name="description" type="html">
+            <p>Please give us your preferences for this event's dinner!</p>
+        </field>
+        <field name="description_done" type="html">
+            <p>Got it!</p>
+            <p>See you soon!</p>
+        </field>
+    </record>
+
+    <record id="survey_demo_food_preferences_q1" model="survey.question">
+        <field name="survey_id" ref="survey_demo_food_preferences"/>
+        <field name="sequence">1</field>
+        <field name="title">Are you vegetarian?</field>
+        <field name="question_type">simple_choice</field>
+        <field name="constr_mandatory" eval="True"/>
+    </record>
+        <record id="survey_demo_food_preferences_q1_sug1" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q1"/>
+            <field name="sequence">1</field>
+            <field name="value">Yes</field>
+        </record>
+        <record id="survey_demo_food_preferences_q1_sug2" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q1"/>
+            <field name="sequence">2</field>
+            <field name="value">No</field>
+        </record>
+        <record id="survey_demo_food_preferences_q1_sug3" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q1"/>
+            <field name="sequence">3</field>
+            <field name="value">It depends</field>
+        </record>
+
+    <record id="survey_demo_food_preferences_q2" model="survey.question">
+        <field name="survey_id" ref="survey_demo_food_preferences"/>
+        <field name="sequence">2</field>
+        <field name="title">Would you prefer a veggie meal if possible?</field>
+        <field name="question_type">simple_choice</field>
+        <field name="constr_mandatory" eval="True"/>
+        <field name="triggering_answer_ids" eval="[
+            Command.link(ref('survey.survey_demo_food_preferences_q1_sug3')),
+        ]"/>
+
+    </record>
+        <record id="survey_demo_food_preferences_q2_sug1" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q2"/>
+            <field name="sequence">1</field>
+            <field name="value">Yes</field>
+        </record>
+        <record id="survey_demo_food_preferences_q2_sug2" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q2"/>
+            <field name="sequence">2</field>
+            <field name="value">No</field>
+        </record>
+
+    <record id="survey_demo_food_preferences_q3" model="survey.question">
+        <field name="survey_id" ref="survey_demo_food_preferences"/>
+        <field name="sequence">3</field>
+        <field name="title">Choose your green meal</field>
+        <field name="question_type">simple_choice</field>
+        <field name="constr_mandatory" eval="True"/>
+        <field name="triggering_answer_ids" eval="[
+            Command.link(ref('survey.survey_demo_food_preferences_q1_sug1')),
+            Command.link(ref('survey.survey_demo_food_preferences_q2_sug1')),
+        ]"/>
+    </record>
+        <record id="survey_demo_food_preferences_q3_sug1" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q3"/>
+            <field name="sequence">1</field>
+            <field name="value">Vegetarian pizza</field>
+        </record>
+        <record id="survey_demo_food_preferences_q3_sug2" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q3"/>
+            <field name="sequence">2</field>
+            <field name="value">Vegetarian burger</field>
+        </record>
+
+    <record id="survey_demo_food_preferences_q4" model="survey.question">
+        <field name="survey_id" ref="survey_demo_food_preferences"/>
+        <field name="sequence">4</field>
+        <field name="title">Choose your meal</field>
+        <field name="question_type">simple_choice</field>
+        <field name="constr_mandatory" eval="True"/>
+        <field name="triggering_answer_ids" eval="[
+            Command.link(ref('survey.survey_demo_food_preferences_q1_sug2')),
+            Command.link(ref('survey.survey_demo_food_preferences_q2_sug2')),
+        ]"/>
+    </record>
+        <record id="survey_demo_food_preferences_q4_sug1" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q4"/>
+            <field name="sequence">1</field>
+            <field name="value">Steak with french fries</field>
+        </record>
+        <record id="survey_demo_food_preferences_q4_sug2" model="survey.question.answer">
+            <field name="question_id" ref="survey_demo_food_preferences_q4"/>
+            <field name="sequence">2</field>
+            <field name="value">Fish</field>
         </record>
 
 </data></odoo>

--- a/addons/survey/static/src/question_page/question_page_list_renderer.js
+++ b/addons/survey/static/src/question_page/question_page_list_renderer.js
@@ -134,7 +134,7 @@ export class QuestionPageListRenderer extends ListRenderer {
      */
     async onDeleteRecord(record) {
         const triggeredRecords = this.props.list.records.filter(
-            (rec) => rec.data.triggering_question_id[0] === record.resId
+            (rec) => rec.data.triggering_question_ids.records.map(a => a.resId).includes(record.resId)
         );
         if (triggeredRecords.length) {
             const res = await super.onDeleteRecord(record);

--- a/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
+++ b/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
@@ -7,6 +7,11 @@ import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 const { Component, useEffect, useRef, useState } = owl;
 
 export class SurveyQuestionTriggerWidget extends Component {
+    static template = "survey.surveyQuestionTrigger";
+    static props = {
+    ...standardWidgetProps,
+    };
+
     setup() {
         super.setup();
         this.button = useRef('survey_question_trigger');
@@ -15,19 +20,20 @@ export class SurveyQuestionTriggerWidget extends Component {
             triggerTooltip: "",
         });
         useEffect(() => {
-            if (this.button && this.button.el) {
-                const triggeringQuestionTitle = this.props.record.data.triggering_question_id[1];
-                const triggerError = this.surveyQuestionTriggerError;
+            if (this.button?.el && this.props.record.data.triggering_question_ids.records?.length !== 0) {
+                const { triggerError, misplacedTriggerQuestionRecords } = this.surveyQuestionTriggerError;
                 if (triggerError === "MISPLACED_TRIGGER_WARNING") {
                     this.state.surveyIconWarning = true;
-                    this.state.triggerTooltip = _t(
-                        '⚠ This question is positioned before its trigger ("%s") and will be skipped.',
-                        triggeringQuestionTitle
+                    this.state.triggerTooltip = '⚠ ' + _t(
+                        'Triggers based on the following questions will not work because they are positioned after this question:\n"%s".',
+                        misplacedTriggerQuestionRecords
+                            .map((question) => question.data.title)
+                            .join('", "')
                     );
                 } else if (triggerError === "WRONG_QUESTIONS_SELECTION_WARNING") {
                     this.state.surveyIconWarning = true;
-                    this.state.triggerTooltip = _t(
-                        "⚠ Conditional display is not available when questions are randomly picked."
+                    this.state.triggerTooltip = '⚠ ' + _t(
+                        "Conditional display is not available when questions are randomly picked."
                     );
                 } else if (triggerError === "MISSING_TRIGGER_ERROR") {
                     // This case must be handled to not temporarily render the "normal" icon if previously
@@ -36,9 +42,10 @@ export class SurveyQuestionTriggerWidget extends Component {
                 } else {
                     this.state.surveyIconWarning = false;
                     this.state.triggerTooltip = _t(
-                        'Displayed if "%s: %s"',
-                        triggeringQuestionTitle,
-                        this.props.record.data.triggering_answer_id[1]
+                        'Displayed if "%s".',
+                        this.props.record.data.triggering_answer_ids.records
+                            .map((answer) => answer.data.display_name)
+                            .join('", "'),
                     );
                 }
             } else {
@@ -55,12 +62,12 @@ export class SurveyQuestionTriggerWidget extends Component {
      * 2. Robustness, as sequences values do not always match between server
      * provided values when the records are not saved.
      *
-     * @returns { String }
+     * @returns {{ triggerError: String, misplacedTriggerQuestionRecords: Record[] }}
      *   * `""`: No trigger error (also if `triggering_question_id`
      *     field is not set).
-     *   * `"MISSING_TRIGGER_ERROR"`: `triggering_question_id` field is set
-     *     and trigger record is not found. This can happen when a question
-     *     used as trigger is deleted on the client but not yet saved to DB.
+     *   * `"MISSING_TRIGGER_ERROR"`: `triggering_questions_ids` field is set
+     *     but trigger record is not found. This can happen if all questions
+     *     used as triggers are deleted on the client but not yet saved to DB.
      *   * `"MISPLACED_TRIGGER_WARNING"`: a `triggering_question_id` is set
      *     but is positioned after the current record in the list. This can
      *     happen if the triggering or the triggered question is moved.
@@ -71,37 +78,48 @@ export class SurveyQuestionTriggerWidget extends Component {
      */
     get surveyQuestionTriggerError() {
         const record = this.props.record;
-        if (!record.data.triggering_question_id) {
-            return "";
+        if (!record.data.triggering_question_ids.records.length) {
+            return { triggerError: "", misplacedTriggerQuestionRecords: [] };
         }
-        const triggerId = record.data.triggering_question_id[0];
-        let triggerRecord = record.model.root.data.question_and_page_ids.records.find(rec => rec.resId === triggerId);
+        if (this.props.record.data.questions_selection === 'random') {
+            return { triggerError: 'WRONG_QUESTIONS_SELECTION_WARNING', misplacedTriggerQuestionRecords: [] };
+        }
 
-        if (!triggerRecord) {
-            return "MISSING_TRIGGER_ERROR";
+        const missingTriggerQuestionsIds = [];
+        let triggerQuestionsRecords = [];
+        for (const triggeringQuestion of record.data.triggering_question_ids.records) {
+            const triggeringQuestionRecord = record.model.root.data.question_and_page_ids.records.find(
+                rec => rec.resId === triggeringQuestion.resId);
+            if (triggeringQuestionRecord) {
+                triggerQuestionsRecords.push(triggeringQuestionRecord);
+            } else {  // Trigger question was deleted from the list
+                missingTriggerQuestionsIds.push(triggeringQuestion.resId);
+            }
         }
-        if (record.data.questions_selection === 'random') {
-            return "WRONG_QUESTIONS_SELECTION_WARNING";
+
+        if (missingTriggerQuestionsIds.length === this.props.record.data.triggering_question_ids.records.length) {
+            return { triggerError: 'MISSING_TRIGGER_ERROR', misplacedTriggerQuestionRecords: [] }; // only if all are missing
         }
-        if (record.data.sequence < triggerRecord.data.sequence ||
-            (record.data.sequence === triggerRecord.data.sequence && record.resId < triggerId)) {
-            return "MISPLACED_TRIGGER_WARNING";
+        const misplacedTriggerQuestionRecords = [];
+        for (const triggerQuestionRecord of triggerQuestionsRecords) {
+            if (record.data.sequence < triggerQuestionRecord.data.sequence ||
+                (record.data.sequence === triggerQuestionRecord.data.sequence && record.resId < triggerQuestionRecord.resId)) {
+                misplacedTriggerQuestionRecords.push(triggerQuestionRecord);
+            }
         }
-        return "";
+        return {
+            triggerError: misplacedTriggerQuestionRecords.length ? "MISPLACED_TRIGGER_WARNING" : "",
+            misplacedTriggerQuestionRecords: misplacedTriggerQuestionRecords,
+        };
     }
 }
-
-SurveyQuestionTriggerWidget.template = "survey.surveyQuestionTrigger";
-SurveyQuestionTriggerWidget.props = {
-    ...standardWidgetProps,
-};
 
 export const surveyQuestionTriggerWidget = {
     component: SurveyQuestionTriggerWidget,
     displayName: "Trigger",
     fieldDependencies: [
-        { name: "triggering_question_id", type: "many2one" },
-        { name: "triggering_answer_id", type: "many2one" },
+        { name: "triggering_question_ids", type: "many2one" },
+        { name: "triggering_answer_ids", type: "many2one" },
     ],
 };
 registry.category("view_widgets").add("survey_question_trigger", surveyQuestionTriggerWidget);

--- a/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.xml
+++ b/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="survey.surveyQuestionTrigger">
-        <button t-if="this.props.record.data.triggering_question_id" disabled="disabled" t-ref="survey_question_trigger"
+        <button t-if="this.props.record.data.triggering_question_ids.records.length" disabled="disabled" t-ref="survey_question_trigger"
                 class="btn btn-link px-1 py-0 pe-auto" t-att-class="this.state.surveyIconWarning ? 'opacity-100' : 'icon_rotates'">
             <i class="fa fa-fw o_button_icon " t-att-class="this.state.surveyIconWarning ? 'fa-exclamation-triangle text-warning' : 'fa-code-fork'"
                t-att-data-tooltip="this.state.triggerTooltip"/>

--- a/addons/survey/static/tests/components/survey_question_trigger_widget_tests.js
+++ b/addons/survey/static/tests/components/survey_question_trigger_widget_tests.js
@@ -26,17 +26,17 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                 survey_question: {
                     fields: {
                         sequence: { type: "number" },
-                        name: { type: "char", string: "name", },
-                        triggering_question_id: {
-                            type: "many2one",
+                        title: { type: "char", string: "title", },
+                        triggering_question_ids: {
+                            type: "many2many",
                             string: "Triggering question",
                             relation: "survey_question",
                             required: false,
                             searchable: true,
                         },
-                        triggering_answer_id: {
-                            type: "many2one",
-                            string: "Triggering answer",
+                        triggering_answer_ids: {
+                            type: "many2many",
+                            string: "Triggering answers",
                             relation: "survey_question_answer",
                             required: false,
                             searchable: true,
@@ -46,15 +46,15 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                         {
                             id: 1,
                             sequence: 1,
-                            name: "Question 1",
-                            triggering_question_id: null,
-                            triggering_answer_id: null,
+                            title: "Question 1",
+                            triggering_question_ids: null,
+                            triggering_answer_ids: null,
                         }, {
                             id: 2,
                             sequence: 2,
-                            name: "Question 2",
-                            triggering_question_id: 1,
-                            triggering_answer_id: 1,
+                            title: "Question 2",
+                            triggering_question_ids: [1],
+                            triggering_answer_ids: [1],
                         },
                     ],
                 },
@@ -65,7 +65,8 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                     records: [
                         {
                             id: 1,
-                            name: "Answer 1"
+                            name: "Answer 1",
+                            display_name: "Question 1: Answer 1",
                         },
                     ]
                 }
@@ -74,9 +75,9 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                 "survey_question,false,form": `
                     <form>
                         <group>
-                            <field name="name"/>
-                            <field name="triggering_answer_id" invisible="1"/>
-                            <field name="triggering_question_id" invisible="1"/> 
+                            <field name="title"/>
+                            <field name="triggering_question_ids" invisible="1"/>
+                            <field name="triggering_answer_ids" invisible="1" widget="many2many_tags"/>
                         </group>
                     </form>
                 `,
@@ -97,9 +98,9 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
                     <field name="question_and_page_ids">  
                         <tree>
                             <field name="sequence" widget="handle"/>
-                            <field name="name"/>
-                            <field name="triggering_answer_id" invisible="1"/>
-                            <field name="triggering_question_id" invisible="1"/> 
+                            <field name="title"/>
+                            <field name="triggering_question_ids" invisible="1"/>
+                            <field name="triggering_answer_ids" invisible="1" widget="many2many_tags"/> <!-- widget to fetch display_name -->
                             <widget name="survey_question_trigger"/>
                         </tree>
                     </field>
@@ -121,8 +122,8 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
         // Question 2 is correctly placed after Question 1
         let triggerIcon = q2TriggerDiv.querySelector("button i");
         assert.doesNotHaveClass(triggerIcon, "text-warning");
-        assert.hasAttrValue(triggerIcon, 'data-tooltip', 'Displayed if "Question 1: Answer 1"',
-                       'Trigger tooltip should be \'Displayed if "Question 1: Answer 1"\'.');
+        assert.hasAttrValue(triggerIcon, 'data-tooltip', 'Displayed if "Question 1: Answer 1".',
+                       'Trigger tooltip should be \'Displayed if "Question 1: Answer 1".\'.');
 
         // drag and drop Question 2 (triggered) before Question 1 (trigger)
         await dragAndDrop("tbody tr:nth-child(2) .o_handle_cell", "tbody tr:nth-child(1)");
@@ -136,7 +137,7 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
         assert.hasClass(triggerIcon, "text-warning");
         assert.strictEqual(
             triggerIcon.getAttribute('data-tooltip'),
-            '⚠ This question is positioned before its trigger ("Question 1") and will be skipped.',
+            '⚠ Triggers based on the following questions will not work because they are positioned after this question:\n"Question 1".',
             'Trigger tooltip should have been changed to misplacement error message.'
         );
 
@@ -148,7 +149,7 @@ QUnit.module("SurveyQuestionTriggerWidget", (hooks) => {
 
         assert.strictEqual(rows[1].textContent, "Question 2");
         assert.doesNotHaveClass(rows[1].querySelector("td.o_data_cell div.o_widget_survey_question_trigger button i"), "text-warning");
-        assert.hasAttrValue(triggerIcon, 'data-tooltip', 'Displayed if "Question 1: Answer 1"',
-                       'Trigger tooltip should be back to \'Displayed if "Question 1: Answer 1"\'.');
+        assert.hasAttrValue(triggerIcon, 'data-tooltip', 'Displayed if "Question 1: Answer 1".',
+                       'Trigger tooltip should be back to \'Displayed if "Question 1: Answer 1".\'.');
     });
 });

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
+import { TourError } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add('test_survey_chained_conditional_questions', {
     test: true,
@@ -19,17 +20,45 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
         content: 'Answer Q3 with Answer 1',
         trigger: 'div.js_question-wrapper:contains("Q3") label:contains("Answer 1")',
     }, {
-        content: 'Answer Q1 with Answer 2',  // This should hide all remaining questions.
+        content: 'Answer Q1 with Answer 3',  // This should hide Q2 but not Q3.
+        trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 3")',
+    }, {
+        content: 'Check that Q2 was hidden',
+        trigger: 'div.js_question-wrapper:contains("Q3")',
+        run : () => expectHiddenQuestion("Q2"),
+    }, {
+        content: 'Answer Q3 with Answer 2',
+        trigger: 'div.js_question-wrapper:contains("Q3") label:contains("Answer 2")',
+    }, {
+        content: 'Answer Q1 with Answer 2',  // This should hide all other questions.
         trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 2")',
     }, {
         content: 'Check that only question 1 is now visible',
         trigger: 'div.js_question-wrapper:contains("Q1")',
-        run: () => {
-            const selector = 'div.js_question-wrapper.d-none';
-            if (document.querySelectorAll(selector).length !== 2) {
-                throw new Error('Q2 and Q3 should have been hidden.');
-            }
-        }
+        run : () => {
+            expectHiddenQuestion("Q2", "Q2's trigger is gone.");
+            expectHiddenQuestion("Q3", "No reason to show it now.");
+        },
+    }, {
+        content: 'Answer Q1 with Answer 3',  // This shows Q3.
+        trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 3")',
+    }, {
+        content: 'Check that a question (Q2) is hidden',
+        trigger: 'div.js_question-wrapper:contains("Q1")',
+        run : () => expectHiddenQuestion("Q2", "Q2 should stay hidden."),
+    }, {
+        content: 'Answer Q3 with Answer 2',
+        trigger: 'div.js_question-wrapper:contains("Q3") label:contains("Answer 2")',
+    }, {
+        content: 'Answer Q1 with Answer 2',
+        trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 2")',
+    }, {
+        content: 'Check that only question 1 is now the only one visible again',
+        trigger: 'div.js_question-wrapper:contains("Q1")',
+        run : () => {
+            expectHiddenQuestion("Q2", "Q2's trigger is gone, again.");
+            expectHiddenQuestion("Q3", "As Q2's gone, so should this one.");
+        },
     }, {
         content: 'Click Submit and finish the survey',
         trigger: 'button[value="finish"]',
@@ -41,3 +70,9 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
     }
 
 ]});
+
+export function expectHiddenQuestion (questionTitle, msg){
+    if ($(`div.js_question-wrapper.d-none:contains('${questionTitle}')`).length !== 1) {
+        throw new TourError(msg);
+    }
+}

--- a/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
+++ b/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
@@ -1,0 +1,52 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { expectHiddenQuestion } from "@survey/../tests/tours/survey_chained_conditional_questions";
+
+registry.category("web_tour.tours").add('test_survey_conditional_question_on_different_page', {
+    test: true,
+    url: '/survey/start/1cb935bd-2399-4ed1-9e10-c649318fb4dc',
+    steps: () => [
+        {
+            content: 'Click on Start',
+            trigger: 'button.btn:contains("Start")',
+        }, {
+            content: 'Answer Q1 with Answer 1',
+            trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 1")',
+        }, {
+            content: 'Go to next page',
+            trigger: 'button[value="next"]',
+        }, {
+            content: 'Check that Q3 is visible',
+            trigger: 'div.js_question-wrapper:contains("Q3")',
+            isCheck: true,
+        }, {
+            content: 'Answer Q2 with Answer 2',
+            trigger: 'div.js_question-wrapper:contains("Q2") label:contains("Answer 2")',
+        }, {
+            content: 'Check that Q3 is still visible',
+            trigger: 'div.js_question-wrapper:contains("Q3")',
+            isCheck: true,
+        }, {
+            content: 'Go back',
+            trigger: 'button[value="previous"]',
+        }, {
+            content: 'Answer Q1 with Answer 2',
+            trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 2")',
+        }, {
+            content: 'Go to next page',
+            trigger: 'button[value="next"]',
+        }, {
+            content: 'Check that Q3 is hidden',
+            trigger: 'div.js_question-wrapper:contains("Q2")',
+            run : () => expectHiddenQuestion("Q3", "Q3 should be hidden as q1_a1 trigger is not selected anymore"),
+        }, {
+            content: 'Answer Q2 with Answer 1',
+            trigger: 'div.js_question-wrapper:contains("Q2") label:contains("Answer 1")',
+        }, {
+            content: 'Check that Q3 is now visible again',
+            trigger: 'div.js_question-wrapper:contains("Q3")',
+            isCheck: true,
+        }
+    ],
+});

--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -35,26 +35,17 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         in_modal: true,
     },
     ...addTwoAnswers(),
-    ...toggleIsConditional(),
+    ...changeTab("options"),
     {
-        content: "Set a trigger question for the first question",
-        trigger: ".o_field_widget[name=triggering_question_id] input",
+        content: "Set a trigger for the first question",
+        trigger: ".o_field_widget[name=triggering_answer_ids] input",
         run: "click",
         in_modal: true,
     }, {
-        content: "Set the first question as trigger",
-        trigger: 'ul.ui-autocomplete a:contains("Question 1")',
+        content: "Set the first question's first answer as trigger",
+        trigger: 'ul.ui-autocomplete a:contains("Question 1 : Answer A")',
         run: 'click',
         in_modal: true,
-    }, {
-        content: "Set a trigger answer for first question",
-        trigger: ".modal-content .o_field_widget[name=triggering_answer_id] input",
-        run: "click",
-        in_modal: true,
-    }, {
-        content: "Set the first answer as trigger",
-        trigger: 'ul.ui-autocomplete a:contains("Answer A")',
-        run: 'click',
     },
     ...changeTab("answers"),
     ...saveAndNew(),
@@ -65,38 +56,27 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         in_modal: true,
     },
     ...addTwoAnswers(),
-    ...toggleIsConditional(),
+    ...changeTab("options"),
     {
-        content: "Set a trigger question for the second question",
-        trigger: ".o_field_widget[name=triggering_question_id] input",
+        content: "Set a trigger for the second question",
+        trigger: ".o_field_widget[name=triggering_answer_ids] input",
         run: "click",
         in_modal: true,
     }, {
-        content: "Set the second question as trigger",
-        trigger: 'ul.ui-autocomplete a:contains("Question 2")',
+        content: "Set the second question's second answer as trigger",
+        trigger: 'ul.ui-autocomplete a:contains("Question 2 : Answer B")',
         run: 'click',
         in_modal: true,
-    }, {
-        content: "Set a trigger answer for second question",
-        trigger: ".modal-content .o_field_widget[name=triggering_answer_id] input",
-        run: "click",
-        in_modal: true,
-    }, {
-        content: "Set the second answer as trigger",
-        trigger: 'ul.ui-autocomplete a:contains("Answer B")',
-        run: 'click',
     },
-    ...changeTab("answers"),
     ...stepUtils.saveForm(),
-    // Q2 and Q3 should have fa-fork icons. Assumes that the Trigger widget's column is 2 places after the title's.
     {
         content: "Check that Question 2 has 'normal' trigger icon",
         trigger: "tr:contains('Question 2') button i.fa-code-fork",
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: "Check that Question 3 has 'normal' trigger icon",
         trigger: "tr:contains('Question 3') button i.fa-code-fork",
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: "Move Question 3 above its trigger (Question 2)",
         trigger: "tr.o_data_row:nth-child(3) td[name=sequence]",
@@ -104,81 +84,107 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
     }, {
         content: "Check that Question 3 has 'warning' trigger icon",
         trigger: "tr:contains('Question 3') button i.fa-exclamation-triangle",
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: "Open that question to check the server's misplacement evaluation agrees",
-        trigger: "tr.o_data_row td[data-tooltip='Question 3']",
+        trigger: "tr.o_data_row td:contains('Question 3')",
         run: "click",
     }, {
         content: "Check that an alert is shown",
-        trigger: ".o_form_sheet_bg div:first-child.alert-warning:contains('positioned before its trigger')",
+        trigger: ".o_form_sheet_bg div:first-child.alert-warning:contains('positioned before some or all of its triggers')",
         in_modal: true,
     },
     ...changeTab("options"),
     {
-        content: "Change trigger question",
-        trigger: ".o_field_widget[name=triggering_question_id] input",
+        content: "Remove invalid trigger",
+        trigger: ".o_field_widget[name=triggering_answer_ids] span:contains('Question 2') a.o_delete",
         run: "click",
-        in_modal: true,
-    }, {
-        content: "Set the first question as trigger instead",
-        trigger: 'ul.ui-autocomplete a:contains("Question 1")',
-        run: 'click',
         in_modal: true,
     }, {
         content: "Check that the alert is gone",
         trigger: `.o_form_sheet_bg div:first-child:not(.alert-warning).o_form_sheet`,
         in_modal: true,
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
-        content: "Change the trigger answer as well",
-        trigger: ".modal-content .o_field_widget[name=triggering_answer_id] input",
+        content: "Choose a new valid trigger",
+        trigger: ".o_field_widget[name=triggering_answer_ids] input",
         run: "click",
         in_modal: true,
     }, {
-        content: "Set the second answer as trigger, then",
-        trigger: 'ul.ui-autocomplete a:contains("Answer B")',
+        content: "Set the first question's second answer as trigger, then",
+        trigger: 'ul.ui-autocomplete a:contains("Question 1 : Answer B")',
         run: 'click',
     },
     ...stepUtils.saveForm(),
-     {
+    {
         content: "Check that Question 3 has its 'normal' trigger icon back",
         trigger: "tr:contains('Question 3') button i.fa-code-fork",
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: "Move Question 3 back below Question 2",
         trigger: "tr.o_data_row:nth-child(2) td[name=sequence]",
         run: "drag_and_drop_native div[name=question_and_page_ids] table tbody tr:nth-child(3)",
     }, {
         content: "Open that question again",
-        trigger: "tr.o_data_row td[data-tooltip='Question 3']",
+        trigger: "tr.o_data_row td:contains('Question 3')",
         run: "click",
     },
     ...changeTab("options"),
     {
-        content: "Change trigger to confirm we can now use Question 2 again",
-        trigger: ".modal-content .o_field_widget[name=triggering_question_id] input",
+        content: "Add a second trigger to confirm we can now use Question 2 again",
+        trigger: ".modal-content .o_field_widget[name=triggering_answer_ids] input",
         run: "click",
         in_modal: true,
     }, {
-        content: "Question 2 is allowed as trigger again",
-        trigger: '.modal-content ul.ui-autocomplete a:contains("Question 2")',
-        in_modal: true,
-    }, {
-        content: "Change the trigger answer back as well",
-        trigger: ".modal-content .o_field_widget[name=triggering_answer_id] input",
-        run: "text A",
-        in_modal: true,
-    }, {
-        content: "Set the second answer as trigger, then",
-        trigger: '.modal-content ul.ui-autocomplete a:contains("Answer B")',
+        content: "Add the second question's second answer as trigger, then",
+        trigger: '.modal-content ul.ui-autocomplete a:contains("Question 2 : Answer B")',
         run: "click",
     },
     ...stepUtils.saveForm(),
+    // Move question 1 below question 3,
+    {
+        content: "Move Question 1 back below Question 3",
+        trigger: "tr.o_data_row:nth-child(1) td[name=sequence]",
+        run: "drag_and_drop_native div[name=question_and_page_ids] table tbody tr:nth-child(3)",
+    }, {
+        content: "Check that Question 3 has 'warning' trigger icon",
+        trigger: "tr:contains('Question 3') button i.fa-exclamation-triangle",
+        isCheck: true,
+    }, {
+        content: "Open that question again",
+        trigger: "tr.o_data_row td:contains('Question 3')",
+        run: "click",
+    }, {
+        content: "Check that an alert is shown also when only one trigger is misplaced",
+        trigger: ".o_form_sheet_bg div:first-child.alert-warning:contains('positioned before some or all of its triggers')",
+        in_modal: true,
+    },
+    ...changeTab("options"),
+    {
+        content: "Remove temporarily used trigger",
+        trigger: ".o_field_widget[name=triggering_answer_ids] span:contains('Question 1') a.o_delete",
+        run: "click",
+        in_modal: true,
+    }, {
+        content: "Check that the alert is gone in this case too",
+        trigger: `.o_form_sheet_bg div:first-child:not(.alert-warning).o_form_sheet`,
+        in_modal: true,
+        isCheck: true,
+    },
+    ...stepUtils.saveForm(),
+    {
+        content: "Check that Question 3 has its 'normal' trigger icon back",
+        trigger: "tr:contains('Question 3') button i.fa-code-fork",
+        isCheck: true,
+    }, {
+        content: "Move Question 1 back above Question 2",
+        trigger: "tr.o_data_row:nth-child(3) td[name=sequence]",
+        run: "drag_and_drop_native div[name=question_and_page_ids] table tbody tr:nth-child(1)",
+    },
     // Deleting trigger answers or whole question gracefully remove the trigger automatically
     {
         content: "Open Question 2 again",
-        trigger: "tr.o_data_row td[data-tooltip='Question 2']",
+        trigger: "tr.o_data_row td:contains('Question 2')",
         run: "click",
     }, {
         content: "Delete Answer B",
@@ -189,11 +195,11 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         content: "Check that Question 3 no longer has a trigger icon",
         trigger: "div[name=question_and_page_ids] tr:contains('Question 3') div.o_widget_survey_question_trigger:not(:has(button))",
         allowInvisible: true,
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: "Check that Question 2 however still has a trigger icon",
         trigger: "tr:contains('Question 2') button i.fa-code-fork",
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: "Delete Question 1",
         trigger: "tr:contains('Question 1') button[name=delete]",
@@ -202,14 +208,14 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         content: "Check that now Question 2 too does no longer have a trigger icon",
         trigger: "tr:contains('Question 2') div.o_widget_survey_question_trigger:not(:has(button))",
         allowInvisible: true,
-        run: () => {}, // it's a check
+        isCheck: true,
     }, {
         content: 'Go back to Kanban View',
         trigger: '[data-menu-xmlid="survey.menu_survey_form"]',
     }, {
         content: "Check that we arrived on the kanban view",
         trigger: ".o-kanban-button-new",
-        run: () => {}, // it's a check
+        isCheck: true,
     }
 ]});
 
@@ -246,22 +252,11 @@ function saveAndNew() {
             // suggested_answer_ids required even though in_modal is specified...
             trigger: "div[name=suggested_answer_ids] .o_list_table tbody tr:first-child:not(.o_data_row)", // empty answers list
             in_modal: true,
-            run: () => {}, // it's a check
+            isCheck: true,
         }
     ];
 }
 
-function toggleIsConditional() {
-    return [
-        ...changeTab("options"),
-        {
-            content: "Toggle is_conditional",
-            trigger: "div[name=is_conditional] input",
-            in_modal: true,
-            run: "click",
-        }
-    ];
-}
 
 function changeTab(tabName) {
     // Currently, .modal-content is required even though "in_modal"
@@ -274,7 +269,7 @@ function changeTab(tabName) {
             content: `Wait for tab ${tabName} tab`,
             trigger: `.modal-content a[name=${tabName}].nav-link.active`,
             in_modal: true,
-            run: () => {}, // it's a check
+            isCheck: true,
         }
     ];
 }

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -9,7 +9,7 @@
             <form string="Survey Question" create="false" class="o_survey_question_view_form">
                 <field name="is_placed_before_trigger" invisible="1"/>
                 <div class="alert alert-warning mb-0 text-center" role="alert" invisible="not is_placed_before_trigger">
-                    ⚠️ This question is positioned before its trigger and will be skipped.
+                    ⚠️ This question is positioned before some or all of its triggers and could be skipped.
                 </div>
                 <field name="is_page" invisible="1"/>
                 <field name="page_id" invisible="1" required="False"/>
@@ -217,19 +217,16 @@
                                     <field name='comment_count_as_answer'
                                         invisible="question_type not in ['simple_choice', 'multiple_choice', 'matrix'] or not comments_allowed"/>
                                 </group>
-                                <group string="Layout">
+                                <group string="Conditional display">
                                     <p class="text-muted" colspan="2" invisible="questions_selection == 'all'">
                                         Conditional display is not available when questions are randomly picked.
                                     </p>
-                                    <field name="is_conditional" invisible="questions_selection == 'random'"/>
                                     <field name="allowed_triggering_question_ids" invisible="1"/>
-                                    <field name="triggering_question_id"  options="{'no_create_edit': True, 'no_open': True, 'no_create': True}"
-                                           domain="[('id', 'in', allowed_triggering_question_ids)]" placeholder="Pick a previous multiple-choice question"
-                                           invisible="questions_selection == 'random' or not is_conditional"
-                                           required="is_conditional"/>
-                                    <field name="triggering_answer_id" options="{'no_open': True, 'no_create': True}"
-                                        invisible="questions_selection == 'random' or not triggering_question_id"
-                                        required="is_conditional"/>
+                                    <field name="triggering_answer_ids" widget="many2many_tags" options="{'no_open': True, 'no_create': True}"
+                                           domain="[('question_id', 'in', allowed_triggering_question_ids)]"
+                                           invisible="questions_selection == 'random'"
+                                           placeholder="Optional previous answers required"
+                                    />
                                 </group>
                             </group>
                             <group>
@@ -304,11 +301,10 @@
         <field name="name">survey.question.answer.view.tree</field>
         <field name="model">survey.question.answer</field>
         <field name="arch" type="xml">
-            <tree string="Survey Label" create="false">
+            <tree string="Survey Label" create="false" default_order="question_id">
                 <field name="sequence" widget="handle"/>
                 <field name="question_id"/>
-                <field name="matrix_question_id"/>
-                <field name="value"/>
+                <field name="value" string="Answer"/>
                 <field name="answer_score" groups="base.group_no_one"/>
             </tree>
         </field>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -77,11 +77,8 @@
                                     <field name="random_questions_count"
                                         column_invisible="parent.questions_selection == 'all'"
                                         invisible="not is_page"/>
-                                    <field name="is_conditional" column_invisible="True"/>
-                                    <field name="triggering_question_id" column_invisible="True"/>
-                                    <field name="triggering_answer_id" column_invisible="True"/>
-                                    <field name="is_placed_before_trigger" column_invisible="True"/>
-                                    <field name="allowed_triggering_question_ids" column_invisible="True"/>
+                                    <field name="triggering_question_ids" column_invisible="True"/>
+                                    <field name="triggering_answer_ids" column_invisible="True" widget="many2many_tags"/> <!-- widget to fetch display_name -->
                                     <widget name="survey_question_trigger"/>
                                     <button name="copy" type="object" icon="fa-clone" title="Duplicate Question"/>
                                     <control>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -113,6 +113,7 @@
                 t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
                 t-att-data-questions-layout="survey.questions_layout"
                 t-att-data-triggered-questions-by-answer="json.dumps(triggered_questions_by_answer)"
+                t-att-data-triggering-answers-by-question="json.dumps(triggering_answers_by_question)"
                 t-att-data-selected-answers="json.dumps(selected_answers)"
                 t-att-data-refresh-background="any(page.background_image for page in survey.page_ids)">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
@@ -304,8 +305,9 @@
         <t t-set="display_question"
            t-value="survey.questions_layout == 'page_per_question'
                     or survey.questions_selection == 'random'
-                    or (survey.questions_layout == 'one_page' and not question.is_conditional)
-                    or (survey.questions_layout == 'page_per_section' and (not question.is_conditional or triggering_answer_by_question[question.id] in selected_answers))"/>
+                    or (survey.questions_layout == 'one_page' and not question.triggering_answer_ids)
+                    or (survey.questions_layout == 'page_per_section' and (not question.triggering_answer_ids
+                        or any(triggering_answer in selected_answers for triggering_answer in triggering_answers_by_question[question.id])))"/>
 
         <t t-set="answer_lines" t-value="answer.user_input_line_ids.filtered(lambda line: line.question_id == question)"/>
         <!--Use Key selection if number of choices is < 26 to keep Z for other choice if any-->


### PR DESCRIPTION
Purpose: allowing users to select multiple answers, even from
different questions, as triggers to display a subsequent question.

For example, we could ask the question
"What qualities do you look for in a desk?"
if the participant selected one of the following answers before:
"What furniture did you already buy from us?" - "A desk"
"What kind of furniture are you looking for?" - "Office furniture"

Demo data and tests are adapted and new ones are added.

We also take this opportunity to remove `is_conditional` because:
1. This field isn't useful anymore.
2. It could cause inconsistencies as it is not supported to check
 with a sql constraint that `suggested_answer_ids` is set when this
  flag is `True`.

Task-2937533

Co-authored-by: Pratik Raval <prra@odoo.com>
