### PR TITLE
[FIX] l10n_in_edi_ewaybill: neutralize

### DIFF
--- a/addons/l10n_in_edi_ewaybill/data/neutralize.sql
+++ b/addons/l10n_in_edi_ewaybill/data/neutralize.sql
@@ -1,0 +1,1 @@
+DELETE FROM ir_config_parameter WHERE key='l10n_in_edi_ewaybill.endpoint';


### PR DESCRIPTION
add missing neutralisation for the the `l10n_in_edi_ewaybill` module introduced in https://github.com/odoo/odoo/pull/93773


