### PR TITLE
[FIX] sale_product_configurator: Don't hide optional product line after edit

### DIFF
--- a/addons/sale_product_configurator/static/src/js/product_configurator_widget.js
+++ b/addons/sale_product_configurator/static/src/js/product_configurator_widget.js
@@ -105,6 +105,7 @@ ProductConfiguratorWidget.include({
                 onSuccess: function () {
                     // Leave edit mode of one2many list.
                     unselectRow();
+                    self.trigger_up('set_dirty', {dataPointID: self.dataPointID});
                 }
             });
         } else if (!self._isConfigurableLine() && self._isConfigurableProduct()) {


### PR DESCRIPTION
Steps:
 - Open sales
 - Enable variants products
 - Add a product with optional products (example 'Conference chair')
 - Select a product on the modal
 - Click to edit the optional product in the lines
 - click outside
 - Optional product is deleted

Make the record dirty to prevent deletion

opw-3114276