### PR TITLE
[FIX] website_sale: apply taxes according to fiscal position

### DIFF
--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -297,7 +297,6 @@ class ProductTemplate(models.Model):
 
             # The list_price is always the price of one.
             quantity_1 = 1
-            combination_info['price'] = self.env['account.tax']._fix_tax_included_price_company(combination_info['price'], product.sudo().taxes_id, taxes, company_id)
             price = taxes.compute_all(combination_info['price'], pricelist.currency_id, quantity_1, product, partner)[tax_display]
             if pricelist.discount_policy == 'without_discount':
                 combination_info['list_price'] = self.env['account.tax']._fix_tax_included_price_company(combination_info['list_price'], product.sudo().taxes_id, taxes, company_id)

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -147,18 +147,6 @@ class SaleOrder(models.Model):
                 pu = price
         else:
             pu = product.price
-            if order.pricelist_id and order.partner_id:
-                order_line = order._cart_find_product_line(product.id, force_search=True)
-                if order_line:
-                    pu = product._get_tax_included_unit_price(
-                        self.company_id,
-                        order.currency_id,
-                        order.date_order,
-                        'sale',
-                        fiscal_position=order.fiscal_position_id,
-                        product_price_unit=product.price,
-                        product_currency=order.currency_id
-                    )
 
         return {
             'product_id': product_id,


### PR DESCRIPTION
Version:
--------
V14, V15 and V16

Module:
-------
- website_sale

Setup:
------
Two taxes:
- a 15% tax included for the sale
- a 20% tax included for the sale

A fiscal position:
- map the tax from 15% (included) to 20% (included)

A product:
- sales price equals to 100
- customer taxes: Tax 15%

A user:
- must be detected in the fiscal position created before

Website:
- product prices: Tax-Included

Steps to reproduce:
-------------------
- go to ecommerce with the new user
- add the product to the cart (the fiscal position must be correctly detected)
(be careful with the pricelist, use Public Pricelist)

Issue:
------
On the shop page: 86.96
On the product page: 86.96
On the cart 86.96 + 17.39 = 104.35

Cause:
------
The price including tax of 86.96 is calculated as follows: (100 / 1.15) = 86.96 (tax included)
(86.96 / 1.20) = 72.46 (tax excluded)
because 20% are included

The price of 104.35 is calculated as follows:
(100 / 1.15) = 86.96 (base price)
86.96 * 1.20 = 104.35
because we have the base price
so the next taxes should be excluded

There is a disagreement in the way
the price is calculated according to the new tax position

Objective:
----------
The "website_sale" and "sale" apps agree
on the application of taxes modified with a fiscal position.

Solution:
---------
The change in tax position should reflect the manual replacement of taxes in the product form view.

Result:
-------
price without VAT:
(100 / 1.20) = 83.33 because 20% included
VAT: 100 - 83.33 = 16.67
TOTAL: 100 which is the selling price mentioned

opw-3078766
opw-3125121