### PR TITLE
[FIX] web_editor, *: activate all snippets after move with drag and drop

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -635,7 +635,7 @@ var SnippetEditor = publicWidget.Widget.extend({
      * @param {boolean} [show=false]
      */
     toggleOverlayVisibility: function (show) {
-        if (this.$el && !this.scrollingTimeout) {
+        if (this.$el && !this.scrollingTimeout && !this.dragAndDropResolve) {
             this.$el.toggleClass('o_overlay_hidden', (!show || this.$target[0].matches('.o_animating:not(.o_animate_on_scroll)')) && this.isShown());
         }
     },
@@ -1060,6 +1060,13 @@ var SnippetEditor = publicWidget.Widget.extend({
      * @private
      */
     _onDragAndDropStart({ helper, addStyle }) {
+        if (this.dragAndDropResolve) {
+            // A drag is already in progress.
+            return;
+        }
+        this.toggleOverlayVisibility(false);
+        const prom = new Promise(resolve => this.dragAndDropResolve = () => resolve());
+        this.trigger_up('snippet_edition_suspend', {exec: () => prom});
         this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
         this.trigger_up('drag_and_drop_start');
         this.options.wysiwyg.odooEditor.automaticStepUnactive();
@@ -1392,6 +1399,7 @@ var SnippetEditor = publicWidget.Widget.extend({
         this.options.wysiwyg.odooEditor.automaticStepActive();
         this.options.wysiwyg.odooEditor.automaticStepSkipStack();
         this.options.wysiwyg.odooEditor.unbreakableStepUnactive();
+        this.trigger_up('snippet_edition_block_until_completed');
 
         const rowEl = this.$target[0].parentNode;
         if (rowEl && rowEl.classList.contains('o_grid_mode')) {
@@ -1506,6 +1514,7 @@ var SnippetEditor = publicWidget.Widget.extend({
         $clone.remove();
 
         this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
+        const moves = [];
         if (this.dropped) {
             if (prev) {
                 this.$target.insertAfter(prev);
@@ -1516,7 +1525,7 @@ var SnippetEditor = publicWidget.Widget.extend({
             }
 
             for (var i in this.styles) {
-                this.styles[i].onMove();
+                moves.push(this.styles[i].onMove());
             }
 
             // If the target has a mobile order class, and if it was dropped in
@@ -1525,26 +1534,32 @@ var SnippetEditor = publicWidget.Widget.extend({
                 && this.$target[0].parentNode !== this.dragState.startingParent) {
                 ColumnLayoutMixin._fillRemovedItemGap(this.dragState.startingParent, this.dragState.mobileOrder);
             }
-
-            this.$target.trigger('content_changed');
-            $from.trigger('content_changed');
         }
+        Promise.allSettled(moves).then(() => {
+            if (this.dropped) {
+                this.$target.trigger('content_changed');
+                $from.trigger('content_changed');
+            }
+            this.trigger_up('drag_and_drop_stop', {
+                $snippet: this.$target,
+            });
+            const samePositionAsStart = this.$target[0].classList.contains('o_grid_item')
+                ? (this.$target[0].parentNode === this.dragState.startingGrid
+                    && this.$target[0].style.gridArea === this.dragState.prevGridArea)
+                : this._dropSiblings.prev === this.$target.prev()[0] && this._dropSiblings.next === this.$target.next()[0];
+            if (!samePositionAsStart) {
+                this.options.wysiwyg.odooEditor.historyStep();
+            }
 
-        this.trigger_up('drag_and_drop_stop', {
-            $snippet: this.$target,
+            this.dragState.restore();
+
+            delete this.$dropZones;
+            delete this.dragState;
+
+            this.dragAndDropResolve();
+            delete this.dragAndDropResolve;
+            this.toggleOverlayVisibility(true);
         });
-        const samePositionAsStart = this.$target[0].classList.contains('o_grid_item')
-            ? (this.$target[0].parentNode === this.dragState.startingGrid
-                && this.$target[0].style.gridArea === this.dragState.prevGridArea)
-            : this._dropSiblings.prev === this.$target.prev()[0] && this._dropSiblings.next === this.$target.next()[0];
-        if (!samePositionAsStart) {
-            this.options.wysiwyg.odooEditor.historyStep();
-        }
-
-        this.dragState.restore();
-
-        delete this.$dropZones;
-        delete this.dragState;
     },
     /**
      * @private
@@ -1813,7 +1828,9 @@ class SnippetsMenu extends Component {
         'find_snippet_template': '_onFindSnippetTemplate',
         'is_element_selected': '_onIsElementSelected',
         'remove_snippet': '_onRemoveSnippet',
+        'snippet_edition_block_until_completed': '_onSnippetEditionBlockUntilCompleted',
         'snippet_edition_request': '_onSnippetEditionRequest',
+        'snippet_edition_suspend': '_onSnippetEditionSuspend',
         'snippet_editor_destroyed': '_onSnippetEditorDestroyed',
         'snippet_removed': '_onSnippetRemoved',
         'snippet_cloned': '_onSnippetCloned',
@@ -3923,6 +3940,20 @@ class SnippetsMenu extends Component {
             };
         }
         const mutexExecResult = this._mutex.exec(action);
+        this._withLoadingEffect(contentLoading, delay);
+        return mutexExecResult;
+    }
+    /**
+     * Sets a loading effect over the editor to appear if the action takes too
+     * much time.
+     * As soon as the mutex is unlocked, the loading effect will be removed.
+     *
+     * @private
+     * @param {boolean} [contentLoading=true]
+     * @param {number} [delay=500]
+     * @returns {Promise}
+     */
+    _withLoadingEffect(contentLoading = true, delay = 500) {
         if (!this.loadingTimers[contentLoading]) {
             const addLoader = () => {
                 if (this._loadingEffectDisabled || this.loadingElements[contentLoading]) {
@@ -3957,7 +3988,6 @@ class SnippetsMenu extends Component {
                 }
             });
         }
-        return mutexExecResult;
     }
     /**
      * Update the options pannel as being empty.
@@ -4546,6 +4576,30 @@ class SnippetsMenu extends Component {
      */
     _onSnippetEditionRequest(ev) {
         this._execWithLoadingEffect(ev.data.exec, ev.data.optionsLoader ? "both" : true);
+    }
+    /**
+     * Execs within mutex but without loading effect - e.g. for intra-page
+     * drag'n'drop.
+     *
+     * @private
+     * @param {OdooEvent} ev
+     * @param {Object} ev.data
+     * @param {function} ev.data.exec
+     */
+    _onSnippetEditionSuspend(ev) {
+        this._mutex.exec(ev.data.exec);
+    }
+    /**
+     * Blocks the UI with a loading effect until the current mutexed operation
+     * completes. This is to be used after a call to _onSnippetEditionSuspend
+     * if the UI needs to be blocked after all.
+     *
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onSnippetEditionBlockUntilCompleted(ev) {
+        this._withLoadingEffect(false);
+        this._withLoadingEffect(true);
     }
     /**
      * @private

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3455,8 +3455,11 @@ const SnippetOptionWidget = publicWidget.Widget.extend({
     onClone: function (options) {},
     /**
      * Called when the associated snippet is moved to another DOM location.
+     * If a Promise is returned, it is awaited upon before proceeding with the
+     * ongoing move.
      *
      * @abstract
+     * @returns {Promise|undefined}
      */
     onMove: function () {},
     /**
@@ -5843,9 +5846,10 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
      * @override
      */
     onMove() {
-        this._super.apply(this, arguments);
+        const result = this._super.apply(this, arguments);
         // Remove all the mobile order classes after a drag and drop.
         this._removeMobileOrders(this.$target[0].parentElement.children);
+        return result;
     },
     /**
      * @override

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2721,6 +2721,7 @@ we-button:hover .o_we_shape_animated_label {
     z-index: $o-we-zindex;
     background-color: $o-we-sidebar-content-backdrop-bg;
     color: $o-we-fg-lighter;
+    pointer-events: initial;
 }
 #oe_manipulators > .o_we_ui_loading {
     // hacky solution to be over the content, ideally that loader should only

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2309,7 +2309,7 @@ options.registry.Parallax = options.Class.extend({
      * @override
      */
     onMove() {
-        this._refreshPublicWidgets();
+        return this._refreshPublicWidgets();
     },
     /**
      * @override


### PR DESCRIPTION
*: website

Before this commit, dynamic snippets were not activated after being
moved by using the drag and drop, because they are made invisible until
their content is fetched.

This commit makes sure any pending `onMove` is completed during a drop
before proceeding so that `_activateSnippet` does not ignore snippets
that could be in the process of being refreshed.

Steps to reproduce:
- Edit a website page.
- Drop a Banner snippet.
- Drop a Products snippet.
- Drag the Products snippet above the Banner.
=> On drop, the Products snippet is not selected.

task-3129065