### PR TITLE
[FIX] account: tax update country based on tempalte tax group

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -48,6 +48,10 @@ def update_taxes_from_templates(cr, chart_template_xmlid):
             xml_id = old_tax.get_xml_id().get(old_tax.id)
             if xml_id:
                 _remove_xml_id(xml_id)
+
+        if not template_vals.get('country_id') and template.tax_group_id:
+            template_vals['country_id'] = template.tax_group_id.country_id.id
+
         chart_template.create_record_with_xmlid(company, template, "account.tax", template_vals)
 
     def _update_tax_from_template(template, tax):


### PR DESCRIPTION
when a template repartition line had no tags and template has tax group id,  our update does not create the related tax in that country,but instead created it in our company's country. it was breaking migration tests. This pr fixed that bug.

related: odoo#108571
also related: https://github.com/odoo/odoo/pull/109412

```
  File "/home/odoo/src/odoo/16.0/addons/account/models/account_tax.py", line 156, in validate_tax_group_id
    raise ValidationError(_("The tax group must have the same country_id as the tax using it."))
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
