### PR TITLE
[FIX] web: use same lang for menus and translations

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -122,7 +122,8 @@ class Http(models.AbstractModel):
             # but is still included in some other calls (e.g. '/web/session/authenticate')
             # to avoid access errors and unnecessary information, it is only included for users
             # with access to the backend ('internal'-type users)
-            menus = self.env['ir.ui.menu'].load_menus(request.session.debug)
+            lang = request.session.context['lang']
+            menus = self.env['ir.ui.menu'].with_context(lang=lang).load_menus(request.session.debug)
             ordered_menus = {str(k): v for k, v in menus.items()}
             menu_json_utf8 = json.dumps(ordered_menus, default=ustr, sort_keys=True).encode()
             session_info['cache_hashes'].update({


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In some cases, when a user changes its language the menus are not updated but the other UI elements (fields etc) are properly translated.

We now force the same language for translation hash than for menu hash.
https://github.com/odoo/odoo/blob/54c159d1f329c6a32d57958bfad649e0f78dbc73/addons/web/models/ir_http.py#L108-L112

**Current behavior before PR:**
Menus are not in the same language as fields and other UI elements.

**Desired behavior after PR is merged:**
Same language everywhere.

opw-3105014

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
