### PR TITLE
[FIX] sale_loyalty: apply the promotion several times

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -545,6 +545,9 @@ class SaleOrder(models.Model):
         self.ensure_one()
         # Use the old lines before creating new ones. These should already be in a 'reset' state.
         old_reward_lines = kwargs.get('old_lines', self.env['sale.order.line'])
+        if not old_reward_lines:
+            # The reward line to be removed are those that concern the coupon to be applied.
+            old_reward_lines = self.order_line.filtered(lambda line: line.is_reward_line and line.coupon_id == coupon)
         if reward.is_global_discount:
             global_discount_reward_lines = self._get_applied_global_discount_lines()
             global_discount_reward = global_discount_reward_lines.reward_id


### PR DESCRIPTION
Steps to reproduce:
- create a coupon program with a discount type reward on specific product;
- "reward_point_mode" has to be "per unit paid";
- create a sale order;
- add a product on several lines;
- change the quantity of the product;
- add a second product;

(click each time on the "PROMOTIONS" button between steps)

Issue:
Promotions already in progress are not taken into account.

Solution:
If no current promotions are given when applying new promotions,
the sale order is broswed to make sure that they are found
if there are any.

opw-3112925