### PR TITLE
[FIX] l10n_gcc_pos: fix country undefined

### DIFF
--- a/addons/l10n_gcc_pos/static/src/js/OrderReceipt.js
+++ b/addons/l10n_gcc_pos/static/src/js/OrderReceipt.js
@@ -10,7 +10,8 @@ odoo.define('l10n_gcc_pos.OrderReceipt', function (require) {
             get receiptEnv() {
                 let receipt_render_env = super.receiptEnv;
                 let receipt = receipt_render_env.receipt;
-                receipt.is_gcc_country = ['SA', 'AE', 'BH', 'OM', 'QA', 'KW'].includes(receipt_render_env.order.pos.company.country.code);
+                let company = this.env.pos.company;
+                receipt.is_gcc_country = company.country ? ['SA', 'AE', 'BH', 'OM', 'QA', 'KW'].includes(company.country.code) : false;
                 return receipt_render_env;
             }
         }

--- a/addons/l10n_sa_pos/models/__init__.py
+++ b/addons/l10n_sa_pos/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import pos_order
+from . import pos_config

--- a/addons/l10n_sa_pos/models/pos_config.py
+++ b/addons/l10n_sa_pos/models/pos_config.py
@@ -1,0 +1,15 @@
+	# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+from odoo.exceptions import UserError
+from odoo.tools.translate import _
+
+
+class pos_config(models.Model):
+    _inherit = 'pos.config'
+
+    def open_ui(self):
+        for config in self:
+            if not config.company_id.country_id:
+                raise UserError(_("You have to set a country in your company setting."))
+        return super(pos_config, self).open_ui()

--- a/addons/l10n_sa_pos/static/src/js/models.js
+++ b/addons/l10n_sa_pos/static/src/js/models.js
@@ -7,7 +7,7 @@ var Registries = require('point_of_sale.Registries');
 const PosL10nSAOrder = (Order) => class PosL10nSAOrder extends Order {
     export_for_printing() {
         var result = super.export_for_printing(...arguments);
-        if (this.pos.company.country.code === 'SA') {
+        if (this.pos.company.country && this.pos.company.country.code === 'SA') {
             result.is_settlement = this.is_settlement();
             if (!result.is_settlement) {
                 const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter()

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -473,11 +473,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 
         # Change the default sale pricelist of customers,
         # so the js tests can expect deterministically this pricelist when selecting a customer.
-        env['ir.property']._set_default(
-            "property_product_pricelist",
-            "res.partner",
-            public_pricelist,
-        )
+        env['ir.property']._set_default("property_product_pricelist", "res.partner", public_pricelist, main_company)
 
 
 @odoo.tests.tagged('post_install', '-at_install')


### PR DESCRIPTION
When the country is not defined on the company, there was an error when using the gcc l10n. To fix this, we check if the country is set before going further.

This commit also fixes the test when different localisation are used to make sure that the public pricelist is used. Before, when pos_pricelist test was done and some localisation were installed, it could lead to test failure because the default pricelist wasn't correct on the partners.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
