### PR TITLE
[IMP] account_edi_proxy_client, l10n_it_edi: operating mode per company

### DIFF
--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -66,32 +66,26 @@
                     <field name="edi_error_count" invisible="1" />
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_web_services_to_process', 'in', ['', False]), ('state', '=', 'draft')]}">
-                         <div>The invoice will be processed asynchronously by the following E-invoicing service :
+                         <div>The invoice will be processed automatically by the following E-invoicing service:
                             <field name="edi_web_services_to_process" class="oe_inline"/>
                          </div>
-                         <button name="button_process_edi_web_services" type="object" class="oe_link" string="Process now" /> 
+                         <button name="button_process_edi_web_services" type="object" class="btn btn-secondary" string="Process now" /> 
                     </div>
                     <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'error')]}">
-                        <div class="o_row">
-                            <field name="edi_error_message" />
-                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
-                            <button name="action_retry_edi_documents_error" type="object" class="oe_link oe_inline" string="Retry" />
-                        </div>
+                        <field name="edi_error_message" />
+                        <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="btn btn-secondary" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
+                        <button name="action_retry_edi_documents_error" type="object" class="btn btn-secondary" string="Retry" />
                     </div>
                     <div class="alert alert-warning" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'warning')]}">
-                        <div class="o_row">
-                            <field name="edi_error_message" />
-                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
-                        </div>
+                        <field name="edi_error_message" />
+                        <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="btn btn-secondary" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
                     </div>
                     <div class="alert alert-info" role="alert" style="margin-bottom:0px;"
                         attrs="{'invisible': ['|', ('edi_error_count', '=', 0), ('edi_blocking_level', '!=', 'info')]}">
-                        <div class="o_row">
-                            <field name="edi_error_message" />
-                            <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="oe_link" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
-                        </div>
+                        <field name="edi_error_message" />
+                        <button name="%(account_edi.action_open_edi_documents)d" string="⇒ See errors" type="action" class="btn btn-secondary" attrs="{'invisible': [('edi_error_count', '=', 1)]}" /> 
                     </div>
                 </xpath>
                 <xpath expr="//div[@name='journal_div']" position="after">

--- a/addons/account_edi_proxy_client/models/account_edi_format.py
+++ b/addons/account_edi_proxy_client/models/account_edi_format.py
@@ -13,15 +13,4 @@ class AccountEdiFormat(models.Model):
         '''Returns the proxy_user associated with this edi format.
         '''
         self.ensure_one()
-        return company.account_edi_proxy_client_ids.filtered(lambda u: u.edi_format_id == self)
-
-    # -------------------------------------------------------------------------
-    # To override
-    # -------------------------------------------------------------------------
-
-    def _get_proxy_identification(self, company):
-        '''Returns the key that will identify company uniquely for this edi format (for example, the vat)
-        or raises a UserError (if the user didn't fill the related field).
-        TO OVERRIDE
-        '''
-        return False
+        return company.account_edi_proxy_client_user_ids.filtered(lambda u: u.edi_format_id == self)

--- a/addons/account_edi_proxy_client/models/res_company.py
+++ b/addons/account_edi_proxy_client/models/res_company.py
@@ -6,4 +6,9 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    account_edi_proxy_client_ids = fields.One2many('account_edi_proxy_client.user', inverse_name='company_id')
+    account_edi_proxy_client_user_ids = fields.One2many('account_edi_proxy_client.user', inverse_name='company_id')
+
+    def _get_proxy_users(self, edi_format_code=None, edi_operating_mode=None):
+        return self.account_edi_proxy_client_user_ids.filtered(
+            lambda u: (not edi_format_code or edi_format_code == u.edi_format_code)
+                  and (not edi_operating_mode or edi_operating_mode == u.edi_operating_mode))

--- a/addons/l10n_it_edi/models/__init__.py
+++ b/addons/l10n_it_edi/models/__init__.py
@@ -8,5 +8,6 @@ from . import account_chart_template
 from . import account_invoice
 from . import account_edi_document
 from . import account_edi_format
+from . import account_edi_proxy_user
 from . import ddt
 from . import ir_attachment

--- a/addons/l10n_it_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_it_edi/models/account_edi_proxy_user.py
@@ -1,0 +1,24 @@
+# -*- coding:utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+class AccountEdiProxyClientUser(models.Model):
+    _inherit = 'account_edi_proxy_client.user'
+
+    def _get_server_url(self, edi_operating_mode=False):
+        """ Return the base server URL for each operating mode. """
+        urls = {
+            'test': 'https://iap-services-test.odoo.com',
+            'prod': 'https://l10n-it-edi.api.odoo.com',
+        }
+        return urls.get(edi_operating_mode or self.edi_operating_mode, False)
+
+    def _retrieve_edi_identification(self, edi_format_code, company):
+        if edi_format_code != 'fattura_pa':
+            return super()._get_edi_identification(edi_format_code, company)
+        edi_identification = company.partner_id._l10n_it_normalize_codice_fiscale(company.partner_id.l10n_it_codice_fiscale)
+        if not edi_identification:
+            raise UserError(_('Please fill your codice fiscale to be able to receive invoices from FatturaPA'))
+        return edi_identification

--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -1,100 +1,53 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields, _
+from odoo import _, api, models, fields
 from odoo.exceptions import UserError
+
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
-    l10n_it_edi_proxy_current_state = fields.Char(compute='_compute_l10n_it_edi_proxy_current_state')
-    l10n_it_edi_sdicoop_register = fields.Boolean(compute='_compute_l10n_it_edi_sdicoop_register', inverse='_set_l10n_it_edi_sdicoop_register_demo_mode')
-    l10n_it_edi_sdicoop_demo_mode = fields.Selection(
-        [('demo', 'Demo'),
-         ('test', 'Test (experimental)'),
-         ('prod', 'Official')],
-        compute='_compute_l10n_it_edi_sdicoop_demo_mode',
-        inverse='_set_l10n_it_edi_sdicoop_register_demo_mode',
+    l10n_it_edi_already_registered = fields.Boolean(compute='_compute_l10n_it_edi_already_registered')
+    l10n_it_edi_register_user = fields.Boolean(
+        compute='_compute_l10n_it_edi_register_user',
+        inverse='_set_l10n_it_edi_register_user',
+        store=True)
+    l10n_it_edi_operating_mode = fields.Selection(
+        selection=[('demo', 'Demo'), ('test', 'Test (Experimental)'), ('prod', 'Official')],
+        compute='_compute_l10n_it_edi_operating_mode',
+        inverse='_set_l10n_it_edi_operating_mode',
         readonly=False)
 
-    def _create_proxy_user(self, company_id):
-        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
-        edi_identification = fattura_pa._get_proxy_identification(company_id)
-        self.env['account_edi_proxy_client.user']._register_proxy_user(company_id, fattura_pa, edi_identification)
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_sdicoop_demo_mode(self):
+    @api.depends('company_id')
+    def _compute_l10n_it_edi_operating_mode(self):
         for config in self:
-            config.l10n_it_edi_sdicoop_demo_mode = self.env['account_edi_proxy_client.user']._get_demo_state()
+            proxy_user = config.company_id.l10n_it_edi_proxy_user
+            config.l10n_it_edi_operating_mode = proxy_user and proxy_user.edi_operating_mode or 'demo'
 
-    def _set_l10n_it_edi_sdicoop_demo_mode(self):
-        for config in self:
-            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', config.l10n_it_edi_sdicoop_demo_mode)
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_is_edi_proxy_active(self):
-        for config in self:
-            config.is_edi_proxy_active = config.company_id.account_edi_proxy_client_ids
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_proxy_current_state(self):
-        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
-        for config in self:
-            proxy_user = config.company_id.account_edi_proxy_client_ids.search([
-                ('company_id', '=', config.company_id.id),
-                ('edi_format_id', '=', fattura_pa.id),
-            ], limit=1)
-
-            config.l10n_it_edi_proxy_current_state = 'inactive' if not proxy_user else 'demo' if proxy_user.id_client[:4] == 'demo' else 'active'
+    @api.depends('l10n_it_edi_operating_mode')
+    def _set_l10n_it_edi_operating_mode(self, *args):
+        if not self.l10n_it_edi_register_user:
+            company = self.company_id
+            raise UserError(_("Please authorize Odoo to handle your invoices by checking the field below for the company %s (id=%s)", company.name, company.id))
+        self.company_id._set_l10n_it_edi_proxy_user(self.l10n_it_edi_operating_mode)
 
     @api.depends('company_id')
-    def _compute_l10n_it_edi_sdicoop_register(self):
-        """Needed because it expects a compute"""
-        self.l10n_it_edi_sdicoop_register = False
-
-    def button_create_proxy_user(self):
-        # For now, only fattura_pa uses the proxy.
-        # To use it for more, we have to either make the activation of the proxy on a format basis
-        # or create a user per format here (but also when installing new formats)
-        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
-        edi_identification = fattura_pa._get_proxy_identification(self.company_id)
-        if not edi_identification:
-            return
-
-        self.env['account_edi_proxy_client.user']._register_proxy_user(self.company_id, fattura_pa, edi_identification)
-
-    def _set_l10n_it_edi_sdicoop_register_demo_mode(self):
-
-        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
+    def _compute_l10n_it_edi_register_user(self):
+        """ This field will be changed by the user """
         for config in self:
+            config.l10n_it_edi_register_user = bool(config.company_id._get_proxy_users('fattura_pa'))
 
-            proxy_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('edi_format_id', '=', fattura_pa.id)
-            ], limit=1)
+    @api.depends('company_id')
+    def _compute_l10n_it_edi_already_registered(self):
+        """ This field will hold the old value while the user changes l10n_it_edi_register_user
+            Needed to compute the 'invisible' attribute in the view.
+        """
+        for config in self:
+            config.l10n_it_edi_already_registered = bool(config.company_id._get_proxy_users('fattura_pa'))
 
-            real_proxy_users = self.env['account_edi_proxy_client.user'].sudo().search([
-                ('id_client', 'not like', 'demo'),
-            ])
-
-            # Update the config as per the selected radio button
-            previous_demo_state = proxy_user._get_demo_state()
-            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', config.l10n_it_edi_sdicoop_demo_mode)
-
-            # If the user is trying to change from a state in which they have a registered official or testing proxy client
-            # to another state, we should stop them
-            if real_proxy_users and previous_demo_state != config.l10n_it_edi_sdicoop_demo_mode:
-                raise UserError(_("The company has already registered with the service as 'Test' or 'Official', it cannot change."))
-
-            if config.l10n_it_edi_sdicoop_register:
-                # There should only be one user at a time, if there are no users, register one
-                if not proxy_user:
-                    self._create_proxy_user(config.company_id)
-                    return
-
-                # If there is a demo user, and we are transitioning from demo to test or production, we should
-                # delete all demo users and then create the new user.
-                elif proxy_user.id_client[:4] == 'demo' and config.l10n_it_edi_sdicoop_demo_mode != 'demo':
-                    self.env['account_edi_proxy_client.user'].search([('id_client', '=like', 'demo%')]).sudo().unlink()
-                    self._create_proxy_user(config.company_id)
+    def _set_l10n_it_edi_register_user(self):
+        """ If l10n_it_edi_operating_mode is on, let _l10n_it_edi_set_proxy_user create the user """
+        for config in self:
+            if not config.l10n_it_edi_operating_mode and not self.company_id.l10n_it_edi_proxy_user:
+                config.l10n_it_edi_operating_mode = 'demo'

--- a/addons/l10n_it_edi/tests/common.py
+++ b/addons/l10n_it_edi/tests/common.py
@@ -12,7 +12,6 @@ from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import A
 def patch_proxy_user(func):
     @patch.object(AccountEdiProxyClientUser, '_make_request', MagicMock(spec=AccountEdiProxyClientUser._make_request))
     @patch.object(AccountEdiProxyClientUser, '_decrypt_data', MagicMock(spec=AccountEdiProxyClientUser._decrypt_data))
-    @patch.object(AccountEdiProxyClientUser, '_get_demo_state', MagicMock(spec=AccountEdiProxyClientUser._get_demo_state))
     def patched(self, *args, **kwargs):
         return func(self, *args, **kwargs)
     return patched

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -87,7 +87,7 @@
         <field name="name">account.move.form.l10n.it</field>
         <field name="model">account.move</field>
         <field name="priority">20</field>
-        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="inherit_id" ref="account_edi.view_move_form_inherit"/>
         <field name="arch" type="xml">
         <data>
             <xpath expr="//page[@name='other_info']" position="after">
@@ -102,6 +102,13 @@
                         </group>
                     </group>
                 </page>
+            </xpath>
+            <xpath expr="//button[@name='button_process_edi_web_services']" position="replace">
+                 <field name="l10n_it_edi_transaction" invisible="1"/>
+                 <button name="button_process_edi_web_services" type="object" class="btn btn-secondary" string="Send manually now"
+                    attrs="{'invisible': [('l10n_it_edi_transaction', '!=', False)]}"/> 
+                 <button name="button_process_edi_web_services" type="object" class="btn btn-secondary" string="Update state"
+                    attrs="{'invisible': [('l10n_it_edi_transaction', '=', False)]}"/> 
             </xpath>
         </data>
         </field>

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -9,36 +9,39 @@
             <xpath expr="//block[@id='account_vendor_bills']" position="after">
                 <block title="Electronic Document Invoicing" attrs="{'invisible':[('country_code', '!=', 'IT')]}" id='account_edi'>
                     <setting>
+                        <field name="l10n_it_edi_operating_mode" invisible="1"/>
+                        <field name="l10n_it_edi_already_registered" invisible="1"/>
                         <div class="group-content">
-                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
-                            <span class="o_form_label">
-                                Fattura Elettronica mode
-                            </span>
+                            <span class="o_form_label">Fattura Elettronica operating mode</span>
+                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
                             <div class="text-muted">
                                 In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
                                 In test mode (experimental) Odoo will send the invoices to a non-production service.
-                                Saving this change will direct all companies on this database to this use this configuration.
                                 Once registered for testing or official, the mode cannot be changed.
                             </div>
-                            <field name="l10n_it_edi_sdicoop_demo_mode"
-                                    widget="radio"
-                                    options="{'horizontal': true}"/>
-                        </div>
-                        <div class="mt8 content-group" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','=','active'), '&amp;', ('l10n_it_edi_proxy_current_state','=','demo'), ('l10n_it_edi_sdicoop_demo_mode','=','demo')]}">
-                            <span class="o_form_label">Allow Odoo to process invoices</span>
-                            <div class="text-muted">
-                                By checking this box, I accept that Odoo may process my invoices.
+                            <field name="l10n_it_edi_operating_mode" widget="radio" options="{'horizontal': true}"/>
+                            <div class="mt8 content-group" attrs="{'invisible': ['|', ('l10n_it_edi_operating_mode', '=', 'demo'), ('l10n_it_edi_already_registered', '=', True) ]}">
+                                <span class="o_form_label">Allow Odoo to process invoices</span>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
+                                <div class="text-muted">
+                                    By checking this box, I accept that Odoo may process my invoices.
+                                </div>
+                                <div class="content-group">
+                                    <field name="l10n_it_edi_register_user"/>
+                                </div>
                             </div>
-                            <div class="content-group">
-                                <field name="l10n_it_edi_sdicoop_register"/>
+                            <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_operating_mode', '!=', 'demo')]}">
+                                Demo mode: EDI is just simulated, no real invoice will be sent to the Tax Agency through the SDI.
                             </div>
-
-                        </div>
-                        <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_proxy_current_state','in', ['inactive', 'demo'])]}">
-                            An Official or Test service has been registered.
-                        </div>
-                        <div class="text-success mt8" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','!=', 'demo'), ('l10n_it_edi_sdicoop_demo_mode', '!=', 'demo')]}">
-                            A Demo service is in use.
+                            <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_operating_mode', '!=', 'test')]}">
+                                Test mode: invoices will not be sent to the Tax Agency, a non-production service is used.
+                            </div>
+                            <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_operating_mode', '!=', 'prod')]}">
+                                Official mode: real invoice will be sent to the Tax Agency through the SDI.
+                            </div>
+                            <div class="mt8" attrs="{'invisible': [('l10n_it_edi_operating_mode', '!=', 'demo'), ('l10n_it_edi_already_registered', '=', False) ]}">
+                                You already allowed Odoo to process this company's invoices.
+                            </div>
                         </div>
                     </setting>
                 </block>

--- a/addons/l10n_it_stock_ddt/tests/test_ddt.py
+++ b/addons/l10n_it_stock_ddt/tests/test_ddt.py
@@ -31,10 +31,7 @@ class TestDDT(TestSaleCommon):
             'vat': 'IT12345670124'
         })
 
-        settings = cls.env['res.config.settings'].create({})
-        if hasattr(settings, 'button_create_proxy_user'):
-            # Needed when `l10n_it_edi_sdiscoop` is installed
-            settings.button_create_proxy_user()
+        cls.env['res.config.settings'].create({}).l10n_it_edi_register_user = True
 
 
     def test_ddt_flow(self):


### PR DESCRIPTION
The operating mode (`demo`, `test`, `prod`) is now an attribute of the `account_edi_proxy_client.user` instead of being a configuration parameter. This allows for different values for different companies, registering to different EDI proxy servers (the test one and the prod).

Clients can then create a test company and try out the EDI with that before going official.

[WIP] 
- Next feature planned is passing from Test to Official by deleting the `account_edi_proxy_client.user`, removing all `account_edi_document`s and resetting invoice/bills `sent` status
- Once you select Test or Official, the other options disappear
- I specified better user description for the operating modes
- If you select an operating mode with the radiobutton, you now must also explicitly check the flag to let the user allow the invoices be sent to the Tax Agency
- Tested just with a single company at the moment.
- Some field has been renamed, renaming `fatturapa` or `sdicoop` for `l10n_it_edi` which is less ambiguous
- `res_config_settings.l10n_it_edi_register_user` is now a stored field
![image](https://user-images.githubusercontent.com/1665365/213157483-daac570a-ddda-4b3f-be87-5f0074c49686.png)
