### PR TITLE
[FIX] base: lang should fallback on english instead of arab

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1259,6 +1259,22 @@ class Request:
             self.session.is_dirty = was_dirty
         return self.session._geoip
 
+    @lazy_property
+    def best_lang(self):
+        lang = self.httprequest.accept_languages.best
+        if not lang:
+            return None
+
+        try:
+            code, territory, _, _ = babel.core.parse_locale(lang, sep='-')
+            if territory:
+                lang = f'{code}_{territory}'
+            else:
+                lang = babel.core.LOCALE_ALIASES[code]
+            return lang
+        except (ValueError, KeyError):
+            return None
+
     # =====================================================
     # Helpers
     # =====================================================
@@ -1321,19 +1337,7 @@ class Request:
         :returns: Preferred language if specified or 'en_US'
         :rtype: str
         """
-        lang = self.httprequest.accept_languages.best
-        if not lang:
-            return DEFAULT_LANG
-
-        try:
-            code, territory, _, _ = babel.core.parse_locale(lang, sep='-')
-            if territory:
-                lang = f'{code}_{territory}'
-            else:
-                lang = babel.core.LOCALE_ALIASES[code]
-            return lang
-        except (ValueError, KeyError):
-            return DEFAULT_LANG
+        return self.best_lang or DEFAULT_LANG
 
     def _geoip_resolve(self):
         if not (root.geoip_resolver and self.httprequest.remote_addr):


### PR DESCRIPTION
Install a database with many langs, arab, french, english, ... Keep english as the default lang. Start a shell and validate a sale-order using the superuser. On the web client, the sale order has been validated in arab instead of in english.

In 16.0 the `context_get` method was changed to ensure there was always a lang set in the returned context. It used the following fallback order: context > request. The solution was partial because in case there was no request to extract a lang from, no lang was set on the context.

In a recent 16.0 fix (f2523c4a), the mechanism was changed to fix the previous problem. The fallback order became: context > request > first installed lang. This solution is sub-optimal because the first installed lang isn't always the best pick. e.g. when you have a mostly english company but that arab is installed for some website pages, arab is selected instead of english (the langs are alphabetically sorted)

In this work, the fallback order is changed once again:

  1. The lang set on the user's profile if activated
  2. The prefered lang extracted from the user's browser if activated
  3. (new) The lang of the user's current company if activated
  4. (new) English if activated
  5. The first lang (ordered by ISO code) if any
  6. English

The 3rd should cover most of ill-cases. For the 4th step, we assume that english is prioritaty to other installed langs when no lang standout.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
