### PR TITLE
[FIX] point_of_sale: fix tax calculation when fiscal position selected to change taxes

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2697,7 +2697,7 @@ exports.Orderline = Backbone.Model.extend({
 
             if (mapped_included_taxes.length > 0) {
                 if (new_included_taxes.length > 0) {
-                    var price_without_taxes = this.compute_all(mapped_included_taxes, price, 1, order.pos.currency.rounding, true).total_excluded
+                    var price_without_taxes = this.compute_all(new_included_taxes, price, 1, order.pos.currency.rounding, true).total_excluded
                     return this.compute_all(new_included_taxes, price_without_taxes, 1, order.pos.currency.rounding, false).total_included
                 }
                 else{


### PR DESCRIPTION
Steps to reproduce:

- Install PoS, Accounting, and Sales
- Set up a product with taxes set as 15% and included in price.
- Now we set a fiscal position that changes the 15% included to 8% also included.
- If we test this in sales app it works properly.
- Now we go to PoS and select the product and the fiscal position.

Issue:

We can see that we have different results that if we do the same thing in sales, this is because the tax is calculated in pos based on the untaxed price from the 15% tax, and then we apply the fiscal position.

Solution:

Changed so we will calculate the tax based on the tax set in the fiscal position, assuming this is the expected behavior, and we don't want to modify the total price of the product, only how much of the price are taxes.

Reproductible until master

opw-3118888