### PR TITLE
[REV][REF] web: sample server: _mockReadGroup"

### DIFF
--- a/addons/web/static/src/views/sample_server.js
+++ b/addons/web/static/src/views/sample_server.js
@@ -447,7 +447,14 @@ export class SampleServer {
         const groups = arrayGroupBy(records, (record) => {
             const vals = {};
             for (const gb of normalizedGroupBys) {
-                vals[gb.fieldName] = record[gb.fieldName];
+                const { fieldName, type } = gb;
+                let value;
+                if (["date", "datetime"].includes(type)) {
+                    value = this._formatValue(record[fieldName], gb);
+                } else {
+                    value = record[fieldName];
+                }
+                vals[fieldName] = value;
             }
             return JSON.stringify(vals);
         });


### PR DESCRIPTION
This reverts commit 8d437bf5615c7ba84faa2eb289574709db0c3a5b.

The refactoring was false as when grouped by date/datetime it created almost one group per record instead of properly grouping them.

