### PR TITLE
[FIX] partner_autocomplete: don't lose placeholder values

### DIFF
--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -5,6 +5,7 @@
             <t t-elif="props.record.resModel !== 'res.partner' || props.record.data.company_type === 'company'">
                 <AutoComplete
                     value="props.value || ''"
+                    placeholder="props.placeholder || ''"
                     sources="sources"
                     onSelect.bind="onSelect"
                     input="inputRef"

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -121,7 +121,7 @@ QUnit.module('partner_autocomplete', {
         arch:
             `<form>
                 <field name="company_type"/>
-                <field name="name" widget="field_partner_autocomplete"/>
+                <field name="name" widget="field_partner_autocomplete" placeholder="test placeholder"/>
                 <field name="parent_id" widget="res_partner_many2one"/>
                 <field name="website"/>
                 <field name="image_1920" widget="image"/>
@@ -243,13 +243,15 @@ QUnit.module('partner_autocomplete', {
     });
 
     QUnit.test("Partner autocomplete : Company type = Company / Name search", async function (assert) {
-        assert.expect(12);
+        assert.expect(13);
         await makeView(makeViewParams);
 
         // Set company type to Company
         await editSelect(target, "[name='company_type'] > select", '"company"');
 
         const input = target.querySelector("[name='name'] .dropdown input");
+
+        assert.equal(input.placeholder,'test placeholder','placeholder should be visible in the view');
 
         await click(input, null);
         assert.containsNone(


### PR DESCRIPTION
Due to recent owl conversion changes in partner_autocomplete module, during contact creation placeholder value for company disappears. With this fix we show said value back where it is supposed to be.

Task-3135708





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
