### PR TITLE
[FIX] web: list_renderer out of index

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1773,9 +1773,16 @@ export class ListRenderer extends Component {
         const table = this.tableRef.el;
         const headers = [...table.querySelectorAll("thead th")];
         const cells = [...element.querySelectorAll("td")];
-        for (const [index, header] of Object.entries(headers)) {
-            const style = getComputedStyle(header);
-            cells[index].style.width = style.width;
+        let headerIndex = 0;
+        for (const cell of cells) {
+            let width = 0;
+            for (let i = 0; i < cell.colSpan; i++) {
+                const header = headers[headerIndex + i];
+                const style = getComputedStyle(header);
+                width += parseFloat(style.width);
+            }
+            cell.style.width = `${width}px`;
+            headerIndex += cell.colSpan;
         }
     }
 


### PR DESCRIPTION
With PR https://github.com/odoo/odoo/pull/109461, when moving list lines, list renderer gets all the supposed cells from each line and gives attributes to them them accordingly. However, if one list line doesn't have all the cells (for example section in Elearning and survey, it only has name, not completion type or other values), cell[index] will be out of range and it'll give us error. This commit checks if cell[index] exists before giving it extra attributes, which fixes said issue.

Task-3138147




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
