### PR TITLE
[FIX] project: readd project in some tasks list views

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1195,7 +1195,7 @@
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('allow_subtasks', '=', False)]}">
                             <field name="child_ids"
                                    context="{'search_view_ref' : 'project.view_task_search_form', 'default_project_id': project_id if not parent_id or not display_project_id else display_project_id, 'default_user_ids': user_ids, 'default_parent_id': id,
-                                    'default_partner_id': partner_id, 'default_milestone_id': allow_milestones and milestone_id, 'search_default_display_project_id': project_id}"
+                                    'default_partner_id': partner_id, 'default_milestone_id': allow_milestones and milestone_id, 'search_default_display_project_id': project_id, 'tree_view_ref': 'project.view_task_tree2_extended'}"
                                    widget="many2many"
                                    domain="['!', ('id', 'parent_of', id)]">
                                 <tree editable="bottom" decoration-muted="is_closed == True">
@@ -1236,7 +1236,7 @@
                         </page>
                         <page name="task_dependencies" string="Blocked By" attrs="{'invisible': [('allow_task_dependencies', '=', False)]}" groups="project.group_project_task_dependencies">
                             <field name="depend_on_ids" nolabel="1"
-                                   context="{'default_project_id' : project_id, 'search_view_ref' : 'project.view_task_search_form', 'search_default_display_project_id': project_id}">
+                                   context="{'default_project_id' : project_id, 'search_view_ref' : 'project.view_task_search_form', 'search_default_display_project_id': project_id, 'tree_view_ref': 'project.view_task_tree2_extended'}">
                                 <tree editable="bottom" decoration-muted="is_closed == True">
                                     <field name="allow_milestones" invisible="1"/>
                                     <field name="parent_id" invisible="1" />
@@ -1557,6 +1557,18 @@
             <field name="priority">2</field>
             <field name="arch" type="xml">
                 <tree position="inside"/>
+            </field>
+        </record>
+
+        <record id="view_task_tree2_extended" model="ir.ui.view">
+            <field name="name">project.task.tree.extended</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_tree2"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <field name="project_id" position="attributes">
+                    <attribute name="invisible">0</attribute>
+                </field>
             </field>
         </record>
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/106015, the "Project" field is missing from the list view opened when clicking on "Add a line" in the "Sub-tasks" or "Blocked By" tabs in the task form view.

This PR readds this field.