### PR TITLE
[FIX] core: prevent converting jsonb fields to char

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1015,6 +1015,13 @@ class Field(MetaField('DummyField', (object,), {})):
             return
         if column['udt_name'] == self.column_type[0]:
             return
+        if  column['udt_name'] == 'jsonb':
+            # Never convert jsonb field back to char.
+            # 1. If translate=True was removed, then migration scripts must be used instead
+            # 2. If the field temporary lost its translate attribute during the
+            #    loading phase, converting to char and then back to jsonb
+            #    removes all translations made by user
+            return
         if column['is_nullable'] == 'NO':
             sql.drop_not_null(model._cr, model._table, self.name)
         self._convert_db_column(model, column)


### PR DESCRIPTION
During the modules loading phase, a translatable field may temporary get `translate` value equal to False if the field is marked as translatable in another module. Converting jsonb field to char and then back to jsonb obviously leads to losing all translations.

Fix it by preventing any convertion of jsonb field to char.

STEPS:

* install l10n_multilang, account_accountant
* translate journal name to second language
* update account_accountant module
* Result: translation of the journal names are lost

opw-3109670

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
