### PR TITLE
[IMP] core: `is_false` takes in account hierarchical domain leaf.

### DIFF
--- a/addons/google_calendar/security/google_calendar_security.xml
+++ b/addons/google_calendar/security/google_calendar_security.xml
@@ -13,7 +13,7 @@
         <record id="google_calendar_own_token_rule" model="ir.rule">
             <field name="name">Google Calendar own token access rule</field>
             <field name="model_id" ref="model_google_calendar_credentials"/>
-            <field name="domain_force">[('user_ids', 'in', user.id)]</field>
+            <field name="domain_force">[('user_ids', '=', user.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_create" eval="0"/>
             <field name="perm_write" eval="1"/>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -96,7 +96,7 @@
                 '|',
                     ('message_partner_ids', 'in', [user.partner_id.id]),
                     # to subscribe check access to the record, follower is not enough at creation
-                    ('user_ids', 'in', user.id)
+                    ('user_ids', '=', user.id)
         ]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
@@ -106,7 +106,7 @@
         <field name="model_id" ref="model_project_task"/>
         <field name="domain_force">[
             '|', ('project_id', '!=', False),
-                 ('user_ids', 'in', user.id),
+                 ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
@@ -154,7 +154,7 @@
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|', '|', ('project_id', '!=', False),
                       ('parent_id', '!=', False),
-                 ('user_ids', 'in', user.id),
+                 ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -248,7 +248,7 @@
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                 '|',
                     ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('user_ids', 'in', user.id),
+                    ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -275,7 +275,7 @@
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|',
                 ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                ('user_ids', 'in', user.id),
+                ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -65,7 +65,7 @@
                     <field name="company_id" groups="base.group_multi_company"/>
                 </field>
                 <field name="description" position="after">
-                    <filter string="My Tasks" name="my_tasks" domain="[('user_ids', 'in', uid)]"/>
+                    <filter string="My Tasks" name="my_tasks" domain="[('user_ids', '=', uid)]"/>
                 </field>
                 <filter name="stage" position="after">
                     <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
@@ -1115,8 +1115,8 @@
                     <field name="parent_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <header>
-                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', False)]&quot;}" data-hotkey="q"/>
-                        <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', 'in', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', '=', uid), ('user_ids', '!=', False)]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', '=', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                         <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '!=', False)]}" domain="[('user_id', '=', uid)]" string="Personal Stage"/>
                     </header>

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1115,7 +1115,7 @@
                     <field name="parent_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <header>
-                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', [])]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', False)]&quot;}" data-hotkey="q"/>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', 'in', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                         <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '!=', False)]}" domain="[('user_id', '=', uid)]" string="Personal Stage"/>

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -708,7 +708,7 @@ class Users(models.Model):
     @tools.ormcache('self.id')
     def _get_company_ids(self):
         # use search() instead of `self.company_ids` to avoid extra query for `active_test`
-        domain = [('active', '=', True), ('user_ids', 'in', self.id)]
+        domain = [('active', '=', True), ('user_ids', '=', self.id)]
         return self.env['res.company'].search(domain)._ids
 
     @api.model

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -295,7 +295,8 @@ class TestExpression(SavepointCaseWithUserDemo):
         # res_9 = Partner.search([('name', 'in', one.name)]) # TODO
 
     def test_15_m2o(self):
-        Partner = self.env['res.partner']
+        # Force active_test=False to avoid any issue from the `res.parnter`` override of _search
+        Partner = self.env['res.partner'].with_context(active_test=False)
 
         # testing equality with name
         partners = self._search(Partner, [('parent_id', '=', 'Pepper Street')])
@@ -403,6 +404,9 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertEqual(res_7, without_parent)
         res_8 = self._search(Partner, [('parent_id', 'in', [])])
         self.assertFalse(res_8)
+        with self.assertLogs('odoo.osv.expression', level='WARNING'):
+            res_8b = self._search(Partner, [('parent_id', 'in', False)])  # => ('parent_id', '=', False)
+        self.assertEqual(res_8b, without_parent)
         res_9 = self._search(Partner, [('parent_id', 'in', [False])])
         self.assertEqual(res_9, without_parent)
         res_9b = self._search(Partner, [('parent_id', 'ilike', '')]) # get those with a parent
@@ -418,6 +422,9 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertEqual(res_2, res_12)
         res_13 = self._search(Partner, ['!', ('parent_id', 'in', [])])
         self.assertEqual(res_3, res_13)
+        with self.assertLogs('odoo.osv.expression', level='WARNING'):
+            res_13b = self._search(Partner, ['!', ('parent_id', 'in', False)])  # => ('parent_id', '!=', False)
+        self.assertEqual(res_2, res_13b)
         res_14 = self._search(Partner, ['!', ('parent_id', 'in', [False])])
         self.assertEqual(res_4, res_14)
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -895,6 +895,13 @@ class TestExpression(SavepointCaseWithUserDemo):
         domain = ['|', ('id', '=', id2), ('id', '=', id1)]
         self.assertEqual(countries.filtered_domain(domain)._ids, expected._ids)
 
+    def test_falsy_domain_no_query(self):
+        """ Test that falsy domain doesn't generate queries to avoid useless round trip. """
+        with self.assertQueryCount(0):
+            self.env['res.partner.category'].search([('id', 'in', [])])
+            self.env['res.partner.category'].search([('id', 'parent_of', [])])
+            self.env['res.partner.category'].search([('id', 'child_of', [])])
+
 
 class TestExpression2(TransactionCase):
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -547,7 +547,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         u1b = Users.create({'login': 'dbo2', 'partner_id': p1}).id
         u2 = Users.create({'login': 'rpo', 'partner_id': p2}).id
 
-        res = self._search(Partner, [('user_ids', 'in', u1a)])
+        res = self._search(Partner, [('user_ids', '=', u1a)])
         self.assertEqual([p1], res.ids, "o2m IN accept single int on right side")
         res = self._search(Partner, [('user_ids', '=', 'Dédé Boitaclou')])
         self.assertEqual([p1], res.ids, "o2m NOT IN matches none on the right side")

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -192,7 +192,7 @@
                     <group>
                         <group>
                             <span class="o_form_label o_td_label" name="address_name">
-                                <field name="type" attrs="{'invisible': [('is_company','=', True)], 'required': [('is_company','!=', True)], 'readonly': [('user_ids', '!=', [])]}" class="fw-bold"/>
+                                <field name="type" attrs="{'invisible': [('is_company','=', True)], 'required': [('is_company','!=', True)], 'readonly': [('user_ids', '!=', False)]}" class="fw-bold"/>
                                 <b attrs="{'invisible': [('is_company', '=', False)]}">Address</b>
                             </span>
                             <div class="o_address_format">

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -222,7 +222,7 @@ def is_false(model, domain):
             stack.append(+1)
         elif token == FALSE_LEAF:
             stack.append(-1)
-        elif token[1] == 'in' and not (isinstance(token[2], Query) or token[2]):
+        elif token[1] in ('in', 'child_of', 'parent_of') and not (isinstance(token[2], Query) or token[2]):
             stack.append(-1)
         elif token[1] == 'not in' and not (isinstance(token[2], Query) or token[2]):
             stack.append(+1)


### PR DESCRIPTION
### [IMP] core: `is_false` takes in account hierarchical domain leaf.

Since a16c44210ad143af5328a11ee198176f08ab664c, the `is_false` method
(expression.py) detects 'falsy' domains, i.e. domains that will never
match any record in the database. We used it in the `_search` to avoid
the SQL query if possible.

In the `is_false` method, we consider a leaf to be false if the right
value is 'falsy' and the operator is 'in'. We can extend this logic to
the hierarchical operator. In fact, the leaf
`[('<field>', 'child_of/parent_of', []/False)]` won't match any record.
This can save some SQL queries.