### PR TITLE
[FIX] purchase_stock: bill can't be created

### DIFF
--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -45,15 +45,16 @@ class AccountMove(models.Model):
                 debit_expense_account = line._get_price_diff_account()
                 if not debit_expense_account:
                     continue
+                    
+                # Retrieve stock valuation moves.
+                valuation_stock_moves = self.env['stock.move'].search([
+                    ('purchase_line_id', '=', line.purchase_line_id.id),
+                    ('state', '=', 'done'),
+                    ('product_qty', '!=', 0.0),
+                    ('product_id', '=', line.product_id.id),  # kits must be handled manually
+                ])
+                
                 if line.product_id.cost_method != 'standard' and line.purchase_line_id:
-
-                    # Retrieve stock valuation moves.
-                    valuation_stock_moves = self.env['stock.move'].search([
-                        ('purchase_line_id', '=', line.purchase_line_id.id),
-                        ('state', '=', 'done'),
-                        ('product_qty', '!=', 0.0),
-                        ('product_id', '=', line.product_id.id),    # kits must be handled manually
-                    ])
 
                     if move.move_type == 'in_refund':
                         valuation_stock_moves = valuation_stock_moves.filtered(lambda stock_move: stock_move._is_out())


### PR DESCRIPTION
Steps to reproduce:

- install purchase_stock
- activate ango-saxon accounting
- create a product p with costing method "AVCO" and automated pricing
- try to create a vendor bill with p
- you get a python traceback

Bug:

in 84733fb89faffe2480def97f076633056e16572f
the function `_stock_account_prepare_anglo_saxon_in_lines_vals` was reintroduced with some edits. However, the variable `valuation_stock_moves` is now declared inside the if statement and then used after the if-else branching, which renders the else statement
 erroneous.

Fix:

Define the variable before the branching

OPW-3145528