### PR TITLE
[FIX] hr_holidays: wrong allocation when archived

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -221,7 +221,7 @@ class HolidaysType(models.Model):
             ('holiday_status_id', 'in', self.ids)
         ])
 
-        allocations = self.env['hr.leave.allocation'].with_context(active_test=False).search([
+        allocations = self.env['hr.leave.allocation'].search([
             ('employee_id', 'in', employee_ids),
             ('state', 'in', ['validate']),
             ('holiday_status_id', 'in', self.ids),
@@ -348,8 +348,6 @@ class HolidaysType(models.Model):
                     if future_allocation_interval[0].date() > search_date:
                         continue
                     for allocation in future_allocation_interval[2]:
-                        if not allocation.active:
-                            continue
                         days_consumed = allocations_days_consumed[employee_id][holiday_status_id][allocation]
                         if future_allocation_interval[1] != fields.datetime.combine(date, time.max) + timedelta(days=5*365):
                             # Compute the remaining number of days/hours in the allocation only if it has an end date

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -803,11 +803,10 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
             allocation_2021.active = False
 
-            # If the allocation is archived, the leaves taken are still counted on this allocation
-            # but the max leaves and remaining leaves are not counted anymore
+            # If the allocation is archived, the leaves taken are not counted on any allocation
             self._check_holidays_count(
                 self.holidays_type_2.get_employees_days([self.employee_emp_id], date=date(2021, 12, 1))[self.employee_emp_id][self.holidays_type_2.id],
-                ml=0, lt=5, rl=0, vrl=0, vlt=5,
+                ml=0, lt=0, rl=0, vrl=0, vlt=0,
             )
 
             # The holidays count in 2022 is not affected by the archived allocation in 2021


### PR DESCRIPTION
Steps to reproduce:
- duplicate an existing allocation (or create 2 of them), with same/overlapping time periods
- archive the oldest of them (by create date / id)
- create a new leave in days that are covered by both allocations

Issue:
- Wrong allocation

Cause:
We sort the allocation by "expiration" date. So, the archived allocation goes first and then it is the allocation that is not archived because it that has no `date_to` (when duplicated, `date_to` is not set).
https://github.com/odoo/odoo/blob/0306262f89fdd78b6e7cfe40ebb459bdaccaf71d/addons/hr_holidays/models/hr_leave_type.py#L307

Solution:
- make sure we don't retrieve archived allocations.

opw-2991368