### PR TITLE
[FIX] mrp: Do not reserve byproducts in production location

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -399,11 +399,6 @@ class StockMove(models.Model):
             return True
         return False
 
-    def _should_bypass_reservation(self, forced_location=False):
-        res = super(StockMove, self)._should_bypass_reservation(
-            forced_location=forced_location)
-        return bool(res and not self.production_id)
-
     def _key_assign_picking(self):
         keys = super(StockMove, self)._key_assign_picking()
         return keys + (self.created_production_id,)

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -549,6 +549,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         self.assertFalse(sam_move.move_dest_ids)
 
         subproduction = self.env['mrp.production'].browse(production.id+1)
+        subproduction.invalidate_cache()
         sfp_pickings = subproduction.picking_ids.sorted('id')
 
         # SFP Production: 2 pickings, 1 group


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Tracked byproducts are reserved in the Virtual Locations/Production

Current behavior before PR:

Lot/Serial numbers that were consumed in another MO are reserved automatically

Desired behavior after PR is merged:

Lot/Serial numbers that were consumed in another MO are NOT reserved automatically


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
