### PR TITLE
[FIX] pos_coupon: allowing programs to be initialized, if not in the original activeProrgams property

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -362,14 +362,23 @@ odoo.define('pos_coupon.pos', function (require) {
                  */
                 this.bookedCouponCodes = {};
             }
-            if (!this.activePromoProgramIds) {
-                /**
-                 * This field contains the ids of automatically/manually activated
-                 * promo programs.
-                 * @type {number[]} array of program ids.
-                 */
-                this.activePromoProgramIds = this._getAutomaticPromoProgramIds();
-            }
+            /**
+             * This field contains the ids of automatically/manually activated
+             * promo programs.
+             *
+             * Since these are "automatic" promotion programs, they should be always active,
+             * so we are always ensuring the Ids aplicable for this PoSOrder record.
+             *
+             * @type {number[]} array of program ids.
+             */
+            this.activePromoProgramIds = this._getAutomaticPromoProgramIds().reduce(
+                (activePromoProgramsIds, programId) => {
+                    if (activePromoProgramsIds.indexOf(programId) === -1)
+                        activePromoProgramsIds.push(programId)
+                    return activePromoProgramsIds;
+                },
+                this.activePromoProgramIds ?? [],
+            );
         },
         resetPrograms: function () {
             let deactivatedCount = 0;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The property `this.activePromoProgramIds` in the `PosOrder._initializePrograms` method, is not being updated to the automatic promo programs, if that same property, is not null. After this commit, that method ensures that the property has always the automatic promotions.

Steps to reproduce

1. Create 2 promotion programs that give you free products (duplicate data demo program: "3 large cabinetes + 1 free" may help for fast testing). We are going to call them A and B (ensure the promotions apply to different products to have a consistent test).
2. Open a restaurant session, with tables, and promotions (include the just created ones in the previous step).
3. Create a new PosOrder, then add the enough products to trigger promotion A.
4. Exit to the floor screen.
5. Return to the same order, then repeat step [3] but for promotion B.

Current behavior before PR:

The order is not being automatically updated with the "automatic promotion" for the promotion B.

Desired behavior after PR is merged:

The order is being automatically updated with all the "automatic promotion" for all the promotions that apply for the current record.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
