### PR TITLE
[FIX] web: don't parse JSON as HTML

### DIFF
--- a/addons/web/static/src/js/core/ajax.js
+++ b/addons/web/static/src/js/core/ajax.js
@@ -299,7 +299,14 @@ function get_file(options) {
             var nodes = doc.body.children.length === 0 ? doc.body.childNodes : doc.body.children;
             try { // Case of a serialized Odoo Exception: It is Json Parsable
                 var node = nodes[1] || nodes[0];
-                err = JSON.parse(node.textContent);
+                if (mimetype == 'application/json') {
+                    // Ignore the HTML parsing if the entire response is JSON, otherwise the contents can be
+                    // misinterpreted if they contain HTML tags.
+                    err = JSON.parse(contents);
+                }
+                else {
+                    err = JSON.parse(node.textContent);
+                }
             } catch (e) { // Arbitrary uncaught python side exception
                 err = {
                     message: nodes.length > 1 ? nodes[1].textContent : '',


### PR DESCRIPTION
The `/account_reports` API will return a 500 error with MIME type `application/json` and a JSON dict if something goes wrong. `get_file` will first interpret this response as HTML and will then try to parse the text contents as JSON. Most of the time this works, but if the response contains any HTML tags, like `<lambda>` from a Python stacktrace, the JSON response will get interpreted as HTML instead of text, causing the subsequent JSON interpretation to fail.

The end result for the user is that empty tracebacks will be displayed instead of UserErrors or actual tracebacks.

This fix skips the HTML parsing and directly parses the response as JSON if the Content-Type indicates so. The existing code already detects if the MIME type is something else than 'text/html' when the status code is 200, so this direct JSON parsing will only happen for non-200 status codes.

opw-3131030
