### PR TITLE
[FIX] web_editor: compare history id to avoid divergence

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -32,7 +32,7 @@ def ensure_no_history_divergence(record, html_field_name, incoming_history_ids):
     server_history_matches = re.search(diverging_history_regex, record[html_field_name])
     # Do not check old documents without data-last-history-steps.
     if server_history_matches:
-        server_last_history_id = server_history_matches[1]
+        server_last_history_id = server_history_matches[1].split(',')[-1]
         if server_last_history_id not in incoming_history_ids:
             logger.error('The document was already saved from someone with a different history for model %r, field %r with id %r.', record._name, html_field_name, record.id)
             raise ValidationError(_('The document was already saved from someone with a different history for model %r, field %r with id %r.', record._name, html_field_name, record.id))


### PR DESCRIPTION
Steps to reproduce:
- trying to change the description of a task;
- save.

Issue:
A "Validation Error" appears.

Cause:
The id of the last history (on the record)
is a string of characters with several histories.
The comparison with ids of the incoming history
is not well done.

Introduced with the commit: e403db2d47565aa53f09925123255853551b7807

opw-3145329