### PR TITLE
[FIX] web_editor: fix editor's history on darg & drop

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3948,6 +3948,11 @@ const SnippetOptionWidget = Widget.extend({
      */
     _select: async function (previewMode, widget) {
         let $applyTo = null;
+        // Wait until the observer is activated: In some specific situations,
+        // option methods are called while the editor observer is disabled from
+        // an external widget. E.g. On link popover, the observer is unactive on
+        // "hide" to prevent the popover mutations to be recorded).
+        await Promise.all(this.options.wysiwyg.odooEditor.observerUnactivePromises);
 
         if (previewMode === true) {
             this.options.wysiwyg.odooEditor.automaticStepUnactive('preview_option');

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -128,9 +128,9 @@ const LinkPopoverWidget = Widget.extend({
                 }
             }
         }
-        $(document).on('mouseup.link_popover', onClickDocument);
+        $(document).on('mouseup.link_popover dragstart.link_popover', onClickDocument);
         if (document !== this.options.wysiwyg.odooEditor.document) {
-            $(this.options.wysiwyg.odooEditor.document).on('mouseup.link_popover', onClickDocument);
+            $(this.options.wysiwyg.odooEditor.document).on('mouseup.link_popover dragstart.link_popover', onClickDocument);
         }
 
         return this._super(...arguments);

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -200,6 +200,7 @@ const Wysiwyg = Widget.extend({
             plugins: options.editorPlugins,
             direction: localization.direction || 'ltr',
             renderingClasses: ['o_dirty', 'o_transform_removal', 'oe_edited_link', 'o_menu_loading'],
+            renderingObserverLabels: ['hide.bs.popover'],
         }, editorCollaborationOptions));
 
         document.addEventListener("mousemove", this._signalOnline, true);


### PR DESCRIPTION
To reproduce the issue:

[1]:

- Go to website (Edit mode) > drop a "Text-Image" snippet.
- Click on the "Learn More" button to show the link popover.
- With the popover visible, drag and drop a column.
- Undo > the history step is lost.

[2]:

- Drop a "Text-Image" snippet > Add a "Background Shape" > Save.
- Edit mode > Click on the "Learn More" button to show the link popover.
- With the popover visible, disable the "Background Shape".
- Undo > the history step is lost.

While hiding the link popover, the editor observer is unactive in order
to prevent the popover mutation to be recorded [A].

On [1]:

The popover will stay visible until the end of the "drag and drop"
(since it should be hidden on `mouseup`), and the behaviour in [A] will
prevent the mutations to be recorded (including the 'remove' and 'add'
mutations).

On [2]:

In this specific case, option methods are also called while the editor
observer is disabled because of [A].

The goal of this commit is to fix this behaviour by triggering the
popover's `onClickDocument()` on `dragstart` and waiting for the
observer to be activated if it's already disabled by external widgets
(the `renderingObserverLabels` option was added to track their
activation / deactivation labels).

task-3144032