### PR TITLE
[FIX] mass_mailing, web{_editor}: powerbox click loses range

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -43,8 +43,10 @@ export class MassMailingHtmlField extends HtmlField {
         });
 
         useEffect(() => {
-            const listener = () => {
-                this._lastClickInIframe = false;
+            const listener = (ev) => {
+                if (!ev.target.closest(".oe-powerbox-wrapper")) {
+                    this._lastClickInIframe = false;
+                }
             };
             document.addEventListener('mousedown', listener, true);
 

--- a/addons/web/static/src/views/fields/dynamicplaceholder_hook.js
+++ b/addons/web/static/src/views/fields/dynamicplaceholder_hook.js
@@ -27,6 +27,7 @@ export function useDynamicPlaceholder() {
          * @param {function} options.validateCallback
          * @param {function} options.closeCallback
          * @param {function} [options.positionCallback]
+         * @param {function} options.preventClose
          */
          async open(
              element,
@@ -52,6 +53,7 @@ export function useDynamicPlaceholder() {
                     closeOnClickAway: true,
                     onClose: options.closeCallback,
                     onPositioned: options.positionCallback,
+                    preventClose: options.preventClose,
                 }
             );
         }

--- a/addons/web_editor/static/src/js/backend/QWebPlugin.js
+++ b/addons/web_editor/static/src/js/backend/QWebPlugin.js
@@ -111,7 +111,8 @@ export class QWebPlugin {
                 }
             });
         };
-        const tElements = subRoot.querySelectorAll('t');
+        const closestDiv = subRoot.closest("DIV")
+        const tElements = closestDiv.querySelectorAll('t');
         // Wait for the content to be on the dom to check checkAllInline
         // otherwise the getComputedStyle will be wrong.
         // todo: remove the setTimeout when the editor will provide a signal

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -194,6 +194,7 @@ export class HtmlField extends Component {
                                             validateCallback: this.onDynamicPlaceholderValidate.bind(this),
                                             closeCallback: this.onDynamicPlaceholderClose.bind(this),
                                             positionCallback: this.positionDynamicPlaceholder.bind(this),
+                                            preventClose: () => document.activeElement.closest(".o_popover"),
                                         }
                                     );
                                 });


### PR DESCRIPTION
**Current behavior before PR:**

- Dynamic placeholder close itself after it opens instantly.
- when an image, document, and dynamic placeholder are added from the powerbox in mass mailing they will place at the 
  template header instead of the cursor position.

**Desired behavior after PR is merged:**

- Dynamic placeholder will stay open.
- An image, document, and a dynamic placeholder will be placed at the cursor position.

Task-3072813

