### PR TITLE
[FIX] web: import model fix colors in dark mode

### DIFF
--- a/addons/base_import/static/src/legacy/scss/base_import.scss
+++ b/addons/base_import/static/src/legacy/scss/base_import.scss
@@ -191,7 +191,7 @@
             background-repeat: no-repeat;
             appearance: none;
             width: auto;
-            background-color: white;
+            background-color: $o-white;
         }
 
         .select2-arrow {

--- a/addons/base_import/static/src/legacy/xml/base_import.xml
+++ b/addons/base_import/static/src/legacy/xml/base_import.xml
@@ -213,7 +213,7 @@
     </t>
 
     <t t-name="ImportView.data_matching">
-        <div class="oe_import_with_file d-none">
+        <div class="oe_import_with_file bg-view d-none">
             <div class="oe_import_noheaders">
                 <p class="alert alert-info">If the file contains
                     the column names, Odoo can try auto-detecting the
@@ -236,7 +236,7 @@
         <div class="oe_import_box d-none bg-white overflow-auto">
             <input accept=".csv, .xls, .xlsx, .xlsm, .ods" t-attf-id="file_#{_id}"
                   name="file" class="oe_import_file" type="file" style="display:none;"/>
-            <div class="oe_import_with_file">
+            <div class="oe_import_with_file bg-view">
                 <h4>Imported file</h4>
                 <div class="mb-2 d-flex align-items-center">
                     <i class="fa fa-file white me-2"></i>


### PR DESCRIPTION
Prior to this PR, the background and the select inputs, in the import file, were still white.

This is a temporary fix, only for 16.0, to be dropped in 16.1, because the import file was converted to owl in this version. (cf: commit 0566b5f6bad1ee34a6b63b3c8d05b7369276991d)

task-3113726