### PR TITLE
[FIX] http_routing: support `/web` in `url_for`

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -198,6 +198,7 @@ def url_for(url_from, lang_code=None, no_rewrite=False):
             len(path) > 1
             and path.startswith('/')
             and '/static/' not in path
+            and path != '/web'
             and not path.startswith('/web/')
     )):
         new_url, _ = request.env['ir.http'].url_rewrite(path)
@@ -225,7 +226,7 @@ def is_multilang_url(local_url, lang_url_codes=None):
     path = url[0]
 
     # Consider /static/ and /web/ files as non-multilang
-    if '/static/' in path or path.startswith('/web/'):
+    if '/static/' in path or path == '/web' or path.startswith('/web/'):
         return False
 
     query_string = url[1] if len(url) > 1 else None


### PR DESCRIPTION
This is necessary for instance with [1], where `url_for('/web')` is called explicitely.

Fixes [2], which doesn't include a lot of other builds.

[1]: https://github.com/odoo/enterprise/commit/477ef590318261c334c1797263192824d8156954
[2]: https://runbot.odoo.com/web#id=15349&model=runbot.build.error




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
