### PR TITLE
[IMP] core: new filtered method

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -46,6 +46,11 @@ class Users(models.Model):
         # when it's not `mail.group_mail_notification_type_inbox` or `share` that are being changed.
         inbox_group_id = self.env['ir.model.data']._xmlid_to_res_id('mail.group_mail_notification_type_inbox')
 
+        # During module installation, the field is initialized before the group is created
+        if not inbox_group_id:
+            self.filtered_domain([('notification_type', '=', 'inbox')]).notification_type = 'email'
+            return
+
         self.filtered_domain([
             ('groups_id', 'in', inbox_group_id), ('notification_type', '!=', 'inbox')
         ]).notification_type = 'inbox'

--- a/addons/stock/populate/stock.py
+++ b/addons/stock/populate/stock.py
@@ -136,7 +136,7 @@ class Location(models.Model):
                 scenario_index += 1
 
         # Change 20 % the usage of some no-leaf location into 'view' (instead of 'internal')
-        to_views = locations_sample.filtered_domain([('child_ids', '!=', [])]).ids
+        to_views = locations_sample.filtered('child_ids').ids
         random = populate.Random('stock_location_views')
         view_locations = self.browse(random.sample(to_views, int(len(to_views) * 0.1)))
         view_locations.write({

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -40,8 +40,8 @@ class TestStandardPerformance(UtilPerf):
         # not published user, get the not found image placeholder
         self.assertEqual(self.env['res.users'].sudo().browse(2).website_published, False)
         url = '/web/image/res.users/2/image_256'
-        self.assertEqual(self._get_url_hot_query(url), 8)
-        self.assertEqual(self._get_url_hot_query(url, cache=False), 8)
+        self.assertEqual(self._get_url_hot_query(url), 6)
+        self.assertEqual(self._get_url_hot_query(url, cache=False), 6)
 
     @mute_logger('odoo.http')
     def test_11_perf_sql_img_controller(self):

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -749,6 +749,17 @@ class TestExpression(SavepointCaseWithUserDemo):
         countries = self._search(Country, [('name', '=ilike', 'z%')])
         self.assertTrue(len(countries) == 2, "Must match only countries with names starting with Z (currently 2)")
 
+        # check that we can escape wildcards
+        p1 = Partner.create({'name': '100% Machinery Inc.'})
+        p2 = Partner.create({'name': '_ underscored _'})
+        p3 = Partner.create({'name': r'/\ Slashed Rooftop Inc.'})
+        partners = self._search(Partner, [('name', 'like', r'\%')])
+        self.assertEqual(partners, p1, "Must match only partners with '%' in their name")
+        partners = self._search(Partner, [('name', 'like', r'\_')])
+        self.assertEqual(partners, p2, "Must match only partners with '_' in their name")
+        partners = self._search(Partner, [('name', 'like', r'\\')])
+        self.assertEqual(partners, p3, "Must match only partners with a backslash in their name")
+
     def test_filtered_limit(self):
         Partner = self.env['res.partner']
         res = self._search(Partner, [('parent_id', '!=', False)], limit=5)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5435,8 +5435,10 @@ class BaseModel(metaclass=MetaModel):
             for field in self._resolve_field_sequence(func):
                 recs = field.mapped(recs)
             return recs
-        else:
+        elif callable(func):
             return self._mapped_func(func)
+        else:
+            raise TypeError("Expected a function or a dot-separated sequence of field names")
 
     def filtered(self, func):
         """Return the records in ``self`` satisfying ``func``.

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -462,12 +462,33 @@ def compile_like_regex(pattern, ignorecase=False):
         '%': matches any number of characters
         '_': matches exactly one character
 
+    The special characters can be escaped by prefixing them with a backslash.
+    For this reason, backslashes need to be escaped, too.
+
     :param str pattern: the search string using postgres 'LIKE' syntax
     :param ignorecase: whether the regex should be case insensitive
     """
     if not pattern:
         return re.compile(r"")
-    pattern = re.escape(pattern).replace("%", ".*").replace("_", ".")
+
+    def translate(pattern):
+        res = ""
+        escape_next = False
+        for char in pattern:
+            if escape_next:
+                escape_next = False
+                res += re.escape(char)
+            elif char == '\\':
+                escape_next = True
+            elif char == '%':
+                res += ".*"
+            elif char == '_':
+                res += "."
+            else:
+                res += re.escape(char)
+        return res
+
+    pattern = translate(pattern)
     flags = re.IGNORECASE if ignorecase else 0
     return re.compile(pattern, flags=flags)
 


### PR DESCRIPTION
* **Implement a `limit` on `filtered`**: if the limit is reached, the iteration is stopped and the result is returned. This allows to gain performance when we only need the first N matching records.

* **Delegate `filtered_domain` to `filtered`**: the new method can take either a function, a string or a domain as parameter. In terms of API, it seems unnecessary having a different method for each case, so it's likely that `filtered_domain` will be completely deprecated in the future.

  The way records are filtered by domain has been completely refactored. Now, the domain is compiled into a function `f` such that `f(rec)` returns True if the domain is valid for a given record `rec`. This function is then used to filter the records.

  This is a requirement to support the new `limit` feature on domain-based filtering, but it's also a huge performance improvement because the compiled function evaluates the domain left-to-right, and this enables logic shortcuts (`A and B` does not require evaluating `B` when `A` evaluates to `False`).

  e.g.: `[('parent_id', '!=', False), ('name', '=', 'David')]` translates roughly to `lambda rec: rec.parent_id != False and rec.name == 'David'`, and so the second part of the expression is only evaluated on records where the first part is True.

* **Performance optimization for 'like' operators**: directly use a compiled regexp instead of a `fnmatch` filter function. Under the hood, `fnmatch` is also doing that, but it's doing so much more. We can cut out the middle man.

---

Benchmarks:

```
Name: "like operator" (res.partner)
Domain: [('name', 'like', 'Tom')]
Records: 90070
Hot  x5: 3.32s vs 3.00s (-9.9%) ✔️
Cold x2: 4.54s vs 4.61s (+1.6%) ~


Name: "ilike operator" (res.partner)
Domain: [('name', 'ilike', 'Tom')]
Records: 90070
Hot  x5: 3.57s vs 3.04s (-14.8%) ✔️
Cold x2: 4.33s vs 4.32s (-0.3%) ~


Name: "short-circuit operator" (res.partner)
Domain: [('country_id', '=?', False), ('state_id', '=?', False)]
Records: 90070
Hot  x5: 6.80s vs 0.63s (-90.8%) 🤩⚡⚡
Cold x2: 5.77s vs 0.36s (-93.8%) 🤩⚡⚡


Name: "in operator" (res.partner)
Domain: [('category_id', 'in', [0, 1, 2])]
Records: 90070
Hot  x5: 4.44s vs 4.53s (+2.2%) ~
Cold x2: 2.24s vs 2.33s (+4.2%) ~


Name: "not in operator" (res.partner)
Domain: [('category_id', 'in', [0, 1, 2])]
Records: 90070
Hot  x5: 4.57s vs 4.68s (+2.3%) ~
Cold x2: 2.29s vs 2.43s (+6.1%) ❌


Name: "hierarchy: child_of" (res.partner)
Domain: [('id', 'child_of', [1])]
Records: 90070
Hot  x5: 0.95s vs 1.57s (+66.0%) ❌
Cold x2: 0.38s vs 0.63s (+64.3%) ❌


Name: "hierarchy: parent_of" (res.partner)
Domain: [('id', 'parent_of', [18])]
Records: 90070
Hot  x5: 0.93s vs 1.57s (+69.0%) ❌
Cold x2: 0.38s vs 0.63s (+67.4%) ❌


Name: "combined domain 1" (res.partner)
Domain: [('parent_id', '=', False), ('country_id', '!=', False), ('state_id', '=', False)]
Records: 90070
Hot  x5: 10.66s vs 6.83s (-35.9%) 🤩
Cold x2: 7.10s vs 5.63s (-20.6%) 🤩


Name: "combined domain 2" (res.partner)
Domain: [('email', '=ilike', '%@example.com'), ('parent_id', '=', False), ('company_id', '=', False)]
Records: 90070
Hot  x5: 10.49s vs 4.23s (-59.7%) 🤩⚡
Cold x2: 7.18s vs 4.60s (-36.0%) 🤩


Name: "combined domain 3" (res.partner)
Domain: [('type', '=', 'delivery'), ('name', '!=', False), ('street', '!=', False), ('zip', '!=', False), ('city', '!=', False), ('country_id', 'in', [0, ..., 148, 149])]
Records: 90070
Hot  x5: 17.82s vs 2.80s (-84.3%) 🤩⚡⚡
Cold x2: 10.72s vs 4.62s (-56.9%) 🤩⚡
```

NOTE: The cases where it's worse than before are cases where the generated leaf function has to evaluate an expression like `a in b`. (e.g: `[('id', 'in', [1,2,3,4])]`).

This is because with the old implementation that leaf was evaluated very easily (the leaf set was computed directly from the values `{1,2,3,4}`. In the new implementation, the leaf function has to check if the set contains the id for every record, making it slightly slower.

In any case, seems like a small trade-off considering all the other perf improments (specially the cases of domains with multiple leaves)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
