### PR TITLE
[FIX] web: fix title overflow

### DIFF
--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -140,49 +140,51 @@
                   </div>
                 </div>
                 <h3 class="font-weight-normal">Pricing</h3>
-                <table class="table table-sm">
-                  <thead class="bg-100">
-                    <tr>
-                      <th>Products</th>
-                      <th class="text-right d-none d-sm-table-cell" t-if="order.state in ['purchase', 'done']">Unit Price</th>
-                      <th class="text-right">Quantity</th>
-                      <th class="text-right" t-if="order.state in ['purchase', 'done']">Subtotal</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <t t-foreach="order.order_line" t-as="ol">
-                      <tr t-att-class="'bg-200 font-weight-bold o_line_section' if ol.display_type == 'line_section' else 'font-italic o_line_note' if ol.display_type == 'line_note' else ''">
-                        <t t-if="not ol.display_type">
-                          <td>
-                            <img t-att-src="image_data_uri(resize_to_48(ol.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
-                            <span t-esc="ol.name"/>
-                          </td>
-                          <td class="text-right d-none d-sm-table-cell" t-if="order.state in ['purchase', 'done']">
-                            <span t-field="ol.price_unit" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
-                          </td>
-                          <td class="text-right">
-                            <span t-esc="ol.product_qty"/>
-                          </td>
-                          <td class="text-right" t-if="order.state in ['purchase', 'done']">
-                            <span t-field="ol.price_subtotal" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
-                          </td>
-                        </t>
-                        <t t-if="ol.display_type == 'line_section'">
-                            <td colspan="99">
-                                <span t-field="ol.name"/>
-                            </td>
-                            <t t-set="current_section" t-value="line"/>
-                            <t t-set="current_subtotal" t-value="0"/>
-                        </t>
-                        <t t-if="ol.display_type == 'line_note'">
-                            <td colspan="99">
-                                <span t-field="ol.name"/>
-                            </td>
-                        </t>
+                <div class="table-responsive">
+                  <table class="table table-sm">
+                    <thead class="bg-100">
+                      <tr>
+                        <th>Products</th>
+                        <th class="text-right d-none d-sm-table-cell" t-if="order.state in ['purchase', 'done']">Unit Price</th>
+                        <th class="text-right">Quantity</th>
+                        <th class="text-right" t-if="order.state in ['purchase', 'done']">Subtotal</th>
                       </tr>
-                    </t>
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody>
+                      <t t-foreach="order.order_line" t-as="ol">
+                        <tr t-att-class="'bg-200 font-weight-bold o_line_section' if ol.display_type == 'line_section' else 'font-italic o_line_note' if ol.display_type == 'line_note' else ''">
+                          <t t-if="not ol.display_type">
+                            <td>
+                              <img t-att-src="image_data_uri(resize_to_48(ol.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
+                              <span t-esc="ol.name"/>
+                            </td>
+                            <td class="text-right d-none d-sm-table-cell" t-if="order.state in ['purchase', 'done']">
+                              <span t-field="ol.price_unit" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
+                            </td>
+                            <td class="text-right">
+                              <span t-esc="ol.product_qty"/>
+                            </td>
+                            <td class="text-right" t-if="order.state in ['purchase', 'done']">
+                              <span t-field="ol.price_subtotal" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
+                            </td>
+                          </t>
+                          <t t-if="ol.display_type == 'line_section'">
+                              <td colspan="99">
+                                  <span t-field="ol.name"/>
+                              </td>
+                              <t t-set="current_section" t-value="line"/>
+                              <t t-set="current_subtotal" t-value="0"/>
+                          </t>
+                          <t t-if="ol.display_type == 'line_note'">
+                              <td colspan="99">
+                                  <span t-field="ol.name"/>
+                              </td>
+                          </t>
+                        </tr>
+                      </t>
+                    </tbody>
+                  </table>
+                </div>
                 <div class="row" t-if="order.state in ['purchase', 'done']">
                   <div class="col-sm-7 col-md-5 ml-auto">
                     <table class="table table-sm">
@@ -240,62 +242,64 @@
           </div>
         </div>
         <h3 class="font-weight-normal">Pricing</h3>
-          <table class="table table-sm">
-            <thead class="bg-100">
-              <tr>
-                <th>Products</th>
-                <th class="text-right d-none d-sm-table-cell">Unit Price</th>
-                <th class="text-right">Quantity</th>
-                <th class="text-right">Scheduled Date</th>
-                <th class="text-right" style="color:#3aadaa"><strong>Update Dates Here</strong></th>
-                <th class="text-right">Subtotal</th>
-              </tr>
-            </thead>
-            <tbody>
-              <t t-foreach="order.order_line" t-as="ol">
-                <t t-if="not ol.display_type">
-                  <tr>
-                    <td>
-                      <img t-att-src="image_data_uri(resize_to_48(ol.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
-                      <span t-esc="ol.name"/>
-                    </td>
-                    <td class="text-right d-none d-sm-table-cell">
-                      <span t-field="ol.price_unit" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
-                    </td>
-                    <td class="text-right">
-                      <span t-esc="ol.product_qty"/>
-                    </td>
-                    <td class="text-right">
-                      <span t-esc="ol.date_planned.date()"/>
-                    </td>
-                    <td class="text-right">
-                      <form t-attf-action="/my/purchase/#{order.id}/update?access_token=#{order.access_token}" method="post">
-                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                        <div class="container">
-                          <div class="form-group">
-                            <div class="input-group date">
-                                <input type="text" class="form-control datetimepicker-input o-purchase-datetimepicker" t-attf-id="datetimepicker_#{ol.id}" t-att-name="ol.id"
-                                  data-toggle="datetimepicker" data-date-format="YYYY-MM-DD" t-attf-data-target="#datetimepicker_#{ol.id}"/>
+          <div class="table-responsive">
+            <table class="table table-sm">
+              <thead class="bg-100">
+                <tr>
+                  <th>Products</th>
+                  <th class="text-right d-none d-sm-table-cell">Unit Price</th>
+                  <th class="text-right">Quantity</th>
+                  <th class="text-right">Scheduled Date</th>
+                  <th class="text-right" style="color:#3aadaa"><strong>Update Dates Here</strong></th>
+                  <th class="text-right">Subtotal</th>
+                </tr>
+              </thead>
+              <tbody>
+                <t t-foreach="order.order_line" t-as="ol">
+                  <t t-if="not ol.display_type">
+                    <tr>
+                      <td>
+                        <img t-att-src="image_data_uri(resize_to_48(ol.product_id.image_1024))" alt="Product" class="d-none d-lg-inline"/>
+                        <span t-esc="ol.name"/>
+                      </td>
+                      <td class="text-right d-none d-sm-table-cell">
+                        <span t-field="ol.price_unit" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
+                      </td>
+                      <td class="text-right">
+                        <span t-esc="ol.product_qty"/>
+                      </td>
+                      <td class="text-right">
+                        <span t-esc="ol.date_planned.date()"/>
+                      </td>
+                      <td class="text-right">
+                        <form t-attf-action="/my/purchase/#{order.id}/update?access_token=#{order.access_token}" method="post">
+                          <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                          <div class="container">
+                            <div class="form-group">
+                              <div class="input-group date">
+                                  <input type="text" class="form-control datetimepicker-input o-purchase-datetimepicker" t-attf-id="datetimepicker_#{ol.id}" t-att-name="ol.id"
+                                    data-toggle="datetimepicker" data-date-format="YYYY-MM-DD" t-attf-data-target="#datetimepicker_#{ol.id}"/>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      </form>
-                    </td>
-                    <td class="text-right">
-                      <span t-field="ol.price_subtotal" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
-                    </td>
-                  </tr>
+                        </form>
+                      </td>
+                      <td class="text-right">
+                        <span t-field="ol.price_subtotal" t-options='{"widget": "monetary", "display_currency": order.currency_id}'/>
+                      </td>
+                    </tr>
+                  </t>
+                  <t t-if="ol.display_type">
+                    <tr>
+                      <td colspan="99">
+                        <span t-esc="ol.name"/>
+                      </td>
+                    </tr>
+                  </t>
                 </t>
-                <t t-if="ol.display_type">
-                  <tr>
-                    <td colspan="99">
-                      <span t-esc="ol.name"/>
-                    </td>
-                  </tr>
-                </t>
-              </t>
-            </tbody>
-          </table>
+              </tbody>
+            </table>
+          </div>
           <div class="row">
             <div class="col-sm-7 col-md-5 ml-auto">
               <table class="table table-sm">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -426,94 +426,96 @@
 
                 <t t-set="display_discount" t-value="True in [line.discount > 0 for line in sale_order.order_line]"/>
 
-                <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table table-sm" id="sales_order_table">
-                    <thead class="bg-100">
-                        <tr>
-                            <th class="text-left">Products</th>
-                            <th class="text-right">Quantity</th>
-                            <th t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">Unit Price</th>
-                            <th t-if="display_discount" t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                <span>Disc.%</span>
-                            </th>
-                            <th t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                <span>Taxes</span>
-                            </th>
-                            <th class="text-right" >
-                                <span groups="account.group_show_line_subtotals_tax_excluded">Amount</span>
-                                <span groups="account.group_show_line_subtotals_tax_included">Total Price</span>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody class="sale_tbody">
-
-                        <t t-set="current_subtotal" t-value="0"/>
-
-                        <t t-foreach="sale_order.order_line" t-as="line">
-
-                            <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
-                            <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
-
-                            <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                <t t-if="not line.display_type">
-                                    <td id="product_name"><span t-field="line.name"/></td>
-                                    <td class="text-right">
-                                        <div id="quote_qty">
-                                            <span t-field="line.product_uom_qty"/>
-                                            <span t-field="line.product_uom"/>
-                                        </div>
-                                    </td>
-                                    <td t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                        <div
-                                            t-if="line.discount &gt;= 0"
-                                            t-field="line.price_unit"
-                                            t-att-style="line.discount and 'text-decoration: line-through' or None"
-                                            t-att-class="(line.discount and 'text-danger' or '') + ' text-right'"
-                                        />
-                                        <div t-if="line.discount">
-                                            <t t-esc="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "float", "decimal_precision": "Product Price"}'/>
-                                        </div>
-                                    </td>
-                                    <td t-if="display_discount" t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                        <strong t-if="line.discount &gt; 0" class="text-info">
-                                            <t t-esc="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
-                                        </strong>
-                                    </td>
-                                    <td t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                        <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"/>
-                                    </td>
-                                    <td class="text-right">
-                                        <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
-                                        <span class="oe_order_line_price_total" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
-                                    </td>
-                                </t>
-                                <t t-if="line.display_type == 'line_section'">
-                                    <td colspan="99">
-                                        <span t-field="line.name"/>
-                                    </td>
-                                    <t t-set="current_section" t-value="line"/>
-                                    <t t-set="current_subtotal" t-value="0"/>
-                                </t>
-                                <t t-if="line.display_type == 'line_note'">
-                                    <td colspan="99">
-                                        <span t-field="line.name"/>
-                                    </td>
-                                </t>
+                <div class="table-responsive">
+                    <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table table-sm" id="sales_order_table">
+                        <thead class="bg-100">
+                            <tr>
+                                <th class="text-left">Products</th>
+                                <th class="text-right">Quantity</th>
+                                <th t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">Unit Price</th>
+                                <th t-if="display_discount" t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                    <span>Disc.%</span>
+                                </th>
+                                <th t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                    <span>Taxes</span>
+                                </th>
+                                <th class="text-right" >
+                                    <span groups="account.group_show_line_subtotals_tax_excluded">Amount</span>
+                                    <span groups="account.group_show_line_subtotals_tax_included">Total Price</span>
+                                </th>
                             </tr>
+                        </thead>
+                        <tbody class="sale_tbody">
 
-                            <t t-if="current_section and (line_last or sale_order.order_line[line_index+1].display_type == 'line_section')">
-                                <tr class="is-subtotal text-right">
-                                    <td colspan="99">
-                                        <strong class="mr16">Subtotal</strong>
-                                        <span
-                                            t-esc="current_subtotal"
-                                            t-options='{"widget": "monetary", "display_currency": sale_order.pricelist_id.currency_id}'
-                                        />
-                                    </td>
+                            <t t-set="current_subtotal" t-value="0"/>
+
+                            <t t-foreach="sale_order.order_line" t-as="line">
+
+                                <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
+                                <t t-set="current_subtotal" t-value="current_subtotal + line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
+
+                                <tr t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''">
+                                    <t t-if="not line.display_type">
+                                        <td id="product_name"><span t-field="line.name"/></td>
+                                        <td class="text-right">
+                                            <div id="quote_qty">
+                                                <span t-field="line.product_uom_qty"/>
+                                                <span t-field="line.product_uom"/>
+                                            </div>
+                                        </td>
+                                        <td t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                            <div
+                                                t-if="line.discount &gt;= 0"
+                                                t-field="line.price_unit"
+                                                t-att-style="line.discount and 'text-decoration: line-through' or None"
+                                                t-att-class="(line.discount and 'text-danger' or '') + ' text-right'"
+                                            />
+                                            <div t-if="line.discount">
+                                                <t t-esc="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "float", "decimal_precision": "Product Price"}'/>
+                                            </div>
+                                        </td>
+                                        <td t-if="display_discount" t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                            <strong t-if="line.discount &gt; 0" class="text-info">
+                                                <t t-esc="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
+                                            </strong>
+                                        </td>
+                                        <td t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                            <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"/>
+                                        </td>
+                                        <td class="text-right">
+                                            <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal" groups="account.group_show_line_subtotals_tax_excluded"/>
+                                            <span class="oe_order_line_price_total" t-field="line.price_total" groups="account.group_show_line_subtotals_tax_included"/>
+                                        </td>
+                                    </t>
+                                    <t t-if="line.display_type == 'line_section'">
+                                        <td colspan="99">
+                                            <span t-field="line.name"/>
+                                        </td>
+                                        <t t-set="current_section" t-value="line"/>
+                                        <t t-set="current_subtotal" t-value="0"/>
+                                    </t>
+                                    <t t-if="line.display_type == 'line_note'">
+                                        <td colspan="99">
+                                            <span t-field="line.name"/>
+                                        </td>
+                                    </t>
                                 </tr>
+
+                                <t t-if="current_section and (line_last or sale_order.order_line[line_index+1].display_type == 'line_section')">
+                                    <tr class="is-subtotal text-right">
+                                        <td colspan="99">
+                                            <strong class="mr16">Subtotal</strong>
+                                            <span
+                                                t-esc="current_subtotal"
+                                                t-options='{"widget": "monetary", "display_currency": sale_order.pricelist_id.currency_id}'
+                                            />
+                                        </td>
+                                    </tr>
+                                </t>
                             </t>
-                        </t>
-                    </tbody>
-                </table>
+                        </tbody>
+                    </table>
+                </div>
 
                 <div id="total" class="row" name="total" style="page-break-inside: avoid;">
                     <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto">

--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -475,6 +475,7 @@
             margin-top: 0;
             margin-bottom: 0;
             line-height: inherit;
+            overflow-wrap: anywhere;
 
             &.d-flex > .o_input {
                 height: max-content;


### PR DESCRIPTION
Steps to reproduce:

- Install stock, purchase
- Create a product with a long name
- Create a purchase order with that product
- Go to portal and access the purchase order

Current behavior:
- Product title overflows in `product.template` form
- Product title overflows when accessing the PO from the portal

Behavior after the PR:
- To fix the problem on the form we add `overflow-wrap` to titles
- To fix the problem in the Portal we add `table-responsive` to the table

opw-3133407


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
