### PR TITLE
[ADD] l10n_ar: AFIP Concept Otros option

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -78,9 +78,14 @@ class AccountMove(models.Model):
         # on expo invoice you can mix services and products
         expo_invoice = self.l10n_latam_document_type_id.code in ['19', '20', '21']
 
+        # WSFE 1668 Si es factura de expo y esta asociado a un partner IVA Liberado – Ley Nº 19.640 (Zona Franca)
+        # reportamos el concepto como Otros.
+        is_zona_franca = self.partner_id.l10n_ar_afip_responsibility_type_id == self.env.ref("l10n_ar.res_IVA_LIB")
         # Default value "product"
         afip_concept = '1'
-        if product_types == service:
+        if expo_invoice and is_zona_franca:
+            afip_concept = '4'
+        elif product_types == service:
             afip_concept = '2'
         elif product_types - consumable and product_types - service and not expo_invoice:
             afip_concept = '3'


### PR DESCRIPTION
Si el cliente a facturar es partner es liberado zona franca y le hacemos una factura de exportación, y en si la compañia no es exportador debemos informar como concepto afip el codigo 4 (otros).

esto es solo temporal. ver de mejorar y mover esto a modulo de l10n_ar_edi

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
