### PR TITLE
[FIX] l10n_id_efaktur: custom settings visibility

### DIFF
--- a/addons/l10n_id_efaktur/views/res_config_settings_views.xml
+++ b/addons/l10n_id_efaktur/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//block[@id='invoicing_settings']" position="after">
-                <block title="Indonesian Localization" id="l10n_cl_section">
+                <block title="Indonesian Localization" id="l10n_cl_section" attrs="{'invisible': [('country_code', '!=', 'ID')]}">
                     <setting company_dependent="1">
                         <div class="content-group">
                             <div class="row mt16">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixing a small bug where the custom invoicing settings for  l10n Indonesian E-invoicing appears even in companies not located in Indonesia in a multi company environment

Current behavior before PR:

<img width="861" alt="before" src="https://user-images.githubusercontent.com/50016803/214837775-47cc511c-08d0-4e04-aba0-31f8b9d6d0f0.png">


Desired behavior after PR is merged:

<img width="773" alt="after" src="https://user-images.githubusercontent.com/50016803/214837869-e998da55-750d-48eb-b22f-dd2e797b9eca.png">

