### PR TITLE
[FIX] base: add id constrain for custom computed fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -636,6 +636,8 @@ class IrModelFields(models.Model):
                 names = seq.strip().split(".")
                 last = len(names) - 1
                 for index, name in enumerate(names):
+                    if name == "id":
+                        raise UserError("Compute method cannot depend on field 'id'.")
                     field = model._fields.get(name)
                     if field is None:
                         raise UserError(_("Unknown field %r in dependency %r") % (name, seq.strip()))


### PR DESCRIPTION
Computed fields cannot depend on field 'id' [1].
The missing constrain in `ir.model.fields` leads to ignoring such field [2]. However, the error message is visible in logs only, while in UI it's just *Invalid field* error (see STEPS).

As a side note, the problem is provoked by the fact that field is required and it might be not obvious for user what should be specified there [3]

STEPS:

1. Via Studio, add a char field to list view of `res.partner` model
2. Open field form, add compute method:

```
for record in self:
  record['x_xxx'] = str(record.id)
```
3. Use `id` for Dependencies field.
4. Open the list view

[1]:
https://github.com/odoo/odoo/blob/29cc267fc15fab94c679a4b5a5bb0eb9fb12787f/odoo/api.py#L263-L264 [2]: https://github.com/odoo/odoo/blob/29cc267fc15fab94c679a4b5a5bb0eb9fb12787f/odoo/addons/base/models/ir_model.py#L1180-L1185 [3]: https://github.com/odoo/odoo/blob/29cc267fc15fab94c679a4b5a5bb0eb9fb12787f/odoo/addons/base/views/ir_model_views.xml#L126

opw-3138440

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
