### PR TITLE
[FIX] web: percentpie will actually calculate percent value to show

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -3070,6 +3070,8 @@ var FieldPercentPie = AbstractField.extend({
         this.$leftMask = this.$('.o_mask').first();
         this.$rightMask = this.$('.o_mask').last();
         this.$pieValue = this.$('.o_pie_value');
+        this.edit_max_value = !!this.nodeOptions.edit_max_value;
+        this.max_value = this.recordData[this.nodeOptions.max_value] || 100;
         return this._super();
     },
 
@@ -3098,7 +3100,7 @@ var FieldPercentPie = AbstractField.extend({
      * @private
      */
     _render: function () {
-        var value = this.value || 0;
+        var value = (this.value / this.max_value) * 100 || 0;
         var degValue = 360*value/100;
 
         this.$rightMask.toggleClass('o_full', degValue >= 180);


### PR DESCRIPTION
Steps to reproduce:

- Install CRM, Sales and Studio
- Go to CRM > Sales > Teams
- Now activate studio and try to modify the progressbar to percentpie watch the new percentpie generated.
Note: You might need to remove the options from studio to get the proper ones.

Issue:

Percent pie is only displaying the absolute value of the current value invoiced this month.

Solution:

Added the max value in order to be able to calculate and display the percent value of the current progress for the goal.

This affects all versions.

opw-3106068
