### PR TITLE
[FIX] sale: modifying sales team views widget through studio posible

### DIFF
--- a/addons/sale/views/crm_team_views.xml
+++ b/addons/sale/views/crm_team_views.xml
@@ -132,11 +132,9 @@
             </xpath>
 
             <xpath expr="//div[hasclass('o_kanban_primary_bottom')]" position="after">
-                <t groups="sales_team.group_sale_manager">
-                    <div class="col-12 o_kanban_primary_bottom bottom_block">
+                    <div class="col-12 o_kanban_primary_bottom bottom_block" groups="sales_team.group_sale_manager">
                         <field name="invoiced" widget="sales_team_progressbar" title="Invoicing" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true, 'on_change': 'update_invoiced_target'}"/>
                     </div>
-                </t>
             </xpath>
 
             <xpath expr="//div[hasclass('o_kanban_manage_view')]" position="inside">


### PR DESCRIPTION
Steps to reproduce:

- Install Sales, CRM and studio
- Go to Sales > Sales > Sales Teams
- Now activate studio, and try to modify the progressbar widget.

Issue:

We are going to receive an error message and we will be unable to change ths widget.

Solution:

For the moment removing the `<t groups="...>` will fix the issue, as with the changes in 16.0 it doesn't take the t element when it has groups inside.

opw-3106068
