### PR TITLE
[FIX] mrp_workorder_hr: open workorder view without HR rights

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -207,6 +207,10 @@ class MrpWorkcenter(models.Model):
         }
         return action
 
+    def get_employee_barcode(self, barcode):
+        employee_ids = self.employee_ids or self.env['hr.employee'].search([])
+        return employee_ids.sudo().filtered(lambda e: e.barcode == barcode)[:1].id
+
     def action_work_order(self):
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.action_work_orders")
         return action


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a new user “User 1” with the following roles:
    - Inventory - user
    - Manufacturing - user
    - Quality - user
- Create Employee for that user and set PIN Code
- Create a work center and require login and assign the employee
   “User 1” to the workcenter
- Create a Manufacturing Order using the Work Center, Confirm and Plan
- Login as the new user:
    - go to Manufacturing view work orders from Overview
    - click the Work Order button for the Work Center

Problem:
An access error is triggered, "The fields "barcode" you try to read is
not available on the public employee profile."

The “User 1” has access only to the public profile of the employees,
so access is limited only to specific fields, but for the tablet view
we need the barcodes of the employees which is a private field, so we
must access the field as a super user

opw-3077401
opw-3123556