### PR TITLE
[IMP] core: make field triggers faster

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -769,7 +769,7 @@ class IrModelFields(models.Model):
                 else:
                     # field hasn't been loaded (yet?)
                     continue
-                for dep in model._dependent_fields(field):
+                for dep in self.pool.get_dependent_fields(field):
                     if dep.manual:
                         failed_dependencies.append((field, dep))
                 for inverse in model.pool.field_inverses[field]:
@@ -840,23 +840,7 @@ class IrModelFields(models.Model):
 
         # clean the registry from the fields to remove
         self.pool.registry_invalidated = True
-
-        # discard the removed fields from field triggers
-        def discard_fields(tree):
-            # discard fields from the tree's root node
-            tree.get(None, set()).difference_update(fields)
-            # discard subtrees labelled with any of the fields
-            for field in fields:
-                tree.pop(field, None)
-            # discard fields from remaining subtrees
-            for field, subtree in tree.items():
-                if field is not None:
-                    discard_fields(subtree)
-
-        discard_fields(self.pool.field_triggers)
-
-        # discard the removed fields from field inverses
-        self.pool.field_inverses.discard_keys_and_values(fields)
+        self.pool._discard_fields(fields)
 
         # discard the removed fields from fields to compute
         for field in fields:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -133,7 +133,7 @@ class Groups(models.Model):
     users = fields.Many2many('res.users', 'res_groups_users_rel', 'gid', 'uid')
     model_access = fields.One2many('ir.model.access', 'group_id', string='Access Controls', copy=True)
     rule_groups = fields.Many2many('ir.rule', 'rule_group_rel',
-        'group_id', 'rule_group_id', string='Rules', domain=[('global', '=', False)])
+        'group_id', 'rule_group_id', string='Rules', domain="[('global', '=', False)]")
     menu_access = fields.Many2many('ir.ui.menu', 'ir_ui_menu_group_rel', 'gid', 'menu_id', string='Access Menu')
     view_access = fields.Many2many('ir.ui.view', 'ir_ui_view_group_rel', 'group_id', 'view_id', string='Views')
     comment = fields.Text(translate=True)

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -219,18 +219,18 @@ class TestFields(TransactionCaseWithUserDemo):
         invalid_depends = fields["x_computed_custom_invalid_depends"]
         invalid_transitive_depends = fields["x_computed_custom_invalid_transitive_depends"]
         # `x_computed_custom_valid_depends` in the triggers of the field `value1`
-        self.assertTrue(valid_depends in get_trigger_tree([value1])[None])
+        self.assertTrue(valid_depends in get_trigger_tree([value1]).root)
         # `x_computed_custom_valid_transitive_depends` in the triggers `x_computed_custom_valid_depends` and `value1`
-        self.assertTrue(valid_transitive_depends in get_trigger_tree([valid_depends])[None])
-        self.assertTrue(valid_transitive_depends in get_trigger_tree([value1])[None])
+        self.assertTrue(valid_transitive_depends in get_trigger_tree([valid_depends]).root)
+        self.assertTrue(valid_transitive_depends in get_trigger_tree([value1]).root)
         # `x_computed_custom_invalid_depends` not in any triggers, as it was invalid and was skipped
         self.assertEqual(
-            sum(invalid_depends in get_trigger_tree([field]).get(None, ()) for field in fields.values()), 0
+            sum(invalid_depends in get_trigger_tree([field]).root for field in fields.values()), 0
         )
         # `x_computed_custom_invalid_transitive_depends` in the triggers of `x_computed_custom_invalid_depends` only
-        self.assertTrue(invalid_transitive_depends in get_trigger_tree([invalid_depends])[None])
+        self.assertTrue(invalid_transitive_depends in get_trigger_tree([invalid_depends]).root)
         self.assertEqual(
-            sum(invalid_transitive_depends in get_trigger_tree([field]).get(None, ()) for field in fields.values()), 1
+            sum(invalid_transitive_depends in get_trigger_tree([field]).root for field in fields.values()), 1
         )
 
     @mute_logger('odoo.fields')

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6054,14 +6054,11 @@ class BaseModel(metaclass=MetaModel):
             return
 
         # first yield what to compute
-        for field in tree.get(None, ()):
+        for field in tree.root:
             yield field, self, create
 
         # then traverse dependencies backwards, and proceed recursively
         for field, subtree in tree.items():
-            if field is None:
-                continue
-
             if create and field.type in ('many2one', 'many2one_reference'):
                 # upon creation, no other record has a reference to self
                 continue

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -132,34 +132,6 @@ def fix_import_export_id_paths(fieldname):
     fixed_external_id = re.sub(r'([^/]):id', r'\1/id', fixed_db_id)
     return fixed_external_id.split('/')
 
-def merge_trigger_trees(trees: list, select=bool) -> dict:
-    """ Merge trigger trees list into a final tree. The function ``select`` is
-    called on every field to determine which fields should be kept in the tree
-    nodes. This enables to discard some fields from the tree nodes.
-    """
-    result_tree = {}                        # the resulting tree
-    root_fields = OrderedSet()              # the fields in the root node
-    subtrees_to_merge = defaultdict(list)   # the subtrees to merge grouped by key
-
-    for tree in trees:
-        for key, val in tree.items():
-            if key is None:
-                root_fields.update(val)
-            else:
-                subtrees_to_merge[key].append(val)
-
-    # the root node contains the collected fields for which select is true
-    root_node = [field for field in root_fields if select(field)]
-    if root_node:
-        result_tree[None] = root_node
-
-    for key, subtrees in subtrees_to_merge.items():
-        subtree = merge_trigger_trees(subtrees, select)
-        if subtree:
-            result_tree[key] = subtree
-
-    return result_tree
-
 
 class MetaModel(api.Meta):
     """ The metaclass of all model classes.
@@ -3669,7 +3641,7 @@ class BaseModel(metaclass=MetaModel):
                     # order to avoid an inconsistent update.
                     self[fname]
                 determine_inverses[field.inverse].append(field)
-            if field in self.pool.fields_modifying_relations:
+            if self.pool.is_modifying_relations(field):
                 fnames_modifying_relations.append(fname)
             if field.inverse or (field.compute and not field.readonly):
                 if field.store or field.type not in ('one2many', 'many2many'):
@@ -6023,61 +5995,55 @@ class BaseModel(metaclass=MetaModel):
         #  - mark H to recompute on inverse(X, records),
         #  - mark I to recompute on inverse(W, inverse(X, records)),
         #  - mark J to recompute on inverse(Y, records).
-        fields = [self._fields[fname] for fname in fnames]
-        field_triggers = self.pool.field_triggers
-        trees = [field_triggers[field] for field in fields if field in field_triggers]
 
-        if not trees:
-            return
-
+        # The fields' trigger trees are merged in order to evaluate all triggers
+        # at once. For non-stored computed fields, `_modified_triggers` might
+        # traverse the tree (at the cost of extra queries) only to know which
+        # records to invalidate in cache. But in many cases, most of these
+        # fields have no data in cache, so they can be ignored from the start.
+        # This allows us to discard subtrees from the merged tree when they
+        # only contain such fields.
         cache = self.env.cache
-
-        # Merge dependency trees to evaluate all triggers at once.
-        # For non-stored computed fields, `_modified_triggers` might traverse
-        # the tree (at the cost of extra queries) only to know which records to
-        # invalidate in cache. But in many cases, most of these fields have no
-        # data in cache, so they can be ignored from the start. This allows us
-        # to discard subtrees from the merged tree when they only contain such
-        # fields.
-        tree = merge_trigger_trees(
-            trees,
+        tree = self.pool.get_trigger_tree(
+            [self._fields[fname] for fname in fnames],
             select=lambda field: (field.compute and field.store) or cache.contains_field(field),
         )
+        if not tree:
+            return
 
-        if tree:
-            # determine what to compute (through an iterator)
-            tocompute = self.sudo().with_context(active_test=False)._modified_triggers(tree, create)
+        # determine what to compute (through an iterator)
+        tocompute = self.sudo().with_context(active_test=False)._modified_triggers(tree, create)
 
-            # When called after modification, one should traverse backwards
-            # dependencies by taking into account all fields already known to be
-            # recomputed.  In that case, we mark fieds to compute as soon as
-            # possible.
-            #
-            # When called before modification, one should mark fields to compute
-            # after having inversed all dependencies.  This is because we
-            # determine what currently depends on self, and it should not be
-            # recomputed before the modification!
-            if before:
-                tocompute = list(tocompute)
+        # When called after modification, one should traverse backwards
+        # dependencies by taking into account all fields already known to be
+        # recomputed.  In that case, we mark fieds to compute as soon as
+        # possible.
+        #
+        # When called before modification, one should mark fields to compute
+        # after having inversed all dependencies.  This is because we
+        # determine what currently depends on self, and it should not be
+        # recomputed before the modification!
+        if before:
+            tocompute = list(tocompute)
 
-            # process what to compute
-            for field, records, create in tocompute:
-                records -= self.env.protected(field)
-                if not records:
-                    continue
-                if field.compute and field.store:
-                    if field.recursive:
-                        recursively_marked = self.env.not_to_compute(field, records)
-                    self.env.add_to_compute(field, records)
-                else:
-                    # Don't force the recomputation of compute fields which are
-                    # not stored as this is not really necessary.
-                    if field.recursive:
-                        recursively_marked = records & self.env.cache.get_records(records, field)
-                    self.env.cache.invalidate([(field, records._ids)])
-                # recursively trigger recomputation of field's dependents
+        # process what to compute
+        for field, records, create in tocompute:
+            records -= self.env.protected(field)
+            if not records:
+                continue
+            if field.compute and field.store:
                 if field.recursive:
-                    recursively_marked.modified([field.name], create)
+                    recursively_marked = self.env.not_to_compute(field, records)
+                self.env.add_to_compute(field, records)
+            else:
+                # Don't force the recomputation of compute fields which are
+                # not stored as this is not really necessary.
+                if field.recursive:
+                    recursively_marked = records & self.env.cache.get_records(records, field)
+                self.env.cache.invalidate([(field, records._ids)])
+            # recursively trigger recomputation of field's dependents
+            if field.recursive:
+                recursively_marked.modified([field.name], create)
 
     def _modified_triggers(self, tree, create=False):
         """ Return an iterator traversing a tree of field triggers on ``self``,
@@ -6092,49 +6058,51 @@ class BaseModel(metaclass=MetaModel):
             yield field, self, create
 
         # then traverse dependencies backwards, and proceed recursively
-        for key, val in tree.items():
-            if key is None:
+        for field, subtree in tree.items():
+            if field is None:
                 continue
-            elif create and key.type in ('many2one', 'many2one_reference'):
+
+            if create and field.type in ('many2one', 'many2one_reference'):
                 # upon creation, no other record has a reference to self
                 continue
-            else:
-                # val is another tree of dependencies
-                model = self.env[key.model_name]
-                for invf in model.pool.field_inverses[key]:
-                    # use an inverse of field without domain
-                    if not (invf.type in ('one2many', 'many2many') and invf.domain):
-                        if invf.type == 'many2one_reference':
-                            rec_ids = OrderedSet()
-                            for rec in self:
-                                try:
-                                    if rec[invf.model_field] == key.model_name:
-                                        rec_ids.add(rec[invf.name])
-                                except MissingError:
-                                    continue
-                            records = model.browse(rec_ids)
-                        else:
-                            try:
-                                records = self[invf.name]
-                            except MissingError:
-                                records = self.exists()[invf.name]
 
-                        # TODO: find a better fix
-                        if key.model_name == records._name:
-                            if not any(self._ids):
-                                # if self are new, records should be new as well
-                                records = records.browse(it and NewId(it) for it in records._ids)
-                            break
-                else:
-                    new_records = self.filtered(lambda r: not r.id)
-                    real_records = self - new_records
-                    records = model.browse()
-                    if real_records:
-                        records = model.search([(key.name, 'in', real_records.ids)], order='id')
-                    if new_records:
-                        cache_records = self.env.cache.get_records(model, key)
-                        records |= cache_records.filtered(lambda r: set(r[key.name]._ids) & set(self._ids))
-                yield from records._modified_triggers(val)
+            # subtree is another tree of dependencies
+            model = self.env[field.model_name]
+            for invf in model.pool.field_inverses[field]:
+                # use an inverse of field without domain
+                if not (invf.type in ('one2many', 'many2many') and invf.domain):
+                    if invf.type == 'many2one_reference':
+                        rec_ids = OrderedSet()
+                        for rec in self:
+                            try:
+                                if rec[invf.model_field] == field.model_name:
+                                    rec_ids.add(rec[invf.name])
+                            except MissingError:
+                                continue
+                        records = model.browse(rec_ids)
+                    else:
+                        try:
+                            records = self[invf.name]
+                        except MissingError:
+                            records = self.exists()[invf.name]
+
+                    # TODO: find a better fix
+                    if field.model_name == records._name:
+                        if not any(self._ids):
+                            # if self are new, records should be new as well
+                            records = records.browse(it and NewId(it) for it in records._ids)
+                        break
+            else:
+                new_records = self.filtered(lambda r: not r.id)
+                real_records = self - new_records
+                records = model.browse()
+                if real_records:
+                    records = model.search([(field.name, 'in', real_records.ids)], order='id')
+                if new_records:
+                    cache_records = self.env.cache.get_records(model, field)
+                    records |= cache_records.filtered(lambda r: set(r[field.name]._ids) & set(self._ids))
+
+            yield from records._modified_triggers(subtree)
 
     @api.model
     def recompute(self, fnames=None, records=None):
@@ -6213,23 +6181,13 @@ class BaseModel(metaclass=MetaModel):
     # Generic onchange method
     #
 
-    @classmethod
-    def _dependent_fields(cls, field):
-        """ Return an iterator on the fields that depend on ``field``. """
-        def traverse(node):
-            for key, val in node.items():
-                if key is None:
-                    yield from val
-                else:
-                    yield from traverse(val)
-        return traverse(cls.pool.field_triggers.get(field, {}))
-
     def _has_onchange(self, field, other_fields):
         """ Return whether ``field`` should trigger an onchange event in the
             presence of ``other_fields``.
         """
         return (field.name in self._onchange_methods) or any(
-            dep in other_fields for dep in self._dependent_fields(field.base_field)
+            dep in other_fields
+            for dep in self.pool.get_dependent_fields(field.base_field)
         )
 
     def _onchange_eval(self, field_name, onchange, result):

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -324,7 +324,7 @@ class Registry(Mapping):
                                     model_name, ", ".join(field.name for field in fields))
         return computed
 
-    def get_trigger_tree(self, fields: list, select=bool):
+    def get_trigger_tree(self, fields: list, select=bool) -> "TriggerTree":
         """ Return the trigger tree to traverse when ``fields`` have been modified.
         The function ``select`` is called on every field to determine which fields
         should be kept in the tree nodes.  This enables to discard some unnecessary
@@ -335,19 +335,15 @@ class Registry(Mapping):
             for field in fields
             if field in self._field_triggers
         ]
-        if not trees:
-            return {}
-        return merge_trigger_trees(trees, select)
+        return TriggerTree.merge(trees, select)
 
     def get_dependent_fields(self, field):
         """ Return an iterator on the fields that depend on ``field``. """
-        def traverse(tree):
-            for key, val in tree.items():
-                if key is None:
-                    yield from val
-                else:
-                    yield from traverse(val)
-        return traverse(self.get_field_trigger_tree(field))
+        return (
+            field
+            for tree in self.get_field_trigger_tree(field).depth_first()
+            for field in tree.root
+        )
 
     def _discard_fields(self, fields: list):
         """ Discard the given fields from the registry's internal data structures. """
@@ -359,7 +355,7 @@ class Registry(Mapping):
         # discard fields from field inverses
         self.field_inverses.discard_keys_and_values(fields)
 
-    def get_field_trigger_tree(self, field):
+    def get_field_trigger_tree(self, field) -> "TriggerTree":
         """ Return the trigger tree of a field by computing it from the transitive
         closure of field triggers.
         """
@@ -371,7 +367,7 @@ class Registry(Mapping):
         triggers = self._field_triggers
 
         if field not in triggers:
-            return {}
+            return TriggerTree()
 
         def transitive_triggers(field, prefix=(), seen=()):
             if field in seen or field not in triggers:
@@ -394,18 +390,15 @@ class Registry(Mapping):
                     return concat(seq1[:-1], seq2[1:])
             return seq1 + seq2
 
-        def Tree():
-            return defaultdict(Tree)
-
-        tree = Tree()
+        tree = TriggerTree()
         for path, targets in transitive_triggers(field):
             current = tree
             for label in path:
-                current = current[label]
-            if None in current:
-                current[None].update(targets)
+                current = current.increase(label)
+            if current.root:
+                current.root.update(targets)
             else:
-                current[None] = OrderedSet(targets)
+                current.root = OrderedSet(targets)
 
         self._field_trigger_trees[field] = tree
 
@@ -860,30 +853,68 @@ class DummyRLock(object):
         self.release()
 
 
-def merge_trigger_trees(trees: list, select=bool) -> dict:
-    """ Merge trigger trees list into a final tree. The function ``select`` is
-    called on every field to determine which fields should be kept in the tree
-    nodes. This enables to discard some fields from the tree nodes.
+class TriggerTree(dict):
+    """ The triggers of a field F is a tree that contains the fields that
+    depend on F, together with the fields to inverse to find out which records
+    to recompute.
+
+    For instance, assume that G depends on F, H depends on X.F, I depends on
+    W.X.F, and J depends on Y.F. The triggers of F will be the tree:
+
+                                 [G]
+                               X/   \\Y
+                             [H]     [J]
+                           W/
+                         [I]
+
+    This tree provides perfect support for the trigger mechanism:
+    when F is # modified on records,
+     - mark G to recompute on records,
+     - mark H to recompute on inverse(X, records),
+     - mark I to recompute on inverse(W, inverse(X, records)),
+     - mark J to recompute on inverse(Y, records).
     """
-    result_tree = {}                        # the resulting tree
-    root_fields = OrderedSet()              # the fields in the root node
-    subtrees_to_merge = defaultdict(list)   # the subtrees to merge grouped by key
+    __slots__ = ['root']
 
-    for tree in trees:
-        for key, val in tree.items():
-            if key is None:
-                root_fields.update(val)
-            else:
-                subtrees_to_merge[key].append(val)
+    # pylint: disable=keyword-arg-before-vararg
+    def __init__(self, root=(), *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.root = root
 
-    # the root node contains the collected fields for which select is true
-    root_node = [field for field in root_fields if select(field)]
-    if root_node:
-        result_tree[None] = root_node
+    def __bool__(self):
+        return bool(self.root or len(self))
 
-    for key, subtrees in subtrees_to_merge.items():
-        subtree = merge_trigger_trees(subtrees, select)
-        if subtree:
-            result_tree[key] = subtree
+    def increase(self, key):
+        try:
+            return self[key]
+        except KeyError:
+            subtree = self[key] = TriggerTree()
+            return subtree
 
-    return result_tree
+    def depth_first(self):
+        yield self
+        for subtree in self.values():
+            yield from subtree.depth_first()
+
+    @classmethod
+    def merge(cls, trees: list, select=bool) -> "TriggerTree":
+        """ Merge trigger trees into a single tree. The function ``select`` is
+        called on every field to determine which fields should be kept in the
+        tree nodes. This enables to discard some fields from the tree nodes.
+        """
+        root_fields = OrderedSet()              # fields in the root node
+        subtrees_to_merge = defaultdict(list)   # subtrees to merge grouped by key
+
+        for tree in trees:
+            root_fields.update(tree.root)
+            for label, subtree in tree.items():
+                subtrees_to_merge[label].append(subtree)
+
+        # the root node contains the collected fields for which select is true
+        result = cls([field for field in root_fields if select(field)])
+        for label, subtrees in subtrees_to_merge.items():
+            subtree = cls.merge(subtrees, select)
+            if subtree:
+                result[label] = subtree
+
+        return result

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -325,6 +325,48 @@ class Registry(Mapping):
                                     model_name, ", ".join(field.name for field in fields))
         return computed
 
+    def get_trigger_tree(self, fields: list, select=bool):
+        """ Return the trigger tree to traverse when ``fields`` have been modified.
+        The function ``select`` is called on every field to determine which fields
+        should be kept in the tree nodes.  This enables to discard some unnecessary
+        fields from the tree nodes.
+        """
+        field_triggers = self.field_triggers
+        trees = [field_triggers[field] for field in fields if field in field_triggers]
+        if not trees:
+            return {}
+        return merge_trigger_trees(trees, select)
+
+    def get_dependent_fields(self, field):
+        """ Return an iterator on the fields that depend on ``field``. """
+        def traverse(tree):
+            for key, val in tree.items():
+                if key is None:
+                    yield from val
+                else:
+                    yield from traverse(val)
+        return traverse(self.field_triggers.get(field) or {})
+
+    def _discard_fields(self, fields: list):
+        """ Discard the given fields from the registry's internal data structures. """
+
+        # discard fields from field triggers
+        def discard(tree):
+            # discard fields from the tree's root node
+            tree.get(None, set()).difference_update(fields)
+            # discard subtrees labelled with any of the fields
+            for field in fields:
+                tree.pop(field, None)
+            # discard fields from remaining subtrees
+            for field, subtree in tree.items():
+                if field is not None:
+                    discard(subtree)
+
+        discard(self.field_triggers)
+
+        # discard fields from field inverses
+        self.field_inverses.discard_keys_and_values(fields)
+
     @lazy_property
     def field_triggers(self):
         # determine field dependencies
@@ -367,29 +409,27 @@ class Registry(Mapping):
 
         return triggers
 
+    def is_modifying_relations(self, field):
+        """ Return whether ``field`` has dependent fields on some records, and
+        that modifying ``field`` might change the dependent records.
+        """
+        try:
+            return self._is_modifying_relations[field]
+        except KeyError:
+            result = (
+                (field.relational or self.field_inverses[field])
+                and field in self.field_triggers
+            ) or any(
+                dep.relational or self.field_inverses[dep]
+                for dep in self.get_dependent_fields(field)
+            )
+            self._is_modifying_relations[field] = result
+            return result
+
     @lazy_property
-    def fields_modifying_relations(self):
-        '''
-        Return the union of the set of relational fields that are dependencies
-        of other fields, with the set of non-relational fields that are
-        dependencies of relational fields.
-        '''
-        result = set()
-
-        for field in self.field_triggers:
-            # If the field is itself a relational field, it is also considered
-            # as triggering relational fields.
-            if field.relational or self.field_inverses[field]:
-                result.add(field)
-                continue
-
-            Model = self.models[field.model_name]
-            for dep in Model._dependent_fields(field):
-                if dep.relational or self.field_inverses[dep]:
-                    result.add(field)
-                    break
-
-        return result
+    def _is_modifying_relations(self):
+        # internal cache of method is_modifying_relations()
+        return {}
 
     def post_init(self, func, *args, **kwargs):
         """ Register a function to call at the end of :meth:`~.init_models`. """
@@ -789,3 +829,32 @@ class DummyRLock(object):
         self.acquire()
     def __exit__(self, type, value, traceback):
         self.release()
+
+
+def merge_trigger_trees(trees: list, select=bool) -> dict:
+    """ Merge trigger trees list into a final tree. The function ``select`` is
+    called on every field to determine which fields should be kept in the tree
+    nodes. This enables to discard some fields from the tree nodes.
+    """
+    result_tree = {}                        # the resulting tree
+    root_fields = OrderedSet()              # the fields in the root node
+    subtrees_to_merge = defaultdict(list)   # the subtrees to merge grouped by key
+
+    for tree in trees:
+        for key, val in tree.items():
+            if key is None:
+                root_fields.update(val)
+            else:
+                subtrees_to_merge[key].append(val)
+
+    # the root node contains the collected fields for which select is true
+    root_node = [field for field in root_fields if select(field)]
+    if root_node:
+        result_tree[None] = root_node
+
+    for key, subtrees in subtrees_to_merge.items():
+        subtree = merge_trigger_trees(subtrees, select)
+        if subtree:
+            result_tree[key] = subtree
+
+    return result_tree


### PR DESCRIPTION
This patch optimizes the way field trigger trees are computed.  Overall, the resulting trigger trees are mostly identical, but they can now be determined one by one, which enables an on-demand approach and partial cache.

Before this patch, getting the first trigger tree proceeded as follows:
 - resolve the dependencies of all fields;
 - compute the transitive closure of the dependencies of all fields;
 - store the transitive closure above as field triggers for all fields in a cache.

After this patch, getting the first trigger tree proceeded as follows:
 - resolve the dependencies of all fields;
 - cache them as direct triggers for all fields;
 - compute one trigger tree as the transitive closure of the field's triggers, and cache it.

This optimization is quite effective during the installation of modules, and is even more effective when the number of fields is large.  For instance, a complete installation with all community modules is now takes 25% less time.  For a complete installation with all enterprise modules, the installation time is even 30% less!  A medium installation is about 16% less time.

The optimization also speeds up the first request on a new Odoo worker, since the minimum time for computing a handful of trigger trees is much smaller than before.

We have observed slight differences in trigger trees, but they occur in places where the tree has redundant branches, in particular with fields having recursive dependencies.  It therefore makes no difference in what is being triggered or invalidated.