### PR TITLE
[FIX] hr: use employee's partner for user creation

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -173,6 +173,7 @@ class HrEmployeePrivate(models.Model):
                 'default_phone': self.work_phone,
                 'default_mobile': self.mobile_phone,
                 'default_login': self.work_email,
+                'default_partner_id': self.work_contact_id.id,
             }
         }
 


### PR DESCRIPTION
When using the Create User action, it was not re-using the existing res.partner of the employee for the user, while the inverse action (Create Employee) was using it.
