### PR TITLE
[FIX] account: avoid recursion in _sync_dynamic_lines

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2102,10 +2102,10 @@ class AccountMove(models.Model):
                     container=invoice_container,
                 ))
                 stack.enter_context(self._sync_invoice(invoice_container))
-                line_container = {'records': self.line_ids}
+                line_container = {'records': self.line_ids.with_context(skip_invoice_sync=True)}
                 with self.line_ids._sync_invoice(line_container):
                     yield
-                    line_container['records'] = self.line_ids
+                    line_container['records'] = self.line_ids.with_context(skip_invoice_sync=True)
                 tax_container['records'] = container['records'].filtered(tax_filter)
                 invoice_container['records'] = container['records'].filtered(invoice_filter)
                 misc_container['records'] = container['records'].filtered(misc_filter)


### PR DESCRIPTION
Problem:  Writing on all move lines of a big invoice (>120 lines) takes too much time.

Cause: I think there are some recursion that can be avoided in the `_sync_dynamic_lines` method.

Solution:  Add `skip_invoice_sync=True` for the argument `line_container` of the function `_sync_invoice`.  Because this function will also call `_sync_dynamic_lines`, which I don't think is necessary and adding this context will avoid that.

opw-3125464
