### PR TITLE
[FIX] google_calendar: non admin sync

### DIFF
--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -19,17 +19,15 @@ patch(AttendeeCalendarController.prototype, "google_calendar_google_calendar_con
             [[this.user.userId]],
         );
         const syncResult = await this.model.syncGoogleCalendar();
-        if (["need_auth", "need_config_from_admin"].includes(syncResult.status)) {
+        if (syncResult.status === "need_auth") {
+            window.location.assign(syncResult.url);
+        }else if (syncResult.status === "need_config_from_admin") {
             if (this.isSystemUser) {
-                if (syncResult.status === "need_auth") {
-                    this.configureCalendarProviderSync("google");
-                } else if (syncResult.status === "need_config_from_admin") {
-                    this.dialog.add(ConfirmationDialog, {
-                        title: this.env._t("Configuration"),
-                        body: this.env._t("The Google Synchronization needs to be configured before you can use it, do you want to do it now?"),
-                        confirm: this.actionService.doAction.bind(this.actionService, syncResult.action),
-                    });
-                }
+                this.dialog.add(ConfirmationDialog, {
+                    title: this.env._t("Configuration"),
+                    body: this.env._t("The Google Synchronization needs to be configured before you can use it, do you want to do it now?"),
+                    confirm: this.actionService.doAction.bind(this.actionService, syncResult.action),
+                });
             } else {
                 this.dialog.add(AlertDialog, {
                     title: this.env._t("Configuration"),


### PR DESCRIPTION
Steps to reproduce:
- connect as admin and configure google calendar
- reconnect as non admin user and try synciing you account
- acsess not allowed

Bug:
Admin acsess is only needed to setup client id and secret

Fix:
when client id is setup redirect to the Oauth url

opw-3048275

