### PR TITLE
[FIX] l10n_*: fix translation on accounting report

### DIFF
--- a/addons/l10n_be/i18n/de.po
+++ b/addons/l10n_be/i18n/de.po
@@ -145,42 +145,42 @@ msgid "0% S."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_00
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
 msgid "00"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_00
+#: model:account.report.line,name:l10n_be.tax_report_line_00
 msgid "00 - Opérations soumises à un régime particulier"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_01
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
 msgid "01"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_01
+#: model:account.report.line,name:l10n_be.tax_report_line_01
 msgid "01 - Opérations avec TVA à 6%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_02
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
 msgid "02"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_02
+#: model:account.report.line,name:l10n_be.tax_report_line_02
 msgid "02 - Opérations avec TVA à 12%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_03
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
 msgid "03"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_03
+#: model:account.report.line,name:l10n_be.tax_report_line_03
 msgid "03 - Opérations avec TVA à 21%"
 msgstr ""
 
@@ -408,102 +408,102 @@ msgid "21% S. TTC"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
 msgid "44"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_44
+#: model:account.report.line,name:l10n_be.tax_report_line_44
 msgid "44 - Services intra-communautaires"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_45
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
 msgid "45"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_45
+#: model:account.report.line,name:l10n_be.tax_report_line_45
 msgid "45 - Opérations avec TVA due par le cocontractant"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_sortie_46
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_46
 msgid "46 - Livraisons intra-communautaires exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
 msgid "46L"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_46L
+#: model:account.report.line,name:l10n_be.tax_report_line_46L
 msgid "46L - Livraisons biens intra-communautaires exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
 msgid "46T"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_46T
+#: model:account.report.line,name:l10n_be.tax_report_line_46T
 msgid "46T - Livraisons biens intra-communautaire exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_47
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
 msgid "47"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_47
+#: model:account.report.line,name:l10n_be.tax_report_line_47
 msgid "47 - Autres opérations exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_sortie_48
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_48
 msgid "48 - Notes de crédit aux opérations grilles [44] et [46]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
 msgid "48s44"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,name:l10n_be.tax_report_line_48s44
 msgid "48s44 - Notes de crédit aux opérations grilles [44]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
 msgid "48s46L"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,name:l10n_be.tax_report_line_48s46L
 msgid "48s46L - Notes de crédit aux opérations grilles [46L]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
 msgid "48s46T"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,name:l10n_be.tax_report_line_48s46T
 msgid "48s46T - Notes de crédit aux opérations grilles [46T]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_49
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
 msgid "49"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_49
+#: model:account.report.line,name:l10n_be.tax_report_line_49
 msgid "49 - Notes de crédit aux opérations du point II"
 msgstr ""
 
@@ -515,52 +515,52 @@ msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_54
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
 msgid "54"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_54
+#: model:account.report.line,name:l10n_be.tax_report_line_54
 msgid "54 - TVA sur opérations des grilles [01], [02], [03]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_55
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
 msgid "55"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_55
+#: model:account.report.line,name:l10n_be.tax_report_line_55
 msgid "55 - TVA sur opérations des grilles [86] et [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_56
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
 msgid "56"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_56
+#: model:account.report.line,name:l10n_be.tax_report_line_56
 msgid "56 - TVA sur opérations de la grille [87]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_57
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
 msgid "57"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_57
+#: model:account.report.line,name:l10n_be.tax_report_line_57
 msgid "57 - TVA relatives aux importations"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_59
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
 msgid "59"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_59
+#: model:account.report.line,name:l10n_be.tax_report_line_59
 msgid "59 - TVA déductible"
 msgstr ""
 
@@ -666,132 +666,132 @@ msgid "6% S."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_61
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
 msgid "61"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_61
+#: model:account.report.line,name:l10n_be.tax_report_line_61
 msgid "61 - Diverses régularisations en faveur de l'Etat"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_62
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
 msgid "62"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_62
+#: model:account.report.line,name:l10n_be.tax_report_line_62
 msgid "62 - Diverses régularisations en faveur du déclarant"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_63
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
 msgid "63"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_63
+#: model:account.report.line,name:l10n_be.tax_report_line_63
 msgid "63 - TVA à reverser sur notes de crédit recues"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_64
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
 msgid "64"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_64
+#: model:account.report.line,name:l10n_be.tax_report_line_64
 msgid "64 - TVA à récupérer sur notes de crédit delivrées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_71
+#: model:account.report.line,name:l10n_be.tax_report_line_71
 msgid "71 - Taxes dues à l'état"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_72
+#: model:account.report.line,name:l10n_be.tax_report_line_72
 msgid "72 - Somme due par l'état"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_81
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
 msgid "81"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_81
+#: model:account.report.line,name:l10n_be.tax_report_line_81
 msgid "81 - Marchandises, matières premières et auxiliaires"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_82
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
 msgid "82"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_82
+#: model:account.report.line,name:l10n_be.tax_report_line_82
 msgid "82 - Services et biens divers"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_83
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
 msgid "83"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_83
+#: model:account.report.line,name:l10n_be.tax_report_line_83
 msgid "83 - Biens d'investissement"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_84
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
 msgid "84"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_84
+#: model:account.report.line,name:l10n_be.tax_report_line_84
 msgid "84 - Notes de crédits sur opérations case [86] et [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_85
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
 msgid "85"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_85
+#: model:account.report.line,name:l10n_be.tax_report_line_85
 msgid "85 - Notes de crédits autres opérations"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_86
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
 msgid "86"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_86
+#: model:account.report.line,name:l10n_be.tax_report_line_86
 msgid "86 - Acquisition intra-communautaires et ventes ABC"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_87
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
 msgid "87"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_87
+#: model:account.report.line,name:l10n_be.tax_report_line_87
 msgid "87 - Autres opérations"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_88
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
 msgid "88"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_88
+#: model:account.report.line,name:l10n_be.tax_report_line_88
 msgid "88 - Acquisition services intra-communautaires"
 msgstr ""
 
@@ -3479,17 +3479,17 @@ msgid "Holders of options (buying or selling securities)"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_sortie
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie
 msgid "II A la sortie"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_entree
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_entree
 msgid "III A l'entrée"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes_dues
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes_dues
 msgid "IV Dues"
 msgstr ""
 
@@ -4241,7 +4241,7 @@ msgid "Options (buy or sell) on securities issued."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations
+#: model:account.report.line,name:l10n_be.tax_report_title_operations
 msgid "Opérations"
 msgstr ""
 
@@ -6180,7 +6180,7 @@ msgid "Tantièmes de l'exercice"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes
 msgid "Taxes"
 msgstr ""
 
@@ -6497,7 +6497,7 @@ msgid "Untaxed reserves"
 msgstr "Steuerfreie Rücklagen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes_deductibles
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes_deductibles
 msgid "V Déductibles"
 msgstr ""
 
@@ -6586,7 +6586,7 @@ msgid "VAT recoverable - Current Account"
 msgstr "Mehrwertsteuer erstattungsfähig - Girokonto"
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes_soldes
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes_soldes
 msgid "VI Soldes"
 msgstr ""
 

--- a/addons/l10n_be/i18n/fr.po
+++ b/addons/l10n_be/i18n/fr.po
@@ -145,7 +145,7 @@ msgid "0% S."
 msgstr "0% S."
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_00
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
 msgid "00"
 msgstr "00"
 
@@ -156,7 +156,7 @@ msgid "00 - Operations subject to a special regulation"
 msgstr "00 - Opérations soumises à un régime particulier"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_01
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
 msgid "01"
 msgstr "01"
 
@@ -167,7 +167,7 @@ msgid "01 - Operations subject to 6% VAT"
 msgstr "01 - Opérations soumises à la TVA à 6%"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_02
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
 msgid "02"
 msgstr "02"
 
@@ -178,7 +178,7 @@ msgid "02 - Operations subject to 12% VAT"
 msgstr "02 - Opérations soumises à la TVA à 12%"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_03
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
 msgid "03"
 msgstr "03"
 
@@ -412,7 +412,7 @@ msgid "21% S. TTC"
 msgstr "21% S. TTC"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
 msgid "44"
 msgstr "44"
 
@@ -423,7 +423,7 @@ msgid "44 - Intra-Community services"
 msgstr "44 - Services intracommunautaires"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_45
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
 msgid "45"
 msgstr "45"
 
@@ -439,7 +439,7 @@ msgid "46 - Exempted intra-Community deliveries and ABC sales"
 msgstr "46 - Livraisons intracommunautaires exemptées et ventes ABC"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
 msgid "46L"
 msgstr "46L"
 
@@ -450,7 +450,7 @@ msgid "46L - Exempted intra-Community deliveries"
 msgstr "46L - Livraisons intracommunautaires exemptées"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
 msgid "46T"
 msgstr "46T"
 
@@ -461,7 +461,7 @@ msgid "46T - ABC sales"
 msgstr "46T - Ventes ABC"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_47
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
 msgid "47"
 msgstr "47"
 
@@ -477,7 +477,7 @@ msgid "48 - Credit notes for operations in grids [44] and [46]"
 msgstr "48 - Notes de crédit relatif aux opérations inscrites en grilles [44] et [46]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
 msgid "48s44"
 msgstr "48s44"
 
@@ -488,7 +488,7 @@ msgid "48s44 - Credit notes for operations in grid [44]"
 msgstr "48s44 - Notes de crédit relatif aux opérations inscrites en grille [44]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
 msgid "48s46L"
 msgstr "48s46L"
 
@@ -499,7 +499,7 @@ msgid "48s46L - Credit notes for operations in grid [46L]"
 msgstr "48s46L - Notes de crédit relatif aux opérations inscrites en grille [46L]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
 msgid "48s46T"
 msgstr "48s46T"
 
@@ -510,7 +510,7 @@ msgid "48s46T - Credit notes for operations in grid [46T]"
 msgstr "48s46T - Notes de crédit relatif aux opérations inscrites en grille [46T]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_49
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
 msgid "49"
 msgstr "49"
 
@@ -528,7 +528,7 @@ msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
 msgstr "50% Non Déductible - Frais de voiture (Prix Excl.)"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_54
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
 msgid "54"
 msgstr "54"
 
@@ -539,7 +539,7 @@ msgid "54 - VAT on operations in grids [01], [02] and [03]"
 msgstr "54 - TVA relative aux opérations déclarées en grilles [01], [02] et [03]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_55
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
 msgid "55"
 msgstr "55"
 
@@ -550,7 +550,7 @@ msgid "55 - VAT on operations in grids [86] and [88]"
 msgstr "55 - TVA relative aux opérations déclarées en grilles [86] et [88]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_56
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
 msgid "56"
 msgstr "56"
 
@@ -561,7 +561,7 @@ msgid "56 - VAT on operations in grid [87], with the exception of imports with r
 msgstr "56 - TVA relative aux opérations déclarées en grille [87], à l'exception des importations avec report de perception"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_57
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
 msgid "57"
 msgstr "57"
 
@@ -572,7 +572,7 @@ msgid "57 - VAT on import with reverse charge"
 msgstr "57 - TVA relative aux importations avec report de perception"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_59
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
 msgid "59"
 msgstr "59"
 
@@ -684,7 +684,7 @@ msgid "6% S."
 msgstr "6% S."
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_61
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
 msgid "61"
 msgstr "61"
 
@@ -695,7 +695,7 @@ msgid "61 - Various VAT regularizations in favor of the State"
 msgstr "61 - Diverses régularisations TVA en faveur de l'Etat"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_62
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
 msgid "62"
 msgstr "62"
 
@@ -706,7 +706,7 @@ msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr "62 - Diverses régularisations TVA en faveur du déclarant"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_63
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
 msgid "63"
 msgstr "63"
 
@@ -717,7 +717,7 @@ msgid "63 - VAT to be paid back on credit notes received"
 msgstr "63 - TVA à reverser mentionnée sur les notes de crédit reçues"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_64
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
 msgid "64"
 msgstr "64"
 
@@ -740,7 +740,7 @@ msgid "72 - Amount owed by the State"
 msgstr "72 - Sommes dues par l'Etat"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_81
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
 msgid "81"
 msgstr "81"
 
@@ -755,7 +755,7 @@ msgid "81 - Trade goods, raw materials and consumables"
 msgstr "81 - Marchandises, matières premières et matières auxiliaires"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_82
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
 msgid "82"
 msgstr "82"
 
@@ -770,7 +770,7 @@ msgid "82 - Services and miscellaneous goods"
 msgstr "82 - Services et biens divers"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_83
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
 msgid "83"
 msgstr "83"
 
@@ -785,7 +785,7 @@ msgid "83 - Investment goods"
 msgstr "83 - Biens d'investissement"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_84
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
 msgid "84"
 msgstr "84"
 
@@ -796,7 +796,7 @@ msgid "84 - Credit notes for operations in grids [86] and [88]"
 msgstr "84 - Notes de crédits reçues relatif aux opérations inscrites en grilles [86] et [88]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_85
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
 msgid "85"
 msgstr "85"
 
@@ -807,7 +807,7 @@ msgid "85 - Credit notes received relating to other operations in part III"
 msgstr "85 - Notes de crédits reçues relatif aux autres opérations de la partie III"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_86
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
 msgid "86"
 msgstr "86"
 
@@ -822,7 +822,7 @@ msgid "86 - Intra-Community acquisitions and ABC sales"
 msgstr "86 - Acquisitions intracommunautaires et ventes ABC"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_87
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
 msgid "87"
 msgstr "87"
 
@@ -837,7 +837,7 @@ msgid "87 - Other operations subject to VAT"
 msgstr "87 - Autres opérations soumises à la TVA"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_88
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
 msgid "88"
 msgstr "88"
 

--- a/addons/l10n_be/i18n/fr_BE.po
+++ b/addons/l10n_be/i18n/fr_BE.po
@@ -145,42 +145,42 @@ msgid "0% S."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_00
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
 msgid "00"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_00
+#: model:account.report.line,name:l10n_be.tax_report_line_00
 msgid "00 - Opérations soumises à un régime particulier"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_01
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
 msgid "01"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_01
+#: model:account.report.line,name:l10n_be.tax_report_line_01
 msgid "01 - Opérations avec TVA à 6%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_02
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
 msgid "02"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_02
+#: model:account.report.line,name:l10n_be.tax_report_line_02
 msgid "02 - Opérations avec TVA à 12%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_03
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
 msgid "03"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_03
+#: model:account.report.line,name:l10n_be.tax_report_line_03
 msgid "03 - Opérations avec TVA à 21%"
 msgstr ""
 
@@ -408,102 +408,102 @@ msgid "21% S. TTC"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
 msgid "44"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_44
+#: model:account.report.line,name:l10n_be.tax_report_line_44
 msgid "44 - Services intra-communautaires"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_45
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
 msgid "45"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_45
+#: model:account.report.line,name:l10n_be.tax_report_line_45
 msgid "45 - Opérations avec TVA due par le cocontractant"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_sortie_46
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_46
 msgid "46 - Livraisons intra-communautaires exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
 msgid "46L"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_46L
+#: model:account.report.line,name:l10n_be.tax_report_line_46L
 msgid "46L - Livraisons biens intra-communautaires exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
 msgid "46T"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_46T
+#: model:account.report.line,name:l10n_be.tax_report_line_46T
 msgid "46T - Livraisons biens intra-communautaire exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_47
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
 msgid "47"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_47
+#: model:account.report.line,name:l10n_be.tax_report_line_47
 msgid "47 - Autres opérations exemptées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_sortie_48
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_48
 msgid "48 - Notes de crédit aux opérations grilles [44] et [46]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
 msgid "48s44"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,name:l10n_be.tax_report_line_48s44
 msgid "48s44 - Notes de crédit aux opérations grilles [44]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
 msgid "48s46L"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,name:l10n_be.tax_report_line_48s46L
 msgid "48s46L - Notes de crédit aux opérations grilles [46L]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
 msgid "48s46T"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,name:l10n_be.tax_report_line_48s46T
 msgid "48s46T - Notes de crédit aux opérations grilles [46T]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_49
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
 msgid "49"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_49
+#: model:account.report.line,name:l10n_be.tax_report_line_49
 msgid "49 - Notes de crédit aux opérations du point II"
 msgstr ""
 
@@ -515,52 +515,52 @@ msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_54
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
 msgid "54"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_54
+#: model:account.report.line,name:l10n_be.tax_report_line_54
 msgid "54 - TVA sur opérations des grilles [01], [02], [03]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_55
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
 msgid "55"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_55
+#: model:account.report.line,name:l10n_be.tax_report_line_55
 msgid "55 - TVA sur opérations des grilles [86] et [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_56
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
 msgid "56"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_56
+#: model:account.report.line,name:l10n_be.tax_report_line_56
 msgid "56 - TVA sur opérations de la grille [87]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_57
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
 msgid "57"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_57
+#: model:account.report.line,name:l10n_be.tax_report_line_57
 msgid "57 - TVA relatives aux importations"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_59
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
 msgid "59"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_59
+#: model:account.report.line,name:l10n_be.tax_report_line_59
 msgid "59 - TVA déductible"
 msgstr ""
 
@@ -666,132 +666,132 @@ msgid "6% S."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_61
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
 msgid "61"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_61
+#: model:account.report.line,name:l10n_be.tax_report_line_61
 msgid "61 - Diverses régularisations en faveur de l'Etat"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_62
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
 msgid "62"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_62
+#: model:account.report.line,name:l10n_be.tax_report_line_62
 msgid "62 - Diverses régularisations en faveur du déclarant"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_63
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
 msgid "63"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_63
+#: model:account.report.line,name:l10n_be.tax_report_line_63
 msgid "63 - TVA à reverser sur notes de crédit recues"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_64
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
 msgid "64"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_64
+#: model:account.report.line,name:l10n_be.tax_report_line_64
 msgid "64 - TVA à récupérer sur notes de crédit delivrées"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_71
+#: model:account.report.line,name:l10n_be.tax_report_line_71
 msgid "71 - Taxes dues à l'état"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_72
+#: model:account.report.line,name:l10n_be.tax_report_line_72
 msgid "72 - Somme due par l'état"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_81
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
 msgid "81"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_81
+#: model:account.report.line,name:l10n_be.tax_report_line_81
 msgid "81 - Marchandises, matières premières et auxiliaires"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_82
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
 msgid "82"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_82
+#: model:account.report.line,name:l10n_be.tax_report_line_82
 msgid "82 - Services et biens divers"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_83
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
 msgid "83"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_83
+#: model:account.report.line,name:l10n_be.tax_report_line_83
 msgid "83 - Biens d'investissement"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_84
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
 msgid "84"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_84
+#: model:account.report.line,name:l10n_be.tax_report_line_84
 msgid "84 - Notes de crédits sur opérations case [86] et [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_85
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
 msgid "85"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_85
+#: model:account.report.line,name:l10n_be.tax_report_line_85
 msgid "85 - Notes de crédits autres opérations"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_86
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
 msgid "86"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_86
+#: model:account.report.line,name:l10n_be.tax_report_line_86
 msgid "86 - Acquisition intra-communautaires et ventes ABC"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_87
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
 msgid "87"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_87
+#: model:account.report.line,name:l10n_be.tax_report_line_87
 msgid "87 - Autres opérations"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_88
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
 msgid "88"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_line_88
+#: model:account.report.line,name:l10n_be.tax_report_line_88
 msgid "88 - Acquisition services intra-communautaires"
 msgstr ""
 
@@ -3311,17 +3311,17 @@ msgid "Holders of options (buying or selling securities)"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_sortie
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie
 msgid "II A la sortie"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations_entree
+#: model:account.report.line,name:l10n_be.tax_report_title_operations_entree
 msgid "III A l'entrée"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes_dues
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes_dues
 msgid "IV Dues"
 msgstr ""
 
@@ -3993,7 +3993,7 @@ msgid "Options (buy or sell) on securities issued."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_operations
+#: model:account.report.line,name:l10n_be.tax_report_title_operations
 msgid "Opérations"
 msgstr ""
 
@@ -5839,7 +5839,7 @@ msgid "Tantièmes de l'exercice"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes
 msgid "Taxes"
 msgstr ""
 
@@ -6117,7 +6117,7 @@ msgid "Untaxed reserves"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes_deductibles
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes_deductibles
 msgid "V Déductibles"
 msgstr ""
 
@@ -6206,7 +6206,7 @@ msgid "VAT recoverable - Current Account"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,name:l10n_be.tax_report_title_taxes_soldes
+#: model:account.report.line,name:l10n_be.tax_report_title_taxes_soldes
 msgid "VI Soldes"
 msgstr ""
 

--- a/addons/l10n_be/i18n/l10n_be.pot
+++ b/addons/l10n_be/i18n/l10n_be.pot
@@ -124,7 +124,7 @@ msgid "0% S."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_00
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
 msgid "00"
 msgstr ""
 
@@ -135,7 +135,7 @@ msgid "00 - Operations subject to a special regulation"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_01
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
 msgid "01"
 msgstr ""
 
@@ -146,7 +146,7 @@ msgid "01 - Operations subject to 6% VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_02
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
 msgid "02"
 msgstr ""
 
@@ -157,7 +157,7 @@ msgid "02 - Operations subject to 12% VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_03
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
 msgid "03"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid "21% S. TTC"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
 msgid "44"
 msgstr ""
 
@@ -369,7 +369,7 @@ msgid "44 - Intra-Community services"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_45
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
 msgid "45"
 msgstr ""
 
@@ -385,7 +385,7 @@ msgid "46 - Exempted intra-Community deliveries and ABC sales"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
 msgid "46L"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgid "46L - Exempted intra-Community deliveries"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
 msgid "46T"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgid "46T - ABC sales"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_47
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
 msgid "47"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgid "48 - Credit notes for operations in grids [44] and [46]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
 msgid "48s44"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgid "48s44 - Credit notes for operations in grid [44]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
 msgid "48s46L"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgid "48s46L - Credit notes for operations in grid [46L]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
 msgid "48s46T"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgid "48s46T - Credit notes for operations in grid [46T]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_49
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
 msgid "49"
 msgstr ""
 
@@ -473,7 +473,7 @@ msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_54
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
 msgid "54"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgid "54 - VAT on operations in grids [01], [02] and [03]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_55
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
 msgid "55"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgid "55 - VAT on operations in grids [86] and [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_56
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
 msgid "56"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgid "56 - VAT on operations in grid [87], with the exception of imports with r
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_57
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
 msgid "57"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgid "57 - VAT on import with reverse charge"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_59
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
 msgid "59"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgid "6% S."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_61
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
 msgid "61"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgid "61 - Various VAT regularizations in favor of the State"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_62
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
 msgid "62"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_63
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
 msgid "63"
 msgstr ""
 
@@ -647,7 +647,7 @@ msgid "63 - VAT to be paid back on credit notes received"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_64
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
 msgid "64"
 msgstr ""
 
@@ -670,7 +670,7 @@ msgid "72 - Amount owed by the State"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_81
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
 msgid "81"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgid "81 - Trade goods, raw materials and consumables"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_82
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
 msgid "82"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgid "82 - Services and miscellaneous goods"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_83
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
 msgid "83"
 msgstr ""
 
@@ -715,7 +715,7 @@ msgid "83 - Investment goods"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_84
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
 msgid "84"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgid "84 - Credit notes for operations in grids [86] and [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_85
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
 msgid "85"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "85 - Credit notes received relating to other operations in part III"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_86
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
 msgid "86"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgid "86 - Intra-Community acquisitions and ABC sales"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_87
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
 msgid "87"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgid "87 - Other operations subject to VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_88
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
 msgid "88"
 msgstr ""
 

--- a/addons/l10n_be/i18n/nl.po
+++ b/addons/l10n_be/i18n/nl.po
@@ -145,7 +145,7 @@ msgid "0% S."
 msgstr "0% D."
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_00
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
 msgid "00"
 msgstr "00"
 
@@ -156,7 +156,7 @@ msgid "00 - Operations subject to a special regulation"
 msgstr "00 - Handelingen onderworpen aan een bijzondere regeling"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_01
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
 msgid "01"
 msgstr "01"
 
@@ -167,7 +167,7 @@ msgid "01 - Operations subject to 6% VAT"
 msgstr "01 - Handelingen onderworpen aan 6% btw"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_02
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
 msgid "02"
 msgstr "02"
 
@@ -178,7 +178,7 @@ msgid "02 - Operations subject to 12% VAT"
 msgstr "02 - Handelingen onderworpen aan 12% btw"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_03
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
 msgid "03"
 msgstr "03"
 
@@ -412,7 +412,7 @@ msgid "21% S. TTC"
 msgstr "21% D. (Inclusief BTW)"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
 msgid "44"
 msgstr "44"
 
@@ -423,7 +423,7 @@ msgid "44 - Intra-Community services"
 msgstr "44 - Intracommunautaire diensten"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_45
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
 msgid "45"
 msgstr "45"
 
@@ -439,7 +439,7 @@ msgid "46 - Exempted intra-Community deliveries and ABC sales"
 msgstr "46 - Vrijgestelde intracommunautaire leveringen en ABC-verkopen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
 msgid "46L"
 msgstr "46L"
 
@@ -450,7 +450,7 @@ msgid "46L - Exempted intra-Community deliveries"
 msgstr "46L - Vrijgestelde intracommunautaire leveringen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
 msgid "46T"
 msgstr "46T"
 
@@ -461,7 +461,7 @@ msgid "46T - ABC sales"
 msgstr "46T - ABC-verkopen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_47
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
 msgid "47"
 msgstr "47"
 
@@ -477,7 +477,7 @@ msgid "48 - Credit notes for operations in grids [44] and [46]"
 msgstr "48 - Creditnota's met betrekking tot de handelingen ingeschreven in de roosters [44] en [46]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s44
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
 msgid "48s44"
 msgstr "48s44"
 
@@ -488,7 +488,7 @@ msgid "48s44 - Credit notes for operations in grid [44]"
 msgstr "48s44 - Creditnota's met betrekking tot de handelingen ingeschreven in rooster [44]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46L
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
 msgid "48s46L"
 msgstr "48s46L"
 
@@ -499,7 +499,7 @@ msgid "48s46L - Credit notes for operations in grid [46L]"
 msgstr "48s46L - Creditnota's met betrekking tot de handelingen ingeschreven in rooster [46L]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46T
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
 msgid "48s46T"
 msgstr "48s46T"
 
@@ -510,7 +510,7 @@ msgid "48s46T - Credit notes for operations in grid [46T]"
 msgstr "48s46T - Creditnota's met betrekking tot de handelingen ingeschreven in rooster [46T]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_49
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
 msgid "49"
 msgstr "49"
 
@@ -528,7 +528,7 @@ msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
 msgstr "50% Non Déductible - Frais de voiture (Prix Excl.)"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_54
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
 msgid "54"
 msgstr "54"
 
@@ -539,7 +539,7 @@ msgid "54 - VAT on operations in grids [01], [02] and [03]"
 msgstr "54 - Btw op de handelingen aangegeven in de roosters [01], [02] en [03]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_55
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
 msgid "55"
 msgstr "55"
 
@@ -550,7 +550,7 @@ msgid "55 - VAT on operations in grids [86] and [88]"
 msgstr "55 - Btw op de handelingen aangegeven in de roosters [86] en [88]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_56
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
 msgid "56"
 msgstr "56"
 
@@ -561,7 +561,7 @@ msgid "56 - VAT on operations in grid [87], with the exception of imports with r
 msgstr "56 - Btw op de handelingen aangegeven in rooster [87], met uitzondering van invoeren met verlegging van heffing"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_57
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
 msgid "57"
 msgstr "57"
 
@@ -572,7 +572,7 @@ msgid "57 - VAT on import with reverse charge"
 msgstr "57 - Btw op invoeren met verlegging van heffing"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_59
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
 msgid "59"
 msgstr "59"
 
@@ -684,7 +684,7 @@ msgid "6% S."
 msgstr "6% D."
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_61
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
 msgid "61"
 msgstr "61"
 
@@ -695,7 +695,7 @@ msgid "61 - Various VAT regularizations in favor of the State"
 msgstr "61 - Diverse btw-regularisaties in het voordeel van de Staat"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_62
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
 msgid "62"
 msgstr "62"
 
@@ -706,7 +706,7 @@ msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr "62 - Diverse btw-regularisaties in het voordeel van de aangever"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_63
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
 msgid "63"
 msgstr "63"
 
@@ -717,7 +717,7 @@ msgid "63 - VAT to be paid back on credit notes received"
 msgstr "63 - Terug te storten btw vermeld op ontvangen creditnota's"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_64
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
 msgid "64"
 msgstr "64"
 
@@ -740,7 +740,7 @@ msgid "72 - Amount owed by the State"
 msgstr "72 - Sommen verschuldigd door de Staat"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_81
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
 msgid "81"
 msgstr "81"
 
@@ -755,7 +755,7 @@ msgid "81 - Trade goods, raw materials and consumables"
 msgstr "81 - Handelsgoederen, grond- en hulpstoffen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_82
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
 msgid "82"
 msgstr "82"
 
@@ -770,7 +770,7 @@ msgid "82 - Services and miscellaneous goods"
 msgstr "82 - Diensten en diverse goederen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_83
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
 msgid "83"
 msgstr "83"
 
@@ -785,7 +785,7 @@ msgid "83 - Investment goods"
 msgstr "83 - Bedrijfsmiddelen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_84
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
 msgid "84"
 msgstr "84"
 
@@ -796,7 +796,7 @@ msgid "84 - Credit notes for operations in grids [86] and [88]"
 msgstr "84 - Creditnota's met betrekking tot de handelingen ingeschreven in de roosters [86] en [88]"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_85
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
 msgid "85"
 msgstr "85"
 
@@ -807,7 +807,7 @@ msgid "85 - Credit notes received relating to other operations in part III"
 msgstr "85 - Creditnota's met betrekking tot de andere handelingen van deel III"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_86
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
 msgid "86"
 msgstr "86"
 
@@ -822,7 +822,7 @@ msgid "86 - Intra-Community acquisitions and ABC sales"
 msgstr "86 - Intracommunautaire verwervingen en ABC-verkopen"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_87
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
 msgid "87"
 msgstr "87"
 
@@ -837,7 +837,7 @@ msgid "87 - Other operations subject to VAT"
 msgstr "87 - Andere handelingen waarvoor de btw verschuldigd is"
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_88
+#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
 msgid "88"
 msgstr "88"
 

--- a/addons/l10n_bg/i18n/bg.po
+++ b/addons/l10n_bg/i18n/bg.po
@@ -119,52 +119,52 @@ msgid "0% VAT"
 msgstr "0% ДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_11
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_11
 msgid "11"
 msgstr "11"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_1
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_1
 msgid "12_1"
 msgstr "12_1"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_2
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_2
 msgid "12_2"
 msgstr "12_2"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_13
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_13
 msgid "13"
 msgstr "13"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_14
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_14
 msgid "14"
 msgstr "14"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_15
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_15
 msgid "15"
 msgstr "15"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_16
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_16
 msgid "16"
 msgstr "16"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_17
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_17
 msgid "17"
 msgstr "17"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_18
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_18
 msgid "18"
 msgstr "18"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_19
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_19
 msgid "19"
 msgstr "19"
 
@@ -326,47 +326,47 @@ msgid "20% VAT"
 msgstr "20% ДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_21
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_21
 msgid "21"
 msgstr "21"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_22
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_22
 msgid "22"
 msgstr "22"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_23
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_23
 msgid "23"
 msgstr "23"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_24
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_24
 msgid "24"
 msgstr "24"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_30
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_30
 msgid "30"
 msgstr "30"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_31
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_31
 msgid "31"
 msgstr "31"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_32
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_32
 msgid "32"
 msgstr "32"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_41
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_41
 msgid "41"
 msgstr "41"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_42
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_42
 msgid "42"
 msgstr "42"
 
@@ -888,7 +888,7 @@ msgid "Deferred tax estimates"
 msgstr "Разчети по отсрочени данъци"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_12_2
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_12_2
 msgid "Deliveries under Art. 82, para. 2-6"
 msgstr "Доставки по чл. 82, ал. 2-6"
 
@@ -1798,7 +1798,7 @@ msgid "Internal settlements on intrabank operations"
 msgstr "Вътрешни разчети по вътрешнобанкови операции"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_12_1
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_12_1
 msgid "Intra-community acquisitions"
 msgstr "Вътрешнообщностни придобивания"
 
@@ -2901,17 +2901,17 @@ msgid "Sales revenue"
 msgstr "Приходи от продажби"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_a
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_a
 msgid "Section A: Data on value added tax charged"
 msgstr "Раздел А: Данни за начислен данък върху добавената стойност"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_b
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_b
 msgid "Section B: Data on the exercised right to a tax credit"
 msgstr "Раздел Б: Данни за упражнено право на данъчен кредит"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_c
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_c
 msgid "Section C: Result for the period"
 msgstr "Раздел В: Резултат за периода"
 
@@ -3111,7 +3111,7 @@ msgid "Tangible fixed assets"
 msgstr "Дълготрайни материални активи"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_b_2
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_b_2
 msgid ""
 "Tax base of the received deliveries, VAT, the received deliveries under art."
 " 82, para 2-6 of the VAT Act, the import, as well as the tax base of the "
@@ -3120,12 +3120,12 @@ msgid ""
 msgstr "Данъчна основа на получените доставки, ВОП, получените доставки по чл.82, ал.2-6 от ЗДДС, вноса, както и данъчната основа на получени доставки, използвани за извършване на доставки по чл.69, ал.2 ЗДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_a_2
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_a_2
 msgid "Tax base subject to 0% tax"
 msgstr "Данъчна основа, подлежаща на облагане със ставка 0%:"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_a_1
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_a_1
 msgid "Tax base subject to taxation at a rate of 20%"
 msgstr "Данъчна основа, подлежаща на облагане със ставка 20%:"
 
@@ -3256,14 +3256,14 @@ msgid "Young animals"
 msgstr "Млади животни"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_01
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_01
 msgid ""
 "[01] Total amount of the tax bases for VAT taxation (amount from class 11 to"
 " class 16)"
 msgstr "[01] Общ размер на данъчните основи за облагане с ДДС (сума от кл.11 до кл.16)"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_11
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_11
 msgid ""
 "[11] - tax base of taxable supplies, incl. deliveries under the conditions "
 "of distance sales with a place of performance on the territory of the "
@@ -3271,42 +3271,42 @@ msgid ""
 msgstr "[11] - данъчна основа на облагаемите доставки, вкл. доставките при условията на дистанционни продажби с място на изпълнение на територията на страната  "
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_12
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_12
 msgid ""
 "[12] - tax base of VAT and tax base of received supplies under Article 82, "
 "paragraphs 2-6 of the VAT Act"
 msgstr "[12] - данъчна основа на ВОП и данъчна основа на получени доставки по чл.82, ал.2-6 от ЗДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_13
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_13
 msgid "[13] Tax base of taxable supplies at a rate of 9%"
 msgstr "[13] Данъчна основа на облагаемите доставки със ставка 9%"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_14
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_14
 msgid "[14] Tax base for supplies under Chapter Three of the VAT Act"
 msgstr "[14] - данъчна основа за доставки по глава трета от ЗДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_15
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_15
 msgid "[15] Tax base of AEO of goods"
 msgstr "[15] - данъчна основа на ВОД на стоки"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_16
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_16
 msgid ""
 "[16] Tax base of supplies under Articles 140, 146 and 173 of the VAT Act "
 msgstr "[16] - данъчна основа на доставки по чл.140, 146 и чл.173 ЗДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_17
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_17
 msgid ""
 "[17] Tax base for supplies of services under Article 21, paragraph 2 with a "
 "place of performance on the territory of another member state"
 msgstr "[17] Данъчна основа на доставки на услуги по чл.21, ал.2 с място на изпълнение на територията на друга страна членка"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_18
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_18
 msgid ""
 "[18] Tax base of supplies under Article 69, paragraph 2 of the VAT Act, "
 "incl. deliveries on the basis of distance selling with a place of "
@@ -3315,38 +3315,38 @@ msgid ""
 msgstr "[18] Данъчна основа на доставки по чл.69, ал.2 ЗДДС, вкл. доставките при условията на дистанционни продажби с място на изпълнение на територията на друга държава членка, както и на доставки като посредник в тристранна"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_19
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_19
 msgid "[19] Tax base of exempt supplies and exempt VOP"
 msgstr "[19] Данъчна основа на освободените доставки и освободените ВОП"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_20
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_20
 msgid "[20] All VAT charged (amount from class 21 to class 24)"
 msgstr "[20] Всичко начислен ДДС (сума от кл.21 до кл.24)"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_21
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_21
 msgid "[21] VAT charged"
 msgstr "[21] Начислен ДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_22
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_22
 msgid ""
 "[22] VAT charged for VAT and for received deliveries under Art. 82, para 2-6"
 msgstr "[22] Начислен ДДС за ВОП и за получени доставки по чл. 82, ал.2-6"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_23
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_23
 msgid "[23] Tax charged on supplies of goods and services for personal use"
 msgstr "[23] Начислен данък за доставки на стоки и услуги за лични нужди"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_24
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_24
 msgid "[24] VAT charged (9%)"
 msgstr "[24] Начислен ДДС (9%)"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_30
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_30
 msgid ""
 "[30] Tax base and tax on the received deliveries, VAT, the received "
 "deliveries under art. 82, para. 2-6 of the VAT Act and imports without the "
@@ -3354,46 +3354,46 @@ msgid ""
 msgstr "[30] Данъчна основа и данък на получените доставки, ВОП, получените доставки по чл.82, ал. 2-6 от ЗДДС и вноса без право на данъчен кредит или без данък"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_31
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_31
 msgid "[31] - entitled to a full tax credit"
 msgstr "[31] - с право на пълен данъчен кредит"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_32
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_32
 msgid "[32] - with the right to a partial tax credit"
 msgstr "[32] - с право на частичен данъчен кредит"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_33
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_33
 msgid "[33] Coefficient under Article 73, paragraph 5 of the VAT Act"
 msgstr "[33] Коефициент по чл.73, ал.5 ЗДДС"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_40
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_40
 msgid "[40] Total tax credit (41 + 42 x class 33 + 43)"
 msgstr "[40] Общо данъчен кредит (41 + 42 х кл.33 + 43)"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_41
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_41
 msgid "[41] VAT eligible for a full tax credit"
 msgstr "[41] ДДС с право на пълен данъчен кредит"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_42
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_42
 msgid "[42] VAT with the right to a partial tax credit"
 msgstr "[42] ДДС с право на частичен даннъчен кредит"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_43
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_43
 msgid "[43] Annual adjustment under Article 73, paragraph 8 (+/-)"
 msgstr "[43] Годишна корекция по чл.73, ал.8 (+ / -)"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_50
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_50
 msgid "[50] VAT to be paid (class 20 - class 40) >= 0"
 msgstr "[50] ДДС за внасяне (кл.20 - кл.40) >= 0"
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_60
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_60
 msgid "[60] VAT for refund (class 20 - class 40) < 0"
 msgstr "[60] ДДС за възстановяване (кл.20 - кл.40) < 0"

--- a/addons/l10n_bg/i18n/l10n_bg.pot
+++ b/addons/l10n_bg/i18n/l10n_bg.pot
@@ -119,52 +119,52 @@ msgid "0% VAT"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_11
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_11
 msgid "11"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_1
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_1
 msgid "12_1"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_2
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_12_2
 msgid "12_2"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_13
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_13
 msgid "13"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_14
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_14
 msgid "14"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_15
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_15
 msgid "15"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_16
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_16
 msgid "16"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_17
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_17
 msgid "17"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_18
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_18
 msgid "18"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_19
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_19
 msgid "19"
 msgstr ""
 
@@ -326,47 +326,47 @@ msgid "20% VAT"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_21
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_21
 msgid "21"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_22
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_22
 msgid "22"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_23
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_23
 msgid "23"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_24
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_24
 msgid "24"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_30
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_30
 msgid "30"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_31
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_31
 msgid "31"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_32
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_32
 msgid "32"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_41
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_41
 msgid "41"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,tag_name:l10n_bg.l10n_bg_tax_report_42
+#: model:account.report.line,tag_name:l10n_bg.l10n_bg_tax_report_42
 msgid "42"
 msgstr ""
 
@@ -888,7 +888,7 @@ msgid "Deferred tax estimates"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_12_2
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_12_2
 msgid "Deliveries under Art. 82, para. 2-6"
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgid "Internal settlements on intrabank operations"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_12_1
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_12_1
 msgid "Intra-community acquisitions"
 msgstr ""
 
@@ -2901,17 +2901,17 @@ msgid "Sales revenue"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_a
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_a
 msgid "Section A: Data on value added tax charged"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_b
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_b
 msgid "Section B: Data on the exercised right to a tax credit"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_c
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_c
 msgid "Section C: Result for the period"
 msgstr ""
 
@@ -3111,7 +3111,7 @@ msgid "Tangible fixed assets"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_b_2
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_b_2
 msgid ""
 "Tax base of the received deliveries, VAT, the received deliveries under art."
 " 82, para 2-6 of the VAT Act, the import, as well as the tax base of the "
@@ -3120,12 +3120,12 @@ msgid ""
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_a_2
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_a_2
 msgid "Tax base subject to 0% tax"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_a_1
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_a_1
 msgid "Tax base subject to taxation at a rate of 20%"
 msgstr ""
 
@@ -3256,14 +3256,14 @@ msgid "Young animals"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_01
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_01
 msgid ""
 "[01] Total amount of the tax bases for VAT taxation (amount from class 11 to"
 " class 16)"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_11
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_11
 msgid ""
 "[11] - tax base of taxable supplies, incl. deliveries under the conditions "
 "of distance sales with a place of performance on the territory of the "
@@ -3271,42 +3271,42 @@ msgid ""
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_12
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_12
 msgid ""
 "[12] - tax base of VAT and tax base of received supplies under Article 82, "
 "paragraphs 2-6 of the VAT Act"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_13
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_13
 msgid "[13] Tax base of taxable supplies at a rate of 9%"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_14
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_14
 msgid "[14] Tax base for supplies under Chapter Three of the VAT Act"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_15
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_15
 msgid "[15] Tax base of AEO of goods"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_16
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_16
 msgid ""
 "[16] Tax base of supplies under Articles 140, 146 and 173 of the VAT Act "
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_17
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_17
 msgid ""
 "[17] Tax base for supplies of services under Article 21, paragraph 2 with a "
 "place of performance on the territory of another member state"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_18
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_18
 msgid ""
 "[18] Tax base of supplies under Article 69, paragraph 2 of the VAT Act, "
 "incl. deliveries on the basis of distance selling with a place of "
@@ -3315,38 +3315,38 @@ msgid ""
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_19
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_19
 msgid "[19] Tax base of exempt supplies and exempt VOP"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_20
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_20
 msgid "[20] All VAT charged (amount from class 21 to class 24)"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_21
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_21
 msgid "[21] VAT charged"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_22
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_22
 msgid ""
 "[22] VAT charged for VAT and for received deliveries under Art. 82, para 2-6"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_23
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_23
 msgid "[23] Tax charged on supplies of goods and services for personal use"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_24
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_24
 msgid "[24] VAT charged (9%)"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_30
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_30
 msgid ""
 "[30] Tax base and tax on the received deliveries, VAT, the received "
 "deliveries under art. 82, para. 2-6 of the VAT Act and imports without the "
@@ -3354,46 +3354,46 @@ msgid ""
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_31
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_31
 msgid "[31] - entitled to a full tax credit"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_32
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_32
 msgid "[32] - with the right to a partial tax credit"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_33
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_33
 msgid "[33] Coefficient under Article 73, paragraph 5 of the VAT Act"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_40
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_40
 msgid "[40] Total tax credit (41 + 42 x class 33 + 43)"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_41
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_41
 msgid "[41] VAT eligible for a full tax credit"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_42
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_42
 msgid "[42] VAT with the right to a partial tax credit"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_43
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_43
 msgid "[43] Annual adjustment under Article 73, paragraph 8 (+/-)"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_50
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_50
 msgid "[50] VAT to be paid (class 20 - class 40) >= 0"
 msgstr ""
 
 #. module: l10n_bg
-#: model:account.tax.report.line,name:l10n_bg.l10n_bg_tax_report_60
+#: model:account.report.line,name:l10n_bg.l10n_bg_tax_report_60
 msgid "[60] VAT for refund (class 20 - class 40) < 0"
 msgstr ""

--- a/addons/l10n_ch/i18n/fr_BE.po
+++ b/addons/l10n_ch/i18n/fr_BE.po
@@ -165,77 +165,77 @@ msgid "2.50%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_200
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_200
 msgid "200 Total amount of agreed or collected consideration incl. from supplies opted for taxation, transfer of supplies acc. to the notification procedure and supplies provided abroad (worldwide turnover)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_220_289
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_220_289
 msgid "220"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_220_289
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_220_289
 msgid "220 Supplies exempt from the tax (e.g. export, art. 23) and supplies provided to institutional and individual beneficiaries that are exempt from liability for tax (art. 107 para. 1 lit. a)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_221
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_221
 msgid "221"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_221
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_221
 msgid "221 Supplies provided abroad (place of supply is abroad)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_225
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_225
 msgid "225"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_225
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_225
 msgid "225 Transfer of supplies according to the notification procedure (art. 38, please submit Form 764)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_230
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_230
 msgid "230"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_230
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_230
 msgid "230 Supplies provided on Swiss territory exempt from the tax without credit (art. 21) and where the option for their taxation according to art. 22 has not been exercised"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_235
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_235
 msgid "235"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_235
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_235
 msgid "235 Reduction of consideration (discounts, rebates etc.)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_280
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_280
 msgid "280"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_280
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_280
 msgid "280 Miscellaneous (e.g. land value, purchase prices in case of margin taxation)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_289
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_289
 msgid "289 Consideration reported in Ref. 200 from supplies exempt from the tax without credit (art. 21) where the option for their taxation according to art. 22 has been exercised"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_299
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_299
 msgid "299 Taxable turnover (Ref. 200 minus Ref. 289)"
 msgstr ""
 
@@ -312,172 +312,172 @@ msgid "3.70%%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_302a
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_302a
 msgid "302a"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_302a
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_302a
 msgid "302a Taxable turnover at 7.7% (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_302b
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_302b
 msgid "302b"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_302b
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_302b
 msgid "302b Tax due at 7.7% (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_312a
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_312a
 msgid "312a"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_312a
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_312a
 msgid "312a Taxable turnover at 2.5% (TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_312b
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_312b
 msgid "312b"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_312b
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_312b
 msgid "312b Tax due at 2.5% (TR)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_342a
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_342a
 msgid "342a"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_342a
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_342a
 msgid "342a Taxable turnover at 3.7% (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_342b
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_342b
 msgid "342b"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_342b
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_342b
 msgid "342b Tax due at 3.7% (TS)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_381a
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_381a
 msgid "381a"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_381a
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_381a
 msgid "381a Acquisition tax"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_381b
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_381b
 msgid "381b"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_381b
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_381b
 msgid "381b Acquisition tax"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_382a
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_382a
 msgid "382a"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_382a
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_382a
 msgid "382a Acquisition tax"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_382b
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_382b
 msgid "382b"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_382b
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_382b
 msgid "382b Acquisition tax"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_399
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_399
 msgid "399 Total amount of tax due"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_400
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_400
 msgid "400"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_400
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_400
 msgid "400 Input tax on cost of materials and supplies of services"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_405
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_405
 msgid "405"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_405
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_405
 msgid "405 Input tax on investments and other operating costs"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_410
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_410
 msgid "410"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_410
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_410
 msgid "410 De-taxation (art. 32, please enclose a detailed list)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_415
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_415
 msgid "415"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_415
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_415
 msgid "415 Correction of the input tax deduction: mixed use (art. 30), own use (art. 31)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_420
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_420
 msgid "420"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_420
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_420
 msgid "420 Reduction of the input tax deduction: Flow of funds, which are not deemed to be consideration, such as subsidies, tourist charges (art. 33 para. 2)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_479
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_479
 msgid "479 Input VAT"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_500
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_500
 msgid "500 Amount of VAT payable to AFC"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_510
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_510
 msgid "510 Credit in favour of the taxable person"
 msgstr ""
 
@@ -578,22 +578,22 @@ msgid "7.70%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_900
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_900
 msgid "900"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_900
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_900
 msgid "900 Subsidies, tourist funds collected by tourist offices, contributions from cantonal water, sewage or waste funds (art. 18 para. 2 lit. a to c)"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_910
+#: model:account.report.line,tag_name:l10n_ch.account_tax_report_line_chtax_910
 msgid "910"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_910
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_910
 msgid "910 Donations, dividends, payments of damages etc. (art. 18 para. 2 lit. d to l)"
 msgstr ""
 
@@ -663,7 +663,7 @@ msgid "<span>Reference</span>"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_solde
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_solde
 msgid "AMOUNT PAYABLE"
 msgstr ""
 
@@ -1272,12 +1272,12 @@ msgid "Horizontal offset"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chiffre_af
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chiffre_af
 msgid "I – TURNOVER"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_calc_impot
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_calc_impot
 msgid "II - TAX CALCULATION"
 msgstr ""
 
@@ -1550,7 +1550,7 @@ msgid "Non-paid-in share capital"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_chtax_autres_mouv
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_autres_mouv
 msgid "OTHER CASH FLOWS (art. 18 para. 2)"
 msgstr ""
 
@@ -1949,12 +1949,12 @@ msgid "TVA 7.7%"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_calc_impot_base
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_calc_impot_base
 msgid "Tax base on service acquisitions"
 msgstr ""
 
 #. module: l10n_ch
-#: model:account.tax.report.line,name:l10n_ch.account_tax_report_line_calc_impot_chiffre
+#: model:account.report.line,name:l10n_ch.account_tax_report_line_calc_impot_chiffre
 msgid "Taxable turnover"
 msgstr ""
 

--- a/addons/l10n_eg/i18n_extra/ar_001.po
+++ b/addons/l10n_eg/i18n_extra/ar_001.po
@@ -16,22 +16,22 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base_fourteen
 msgid "1. Standard Rated 14% (Base)"
 msgstr "1. المبيعات الخاضعة لنسبة أساسية (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
 msgid "1. Standard Rated 14% (Tax)"
 msgstr "1. المبيعات الخاضعة لنسبة أساسية (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_fourteen
 msgid "1. VAT 14% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
 msgid "1. VAT 14% (Tax)"
 msgstr ""
 
@@ -46,26 +46,26 @@ msgid "2. Withholding Tax"
 msgstr "ضرائب خصم المنبع"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_zero
 msgid "2. Zero Rated (Base)"
 msgstr "2. المبيعات المحلية الخاضعة للنسبة الصفرية (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_zero
 msgid "2. Zero Rated (Tax)"
 msgstr "2. المبيعات المحلية الخاضعة للنسبة الصفرية (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_exempt
 msgid "3. Exempt Sales (Base)"
 msgstr "3. المبيعات معفاة من الضريبة (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_exempt
 msgid "3. Exempt Sales (Tax)"
 msgstr "3. المبيعات معفاة من الضريبة (ضريبة)"
 
@@ -80,46 +80,46 @@ msgid "4. Other Taxes"
 msgstr "ضرائب اخرى"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base_fourteen
 msgid "5. Standard Rated 14% Expenses (Base)"
 msgstr "5. ضريبة القيمة المضافة على المشتريات (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
 msgid "5. Standard Rated 14% Expenses (Tax)"
 msgstr "5. ضريبة القيمة المضافة على المشتريات (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_fourteen
 msgid "5. VAT 14% Expenses (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
 msgid "5. VAT 14% Expenses (Tax)"
 msgstr "5. ضريبة القيمة المضافة على المشتريات (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_zero
 msgid "6. Zero Rated (Base)"
 msgstr "2. المشتريات المحلية الخاضعة للنسبة الصفرية (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_zero
 msgid "6. Zero Rated (Tax)"
 msgstr "6. المشتريات الخاضعة للنسبة الصفرية (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_exempt
 msgid "7. Exempt Expenses (Base)"
 msgstr "7. المشتريات معفاة من الضريبة (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_exempt
 msgid "7. Exempt Expenses (Tax)"
 msgstr "7. المشتريات معفاة من الضريبة (ضريبة)"
 
@@ -809,12 +809,12 @@ msgid "Name of this tax report"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net
 msgid "Net VAT Due"
 msgstr "صافي الضريبة المستحق"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net_3
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net_3
 msgid "Net VAT due (or reclaimed) for the period"
 msgstr "صافي ضريبة القيمة المستحقة الواجب توريدها (استرجاعها)"
 
@@ -1188,142 +1188,142 @@ msgid "SCHD 8%"
 msgstr "الجدول %8"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
 msgid "SCHD Purchases 0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
 msgid "SCHD Purchases 0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
 msgid "SCHD Purchases 1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
 msgid "SCHD Purchases 1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
 msgid "SCHD Purchases 10% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
 msgid "SCHD Purchases 10% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
 msgid "SCHD Purchases 15% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
 msgid "SCHD Purchases 15% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
 msgid "SCHD Purchases 30% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
 msgid "SCHD Purchases 30% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
 msgid "SCHD Purchases 5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
 msgid "SCHD Purchases 5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
 msgid "SCHD Purchases 8% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
 msgid "SCHD Purchases 8% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
 msgid "SCHD Sales 0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
 msgid "SCHD Sales 0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
 msgid "SCHD Sales 1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
 msgid "SCHD Sales 1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
 msgid "SCHD Sales 10% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
 msgid "SCHD Sales 10% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
 msgid "SCHD Sales 15% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
 msgid "SCHD Sales 15% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
 msgid "SCHD Sales 30% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
 msgid "SCHD Sales 30% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
 msgid "SCHD Sales 5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
 msgid "SCHD Sales 5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
 msgid "SCHD Sales 8% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
 msgid "SCHD Sales 8% (Tax)"
 msgstr ""
 
@@ -1475,162 +1475,162 @@ msgid "Schedule Tax collected & payable"
 msgstr "ضريبة جدول دائنة"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base
 msgid "Schedule Tax on Purchases (Base)"
 msgstr "مشترات ضريبة الجدول (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax
 msgid "Schedule Tax on Purchases (Tax)"
 msgstr "مشتريات ضريبة الجدول (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
 msgid "Schedule Tax on Purchases 0.5% (Base)"
 msgstr "مشتريات ضريبة الجدول %0.5 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
 msgid "Schedule Tax on Purchases 0.5% (Tax)"
 msgstr "مشتريات ضريبة الجدول %0.5 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
 msgid "Schedule Tax on Purchases 1% (Base)"
 msgstr "مشتريات ضريبة الجدول %1 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
 msgid "Schedule Tax on Purchases 1% (Tax)"
 msgstr "مشتريات ضريبة الجدول %1 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
 msgid "Schedule Tax on Purchases 10% (Base)"
 msgstr "مشتريات ضريبة الجدول %10 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
 msgid "Schedule Tax on Purchases 10% (Tax)"
 msgstr "مشتريات ضريبة الجدول %10 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
 msgid "Schedule Tax on Purchases 15% (Base)"
 msgstr "مشتريات ضريبة الجدول %15 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
 msgid "Schedule Tax on Purchases 15% (Tax)"
 msgstr "مشتريات ضريبة الجدول %15 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
 msgid "Schedule Tax on Purchases 30% (Base)"
 msgstr "مشتريات ضريبة الجدول %30 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
 msgid "Schedule Tax on Purchases 30% (Tax)"
 msgstr "مشتريات ضريبة الجدول %30 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
 msgid "Schedule Tax on Purchases 5% (Base)"
 msgstr "مشتريات ضريبة الجدول %5 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
 msgid "Schedule Tax on Purchases 5% (Tax)"
 msgstr "مشتريات ضريبة الجدول %5 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
 msgid "Schedule Tax on Purchases 8% (Base)"
 msgstr "مشتريات ضريبة الجدول %8 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
 msgid "Schedule Tax on Purchases 8% (Tax)"
 msgstr "مشتريات ضريبة الجدول %8 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base
 msgid "Schedule Tax on Sales (Base)"
 msgstr "مبيعات ضريبة الجدول ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax
 msgid "Schedule Tax on Sales (Tax)"
 msgstr "مبيعات ضريبة الجدول (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
 msgid "Schedule Tax on Sales 0.5% (Base)"
 msgstr "مبيعات ضريبة الجدول %0.5 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
 msgid "Schedule Tax on Sales 0.5% (Tax)"
 msgstr "مبيعات ضريبة الجدول %0.5 ( ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
 msgid "Schedule Tax on Sales 1% (Base)"
 msgstr "مبيعات ضريبة الجدول %1 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
 msgid "Schedule Tax on Sales 1% (Tax)"
 msgstr "مبيعات ضريبة الجدول %1 ( ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
 msgid "Schedule Tax on Sales 10% (Base)"
 msgstr "مبيعات ضريبة الجدول %10 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
 msgid "Schedule Tax on Sales 10% (Tax)"
 msgstr "مبيعات ضريبة الجدول %10 ( ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
 msgid "Schedule Tax on Sales 15% (Base)"
 msgstr "مبيعات ضريبة الجدول %15 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
 msgid "Schedule Tax on Sales 15% (Tax)"
 msgstr "مبيعات ضريبة الجدول %15 ( ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
 msgid "Schedule Tax on Sales 30% (Base)"
 msgstr "مبيعات ضريبة الجدول %30 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
 msgid "Schedule Tax on Sales 30% (Tax)"
 msgstr "مبيعات ضريبة الجدول %30 ( ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
 msgid "Schedule Tax on Sales 5% (Base)"
 msgstr "مبيعات ضريبة الجدول %5 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
 msgid "Schedule Tax on Sales 5% (Tax)"
 msgstr "مبيعات ضريبة الجدول %5 ( ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
 msgid "Schedule Tax on Sales 8% (Base)"
 msgstr "مبيعات ضريبة الجدول %8 ( اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
 msgid "Schedule Tax on Sales 8% (Tax)"
 msgstr "مبيعات ضريبة الجدول %8 ( ضريبة)"
 
@@ -1719,46 +1719,46 @@ msgid "Stamp Tax 20%"
 msgstr "ضريبة الدمغة"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base
 msgid "Stamp Tax Purchases (Base)"
 msgstr "مشتريات ضريبة الدمغة (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax
 msgid "Stamp Tax Purchases (Tax)"
 msgstr "مشتريات ضريبة الدمغة (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
 msgid "Stamp Tax Purchases 20% (Base)"
 msgstr "مشتريات ضريبة الدمغة %20 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
 msgid "Stamp Tax Purchases 20% (Tax)"
 msgstr "مشتريات ضريبة الدمغة %20 (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base
 msgid "Stamp Tax Sales (Base)"
 msgstr "مبيعات ضريبة الدمغة (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax
 msgid "Stamp Tax Sales (Tax)"
 msgstr "مبيعات ضريبة الدمغة (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
 msgid "Stamp Tax Sales 20% (Base)"
 msgstr "مبيعات ضريبة الدمغة %20 (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
 msgid "Stamp Tax Sales 20% (Tax)"
 msgstr "مبيعات ضريبة الدمغة %20 (ضريبة)"
 
@@ -2206,12 +2206,12 @@ msgid "Templates for Taxes"
 msgstr "قوالب الضرائب"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net_1
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net_1
 msgid "Total value of due tax for the period"
 msgstr "إجمالي ضريبة القيمة المستحقة للفترة الحالية"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net_2
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net_2
 msgid "Total value of recoverable tax for the period"
 msgstr "اجمالي الضريبة القيمة المضافة المدفوعة مقدما"
 
@@ -2296,22 +2296,22 @@ msgid "VAT Receivable"
 msgstr "ضريبة القيمة المضافة المدينة"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base
 msgid "VAT on Expenses and all other Inputs (Base)"
 msgstr "ضريبة القيمة المضافة على المشتريات (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax
 msgid "VAT on Expenses and all other Inputs (Tax)"
 msgstr "ضريبة القيمة المضافة على المشتريات (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base
 msgid "VAT on Sales and all other Outputs (Base)"
 msgstr "ضريبة القيمة المضافة على المبيعات (أساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax
 msgid "VAT on Sales and all other Outputs (Tax)"
 msgstr "ضريبة القيمة المضافة على المبيعات (ضريبة)"
 
@@ -2377,67 +2377,67 @@ msgid "WH -5%"
 msgstr "الصناعة و التجارة %5"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_half
 msgid "WH Purchases -0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
 msgid "WH Purchases -0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_one
 msgid "WH Purchases -1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
 msgid "WH Purchases -1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_three
 msgid "WH Purchases -3% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
 msgid "WH Purchases -3% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_five
 msgid "WH Purchases -5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
 msgid "WH Purchases -5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_half
 msgid "WH Sales -0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_half
 msgid "WH Sales -0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_one
 msgid "WH Sales -1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_three
 msgid "WH Sales -3% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_five
 msgid "WH Sales -5% (Tax)"
 msgstr ""
 
@@ -2449,17 +2449,17 @@ msgid "WH Tax Expense"
 msgstr "مصروف ضريبة خصم المنبع "
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_one
 msgid "WH on Sales -1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_three
 msgid "WH on Sales -3% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_five
 msgid "WH on Sales -5% (Base)"
 msgstr ""
 
@@ -2559,102 +2559,102 @@ msgid "Withholding Tax -5%"
 msgstr "-ضرائب الصناعة و التجارة %5"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base
 msgid "Withholding Tax on Purchases (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax
 msgid "Withholding Tax on Purchases (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_half
 msgid "Withholding Tax on Purchases -0.5% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %0.5- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
 msgid "Withholding Tax on Purchases -0.5% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %0.5- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_one
 msgid "Withholding Tax on Purchases -1% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %1- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
 msgid "Withholding Tax on Purchases -1% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %1- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_three
 msgid "Withholding Tax on Purchases -3% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %3- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
 msgid "Withholding Tax on Purchases -3% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %3- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_five
 msgid "Withholding Tax on Purchases -5% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %5- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
 msgid "Withholding Tax on Purchases -5% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المشتريات %5- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base
 msgid "Withholding Tax on Sales (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax
 msgid "Withholding Tax on Sales (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_half
 msgid "Withholding Tax on Sales -0.5% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %0.5- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_half
 msgid "Withholding Tax on Sales -0.5% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %0.5- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_one
 msgid "Withholding Tax on Sales -1% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %1- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_one
 msgid "Withholding Tax on Sales -1% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %1- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_three
 msgid "Withholding Tax on Sales -3% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %3- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_three
 msgid "Withholding Tax on Sales -3% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %3- (ضريبة)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_five
 msgid "Withholding Tax on Sales -5% (Base)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %5- (اساسي)"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_five
 msgid "Withholding Tax on Sales -5% (Tax)"
 msgstr "ضريبة الصناعة و التجارة (خصم المنبع) على المبيعات %5- (ضريبة)"
 

--- a/addons/l10n_eg/i18n_extra/l10n_eg.pot
+++ b/addons/l10n_eg/i18n_extra/l10n_eg.pot
@@ -16,22 +16,22 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base_fourteen
 msgid "1. Standard Rated 14% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
 msgid "1. Standard Rated 14% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_fourteen
 msgid "1. VAT 14% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_fourteen
 msgid "1. VAT 14% (Tax)"
 msgstr ""
 
@@ -46,26 +46,26 @@ msgid "2. Withholding Tax"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_zero
 msgid "2. Zero Rated (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_zero
 msgid "2. Zero Rated (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_base_exempt
 msgid "3. Exempt Sales (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_sale_tax_exempt
 msgid "3. Exempt Sales (Tax)"
 msgstr ""
 
@@ -80,46 +80,46 @@ msgid "4. Other Taxes"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base_fourteen
 msgid "5. Standard Rated 14% Expenses (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
 msgid "5. Standard Rated 14% Expenses (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_fourteen
 msgid "5. VAT 14% Expenses (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_fourteen
 msgid "5. VAT 14% Expenses (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_zero
 msgid "6. Zero Rated (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_zero
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_zero
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_zero
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_zero
 msgid "6. Zero Rated (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_base_exempt
 msgid "7. Exempt Expenses (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_exempt
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_exempt
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax_exempt
+#: model:account.report.line,tag_name:l10n_eg.tax_report_vat_return_expense_tax_exempt
 msgid "7. Exempt Expenses (Tax)"
 msgstr ""
 
@@ -809,12 +809,12 @@ msgid "Name of this tax report"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net
 msgid "Net VAT Due"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net_3
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net_3
 msgid "Net VAT due (or reclaimed) for the period"
 msgstr ""
 
@@ -1188,142 +1188,142 @@ msgid "SCHD 8%"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
 msgid "SCHD Purchases 0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
 msgid "SCHD Purchases 0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
 msgid "SCHD Purchases 1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
 msgid "SCHD Purchases 1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
 msgid "SCHD Purchases 10% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
 msgid "SCHD Purchases 10% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
 msgid "SCHD Purchases 15% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
 msgid "SCHD Purchases 15% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
 msgid "SCHD Purchases 30% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
 msgid "SCHD Purchases 30% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
 msgid "SCHD Purchases 5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
 msgid "SCHD Purchases 5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
 msgid "SCHD Purchases 8% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
 msgid "SCHD Purchases 8% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
 msgid "SCHD Sales 0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
 msgid "SCHD Sales 0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
 msgid "SCHD Sales 1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
 msgid "SCHD Sales 1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
 msgid "SCHD Sales 10% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
 msgid "SCHD Sales 10% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
 msgid "SCHD Sales 15% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
 msgid "SCHD Sales 15% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
 msgid "SCHD Sales 30% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
 msgid "SCHD Sales 30% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
 msgid "SCHD Sales 5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
 msgid "SCHD Sales 5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
 msgid "SCHD Sales 8% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
+#: model:account.report.line,tag_name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
 msgid "SCHD Sales 8% (Tax)"
 msgstr ""
 
@@ -1475,162 +1475,162 @@ msgid "Schedule Tax collected & payable"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base
 msgid "Schedule Tax on Purchases (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax
 msgid "Schedule Tax on Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_half
 msgid "Schedule Tax on Purchases 0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_half
 msgid "Schedule Tax on Purchases 0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_one
 msgid "Schedule Tax on Purchases 1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_one
 msgid "Schedule Tax on Purchases 1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_ten
 msgid "Schedule Tax on Purchases 10% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_ten
 msgid "Schedule Tax on Purchases 10% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_fifteen
 msgid "Schedule Tax on Purchases 15% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_fifteen
 msgid "Schedule Tax on Purchases 15% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_thirty
 msgid "Schedule Tax on Purchases 30% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_thirty
 msgid "Schedule Tax on Purchases 30% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_five
 msgid "Schedule Tax on Purchases 5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_five
 msgid "Schedule Tax on Purchases 5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_base_eight
 msgid "Schedule Tax on Purchases 8% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_purchase_tax_eight
 msgid "Schedule Tax on Purchases 8% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base
 msgid "Schedule Tax on Sales (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax
 msgid "Schedule Tax on Sales (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_half
 msgid "Schedule Tax on Sales 0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_half
 msgid "Schedule Tax on Sales 0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_one
 msgid "Schedule Tax on Sales 1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_one
 msgid "Schedule Tax on Sales 1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_ten
 msgid "Schedule Tax on Sales 10% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_ten
 msgid "Schedule Tax on Sales 10% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_fifteen
 msgid "Schedule Tax on Sales 15% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_fifteen
 msgid "Schedule Tax on Sales 15% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_thirty
 msgid "Schedule Tax on Sales 30% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_thirty
 msgid "Schedule Tax on Sales 30% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_five
 msgid "Schedule Tax on Sales 5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_five
 msgid "Schedule Tax on Sales 5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_base_eight
 msgid "Schedule Tax on Sales 8% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
+#: model:account.report.line,name:l10n_eg.tax_report_schedule_tax_schedule_tax_sale_tax_eight
 msgid "Schedule Tax on Sales 8% (Tax)"
 msgstr ""
 
@@ -1719,46 +1719,46 @@ msgid "Stamp Tax 20%"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base
 msgid "Stamp Tax Purchases (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax
 msgid "Stamp Tax Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_base_purchase
 msgid "Stamp Tax Purchases 20% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_purchase_tax_tax_purchase
 msgid "Stamp Tax Purchases 20% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base
 msgid "Stamp Tax Sales (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax
 msgid "Stamp Tax Sales (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_base_sales
 msgid "Stamp Tax Sales 20% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
+#: model:account.report.line,name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
+#: model:account.report.line,tag_name:l10n_eg.tax_report_other_taxes_stamp_tax_tax_sales
 msgid "Stamp Tax Sales 20% (Tax)"
 msgstr ""
 
@@ -2206,12 +2206,12 @@ msgid "Templates for Taxes"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net_1
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net_1
 msgid "Total value of due tax for the period"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_net_2
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_net_2
 msgid "Total value of recoverable tax for the period"
 msgstr ""
 
@@ -2296,22 +2296,22 @@ msgid "VAT Receivable"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_base
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_base
 msgid "VAT on Expenses and all other Inputs (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_expense_tax
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_expense_tax
 msgid "VAT on Expenses and all other Inputs (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_base
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_base
 msgid "VAT on Sales and all other Outputs (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_vat_return_sale_tax
+#: model:account.report.line,name:l10n_eg.tax_report_vat_return_sale_tax
 msgid "VAT on Sales and all other Outputs (Tax)"
 msgstr ""
 
@@ -2377,67 +2377,67 @@ msgid "WH -5%"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_half
 msgid "WH Purchases -0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
 msgid "WH Purchases -0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_one
 msgid "WH Purchases -1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
 msgid "WH Purchases -1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_three
 msgid "WH Purchases -3% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
 msgid "WH Purchases -3% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_base_five
 msgid "WH Purchases -5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
 msgid "WH Purchases -5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_half
 msgid "WH Sales -0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_half
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_half
 msgid "WH Sales -0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_one
 msgid "WH Sales -1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_three
 msgid "WH Sales -3% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_tax_five
 msgid "WH Sales -5% (Tax)"
 msgstr ""
 
@@ -2449,17 +2449,17 @@ msgid "WH Tax Expense"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_one
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_one
 msgid "WH on Sales -1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_three
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_three
 msgid "WH on Sales -3% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_five
+#: model:account.report.line,tag_name:l10n_eg.tax_report_withholding_tax_sale_base_five
 msgid "WH on Sales -5% (Base)"
 msgstr ""
 
@@ -2559,102 +2559,102 @@ msgid "Withholding Tax -5%"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base
 msgid "Withholding Tax on Purchases (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax
 msgid "Withholding Tax on Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_half
 msgid "Withholding Tax on Purchases -0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_half
 msgid "Withholding Tax on Purchases -0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_one
 msgid "Withholding Tax on Purchases -1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_one
 msgid "Withholding Tax on Purchases -1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_three
 msgid "Withholding Tax on Purchases -3% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_three
 msgid "Withholding Tax on Purchases -3% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_base_five
 msgid "Withholding Tax on Purchases -5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_purchase_tax_five
 msgid "Withholding Tax on Purchases -5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base
 msgid "Withholding Tax on Sales (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax
 msgid "Withholding Tax on Sales (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_half
 msgid "Withholding Tax on Sales -0.5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_half
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_half
 msgid "Withholding Tax on Sales -0.5% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_one
 msgid "Withholding Tax on Sales -1% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_one
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_one
 msgid "Withholding Tax on Sales -1% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_three
 msgid "Withholding Tax on Sales -3% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_three
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_three
 msgid "Withholding Tax on Sales -3% (Tax)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_base_five
 msgid "Withholding Tax on Sales -5% (Base)"
 msgstr ""
 
 #. module: l10n_eg
-#: model:account.tax.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_five
+#: model:account.report.line,name:l10n_eg.tax_report_withholding_tax_sale_tax_five
 msgid "Withholding Tax on Sales -5% (Tax)"
 msgstr ""
 

--- a/addons/l10n_hu/i18n/hu.po
+++ b/addons/l10n_hu/i18n/hu.po
@@ -179,10 +179,10 @@ msgstr "12% Kompenzációs felár"
 #: model:account.tax,name:l10n_hu.1_F18 model:account.tax,name:l10n_hu.1_V18
 #: model:account.tax,name:l10n_hu.2_F18 model:account.tax,name:l10n_hu.2_V18
 #: model:account.tax.group,name:l10n_hu.tax_group_afa_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
 #: model:account.tax.template,description:l10n_hu.F18
 #: model:account.tax.template,description:l10n_hu.V18
 #: model:account.tax.template,name:l10n_hu.F18
@@ -264,10 +264,10 @@ msgstr "27% Szolgáltatások Közösségen belüli beszerzés"
 #: model:account.tax,name:l10n_hu.1_F27 model:account.tax,name:l10n_hu.1_V27
 #: model:account.tax,name:l10n_hu.2_F27 model:account.tax,name:l10n_hu.2_V27
 #: model:account.tax.group,name:l10n_hu.tax_group_afa_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
 #: model:account.tax.template,description:l10n_hu.F27
 #: model:account.tax.template,description:l10n_hu.V27
 #: model:account.tax.template,name:l10n_hu.F27
@@ -283,10 +283,10 @@ msgstr "27% ÁFA"
 #: model:account.tax,name:l10n_hu.1_F5 model:account.tax,name:l10n_hu.1_V5
 #: model:account.tax,name:l10n_hu.2_F5 model:account.tax,name:l10n_hu.2_V5
 #: model:account.tax.group,name:l10n_hu.tax_group_afa_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_afa_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_5
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_5
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_5
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_5
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_5
 #: model:account.tax.template,description:l10n_hu.F5
 #: model:account.tax.template,description:l10n_hu.V5
 #: model:account.tax.template,name:l10n_hu.F5
@@ -716,8 +716,8 @@ msgid "Compensation"
 msgstr "Kártérítés"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_komp
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_komp
+#: model:account.report.line,name:l10n_hu.tax_report_alap_komp
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_komp
 msgid "Compensation Surcharge"
 msgstr "Kompenzációs Felár"
 
@@ -1244,24 +1244,24 @@ msgid "Excipients"
 msgstr "Segédanyagok"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_koron_kivuli
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_koron_kivuli
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_koron_kivuli
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_koron_kivuli
 msgid "Exempt"
 msgstr "Mentes"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_targyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_targyi
 msgid "Exempt from material tax"
 msgstr "Mentes az anyagi adó alól"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_targyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_targyi
 msgid "Exempt from property tax"
 msgstr "Mentes az ingatlanadó alól"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_alanyi
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_alanyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_alanyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_alanyi
 msgid "Exempt from tax"
 msgstr "Adómentes"
 
@@ -1347,7 +1347,7 @@ msgid "Export sales revenue"
 msgstr "Export árbevétel"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_export
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_export
 msgid "Exports"
 msgstr "Export"
 
@@ -1869,7 +1869,7 @@ msgid "Impairment, unplanned depreciation"
 msgstr "Értékvesztés, nem tervezett értékcsökkenés"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_import
+#: model:account.report.line,name:l10n_hu.tax_report_alap_import
 msgid "Import"
 msgstr "Importálás"
 
@@ -1975,8 +1975,8 @@ msgid "Internal relocation"
 msgstr "Belső költöztetés"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_eu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_eu
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss
 msgid "Intra-community"
 msgstr "Közösségen belüli"
 
@@ -2638,8 +2638,8 @@ msgid "Partner outside the EU"
 msgstr "EU-n kívüli partner"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_base_pay
-#: model:account.tax.report.line,name:l10n_hu.tax_report_vat_pay
+#: model:account.report.line,name:l10n_hu.tax_report_base_pay
+#: model:account.report.line,name:l10n_hu.tax_report_vat_pay
 msgid "Payable"
 msgstr "Kifizetendő"
 
@@ -2947,8 +2947,8 @@ msgid "Recognized value of receivables sold, assigned (assigned)"
 msgstr "Eladott, engedményezett (engedményezett) követelések elismert értéke"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_base_rec
-#: model:account.tax.report.line,name:l10n_hu.tax_report_vat_rec
+#: model:account.report.line,name:l10n_hu.tax_report_base_rec
+#: model:account.report.line,name:l10n_hu.tax_report_vat_rec
 msgid "Recoverable"
 msgstr "Helyrehozható"
 
@@ -3075,7 +3075,7 @@ msgid "Reversal of impairment, unplanned depreciation"
 msgstr "Értékvesztés visszaírása, nem tervezett értékcsökkenés"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_forditott
+#: model:account.report.line,name:l10n_hu.tax_report_alap_forditott
 msgid "Reverse"
 msgstr "Fordított"
 
@@ -3341,7 +3341,7 @@ msgid "Suppliers"
 msgstr "Szállítók"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap
+#: model:account.report.line,name:l10n_hu.tax_report_alap
 msgid "Tax base"
 msgstr "Adó alap"
 
@@ -3491,7 +3491,7 @@ msgid "Use of provision (decrease, termination)"
 msgstr "Céltartalék felhasználása (csökkentés, megszüntetés)"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo
 msgid "VAT payable/recoverable"
 msgstr "Fizetendő/visszaigényelhető ÁFA"
 
@@ -3722,126 +3722,126 @@ msgid "Work in progress and semi-finished products"
 msgstr "Befejezetlen termelés és félkész termékek"
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_18
 msgid "base_pay_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_27
 msgid "base_pay_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_5
 msgid "base_pay_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_koron_kivuli
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_koron_kivuli
 msgid "base_pay_exempt"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_targyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_targyi
 msgid "base_pay_exempt_property"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_alanyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_alanyi
 msgid "base_pay_exempt_tax"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_export
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_export
 msgid "base_pay_exports"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_eu
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_eu
 msgid "base_pay_intra"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_18
 msgid "base_rec_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_27
 msgid "base_rec_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_5
 msgid "base_rec_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_komp
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_komp
 msgid "base_rec_compensation"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_koron_kivuli
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_koron_kivuli
 msgid "base_rec_exempt"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_targyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_targyi
 msgid "base_rec_exempt_material"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_alanyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_alanyi
 msgid "base_rec_exempt_tax"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_import
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_import
 msgid "base_rec_import"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss
 msgid "base_rec_intra"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_forditott
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_forditott
 msgid "base_rec_reverse"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_18
 msgid "vat_pay_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_27
 msgid "vat_pay_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_5
 msgid "vat_pay_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_18
 msgid "vat_rec_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_27
 msgid "vat_rec_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_5
 msgid "vat_rec_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_komp
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_komp
 msgid "vat_rec_compensation"
 msgstr ""

--- a/addons/l10n_hu/i18n/l10n_hu.pot
+++ b/addons/l10n_hu/i18n/l10n_hu.pot
@@ -179,10 +179,10 @@ msgstr ""
 #: model:account.tax,name:l10n_hu.1_F18 model:account.tax,name:l10n_hu.1_V18
 #: model:account.tax,name:l10n_hu.2_F18 model:account.tax,name:l10n_hu.2_V18
 #: model:account.tax.group,name:l10n_hu.tax_group_afa_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_18
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_18
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_18
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_18
 #: model:account.tax.template,description:l10n_hu.F18
 #: model:account.tax.template,description:l10n_hu.V18
 #: model:account.tax.template,name:l10n_hu.F18
@@ -264,10 +264,10 @@ msgstr ""
 #: model:account.tax,name:l10n_hu.1_F27 model:account.tax,name:l10n_hu.1_V27
 #: model:account.tax,name:l10n_hu.2_F27 model:account.tax,name:l10n_hu.2_V27
 #: model:account.tax.group,name:l10n_hu.tax_group_afa_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_27
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_27
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_27
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_27
 #: model:account.tax.template,description:l10n_hu.F27
 #: model:account.tax.template,description:l10n_hu.V27
 #: model:account.tax.template,name:l10n_hu.F27
@@ -283,10 +283,10 @@ msgstr ""
 #: model:account.tax,name:l10n_hu.1_F5 model:account.tax,name:l10n_hu.1_V5
 #: model:account.tax,name:l10n_hu.2_F5 model:account.tax,name:l10n_hu.2_V5
 #: model:account.tax.group,name:l10n_hu.tax_group_afa_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_afa_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_5
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_5
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_afa_5
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_5
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_5
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_5
 #: model:account.tax.template,description:l10n_hu.F5
 #: model:account.tax.template,description:l10n_hu.V5
 #: model:account.tax.template,name:l10n_hu.F5
@@ -710,8 +710,8 @@ msgid "Compensation"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_komp
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo_viss_komp
+#: model:account.report.line,name:l10n_hu.tax_report_alap_komp
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo_viss_komp
 msgid "Compensation Surcharge"
 msgstr ""
 
@@ -1229,24 +1229,24 @@ msgid "Excipients"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_koron_kivuli
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_koron_kivuli
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_koron_kivuli
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_koron_kivuli
 msgid "Exempt"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_targyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_targyi
 msgid "Exempt from material tax"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_targyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_targyi
 msgid "Exempt from property tax"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_alanyi
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss_alanyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_alanyi
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss_alanyi
 msgid "Exempt from tax"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgid "Export sales revenue"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_export
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_export
 msgid "Exports"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgid "Impairment, unplanned depreciation"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_import
+#: model:account.report.line,name:l10n_hu.tax_report_alap_import
 msgid "Import"
 msgstr ""
 
@@ -1934,8 +1934,8 @@ msgid "Internal relocation"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_fiz_eu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_viss
+#: model:account.report.line,name:l10n_hu.tax_report_alap_fiz_eu
+#: model:account.report.line,name:l10n_hu.tax_report_alap_viss
 msgid "Intra-community"
 msgstr ""
 
@@ -2591,8 +2591,8 @@ msgid "Partner outside the EU"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_base_pay
-#: model:account.tax.report.line,name:l10n_hu.tax_report_vat_pay
+#: model:account.report.line,name:l10n_hu.tax_report_base_pay
+#: model:account.report.line,name:l10n_hu.tax_report_vat_pay
 msgid "Payable"
 msgstr ""
 
@@ -2894,8 +2894,8 @@ msgid "Recognized value of receivables sold, assigned (assigned)"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_base_rec
-#: model:account.tax.report.line,name:l10n_hu.tax_report_vat_rec
+#: model:account.report.line,name:l10n_hu.tax_report_base_rec
+#: model:account.report.line,name:l10n_hu.tax_report_vat_rec
 msgid "Recoverable"
 msgstr ""
 
@@ -3022,7 +3022,7 @@ msgid "Reversal of impairment, unplanned depreciation"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap_forditott
+#: model:account.report.line,name:l10n_hu.tax_report_alap_forditott
 msgid "Reverse"
 msgstr ""
 
@@ -3283,7 +3283,7 @@ msgid "Suppliers"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_alap
+#: model:account.report.line,name:l10n_hu.tax_report_alap
 msgid "Tax base"
 msgstr ""
 
@@ -3428,7 +3428,7 @@ msgid "Use of provision (decrease, termination)"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,name:l10n_hu.tax_report_fizetndo
+#: model:account.report.line,name:l10n_hu.tax_report_fizetndo
 msgid "VAT payable/recoverable"
 msgstr ""
 
@@ -3659,126 +3659,126 @@ msgid "Work in progress and semi-finished products"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_18
 msgid "base_pay_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_27
 msgid "base_pay_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_afa_5
 msgid "base_pay_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_koron_kivuli
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_koron_kivuli
 msgid "base_pay_exempt"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_targyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_targyi
 msgid "base_pay_exempt_property"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_alanyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_alanyi
 msgid "base_pay_exempt_tax"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_export
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_export
 msgid "base_pay_exports"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_fiz_eu
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_fiz_eu
 msgid "base_pay_intra"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_18
 msgid "base_rec_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_27
 msgid "base_rec_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_5
 msgid "base_rec_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_komp
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_komp
 msgid "base_rec_compensation"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_koron_kivuli
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_koron_kivuli
 msgid "base_rec_exempt"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_targyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_targyi
 msgid "base_rec_exempt_material"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss_alanyi
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss_alanyi
 msgid "base_rec_exempt_tax"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_import
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_import
 msgid "base_rec_import"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_viss
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_viss
 msgid "base_rec_intra"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_alap_forditott
+#: model:account.report.line,tag_name:l10n_hu.tax_report_alap_forditott
 msgid "base_rec_reverse"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_18
 msgid "vat_pay_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_27
 msgid "vat_pay_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_5
 msgid "vat_pay_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_18
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_18
 msgid "vat_rec_18"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_27
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_27
 msgid "vat_rec_27"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_5
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_5
 msgid "vat_rec_5"
 msgstr ""
 
 #. module: l10n_hu
-#: model:account.tax.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_komp
+#: model:account.report.line,tag_name:l10n_hu.tax_report_fizetndo_viss_komp
 msgid "vat_rec_compensation"
 msgstr ""

--- a/addons/l10n_il/i18n/he_IL.po
+++ b/addons/l10n_il/i18n/he_IL.po
@@ -516,26 +516,26 @@ msgid "VAT 17%"
 msgstr "מע\"מ 17%"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_due
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_due
 msgid "VAT DUE"
 msgstr "מע\"מ לתשלום"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base_exempt
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base_exempt_title
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_base_exempt
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base_exempt
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base_exempt_title
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_base_exempt
 msgid "VAT Exempt Sales (BASE)"
 msgstr "הכנסות פטורות ממע\"מ"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance
 msgid "VAT INPUTS (TAX)"
 msgstr "מע\"מ תשומות"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_in_fa
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_in_fa_title
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_vat_in_fa
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_in_fa
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_in_fa_title
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_vat_in_fa
 msgid "VAT INPUTS (fixed assets)"
 msgstr "מע\"מ תשומות (רכוש קבוע)"
 
@@ -546,55 +546,55 @@ msgid "VAT Import Line"
 msgstr "שורת מע\"מ ייבוא"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_1_4
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_1_4
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_1_4
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_1_4
 #: model:account.tax.template,name:l10n_il.il_vat_inputs_1_4_17
 msgid "VAT Inputs 1/4"
 msgstr "מע\"מ תשומות 1/4"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_17
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_17
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_17
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_17
 msgid "VAT Inputs 17%"
 msgstr "מע\"מ תשומות 17%"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_2_3
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_2_3
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_2_3
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_2_3
 #: model:account.tax.template,name:l10n_il.il_vat_inputs_2_3_17
 msgid "VAT Inputs 2/3"
 msgstr "מע\"מ תשומות 2/3"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_pa_16
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_pa_16
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_pa_16
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_pa_16
 msgid "VAT Inputs PA 16%"
 msgstr "מע\"מ תשומות 16%"
 
 #. module: l10n_il
 #: model:account.account.template,name:l10n_il.il_account_111120
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_balance_pa
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_balance_pa
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_balance_pa
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_balance_pa
 #: model:account.tax.template,name:l10n_il.il_vat_pa_sales_17
 msgid "VAT PA Sales"
 msgstr "מע\"מ עסקאות- פלסטין"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base_title
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_base
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base_title
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_base
 msgid "VAT SALES (BASE)"
 msgstr "הכנסות חייבות במע\"מ"
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_sales_tax
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_sales_tax
 msgid "VAT SALES (TAX)"
 msgstr "מע\"מ עסקאות"
 
 #. module: l10n_il
 #: model:account.account.template,name:l10n_il.il_account_111110
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_balance
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_balance
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_balance
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_balance
 #: model:account.tax.template,name:l10n_il.il_vat_sales_17
 msgid "VAT Sales"
 msgstr "מע\"מ עסקאות"

--- a/addons/l10n_il/i18n/l10n_il.pot
+++ b/addons/l10n_il/i18n/l10n_il.pot
@@ -516,26 +516,26 @@ msgid "VAT 17%"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_due
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_due
 msgid "VAT DUE"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base_exempt
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base_exempt_title
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_base_exempt
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base_exempt
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base_exempt_title
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_base_exempt
 msgid "VAT Exempt Sales (BASE)"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance
 msgid "VAT INPUTS (TAX)"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_in_fa
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_in_fa_title
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_vat_in_fa
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_in_fa
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_in_fa_title
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_vat_in_fa
 msgid "VAT INPUTS (fixed assets)"
 msgstr ""
 
@@ -546,55 +546,55 @@ msgid "VAT Import Line"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_1_4
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_1_4
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_1_4
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_1_4
 #: model:account.tax.template,name:l10n_il.il_vat_inputs_1_4_17
 msgid "VAT Inputs 1/4"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_17
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_17
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_17
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_17
 msgid "VAT Inputs 17%"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_2_3
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_2_3
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_2_3
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_2_3
 #: model:account.tax.template,name:l10n_il.il_vat_inputs_2_3_17
 msgid "VAT Inputs 2/3"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_in_balance_pa_16
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_pa_16
+#: model:account.report.line,name:l10n_il.account_tax_report_line_in_balance_pa_16
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_in_balance_pa_16
 msgid "VAT Inputs PA 16%"
 msgstr ""
 
 #. module: l10n_il
 #: model:account.account.template,name:l10n_il.il_account_111120
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_balance_pa
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_balance_pa
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_balance_pa
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_balance_pa
 #: model:account.tax.template,name:l10n_il.il_vat_pa_sales_17
 msgid "VAT PA Sales"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_base_title
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_base
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_base_title
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_base
 msgid "VAT SALES (BASE)"
 msgstr ""
 
 #. module: l10n_il
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_vat_sales_tax
+#: model:account.report.line,name:l10n_il.account_tax_report_line_vat_sales_tax
 msgid "VAT SALES (TAX)"
 msgstr ""
 
 #. module: l10n_il
 #: model:account.account.template,name:l10n_il.il_account_111110
-#: model:account.tax.report.line,name:l10n_il.account_tax_report_line_out_balance
-#: model:account.tax.report.line,tag_name:l10n_il.account_tax_report_line_out_balance
+#: model:account.report.line,name:l10n_il.account_tax_report_line_out_balance
+#: model:account.report.line,tag_name:l10n_il.account_tax_report_line_out_balance
 #: model:account.tax.template,name:l10n_il.il_vat_sales_17
 msgid "VAT Sales"
 msgstr ""

--- a/addons/l10n_lu/i18n_extra/de.po
+++ b/addons/l10n_lu/i18n_extra/de.po
@@ -152,47 +152,47 @@ msgid "0-ST-G"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
 msgid "012 - Overall turnover"
 msgstr "012 - Gesamtumsatz"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
 msgstr "014 - Ausfuhren"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015 - Other exemptions"
 msgstr "015 - Andere Befreiungen"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
 msgstr "016 - Andere Befreiungen"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
 msgid "017"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
 msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
@@ -201,12 +201,12 @@ msgstr ""
 "Steuerlagers gemeinsam mit den Verbrauchsteuern erhoben wurde"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid "018"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
@@ -215,174 +215,174 @@ msgstr ""
 "Dreiecksgeschäften..."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019 - Supplies other than referred to in 018 and 423 or 424"
 msgstr "019 - Andere im Ausland getätigte (steuerpflichtige) Umsätze"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
 msgid "021 - Exemptions and deductible amounts"
 msgstr "021 - Steuerbefreiungen und abzugsfähige Beträge"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
 msgid "022 - Taxable turnover"
 msgstr "022 - Steuerpflichtiger Umsatz"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
 msgstr "031 - Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
 msgstr "033 - Besteuerungsgrundlage 0%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
 msgstr "037 - Steuerpflichtiger Umsatz: Aufteilung - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
 msgstr "040 - MwSt. 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
 msgstr "046 - Steuerpflichtiger Umsatz: Aufteilung - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
 msgstr "049 - Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
 msgstr "051 - Innergemeinschaftliche Erwerbe von Gegenständen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
 msgstr "054 - MwSt. 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
 msgid "056 - Intra-Community acquisitions of goods – tax"
 msgstr "056 - Innergemeinschaftliche Erwerbe von Gegenständen - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
 msgstr "059 - für Zwecke des Unternehmens: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063 - for non-business purposes: base 3%"
 msgstr "063 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
 msgid "065 - Importation of goods – base"
 msgstr "065 - Einfuhren von Gegenständen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
 msgstr "068 - für Zwecke des Unternehmens: MwSt. 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073 - for non-business purposes: tax 3%"
 msgstr "073 - für unternehmensfremde Zwecke: MwSt. 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
 msgid "076 - Total tax due"
 msgstr "076 - Gesamtbetrag der Steuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
 msgstr ""
 "090 - Erklärte Mehrwertsteuer für die Zuordnung von Gegenständen zu Zwecken "
 "des Unternehmens"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092 - Paid as joint and several guarantee"
 msgstr "092 - Als solidarisch haftender Bürge bezahlte MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
 msgid "093 - Total input tax"
 msgstr "093 - Gesamtbetrag Vorsteuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
 msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
@@ -391,7 +391,7 @@ msgstr ""
 "steuerfreien Umsätze"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
 msgid ""
 "095 - where the deductible proportion determined in accordance to article 50 "
 "is applied"
@@ -400,39 +400,39 @@ msgstr ""
 "Prorata-Regel"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid "096"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid ""
 "096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
 "56ter-2(7) (when applying the margin scheme)"
 msgstr "096 - Nicht abziehbare Vorsteuer in Anwendung von Art. 56ter-1/7 und 56ter-2/7 "
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
 msgstr "097 - Gesamtbetrag der nicht abziehbaren Vorsteuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
 msgid "102 - Total input tax deductible"
 msgstr "102 - Gesamtbetrag der abziehbaren Vorsteuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
 msgid "103 - Total tax due"
 msgstr "103 - Gesamtbetrag der Steuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
 msgid "104 - Total input tax deductible"
 msgstr "104 - Gesamtbetrag der abziehbaren Vorsteuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
 msgid "105 - Exceeding amount"
 msgstr "105 - Überschuss"
 
@@ -579,12 +579,12 @@ msgid "14-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152 - Acquisitions, in the context of triangular transactions – base"
 msgstr "152 - Im Rahmen von Dreiecksgeschäften getätigte Erwerbe - Besteuerungsgrundlage"
 
@@ -731,64 +731,64 @@ msgid "17-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194 - base exempt"
 msgstr "194 - Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
 msgstr "195 - für Zwecke des Unternehmens: Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
 msgstr "196 - für unternehmensfremde Zwecke: Besteuerungsgrundlage steuerbefreit"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid "226"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
 msgstr "226 - Im Rahmen der Sonderregelung von Artikel 56sexies getätigte Umsätze"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
 msgstr "227 - Sonderregelung zur Steueraussetzung: Berichtigung"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
 msgstr "228 - Berichtigte Steuer - Sonderregelung zur Steueraussetzung"
 
@@ -908,12 +908,12 @@ msgid "3-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
 msgid "407 - Importation of goods – tax"
 msgstr "407 - Einfuhren von Gegenständen - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
 msgid ""
 "409 - Supply of services for which the customer is liable for the payment of "
 "VAT – base"
@@ -922,7 +922,7 @@ msgstr ""
 " - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
 msgid ""
 "410 - Supply of services for which the customer is liable for the payment of "
 "VAT – tax"
@@ -931,24 +931,24 @@ msgstr ""
 " - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid "419"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of VAT"
 msgstr ""
 "419 - Umsätze im Inland, für die der Empfänger Steuerschuldner ist"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid "423"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
@@ -956,100 +956,100 @@ msgstr ""
 "Zwecke der MwSt. erfasst und Steuerschuldner ist, nicht steuerbefreit sind"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
 msgstr ""
 "424 - Dienstleistungen, die im Mitgliedstaat des Empfängers, "
 "der dort für Zwecke der MwSt. erfasst ist, steuerbefreit sind"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
 msgstr "431 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
 msgstr "432 - nicht steuerbefreit im Inland: MwSt. 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435 - exempt within the territory: exempt"
 msgstr "435 - steuerbefreit im Inland: steuerbefreit"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
 msgid "436 - base"
 msgstr "436 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
 msgstr ""
 "441 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
 msgstr ""
 "442 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: MwSt. 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
 msgstr ""
 "445 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: steuerbefreit"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
 msgstr "454 - Gesamtbetrag der Entgelte"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid "455"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
@@ -1057,22 +1057,22 @@ msgstr ""
 "unternehmensfremde Zwecke"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
 msgstr "456 - Erbringung von Dienstleistungen für unternehmensfremde Zwecke"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid "457"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid ""
 "457 - Intra-Community supply of goods to persons identified for VAT purposes "
 "in another Member State (MS)"
@@ -1081,207 +1081,207 @@ msgstr ""
 "einem anderen Mitgliedstaat besitzen"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
 msgstr "458 - Von anderen Steuerpflichtigen für Warenlieferungen und "
 "Dienstleistungen in Rechnung gestellte Mehrwertsteuer"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
 msgstr ""
 "459 - Erklärte oder bezahlte Mehrwertsteuer für innergemeinschaftliche "
 "Erwerbe von Gegenständen"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
 msgstr "460 - Erklärte oder bezahlte Mehrwertsteuer für eingeführte Waren"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461 - Due under the reverse charge (see points II.E and F)"
 msgstr "461 - Als Schuldner erklärte Mehrwertsteuer (Siehe Punkte II.E und F)"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
 msgid "462 - tax"
 msgstr "462 - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
 msgid "463 - base"
 msgstr "463 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
 msgid "464 - tax"
 msgstr "464 - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid "471"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
 msgstr "471 - Telekommunikationsdienstleistungen, Rundfunk- und Fernsehdienstleistungen..."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
 msgid "472 - Other sales / receipts"
 msgstr "472 - Andere Umsätze / Erträge"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701 - base 17%"
 msgstr "701 - Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
 msgstr "702 - MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703 - base 14%"
 msgstr "703 - Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
 msgstr "704 - MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705 - base 8%"
 msgstr "705 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
 msgstr "706 - MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711 - base 17%"
 msgstr "711 - Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
 msgstr "712 - MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713 - base 14%"
 msgstr "713 - Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
 msgstr "714 - MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715 - base 8%"
 msgstr "715 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
 msgstr "716 - MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid "719"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid ""
 "719 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
@@ -1290,72 +1290,72 @@ msgstr ""
 "gemeinsam mit den Verbrauchsteuern erhoben wird"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
 msgstr "721 - für Zwecke des Unternehmens: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
 msgstr "722 - für Zwecke des Unternehmens: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
 msgstr "723 - für Zwecke des Unternehmens: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
 msgstr "724 - für Zwecke des Unternehmens: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
 msgstr "725 - für Zwecke des Unternehmens: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
 msgstr "726 - für Zwecke des Unternehmens: MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
 msgid "729"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
 msgid ""
 "729 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
@@ -1364,251 +1364,251 @@ msgstr ""
 "gemeinsam mit den Verbrauchsteuern erhoben wird"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
 msgstr "731 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
 msgstr "732 - für unternehmensfremde Zwecke: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
 msgstr "733 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
 msgstr "734 - für unternehmensfremde Zwecke: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
 msgstr "735 - für unternehmensfremde Zwecke: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
 msgstr "736 - für unternehmensfremde Zwecke: MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
 msgstr "741 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
 msgstr "742 - nicht steuerbefreit im Inland: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
 msgstr "743 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
 msgstr "744 - nicht steuerbefreit im Inland: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
 msgstr "745 - nicht steuerbefreit im Inland: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
 msgstr "746 - nicht steuerbefreit im Inland: MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
 msgstr ""
 "751 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
 msgstr ""
 "752 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
 msgstr ""
 "753 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
 msgstr ""
 "754 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: MwSt. 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
 msgstr ""
 "755 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
 msgstr "756 - erbracht an den Erklärenden von Steuerpflichtigen, die nicht "
 "in der Gemeinschaft ansässig sind: MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
 msgstr ""
 "761 - erbracht an den Erklärenden von im Inland ansässigen Steuerpflichtigen: "
 "Besteuerungsgrundlage 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
 msgstr "762 - erbracht an den Erklärenden von im Inland ansässigen "
 "Steuerpflichtigen: MwSt. 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
 msgstr "763 - Besteuerungsgrundlage 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764 - tax 8%"
 msgstr "764 - MwSt. 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
 msgid "765 - base"
 msgstr "765 - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
 msgid "766 - tax"
 msgstr "766 - MwSt."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
 msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
@@ -1616,7 +1616,7 @@ msgstr ""
 "767 -Vom Erwerber als Steuerschuldner zu erklärende Lieferungen - Besteuerungsgrundlage"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
 msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
@@ -3777,17 +3777,17 @@ msgid "Heating, gas, electricity"
 msgstr "Heizung, Gas, Strom"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1_assessment_taxable_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1_assessment_taxable_turnover
 msgid "I. ASSESSMENT OF TAXABLE TURNOVER"
 msgstr "I. BERECHNUNG DES STEUERPFLICHTIGEN UMSATZES"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2_assesment_of_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2_assesment_of_tax_due
 msgid "II. ASSESSMENT OF TAX DUE (output tax)"
 msgstr "II. BERECHNUNG DER STEUER"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
 msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
 msgstr "III. BERECHNUNG DER ABZIEHBAREN VORSTEUER"
 
@@ -3808,7 +3808,7 @@ msgid "IT services"
 msgstr "IT - Instandhaltung"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
 msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
 msgstr "IV. BERECHNUNG DES ÜBERSCHUSSES"
 

--- a/addons/l10n_lu/i18n_extra/fr.po
+++ b/addons/l10n_lu/i18n_extra/fr.po
@@ -152,47 +152,47 @@ msgid "0-ST-G"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
 msgid "012 - Overall turnover"
 msgstr "012 - Chiffre d'affaires global"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
 msgstr "014 - Exportations"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015 - Other exemptions"
 msgstr "015 - Autres exonérations"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
 msgstr "016 - Autres exonérations"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
 msgid "017"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
 msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
@@ -201,12 +201,12 @@ msgstr ""
 "à la sortie de l'entrepôt fiscal..."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid "018"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
@@ -215,172 +215,172 @@ msgstr ""
 "triangulaires…"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019 - Supplies other than referred to in 018 and 423 or 424"
 msgstr "019 - Autres opérations réalisées (imposables) à l'étranger"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
 msgid "021 - Exemptions and deductible amounts"
 msgstr "021 - Exonérations et montants déductibles"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
 msgid "022 - Taxable turnover"
 msgstr "022 - Chiffre d'affaires imposable"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
 msgstr "031 - base 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
 msgstr "033 - base 0%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
 msgstr "037 - Chiffre d'affaires imposable – base"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
 msgstr "040 - taxe 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
 msgstr "046 - Chiffre d'affaires imposable – taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
 msgstr "049 - base 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
 msgstr "051 - Acquisitions intracommunautaires de biens - base"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
 msgstr "054 - taxe 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
 msgid "056 - Intra-Community acquisitions of goods – tax"
 msgstr "056 - Acquisitions intracommunautaires de biens - taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
 msgstr "059 - à des fins de l'entreprise: base 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063 - for non-business purposes: base 3%"
 msgstr "063 - à des fins étrangères à l'entreprise: base 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
 msgid "065 - Importation of goods – base"
 msgstr "065 - Importations de biens - base"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
 msgstr "068 - à des fins de l'entreprise: taxe de 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073 - for non-business purposes: tax 3%"
 msgstr "073 - à des fins étrangères à l'entreprise: taxe de 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
 msgid "076 - Total tax due"
 msgstr "076 - Total de la taxe en aval"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
 msgstr "090 - Taxe déclarée pour l'affectation de biens à l'entreprise"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092 - Paid as joint and several guarantee"
 msgstr "092 - Taxe acquittée comme caution solidaire"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
 msgid "093 - Total input tax"
 msgstr "093 - Total de la taxe en amont"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
 msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
@@ -389,7 +389,7 @@ msgstr ""
 "des articles 44 et 56quater"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
 msgid ""
 "095 - where the deductible proportion determined in accordance to article 50 "
 "is applied"
@@ -397,12 +397,12 @@ msgstr ""
 "095 - Taxe non déductible en application du prorata visé à l'article 50"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid "096"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid ""
 "096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
 "56ter-2(7) (when applying the margin scheme)"
@@ -412,27 +412,27 @@ msgstr ""
 "bénéficiaire)"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
 msgstr "097 - Total de la taxe en amont non déductible"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
 msgid "102 - Total input tax deductible"
 msgstr "102 - Total de la taxe en amont déductible"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
 msgid "103 - Total tax due"
 msgstr "103 - Total de la taxe en aval"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
 msgid "104 - Total input tax deductible"
 msgstr "104 - Total de la taxe en amont déductible"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
 msgid "105 - Exceeding amount"
 msgstr "105 - Excédent"
 
@@ -579,12 +579,12 @@ msgid "14-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152 - Acquisitions, in the context of triangular transactions – base"
 msgstr "152 - Acquisitions triangulaires – base"
 
@@ -731,42 +731,42 @@ msgid "17-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194 - base exempt"
 msgstr "194 - base exonérée"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
 msgstr "195 - à des fins de l'entreprise: base exonérée"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
 msgstr "196 - à des fins étrangères à l'entreprise: base exonérée"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid "226"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
@@ -775,22 +775,22 @@ msgstr ""
 "56sexies"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
 msgstr "227 - Régime particulier suspensif: régularisation"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
 msgstr "228 - Taxe régularisée - régime particulier suspensif"
 
@@ -910,12 +910,12 @@ msgid "3-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
 msgid "407 - Importation of goods – tax"
 msgstr "407 - Importations de biens - taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
 msgid ""
 "409 - Supply of services for which the customer is liable for the payment of "
 "VAT – base"
@@ -924,7 +924,7 @@ msgstr ""
 "- base"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
 msgid ""
 "410 - Supply of services for which the customer is liable for the payment of "
 "VAT – tax"
@@ -933,142 +933,142 @@ msgstr ""
 "- taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid "419"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of VAT"
 msgstr ""
 "419 - Opérations à l'intérieur du pays pour lesquelles le preneur est le redevable"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid "423"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
 "423 - Prestations de services non exonérées dans l'Etat membre du preneur redevable"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
 msgstr "424 - Prestations de services exonérées dans l'Etat membre du preneur"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
 msgstr "431 - non exonérées à l'intérieur du pays: base 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
 msgstr "432 - non exonérées à l'intérieur du pays: tax 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435 - exempt within the territory: exempt"
 msgstr "435 - exonérées à l'intérieur du pays: exonérées"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
 msgid "436 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
 msgstr "441 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: base 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
 msgstr "442 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: tax 3%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
 msgstr "445 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: exonérées"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
 msgstr "454 - Total Ventes / Recettes"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid "455"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
 "455 - Application de biens de l'utilisation privée et à des fins de l'entreprise"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
 msgstr "456 - Prestations de services effectuées à des fins étrangères à "
 "l'entreprise"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid "457"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid ""
 "457 - Intra-Community supply of goods to persons identified for VAT purposes "
 "in another Member State (MS)"
@@ -1077,67 +1077,67 @@ msgstr ""
 "la TVA dans un autre État membre"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
 msgstr "458 - Taxe facturée par d'autres assujettis pour des biens et des services fournis"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
 msgstr "459 - Taxe déclarée ou payée sur des acquisitions intracommunautaires de biens"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
 msgstr "460 - Taxe déclarée ou payée sur des biens importés"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461 - Due under the reverse charge (see points II.E and F)"
 msgstr "461 - Taxe déclarée comme débiteur (cf points II.E et F)"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
 msgid "462 - tax"
 msgstr "462 - taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
 msgid "463 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
 msgid "464 - tax"
 msgstr "464 - taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid "471"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
@@ -1145,137 +1145,137 @@ msgstr ""
 "471 - Prestations de services de télécom., de radio et de tv..."
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
 msgid "472 - Other sales / receipts"
 msgstr "472 - Autres Ventes / Recettes"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
 msgstr "702 - taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703 - base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
 msgstr "704 - taxe 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
 msgstr "706 - taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
 msgstr "712 - taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713 - base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
 msgstr "714 - taxe 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
 msgstr "716 - taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid "719"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid ""
 "719 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
@@ -1284,72 +1284,72 @@ msgstr ""
 "l'entrepôt fiscal conjointement avec les accises"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
 msgstr "721 - à des fins de l'entreprise: base 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
 msgstr "722 - à des fins de l'entreprise: taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
 msgstr "723 - à des fins de l'entreprise: base 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
 msgstr "724 - à des fins de l'entreprise: taxe 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
 msgstr "725 - à des fins de l'entreprise: base 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
 msgstr "726 - à des fins de l'entreprise: taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
 msgid "729"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
 msgid ""
 "729 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
@@ -1358,245 +1358,245 @@ msgstr ""
 "l'entrepôt fiscal conjointement avec les accises"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
 msgstr "731 - à des fins étrangères à l'entreprise: base 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
 msgstr "732 - à des fins étrangères à l'entreprise: taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
 msgstr "733 - à des fins étrangères à l'entreprise: base 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
 msgstr "734 - à des fins étrangères à l'entreprise: taxe 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
 msgstr "735 - à des fins étrangères à l'entreprise: base 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
 msgstr "736 - à des fins étrangères à l'entreprise: taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
 msgstr "741 - non exonérées à l'intérieur du pays: base 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
 msgstr "742 - non exonérées à l'intérieur du pays: taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
 msgstr "743 - non exonérées à l'intérieur du pays: base 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
 msgstr "744 - non exonérées à l'intérieur du pays: taxe 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
 msgstr "745 - non exonérées à l'intérieur du pays: base 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
 msgstr "746 - non exonérées à l'intérieur du pays: taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
 msgstr "751 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: base 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
 msgstr "752 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
 msgstr "753 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: base 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
 msgstr "754 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: taxe 14%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
 msgstr "755 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: base 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
 msgstr "756 - effectuées au déclarant par des assujettis établis en dehors "
 "de la Communauté: taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
 msgstr "761 - effectuées au déclarant par des assujettis établis "
 "à l'intérieur du pays: base 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
 msgstr "762 - effectuées au déclarant par des assujettis établis "
 "à l'intérieur du pays: taxe 17%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764 - tax 8%"
 msgstr "764 - taxe 8%"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
 msgid "765 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
 msgid "766 - tax"
 msgstr "766 - taxe"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
 msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
@@ -1604,7 +1604,7 @@ msgstr ""
 "767 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - base"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
 msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
@@ -3747,17 +3747,17 @@ msgid "Heating, gas, electricity"
 msgstr "Chauffage, gaz, électricité"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1_assessment_taxable_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1_assessment_taxable_turnover
 msgid "I. ASSESSMENT OF TAXABLE TURNOVER"
 msgstr "I. CALCUL DU CHIFFRE D'AFFAIRES IMPOSABLE"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2_assesment_of_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2_assesment_of_tax_due
 msgid "II. ASSESSMENT OF TAX DUE (output tax)"
 msgstr "II. CALCUL DE LA TAXE DUE (taxe en aval)"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
 msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
 msgstr "III. CALCUL DE LA TAXE DEDUCTIBLE (taxe en amont)"
 
@@ -3778,7 +3778,7 @@ msgid "IT services"
 msgstr "Services informatiques"
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
 msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
 msgstr "IV. CALCUL DE L'EXCEDENT"
 

--- a/addons/l10n_lu/i18n_extra/l10n_lu.pot
+++ b/addons/l10n_lu/i18n_extra/l10n_lu.pot
@@ -151,277 +151,277 @@ msgid "0-ST-G"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
 msgid "012 - Overall turnover"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015 - Other exemptions"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
 msgid "017"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
 msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid "018"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
 msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid "019 - Supplies other than referred to in 018 and 423 or 424"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
 msgid "021 - Exemptions and deductible amounts"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
 msgid "022 - Taxable turnover"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
 msgid "056 - Intra-Community acquisitions of goods – tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063 - for non-business purposes: base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
 msgid "065 - Importation of goods – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073 - for non-business purposes: tax 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
 msgid "076 - Total tax due"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092 - Paid as joint and several guarantee"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
 msgid "093 - Total input tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
 msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
 msgid ""
 "095 - where the deductible proportion determined in accordance to article 50"
 " is applied"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid "096"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
 msgid ""
 "096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
 "56ter-2(7) (when applying the margin scheme)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
 msgid "102 - Total input tax deductible"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
 msgid "103 - Total tax due"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
 msgid "104 - Total input tax deductible"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
 msgid "105 - Exceeding amount"
 msgstr ""
 
@@ -568,12 +568,12 @@ msgid "14-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152 - Acquisitions, in the context of triangular transactions – base"
 msgstr ""
 
@@ -720,64 +720,64 @@ msgid "17-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194 - base exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid "226"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
 msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
 msgstr ""
 
@@ -897,675 +897,675 @@ msgid "3-S-S"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
 msgid "407 - Importation of goods – tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
 msgid ""
 "409 - Supply of services for which the customer is liable for the payment of"
 " VAT – base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
 msgid ""
 "410 - Supply of services for which the customer is liable for the payment of"
 " VAT – tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid "419"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
 msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of "
 "VAT"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid "423"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435 - exempt within the territory: exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
 msgid "436 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid "455"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid "457"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
 msgid ""
 "457 - Intra-Community supply of goods to persons identified for VAT purposes"
 " in another Member State (MS)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461 - Due under the reverse charge (see points II.E and F)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
 msgid "462 - tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
 msgid "463 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
 msgid "464 - tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid "471"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
 msgid "472 - Other sales / receipts"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703 - base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711 - base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713 - base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid "719"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
 msgid ""
 "719 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
 msgid "729"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
 msgid ""
 "729 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
+#: model:account.report.line,tag_name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764 - tax 8%"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
 msgid "765 - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
 msgid "766 - tax"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
 msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
 msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
@@ -3678,17 +3678,17 @@ msgid "Heating, gas, electricity"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_1_assessment_taxable_turnover
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_1_assessment_taxable_turnover
 msgid "I. ASSESSMENT OF TAXABLE TURNOVER"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_2_assesment_of_tax_due
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_2_assesment_of_tax_due
 msgid "II. ASSESSMENT OF TAX DUE (output tax)"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
 msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
 msgstr ""
 
@@ -3709,7 +3709,7 @@ msgid "IT services"
 msgstr ""
 
 #. module: l10n_lu
-#: model:account.tax.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
+#: model:account.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
 msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
 msgstr ""
 

--- a/addons/l10n_sa/i18n_extra/ar.po
+++ b/addons/l10n_sa/i18n_extra/ar.po
@@ -809,157 +809,157 @@ msgid "VAT Filing Report"
 msgstr "الإقرار الضريبي"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
 msgid "VAT on Sales and all other Outputs (Base)"
 msgstr "ضريبة القيمة المضافة على المبيعات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_base
 msgid "1. Standard Rated 15% (Base)"
 msgstr "1. المبيعات الخاضعة لنسبة أساسية (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
 msgid "2. Special Sales to Locals (Base)"
 msgstr "2. المبيعات للمواطنين (الخدمات الصحية  الخاصة/التعليم الأهلي الخاص) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
 msgid "3. Local Sales Subject to 0% (Base)"
 msgstr "3. المبيعات المحلية الخاضعة للنسبة الصفرية (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_export_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_base
 msgid "4. Export Sales (Base)"
 msgstr "4. الصادرات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
 msgid "5. Exempt Sales (Base)"
 msgstr "5. المبيعات معفاة من الضريبة (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_base
 msgid "6. Net Sales (Base)"
 msgstr "6. إجمالي المبيعات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
 msgid "VAT on Expenses and all other Inputs (Base)"
 msgstr "ضريبة القيمة المضافة على المشتريات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
 msgid "7. Standard rated 15% Purchases (Base)"
 msgstr "7. ضريبة القيمة المضافة على المشتريات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
 msgid "8. Taxable Imports 15% Paid to Customs (Base)"
 msgstr "8. الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك 15 % (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
 msgid "9. Imports subject to reverse charge mechanism (Base)"
 msgstr "9. الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب العكس (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
 msgid "10. Zero Rated Purchases (Base)"
 msgstr "10. المشتريات الخاضعة للنسبة الصفرية (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
 msgid "11. Exempt Purchases (Base)"
 msgstr "11. المشتريات معفاة من الضريبة (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_base
 msgid "12. Net Purchases (Base)"
 msgstr "12. إجمالي المشتريات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
 msgid "VAT on Sales and all other Outputs (Tax)"
 msgstr "ضريبة القيمة المضافة على المبيعات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_tax
 msgid "1. Standard Rated 15% (Tax)"
 msgstr "1. المبيعات الخاضعة لنسبة أساسية (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
 msgid "2. Special Sales to Locals (Tax)"
 msgstr "2. المبيعات للمواطنين (الخدمات الصحية  الخاصة/التعليم الأهلي الخاص) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
 msgid "3. Local Sales Subject to 0% (Tax)"
 msgstr "3. المبيعات المحلية الخاضعة للنسبة الصفرية (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_export_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_tax
 msgid "4. Export Sales (Tax)"
 msgstr "4. الصادرات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
 msgid "5. Exempt Sales (Tax)"
 msgstr "5. المبيعات معفاة من الضريبة (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_tax
 msgid "6. Net Sales (Tax)"
 msgstr "6. إجمالي المبيعات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
 msgid "VAT on Expenses and all other Inputs (Tax)"
 msgstr "ضريبة القيمة المضافة على المشتريات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
 msgid "7. Standard rated 15% Purchases (Tax)"
 msgstr "7. ضريبة القيمة المضافة على المشتريات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
 msgid "8. Taxable Imports 15% Paid to Customs (Tax)"
 msgstr "8. الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك 15 % (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
 msgid "9. Imports subject to reverse charge mechanism (Tax)"
 msgstr "9. الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب العكس (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_tax
 msgid "10. Zero Rated Purchases (Tax)"
 msgstr "10. المشتريات الخاضعة للنسبة الصفرية (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_tax
 msgid "11. Exempt Purchases (Tax)"
 msgstr "11. المشتريات معفاة من الضريبة (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_tax
 msgid "12. Net Purchases (Tax)"
 msgstr "12. إجمالي المشتريات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_vat_due
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due
 msgid "Net VAT Due"
 msgstr "صافي الضريبة المستحق"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
+#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
 msgid "Total value of due tax for the period"
 msgstr "إجمالي ضريبة القيمة المستحقة للفترة الحالية"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_vat_due_or_reclaimed_for_the_period
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due_or_reclaimed_for_the_period
 msgid "Net VAT due (or reclaimed) for the period"
 msgstr "ضرريبة القيمة المضافة التي تم ترحيلها من الفترة / الفترات السابقة"
 
@@ -969,152 +969,152 @@ msgid "Withholding Tax Report"
 msgstr "تقرير استقطاع الضريبة"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
 msgid "Withholding Tax on Purchased Services (Base)"
 msgstr "استقطاع الضريبة على الخدمات المشتراة (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
 msgid "Withholding Tax 5% (Rental) (Base)"
 msgstr " استقطاع الضريبة 5 % (إيجار) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
 msgid "Withholding Tax 5% (Tickets or Air Freight) (Base)"
 msgstr " استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
 msgid "Withholding Tax 5% (Tickets or Sea Freight)(Base)"
 msgstr " استقطاع الضريبة 5 % (تذاكر أو شحن بحري) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
 msgid "Withholding Tax 5% (International Telecommunication)(Base)"
 msgstr " استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
 msgid "Withholding Tax 5% (Distributed Profits) (Base)"
 msgstr " استقطاع الضريبة 5 % (أرباح موزعة) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
 msgid "Withholding Tax 5% (Consulting and Technical) (Base)"
 msgstr " استقطاع الضريبة 5 % (خدمات فنية أو استشارية) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
 msgid "Withholding Tax 5% (Return from Loans) (Base)"
 msgstr " استقطاع الضريبة 5 % (عوائد قروض) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
 msgid "Withholding Tax 5% (Insurance & Reinsurance) (Base)"
 msgstr " استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
 msgid "Withholding Tax 15% (Royalties)(Base)"
 msgstr " استقطاع الضريبة 15 % (أتاوة أو ريع) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
 msgid "Withholding Tax 15% (Paid Services from Main Branch)(Base)"
 msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة للمركز الرئيسي) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
 msgid "Withholding Tax 15% (Paid Services from another branch)(Base)"
 msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة لشركة مرتبطة) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_base
 msgid "Withholding Tax 15% (Others)(Base)"
 msgstr " استقطاع الضريبة 15 % (لأي دفعات أخرى) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
 msgid "Withholding Tax 20% (Managerial)(Base)"
 msgstr " استقطاع الضريبة 20 % (أتعاب إدارة) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
 msgid "Withholding Tax Total (Base)"
 msgstr "إجمالي استقطاع الضريبة (أساسي)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
 msgid "Withholding Tax on Purchased Services (Tax)"
 msgstr "استقطاع الضريبة على الخدمات المشتراة (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
 msgid "Withholding Tax 5% (Rental) (Tax)"
 msgstr " استقطاع الضريبة 5 % (إيجار) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
 msgid "Withholding Tax 5% (Tickets or Air Freight) (Tax)"
 msgstr " استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
 msgid "Withholding Tax 5% (Tickets or Sea Freight)(Tax)"
 msgstr " استقطاع الضريبة 5 % (تذاكر أو شحن بحري) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
 msgid "Withholding Tax 5% (International Telecommunication)(Tax)"
 msgstr " استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
 msgid "Withholding Tax 5% (Distributed Profits) (Tax)"
 msgstr " استقطاع الضريبة 5 % (أرباح موزعة) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
 msgid "Withholding Tax 5% (Consulting and Technical) (Tax)"
 msgstr " استقطاع الضريبة 5 % (خدمات فنية أو استشارية) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
 msgid "Withholding Tax 5% (Return from Loans) (Tax)"
 msgstr " استقطاع الضريبة 5 % (عوائد قروض) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
 msgid "Withholding Tax 5% (Insurance & Reinsurance) (Tax)"
 msgstr " استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
 msgid "Withholding Tax 15% (Royalties)(Tax)"
 msgstr " استقطاع الضريبة 15 % (أتاوة أو ريع) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax
 msgid "Withholding Tax 15% (Paid Services from Main Branch)(Tax)"
 msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة للمركز الرئيسي) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax
 msgid "Withholding Tax 15% (Paid Services from another branch)(Tax)"
 msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة لشركة مرتبطة) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
 msgid "Withholding Tax 15% (Others)(Tax)"
 msgstr " استقطاع الضريبة 15 % (لأي دفعات أخرى) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_tax
 msgid "Withholding Tax 20% (Managerial)(Tax)"
 msgstr " استقطاع الضريبة 20 % (أتعاب إدارة) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_tax
 msgid "Withholding Tax Total (Tax)"
 msgstr "إجمالي استقطاع الضريبة (ضريبة)"
 

--- a/addons/l10n_sa/i18n_extra/l10n_sa.pot
+++ b/addons/l10n_sa/i18n_extra/l10n_sa.pot
@@ -809,157 +809,157 @@ msgid "VAT Filing Report"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
 msgid "VAT on Sales and all other Outputs (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_base
 msgid "1. Standard Rated 15% (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
 msgid "2. Special Sales to Locals (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
 msgid "3. Local Sales Subject to 0% (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_export_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_base
 msgid "4. Export Sales (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
 msgid "5. Exempt Sales (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_sales_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_base
 msgid "6. Net Sales (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
 msgid "VAT on Expenses and all other Inputs (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
 msgid "7. Standard rated 15% Purchases (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
 msgid "8. Taxable Imports 15% Paid to Customs (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
 msgid "9. Imports subject to reverse charge mechanism (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
 msgid "10. Zero Rated Purchases (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
 msgid "11. Exempt Purchases (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_purchases_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_base
 msgid "12. Net Purchases (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
 msgid "VAT on Sales and all other Outputs (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_tax
 msgid "1. Standard Rated 15% (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
 msgid "2. Special Sales to Locals (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
 msgid "3. Local Sales Subject to 0% (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_export_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_tax
 msgid "4. Export Sales (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
 msgid "5. Exempt Sales (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_sales_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_tax
 msgid "6. Net Sales (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
 msgid "VAT on Expenses and all other Inputs (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
 msgid "7. Standard rated 15% Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
 msgid "8. Taxable Imports 15% Paid to Customs (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
 msgid "9. Imports subject to reverse charge mechanism (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_tax
 msgid "10. Zero Rated Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_exempt_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_tax
 msgid "11. Exempt Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_purchases_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_tax
 msgid "12. Net Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_vat_due
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due
 msgid "Net VAT Due"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
+#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
 msgid "Total value of due tax for the period"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_net_vat_due_or_reclaimed_for_the_period
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due_or_reclaimed_for_the_period
 msgid "Net VAT due (or reclaimed) for the period"
 msgstr ""
 
@@ -969,152 +969,152 @@ msgid "Withholding Tax Report"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
 msgid "Withholding Tax on Purchased Services (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
 msgid "Withholding Tax 5% (Rental) (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
 msgid "Withholding Tax 5% (Tickets or Air Freight) (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
 msgid "Withholding Tax 5% (Tickets or Sea Freight)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
 msgid "Withholding Tax 5% (International Telecommunication)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
 msgid "Withholding Tax 5% (Distributed Profits) (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
 msgid "Withholding Tax 5% (Consulting and Technical) (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
 msgid "Withholding Tax 5% (Return from Loans) (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
 msgid "Withholding Tax 5% (Insurance & Reinsurance) (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
 msgid "Withholding Tax 15% (Royalties)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
 msgid "Withholding Tax 15% (Paid Services from Main Branch)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
 msgid "Withholding Tax 15% (Paid Services from another branch)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_base
 msgid "Withholding Tax 15% (Others)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
 msgid "Withholding Tax 20% (Managerial)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
 msgid "Withholding Tax Total (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
 msgid "Withholding Tax on Purchased Services (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
 msgid "Withholding Tax 5% (Rental) (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
 msgid "Withholding Tax 5% (Tickets or Air Freight) (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
 msgid "Withholding Tax 5% (Tickets or Sea Freight)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
 msgid "Withholding Tax 5% (International Telecommunication)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
 msgid "Withholding Tax 5% (Distributed Profits) (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
 msgid "Withholding Tax 5% (Consulting and Technical) (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
 msgid "Withholding Tax 5% (Return from Loans) (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
 msgid "Withholding Tax 5% (Insurance & Reinsurance) (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
 msgid "Withholding Tax 15% (Royalties)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax
 msgid "Withholding Tax 15% (Paid Services from Main Branch)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax
 msgid "Withholding Tax 15% (Paid Services from another branch)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
 msgid "Withholding Tax 15% (Others)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_tax
 msgid "Withholding Tax 20% (Managerial)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_tax
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_tax
 msgid "Withholding Tax Total (Tax)"
 msgstr ""
 

--- a/addons/l10n_si/i18n/l10n_si.pot
+++ b/addons/l10n_si/i18n/l10n_si.pot
@@ -45,79 +45,79 @@ msgid "0% VAT without deduction"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_11
+#: model:account.report.line,tag_name:l10n_si.tax_report_11
 msgid "11"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_11
+#: model:account.report.line,name:l10n_si.tax_report_11
 msgid "11. Supplies of goods and services"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_11a
+#: model:account.report.line,tag_name:l10n_si.tax_report_11a
 msgid "11a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_11a
+#: model:account.report.line,name:l10n_si.tax_report_11a
 msgid ""
 "11a. Supplies of goods and services in Slovenia, of which VAT is charged by "
 "the recipient"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_12
+#: model:account.report.line,tag_name:l10n_si.tax_report_12
 msgid "12"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_12
+#: model:account.report.line,name:l10n_si.tax_report_12
 msgid "12. Deliveries of goods and services to other EU Member States"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_13
+#: model:account.report.line,tag_name:l10n_si.tax_report_13
 msgid "13"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_13
+#: model:account.report.line,name:l10n_si.tax_report_13
 msgid "13. Sale of goods at a distance"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_14
+#: model:account.report.line,tag_name:l10n_si.tax_report_14
 msgid "14"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_14
+#: model:account.report.line,name:l10n_si.tax_report_14
 msgid "14. Assembly and installation of goods in another Member State"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_15
+#: model:account.report.line,tag_name:l10n_si.tax_report_15
 msgid "15"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_15
+#: model:account.report.line,name:l10n_si.tax_report_15
 msgid "15. Exempt supplies without the right to deduct VAT"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_21
+#: model:account.report.line,tag_name:l10n_si.tax_report_21
 msgid "21"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_21
+#: model:account.report.line,name:l10n_si.tax_report_21
 msgid "21. At a rate of 22%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_22
+#: model:account.report.line,tag_name:l10n_si.tax_report_22
 msgid "22"
 msgstr ""
 
@@ -213,247 +213,247 @@ msgid "22% VAT self-assessment"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_22
+#: model:account.report.line,name:l10n_si.tax_report_22
 msgid "22. At a rate of 9,5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_22a
+#: model:account.report.line,tag_name:l10n_si.tax_report_22a
 msgid "22a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_22a
+#: model:account.report.line,name:l10n_si.tax_report_22a
 msgid "22a. At a rate of 5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_23
+#: model:account.report.line,tag_name:l10n_si.tax_report_23
 msgid "23"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_23
+#: model:account.report.line,name:l10n_si.tax_report_23
 msgid "23. 22% of acquisitions of goods from other EU Member States"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_23a
+#: model:account.report.line,tag_name:l10n_si.tax_report_23a
 msgid "23a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_23a
+#: model:account.report.line,name:l10n_si.tax_report_23a
 msgid ""
 "23a. Of the services received from other EU Member States at a rate of 22%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24
+#: model:account.report.line,tag_name:l10n_si.tax_report_24
 msgid "24"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24
+#: model:account.report.line,name:l10n_si.tax_report_24
 msgid "24. 9,5% of acquisitions of goods from other EU Member States"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24a
+#: model:account.report.line,tag_name:l10n_si.tax_report_24a
 msgid "24a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24a
+#: model:account.report.line,name:l10n_si.tax_report_24a
 msgid ""
 "24a. Of the services received from other EU Member States at the rate of "
 "9,5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24b
+#: model:account.report.line,tag_name:l10n_si.tax_report_24b
 msgid "24b"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24b
+#: model:account.report.line,name:l10n_si.tax_report_24b
 msgid ""
 "24b. Acquisitions of goods from other EU Member States at the rate of 5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24c
+#: model:account.report.line,tag_name:l10n_si.tax_report_24c
 msgid "24c"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24c
+#: model:account.report.line,name:l10n_si.tax_report_24c
 msgid ""
 "24c. Of the services received from other EU Member States at the rate of 5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_25
+#: model:account.report.line,tag_name:l10n_si.tax_report_25
 msgid "25"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_25
+#: model:account.report.line,name:l10n_si.tax_report_25
 msgid ""
 "25. On the basis of self-assessment as a recipient of goods and services at "
 "a rate of 22%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_25a
+#: model:account.report.line,tag_name:l10n_si.tax_report_25a
 msgid "25a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_25a
+#: model:account.report.line,name:l10n_si.tax_report_25a
 msgid ""
 "25a. On the basis of self-assessment as a recipient of goods and services at"
 " a rate of 9,5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_25b
+#: model:account.report.line,tag_name:l10n_si.tax_report_25b
 msgid "25b"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_25b
+#: model:account.report.line,name:l10n_si.tax_report_25b
 msgid ""
 "25b. On the basis of self-assessment as a recipient of goods and services at"
 " a rate of 5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_26
+#: model:account.report.line,tag_name:l10n_si.tax_report_26
 msgid "26"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_26
+#: model:account.report.line,name:l10n_si.tax_report_26
 msgid "26. On the basis of self-assessment of imports"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_31
+#: model:account.report.line,tag_name:l10n_si.tax_report_31
 msgid "31"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_31
+#: model:account.report.line,name:l10n_si.tax_report_31
 msgid "31. Purchases of goods and services"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_31a
+#: model:account.report.line,tag_name:l10n_si.tax_report_31a
 msgid "31a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_31a
+#: model:account.report.line,name:l10n_si.tax_report_31a
 msgid ""
 "31a. Purchases of goods and services in Slovenia, of which the recipient "
 "charges VAT"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_32
+#: model:account.report.line,tag_name:l10n_si.tax_report_32
 msgid "32"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_32
+#: model:account.report.line,name:l10n_si.tax_report_32
 msgid "32. Acquisitions of goods from other EU Member States"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_32a
+#: model:account.report.line,tag_name:l10n_si.tax_report_32a
 msgid "32a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_32a
+#: model:account.report.line,name:l10n_si.tax_report_32a
 msgid "32a. Services received from other EU Member States"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_33
+#: model:account.report.line,tag_name:l10n_si.tax_report_33
 msgid "33"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_33
+#: model:account.report.line,name:l10n_si.tax_report_33
 msgid ""
 "33. Exempt purchases of goods and services and exempt acquisitions of goods"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_34
+#: model:account.report.line,tag_name:l10n_si.tax_report_34
 msgid "34"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_34
+#: model:account.report.line,name:l10n_si.tax_report_34
 msgid "34. Purchase value of real estate"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_35
+#: model:account.report.line,tag_name:l10n_si.tax_report_35
 msgid "35"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_35
+#: model:account.report.line,name:l10n_si.tax_report_35
 msgid "35. Cost of other fixed assets"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_41
+#: model:account.report.line,tag_name:l10n_si.tax_report_41
 msgid "41"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_41
+#: model:account.report.line,name:l10n_si.tax_report_41
 msgid ""
 "41. From purchases of goods and services, acquisition of goods and services "
 "received from other EU Member States and from imports at a rate of 22%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_42
+#: model:account.report.line,tag_name:l10n_si.tax_report_42
 msgid "42"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_42
+#: model:account.report.line,name:l10n_si.tax_report_42
 msgid ""
 "42. From purchases of goods and services, acquisition of goods and services "
 "received from other EU Member States and from imports at a rate of 9,5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_42a
+#: model:account.report.line,tag_name:l10n_si.tax_report_42a
 msgid "42a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_42a
+#: model:account.report.line,name:l10n_si.tax_report_42a
 msgid ""
 "42a. From purchases of goods and services, acquisition of goods and services"
 " received from other EU Member States and from imports at a rate of 5%"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_43
+#: model:account.report.line,tag_name:l10n_si.tax_report_43
 msgid "43"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_43
+#: model:account.report.line,name:l10n_si.tax_report_43
 msgid "43. Of the flat-rate compensation at the rate of 8%"
 msgstr ""
 
@@ -546,12 +546,12 @@ msgid "5% VAT self-assessment"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_51
+#: model:account.report.line,name:l10n_si.tax_report_51
 msgid "51. VAT liability"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_52
+#: model:account.report.line,name:l10n_si.tax_report_52
 msgid "52. VAT surplus"
 msgstr ""
 
@@ -1677,22 +1677,22 @@ msgid "Harvested crops at fair value"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_I
+#: model:account.report.line,name:l10n_si.tax_report_I
 msgid "I. Supplies of goods and services (values excluding VAT)"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_II
+#: model:account.report.line,name:l10n_si.tax_report_II
 msgid "II. VAT charged"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_III
+#: model:account.report.line,name:l10n_si.tax_report_III
 msgid "III. Purchases of goods and services (values excluding VAT)"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_IV
+#: model:account.report.line,name:l10n_si.tax_report_IV
 msgid "IV. VAT deduction"
 msgstr ""
 

--- a/addons/l10n_si/i18n/sl.po
+++ b/addons/l10n_si/i18n/sl.po
@@ -45,79 +45,79 @@ msgid "0% VAT without deduction"
 msgstr "0% DDV brez odbitka"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_11
+#: model:account.report.line,tag_name:l10n_si.tax_report_11
 msgid "11"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_11
+#: model:account.report.line,name:l10n_si.tax_report_11
 msgid "11. Supplies of goods and services"
 msgstr "11. Dobave blaga in storitev"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_11a
+#: model:account.report.line,tag_name:l10n_si.tax_report_11a
 msgid "11a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_11a
+#: model:account.report.line,name:l10n_si.tax_report_11a
 msgid ""
 "11a. Supplies of goods and services in Slovenia, of which VAT is charged by "
 "the recipient"
 msgstr "11a. Dobave blaga in storitev v Sloveniji, od katerih obračunava DDV do prejemnik"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_12
+#: model:account.report.line,tag_name:l10n_si.tax_report_12
 msgid "12"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_12
+#: model:account.report.line,name:l10n_si.tax_report_12
 msgid "12. Deliveries of goods and services to other EU Member States"
 msgstr "12. Dobave blaga in storitev v druge države članice EU"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_13
+#: model:account.report.line,tag_name:l10n_si.tax_report_13
 msgid "13"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_13
+#: model:account.report.line,name:l10n_si.tax_report_13
 msgid "13. Sale of goods at a distance"
 msgstr "13. Prodaja blaga na daljavo"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_14
+#: model:account.report.line,tag_name:l10n_si.tax_report_14
 msgid "14"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_14
+#: model:account.report.line,name:l10n_si.tax_report_14
 msgid "14. Assembly and installation of goods in another Member State"
 msgstr "14. Montaža in montaža blaga v drugi državi članici"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_15
+#: model:account.report.line,tag_name:l10n_si.tax_report_15
 msgid "15"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_15
+#: model:account.report.line,name:l10n_si.tax_report_15
 msgid "15. Exempt supplies without the right to deduct VAT"
 msgstr "15. Oproščene dobave brez pravice do odbitka DDV"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_21
+#: model:account.report.line,tag_name:l10n_si.tax_report_21
 msgid "21"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_21
+#: model:account.report.line,name:l10n_si.tax_report_21
 msgid "21. At a rate of 22%"
 msgstr "21. Po stopnji 22 %"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_22
+#: model:account.report.line,tag_name:l10n_si.tax_report_22
 msgid "22"
 msgstr ""
 
@@ -213,247 +213,247 @@ msgid "22% VAT self-assessment"
 msgstr "22% samoobdavčitev DDV"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_22
+#: model:account.report.line,name:l10n_si.tax_report_22
 msgid "22. At a rate of 9,5%"
 msgstr "22. Po stopnji 9,5 %"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_22a
+#: model:account.report.line,tag_name:l10n_si.tax_report_22a
 msgid "22a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_22a
+#: model:account.report.line,name:l10n_si.tax_report_22a
 msgid "22a. At a rate of 5%"
 msgstr "22a. Po stopnji 5 %"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_23
+#: model:account.report.line,tag_name:l10n_si.tax_report_23
 msgid "23"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_23
+#: model:account.report.line,name:l10n_si.tax_report_23
 msgid "23. 22% of acquisitions of goods from other EU Member States"
 msgstr "23. 22 % nabav blaga iz drugih držav članic EU"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_23a
+#: model:account.report.line,tag_name:l10n_si.tax_report_23a
 msgid "23a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_23a
+#: model:account.report.line,name:l10n_si.tax_report_23a
 msgid ""
 "23a. Of the services received from other EU Member States at a rate of 22%"
 msgstr "23a. Prejetih storitev iz drugih držav članic EU po stopnji 22 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24
+#: model:account.report.line,tag_name:l10n_si.tax_report_24
 msgid "24"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24
+#: model:account.report.line,name:l10n_si.tax_report_24
 msgid "24. 9,5% of acquisitions of goods from other EU Member States"
 msgstr "24. 9,5 % nabav blaga iz drugih držav članic EU"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24a
+#: model:account.report.line,tag_name:l10n_si.tax_report_24a
 msgid "24a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24a
+#: model:account.report.line,name:l10n_si.tax_report_24a
 msgid ""
 "24a. Of the services received from other EU Member States at the rate of "
 "9,5%"
 msgstr "24a. Prejetih storitev iz drugih držav članic EU po stopnji 9,5 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24b
+#: model:account.report.line,tag_name:l10n_si.tax_report_24b
 msgid "24b"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24b
+#: model:account.report.line,name:l10n_si.tax_report_24b
 msgid ""
 "24b. Acquisitions of goods from other EU Member States at the rate of 5%"
 msgstr "24b. Pridobitve blaga iz drugih držav članic EU po stopnji 5 %"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_24c
+#: model:account.report.line,tag_name:l10n_si.tax_report_24c
 msgid "24c"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_24c
+#: model:account.report.line,name:l10n_si.tax_report_24c
 msgid ""
 "24c. Of the services received from other EU Member States at the rate of 5%"
 msgstr "24c. Prejetih storitev iz drugih držav članic EU po stopnji 5 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_25
+#: model:account.report.line,tag_name:l10n_si.tax_report_25
 msgid "25"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_25
+#: model:account.report.line,name:l10n_si.tax_report_25
 msgid ""
 "25. On the basis of self-assessment as a recipient of goods and services at "
 "a rate of 22%"
 msgstr "25. Na podlagi samoocenitve kot prejemnik blaga in storitev po stopnji 22 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_25a
+#: model:account.report.line,tag_name:l10n_si.tax_report_25a
 msgid "25a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_25a
+#: model:account.report.line,name:l10n_si.tax_report_25a
 msgid ""
 "25a. On the basis of self-assessment as a recipient of goods and services at"
 " a rate of 9,5%"
 msgstr "25a. Na podlagi samoocenitve kot prejemnik blaga in storitev po stopnji 9,5 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_25b
+#: model:account.report.line,tag_name:l10n_si.tax_report_25b
 msgid "25b"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_25b
+#: model:account.report.line,name:l10n_si.tax_report_25b
 msgid ""
 "25b. On the basis of self-assessment as a recipient of goods and services at"
 " a rate of 5%"
 msgstr "25b. Na podlagi samoobdavčitve kot prejemnik blaga in storitev po stopnji 5 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_26
+#: model:account.report.line,tag_name:l10n_si.tax_report_26
 msgid "26"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_26
+#: model:account.report.line,name:l10n_si.tax_report_26
 msgid "26. On the basis of self-assessment of imports"
 msgstr "26. Na podlagi samoocenitve uvoza"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_31
+#: model:account.report.line,tag_name:l10n_si.tax_report_31
 msgid "31"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_31
+#: model:account.report.line,name:l10n_si.tax_report_31
 msgid "31. Purchases of goods and services"
 msgstr "31. Nakupi blaga in storitev"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_31a
+#: model:account.report.line,tag_name:l10n_si.tax_report_31a
 msgid "31a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_31a
+#: model:account.report.line,name:l10n_si.tax_report_31a
 msgid ""
 "31a. Purchases of goods and services in Slovenia, of which the recipient "
 "charges VAT"
 msgstr "31a. Nakupi blaga in storitev v Sloveniji, od katerih prejemnik obračuna DDV"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_32
+#: model:account.report.line,tag_name:l10n_si.tax_report_32
 msgid "32"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_32
+#: model:account.report.line,name:l10n_si.tax_report_32
 msgid "32. Acquisitions of goods from other EU Member States"
 msgstr "32. Pridobitve blaga iz drugih držav članic EU"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_32a
+#: model:account.report.line,tag_name:l10n_si.tax_report_32a
 msgid "32a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_32a
+#: model:account.report.line,name:l10n_si.tax_report_32a
 msgid "32a. Services received from other EU Member States"
 msgstr "32a. Storitve, prejete iz drugih držav članic EU"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_33
+#: model:account.report.line,tag_name:l10n_si.tax_report_33
 msgid "33"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_33
+#: model:account.report.line,name:l10n_si.tax_report_33
 msgid ""
 "33. Exempt purchases of goods and services and exempt acquisitions of goods"
 msgstr "33. Oproščeni nakupi blaga in storitev ter oproščene pridobitve blaga"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_34
+#: model:account.report.line,tag_name:l10n_si.tax_report_34
 msgid "34"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_34
+#: model:account.report.line,name:l10n_si.tax_report_34
 msgid "34. Purchase value of real estate"
 msgstr "34. Nabavna vrednost nepremičnine"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_35
+#: model:account.report.line,tag_name:l10n_si.tax_report_35
 msgid "35"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_35
+#: model:account.report.line,name:l10n_si.tax_report_35
 msgid "35. Cost of other fixed assets"
 msgstr "35. Nabavna vrednost drugih osnovnih sredstev"
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_41
+#: model:account.report.line,tag_name:l10n_si.tax_report_41
 msgid "41"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_41
+#: model:account.report.line,name:l10n_si.tax_report_41
 msgid ""
 "41. From purchases of goods and services, acquisition of goods and services "
 "received from other EU Member States and from imports at a rate of 22%"
 msgstr "41. Od nabave blaga in storitev, pridobitve blaga in storitev, prejetih iz drugih držav članic EU in od uvoza po stopnji 22 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_42
+#: model:account.report.line,tag_name:l10n_si.tax_report_42
 msgid "42"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_42
+#: model:account.report.line,name:l10n_si.tax_report_42
 msgid ""
 "42. From purchases of goods and services, acquisition of goods and services "
 "received from other EU Member States and from imports at a rate of 9,5%"
 msgstr "42. Od nabave blaga in storitev, pridobitve blaga in storitev, prejetih iz drugih držav članic EU ter od uvoza po stopnji 9,5 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_42a
+#: model:account.report.line,tag_name:l10n_si.tax_report_42a
 msgid "42a"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_42a
+#: model:account.report.line,name:l10n_si.tax_report_42a
 msgid ""
 "42a. From purchases of goods and services, acquisition of goods and services"
 " received from other EU Member States and from imports at a rate of 5%"
 msgstr "42a. Od nabave blaga in storitev, pridobitve blaga in storitev, prejetih iz drugih držav članic EU ter od uvoza po stopnji 5 %."
 
 #. module: l10n_si
-#: model:account.tax.report.line,tag_name:l10n_si.tax_report_43
+#: model:account.report.line,tag_name:l10n_si.tax_report_43
 msgid "43"
 msgstr ""
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_43
+#: model:account.report.line,name:l10n_si.tax_report_43
 msgid "43. Of the flat-rate compensation at the rate of 8%"
 msgstr "43. Od pavšalnega nadomestila po stopnji 8 %."
 
@@ -546,12 +546,12 @@ msgid "5% VAT self-assessment"
 msgstr "5% samoobdavčitev DDV"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_51
+#: model:account.report.line,name:l10n_si.tax_report_51
 msgid "51. VAT liability"
 msgstr "51. Obveznost za DDV"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_52
+#: model:account.report.line,name:l10n_si.tax_report_52
 msgid "52. VAT surplus"
 msgstr "52. Presežek DDV"
 
@@ -1677,22 +1677,22 @@ msgid "Harvested crops at fair value"
 msgstr "Pobrani pridelki po pošteni vrednosti"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_I
+#: model:account.report.line,name:l10n_si.tax_report_I
 msgid "I. Supplies of goods and services (values excluding VAT)"
 msgstr "I. Dobave blaga in storitev (vrednosti brez DDV)"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_II
+#: model:account.report.line,name:l10n_si.tax_report_II
 msgid "II. VAT charged"
 msgstr "II. Obračunan DDV"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_III
+#: model:account.report.line,name:l10n_si.tax_report_III
 msgid "III. Purchases of goods and services (values excluding VAT)"
 msgstr "III. Nakupi blaga in storitev (vrednosti brez DDV)"
 
 #. module: l10n_si
-#: model:account.tax.report.line,name:l10n_si.tax_report_IV
+#: model:account.report.line,name:l10n_si.tax_report_IV
 msgid "IV. VAT deduction"
 msgstr "IV. Odbitek DDV"
 

--- a/addons/l10n_vn/i18n_extra/l10n_vn.pot
+++ b/addons/l10n_vn/i18n_extra/l10n_vn.pot
@@ -869,7 +869,7 @@ msgid "Purchase costs"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_vn
 msgid "Purchase of Goods and Services"
 msgstr ""
 
@@ -928,7 +928,7 @@ msgid "Revenue from services rendered"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_vn
 msgid "Sales of Goods and Services"
 msgstr ""
 
@@ -1096,48 +1096,48 @@ msgid "Unemployment insurance"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_01_vn
 msgid "Untaxed Purchase of Goods and Services"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_02_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_02_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_01_vn
 msgid "Untaxed Purchase of Goods and Services taxed 0%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_02_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_02_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_01_vn
 msgid "Untaxed Purchase of Goods and Services taxed 10%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_02_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_02_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_01_vn
 msgid "Untaxed Purchase of Goods and Services taxed 5%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_02_vn
 msgid "Untaxed Sales of Goods and Services"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_02_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_02_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_02_vn
 msgid "Untaxed sales of goods and services taxed 0%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_02_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_02_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_02_vn
 msgid "Untaxed sales of goods and services taxed 10%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_02_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_02_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_02_vn
 msgid "Untaxed sales of goods and services taxed 5%"
 msgstr ""
 
@@ -1171,48 +1171,48 @@ msgstr ""
 #. module: l10n_vn
 #: model:account.account,name:l10n_vn.1_chart1331
 #: model:account.account.template,name:l10n_vn.chart1331
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_01_vn
 msgid "VAT on purchase of goods and services"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_01_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_01_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_01_vn
 msgid "VAT on purchase of goods and services 0%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_01_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_01_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_01_vn
 msgid "VAT on purchase of goods and services 10%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_01_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_01_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_01_vn
 msgid "VAT on purchase of goods and services 5%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_02_vn
 msgid "VAT on sales of goods and services"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_01_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_01_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_02_vn
 msgid "VAT on sales of goods and services 0%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_01_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_01_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_02_vn
 msgid "VAT on sales of goods and services 10%"
 msgstr ""
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_01_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_01_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_02_vn
 msgid "VAT on sales of goods and services 5%"
 msgstr ""
 

--- a/addons/l10n_vn/i18n_extra/vi_VN.po
+++ b/addons/l10n_vn/i18n_extra/vi_VN.po
@@ -878,7 +878,7 @@ msgid "Purchase costs"
 msgstr "Giá mua hàng hóa"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_vn
 msgid "Purchase of Goods and Services"
 msgstr "HHDV Mua vào"
 
@@ -937,7 +937,7 @@ msgid "Revenue from services rendered"
 msgstr "Doanh thu cung cấp dịch vụ"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_vn
 msgid "Sales of Goods and Services"
 msgstr "HHDV Bán ra"
 
@@ -1101,48 +1101,48 @@ msgid "Unemployment insurance"
 msgstr "Bảo hiểm thất nghiệp"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_01_vn
 msgid "Untaxed Purchase of Goods and Services"
 msgstr "Giá trị HHDV Mua vào"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_02_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_02_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_01_vn
 msgid "Untaxed Purchase of Goods and Services taxed 0%"
 msgstr "Giá trị HHDV Mua vào chịu thuế 0%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_02_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_02_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_01_vn
 msgid "Untaxed Purchase of Goods and Services taxed 10%"
 msgstr "Giá trị HHDV Mua vào chịu thuế 10%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_02_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_02_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_01_vn
 msgid "Untaxed Purchase of Goods and Services taxed 5%"
 msgstr "Giá trị HHDV Mua vào chịu thuế 5%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_02_vn
 msgid "Untaxed Sales of Goods and Services"
 msgstr "Giá trị HHDV Bán ra"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_02_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_02_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_02_02_vn
 msgid "Untaxed sales of goods and services taxed 0%"
 msgstr "Giá trị HHDV Bán ra chịu thuế 0%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_02_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_02_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_02_02_vn
 msgid "Untaxed sales of goods and services taxed 10%"
 msgstr "Giá trị HHDV Bán ra chịu thuế 10%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_02_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_02_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_02_02_vn
 msgid "Untaxed sales of goods and services taxed 5%"
 msgstr "Giá trị HHDV Bán ra chịu thuế 5%"
 
@@ -1176,48 +1176,48 @@ msgstr "Thuế GTGT được khấu trừ của tài sản cố định"
 #. module: l10n_vn
 #: model:account.account,name:l10n_vn.1_chart1331
 #: model:account.account.template,name:l10n_vn.chart1331
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_01_vn
 msgid "VAT on purchase of goods and services"
 msgstr "Thuế GTGT HHDV mua vào"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_01_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_01_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_01_vn
 msgid "VAT on purchase of goods and services 0%"
 msgstr "Thuế GTGT HHDV mua vào chịu thuế 0%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_01_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_01_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_01_vn
 msgid "VAT on purchase of goods and services 10%"
 msgstr "Thuế GTGT HHDV mua vào chịu thuế 10%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_01_01_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_01_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_01_01_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_01_vn
 msgid "VAT on purchase of goods and services 5%"
 msgstr "Thuế GTGT HHDV mua vào chịu thuế 5%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_02_vn
 msgid "VAT on sales of goods and services"
 msgstr "Thuế GTGT HHDV bán ra"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_01_01_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_01_01_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_01_01_02_vn
 msgid "VAT on sales of goods and services 0%"
 msgstr "Thuế GTGT HHDV bán ra chịu thuế 0%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_03_01_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_03_01_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_03_01_02_vn
 msgid "VAT on sales of goods and services 10%"
 msgstr "Thuế GTGT HHDV bán ra chịu thuế 10%"
 
 #. module: l10n_vn
-#: model:account.tax.report.line,name:l10n_vn.account_tax_report_line_02_01_02_vn
-#: model:account.tax.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_02_vn
+#: model:account.report.line,name:l10n_vn.account_tax_report_line_02_01_02_vn
+#: model:account.report.line,tag_name:l10n_vn.account_tax_report_line_02_01_02_vn
 msgid "VAT on sales of goods and services 5%"
 msgstr "Thuế GTGT HHDV bán ra chịu thuế 5%"
 


### PR DESCRIPTION
How to reproduce
================

1. Load the accounting & any of the modified l10n modules
2. Take any of the languages supported by the selected l10n module

You'll see that all the terms remain in english

opw-3114100