### PR TITLE
[FIX] note: adapt `ActivityMenuView` colors for dark mode

### DIFF
--- a/addons/note/static/src/components/activity_menu_view/activity_menu_view.xml
+++ b/addons/note/static/src/components/activity_menu_view/activity_menu_view.xml
@@ -5,7 +5,7 @@
             <div t-if="!activityMenuView.isAddingNote" class="o_note_show d-grid" t-on-click="activityMenuView.onClickAddNote">
                 <a role="button" class="btn text-center">Add new note</a>
             </div>
-            <div t-if="activityMenuView.isAddingNote" class="o_note o_ActivityMenuView_activityGroup">
+            <div t-if="activityMenuView.isAddingNote" class="o_note o_ActivityMenuView_activityGroup bg-view">
                 <div class="o_ActivityMenuView_activityGroupIconContainer">
                     <img src="/note/static/description/icon.svg" alt="Channel"/>
                 </div>
@@ -19,9 +19,9 @@
                         />
                     </div>
                     <div class="o_note_input_box">
-                        <p><input class="o_note_input" type="text" placeholder="Remember..." t-on-keydown="activityMenuView.onKeydownNoteInput" t-ref="noteInput"/></p>
-                        <span class="ml8 mr4">
-                            <a class="o_note_save" t-on-click="activityMenuView.onClickSaveNote">SAVE</a>
+                        <p><input class="o_note_input form-control ps-0 shadow-none" type="text" placeholder="Remember..." t-on-keydown="activityMenuView.onKeydownNoteInput" t-ref="noteInput"/></p>
+                        <span class="d-flex align-items-end ml8 mr4">
+                            <a class="o_note_save btn-sm btn-link" t-on-click="activityMenuView.onClickSaveNote">SAVE</a>
                         </span>
                     </div>
                 </div>

--- a/addons/note/static/src/scss/note.scss
+++ b/addons/note/static/src/scss/note.scss
@@ -50,7 +50,6 @@
 
 // Quick create notes from systray
 .o_note.o_ActivityMenuView_activityGroup {
-    background-color: white;
     .o_ActivityMenuView_activityGroupInfo {
         .o_ActivityMenuView_activityGroupTitle {
             .o_ActivityMenuView_activityGroupName {


### PR DESCRIPTION
Prior to this commit there were color issues in dark mode when we wanted to add new notes using the Activities dropdown.

This commit fixes this issue.

task-3162833

![before-after](https://user-images.githubusercontent.com/80679690/215749644-06cd8bfa-4101-469e-a8be-1618f6711020.jpg)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
