### PR TITLE
[FIX] delivery: raise traceback while getting shipping rate

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -153,7 +153,7 @@ class SaleOrder(models.Model):
     def _get_estimated_weight(self):
         self.ensure_one()
         weight = 0.0
-        for order_line in self.order_line.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not l.is_delivery and not l.display_type):
+        for order_line in self.order_line.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not l.is_delivery and not l.display_type and l.product_uom_qty > 0):
             weight += order_line.product_qty * order_line.product_id.weight
         return weight
 

--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -19,8 +19,9 @@ class StockMove(models.Model):
 
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
-        carrier_id = self.group_id.sale_id.carrier_id.id
-        vals['carrier_id'] = any(propagate_carrier for propagate_carrier in self.rule_id) and carrier_id
+        if self.picking_type_id.code == 'outgoing':
+            carrier_id = self.group_id.sale_id.carrier_id.id
+            vals['carrier_id'] = any(propagate_carrier for propagate_carrier in self.rule_id) and carrier_id
         return vals
 
     def _key_assign_picking(self):


### PR DESCRIPTION
Steps to produce
================
   - Make SO which has 2 products with the same weight.
   - Both product's quantity is the same but one of the product quantity is negative.
   - Then click on `Add Shipping` and we try to get the shipping rate then it raises traceback.

After this commit
=================
In this commit, I ignore the rate of shipping for negative quantity in the SO line.

TaskId - 3028023