### PR TITLE
[IMP] web: list group header design improvement

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -166,12 +166,12 @@
     </t>
 
     <t t-name="web.ListRenderer.GroupRow" owl="1">
-        <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer"
+        <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header bg-light {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer"
             t-on-click="() => this.toggleGroup(group)"
         >
             <th t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group)"
                 tabindex="-1"
-                t-attf-class="o_group_name fs-6 fw-bold {{!group.isFolded ? 'text-900' : 'text-700'}}"
+                t-attf-class="o_group_name fs-6 fw-bolder {{!group.isFolded ? 'text-900' : 'text-700'}}"
                 t-att-colspan="getGroupNameCellColSpan(group)">
                 <div class="d-flex">
                     <span t-attf-class="o_group_caret fa fa-fw {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }} me-1"


### PR DESCRIPTION
Prior to this PR, the text in the headers of groups in the list view was not bold enough and looked too much like the rows, and the background color was the same as the content as well.

**BEFORE**

<img width="1727" alt="Screenshot 2023-01-31 at 14 24 21" src="https://user-images.githubusercontent.com/108661430/215772752-0ba3d4f1-e35f-4922-a228-7630a1c4924c.png">


**AFTER**

<img width="1727" alt="Screenshot 2023-01-31 at 14 24 58" src="https://user-images.githubusercontent.com/108661430/215772739-87b8e760-85f3-43c9-83a0-381e209f0472.png">

task-3142083