### PR TITLE
[IMP] hr_holidays: add 5 decimal places instead of 2 for the added_value field

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -43,7 +43,7 @@ class AccrualPlanLevel(models.Model):
 
     # Accrue of
     added_value = fields.Float(
-        "Rate", required=True,
+        "Rate", required=True, digits=(4, 5),
         help="The number of hours/days that will be incremented in the specified Time Off Type for every period")
     added_value_type = fields.Selection(
         [('days', 'Days'),


### PR DESCRIPTION
 In a lot of cases the allocated days may lose information, especially over a long period, where
 those missing decimals add up. It's also a legal requirement in San Franciso.