### PR TITLE
[FIX] sale: show in the good price of the delivery

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -206,7 +206,7 @@
                 <td>
                     <strong>Shipping Method:</strong>
                     <t t-out="object.carrier_id.name or ''"></t>
-                    <t t-if="object.carrier_id.fixed_price == 0.0">
+                    <t t-if="object.amount_delivery == 0.0">
                         (Free)
                     </t>
                     <t t-else="">


### PR DESCRIPTION
Steps:
1. Create a shipping method with the fixed price greater than 0.0 and a threshold amount.
2. Go to website, shop an article with price greater than the threshold and pay.

Issue:
In the mail sent to the customer the amount of the delivery is not shown as free

Cause:
The condition to display 'Free' is that the `fixed_price` of the delivery carrier should equal to 0.0 which is not the only condition.

Solution:
Add the case where the delivery ship can be free over a threshold and the sale order amount is greater than that amount.

opw-3138578
