### PR TITLE
[FIX] stock: merge moves rounding precision

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -879,7 +879,7 @@ class StockMove(models.Model):
             for pos_move in moves_by_neg_key.get(neg_key(neg_move), []):
                 currency_prec = pos_move.product_id.currency_id.decimal_places
                 rounding = min(currency_prec, price_unit_prec)
-                if float_compare(pos_move.price_unit, neg_move.price_unit, precision_digits=rounding) == 0:
+                if float_is_zero(pos_move.price_unit - neg_move.price_unit, precision_digits=rounding):
                     new_total_value = pos_move.product_qty * pos_move.price_unit + neg_move.product_qty * neg_move.price_unit
                     # If quantity can be fully absorbed by a single move, update its quantity and remove the negative move
                     if float_compare(pos_move.product_uom_qty, abs(neg_move.product_uom_qty), precision_rounding=pos_move.product_uom.rounding) >= 0:


### PR DESCRIPTION
Bug:
for the unit price of positif and negatif move if one is rounded up and the other down the moves can't be merged

Fix:
reduce the precision required to match moves on unit price

opw-3136160

