### PR TITLE
[REF] l10n_ke_edi_tremol: convert client action

### DIFF
--- a/addons/l10n_ke_edi_tremol/static/src/client_actions/send_invoice.js
+++ b/addons/l10n_ke_edi_tremol/static/src/client_actions/send_invoice.js
@@ -1,0 +1,54 @@
+/** @odoo-module **/
+
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { registry } from "@web/core/registry";
+
+async function postSend(env, action) {
+    let refresh = false;
+    const { orm, http, dialog, action: actionService } = env.services;
+
+    for (const [move_id, invoice] of Object.entries([action.params.invoices])) {
+        const result = JSON.parse(
+            await http
+                .post(invoice.proxy_address + "/hw_proxy/l10n_ke_cu_send", {
+                    messages: invoice.messages,
+                    company_vat: invoice.company_vat,
+                })
+                .catch((error) => {
+                    dialog.add(AlertDialog, {
+                        body:
+                            env._t(
+                                "Error trying to connect to the middleware. Is the middleware running?\n Error code: "
+                            ) + error.status,
+                    });
+                })
+        );
+        if (result.status === "ok") {
+            const { replies, serial_number } = result;
+            orm.call("account.move", "l10n_ke_cu_response", [
+                [],
+                { replies, serial_number, move_id },
+            ]).catch((error) => {
+                dialog.add(AlertDialog, {
+                    body:
+                        env._t(
+                            "Error trying to connect to Odoo. Check your internet connection.\n Error code: "
+                        ) + error.status,
+                });
+            });
+            refresh = true;
+        } else {
+            dialog.add(AlertDialog, {
+                body: env._t("Posting an invoice has failed, with the message: \n") + result.status,
+            });
+        }
+    }
+    if (refresh) {
+        actionService.doAction({
+            type: "ir.actions.client",
+            tag: "reload",
+        });
+    }
+}
+
+registry.category("actions").add("post_send", postSend);


### PR DESCRIPTION
The purpose of this commit is to convert the client actions 'post_send' to the new architecture.

TaskID: 3165941

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
