### PR TITLE
[FIX] website_slides: allow officer to invite members on all courses

### DIFF
--- a/addons/website_slides/i18n/website_slides.pot
+++ b/addons/website_slides/i18n/website_slides.pot
@@ -6002,6 +6002,15 @@ msgid "Yes"
 msgstr ""
 
 #. module: website_slides
+#. odoo-python
+#: code:addons/website_slides/models/slide_channel.py:0
+#, python-format
+msgid ""
+"You are not allowed to add members to this course. Please contact the "
+"administrator."
+msgstr ""
+
+#. module: website_slides
 #. openerp-web
 #: code:addons/website_slides/static/src/js/tours/slides_tour.js:0
 #, python-format

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -680,7 +680,7 @@ class Channel(models.Model):
                 for partner in target_partners if partner.id not in existing_map[channel.id]
             ]
             slide_partners_sudo = self.env['slide.channel.partner'].sudo().create(to_create_values)
-            to_join.message_subscribe(partner_ids=target_partners.ids, subtype_ids=[self.env.ref('website_slides.mt_channel_slide_published').id])
+            to_join.sudo().message_subscribe(partner_ids=target_partners.ids, subtype_ids=[self.env.ref('website_slides.mt_channel_slide_published').id])
             return slide_partners_sudo
         return self.env['slide.channel.partner'].sudo()
 
@@ -690,9 +690,9 @@ class Channel(models.Model):
         if on_invite:
             try:
                 on_invite.check_access_rights('write')
-                on_invite.check_access_rule('write')
+                self.env.user.has_group('website_slides.group_website_slides_officer') or on_invite.check_access_rule('write')
             except:
-                pass
+                raise AccessError(_('You are not allowed add members to this course. Please contact the administrator.'))
             else:
                 allowed |= on_invite
         return allowed

--- a/addons/website_slides/tests/test_security.py
+++ b/addons/website_slides/tests/test_security.py
@@ -47,6 +47,16 @@ class TestAccess(common.SlidesCase):
         with self.assertRaises(AccessError):
             self.slide.with_user(self.user_emp).read(['name'])
 
+        self.channel.user_id = self.user_manager.id # Ensure officer is not responsible, manager will be added to members
+
+        self.channel.with_user(self.user_manager)._action_add_members(self.user_portal.partner_id)
+        self.assertEqual(self.channel.members_count, 3)
+        self.channel.with_user(self.user_officer)._action_add_members(self.user_public.partner_id)
+        self.assertEqual(self.channel.members_count, 4)
+        with self.assertRaises(AccessError):
+            self.channel.with_user(self.user_emp)._action_add_members(self.user_emp.partner_id)
+            self.assertEqual(self.channel.members_count, 4)
+
     @mute_logger('odoo.models', 'odoo.addons.base.models.ir_rule')
     def test_access_channel_public(self):
         """ Public channels don't give enroll if not member """


### PR DESCRIPTION
Steps to reproduce:

- Install `E-learning` module
- Create a user X with only "Officer" as rights for `E-learning`
- Login with user X
- Go to `E-learning` and open any course
- Ensure that the user X is not the responsible and that the course enroll policy is set to "On invitation"
- Invite any user not already a member

Issue:

  No user was invited (not added as member) and no warning message raised.

Cause:

  Due to the ir.rule "Channel: officer: create/write own only", the `Officer` user can only edit (and therefore invite members) on courses where he is responsible.

Solution:

  - Allow to add a member if the user has write access rights and is an `Officer` OR has write access rule.
  - Use sudo() to add member as follower. (since access rights already checked when filtering courses)

opw-3133733