### PR TITLE
[IMP] web: move calendar filter panel to left

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -22,7 +22,7 @@ $o-cw-filter-avatar-size: 20px;
     position: relative;
     @include o-webclient-padding($top: $o-horizontal-padding/2);
     background-color: $o-view-background-color;
-    border-left: 1px solid $border-color;
+    border-right: 1px solid $border-color;
     overflow-y: auto;
 
     .o_calendar_sidebar {

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -10,13 +10,13 @@
 
                 <div class="o_calendar_container">
                     <MobileFilterPanel t-if="env.isSmall" t-props="mobileFilterPanelProps" />
-                    <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps" />
                     <div t-if="showSideBar" class="o_calendar_sidebar_container d-md-block">
                         <div class="o_calendar_sidebar">
                             <DatePicker t-if="!env.isSmall" t-props="datePickerProps" />
                             <FilterPanel t-props="filterPanelProps" />
                         </div>
                     </div>
+                    <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps" />
                 </div>
             </Layout>
         </div>

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -123,7 +123,7 @@
         .fc-timeGridDay-view,
         .fc-timeGridWeek-view {
             .fc-axis {
-                padding-left: $o-horizontal-padding;
+                padding-right: $o-horizontal-padding;
             }
 
             .fc-widget-header.fc-today {
@@ -230,10 +230,6 @@
 
         // ====== Week only
         .fc-timeGridWeek-view {
-            .fc-now-indicator {
-                left: $o-horizontal-padding;
-            }
-
             // Expand tiny events on hover/select
             .fc-event:not(.fc-h-event).o_cw_custom_highlight {
                 transition: margin 0.1s 0.3s, left 0.1s 0.3s, right 0.1s 0.3s;
@@ -245,7 +241,8 @@
 
         // ====== Month only
         .fc-dayGridMonth-view {
-            padding-left: $o-horizontal-padding;
+            margin-right: $o-horizontal-padding;
+            border-right: 1px solid $border-color;
 
             .fc-event {
                 border-radius: 25px;
@@ -360,7 +357,7 @@
         .fc-dayGridYear-view {
             border: none;
             height: 100%;
-            padding-left: $o-horizontal-padding;
+            padding-right: $o-horizontal-padding;
             box-sizing: border-box;
             display: flex;
             flex-wrap: wrap;
@@ -434,7 +431,8 @@
                     }
 
                     .fc-dayGridMonth-view {
-                        padding-left: unset;
+                        margin-right: none;
+                        border-right: none;
 
                         .fc-has-event {
                             background-color: #b4dff5;


### PR DESCRIPTION
This commit moves the filter panel of the calendar view to the left of the view to make it more coherent with other views.

task: 3164391