### PR TITLE
[FIX] Web: float_time should correctly round values

### DIFF
--- a/addons/web/static/src/views/fields/float_time/float_time_field.js
+++ b/addons/web/static/src/views/fields/float_time/float_time_field.js
@@ -21,7 +21,7 @@ export class FloatTimeField extends Component {
     }
 
     get formattedValue() {
-        return formatFloatTime(this.props.value);
+        return formatFloatTime(this.props.value, {roundToMin: this.props.roundToMin});
     }
 }
 
@@ -29,6 +29,7 @@ FloatTimeField.template = "web.FloatTimeField";
 FloatTimeField.props = {
     ...standardFieldProps,
     placeholder: { type: String, optional: true },
+    roundToMin: { type: String, optional: true },
 };
 
 FloatTimeField.displayName = _lt("Time");
@@ -38,6 +39,7 @@ FloatTimeField.isEmpty = () => false;
 FloatTimeField.extractProps = ({ attrs }) => {
     return {
         placeholder: attrs.placeholder,
+        roundToMin: attrs.roundToMin,
     };
 };
 

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -222,6 +222,7 @@ export function formatFloatFactor(value, options = {}) {
  * @param {Object} [options]
  * @param {boolean} [options.noLeadingZeroHour] if true, format like 1:30 otherwise, format like 01:30
  * @param {boolean} [options.displaySeconds] if true, format like ?1:30:00 otherwise, format like ?1:30
+ * @param {string} [options.roundToMin] if true, we will round 59s to 00:01
  * @returns {string}
  */
 export function formatFloatTime(value, options = {}) {
@@ -235,7 +236,13 @@ export function formatFloatTime(value, options = {}) {
     const milliSecLeft = Math.round(value * 3600000) - hour * 3600000;
     // Although looking quite overkill, the following line ensures that we do
     // not have float issues while still considering that 59s is 00:00.
-    let min = Math.floor(milliSecLeft / 60000);
+    let min = 0;
+    if(options.roundToMin){
+        min = Math.round(milliSecLeft/60000)
+    }
+    else{
+        min = Math.floor(milliSecLeft / 60000);
+    }
     if (min === 60) {
         min = 0;
         hour = hour + 1;

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -144,7 +144,7 @@
                                         <field name="user_id" string="Responsible" domain="[('share', '=', False)]" widget="many2one_avatar"/>
                                         <label for="completion_time"/>
                                         <div>
-                                            <field name="completion_time" widget="float_time" class="oe_inline"/>
+                                            <field name="completion_time" widget="float_time"  roundToMin='true' class="oe_inline"/>
                                             <span> hours</span>
                                         </div>
                                         <field name="slide_resource_downloadable" attrs="{'invisible': ['|', ('slide_category', '!=', 'document'), ('source_type', '!=', 'local_file')]}"/>


### PR DESCRIPTION
Due to some changes in  formatter.js file, there are
rounding issues with float_time widget, when putting values into
widget in elearning content page, if we specify 11 minutes in duration
it is rounded wrongly and displayed as 10, 14 is displayed as 13, etc.
With this commit, any field that will have roundToMin attribute will
have 50+ seconds rounded to 1 minutes.

Task-3054391
