### PR TITLE
[FIX] website_sale: block employees from updating their billing address

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -103,7 +103,8 @@ def MockRequest(
             debug=False,
             sale_order_id=sale_order_id,
         ),
-        website=website
+        website=website,
+        render=lambda *a, **kw: '<MockResponse>',
     )
 
     with contextlib.ExitStack() as s:

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -576,12 +576,30 @@ class WebsiteSale(http.Controller):
         error = dict()
         error_message = []
 
-        # prevent name change if invoices exist
         if data.get('partner_id'):
-            partner = request.env['res.partner'].browse(int(data['partner_id']))
-            if partner.exists() and partner.sudo().name and not partner.sudo().can_edit_vat() and 'name' in data and (data['name'] or False) != (partner.sudo().name or False):
+            partner_su = request.env['res.partner'].sudo().browse(int(data['partner_id'])).exists()
+            name_change = partner_su and 'name' in data and data['name'] != partner_su.name
+            email_change = partner_su and 'email' in data and data['email'] != partner_su.email
+
+            # Prevent changing the partner name if invoices have been issued.
+            if name_change and not partner_su.can_edit_vat():
                 error['name'] = 'error'
-                error_message.append(_('Changing your name is not allowed once invoices have been issued for your account. Please contact us directly for this operation.'))
+                error_message.append(_(
+                    "Changing your name is not allowed once invoices have been issued for your"
+                    " account. Please contact us directly for this operation."
+                ))
+
+            # Prevent change the partner name or email if it is an internal user.
+            if (name_change or email_change) and not all(partner_su.user_ids.mapped('share')):
+                error.update({
+                    'name': 'error' if name_change else None,
+                    'email': 'error' if email_change else None,
+                })
+                error_message.append(_(
+                    "If you are ordering for an external person, please place your order via the"
+                    " backend. If you wish to change your name or email address, please do so in"
+                    " the account settings or contact your administrator."
+                ))
 
         # Required fields from form
         required_fields = [f for f in (all_form_values.get('field_required') or '').split(',') if f]

--- a/addons/website_sale/i18n/website_sale.pot
+++ b/addons/website_sale/i18n/website_sale.pot
@@ -1409,6 +1409,15 @@ msgstr ""
 #. module: website_sale
 #: code:addons/website_sale/controllers/main.py:0
 #, python-format
+msgid ""
+"If you are ordering for an external person, please place your order via the "
+"backend. If you wish to change your name or email address, please do so in "
+"the account settings or contact your administrator."
+msgstr ""
+
+#. module: website_sale
+#: code:addons/website_sale/controllers/main.py:0
+#, python-format
 msgid "Invalid Email! Please enter a valid email address."
 msgstr ""
 

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -4,7 +4,7 @@
 import odoo.tests
 
 from odoo import api
-from odoo.addons.base.tests.common import HttpCaseWithUserDemo, TransactionCaseWithUserDemo
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo, TransactionCaseWithUserDemo, HttpCaseWithUserPortal
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.addons.website_sale.tests.common import TestWebsiteSaleCommon
 from odoo.addons.website.tools import MockRequest
@@ -103,7 +103,7 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteSaleCommon):
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo):
+class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo, HttpCaseWithUserPortal):
     ''' The goal of this method class is to test the address management on
         the checkout (new/edit billing/shipping, company_id, website_id..).
     '''
@@ -175,6 +175,9 @@ class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo):
         self.demo_user.company_id = self.company_c
         self.demo_partner = self.demo_user.partner_id
 
+        self.portal_user = self.user_portal
+        self.portal_partner = self.portal_user.partner_id
+
     def test_02_demo_address_and_company(self):
         ''' This test ensure that the company_id of the address (partner) is
             correctly set and also, is not wrongly changed.
@@ -196,12 +199,12 @@ class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo):
             self.assertTrue(new_shipping.company_id != self.env.user.company_id, "Logged in user new shipping should not get the company of the sudo() neither the one from it's partner..")
             self.assertEqual(new_shipping.company_id, self.website.company_id, ".. but the one from the website.")
 
-            # 2. Logged in user, edit billing
+            # 2. Logged in user/internal user, should not edit name or email address of billing
             self.default_address_values['partner_id'] = self.demo_partner.id
-            # Name cannot be changed if there are issued invoices
-            self.default_address_values['name'] = self.demo_partner.name
             self.WebsiteSaleController.address(**self.default_address_values)
             self.assertEqual(self.demo_partner.company_id, self.company_c, "Logged in user edited billing (the partner itself) should not get its company modified.")
+            self.assertNotEqual(self.demo_partner.name, self.default_address_values['name'], "Employee cannot change their name during the checkout process.")
+            self.assertNotEqual(self.demo_partner.email, self.default_address_values['email'], "Employee cannot change their email during the checkout process.")
 
     def test_03_public_user_address_and_company(self):
         ''' Same as test_02 but with public user '''
@@ -240,3 +243,25 @@ class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo):
 
             self.WebsiteSaleController.pricelist('')
             self.assertNotEqual(so.pricelist_id, eur_pl, "Pricelist should be removed when sending an empty pl code")
+
+    def test_05_portal_user_address_and_company(self):
+        ''' Same as test_03 but with portal user '''
+        self._setUp_multicompany_env()
+        so = self._create_so(self.portal_partner.id)
+
+        env = api.Environment(self.env.cr, self.portal_user.id, {})
+        # change also website env for `sale_get_order` to not change order partner_id
+        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+            req.httprequest.method = "POST"
+
+            # 1. Portal user, new shipping, same with the log in user
+            self.WebsiteSaleController.address(**self.default_address_values)
+            new_shipping = self._get_last_address(self.portal_partner)
+            self.assertTrue(new_shipping.company_id != self.env.user.company_id, "Portal user new shipping should not get the company of the sudo() neither the one from it's partner..")
+            self.assertEqual(new_shipping.company_id, self.website.company_id, ".. but the one from the website.")
+
+            # 2. Portal user, edit billing
+            self.default_address_values['partner_id'] = self.portal_partner.id
+            self.WebsiteSaleController.address(**self.default_address_values)
+            # Name cannot be changed if there are issued invoices
+            self.assertNotEqual(self.portal_partner.name, self.default_address_values['name'], "Portal User should not be able to change the name if they have invoices under their name.")


### PR DESCRIPTION
Reproduction:
1. Install Event, Sales, Webiste
2. Login as Admin, go to Website -> Go to website -> Events
3. Click the Open wood event, Register, buy one VIP ticket
4. In Address step, Edit the billing address, change the name to “Test
Name”, click next
5. The user name “Mitchell Admin” is changed to  “Test Name”, we
shouldn’t be able to change the info

Reason: In the fix to block name change here: https://github.com/odoo/odoo/commit/d823033ad67702b1b92d27a3f66c7a4ec304c644
we use the can_edit_vat to check if we have existing invoice(s) or
SO(s). However, we should block the route that an employee changes the
billing address when placing an order. If they are placing an order for
external people, it should be done from the back end.

Fix: add an extra error case when it's an employee trying to change the
name or email address when editing billing address. This is the case
when an employee tries to order for external people. They should do it
from the back end. They can still buy for themselves without changing
the billing address. Also added translation in pot. Edited the test for
editing address of log in user, added tests for portal user. Reformat
the invoice exsits check for name change to have better readability

In website, add render on MockRequest that return a supported type
(string e.g.)

The adding of can_edit_vat:
https://github.com/odoo/odoo/commit/f8b05f52f5ea7f31135f700b0e240ff563204085

Related fix to block the name change:
https://github.com/odoo/odoo/commit/d823033ad67702b1b92d27a3f66c7a4ec304c644

A patch to not block the checkout process when name is not set:
https://github.com/odoo/odoo/commit/781dbeaccac76a6ec4f4b8cac1b607810697e394

opw-3126325


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
