### PR TITLE
[IMP] web: form: remove InnerGroup width calculation

### DIFF
--- a/addons/web/static/src/views/form/form_group/form_group.js
+++ b/addons/web/static/src/views/form/form_group/form_group.js
@@ -93,28 +93,6 @@ export class InnerGroup extends Group {
         }
         rows.push(currentRow);
 
-        // Compute the relative size of non-label cells
-        // The aim is for cells containing business data to occupy as much space as possible
-        rows.forEach((row) => {
-            let labelCount = 0;
-            const dataCells = [];
-            for (const c of row) {
-                if (c.subType === "label") {
-                    labelCount++;
-                } else if (c.subType === "item_component") {
-                    labelCount++;
-                    dataCells.push(c);
-                } else {
-                    dataCells.push(c);
-                }
-            }
-
-            const sizeOfDataCell = 100 / (maxCols - labelCount);
-            dataCells.forEach((c) => {
-                const itemSpan = c.subType === "item_component" ? c.itemSpan - 1 : c.itemSpan;
-                c.width = (itemSpan || 1) * sizeOfDataCell;
-            });
-        });
         return rows;
     }
 }

--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -25,9 +25,9 @@
 
                 <t t-else="">
                     <div
-                        class="o_cell flex-grow-1 flex-sm-grow-0"
-                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}{{ cell.width ? 'width: ' + cell.width + '%' + ';' : '' }}"
-                        t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label w-100 text-break text-900' : null }}"
+                        class="o_cell"
+                        t-attf-style="{{ cell.itemSpan > 1 ? 'grid-column: span ' + cell.itemSpan + ';' : '' }}"
+                        t-attf-class="{{ cell.subType === 'label' ? 'o_wrap_label text-break text-900' : null }}"
                         t-if="cell.isVisible">
                         <t t-slot="{{ cell.name }}" />
                     </div>
@@ -40,12 +40,12 @@
 
 <t t-name="web.Form.InnerGroup.ItemComponent">
     <t t-if="cell.props.fieldInfo.field.component.name !== 'BooleanField'">
-        <div class="o_cell o_wrap_label flex-grow-1 flex-sm-grow-0 w-100 text-break text-900">
+        <div class="o_cell o_wrap_label text-break text-900">
             <t t-component="cell.Component" t-if="cell.isVisible" t-props="cell.props"/>
         </div>
         <div
-        class="o_cell o_wrap_input flex-grow-1 flex-sm-grow-0 text-break"
-        t-attf-style="{{ cell.itemSpan -1 > 1 ? 'grid-column: span ' + (cell.itemSpan -1) + ';' : '' }}{{ cell.width ? 'width: ' + cell.width + '%' + ';' : '' }}">
+        class="o_cell o_wrap_input text-break"
+        t-attf-style="{{ cell.itemSpan -1 > 1 ? 'grid-column: span ' + (cell.itemSpan -1) + ';' : '' }}">
             <t t-slot="{{ cell.name }}"/>
         </div>
     </t>

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -7527,21 +7527,17 @@ test(`form rendering with groups with col/colspan`, async () => {
     expect(`.group_4 > div.o_wrap_field:eq(0) div.o_cell`).toHaveCount(1);
     expect(`.group_4 > div.o_wrap_field:eq(0) div.o_cell`).toHaveAttribute(
         "style",
-        "grid-column: span 3;width: 75%;"
+        "grid-column: span 3;"
     );
     expect(`.group_4 > div.o_wrap_field:eq(1) div.o_cell`).toHaveCount(2);
     expect(`.group_4 > div.o_wrap_field:eq(1) div.o_cell:eq(0)`).toHaveAttribute(
         "style",
-        "grid-column: span 2;width: 50%;"
-    );
-    expect(`.group_4 > div.o_wrap_field:eq(1) div.o_cell:eq(1)`).toHaveAttribute(
-        "style",
-        "width: 25%;"
+        "grid-column: span 2;"
     );
     expect(`.group_4 > div.o_wrap_field:eq(2) div.o_cell`).toHaveCount(1);
     expect(`.group_4 > div.o_wrap_field:eq(2) div.o_cell`).toHaveAttribute(
         "style",
-        "grid-column: span 4;width: 100%;"
+        "grid-column: span 4;"
     );
 
     // Verify .group_3 content
@@ -7557,42 +7553,22 @@ test(`form rendering with groups with col/colspan`, async () => {
     expect(`.field_group > .o_wrap_field:eq(0) .o_cell:eq(0)`).toHaveClass("o_wrap_label");
     expect(`.field_group > .o_wrap_field:eq(0) .o_cell:eq(1)`).toHaveAttribute(
         "style",
-        "grid-column: span 2;width: 100%;"
+        "grid-column: span 2;"
     );
 
     expect(`.field_group > .o_wrap_field:eq(1) .o_cell`).toHaveCount(2);
-    expect(`.field_group > .o_wrap_field:eq(1) .o_cell:eq(0)`).toHaveAttribute(
-        "style",
-        /width: 33/
-    );
-    expect(`.field_group > .o_wrap_field:eq(1) .o_cell:eq(1)`).toHaveAttribute(
-        "style",
-        /width: 33/
-    );
 
     expect(`.field_group > .o_wrap_field:eq(2) .o_cell`).toHaveCount(2);
     expect(`.field_group > .o_wrap_field:eq(2) .o_cell:eq(0)`).toHaveClass("o_wrap_label");
-    expect(`.field_group > .o_wrap_field:eq(2) .o_cell:eq(1)`).toHaveAttribute(
-        "style",
-        "width: 50%;"
-    );
 
     expect(`.field_group > .o_wrap_field:eq(3) .o_cell`).toHaveCount(1);
     expect(`.field_group > .o_wrap_field:eq(3) .o_cell`).toHaveAttribute(
         "style",
-        "grid-column: span 3;width: 100%;"
+        "grid-column: span 3;"
     );
 
     expect(`.field_group > .o_wrap_field:eq(4) .o_cell`).toHaveCount(3);
-    expect(`.field_group > .o_wrap_field:eq(4) .o_cell:eq(0)`).toHaveAttribute(
-        "style",
-        "width: 50%;"
-    );
     expect(`.field_group > .o_wrap_field:eq(4) .o_cell:eq(1)`).toHaveClass("o_wrap_label");
-    expect(`.field_group > .o_wrap_field:eq(4) .o_cell:eq(2)`).toHaveAttribute(
-        "style",
-        "width: 50%;"
-    );
 });
 
 test(`form rendering innergroup: separator should take one line`, async () => {


### PR DESCRIPTION
Since the form view is displayed with grid, we can now remove
some CSS rules :

a) The ´display: grid´ property on the parent element prevents
flex-grow from having an effect.

b) The size of the cells is now handled by the following CSS property:
´grid-template-columns´. There is no need to set ´width´ property
(Note that the width of the label is still set to 150 px max)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
