### PR TITLE
[IMP] account,hr_expense: group payment tooltip

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -9566,8 +9566,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_payment_register__group_payment
 msgid ""
-"Only one payment will be created by partner (bank), instead of one per "
-"billy."
+"Only one global payment will be created, instead of one per bill."
 msgstr ""
 
 #. module: account

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -20,7 +20,7 @@ class AccountPaymentRegister(models.TransientModel):
         compute='_compute_communication')
     group_payment = fields.Boolean(string="Group Payments", store=True, readonly=False,
         compute='_compute_group_payment',
-        help="Only one payment will be created by partner (bank), instead of one per bill.")
+        help="Only one payment will be created by partner, instead of one per bill.")
     early_payment_discount_mode = fields.Boolean(compute='_compute_early_payment_discount_mode')
     currency_id = fields.Many2one(
         comodel_name='res.currency',

--- a/addons/hr_expense/__manifest__.py
+++ b/addons/hr_expense/__manifest__.py
@@ -37,6 +37,7 @@ This module also uses analytic accounting and is compatible with the invoice on 
         'data/mail_templates.xml',
         'data/hr_expense_sequence.xml',
         'data/hr_expense_data.xml',
+        'wizard/account_payment_register.xml',
         'wizard/hr_expense_refuse_reason_views.xml',
         'wizard/hr_expense_approve_duplicate_views.xml',
         'wizard/hr_expense_split_wizard_views.xml',

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1255,6 +1255,8 @@ class HrExpenseSheet(models.Model):
                 'active_model': 'account.move',
                 'active_ids': self.account_move_id.ids,
                 'default_partner_bank_id': self.employee_id.sudo().bank_account_id.id,
+                'default_group_payment': True,
+                'hide_group_payment': True,
             },
             'target': 'new',
             'type': 'ir.actions.act_window',

--- a/addons/hr_expense/wizard/account_payment_register.xml
+++ b/addons/hr_expense/wizard/account_payment_register.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_expense_account_payment_register_inherited" model="ir.ui.view">
+        <field name="name">account.payment.register.form</field>
+        <field name="model">account.payment.register</field>
+        <field name="inherit_id" ref="account.view_account_payment_register_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='group_payment']" position="attributes">
+                <attribute name="invisible">context.get('hide_group_payment')</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In the module expense, modifies the Group Payment tooltip. The 'group payment' boolean field is also set by default to True within the Register payment popup of an expense report paid by an employee.

task : 3165966



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
