### PR TITLE
[FIX] website: fix autohide menu feature on resize

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -33,18 +33,23 @@ const BaseAnimatedHeader = animations.Animation.extend({
      * @override
      */
     start: function () {
+        const self = this;
         this.$main = this.$el.next('main');
         this.isOverlayHeader = !!this.$el.closest('.o_header_overlay, .o_header_overlay_theme').length;
         this.$dropdowns = this.$el.find('.dropdown, .dropdown-menu');
         this.$navbarCollapses = this.$el.find('.navbar-collapse');
+        this.scrollTarget = document.querySelector('#wrapwrap');
+        const navbarEl = this.scrollTarget.querySelector('.navbar');
+        const [breakpoint] = Object.keys(config.device.SIZES).filter((size) => navbarEl.classList.contains(`navbar-expand-${size.toLowerCase()}`));
+        this.navBreakpoint = breakpoint || 'LG';
 
         // While scrolling through navbar menus on medium devices, body should not be scrolled with it
         this.$navbarCollapses.on('show.bs.collapse.BaseAnimatedHeader', function () {
-            if (config.device.size_class <= config.device.SIZES.SM) {
-                $(document.body).addClass('overflow-hidden');
+            if (config.device.size_class < config.device.SIZES[self.navBreakpoint]) {
+                self.scrollTarget.classList.add('overflow-hidden');
             }
         }).on('hide.bs.collapse.BaseAnimatedHeader', function () {
-            $(document.body).removeClass('overflow-hidden');
+            self.scrollTarget.classList.remove('overflow-hidden');
         });
 
         // We can rely on transitionend which is well supported but not on
@@ -227,9 +232,9 @@ const BaseAnimatedHeader = animations.Animation.extend({
      */
     _updateHeaderOnResize: function () {
         this._adaptFixedHeaderPosition();
-        if (document.body.classList.contains('overflow-hidden')
-                && config.device.size_class > config.device.SIZES.SM) {
-            document.body.classList.remove('overflow-hidden');
+        if (this.scrollTarget.classList.contains('overflow-hidden')
+                && config.device.size_class >= config.device.SIZES[this.navBreakpoint]) {
+            this.scrollTarget.classList.remove('overflow-hidden');
             this.$el.find('.navbar-collapse').removeClass('show');
         }
     },


### PR DESCRIPTION
To reproduce the issue:

1- Website > Reduce window width until the navbar is collapsed.
2- Open the hamburger menu.
3- Resize window to expand the navbar.
4- The "autohide menu" adaptation (sets the overflowing menu items in a "+" dropdown)
is disabled > overflowing items are visible.

On each step of this flow (1, 2, 3 & 4), some changes are applied on the menu leading to
this behaviour:

Step 1: The menu is collapsed (device size = `MD`).

Step 2 (on `BaseAnimatedHeader`):

To prevent "body scroll" on medium devices when the navbar is scrolled, the
`show.bs.collapse.BaseAnimatedHeader` handler adds an `overflow-hidden` class on
`document.body`. In this case, the handler will fail to add the class (the device size
should be <= SM).

Step 3:

On resize, and if the menu is open (body has the `overflow-hidden` class),
The `BaseAnimatedHeader` > `_updateHeaderOnResize()` will remove the `show` class
from the `.navbar-collapse` (It will not be removed in this case because of the failure
in step 2 [A]).

Step 4: (`initAutoMoreMenu`)

Starting from this [FIX], and because of [A], The `initAutoMoreMenu` > `_adapt()` will
be skipped and the targeted menu will be considered as toggleable in this case.

The goal of this commit is to fix this behaviour by adding the `overflow-hidden` on the
right target (`#wrapwrap` instead of `document.body`). Then, the menu breakpoint size
will be extracted from the `navbar-expand-XX` class of the navbar. This way, the 
`_adapt()` method will be applied correctly on resize.

[FIX]: https://github.com/odoo/odoo/commit/584b76d70ba60c8725108a40f85629f8ca8d0dd9

task-3086316