### PR TITLE
[FIX] base: add cumulated to rng graph file

### DIFF
--- a/odoo/addons/base/rng/graph_view.rng
+++ b/odoo/addons/base/rng/graph_view.rng
@@ -24,6 +24,7 @@
             <rng:optional><rng:attribute name="disable_linking"/></rng:optional>
             <rng:optional><rng:attribute name="sample"/></rng:optional>
             <rng:optional><rng:attribute name="banner_route"/></rng:optional>
+            <rng:optional><rng:attribute name="cumulated"/></rng:optional>
             <rng:zeroOrMore>
                 <rng:ref name="field"/>
             </rng:zeroOrMore>

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3205,6 +3205,9 @@ class TestViews(ViewCase):
             'A <graph> can only contains <field> nodes, found a <label>'
         )
 
+    def test_graph_attributes(self):
+        self.assertValid('<graph string="Graph" cumulated="1" ><field name="model" type="row"/><field name="inherit_id" type="measure"/></graph>')
+
     def test_view_ref(self):
         view = self.assertValid(
             """


### PR DESCRIPTION
close #111745

This commit adds cumulated optional attribute to the graph view rng definition.

`cumulated` graph attribute is used, defined and tested in PR https://github.com/odoo/odoo/pull/97394.
