### PR TITLE
[FIX] product: ensure the parent company pricelist is used

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -20,12 +20,13 @@ class ResPartner(models.Model):
     @api.depends('country_id')
     @api.depends_context('company')
     def _compute_product_pricelist(self):
-        res = self.env['product.pricelist']._get_partner_pricelist_multi(self.ids)
+        partner_ids = self.commercial_partner_id.ids
+        res = self.env['product.pricelist']._get_partner_pricelist_multi(partner_ids)
         for partner in self:
-            partner.property_product_pricelist = res.get(partner.id)
+            partner.property_product_pricelist = res.get(partner.commercial_partner_id.id)
 
     def _inverse_product_pricelist(self):
-        for partner in self:
+        for partner in self.filtered(lambda p: p == p.commercial_partner_id):
             pls = self.env['product.pricelist'].search(
                 [('country_group_ids.country_ids.code', '=', partner.country_id and partner.country_id.code or False)],
                 limit=1

--- a/addons/test_event_full/tests/test_performance.py
+++ b/addons/test_event_full/tests/test_performance.py
@@ -461,7 +461,7 @@ class TestOnlineEventPerformance(EventPerformanceCase, UtilPerf):
         # website customer data
         with freeze_time(self.reference_now):
             self.authenticate(None, None)
-            with self.assertQueryCount(default=39):
+            with self.assertQueryCount(default=40):
                 self._test_url_open('/event')
 
     # @warmup


### PR DESCRIPTION
Since the pricelist is supposed to be shared with the commercial partner, there is no reason to store the information independently on a partner and its commercial partner.
With this commit, the pricelist of a partner will always be his commercial partner pricelist, disregarding leftover conflicting data in database.

task-3167549