### PR TITLE
[FIX] fields: convert timezone-aware datetime even already have

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2164,7 +2164,8 @@ class Datetime(Field):
         """
         assert isinstance(timestamp, datetime), 'Datetime instance expected'
         tz_name = record._context.get('tz') or record.env.user.tz
-        utc_timestamp = pytz.utc.localize(timestamp, is_dst=False)  # UTC = no DST
+        local_tz = pytz.timezone(tz_name)
+        utc_timestamp = timestamp.replace(tzinfo=pytz.utc).astimezone(local_tz)
         if tz_name:
             try:
                 context_tz = pytz.timezone(tz_name)


### PR DESCRIPTION
#### Summary of changes:
- Timestamp convert to timezone-aware datetime in context timezone If already have timezone for datetime it replace with <UTC>
- In this case, Timezone for datetime(tzinfo) already has,  So I just replaced it with `pytz.utc` which is <UTC>, and rest of the work as it is with the function `astimezone()`

#### Link to task:
- opw-[3148720](https://www.odoo.com/web#id=3148720&menu_id=4720&cids=2&action=333&active_id=70&model=project.task&view_type=form)

#### Traceback:
```python
Traceback (most recent call last):
  File "/tmp/tmp2e_qzu15/migrations/testing.py", line 211, in test_check
    self.check(value)
  File "/tmp/tmp2e_qzu15/migrations/base/tests/test_mock_crawl.py", line 121, in check
    self.assertFalse(diff, msg)
AssertionError: [('studio_customization.punto_de_venta_infor_e78491e6-bff9-4187-87f0-8e03adc5baf8', 581, 'Point of Sale > Reporting > Orders > Detalle Ventas', 570), ('', 583, 'Point of Sale > Informes > Detalle Ventas', 570)] is not false: At least one menu or view working before the upgrade is not working after upgrade.

('studio_customization.punto_de_venta_infor_e78491e6-bff9-4187-87f0-8e03adc5baf8', 581, 'Point of Sale > Reporting > Orders > Detalle Ventas', 570):
 Traceback (most recent call last):
   File "<1677>", line 311, in template_1677
   File "<1677>", line 293, in template_1677_content
   File "<1677>", line 272, in template_1677_t_call_0
   File "<1677>", line 16, in template_1677_t_call_1
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_qweb.py", line 2382, in _get_widget
    content = converter.value_to_html(value, field_options)
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_qweb_fields.py", line 253, in value_to_html
    value = fields.Datetime.context_timestamp(self, value)
   File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 2167, in context_timestamp
    utc_timestamp = pytz.utc.localize(timestamp, is_dst=False)  # UTC = no DST
   File "/home/odoo/.odoo-venvs/15.0/lib/python3.8/site-packages/pytz/__init__.py", line 238, in localize
    raise ValueError('Not naive datetime (tzinfo is already set)')
 ValueError: Not naive datetime (tzinfo is already set)
 
The above exception was the direct cause of the following exception:

 Traceback (most recent call last):
   File "/tmp/tmp2e_qzu15/migrations/base/tests/test_mock_crawl.py", line 221, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmp2e_qzu15/migrations/base/tests/test_mock_crawl.py", line 256, in mock_action
    result = self.render_method(action["report_name"], [], data=None)
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_actions_report.py", line 894, in _render
    return render_func(report_ref, res_ids, data=data)
   File "/home/odoo/src/odoo/16.0/addons/account/models/ir_actions_report.py", line 54, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_actions_report.py", line 791, in _render_qweb_pdf
    return self._render_qweb_html(report_ref, res_ids, data=data)
   File "/home/odoo/src/enterprise/16.0/web_studio/models/ir_actions_report.py", line 19, in _render_qweb_html
    return super(IrActionsReport, self)._render_qweb_html(report_ref, docids, data)
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_actions_report.py", line 862, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_actions_report.py", line 609, in _render_template
    return view_obj._render_template(template, values).encode()
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_ui_view.py", line 2119, in _render_template
    return self.env['ir.qweb']._render(template, values)
   File "/home/odoo/src/odoo/16.0/odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
   File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_qweb.py", line 568, in _render
    result = ''.join(rendering)
   File "<1677>", line 317, in template_1677
 odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
ValueError: Not naive datetime (tzinfo is already set)
Template: point_of_sale.report_saledetails
Path: /t/t[2]/t/div/div/t/strong/t[1]
Node: <t t-esc="date_start" t-options="{\'widget\': \'datetime\'}"/>
```
#### Other references:
- https://github.com/celery/celery/issues/983#issuecomment-1016617298
- https://github.com/celery/django-celery/issues/183#issue-6950689



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

