### PR TITLE
[FIX] Revert part of 2a07d7b

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -107,7 +107,6 @@ class StockMove(models.Model):
 
     def _action_confirm(self, merge=True, merge_into=False):
         subcontract_details_per_picking = defaultdict(list)
-        move_to_not_merge = self.env['stock.move']
         for move in self:
             if move.location_id.usage != 'supplier' or move.location_dest_id.usage == 'supplier':
                 continue
@@ -124,13 +123,10 @@ class StockMove(models.Model):
                 'is_subcontract': True,
                 'location_id': move.picking_id.partner_id.with_company(move.company_id).property_stock_subcontractor.id
             })
-            move_to_not_merge |= move
         for picking, subcontract_details in subcontract_details_per_picking.items():
             picking._subcontracted_produce(subcontract_details)
 
-        # We avoid merging move due to complication with stock.rule.
-        res = super(StockMove, move_to_not_merge)._action_confirm(merge=False)
-        res |= super(StockMove, self - move_to_not_merge)._action_confirm(merge=merge, merge_into=merge_into)
+        res = super(StockMove, self)._action_confirm(merge=merge, merge_into=merge_into)
         if subcontract_details_per_picking:
             self.env['stock.picking'].concat(*list(subcontract_details_per_picking.keys())).action_assign()
         return res


### PR DESCRIPTION
This commit reverts the changes made in `_action_confirm` by the commit https://github.com/odoo-dev/odoo/commit/2a07d7b8f9c0321934b1caf45a7a4a6a15c60e98 .
This part should probably not have been forwarded from 13 to 14. The addition of `move_to_not_merge` can raise the error message "Record does not exist or has been deleted" by adding a stock.move to `res`, that under certain conditions, might be merged and deleted right after.
The test added in that commit is kept to ensure the behaviour remains the same and that the flow does not get broken later.

OPW-3147446
