### PR TITLE
[FIX] sms: Send sms on sale order

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -230,7 +230,9 @@ class SendSMS(models.TransientModel):
         # on the numbers in the database.
         records = records if records is not None else self._get_records()
         records.ensure_one()
-        if self.recipient_single_number_itf and self.recipient_single_number_itf != self.recipient_single_number:
+        if not self.number_field_name:
+            self.numbers = self.recipient_single_number_itf or self.recipient_single_number
+        elif self.recipient_single_number_itf and self.recipient_single_number_itf != self.recipient_single_number:
             records.write({self.number_field_name: self.recipient_single_number_itf})
         return self._action_send_sms_comment(records=records)
 

--- a/addons/test_mail_full/tests/test_sms_composer.py
+++ b/addons/test_mail_full/tests/test_sms_composer.py
@@ -220,6 +220,23 @@ class TestSMSComposerComment(TestMailFullCommon, TestMailFullRecipients):
         self.assertNoSMS()
         self.assertSMSIapSent(self.random_numbers_san, self._test_body)
 
+    def test_composer_sending_with_no_number_field(self):
+        test_record = self.env['mail.test.sms.partner'].create({'name': 'Test'})
+        sms_composer = self.env['sms.composer'].create({
+            'body': self._test_body,
+            'composition_mode': 'comment',
+            'mass_force_send': False,
+            'mass_keep_log': True,
+            'number_field_name': False,
+            'numbers': False,
+            'recipient_single_number_itf': self.random_numbers_san[0],
+            'res_id': test_record.id,
+            'res_model': 'mail.test.sms.partner'
+        })
+        with self.mockSMSGateway():
+            sms_composer._action_send_sms()
+        self.assertSMSNotification([{'number': self.random_numbers_san[0]}], self._test_body)
+
 
 class TestSMSComposerBatch(TestMailFullCommon):
 


### PR DESCRIPTION
Steps:
- Go to Sales
-  Open a sale order
- Click on Action
- Send SMS
- Fill phone number and message
- Send SMS

Issue:
Traceback

Cause:
Sale order doesn't have a phone or mobile field so the sms.composer tries to write on it use "False"

opw-3162761