### PR TITLE
[FIX] web: setupViewRegistries: correct syntax

### DIFF
--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -107,9 +107,9 @@ export function setupViewRegistries() {
         { force: true }
     );
     serviceRegistry.add("router", makeFakeRouterService(), { force: true });
-    serviceRegistry.add("localization", makeFakeLocalizationService()), { force: true };
-    serviceRegistry.add("dialog", dialogService), { force: true };
-    serviceRegistry.add("popover", popoverService), { force: true };
+    serviceRegistry.add("localization", makeFakeLocalizationService(), { force: true });
+    serviceRegistry.add("dialog", dialogService, { force: true });
+    serviceRegistry.add("popover", popoverService, { force: true });
     serviceRegistry.add("company", fakeCompanyService);
     serviceRegistry.add("command", commandService);
 }

--- a/addons/web/static/tests/views/helpers_tests.js
+++ b/addons/web/static/tests/views/helpers_tests.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { setupViewRegistries } from "@web/../tests/views/helpers";
+import { makeFakeLocalizationService } from "../helpers/mock_services";
+import { dialogService } from "@web/core/dialog/dialog_service";
+import { popoverService } from "@web/core/popover/popover_service";
+
+const serviceRegistry = registry.category("services");
+
+QUnit.module("Views", (hooks) => {
+    QUnit.module("Helpers tests");
+
+    QUnit.test("setupViewRegistries overwrite services", async function (assert) {
+        serviceRegistry.add("localization", makeFakeLocalizationService(), { force: true });
+        serviceRegistry.add("dialog", dialogService, { force: true });
+        serviceRegistry.add("popover", popoverService, { force: true });
+        setupViewRegistries(); // crash if does not overwrite (force)
+        assert.ok(true, "setupViewRegistries overwrite services");
+    });
+});


### PR DESCRIPTION
The `setupViewRegistries` helper function had a bad syntax, making it impossible to overwrite services if they already existed.