### PR TITLE
[FIX] web: add and use daterange field with studio

### DIFF
--- a/addons/web/static/src/views/fields/daterange/daterange_field.js
+++ b/addons/web/static/src/views/fields/daterange/daterange_field.js
@@ -125,7 +125,7 @@ export class DateRangeField extends Component {
         const dates = [start, end].map(momentToLuxon);
         await this.updateRange(dates[0], dates[1]);
         const input = document.querySelector(
-            `.o_field_daterange[name='${this.relatedDateRangeField}'] input`
+            `.o_field_daterange[name='${this.props.name}'] input`
         );
         const target = window.$(input).data("daterangepicker");
         target.setStartDate(picker.startDate);


### PR DESCRIPTION
Custom date fields with widget daterange raise an error when clicking on 'APPLY'

Steps to reproduce:
1. Install Project and Studio
2. Open any task
3. Edit the form view by toggling Studio
4. Add a field 'end_date' in the view, set it as readonly
5. Add a field 'start_date' in the view with widget 'daterange' and related end date 'end_date'
6. Close Studio
7. Set a date range on the field 'start_date' and click on 'APPLY'
8. An error is thrown

Solution:
Use the name of the daterange to find it in the document

Problem:
When trying to locate the daterange field in the document, we use the relatedDateRangeField as the name of the field we're searching for but we should use its name

opw-3159698