### PR TITLE
[IMP] core: Balance SQL queries on multiple DB

### DIFF
--- a/addons/base_automation/controllers/main.py
+++ b/addons/base_automation/controllers/main.py
@@ -3,7 +3,7 @@ from odoo.addons.base_automation.models.base_automation import get_webhook_reque
 
 class BaseAutomationController(Controller):
 
-    @route(['/web/hook/<string:rule_uuid>'], type='http', auth='none', methods=['GET', 'POST'], csrf=False, save_session=False)
+    @route(['/web/hook/<string:rule_uuid>'], type='http', auth='public', methods=['GET', 'POST'], csrf=False, save_session=False)
     def call_webhook_http(self, rule_uuid, **kwargs):
         """ Execute an automation webhook """
         rule = request.env['base.automation'].sudo().search([('webhook_uuid', '=', rule_uuid)])

--- a/addons/http_routing/controllers/main.py
+++ b/addons/http_routing/controllers/main.py
@@ -9,7 +9,7 @@ from odoo.addons.web.controllers.webclient import WebClient
 
 class Routing(Home):
 
-    @http.route('/website/translations/<string:unique>', type='http', auth="public", website=True)
+    @http.route('/website/translations/<string:unique>', type='http', auth="public", website=True, readonly=True)
     def get_website_translations(self, unique, lang=None, mods=None):
         IrHttp = request.env['ir.http'].sudo()
         modules = IrHttp.get_translation_frontend_modules()

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -577,6 +577,7 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _frontend_pre_dispatch(cls):
+        request.lang = request.lang.with_env(request.env)
         request.update_context(lang=request.lang._get_cached('code'))
         if request.httprequest.cookies.get('frontend_lang') != request.lang._get_cached('code'):
             request.future_response.set_cookie('frontend_lang', request.lang._get_cached('code'))

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -20,7 +20,7 @@ class WebclientController(http.Controller):
             return guest.with_context(**context)._init_messaging()
         raise NotFound()
 
-    @http.route("/mail/load_message_failures", methods=["POST"], type="json", auth="user")
+    @http.route("/mail/load_message_failures", methods=["POST"], type="json", auth="user", readonly=True)
     def mail_load_message_failures(self):
         # sudo as to not check ACL, which is far too costly
         # sudo: res.users - return only failures of current user as author

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -28,7 +28,7 @@ def add_guest_to_context(func):
             req.httprequest.cookies.get(req.env["mail.guest"]._cookie_name, "")
         )
         guest = req.env["mail.guest"]._get_guest_from_token(token)
-        if guest and not guest.timezone:
+        if guest and not guest.timezone and not req.env.cr.readonly:
             timezone = req.env["mail.guest"]._get_timezone_from_request(req)
             if timezone:
                 guest._update_timezone(timezone)

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -277,6 +277,7 @@ class Users(models.Model):
         return values
 
     @api.model
+    @api.readonly
     def systray_get_activities(self):
         search_limit = int(self.env['ir.config_parameter'].sudo().get_param('mail.activity.systray.limit', 1000))
         activities = self.env["mail.activity"].search(

--- a/addons/mail/tests/test_res_users_settings.py
+++ b/addons/mail/tests/test_res_users_settings.py
@@ -1,7 +1,26 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.tests.common import tagged, users
+from odoo.tests.common import tagged, users, TransactionCase
+
+
+class TestUSerCreationSettings(TransactionCase):
+
+    def test_create_portal_user(self):
+        portal_group = self.env.ref('base.group_portal')
+        user = self.env.user.create({
+            'name': 'A portal user',
+            'login': 'portal_test',
+            'groups_id': [(6, 0, [portal_group.id])],
+        })
+        self.assertFalse(user.res_users_settings_ids, 'Portal users should not have settings by default')
+
+    def test_create_internal_user(self):
+        user = self.env.user.create({
+            'name': 'A internal user',
+            'login': 'test_user',
+        })
+        self.assertTrue(user.res_users_settings_ids, 'Internal users should have settings by default')
 
 
 @tagged("post_install", "-at_install")
@@ -9,6 +28,7 @@ class TestResUsersSettings(MailCommon):
 
     @users('employee')
     def test_find_or_create_for_user_should_create_record_if_not_existing(self):
+        self.user_employee.res_users_settings_ids.unlink()  # pre autocreate or a portal user switching to internal user
         settings = self.user_employee.res_users_settings_ids
         self.assertFalse(settings, "no records should exist")
 
@@ -18,6 +38,7 @@ class TestResUsersSettings(MailCommon):
 
     @users('employee')
     def test_find_or_create_for_user_should_return_correct_res_users_settings(self):
+        self.user_employee.res_users_settings_ids.unlink()
         settings = self.env['res.users.settings'].create({
             'user_id': self.user_employee.id,
         })
@@ -26,11 +47,9 @@ class TestResUsersSettings(MailCommon):
 
     @users('employee')
     def test_set_res_users_settings_should_send_notification_on_bus(self):
-        settings = self.env['res.users.settings'].create({
-            'is_discuss_sidebar_category_channel_open': False,
-            'is_discuss_sidebar_category_chat_open': False,
-            'user_id': self.user_employee.id,
-        })
+        settings = self.user_employee.res_users_settings_id
+        settings.is_discuss_sidebar_category_chat_open = False
+        settings.is_discuss_sidebar_category_channel_open = False
 
         with self.assertBus(
                 [(self.cr.dbname, 'res.partner', self.partner_employee.id)],
@@ -45,11 +64,7 @@ class TestResUsersSettings(MailCommon):
 
     @users('employee')
     def test_set_res_users_settings_should_set_settings_properly(self):
-        settings = self.env['res.users.settings'].create({
-            'is_discuss_sidebar_category_channel_open': False,
-            'is_discuss_sidebar_category_chat_open': False,
-            'user_id': self.user_employee.id,
-        })
+        settings = self.user_employee.res_users_settings_id
         settings.set_res_users_settings({'is_discuss_sidebar_category_chat_open': True})
         self.assertEqual(
             settings.is_discuss_sidebar_category_chat_open,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -9,8 +9,8 @@ from odoo.tests.common import users, tagged, HttpCase, warmup
 
 @tagged('post_install', '-at_install')
 class TestDiscussFullPerformance(HttpCase):
-    _query_count = 55
-    _query_count_discuss_channels = 46
+    _query_count = 56
+    _query_count_discuss_channels = 47
 
     def setUp(self):
         super().setUp()

--- a/addons/web/controllers/action.py
+++ b/addons/web/controllers/action.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 class Action(Controller):
 
-    @route('/web/action/load', type='json', auth="user")
+    @route('/web/action/load', type='json', auth='user', readonly=True)
     def load(self, action_id, additional_context=None):
         Actions = request.env['ir.actions.actions']
         value = False

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -247,41 +247,41 @@ class Binary(http.Controller):
             response = http.Stream.from_path(file_path('web/static/img/logo.png')).get_response()
         else:
             try:
-                # create an empty registry
-                registry = odoo.modules.registry.Registry(dbname)
-                with registry.cursor() as cr:
-                    company = int(kw['company']) if kw and kw.get('company') else False
-                    if company:
-                        cr.execute("""SELECT logo_web, write_date
-                                        FROM res_company
-                                       WHERE id = %s
-                                   """, (company,))
-                    else:
-                        cr.execute("""SELECT c.logo_web, c.write_date
-                                        FROM res_users u
-                                   LEFT JOIN res_company c
-                                          ON c.id = u.company_id
-                                       WHERE u.id = %s
-                                   """, (uid,))
-                    row = cr.fetchone()
-                    if row and row[0]:
-                        image_base64 = base64.b64decode(row[0])
-                        image_data = io.BytesIO(image_base64)
-                        mimetype = guess_mimetype(image_base64, default='image/png')
-                        imgext = '.' + mimetype.split('/')[1]
-                        if imgext == '.svg+xml':
-                            imgext = '.svg'
-                        response = send_file(
-                            image_data,
-                            request.httprequest.environ,
-                            download_name=imgname + imgext,
-                            mimetype=mimetype,
-                            last_modified=row[1],
-                            response_class=Response,
-                        )
-                    else:
-                        response = http.Stream.from_path(file_path('web/static/img/nologo.png')).get_response()
+                company = int(kw['company']) if kw and kw.get('company') else False
+                if company:
+                    request.env.cr.execute("""
+                        SELECT logo_web, write_date
+                          FROM res_company
+                         WHERE id = %s
+                    """, (company,))
+                else:
+                    request.env.cr.execute("""
+                        SELECT c.logo_web, c.write_date
+                          FROM res_users u
+                     LEFT JOIN res_company c
+                            ON c.id = u.company_id
+                         WHERE u.id = %s
+                    """, (uid,))
+                row = request.env.cr.fetchone()
+                if row and row[0]:
+                    image_base64 = base64.b64decode(row[0])
+                    image_data = io.BytesIO(image_base64)
+                    mimetype = guess_mimetype(image_base64, default='image/png')
+                    imgext = '.' + mimetype.split('/')[1]
+                    if imgext == '.svg+xml':
+                        imgext = '.svg'
+                    response = send_file(
+                        image_data,
+                        request.httprequest.environ,
+                        download_name=imgname + imgext,
+                        mimetype=mimetype,
+                        last_modified=row[1],
+                        response_class=Response,
+                    )
+                else:
+                    response = http.Stream.from_path(file_path('web/static/img/nologo.png')).get_response()
             except Exception:
+                _logger.warning("While retrieving the company logo, using the Odoo logo instead", exc_info=True)
                 response = http.Stream.from_path(file_path(f'web/static/img/{imgname}{imgext}')).get_response()
 
         return response

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -116,7 +116,7 @@ class Binary(http.Controller):
             else:
                 # if we don't have a replica, the cursor is not readonly, use the same one to avoid a rollback
                 cursor_manager = nullcontext(env.cr)
-            with cursor_manager as rw_cr:  # TODO add test generating an attachment with this route
+            with cursor_manager as rw_cr:
                 rw_env = api.Environment(rw_cr, env.user.id, {})
                 try:
                     if filename.endswith('.map'):

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -8,6 +8,7 @@ import logging
 import os
 import unicodedata
 
+from contextlib import nullcontext
 try:
     from werkzeug.utils import send_file
 except ImportError:

--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -13,17 +13,27 @@ from .utils import clean_action
 _logger = logging.getLogger(__name__)
 
 
+def _call_kw_readonly(registry, request):
+    params = request.get_json_data()['params']
+    model_class = registry[params['model']]
+    method_name = params['method']
+    for cls in model_class.mro():
+        method = getattr(cls, method_name, None)
+        if method is not None and hasattr(method, '_readonly'):
+            return method._readonly
+    return False
+
 class DataSet(http.Controller):
 
     def _call_kw(self, model, method, args, kwargs):
         check_method_name(method)
         return call_kw(request.env[model], method, args, kwargs)
 
-    @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='json', auth="user")
+    @http.route(['/web/dataset/call_kw', '/web/dataset/call_kw/<path:path>'], type='json', auth="user", readonly=_call_kw_readonly)
     def call_kw(self, model, method, args, kwargs, path=None):
         return self._call_kw(model, method, args, kwargs)
 
-    @http.route(['/web/dataset/call_button', '/web/dataset/call_button/<path:path>'], type='json', auth="user")
+    @http.route(['/web/dataset/call_button', '/web/dataset/call_button/<path:path>'], type='json', auth="user", readonly=_call_kw_readonly)
     def call_button(self, model, method, args, kwargs, path=None):
         action = self._call_kw(model, method, args, kwargs)
         if isinstance(action, dict) and action.get('type') != '':

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -287,7 +287,7 @@ class GroupExportXlsxWriter(ExportXlsxWriter):
 
 class Export(http.Controller):
 
-    @http.route('/web/export/formats', type='json', auth="user")
+    @http.route('/web/export/formats', type='json', auth='user', readonly=True)
     def formats(self):
         """ Returns all valid export formats
 
@@ -304,7 +304,7 @@ class Export(http.Controller):
         fields = Model.fields_get()
         return fields
 
-    @http.route('/web/export/get_fields', type='json', auth="user")
+    @http.route('/web/export/get_fields', type='json', auth='user', readonly=True)
     def get_fields(self, model, prefix='', parent_name='',
                    import_compat=True, parent_field_type=None,
                    parent_field=None, exclude=None):
@@ -360,7 +360,7 @@ class Export(http.Controller):
 
         return records
 
-    @http.route('/web/export/namelist', type='json', auth="user")
+    @http.route('/web/export/namelist', type='json', auth='user', readonly=True)
     def namelist(self, model, export_id):
         # TODO: namelist really has no reason to be in Python (although itertools.groupby helps)
         export = request.env['ir.exports'].browse([export_id]).read()[0]
@@ -509,7 +509,7 @@ class ExportFormat(object):
 
 class CSVExport(ExportFormat, http.Controller):
 
-    @http.route('/web/export/csv', type='http', auth="user")
+    @http.route('/web/export/csv', type='http', auth='user', readonly=True)
     def web_export_csv(self, data):
         try:
             return self.base(data)
@@ -553,7 +553,7 @@ class CSVExport(ExportFormat, http.Controller):
 
 class ExcelExport(ExportFormat, http.Controller):
 
-    @http.route('/web/export/xlsx', type='http', auth="user")
+    @http.route('/web/export/xlsx', type='http', auth='user', readonly=True)
     def web_export_xlsx(self, data):
         try:
             return self.base(data)

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -61,7 +61,7 @@ class Home(http.Controller):
         except AccessError:
             return request.redirect('/web/login?error=access')
 
-    @http.route('/web/webclient/load_menus/<string:unique>', type='http', auth='user', methods=['GET'])
+    @http.route('/web/webclient/load_menus/<string:unique>', type='http', auth='user', methods=['GET'], readonly=True)
     def web_load_menus(self, unique, lang=None):
         """
         Loads the menus for the webclient
@@ -85,7 +85,7 @@ class Home(http.Controller):
     def _login_redirect(self, uid, redirect=None):
         return _get_login_redirect_url(uid, redirect)
 
-    @http.route('/web/login', type='http', auth="none")
+    @http.route('/web/login', type='http', auth='none', readonly=False)
     def web_login(self, redirect=None, **kw):
         ensure_db()
         request.params['login_success'] = False
@@ -139,7 +139,7 @@ class Home(http.Controller):
         valid_values = {k: v for k, v in kwargs.items() if k in LOGIN_SUCCESSFUL_PARAMS}
         return request.render('web.login_successful', valid_values)
 
-    @http.route('/web/become', type='http', auth='user', sitemap=False)
+    @http.route('/web/become', type='http', auth='user', sitemap=False, readonly=True)
     def switch_to_admin(self):
         uid = request.env.user.id
         if request.env.user._is_system():

--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -13,10 +13,6 @@ from odoo.tools.misc import xlsxwriter
 
 class TableExporter(http.Controller):
 
-    @http.route('/web/pivot/check_xlsxwriter', type='json', auth='none')
-    def check_xlsxwriter(self):
-        return xlsxwriter is not None
-
     @http.route('/web/pivot/export_xlsx', type='http', auth="user")
     def export_xlsx(self, data, **kw):
         jdata = json.loads(data)

--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -13,7 +13,7 @@ from odoo.tools.misc import xlsxwriter
 
 class TableExporter(http.Controller):
 
-    @http.route('/web/pivot/export_xlsx', type='http', auth="user")
+    @http.route('/web/pivot/export_xlsx', type='http', auth="user", readonly=True)
     def export_xlsx(self, data, **kw):
         jdata = json.loads(data)
         output = io.BytesIO()

--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -20,7 +20,10 @@ class Profiling(Controller):
         except UserError as e:
             return Response(response='error: %s' % e, status=500, mimetype='text/plain')
 
-    @route(['/web/speedscope', '/web/speedscope/<model("ir.profile"):profile>'], type='http', sitemap=False, auth='user')
+    @route([
+        '/web/speedscope',
+        '/web/speedscope/<model("ir.profile"):profile>',
+    ], type='http', sitemap=False, auth='user', readonly=True)
     def speedscope(self, profile=None):
         # don't server speedscope index if profiling is not enabled
         if not request.env['ir.profile']._enabled_until():

--- a/addons/web/controllers/report.py
+++ b/addons/web/controllers/report.py
@@ -23,7 +23,7 @@ class ReportController(http.Controller):
     @http.route([
         '/report/<converter>/<reportname>',
         '/report/<converter>/<reportname>/<docids>',
-    ], type='http', auth='user', website=True)
+    ], type='http', auth='user', website=True, readonly=True)
     def report_routes(self, reportname, docids=None, converter=None, **data):
         report = request.env['ir.actions.report']
         context = dict(request.env.context)
@@ -52,7 +52,10 @@ class ReportController(http.Controller):
     #------------------------------------------------------
     # Misc. route utils
     #------------------------------------------------------
-    @http.route(['/report/barcode', '/report/barcode/<barcode_type>/<path:value>'], type='http', auth="public")
+    @http.route([
+        '/report/barcode',
+        '/report/barcode/<barcode_type>/<path:value>',
+    ], type='http', auth='public', readonly=True)
     def report_barcode(self, barcode_type, value, **kwargs):
         """Contoller able to render barcode images thanks to reportlab.
         Samples::
@@ -84,7 +87,8 @@ class ReportController(http.Controller):
         return request.make_response(barcode, headers=[('Content-Type', 'image/png')])
 
     @http.route(['/report/download'], type='http', auth="user")
-    def report_download(self, data, context=None, token=None):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    def report_download(self, data, context=None, token=None, readonly=True):
         """This function is used by 'action_manager_report.js' in order to trigger the download of
         a pdf/controller report.
 
@@ -143,6 +147,6 @@ class ReportController(http.Controller):
             res = request.make_response(html_escape(json.dumps(error)))
             raise werkzeug.exceptions.InternalServerError(response=res) from e
 
-    @http.route(['/report/check_wkhtmltopdf'], type='json', auth="user")
+    @http.route(['/report/check_wkhtmltopdf'], type='json', auth='user', readonly=True)
     def check_wkhtmltopdf(self):
         return request.env['ir.actions.report'].get_wkhtmltopdf_state()

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -20,7 +20,7 @@ _logger = logging.getLogger(__name__)
 
 class Session(http.Controller):
 
-    @http.route('/web/session/get_session_info', type='json', auth="user")
+    @http.route('/web/session/get_session_info', type='json', auth='user', readonly=True)
     def get_session_info(self):
         # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@)
         request.session.touch()
@@ -61,16 +61,16 @@ class Session(http.Controller):
         except Exception as e:
             return {"error": e, "title": _("Languages")}
 
-    @http.route('/web/session/modules', type='json', auth="user")
+    @http.route('/web/session/modules', type='json', auth='user', readonly=True)
     def modules(self):
         # return all installed modules. Web client is smart enough to not load a module twice
         return list(request.env.registry._init_modules.union([module.current_test] if module.current_test else []))
 
-    @http.route('/web/session/check', type='json', auth="user")
+    @http.route('/web/session/check', type='json', auth='user', readonly=True)
     def check(self):
         return  # ir.http@_authenticate does the job
 
-    @http.route('/web/session/account', type='json', auth="user")
+    @http.route('/web/session/account', type='json', auth='user', readonly=True)
     def account(self):
         ICP = request.env['ir.config_parameter'].sudo()
         params = {
@@ -81,11 +81,11 @@ class Session(http.Controller):
         }
         return 'https://accounts.odoo.com/oauth2/auth?' + url_encode(params)
 
-    @http.route('/web/session/destroy', type='json', auth="user")
+    @http.route('/web/session/destroy', type='json', auth='user', readonly=True)
     def destroy(self):
         request.session.logout()
 
-    @http.route('/web/session/logout', type='http', auth="none")
+    @http.route('/web/session/logout', type='http', auth='none', readonly=True)
     def logout(self, redirect='/web'):
         request.session.logout(keep_db=True)
         return request.redirect(redirect, 303)

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -28,6 +28,10 @@ class Session(http.Controller):
 
     @http.route('/web/session/authenticate', type='json', auth="none")
     def authenticate(self, db, login, password, base_location=None):
+        if request.db and request.db != db:
+            request.env.cr.close()
+        elif request.db:
+            request.env.cr.rollback()
         if not http.db_filter([db]):
             raise AccessError("Database not found.")
         pre_uid = request.session.authenticate(db, login, password)

--- a/addons/web/controllers/webclient.py
+++ b/addons/web/controllers/webclient.py
@@ -88,7 +88,7 @@ class WebClient(http.Controller):
         return {"modules": translations_per_module,
                 "lang_parameters": None}
 
-    @http.route('/web/webclient/translations/<string:unique>', type='http', auth="public", cors="*")
+    @http.route('/web/webclient/translations/<string:unique>', type='http', auth='public', cors='*', readonly=True)
     def translations(self, unique, mods=None, lang=None):
         """
         Load the translations for the specified language and modules
@@ -123,7 +123,7 @@ class WebClient(http.Controller):
     def version_info(self):
         return odoo.service.common.exp_version()
 
-    @http.route('/web/tests', type='http', auth="user")
+    @http.route('/web/tests', type='http', auth='user', readonly=True)
     def test_suite(self, mod=None, **kwargs):
         return request.render('web.qunit_suite')
 
@@ -131,7 +131,7 @@ class WebClient(http.Controller):
     def test_mobile_suite(self, mod=None, **kwargs):
         return request.render('web.qunit_mobile_suite')
 
-    @http.route('/web/bundle/<string:bundle_name>', auth="public", methods=["GET"])
+    @http.route('/web/bundle/<string:bundle_name>', auth='public', methods=['GET'], readonly=True)
     def bundle(self, bundle_name, **bundle_params):
         """
         Request the definition of a bundle, including its javascript and css bundled assets

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -42,6 +42,7 @@ class Base(models.AbstractModel):
     _inherit = 'base'
 
     @api.model
+    @api.readonly
     def web_search_read(self, domain, specification, offset=0, limit=None, order=None, count_limit=None):
         records = self.search_fetch(domain, specification.keys(), offset=offset, limit=limit, order=order)
         values_records = records.web_read(specification)
@@ -75,6 +76,7 @@ class Base(models.AbstractModel):
             self = self.browse(next_id)
         return self.with_context(bin_size=True).web_read(specification)
 
+    @api.readonly
     def web_read(self, specification: Dict[str, Dict]) -> List[Dict]:
         fields_to_read = list(specification) or ['id']
 
@@ -218,6 +220,7 @@ class Base(models.AbstractModel):
         return values_list
 
     @api.model
+    @api.readonly
     def web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False, lazy=True):
         """
         Returns the result of a read_group and the total number of groups matching the search domain.
@@ -264,6 +267,7 @@ class Base(models.AbstractModel):
         return groups
 
     @api.model
+    @api.readonly
     def read_progress_bar(self, domain, group_by, progress_bar):
         """
         Gets the data needed for all the kanban column progressbars.

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -108,7 +108,8 @@ class Website(Home):
         # Check for controller
         if homepage_url and homepage_url != '/':
             try:
-                return request._serve_ir_http()
+                rule, args = request.env['ir.http']._match(homepage_url)
+                return request._serve_ir_http(rule, args)
             except (AccessError, NotFound, SessionExpiredException):
                 pass
 

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -151,7 +151,6 @@ class Http(models.AbstractModel):
             return False
         if getattr(response, 'status_code', 0) != 200 or request.httprequest.headers.get('X-Disable-Tracking') == '1':
             return False
-
         template = False
         if hasattr(response, '_cached_page'):
             website_page, template = response._cached_page, response._cached_template
@@ -231,10 +230,9 @@ class Http(models.AbstractModel):
         request.website = website.with_context(request.context)
 
     @classmethod
-    def _dispatch(cls, endpoint):
-        response = super()._dispatch(endpoint)
+    def _post_dispatch(cls, response):
+        super()._post_dispatch(response)
         cls._register_website_track(response)
-        return response
 
     @classmethod
     def _get_frontend_langs(cls):
@@ -327,8 +325,6 @@ class Http(models.AbstractModel):
         website_page = cls._serve_page()
         if website_page:
             website_page.flatten()
-            cls._register_website_track(website_page)
-            cls._post_dispatch(website_page)
             return website_page
 
         redirect = cls._serve_redirect()

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -320,7 +320,6 @@ class Http(models.AbstractModel):
             cls._auth_method_public()
         cls._frontend_pre_dispatch()
         cls._handle_debug()
-        request.params = request.get_http_params()
 
         website_page = cls._serve_page()
         if website_page:

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -160,7 +160,7 @@ class Http(models.AbstractModel):
             template = response.qcontext.get('response_template')
 
         view = template and request.env['website'].get_template(template)
-        if view and view.track:
+        if not request.env.cr.readonly and view and view.track:
             request.env['website.visitor']._handle_webpage_dispatch(website_page)
 
         return False

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -281,7 +281,7 @@ class WebsiteVisitor(models.Model):
         else:
             visitor = Visitor.search([('access_token', '=', access_token)])
 
-        if not force_create and visitor and not visitor.timezone:
+        if not force_create and not self.env.cr.readonly and visitor and not visitor.timezone:
             tz = self._get_visitor_timezone()
             if tz:
                 visitor._update_visitor_timezone(tz)

--- a/addons/website/tests/test_http_endpoint.py
+++ b/addons/website/tests/test_http_endpoint.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo.tests import HttpCase
+from odoo.tests import HttpCase, tagged
 
 import werkzeug
 
 
+@tagged('-at_install', 'post_install')
 class TestHttpEndPoint(HttpCase):
 
     def test_can_clear_routing_map_during_render(self):
@@ -37,3 +38,7 @@ class TestHttpEndPoint(HttpCase):
         res = self.url_open('/test_http//greeting', allow_redirects=False)
         self.assertIn(res.status_code, (301, 308))
         self.assertEqual(werkzeug.urls.url_parse(res.headers.get('Location', '')).path, '/test_http/greeting')
+
+    def test_404(self):
+        # the main purpose of this test is to cover the http._serve_db handle_error
+        self.url_open('/not_found')

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -1,27 +1,20 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import copy
+import logging
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal, HttpCaseWithUserDemo
 
 from contextlib import nullcontext
 
+from odoo.sql_db import categorize_query
 from odoo.tools import mute_logger
 from odoo.tests.common import HttpCase, tagged
 
-EXTRA_REQUEST = 2 - 1
-""" During tests, the query on 'base_registry_signaling, base_cache_signaling'
-won't be executed on hot state, but new queries related to the test cursor will
-be added:
 
-    cr = Cursor() # SAVEPOINT
-    cr.execute(...)
-    cr.commit() # RELEASE
-    cr.close()
-"""
+_logger = logging.getLogger(__name__)
 
 class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
-    def _get_url_hot_query(self, url, cache=True, table_count=False):
+    def _get_url_hot_query(self, url, cache=True, query_list=False):
         """ This method returns the number of SQL Queries used inside a request.
         The returned query number will be the same as a "real" (outside of test
         mode) case: the method takes care of removing the extra queries related
@@ -37,11 +30,11 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
 
         :param str url: url to be checked
         :param bool cache: whether the QWeb `t-cache` should be disabled or not
-        :param bool table_count: whether the method should also return data
-            about the queried table
-        :return: the query count plus the queried table data if ``table_count``
+        :param bool query_list: whether the method should also return list of
+            queries (without test cursor savepoint queries)
+        :return: the query count plus the list of queries if ``query_list``
             is ``True``
-        :rtype: int|tuple(int, dict)
+        :rtype: int|tuple(int, list)
         """
         url += ('?' not in url and '?' or '')
         if cache:
@@ -53,35 +46,47 @@ class UtilPerf(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         self.url_open(url)
         self.url_open(url)
         self.url_open(url)
-        sql_count_before = self.cr.sql_log_count
 
-        with (self.cr._enable_table_tracking() if table_count else nullcontext()):
-            if table_count:
-                sql_from_log_before = copy.deepcopy(self.cr.sql_from_log)
-                sql_into_log_before = copy.deepcopy(self.cr.sql_into_log)
-
+        nested_profiler = self.profile(collectors=['sql'], db=False)
+        with nested_profiler:
+            self.registry.get_sequences(self.cr)
             self.url_open(url)
-            sql_count = self.cr.sql_log_count - sql_count_before - EXTRA_REQUEST
-            if table_count:
-                sql_from_tables = {'base_registry_signaling': 1}  # see EXTRA_REQUEST
-                sql_into_tables = {}
-                for table, stats in self.cr.sql_from_log.items():
-                    query_count = stats[0] - sql_from_log_before.get(table, [0])[0]
-                    if query_count:
-                        sql_from_tables[table] = query_count
-                for table, stats in self.cr.sql_into_log.items():
-                    query_count = stats[0] - sql_into_log_before.get(table, [0])[0]
-                    if query_count:
-                        sql_into_tables[table] = query_count
-                return sql_count, sql_from_tables, sql_into_tables
 
+        profiler = nested_profiler.profiler
+        self.assertEqual(len(profiler.sub_profilers), 1, "we expect to have only one accessed url") # if not adapt the code below
+        route_profiler = profiler.sub_profilers[0]
+        route_entries = route_profiler.collectors[0].entries
+        entries = profiler.collectors[0].entries + route_entries
+        sql_queries = [entry['full_query'].strip() for entry in entries]
+        sql_count = len(sql_queries)
+        if not query_list:
             return sql_count
+        return sql_count, sql_queries
 
     def _check_url_hot_query(self, url, expected_query_count, select_tables_perf=None, insert_tables_perf=None):
-        query_count, select_tables, insert_tables = self._get_url_hot_query(url, table_count=True)
-        self.assertEqual(query_count, expected_query_count)
-        self.assertEqual(select_tables, select_tables_perf or {})
-        self.assertEqual(insert_tables, insert_tables_perf or {})
+        query_count, sql_queries = self._get_url_hot_query(url, query_list=True)
+
+        sql_from_tables = {}
+        sql_into_tables = {}
+
+        query_separator = '\n' + '-' * 100 + '\n'
+        queries = query_separator.join(sql_queries)
+
+        for query in sql_queries:
+            query_type, table = categorize_query(query)
+            if query_type == 'into':
+                log_target = sql_into_tables
+            elif query_type == 'from':
+                log_target = sql_from_tables
+            else:
+                _logger.warning("Query type %s for query %s is not supported by _check_url_hot_query", query_type, query)
+            log_target.setdefault(table, 0)
+            log_target[table] = log_target[table] + 1
+        if query_count != expected_query_count:
+            msq = f"Expected {expected_query_count} queries but {query_count} where ran: {query_separator}{queries}{query_separator}"
+            self.fail(msq)
+        self.assertEqual(sql_from_tables, select_tables_perf or {}, f'Select queries does not match: {query_separator}{queries}{query_separator}')
+        self.assertEqual(sql_into_tables, insert_tables_perf or {}, f'Insert queries does not match: {query_separator}{queries}{query_separator}')
 
 
 class TestStandardPerformance(UtilPerf):

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -186,6 +186,8 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
 
 class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
 
+    readonly_enabled = False
+
     def test_visitor_creation_on_tracked_page(self):
         """ Test various flows involving visitor creation and update. """
 

--- a/addons/website_crm/controllers/website_form.py
+++ b/addons/website_crm/controllers/website_form.py
@@ -60,7 +60,7 @@ class WebsiteForm(form.WebsiteForm):
         is_lead_model = model.model == 'crm.lead'
         if is_lead_model:
             values_email_normalized = tools.email_normalize(values.get('email_from'))
-            visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
+            visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
             visitor_partner = visitor_sudo.partner_id
             if values_email_normalized and visitor_partner and visitor_partner.email_normalized == values_email_normalized:
                 # Here, 'phone' in values has already been formatted, see _handle_website_form.

--- a/addons/website_crm/tests/test_website_visitor.py
+++ b/addons/website_crm/tests/test_website_visitor.py
@@ -4,13 +4,13 @@
 from datetime import datetime, timedelta
 
 from odoo.addons.crm.tests.common import TestCrmCommon
-from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTests
+from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTestsCommon
 from odoo.tests import tagged
 from odoo.tests.common import users
 
 
 @tagged('website_visitor')
-class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTests):
+class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTestsCommon):
 
     def setUp(self):
         super(TestWebsiteVisitor, self).setUp()

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -115,7 +115,7 @@ class Event(models.Model):
           * logged as visitor: check partner or visitor are linked to a
             registration;
         """
-        current_visitor = self.env['website.visitor']._get_visitor_from_request(force_create=False)
+        current_visitor = self.env['website.visitor']._get_visitor_from_request()
         base_domain = [('event_id', 'in', self.ids), ('state', 'in', ['open', 'done'])]
         if self.env.user._is_public() and not current_visitor:
             events = self.env['event.event']

--- a/addons/website_event/tests/test_event_visitor.py
+++ b/addons/website_event/tests/test_event_visitor.py
@@ -4,13 +4,13 @@
 from datetime import datetime, timedelta
 
 from odoo import fields
-from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTests
+from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTestsCommon
 from odoo.addons.website_event.tests.common import TestEventOnlineCommon
 from odoo.tests import tagged
 
 
 @tagged('website_visitor')
-class TestEventVisitor(TestEventOnlineCommon, WebsiteVisitorTests):
+class TestEventVisitor(TestEventOnlineCommon, WebsiteVisitorTestsCommon):
 
     def test_clean_inactive_visitors_event(self):
         """ Visitors registered to events should not be deleted even if not connected recently. """

--- a/addons/website_event_track/controllers/webmanifest.py
+++ b/addons/website_event_track/controllers/webmanifest.py
@@ -14,7 +14,7 @@ from odoo.tools.translate import _
 
 class TrackManifest(http.Controller):
 
-    @http.route('/event/manifest.webmanifest', type='http', auth='public', methods=['GET'], website=True, sitemap=False)
+    @http.route('/event/manifest.webmanifest', type='http', auth='public', methods=['GET'], website=True, sitemap=False, readonly=True)
     def webmanifest(self):
         """ Returns a WebManifest describing the metadata associated with a web application.
         Using this metadata, user agents can provide developers with means to create user 

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -286,7 +286,7 @@ class Track(models.Model):
                  'event_track_visitor_ids.is_blacklisted')
     @api.depends_context('uid')
     def _compute_is_reminder_on(self):
-        current_visitor = self.env['website.visitor']._get_visitor_from_request(force_create=False)
+        current_visitor = self.env['website.visitor']._get_visitor_from_request()
         if self.env.user._is_public() and not current_visitor:
             for track in self:
                 track.is_reminder_on = track.wishlisted_by_default

--- a/addons/website_event_track/tests/test_website_visitor.py
+++ b/addons/website_event_track/tests/test_website_visitor.py
@@ -3,13 +3,13 @@
 
 from datetime import datetime, timedelta
 
-from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTests
+from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTestsCommon
 from odoo.addons.website_event.tests.common import TestEventOnlineCommon
 from odoo.tests import tagged
 
 
 @tagged('website_visitor')
-class WebsiteVisitorTestsEventTrack(TestEventOnlineCommon, WebsiteVisitorTests):
+class WebsiteVisitorTestsEventTrack(TestEventOnlineCommon, WebsiteVisitorTestsCommon):
 
     def test_clean_inactive_visitors_event_track(self):
         """ Visitors that have wishlisted tracks should not be deleted even if not connected

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -55,7 +55,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
         return values
 
     def _get_leaderboard(self, event, searched_name=None):
-        current_visitor = request.env['website.visitor']._get_visitor_from_request(force_create=False)
+        current_visitor = request.env['website.visitor']._get_visitor_from_request()
         track_visitor_data = request.env['event.track.visitor'].sudo()._read_group(
             [('track_id', 'in', event.track_ids.ids),
              ('visitor_id', '!=', False),

--- a/addons/website_event_track_quiz/models/event_track.py
+++ b/addons/website_event_track_quiz/models/event_track.py
@@ -33,7 +33,7 @@ class EventTrack(models.Model):
         (self - tracks_quiz).is_quiz_completed = False
         (self - tracks_quiz).quiz_points = 0
         if tracks_quiz:
-            current_visitor = self.env['website.visitor']._get_visitor_from_request(force_create=False)
+            current_visitor = self.env['website.visitor']._get_visitor_from_request()
             if self.env.user._is_public() and not current_visitor:
                 for track in tracks_quiz:
                     track.is_quiz_completed = False

--- a/addons/website_livechat/tests/test_website_visitor.py
+++ b/addons/website_livechat/tests/test_website_visitor.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTests
+from odoo.addons.website.tests.test_website_visitor import WebsiteVisitorTestsCommon
 from odoo.tests import tagged
 
 
 @tagged('website_visitor')
-class WebsiteVisitorTestsLivechat(WebsiteVisitorTests):
+class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
 
     def test_link_to_visitor_livechat(self):
         """ Same as parent's 'test_link_to_visitor' except we also test that conversations

--- a/odoo/addons/base/controllers/rpc.py
+++ b/odoo/addons/base/controllers/rpc.py
@@ -120,11 +120,18 @@ xmlrpc.client.Marshaller = OdooMarshaller
 # ==========================================================
 # RPC Controller
 # ==========================================================
+
+
+def _check_request():
+    if request.db:
+        request.env.cr.close()
+
 class RPC(Controller):
     """Handle RPC connections."""
 
     def _xmlrpc(self, service):
         """Common method to handle an XML-RPC request."""
+        _check_request()
         data = request.httprequest.get_data()
         params, method = xmlrpc.client.loads(data)
         result = dispatch_rpc(service, method, params)
@@ -137,6 +144,7 @@ class RPC(Controller):
         This entrypoint is historical and non-compliant, but kept for
         backwards-compatibility.
         """
+        _check_request()
         try:
             response = self._xmlrpc(service)
         except Exception as error:
@@ -146,6 +154,7 @@ class RPC(Controller):
     @route("/xmlrpc/2/<service>", auth="none", methods=["POST"], csrf=False, save_session=False)
     def xmlrpc_2(self, service):
         """XML-RPC service that returns faultCode as int."""
+        _check_request()
         try:
             response = self._xmlrpc(service)
         except Exception as error:
@@ -155,4 +164,5 @@ class RPC(Controller):
     @route('/jsonrpc', type='json', auth="none", save_session=False)
     def jsonrpc(self, service, method, args):
         """ Method used by client APIs to contact OpenERP. """
+        _check_request()
         return dispatch_rpc(service, method, args)

--- a/odoo/addons/base/data/res_users_data.xml
+++ b/odoo/addons/base/data/res_users_data.xml
@@ -23,6 +23,10 @@ System</span>]]></field>
 Administrator</span>]]></field>
         </record>
 
+        <record id="user_admin_settings" model="res.users.settings">
+            <field name="user_id" ref="base.user_admin"/>
+        </record>
+
         <!-- Default user with full access rights for newly created users -->
         <record id="default_user" model="res.users">
             <field name="name">Default User Template</field>

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -191,8 +191,8 @@ class IrHttp(models.AbstractModel):
 
         # Replace uid placeholder by the current request.env.uid
         for key, val in list(args.items()):
-            if isinstance(val, models.BaseModel) and isinstance(val._uid, RequestUID):
-                args[key] = val.with_user(request.env.uid)
+            if isinstance(val, models.BaseModel):
+                args[key] = val.with_env(request.env)
 
         # verify the default language set in the context is valid,
         # otherwise fallback on the company lang, english or the first

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -380,6 +380,7 @@ import traceback
 import warnings
 import werkzeug
 
+import psycopg2.errors
 from markupsafe import Markup, escape
 from collections.abc import Sized, Mapping
 from itertools import count, chain
@@ -756,6 +757,8 @@ class IrQWeb(models.AbstractModel):
                     except Exception as e:
                         if isinstance(e, TransactionRollbackError):
                             raise
+                        if isinstance(e, ReadOnlySqlTransaction):
+                            raise
                         raise QWebException("Error while render the template",
                             self, template, ref={compile_context['ref']!r}, code=code) from e
                     """, 0)]
@@ -950,6 +953,7 @@ class IrQWeb(models.AbstractModel):
             'QWebException': QWebException,
             'Exception': Exception,
             'TransactionRollbackError': TransactionRollbackError, # for SerializationFailure in assets
+            'ReadOnlySqlTransaction': psycopg2.errors.ReadOnlySqlTransaction,
             'ValueError': ValueError,
             'UserError': UserError,
             'AccessDenied': AccessDenied,

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2384,6 +2384,7 @@ class Model(models.AbstractModel):
         return view
 
     @api.model
+    @api.readonly
     def get_views(self, views, options=None):
         """ Returns the fields_views of given views, along with the fields of
         the current model, and optionally its filters for the given action.

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -591,11 +591,16 @@ class Users(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         users = super(Users, self).create(vals_list)
+        setting_vals = []
         for user in users:
+            if not user.res_users_settings_ids and user.has_group('base.group_user'):
+                setting_vals.append({'user_id': user.id})
             # if partner is global we keep it that way
             if user.partner_id.company_id:
                 user.partner_id.company_id = user.company_id
             user.partner_id.active = user.active
+        if setting_vals:
+            self.env['res.users.settings'].sudo().create(setting_vals)
         return users
 
     def write(self, values):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -987,6 +987,7 @@ class Users(models.Model):
         }
 
     @api.model
+    @api.readonly
     def has_group(self, group_ext_id):
         # use singleton's id if called on a non-empty recordset, otherwise
         # context uid

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -244,20 +244,15 @@ class TestIrAttachment(TransactionCaseWithUserDemo):
         self.assertFalse(os.path.isfile(store_path), 'file removed')
 
     def test_13_rollback(self):
-        self.registry.enter_test_mode(self.cr)
-        self.addCleanup(self.registry.leave_test_mode)
-        self.cr = self.registry.cursor()
-        self.addCleanup(self.cr.close)
-        self.env = odoo.api.Environment(self.cr, odoo.SUPERUSER_ID, {})
-
+        savepoint = self.cr.savepoint()
         # the data needs to be unique so that no other attachment link
         # the file so that the gc removes it
         unique_blob = os.urandom(16)
-        a1 = self.Attachment.create({'name': 'a1', 'raw': unique_blob})
+        a1 = self.env['ir.attachment'].create({'name': 'a1', 'raw': unique_blob})
         store_path = os.path.join(self.filestore, a1.store_fname)
         self.assertTrue(os.path.isfile(store_path), 'file exists')
-        self.env.cr.rollback()
-        self.Attachment._gc_file_store_unsafe()
+        savepoint.rollback()
+        self.env['ir.attachment']._gc_file_store_unsafe()
         self.assertFalse(os.path.isfile(store_path), 'file removed')
 
 

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -37,12 +37,12 @@ class TestHttp(http.Controller):
     def greeting_none(self):
         return "Tek'ma'te"
 
-    @http.route('/test_http/greeting-public', type='http', auth='public')
+    @http.route('/test_http/greeting-public', type='http', auth='public', readonly=True)
     def greeting_public(self):
         assert request.env.user, "ORM should be initialized"
         return "Tek'ma'te"
 
-    @http.route('/test_http/greeting-user', type='http', auth='user')
+    @http.route('/test_http/greeting-user', type='http', auth='user', readonly=True)
     def greeting_user(self):
         assert request.env.user, "ORM should be initialized"
         return "Tek'ma'te"
@@ -87,7 +87,7 @@ class TestHttp(http.Controller):
     def echo_json(self, **kwargs):
         return kwargs
 
-    @http.route('/test_http/echo-json-context', type='json', auth='user', methods=['POST'], csrf=False)
+    @http.route('/test_http/echo-json-context', type='json', auth='user', methods=['POST'], csrf=False, readonly=True)
     def echo_json_context(self, **kwargs):
         return request.env.context
 
@@ -102,7 +102,7 @@ class TestHttp(http.Controller):
     # =====================================================
     # Models
     # =====================================================
-    @http.route('/test_http/<model("test_http.galaxy"):galaxy>', auth='public')
+    @http.route('/test_http/<model("test_http.galaxy"):galaxy>', auth='public', readonly=True)
     def galaxy(self, galaxy):
         if not galaxy.exists():
             raise UserError('The Ancients did not settle there.')
@@ -114,7 +114,17 @@ class TestHttp(http.Controller):
             ]),
         })
 
-    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/<model("test_http.stargate"):gate>', auth='user')
+    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/setname-rw', methods=['GET', 'POST'], type='http', auth='user')
+    def galaxy_set_name_rw(self, galaxy, name):
+        galaxy.name = name
+        return galaxy.name
+
+    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/setname-ro', methods=['GET', 'POST'], type='http', auth='user', readonly=True)
+    def galaxy_set_name_ro(self, galaxy, name):
+        galaxy.name = name
+        return galaxy.name
+
+    @http.route('/test_http/<model("test_http.galaxy"):galaxy>/<model("test_http.stargate"):gate>', auth='user', readonly=True)
     def stargate(self, galaxy, gate):
         if not gate.exists():
             raise UserError("The goa'uld destroyed the gate")

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import html
+
+import odoo
 from odoo.tests import tagged
-from odoo.tests.common import new_test_user
+from odoo.tests.common import new_test_user, Like
 from odoo.tools import mute_logger
 from odoo.addons.test_http.utils import HtmlTokenizer
 
@@ -64,3 +66,41 @@ class TestHttpModels(TestHttpBase):
         res = self.url_open(f'/test_http/{milky_way.id}/9999')  # unknown gate
         self.assertEqual(res.status_code, 400)
         self.assertIn("The goa'uld destroyed the gate", html.unescape(res.text))
+
+    def test_models4_stargate_setname(self):
+        milky_way = self.env.ref('test_http.milky_way')
+
+
+        milky_way.invalidate_recordset()
+        res = self.url_open(f'/test_http/{milky_way.id}/setname-rw', {
+            'name': "Wilky May",
+            'csrf_token': odoo.http.Request.csrf_token(self),
+        })
+        res.raise_for_status()
+
+        milky_way.invalidate_recordset()
+        self.assertEqual(milky_way.name, "Wilky May")
+
+    def test_models5_stargate_setname_readonly(self):
+        milky_way = self.env.ref('test_http.milky_way')
+
+        self.assertEqual(milky_way.name, "Milky Way")
+
+        with self.assertLogs('odoo.http', 'WARNING') as capture_http,\
+             self.assertLogs('odoo.sql_db', 'WARNING') as capture_sql_db:
+            res = self.url_open(f'/test_http/{milky_way.id}/setname-ro', {
+                'name': "Wilky May",
+                'csrf_token': odoo.http.Request.csrf_token(self),
+            })
+            res.raise_for_status()
+
+        milky_way.invalidate_recordset()
+        self.assertEqual(milky_way.name, "Wilky May")
+        self.assertEqual(capture_http.output, [
+            Like("...cannot execute UPDATE in a read-only transaction, retrying with a read/write cursor..."),
+        ])
+        self.assertEqual(
+            # capture_sql_db.ouput contains the full Stack info, we don't want it
+            [rec.msg % rec.args for rec in capture_sql_db.records],
+            [Like('bad query: UPDATE "test_http_galaxy" ... ERROR: cannot execute UPDATE in a read-only transaction')],
+        )

--- a/odoo/addons/test_rpc/tests/test_error.py
+++ b/odoo/addons/test_rpc/tests/test_error.py
@@ -3,6 +3,7 @@
 from functools import partial
 from xmlrpc.client import Fault
 
+from odoo import http
 from odoo.tests import common, tagged
 from odoo.tools.misc import mute_logger
 
@@ -71,3 +72,10 @@ class TestError(common.HttpCase):
         with mute_logger("odoo.sql_db"):
             with self.assertRaisesRegex(Fault, r'The operation cannot be completed: The value must be positive'):
                 self.rpc("test_rpc.model_b", "create", {"name": "B1", "value": -1})
+
+    def test_04_multi_db(self):
+        def db_list(**kwargs):
+            return [self.env.cr.dbname, self.env.cr.dbname + '_another_db']
+        self.patch(http, 'db_list', db_list)  # this is just to ensure that the request won't have a db, breaking monodb behaviour
+
+        self.rpc("test_rpc.model_b", "create", {"name": "B1"})

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -375,6 +375,17 @@ def model(method):
     method._api = 'model'
     return method
 
+def readonly(method):
+    """ Decorate a record-style method where ``self.env.cr`` can be a
+        readonly cursor when called trough a rpc call.
+
+            @api.readonly
+            def method(self, args):
+                ...
+
+    """
+    method._readonly = True
+    return method
 
 _create_logger = logging.getLogger(__name__ + '.create')
 

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -65,6 +65,10 @@ def report_configuration():
     port = config['db_port'] or os.environ.get('PGPORT', 'default')
     user = config['db_user'] or os.environ.get('PGUSER', 'default')
     _logger.info('database: %s@%s:%s', user, host, port)
+    replica_host = config['db_replica_host']
+    replica_port = config['db_replica_port']
+    if replica_host is not False or replica_port:
+        _logger.info('replica database: %s@%s:%s', user, replica_host or 'default', replica_port or 'default')
 
 def rm_pid_file(main_pid):
     config = odoo.tools.config

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -12,37 +12,46 @@ Application developers mostly know this module thanks to the
 :func:`~odoo.http.route`: method decorator. Together they are used to
 register methods responsible of delivering web content to matching URLS.
 
-Those two are only the tip of the iceberg, below is an ascii graph that
+Those two are only the tip of the iceberg, below is a call graph that
 shows the various processing layers each request passes through before
-ending at the @route decorated endpoint. Hopefully, this graph and the
-attached function descriptions will help you understand this module.
+ending at the @route decorated endpoint. Hopefully, this call graph and
+the attached function descriptions will help you understand this module.
 
 Here be dragons:
 
     Application.__call__
-        +-> Request._serve_static
-        |
-        +-> Request._serve_nodb
-        |   -> App.nodb_routing_map.match
-        |   -> Dispatcher.pre_dispatch
-        |   -> Dispatcher.dispatch
-        |      -> route_wrapper
-        |         -> endpoint
-        |   -> Dispatcher.post_dispatch
-        |
-        +-> Request._serve_db
-            -> model.retrying
-               -> Request._serve_ir_http
-                  -> env['ir.http']._match
-                  -> env['ir.http']._authenticate
-                  -> env['ir.http']._pre_dispatch
-                     -> Dispatcher.pre_dispatch
-                  -> Dispatcher.dispatch
-                     -> env['ir.http']._dispatch
-                        -> route_wrapper
-                           -> endpoint
-                  -> env['ir.http']._post_dispatch
-                     -> Dispatcher.post_dispatch
+        if path is like '/<module>/static/<path>':
+            Request._serve_static
+
+        elif not request.db:
+            Request._serve_nodb
+                App.nodb_routing_map.match
+                Dispatcher.pre_dispatch
+                Dispatcher.dispatch
+                    route_wrapper
+                        endpoint
+                Dispatcher.post_dispatch
+
+        else:
+            Request._serve_db
+                env['ir.http']._match
+
+                if not match:
+                    Request._transactioning
+                        model.retrying
+                            env['ir.http']._serve_fallback
+                            env['ir.http']._post_dispatch
+                else:
+                    Request._transactioning
+                        model.retrying
+                            env['ir.http']._authenticate
+                            env['ir.http']._pre_dispatch
+                            Dispatcher.pre_dispatch
+                            Dispatcher.dispatch
+                                env['ir.http']._dispatch
+                                    route_wrapper
+                                        endpoint
+                            env['ir.http']._post_dispatch
 
 Application.__call__
   WSGI entry point, it sanitizes the request, it wraps it in a werkzeug
@@ -66,21 +75,22 @@ Request._serve_nodb
 
 Request._serve_db
   Handle all requests that are not static when it is possible to connect
-  to a database. It opens a session and initializes the ORM before
-  forwarding the request to ``retrying`` and ``_serve_ir_http``.
+  to a database. It opens a registry on the database and then delegates
+  most of the effort the the ``ir.http`` abstract model. This model acts
+  as a module-aware middleware, its implementation in ``base`` is merely
+  more than just delegating to Dispatcher.
 
-service.model.retrying
-  Protect against SQL serialisation errors (when two different
-  transactions write on the same record), when such an error occurs this
-  function resets the session and the environment then re-dispatches the
-  request.
+Request._transactioning & service.model.retrying
+  Manage the cursor, the environment and exceptions that occured while
+  executing the underlying function. They recover from various
+  exceptions such as serialization errors and writes in read-only
+  transactions. They catches all other exceptions and attach a http
+  response to them (e.g. 500 - Internal Server Error)
 
-Request._serve_ir_http
-  Delegate most of the effort to the ``ir.http`` abstract model which
-  itself calls RequestDispatch back. ``ir.http`` grants modularity in
-  the http stack. The notable difference with nodb is that there is an
-  authentication layer and a mechanism to serve pages that are not
-  accessible through controllers.
+ir.http._match
+  Match the controller endpoint that correspond to the request path.
+  Beware that there is an important override for portal and website
+  inside of the ``http_routing`` module.
 
 ir.http._authenticate
   Ensure the user on the current environment fulfill the requirement of
@@ -99,6 +109,11 @@ ir.http._dispatch/Dispatcher.dispatch
 ir.http._post_dispatch/Dispatcher.post_dispatch
   Post process the response returned by the controller endpoint. Used to
   inject various headers such as Content-Security-Policy.
+
+ir.http._handle_error
+  Not present in the call-graph, is called for un-managed exceptions (SE
+  or RO) that occured inside of ``Request._transactioning``. It returns
+  a http response that wraps the error that occured.
 
 route_wrapper, closure of the http.route decorator
   Sanitize the request parameters, call the route endpoint and
@@ -696,6 +711,9 @@ def route(route=None, **routing):
     :param bool csrf: Whether CSRF protection should be enabled for the
         route. Enabled by default for ``'http'``-type requests, disabled
         by default for ``'json'``-type requests.
+    :param Union[bool, Callable[[registry, request], bool]] readonly:
+        Whether this endpoint should open a cursor on a read-only
+        replica instead of (by default) the primary read/write database.
     :param Callable[[Exception], Response] handle_params_access_error:
         Implement a custom behavior if an error occurred when retrieving the record
         from the URL parameters (access error or missing error).
@@ -800,7 +818,6 @@ def _generate_routing_rules(modules, nodb_only, converters=None):
                 'auth': 'user',
                 'methods': None,
                 'routes': [],
-                'readonly': False,
             }
 
             for cls in unique(reversed(type(ctrl).mro()[:-2])):  # ancestors first
@@ -840,10 +857,10 @@ def _check_and_complete_route_definition(controller_cls, submethod, merged_routi
     """Verify and complete the route definition.
 
     * Ensure 'type' is defined on each method's own routing.
-    * also ensure overrides don't change the routing type.
+    * Ensure overrides don't change the routing type or the read/write mode
 
     :param submethod: route method
-    :param dict merged_routing: accumulated routing values (defaults + submethod ancestor methods)
+    :param dict merged_routing: accumulated routing values
     """
     default_type = submethod.original_routing.get('type', 'http')
     routing_type = merged_routing.setdefault('type', default_type)
@@ -853,6 +870,19 @@ def _check_and_complete_route_definition(controller_cls, submethod, merged_routi
             f'{controller_cls.__module__}.{controller_cls.__name__}.{submethod.__name__}',
             routing_type)
     submethod.original_routing['type'] = routing_type
+
+    default_auth = submethod.original_routing.get('auth', merged_routing['auth'])
+    default_mode = submethod.original_routing.get('readonly', default_auth == 'none')
+    parent_readonly = merged_routing.setdefault('readonly', default_mode)
+    child_readonly = submethod.original_routing.get('readonly')
+    if child_readonly not in (None, parent_readonly):
+        _logger.warning(
+            "The endpoint %s made the route %s altough its parent was defined as %s. Setting the route read/write.",
+            f'{controller_cls.__module__}.{controller_cls.__name__}.{submethod.__name__}',
+            'readonly' if child_readonly else 'read/write',
+            'readonly' if parent_readonly else 'read/write',
+        )
+        submethod.original_routing['readonly'] = False
 
 # =========================================================
 # Session
@@ -1697,63 +1727,79 @@ class Request:
         Prepare the user session and load the ORM before forwarding the
         request to ``_serve_ir_http``.
         """
-        try:
-            self.registry = Registry(self.db).check_signaling()
-        except (AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError):
-            # psycopg2 error or attribute error while constructing
-            # the registry. That means either
-            #  - the database probably does not exists anymore, or
-            #  - the database is corrupted, or
-            #  - the database version doesn't match the server version.
-            # So remove the database from the cookie
-            self.db = None
-            self.session.db = None
-            root.session_store.save(self.session)
-            if request.httprequest.path == '/web':
-                # Internal Server Error
-                raise
-            else:
-                return self._serve_nodb()
-
-        with contextlib.closing(self.registry.cursor()) as cr:
-            self.env = odoo.api.Environment(cr, self.session.uid, self.session.context)
-            threading.current_thread().uid = self.env.uid
+        rule = None
+        registry = Registry(self.db)
+        with contextlib.closing(registry.cursor(readonly=True)) as cr:
             try:
-                return service_model.retrying(self._serve_ir_http, self.env)
-            except Exception as exc:
-                if isinstance(exc, HTTPException) and exc.code is None:
-                    raise  # bubble up to odoo.http.Application.__call__
-                exc.error_response = self.registry['ir.http']._handle_error(exc)
-                raise
+                self.registry = registry.check_signaling(cr)
+            except (AttributeError, psycopg2.OperationalError, psycopg2.ProgrammingError):
+                # psycopg2 error or attribute error while constructing
+                # the registry. That means either
+                #  - the database probably does not exists anymore, or
+                #  - the database is corrupted, or
+                #  - the database version doesn't match the server version.
+                # So remove the database from the cookie
+                self.db = None
+                self.session.db = None
+                root.session_store.save(self.session)
+                if request.httprequest.path == '/web':
+                    # Internal Server Error
+                    raise
+                else:
+                    return self._serve_nodb()
+            ir_http = self.registry['ir.http']
+            self.env = odoo.api.Environment(cr, self.session.uid, self.session.context)
+            with contextlib.suppress(NotFound):
+                rule, args = ir_http._match(self.httprequest.path)
+        if not rule:
+            # _serve_fallback can be readwrite in some rare case, imagine a website.page were the qweb contains insert/update
+            # could be interresting to add a field on website.page to define if it is read/write or not and maybe retry just this part or open another cursor?
+            # todo write a test
+            # also, we need to _handle_error inside _transactioning to se the same cursor, will be close in other case
+            def _serve_fallback():
+                self.params = self.get_http_params()  # todo move outside _serve_fallback
+                request.params = request.get_http_params()
+                response = ir_http._serve_fallback()
+                if response:
+                    self.registry['ir.http']._post_dispatch(response)
+                    return response
+                return self.registry['ir.http']._handle_error(NotFound())
 
-    def _serve_ir_http(self):
-        """
-        Delegate most of the processing to the ir.http model that is
-        extensible by applications.
-        """
-        ir_http = self.registry['ir.http']
+            return self._transactioning(_serve_fallback, readonly=True)
+        else:
+            ro = rule.endpoint.routing['readonly']
+            if callable(ro):
+                ro = ro(registry, request)
 
-        try:
-            rule, args = ir_http._match(self.httprequest.path)
-            if rule.endpoint.routing['no_db']:
-                self.env.cr.close()
-                self.env = None
-        except NotFound:
-            self.params = self.get_http_params()
-            response = ir_http._serve_fallback()
-            if response:
-                self.dispatcher.post_dispatch(response)
-                return response
-            raise
+            def _serve_ir_http():
+                return self._serve_ir_http(rule, args)
 
+            return self._transactioning(_serve_ir_http, readonly=ro)
+
+    def _serve_ir_http(self, rule, args):
         self._set_request_dispatcher(rule)
-        ir_http._authenticate(rule.endpoint)
-        ir_http._pre_dispatch(rule, args)
+        self.registry['ir.http']._authenticate(rule.endpoint)
+        self.registry['ir.http']._pre_dispatch(rule, args)
         response = self.dispatcher.dispatch(rule.endpoint, args)
-        # the registry can have been reniewed by dispatch
         self.registry['ir.http']._post_dispatch(response)
         return response
 
+    def _transactioning(self, func, readonly):
+        for readonly_cr in (True, False) if readonly else (False,):
+            with contextlib.closing(self.registry.cursor(readonly=readonly_cr)) as cr:
+                self.env = self.env(cr=cr)
+                try:
+                    return service_model.retrying(func, env=self.env)
+                except psycopg2.errors.ReadOnlySqlTransaction as exc:
+                    _logger.warning("%s, retrying with a read/write cursor", exc.args[0].rstrip(), exc_info=True)
+                    continue
+                except Exception as exc:
+                    if isinstance(exc, HTTPException) and exc.code is None:
+                        raise  # bubble up to odoo.http.Application.__call__
+                    if 'werkzeug' in config['dev_mode'] and self.dispatcher.routing_type != 'json':
+                        raise  # bubble up to werkzeug.debug.DebuggedApplication
+                    exc.error_response = self.registry['ir.http']._handle_error(exc)
+                    raise
 
 # =========================================================
 # Core type-specialized dispatchers

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1786,6 +1786,12 @@ class Request:
 
     def _transactioning(self, func, readonly):
         for readonly_cr in (True, False) if readonly else (False,):
+            threading.current_thread().cursor_mode = (
+                'ro' if readonly_cr
+                else 'ro->rw' if readonly
+                else 'rw'
+            )
+
             with contextlib.closing(self.registry.cursor(readonly=readonly_cr)) as cr:
                 self.env = self.env(cr=cr)
                 try:
@@ -2167,6 +2173,7 @@ class Application:
         current_thread.query_count = 0
         current_thread.query_time = 0
         current_thread.perf_t0 = time.time()
+        current_thread.cursor_mode = None
         if hasattr(current_thread, 'dbname'):
             del current_thread.dbname
         if hasattr(current_thread, 'uid'):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1735,6 +1735,9 @@ class Request:
 
         try:
             rule, args = ir_http._match(self.httprequest.path)
+            if rule.endpoint.routing['no_db']:
+                self.env.cr.close()
+                self.env = None
         except NotFound:
             self.params = self.get_http_params()
             response = ir_http._serve_fallback()

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1567,6 +1567,7 @@ class BaseModel(metaclass=MetaModel):
         return not has_groups
 
     @api.model
+    @api.readonly
     def search_count(self, domain, limit=None):
         """ search_count(domain[, limit=None]) -> int
 
@@ -1584,6 +1585,7 @@ class BaseModel(metaclass=MetaModel):
         return len(query)
 
     @api.model
+    @api.readonly
     @api.returns('self')
     def search(self, domain, offset=0, limit=None, order=None):
         """ search(domain[, offset=0][, limit=None][, order=None])
@@ -1605,6 +1607,7 @@ class BaseModel(metaclass=MetaModel):
         return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
 
     @api.model
+    @api.readonly
     @api.returns('self')
     def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
         """ search_fetch(domain, field_names[, offset=0][, limit=None][, order=None])
@@ -1699,6 +1702,7 @@ class BaseModel(metaclass=MetaModel):
             return False
 
     @api.model
+    @api.readonly
     def name_search(self, name='', args=None, operator='ilike', limit=100):
         """ name_search(name='', args=None, operator='ilike', limit=100) -> records
 
@@ -2619,6 +2623,7 @@ class BaseModel(metaclass=MetaModel):
                 row['__domain'] = expression.AND([row['__domain'], [(fullname, '=', row[fullname])]])
 
     @api.model
+    @api.readonly
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
         """Get the list of records in list view grouped by the given ``groupby`` fields.
 
@@ -3488,6 +3493,7 @@ class BaseModel(metaclass=MetaModel):
 
         return field_names
 
+    @api.readonly
     def read(self, fields=None, load='_classic_read'):
         """ read([fields])
 
@@ -5661,6 +5667,7 @@ class BaseModel(metaclass=MetaModel):
         return cls._transient
 
     @api.model
+    @api.readonly
     def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs):
         """ Perform a :meth:`search_fetch` followed by a :meth:`_read_format`.
 

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -6,7 +6,7 @@
 """
 from collections import defaultdict, deque
 from collections.abc import Mapping
-from contextlib import closing, contextmanager
+from contextlib import closing, contextmanager, nullcontext
 from functools import partial
 from operator import attrgetter
 
@@ -155,7 +155,10 @@ class Registry(Mapping):
         self.loaded_xmlids = set()
 
         self.db_name = db_name
-        self._db = odoo.sql_db.db_connect(db_name)
+        self._db = odoo.sql_db.db_connect(db_name, readonly=False)
+        self._db_readonly = None
+        if config['db_replica_host'] is not False or config['test_enable']:  # by default, only use readonly pool if we have a db_replica_host defined. Allows to have an empty replica host for testing
+            self._db_readonly = odoo.sql_db.db_connect(db_name, readonly=True)
 
         # cursor for test mode; None means "normal" mode
         self.test_cr = None
@@ -838,14 +841,14 @@ class Registry(Mapping):
         cache_sequences = dict(zip(_CACHES_BY_KEY, cache_sequences_values))
         return registry_sequence, cache_sequences
 
-    def check_signaling(self):
+    def check_signaling(self, cr=None):
         """ Check whether the registry has changed, and performs all necessary
         operations to update the registry. Return an up-to-date registry.
         """
         if self.in_test_mode():
             return self
 
-        with closing(self.cursor()) as cr:
+        with nullcontext(cr) if cr is not None else closing(self.cursor()) as cr:
             db_registry_sequence, db_cache_sequences = self.get_sequences(cr)
             changes = ''
             # Check if the model registry must be reloaded
@@ -947,14 +950,18 @@ class Registry(Mapping):
         Registry._lock = Registry._saved_lock
         Registry._saved_lock = None
 
-    def cursor(self):
+    def cursor(self, /, readonly=False):
         """ Return a new cursor for the database. The cursor itself may be used
             as a context manager to commit/rollback and close automatically.
         """
         if self.test_cr is not None:
             # in test mode we use a proxy object that uses 'self.test_cr' underneath
-            return TestCursor(self.test_cr, self.test_lock)
-        return self._db.cursor()
+            return TestCursor(self.test_cr, self.test_lock, readonly)
+
+        connection = self._db
+        if readonly and self._db_readonly is not None:
+            connection = self._db_readonly
+        return connection.cursor()
 
 
 class DummyRLock(object):

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -60,6 +60,7 @@ def execute_kw(db, uid, obj, method, args, kw=None):
 
 
 def execute(db, uid, obj, method, *args, **kw):
+    # TODO could be conditionnaly readonly as in _call_kw_readonly
     with odoo.registry(db).cursor() as cr:
         check_method_name(method)
         res = execute_cr(cr, uid, obj, method, *args, **kw)

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -583,7 +583,7 @@ class TestCursor(BaseCursor):
         self.clear()
         self.prerollback.clear()
         self.postrollback.clear()
-        self.postcommit.clear()         # TestCursor ignores post-commit hooks
+        self.postcommit.clear()         # TestCursor ignores post-commit hooks by default
 
     def rollback(self):
         """ Perform an SQL `ROLLBACK` """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -81,7 +81,6 @@ except ImportError:
 
 _logger = logging.getLogger(__name__)
 
-
 # backward compatibility: Form was defined in this file
 def __getattr__(name):
     # pylint: disable=import-outside-toplevel

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1675,7 +1675,7 @@ class HttpCase(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         if cls.registry_test_mode:
-            cls.registry.enter_test_mode(cls.cr)
+            cls.registry.enter_test_mode(cls.cr, not hasattr(cls, 'readonly_enabled') or cls.readonly_enabled)
             cls.addClassCleanup(cls.registry.leave_test_mode)
 
         ICP = cls.env['ir.config_parameter']

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -253,8 +253,12 @@ class configmanager(object):
         group.add_option("--pg_path", dest="pg_path", help="specify the pg executable path")
         group.add_option("--db_host", dest="db_host", my_default=False,
                          help="specify the database host")
+        group.add_option("--db_replica_host", dest="db_replica_host", my_default=False,
+                         help="specify the replica host. Specify an empty db_replica_host to use the default unix socket.")
         group.add_option("--db_port", dest="db_port", my_default=False,
                          help="specify the database port", type="int")
+        group.add_option("--db_replica_port", dest="db_replica_port", my_default=False,
+                         help="specify the replica port", type="int")
         group.add_option("--db_sslmode", dest="db_sslmode", type="choice", my_default='prefer',
                          choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'],
                          help="specify the database ssl connection mode (see PostgreSQL documentation)")
@@ -447,8 +451,8 @@ class configmanager(object):
 
         # if defined do not take the configfile value even if the defined value is None
         keys = ['gevent_port', 'http_interface', 'http_port', 'longpolling_port', 'http_enable', 'x_sendfile',
-                'db_name', 'db_user', 'db_password', 'db_host', 'db_sslmode',
-                'db_port', 'db_template', 'logfile', 'pidfile', 'smtp_port',
+                'db_name', 'db_user', 'db_password', 'db_host', 'db_replica_host', 'db_sslmode',
+                'db_port', 'db_replica_port', 'db_template', 'logfile', 'pidfile', 'smtp_port',
                 'email_from', 'smtp_server', 'smtp_user', 'smtp_password', 'from_filter',
                 'smtp_ssl_certificate_filename', 'smtp_ssl_private_key_filename',
                 'db_maxconn', 'db_maxconn_gevent', 'import_partial', 'addons_path', 'upgrade_path',


### PR DESCRIPTION
The more Odoo databases grow, the more it is clear that vertical
scalling (to improve the hardware of a single machine) is not a
solution on the long run. Some pretty large databases are stored on very
powerful machines but those machines are reaching their limits.

The solution proposed here is to route some SQL queries to other servers
in order to limit the charge on the primary server. It is possible to
replicate the database on multiple server and to keep them in sync,
what's "easily" (it's not that easy) possible from a infrastructure
standpoint is to configure a single primary server that serves all WRITE
like operations (think UPDATE/INSERT/DELETE) and to configure many other
secondary server that serve READ like operations (tkink SELECT).

It is now possible given the `--db_replica_host` and `--db_replica_port`
CLI options to open a second pool of connection on a replicated database
server (the host/port would typically point to a pgbouncer which in turn
is responsible to re-route the request to an actual postgres server). In
turn, the two `sql_db.db_connect` and `registry.cursor()` now takes an
extra (optional) argument to select the database to connect to (primary
read/write (default), or secondary read-only).

The developers shouldn't open new read/write or read-only cursors
themselves but instead declare their controller endpointes as read/write
or read-only via the new `readonly` argument of `@route`. This new
argument is understood by the HTTP stack which will open its cursor
according to the `@route` spec.

The jsonrpc's `/web/dataset/call_kw` controller has been modified to serve
`search`, `read` and derived methods (`search_read`, `search_count`,
`name_search`, `name_read`, `read_group`) via a read-only transaction too.

Co-authored with @Xavier-Do 

task-id-3151997
Enterprise: https://github.com/odoo/enterprise/pull/36587