### PR TITLE
[IMP] account: french translation

### DIFF
--- a/addons/account/i18n/fr.po
+++ b/addons/account/i18n/fr.po
@@ -2535,7 +2535,7 @@ msgstr ""
 #: model:ir.ui.menu,name:account.menu_action_move_in_invoice_type
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "Bills"
-msgstr "Factures"
+msgstr "Factures fournisseurs"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
@@ -6174,7 +6174,7 @@ msgstr "Facturé"
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_graph
 #: model_terms:ir.ui.view,arch_db:account.view_invoice_tree
 msgid "Invoices"
-msgstr "Factures"
+msgstr "Factures clients"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.portal_my_home_invoice


### PR DESCRIPTION
During labodoo, users could not differentiate the bills screen from customers and from vendors when the language was set to french. The goal is to adapt the translation. 
Invoices -> Factures clients
Bills -> Factures fournisseurs

task: 3171691




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
