### PR TITLE
[IMP] web: list selection should survive actions

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -205,6 +205,13 @@ export class ListController extends Component {
         }
     }
 
+    onActionExecuted() {
+        const { root } = this.model;
+        root.load({
+            selectedIds: root.selection.map((record) => record.resId) || [],
+        });
+    }
+
     onClickCreate() {
         this.createRecord();
     }

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -23,7 +23,7 @@
                             items="actionMenuItems"
                             isDomainSelected="model.root.isDomainSelected"
                             resModel="model.root.resModel"
-                            onActionExecuted="() => model.load()"/>
+                            onActionExecuted="() => this.onActionExecuted()"/>
                     </t>
                 </t>
                 <t t-component="props.Renderer" list="model.root" activeActions="activeActions" archInfo="archInfo" allowSelectors="props.allowSelectors" editable="editable" openRecord.bind="openRecord" noContentHelp="props.info.noContentHelp" onAdd.bind="createRecord"/>

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -8502,6 +8502,8 @@ QUnit.module("Views", (hooks) => {
 
         await toggleActionMenu(target);
         await toggleMenuItem(target, "Custom Action");
+        assert.containsN(target, ".o_list_record_selector input:checked", 5);
+        assert.containsOnce(target, "div.o_control_panel .o_cp_action_menus");
 
         assert.verifySteps([
             "get_views",
@@ -8514,7 +8516,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.test(
         "execute ActionMenus actions with correct params (single page)",
         async function (assert) {
-            assert.expect(12);
+            assert.expect(13);
 
             patchWithCleanup(actionService, {
                 start() {
@@ -8585,6 +8587,7 @@ QUnit.module("Views", (hooks) => {
 
             await toggleActionMenu(target);
             await toggleMenuItem(target, "Custom Action");
+            assert.containsN(target, ".o_list_record_selector input:checked", 2);
 
             assert.verifySteps([
                 '{"action_id":44,"context":{"lang":"en","uid":7,"tz":"taht","active_id":1,"active_ids":[1,2,3,4],"active_model":"foo","active_domain":[]}}',
@@ -8667,10 +8670,15 @@ QUnit.module("Views", (hooks) => {
 
             await toggleActionMenu(target);
             await toggleMenuItem(target, "Custom Action");
+            assert.containsN(target, ".o_list_record_selector input:checked", 3);
+            assert.containsNone(target, ".o_list_selection_box .o_list_select_domain");
 
+            await toggleActionMenu(target);
+            await toggleMenuItem(target, "Custom Action");
             assert.verifySteps([
                 '{"action_id":44,"context":{"lang":"en","uid":7,"tz":"taht","active_id":1,"active_ids":[1,2],"active_model":"foo","active_domain":[]}}',
                 '{"action_id":44,"context":{"lang":"en","uid":7,"tz":"taht","active_id":1,"active_ids":[1,2,3,4],"active_model":"foo","active_domain":[]}}',
+                '{"action_id":44,"context":{"lang":"en","uid":7,"tz":"taht","active_id":1,"active_ids":[1,2,3],"active_model":"foo","active_domain":[["bar","=",true]]}}',
                 '{"action_id":44,"context":{"lang":"en","uid":7,"tz":"taht","active_id":1,"active_ids":[1,2,3],"active_model":"foo","active_domain":[["bar","=",true]]}}',
             ]);
         }


### PR DESCRIPTION
Before this commit, in a list view, if you select records and execute an action (in action menu) then all records are unselected.

How to reproduce:
- Going into a list view with an action menu
- Selecting records
- Click on the action button in the action menu

Before this commit:
 All records are unselected.

After this commit:
 The selected records are still selected after the action is executed.

TaskID: 3133254

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
