### PR TITLE
[IMP] base: Ignore some exceptions in Sentry

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -34,7 +34,9 @@ SMTP_TIMEOUT = 60
 
 class MailDeliveryException(Exception):
     """Specific exception subclass for mail delivery errors"""
-
+    def __init__(self, message, **kwargs):
+        super().__init__(message)
+        self.sentry_ignored = True
 
 # Python 3: patch SMTP's internal printer/debugger
 def _print_debug(self, *args):

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -49,6 +49,7 @@ class RedirectWarning(Exception):
     """
     def __init__(self, message, action, button_text, additional_context=None):
         super().__init__(message, action, button_text, additional_context)
+        self.sentry_ignored = True
 
     # using this RedirectWarning won't crash if used as an UserError
     @property


### PR DESCRIPTION
This commit adds some error to the list of ignored
exception in sentry:

- MailDeliveryException
- RedirectWarning