### PR TITLE
[FIX] web_editor: prevent we-list flicker

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2315,6 +2315,12 @@ const ListUserValueWidget = UserValueWidget.extend({
             // We don't need to rebuild the we-list if it's just a text change,
             // by skipping the rebuild we avoid to lose a direct add new item
             // event.
+            if (!this.el.dataset.idMode || this.el.dataset.idMode !== 'name') {
+                // If the name of the input represents its value, we update the
+                // name to match the new value in order to compute this.selected
+                // correctly with the up to date value.
+                ev.target.name = ev.target.value;
+            }
             this.skipRebuildWeList = true;
             // We call the function below only if the element that recovers the
             // focus after this blur is not an element of the we-list or if it


### PR DESCRIPTION
Since [this commit], when you use a we-list and edit the text of one of these elements and then add a new element to the list, the element is added and deleted directly after. This commit solves this bug. Steps to reproduce the bug:
- Put a form on a page
- Add a multiple checkboxes field
- Edit the text of one of the items in the list
- Click on the button to add a new element

=> The new element is created and deleted directly.

---

This commit permits to prevent the flicker of the list when the user
toggles the checkbox of a list item right after changing the value of
an list input.
Note that the issue was not there on the social media block because the
list compute selected items with ids and not with the value of the
input.

[this commit]: https://github.com/odoo/odoo/commit/be05ac7e2b8d866a72693b761f3bc8576d54e59e

task-3175656
