### PR TITLE
[IMP] web: display "invite" button label on one line

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/widgets/settings_widgets.scss
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/settings_widgets.scss
@@ -5,6 +5,10 @@
     }
 }
 
+.o_web_settings_invite {
+    min-width: fit-content;
+}
+
 .o_doc_link {
     text-decoration: none;
     font-weight: normal;


### PR DESCRIPTION
Settings > General Settings > Section Users:
Button Invite behaves in a weird way.

In dutch, e.g., "Nodig uit" splits into 2 lines,
whereas it could expand, eating out a little bit of the input's space.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
