### PR TITLE
[FIX] web: put the currency properly on a monetary field

### DIFF
--- a/addons/web/static/src/views/fields/monetary/monetary_field.xml
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.xml
@@ -4,8 +4,9 @@
     <t t-name="web.MonetaryField" owl="1">
         <span t-if="props.readonly" t-esc="formattedValue" />
         <div class="text-nowrap d-inline-flex w-100 align-items-baseline" t-else="">
-            <span t-if="!props.hideSymbol and currency" t-out="currencySymbol" />
+            <span t-if="!props.hideSymbol and currency and currency.position == 'before'" t-out="currencySymbol" />
             <input t-ref="numpadDecimal" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" class="o_input flex-grow-1 flex-shrink-1"/>
+            <span t-if="!props.hideSymbol and currency and currency.position == 'after'" t-out="currencySymbol" />
         </div>
     </t>
 


### PR DESCRIPTION
How to reproduce
=================

We can observe this behavior on Invoicing > Vendors > Payement, create a new payement and select EUR as the currency. We can observe that the currency is placed before the amount and not after as it should be.

opw-3166958