### PR TITLE
[FIX] account: zero balance lines should be reconciled

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -746,7 +746,7 @@ class AccountMoveLine(models.Model):
             line.reconciled = (
                 comp_curr.is_zero(line.amount_residual)
                 and foreign_curr.is_zero(line.amount_residual_currency)
-                and (line.matched_debit_ids or line.matched_credit_ids)
+                and (line.matched_debit_ids or line.matched_credit_ids or comp_curr.is_zero(line.balance))
             )
 
     @api.depends('move_id.move_type', 'tax_ids', 'tax_repartition_line_id', 'debit', 'credit', 'tax_tag_ids', 'is_refund')

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -330,6 +330,22 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
                     {'reconciled': False},
                 ])
 
+    def test_reconcile_state_zero_balance(self):
+        """ Tests that Invoices with zero balance are marked as paid and reconciled
+        """
+        zero_invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.from_string('2019-01-01'),
+        })
+        zero_invoice.action_post()
+        self.assertRecordValues(zero_invoice, [{
+            'state': 'posted',
+            'payment_state': 'paid',
+            'amount_total': 0.0
+        }])
+        self.assertTrue(zero_invoice.line_ids.reconciled)
+
     def test_reconcile_lines_corner_case_1_zero_balance_same_foreign_currency(self):
         """ Test the reconciliation of lines having a zero balance in different currencies. In that case, the reconciliation should not be full until
         an additional move is added with the right foreign currency amount. """


### PR DESCRIPTION
Invoices with a total of 0 should not be included in the follow up report. Furthermore, it was found that these invoices appear in the bank recon view for reconciliation. This fix marks entries with a zero balance as reconciled.

Task-3175490
OPW-3171210