### PR TITLE
[FIX] sale_purchase: show purchase description in autogeneration

### DIFF
--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -177,8 +177,10 @@ class SaleOrderLine(models.Model):
         else:
             product_ctx.update({'partner_id': purchase_order.partner_id.id})
 
+        product = self.product_id.with_context(**product_ctx)
         return {
-            'name': self.product_id.with_context(**product_ctx).display_name,
+            'name': product.display_name + ''.join(['\n', product.description_purchase])
+                        if product.description_purchase else product.display_name,
             'product_qty': purchase_qty_uom,
             'product_id': self.product_id.id,
             'product_uom': self.product_id.uom_po_id.id,


### PR DESCRIPTION
1. Install [Manufacturing], [Sales], [Purchase] on Apps

2. On [Settings],
- [Manufacturing]>[Subcontracting]: set

3. [Sales]-[CREATE] product type [Service]

4. On the tab 'Purchase'
- add a vendor, select [Subcontract Service]
- add `Purchase description` then save

5. (still on Sales) [Orders]>[Quotations]
- CREATE, add the product from steps 3-4 and set customer
- CONFIRM

6. [Purchase] - [Requests for Quotation]
- should show on the top of the list. click
- [Description] column does not show `Purchase description`

Desired: show relevant data

Impacted versions: 16 - master

opw-3152072


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
