### PR TITLE
[FIX] web: filter non-exportable fields server side

### DIFF
--- a/addons/test_xlsx_export/models.py
+++ b/addons/test_xlsx_export/models.py
@@ -27,6 +27,8 @@ class GroupOperator(models.Model):
     bool_or = fields.Boolean(group_operator='bool_or')
     many2one = fields.Many2one('export.integer')
     one2many = fields.One2many('export.group_operator.one2many', 'parent_id')
+    exportable_field = fields.Char(exportable=True)
+    non_exportable_field = fields.Char(exportable=False)
 
 class GroupOperatorO2M(models.Model):
     _name = 'export.group_operator.one2many'

--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -391,3 +391,14 @@ class TestGroupedExport(XlsxCreatorCase):
             ['    86420.864 (1)','86420.86'],
             ['1'                ,'86420.86'],
         ])
+
+    def test_exportable_fields(self):
+        values = [
+                {'int_sum': 1, 'exportable_field': 'good', 'non_exportable_field': 'bad'},
+        ]
+        export = self.export(values, fields=['int_sum', 'exportable_field', 'non_exportable_field'])
+
+        self.assertExportEqual(export, [
+            ['Int Sum', 'Exportable Field'],
+            ['1', 'good'],
+        ])

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -27,15 +27,21 @@ class ExportDataItem extends Component {
         });
     }
 
-    async onClick(ev) {
+    async onClick() {
         if (this.props.isFieldExpandable(this.props.field)) {
-            this.subFields = await this.props.onClick(ev);
-            this.state.isExpanded = this.props.isFieldExpanded(this.props.field.name);
+            this.subFields = await this.props.onClick(this.props.field.id);
+            this.state.isExpanded = this.props.isFieldExpanded(this.props.field.id);
+        }
+    }
+
+    onDoubleClick(fieldId) {
+        if (!this.props.isFieldExpandable(this.props.field) && !this.isFieldSelected(fieldId)) {
+            this.props.onAdd(fieldId);
         }
     }
 
     isFieldSelected(current) {
-        return this.props.exportList.find(({ name }) => name === current);
+        return this.props.exportList.find(({ id }) => id === current);
     }
 }
 ExportDataItem.template = "web.ExportDataItem";
@@ -94,7 +100,7 @@ export class ExportDataDialog extends Component {
                     (e) =>
                         e &&
                         Object.values(this.state.exportList).findIndex(
-                            ({ name }) => name === e.dataset.field_id
+                            ({ id }) => id === e.dataset.field_id
                         )
                 );
                 let target;
@@ -177,8 +183,8 @@ export class ExportDataDialog extends Component {
         return this.expandedFields[id] && !this.expandedFields[id].hidden;
     }
 
-    isFieldExpandable({ name }) {
-        return this.knownFields[name].children && name.split("/").length < 3;
+    isFieldExpandable({ id }) {
+        return this.knownFields[id].children && id.split("/").length < 3;
     }
 
     async loadExportList(value) {
@@ -219,7 +225,6 @@ export class ExportDataDialog extends Component {
             parentParams
         );
         for (const field of fields) {
-            field.name = field.id;
             field.label = field.string;
             field.parent = parentField;
             if (!this.knownFields[field.id]) {
@@ -236,18 +241,15 @@ export class ExportDataDialog extends Component {
         this.state.exportList.splice(target, 0, this.state.exportList.splice(item, 1)[0]);
     }
 
-    onAddItemExportList(ev) {
-        const field = ev.target.closest(".o_export_tree_item").dataset.field_id;
-        this.state.exportList.push(this.knownFields[field]);
+    onAddItemExportList(fieldId) {
+        this.state.exportList.push(this.knownFields[fieldId]);
         this.state.search = [];
         this.searchRef.el.value = "";
         this.enterTemplateEdition();
     }
 
-    onRemoveItemExportList(ev) {
-        const item = this.state.exportList.findIndex(
-            ({ name }) => name === ev.target.parentElement.dataset.field_id
-        );
+    onRemoveItemExportList(fieldId) {
+        const item = this.state.exportList.findIndex(({ id }) => id === fieldId);
         this.state.exportList.splice(item, 1);
         this.enterTemplateEdition();
     }
@@ -272,7 +274,7 @@ export class ExportDataDialog extends Component {
                         0,
                         0,
                         {
-                            name: field.name,
+                            name: field.id,
                         },
                     ]),
                     resource: this.props.root.resModel,
@@ -334,22 +336,18 @@ export class ExportDataDialog extends Component {
         );
     }
 
-    async onToggleCompatibleExport(value) {
+    onToggleCompatibleExport(value) {
         this.state.isCompatible = value;
-        await this.fetchFields();
+        this.fetchFields();
     }
 
-    async onToggleExpandField(ev) {
-        const id = ev.target.closest(".o_export_tree_item").dataset.field_id;
-        const fields = await this.loadFields(id);
-        return fields;
+    onToggleExpandField(id) {
+        return this.loadFields(id);
     }
 
     setDefaultExportList() {
         if (this.state.isCompatible) {
-            this.state.exportList = this.state.exportList.filter(
-                ({ name }) => this.knownFields[name]
-            );
+            this.state.exportList = this.state.exportList.filter(({ id }) => this.knownFields[id]);
         } else {
             this.state.exportList = this.props.defaultExportList;
         }
@@ -364,4 +362,15 @@ export class ExportDataDialog extends Component {
     }
 }
 ExportDataDialog.components = { CheckBox, Dialog, ExportDataItem };
+ExportDataDialog.defaultProps = {
+    context: {},
+};
+ExportDataDialog.props = {
+    close: { type: Function },
+    context: { type: Object, optional: true },
+    defaultExportList: { type: Array },
+    download: { type: Function },
+    getExportedFields: { type: Function },
+    root: { type: Object },
+};
 ExportDataDialog.template = "web.ExportDataDialog";

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -12,15 +12,15 @@
     </t>
 
     <t t-name="web.ExportDataItem" owl="1">
-        <div t-att-data-field_id="props.field.name" t-attf-class="o_export_tree_item cursor-pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded mb-2' : '' }}" role="treeitem" t-on-click.stop="onClick" t-on-dblclick="(ev) => !props.isFieldExpandable(props.field) and !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)">
-            <div t-attf-class="o_tree_column {{ props.field.required ? 'fw-bolder' : ''}}">
+        <div t-attf-class="o_export_tree_item cursor-pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded mb-2' : '' }}" role="treeitem" t-on-click.stop="onClick" t-on-dblclick="() => this.onDoubleClick(this.props.field.id)">
+            <div t-attf-class="o_tree_column d-flex align-items-center {{ props.field.required ? 'fw-bolder' : ''}}">
                 <span t-if="props.isFieldExpandable(props.field)" t-attf-class="ms-n3 float-start o_expand_parent small fa {{ state.isExpanded ? 'fa-chevron-down' : 'fa-chevron-right' }}" role="img" aria-label="Show sub-fields" title="Show sub-fields" />
-                <span t-if="props.isDebug and props.field.id" class="overflow-hidden" t-esc="`${props.field.string} (${props.field.id})`" />
-                <span t-else="" class="overflow-hidden" t-esc="props.field.string" />
-                <span title="Select field" t-attf-class="fa fa-plus float-end m-1 o_add_field {{ isFieldSelected(props.field.name) ? 'o_inactive opacity-25' : '' }}" t-on-click.stop="(ev) => !this.isFieldSelected(props.field.name) and this.props.onAdd(ev)" />
+                <span t-if="props.isDebug and props.field.id" class="overflow-hidden w-100" t-esc="`${props.field.string} (${props.field.id})`" />
+                <span t-else="" class="overflow-hidden w-100" t-esc="props.field.string" />
+                <span title="Select field" t-attf-class="fa fa-plus float-end m-1 o_add_field {{ isFieldSelected(props.field.id) ? 'o_inactive opacity-25' : '' }}" t-on-click.stop="() => !this.isFieldSelected(this.props.field.id) and this.props.onAdd(this.props.field.id)" />
             </div>
             <t t-if="state.isExpanded">
-                <t t-foreach="subFields" t-as="field" t-key="field.name">
+                <t t-foreach="subFields" t-as="field" t-key="field.id">
                     <ExportDataItem
                         t-props="props"
                         field="field"
@@ -44,7 +44,7 @@
                     <div class="o_left_field_panel h-100 overflow-auto border">
                         <div class="o_field_tree_structure">
                             <t t-if="fieldsAvailable">
-                                <t t-foreach="rootFields" t-as="field" t-key="field.name">
+                                <t t-foreach="rootFields" t-as="field" t-key="field.id">
                                     <ExportDataItem
                                         field="field"
                                         expandedContent.bind="expandedContent"
@@ -107,11 +107,11 @@
                     </div>
                     <div class="o_right_field_panel h-100 px-2 overflow-auto border">
                         <ul class="o_fields_list list-unstyled" t-ref="draggable">
-                            <t t-foreach="state.exportList" t-as="field" t-key="field.name">
-                                <li t-attf-class="o_export_field {{ state.isSmall ? '' : 'o_export_field_sortable' }}" t-att-data-field_id="field.name">
+                            <t t-foreach="state.exportList" t-as="field" t-key="field.id">
+                                <li t-attf-class="o_export_field {{ state.isSmall ? '' : 'o_export_field_sortable' }}" t-att-data-field_id="field.id">
                                     <span t-if="!state.isSmall" class="fa fa-sort o_sort_field mx-1" t-attf-style="opacity:{{ state.exportList.length === 1 ? 0 : 1 }}" />
                                     <span t-esc="isDebug and field.id ? `${field.string or field.label} (${field.id})` : field.string or field.label" />
-                                    <span class="fa fa-trash m-1 float-end o_remove_field cursor-pointer" t-att-title="removeFieldText" t-on-click.stop="onRemoveItemExportList" />
+                                    <span class="fa fa-trash m-1 float-end o_remove_field cursor-pointer" t-att-title="removeFieldText" t-on-click.stop="() => this.onRemoveItemExportList(field.id)" />
                                 </li>
                             </t>
                         </ul>


### PR DESCRIPTION
Since non exportable fields filtering could be done directly from the server instead of doing it from the browser, this commit moves the filtering logic to the server. Before this commit, it was still possible to export those fields, since the attribute was not passed to the views and the filter was only applied via the JS code. By moving the filtering to the server, we remove the need to send the 'exportable' attribute for the fields at each rpc call.

Now, that attribute is only read in the export controller to determine if the current field must be send or not. This commit also prevent users directly calling the export routes (without the web client, using direct HTTP calls) to require non-exportable fields.

This change required some refactor of the export dialog, by renaming 'name' to 'id', which simplify the code of the component.

The qunit test asserting the absence of non-exportable fields from the view has been removed, since it was no longer coherent to test this from the JS side. Instead, a python test has been added to verify that non-exportable fields cannot be exported, even by calling the export route directly.

Enterprise PR fixing mrp_mps using wrong props : https://github.com/odoo/enterprise/pull/36848