### PR TITLE
[FIX] l10n_in_edi_ewaybill:  Deactivated E-Invoice (IN) edi before load demodata

### DIFF
--- a/addons/l10n_in_edi_ewaybill/demo/__init__.py
+++ b/addons/l10n_in_edi_ewaybill/demo/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import demo
+from . import chart_template

--- a/addons/l10n_in_edi_ewaybill/demo/chart_template.py
+++ b/addons/l10n_in_edi_ewaybill/demo/chart_template.py
@@ -1,0 +1,15 @@
+from odoo import models, api, Command
+
+
+class AccountChartTemplate(models.Model):
+    _inherit='account.chart.template'
+
+    @api.model
+    def _get_demo_data(self):
+        if self.env.company == self.env.ref('l10n_in_edi_ewaybill.demo_company_in_ewaybill'):
+            val = self.env['account.journal'].search([
+                ('type', '=', 'sale'),
+                ('company_id', '=', self.env.ref('l10n_in_edi_ewaybill.demo_company_in_ewaybill').id)])
+            a = {'edi_format_ids': [Command.unlink(self.env.ref('l10n_in_edi.edi_in_einvoice_json_1_03').id)]}
+            val.write(a)
+        return super()._get_demo_data()


### PR DESCRIPTION
Deactivated demo data in  l10n_in_edi_ewaybill module for demo E-Waybill Company

Runbot Nightly build give error: https://runbot.odoo.com/runbot/build/23714129

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
