### PR TITLE
[IMP] test_mail: add tests to justify sudo when writing attachment

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3305,6 +3305,7 @@ class MailThread(models.AbstractModel):
         if not self:
             res['hasReadAccess'] = False
             return res
+        res['canPostOnReadonly'] = getattr(self, '_mail_post_access', False) == 'read'
 
         self.ensure_one()
         try:

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1793,6 +1793,7 @@ class MailThread(models.AbstractModel):
           * limit attachments manipulation when being a shared user;
           * create attachments from ``attachments``. If those are linked to the
             content (body) through CIDs body is updated accordingly;
+        ! Attachments are created/written in sudo, the caller must verify the access rights.
 
         :param list(tuple(str,str), tuple(str,str, dict)) attachments : list of attachment
             tuples in the form ``(name,content)`` or ``(name,content, info)`` where content
@@ -1869,7 +1870,7 @@ class MailThread(models.AbstractModel):
                 # keep cid and name list synced with attachement_values_list length to match ids latter
                 cid_list.append(cid)
                 name_list.append(name)
-            new_attachments = self.env['ir.attachment'].create(attachement_values_list)
+            new_attachments = self.env['ir.attachment'].sudo().create(attachement_values_list)
             cid_mapping = {}
             name_mapping = {}
             for counter, new_attachment in enumerate(new_attachments):

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -13,7 +13,7 @@
                                 'btn-odoo': !chatterTopbar.chatter.composerView,
                                 'btn-light': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
                             }"
-                            t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                            t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                             data-hotkey="m"
                             t-on-click="chatterTopbar.chatter.onClickSendMessage"
                         >

--- a/addons/mail/static/src/models/chatter.js
+++ b/addons/mail/static/src/models/chatter.js
@@ -432,6 +432,12 @@ registerModel({
                 return Boolean(this.thread && !this.thread.isTemporary && this.thread.hasWriteAccess);
             },
         }),
+        canPostMessage: attr({
+            compute() {
+                return Boolean(this.isTemporary || this.hasWriteAccess ||
+                    (this.hasReadAccess && this.thread && this.thread.canPostOnReadonly));
+            },
+        }),
         hasTopbarCloseButton: attr({
             default: false,
         }),

--- a/addons/mail/static/src/models/thread.js
+++ b/addons/mail/static/src/models/thread.js
@@ -40,6 +40,9 @@ registerModel({
             if ('authorizedGroupFullName' in data) {
                 data2.authorizedGroupFullName = data.authorizedGroupFullName;
             }
+            if ('canPostOnReadonly' in data) {
+                data2.canPostOnReadonly = data.canPostOnReadonly;
+            }
             if ('channel' in data) {
                 data2.channel = data.channel;
                 data2.model = 'mail.channel';
@@ -464,6 +467,7 @@ registerModel({
             const {
                 activities: activitiesData,
                 attachments: attachmentsData,
+                canPostOnReadonly,
                 followers: followersData,
                 hasWriteAccess,
                 mainAttachment,
@@ -480,7 +484,7 @@ registerModel({
             if (!this.exists()) {
                 return;
             }
-            const values = { hasWriteAccess, mainAttachment, hasReadAccess };
+            const values = { canPostOnReadonly, hasWriteAccess, mainAttachment, hasReadAccess };
             if (activitiesData) {
                 Object.assign(values, {
                     activities: activitiesData.map(activityData =>
@@ -1137,6 +1141,9 @@ registerModel({
             inverse: 'thread',
             readonly: true,
             required: true,
+        }),
+        canPostOnReadonly: attr({
+            default: false,
         }),
         channel: one('Channel', {
             inverse: 'thread',

--- a/addons/mail/static/tests/helpers/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server.js
@@ -540,6 +540,7 @@ patch(MockServer.prototype, 'mail', {
             res['hasReadAccess'] = false;
             return res;
         }
+        res['canPostOnReadonly'] = thread_model === 'mail.channel'; // model that have attr _mail_post_access='read'
         if (request_list.includes('activities')) {
             const activities = this.pyEnv['mail.activity'].searchRead([['id', 'in', thread.activity_ids || []]]);
             res['activities'] = this._mockMailActivityActivityFormat(activities.map(activity => activity.id));

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -15,6 +15,17 @@ class MailTestSimple(models.Model):
     email_from = fields.Char()
 
 
+class MailTestSimpleMC(models.Model):
+    """ Just mail.test.simple, but multi company and supporting posting
+    even if the user has no write access. """
+    _description = 'Simple Chatter Model '
+    _name = 'mail.test.simple.mc'
+    _inherit = ['mail.test.simple']
+    _mail_post_access = 'read'
+
+    company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
+
+
 class MailTestGateway(models.Model):
     """ A very simple model only inheriting from mail.thread to test pure mass
     mailing features and base performances. """

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -3,6 +3,8 @@ access_mail_performance_thread,access_mail_performance_thread,model_mail_perform
 access_mail_performance_tracking_user,mail.performance.tracking,model_mail_performance_tracking,base.group_user,1,1,1,1
 access_mail_test_simple_portal,mail.test.simple.portal,model_mail_test_simple,base.group_portal,1,0,0,0
 access_mail_test_simple_user,mail.test.simple.user,model_mail_test_simple,base.group_user,1,1,1,1
+access_mail_test_simple_mc_user,mail.test.simple.mc.user,model_mail_test_simple_mc,base.group_user,1,1,1,1
+access_mail_test_simple_mc_portal,mail.test.simple.mc.portal,model_mail_test_simple_mc,base.group_portal,1,0,0,0
 access_mail_test_gateway_portal,mail.test.gateway.portal,model_mail_test_gateway,base.group_portal,1,0,0,0
 access_mail_test_gateway_user,mail.test.gateway.user,model_mail_test_gateway,base.group_user,1,1,1,1
 access_mail_test_gateway_groups_portal,mail.test.gateway.groups.portal,model_mail_test_gateway_groups,base.group_portal,1,0,0,0

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -52,4 +52,13 @@
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
+    <!-- MULTI COMPANY MAIN ATTACHMENT -->
+    <record id="mail_test_simple_mc_rule" model="ir.rule">
+        <field name="name">Test</field>
+        <field name="model_id" ref="test_mail.model_mail_test_simple_mc"/>
+        <field name="perm_read" eval="False"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="global" eval="True"/>
+    </record>
+
 </odoo>

--- a/addons/test_mail/static/tests/chatter_tests.js
+++ b/addons/test_mail/static/tests/chatter_tests.js
@@ -1,0 +1,77 @@
+/** @odoo-module **/
+
+import {
+    start,
+    startServer,
+} from '@mail/../tests/helpers/test_utils';
+
+
+QUnit.module('mail', {}, function () {
+QUnit.module('Chatter');
+
+QUnit.test('Send message button activation (access rights dependent)', async function (assert) {
+    const pyEnv = await startServer();
+    const view = `<form string="Simple">
+                      <sheet>
+                          <field name="name"/>
+                      </sheet>
+                      <div class="oe_chatter">
+                          <field name="message_ids"/>
+                      </div>
+                  </form>`;
+
+    let userAccess = {};
+    const { openView } = await start({
+        serverData: {
+            views: {
+                'mail.test.simple,false,form': view,
+                'mail.test.simple.mc,false,form': view,
+            }
+        },
+        async mockRPC(route, args, performRPC) {
+            const res = await performRPC(route, args);
+            if (route === '/mail/thread/data') {
+                // mimic user with custom access defined in userAccess variable
+                const { thread_model } = args;
+                Object.assign(res, userAccess);
+                res['canPostOnReadonly'] = thread_model === 'mail.test.simple.mc';
+            }
+            return res;
+        },
+    });
+    const resSimpleId1 = pyEnv['mail.test.simple'].create({ name: 'Test simple' });
+    const resSimpleMCId1 = pyEnv['mail.test.simple.mc'].create({ name: 'Test simple MC' });
+    async function assertSendButton(enabled, msg,
+                                    model = null, resId = null,
+                                    hasReadAccess = false, hasWriteAccess = false) {
+        userAccess = { hasReadAccess, hasWriteAccess };
+        await openView({
+            res_id: resId,
+            res_model: model,
+            views: [[false, 'form']],
+        });
+        const details = `hasReadAccess: ${hasReadAccess}, hasWriteAccess: ${hasWriteAccess}, model: ${model}, resId: ${resId}`;
+        if (enabled) {
+            assert.containsNone(document.body, '.o_ChatterTopbar_buttonSendMessage:disabled',
+                `${msg}: send message button must not be disabled (${details}`);
+        } else {
+            assert.containsOnce(document.body, '.o_ChatterTopbar_buttonSendMessage:disabled',
+                `${msg}: send message button must be disabled (${details})`);
+        }
+    }
+    const enabled = true, disabled = false;
+
+    await assertSendButton(enabled, 'Record, all rights', 'mail.test.simple', resSimpleId1, true, true);
+    await assertSendButton(enabled, 'Record, all rights', 'mail.test.simple.mc', resSimpleId1, true, true);
+    await assertSendButton(disabled, 'Record, no write access', 'mail.test.simple', resSimpleId1, true);
+    await assertSendButton(enabled, 'Record, read access but model accept post with read only access',
+        'mail.test.simple.mc', resSimpleMCId1, true);
+    await assertSendButton(disabled, 'Record, no rights', 'mail.test.simple', resSimpleId1);
+    await assertSendButton(disabled, 'Record, no rights', 'mail.test.simple.mc', resSimpleMCId1);
+
+    // Note that rights have no impact on send button for draft record (chatter.isTemporary=true)
+    await assertSendButton(enabled, 'Draft record', 'mail.test.simple');
+    await assertSendButton(enabled, 'Draft record', 'mail.test.simple.mc');
+});
+
+});

--- a/addons/test_mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/test_mail/static/tests/helpers/model_definitions_setup.js
@@ -2,4 +2,4 @@
 
 import { addModelNamesToFetch } from '@bus/../tests/helpers/model_definitions_helpers';
 
-addModelNamesToFetch(['mail.test.track.all', 'mail.test.activity']);
+addModelNamesToFetch(['mail.test.track.all', 'mail.test.activity', 'mail.test.simple', 'mail.test.simple.mc']);


### PR DESCRIPTION
[IMP] test_mail: add test to justify sudo when writing attachment

Add message post with attachment test on record of another company than the
user company but for which the user has readonly access on. The goal is to
justify the sudo added in mail_thread:
- in _message_post_process_attachments method to create attachment linked to
the record (the creation of attachment linked to a record verify the right
to write to the record, so in readonly we need a sudo).
- in _message_set_main_attachment_id method to link the main attachment to the
record. Here we write directly on the record for which we only have readonly
access, so a sudo is needed. Here the attachment is already linked to the model
and we only "tag" it has main attachment (see odoo/odoo#30659).

[FIX] mail: fix send message button activation according to _mail_post_access

The attribute _mail_post_access='read' on a model allows user with read only
access on the model to post a message. It was not taken into account on the
client side, making the send message button disabled for user with readonly
access on such model. This fixes the problem.

[FIX] mail: allow post on model with readonly access when authorized

The attribute _mail_post_access='read' on a model class allows to post on that
model with readonly access. But when providing an attachment, such action was
throwing a security error due to the check done on the attachment. Indeed,
adding an attachment to a model is modifying that model so the write access is
needed. To solve this problem, we add the attachment in sudo.

Justification:
This is an internal method and we have stated in its documentation that it is
the caller responsability to check the rights. Actually, the checks are done at
mail.message creation (to which the attachment are linked) by the overridding
of check_access_rule which call _get_mail_message_access which take into
account that attribute (_mail_post_access). And any way, sudo is already used
in that method to link existing attachment. Here we add a sudo for the new
attachment.

Note:
This fix allows the test test_post_main_attachment_on_record_with_read_access
to pass. But no real use case has been found to reproduce the problem:
- answering an email works as it is executed by the cron
- replying in discuss trigger a multi company error no matter there is an
attachment or not (so it is another problem)
- sending a message (with readonly access) on a thread from the interface works
without this fix because the attachment are created beforehand and the part
that handle already existing attachment is already in sudo.

Task-3178885

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
