### PR TITLE
[IMP] l10n_in*: tax round off in tax Included Price

### DIFF
--- a/addons/l10n_in/data/account_tax_template_data.xml
+++ b/addons/l10n_in/data/account_tax_template_data.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="tax_tag_round_off" model="account.account.tag">
+        <field name="name">Round Off</field>
+        <field name="applicability">taxes</field>
+    </record>
+
     <record id="tax_report" model="account.tax.report">
         <field name="name">Tax Report</field>
         <field name="country_id" ref="base.in"/>


### PR DESCRIPTION
In tax Included Price some time we have issues where sgst cgst tax amount is not equal.
In this commit round-off tag is added in tax tags for calculating the round-off the amount.
This tag will be used in counting round-off values in the e-invoice instead of counting round-off value as other charges.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
