### PR TITLE
[FIX] mrp: avoid forcing SM state if kit

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -36,14 +36,6 @@ class StockMoveLine(models.Model):
             else:
                 return expression.OR([[('production_id.picking_type_id', operator, value)], res])
 
-    def _prepare_stock_move_vals(self):
-        res = super()._prepare_stock_move_vals()
-        if self.product_id.is_kits and res.get('state') not in ('draft', 'cancel', 'done'):
-            # We need to force the state to draft, so the SM will go through the confirmation process and, thus,
-            # will be exploded
-            res['state'] = 'draft'
-        return res
-
     @api.model_create_multi
     def create(self, values):
         res = super(StockMoveLine, self).create(values)


### PR DESCRIPTION
Reverting of [1]

The commit was supposed to fix an issue in `stock_barcode_mrp`, but it
only worked with planned transfers. In case of an immediate one, a
traceback appeared under some conditions. Moreover, the commit
creates a not so good behaviour in Inventory app.

So, we remove [1] and replace it with a new fix oe-side (see PR
linked with the one of this commit).

[1] https://github.com/odoo/odoo/commit/879ef5ef6bc06e6db46f3e5f9285619316f183e8

OPW-3015933