### PR TITLE
[FIX] account: enable menu addition through studio

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3124,6 +3124,13 @@ msgid "Cancelled Invoice"
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_payment_method.py:0
+#, python-format
+msgid ""
+"Cannot add payment methods without valid information"
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -24,6 +24,8 @@ class AccountPaymentMethod(models.Model):
         methods_info = self._get_payment_method_information()
         for method in payment_methods:
             information = methods_info.get(method.code)
+            if not information:
+                raise UserError(_("Cannot add payment methods without valid information"))
 
             if information.get('mode') == 'multi':
                 method_domain = method._get_payment_method_domain()


### PR DESCRIPTION
1. Install [Accounting], [Studio] on Apps
2. Enter [Accounting]
- Click the Studio icon second to left on the top right corner
- [Edit Menu]
- [NEW MENU]
- Fill in e.g.`Test`, select [Existing Model], Model: Payment Methods
- Click the icon on the right, check it is `account.payment.method`
- [SAVE & CLOSE]
- [CONFIRM]
- [CLOSE]
3. Click on `Test` menu created next to [Configuration]
- [NEW]
- Type in all info, click to Save
- Error

Impacted versions: 15-master

opw-3148453

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
