### PR TITLE
[FIX] project: allow computation of recurrence message when each year

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -191,7 +191,8 @@ class ProjectTaskRecurrence(models.Model):
                 return dates
         elif repeat_unit == 'year':
             rrule_kwargs['freq'] = YEARLY
-            month = list(MONTHS.keys()).index(repeat_month) + 1
+            month = list(MONTHS.keys()).index(repeat_month) + 1 if repeat_month else date_start.month
+            repeat_month = repeat_month or list(MONTHS.keys())[month - 1]
             rrule_kwargs['bymonth'] = month
             if repeat_on_year == 'date':
                 rrule_kwargs['bymonthday'] = min(repeat_day, MONTHS.get(repeat_month))


### PR DESCRIPTION
Steps:
Enable recurrence feature.
Go to Project > Office Design > Customer Review.
Enable recurrence on this task > Change month to year.

Issue:
Crash.

Cause:
`_get_next_recurring_dates` is called without a `repeat_month` arg. Is is supposed to be a string which is going to be found in MONTHS keys. Except it is False and so it is not in the list.

Fix:
If we don't receive it, deduce it from `date_start` arg.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
