### PR TITLE
[FIX] base: fix false error message on creating new related field

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -592,7 +592,7 @@ class IrModelFields(models.Model):
         """ Return the ``ir.model.fields`` record corresponding to ``self.related``. """
         names = self.related.split(".")
         last = len(names) - 1
-        model_name = self.model
+        model_name = self.model_id.model
         for index, name in enumerate(names):
             field = self._get(model_name, name)
             if not field:


### PR DESCRIPTION
Method `_related_field` is called by onchange method on adding new field. In some context, `self.model` might be empty and raise false error "Unknownn field name". Fix it by using `self.model_id.model` instead

STEPS

* Open `res.partner` model in *Database Structure > Models* menu.
* Click *Add line* at Fields tab
* Set **Related Field**  to `parent_id.name`, but don't specify **Field Type**

opw-3138440

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
