### PR TITLE
[FIX] netsvc: fix py39 compatibility in WatchedFileHandler

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -28,6 +28,7 @@ def log(logger, level, prefix, msg, depth=None):
 
 class WatchedFileHandler(logging.handlers.WatchedFileHandler):
     def __init__(self, filename):
+        self.errors = None  # compatibility with Python <3.9
         super().__init__(filename)
         # Unfix bpo-26789, in case the fix is present
         self._builtin_open = None


### PR DESCRIPTION
The `errors` argument and attribute on WatchedFileHandler has been introduced in Python 3.9, so `errors=self.errors` was causing an AttributeError in older python versions.

With this commit, the attribute will be defined whatever the Python version, and calls to `_open` won't raise.