### PR TITLE
[WIP][REF] website: make currentWebsite reactive

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -71,7 +71,7 @@ export class WebsitePreview extends Component {
         });
 
         useEffect(() => {
-            this.websiteService.currentWebsiteId = this.websiteId;
+            this.websiteService.setCurrentWebsite(this.websiteId);
             if (this.isRestored) {
                 return;
             }
@@ -119,6 +119,7 @@ export class WebsitePreview extends Component {
          * These changes are reverted when the component is unmounted.
          */
         useEffect(() => {
+            this.websiteContext.displaySystray = true;
             const backendIconEl = document.querySelector("link[rel~='icon']");
             // Save initial backend values.
             const backendIconHref = backendIconEl.href;
@@ -132,6 +133,7 @@ export class WebsitePreview extends Component {
                 }
             }, { once: true });
             return () => {
+                this.websiteContext.displaySystray = false;
                 // Restore backend initial values when leaving.
                 this.title.setParts({ zopenerp, action: null });
                 backendIconEl.href = backendIconHref;

--- a/addons/website/static/src/services/website_custom_menus.js
+++ b/addons/website/static/src/services/website_custom_menus.js
@@ -72,31 +72,26 @@ registry.category('services').add('website_custom_menus', websiteCustomMenus);
 
 registry.category('website_custom_menus').add('website.menu_edit_menu', {
     Component: EditMenuDialog,
-    isDisplayed: (env) => !!env.services.website.currentWebsite
-        && env.services.website.isDesigner
+    isDisplayed: (env) => env.services.website.isDesigner
         && !env.services.ui.isSmall
         && !env.services.website.currentWebsite.metadata.translatable,
 });
 registry.category('website_custom_menus').add('website.menu_optimize_seo', {
     Component: OptimizeSEODialog,
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && env.services.website.isDesigner
+    isDisplayed: (env) => env.services.website.isDesigner
         && !!env.services.website.currentWebsite.metadata.mainObject,
 });
 registry.category('website_custom_menus').add('website.menu_current_page', {
-    isDisplayed: (env) => !!env.services.website.currentWebsite
-        && !!env.services.website.pageDocument,
+    isDisplayed: (env) => !!env.services.website.pageDocument,
 },);
 registry.category('website_custom_menus').add('website.menu_ace_editor', {
     openWidget: (services) => services.website.context.showAceEditor = true,
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && env.services.website.currentWebsite.metadata.viewXmlid
+    isDisplayed: (env) => env.services.website.currentWebsite.metadata.viewXmlid
         && !env.services.ui.isSmall,
 });
 registry.category('website_custom_menus').add('website.menu_page_properties', {
     Component: PagePropertiesDialog,
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && env.services.website.isDesigner
+    isDisplayed: (env) => env.services.website.isDesigner
         && !!env.services.website.currentWebsite.metadata.mainObject
         && env.services.website.currentWebsite.metadata.mainObject.model === 'website.page',
     getProps: (services) => ({
@@ -112,8 +107,7 @@ registry.category('website_custom_menus').add('website.custom_menu_edit_menu', {
     // 'isDisplayed' === true => at least 1 content menu was found on the page. This
     // menuitem will be cloned (in 'addCustomMenus()') to edit every content menu using
     // the 'EditMenuDialog' component.
-    isDisplayed: (env) => env.services.website.currentWebsite
-        && env.services.website.currentWebsite.metadata.contentMenus
+    isDisplayed: (env) => env.services.website.currentWebsite.metadata.contentMenus
         && env.services.website.currentWebsite.metadata.contentMenus.length
         && !env.services.ui.isSmall,
 });

--- a/addons/website/static/src/systray_items/edit_in_backend.js
+++ b/addons/website/static/src/systray_items/edit_in_backend.js
@@ -36,7 +36,7 @@ EditInBackendSystray.template = "website.EditInBackendSystray";
 
 export const systrayItem = {
     Component: EditInBackendSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.editableInBackend,
+    isDisplayed: env => env.services.website.currentWebsite.metadata.editableInBackend,
 };
 
 registry.category("website_systray").add("EditInBackend", systrayItem, { sequence: 9 });

--- a/addons/website/static/src/systray_items/edit_website.js
+++ b/addons/website/static/src/systray_items/edit_website.js
@@ -9,6 +9,7 @@ class EditWebsiteSystray extends Component {
     setup() {
         this.websiteService = useService('website');
         this.websiteContext = useState(this.websiteService.context);
+        this.currentWebsite = useState(this.websiteService.currentWebsite);
 
         this.state = useState({
             isLoading: false,
@@ -28,7 +29,7 @@ class EditWebsiteSystray extends Component {
     }
 
     get translatable() {
-        return this.websiteService.currentWebsite && this.websiteService.currentWebsite.metadata.translatable;
+        return this.currentWebsite.metadata.translatable;
     }
 
     get label() {

--- a/addons/website/static/src/systray_items/publish.js
+++ b/addons/website/static/src/systray_items/publish.js
@@ -12,9 +12,9 @@ class PublishSystray extends Component {
     setup() {
         this.website = useService('website');
         this.rpc = useService('rpc');
+        this.currentWebsite = useState(this.website.currentWebsite);
 
         this.state = useState({
-            published: this.website.currentWebsite.metadata.isPublished,
             processing: false,
         });
 
@@ -34,8 +34,8 @@ class PublishSystray extends Component {
             return;
         }
         this.state.processing = true;
-        this.state.published = !this.state.published;
-        const { metadata: { mainObject } } = this.website.currentWebsite;
+        this.currentWebsite.published = !this.state.published;
+        const { metadata: { mainObject } } = this.currentWebsite;
         return this.rpc('/website/publish', {
             id: mainObject.id,
             object: mainObject.model,
@@ -56,7 +56,7 @@ class PublishSystray extends Component {
 PublishSystray.template = xml`
 <div t-on-click="publishContent" class="o_menu_systray_item d-md-flex ms-auto" data-hotkey="p" t-att-data-processing="state.processing and 1">
     <a href="#">
-        <Switch value="state.published" disabled="true" extraClasses="'mb-0 o_switch_danger_success'"/>
+        <Switch value="currentWebsite.published" disabled="true" extraClasses="'mb-0 o_switch_danger_success'"/>
         <span class="d-none d-md-block ms-2" t-esc="this.label"/>
     </a>
 </div>`;
@@ -66,7 +66,7 @@ PublishSystray.components = {
 
 export const systrayItem = {
     Component: PublishSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.canPublish,
+    isDisplayed: env => env.services.website.currentWebsite.metadata.canPublish,
 };
 
 websiteSystrayRegistry.add("Publish", systrayItem, { sequence: 12 });

--- a/addons/website/static/src/systray_items/translate_website.js
+++ b/addons/website/static/src/systray_items/translate_website.js
@@ -29,7 +29,7 @@ TranslateWebsiteSystray.template = "website.TranslateWebsiteSystray";
 
 export const systrayItem = {
     Component: TranslateWebsiteSystray,
-    isDisplayed: env => env.services.website.currentWebsite && env.services.website.currentWebsite.metadata.translatable,
+    isDisplayed: env => env.services.website.currentWebsite.metadata.translatable,
 };
 
 registry.category("website_systray").add("TranslateWebsiteSystray", systrayItem, { sequence: 8 });

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -4,13 +4,14 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { Component, useState } from "@odoo/owl";
 import wUtils from 'website.utils';
 
-const { Component } = owl;
 
 export class WebsiteSwitcherSystray extends Component {
     setup() {
         this.websiteService = useService('website');
+        this.currentWebsite = useState(this.websiteService.currentWebsite);
     }
 
     getElements() {
@@ -26,7 +27,7 @@ export class WebsiteSwitcherSystray extends Component {
                     this.websiteService.goToWebsite({ websiteId: website.id });
                 }
             },
-            class: website.id === this.websiteService.currentWebsite.id ? 'active' : '',
+            class: website.id === this.currentWebsite.id ? 'active' : '',
         }));
     }
 }

--- a/addons/website_links/static/src/services/website_custom_menus.js
+++ b/addons/website_links/static/src/services/website_custom_menus.js
@@ -4,5 +4,5 @@ import { registry } from '@web/core/registry';
 
 registry.category('website_custom_menus').add('website_links.menu_link_tracker', {
     openWidget: (services) => services.website.goToWebsite({ path: `/r?u=${encodeURIComponent(services.website.contentWindow.location.href)}` }),
-    isDisplayed: (env) => env.services.website.currentWebsite && env.services.website.contentWindow,
+    isDisplayed: (env) => env.services.website.contentWindow,
 });


### PR DESCRIPTION
Before this commit, two events were sent when updating values from the website service's currentWebsite: CONTENT-UPDATED and EDIT-WEBSITE, introduced in [1]. However, if the `currentWebsite` variable is made reactive, we can avoid having to call these events when values are updated.

This allows for any component or service to change the values of currentWebsite without having the extra weight of triggering events. This makes the flow of using `currentWebsite` more in line with OWL components:
Just use `useState` when using the value in your component.

[1]: https://github.com/odoo/odoo/commit/31cc10b91dc7762e23b4bde9b945be0c4ce3fe3b

Co-authored-by: Younn Olivier <yol@odoo.com>