### PR TITLE
[IMP] account,purchase: vendor bill line matching

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3484,7 +3484,7 @@ class AccountMove(models.Model):
 
         return to_post
 
-    def _find_and_set_purchase_orders(self, po_references, partner_id, amount_total, prefer_purchase_line=False, timeout=10):
+    def _find_and_set_purchase_orders(self, po_references, partner_id, amount_total, from_ocr=False, timeout=10):
         # hook to be used with purchase, so that vendor bills are sync/autocompleted with purchase orders
         self.ensure_one()
 


### PR DESCRIPTION
The current algorithm to match vendor bills with purchase orders was written while keeping in mind that the vendor bill data came from an OCR scan and was thus not very detailed or totally reliable.

The current algorithm tries to match in this order:
1. Document reference(s) match(es) one or more purchase orders and the total amounts of the bill and the purchase order(s) match as well.
2. Document reference(s) match(es) one or more purchase orders and the total amount of the bill matches a subset of lines in the matched purchase order(s).
3. Document reference(s) match(es) one or more purchase orders but the amounts do not match.
4. No document reference, but the vendor and total amount of the bill matches exactly one purchase order.

When we generate a vendor bill from an EDI document (electronic invoice), we do have very accurate information however and can also match line by line, since our vendor bill will contain separate lines.

In this commit we add an extra algorithm specifically for EDI documents:
* We find all purchase orders matching the vendor bill reference(s)
* For every vendor bill line (having a unit price), we try looking in our matched purchase orders' lines for the same unit price and a remaining quantity higher than or equal to what is in the vendor bill. If multiple matches are found, we check the name similarity and take the most similar line.
* We replace the vendor bill line with the purchase order line, changing the quantity to the one on the original vendor bill line.
* Unmatched vendor bill lines remain untouched.

We also remove matching method 2 (see above) for EDI documents, in favor of the new algorithm.

This approach makes that more purchase order lines will be able to get matched when using EDI documents.

task-3140712

Related to https://github.com/odoo/enterprise/pull/37061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
