### PR TITLE
[FIX] base: name field in contacts have more space to display the name

### DIFF
--- a/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
+++ b/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
@@ -30,3 +30,7 @@
         }
     }
 }
+
+.o_field_field_partner_autocomplete {
+    width: 100%;
+}


### PR DESCRIPTION
Steps to reproduce:

- Go to Contacts
- Go to any contact or create one, and put a long name.

Issue:

The name won't be displayed correctly, as it will only take a certain space even we still have more space to display the name.

Solution:

We add the class `o_field_char` to the name field so it takes the 100% of the space available, this way we will have more space to display long names.

opw-3182991
