### PR TITLE
[FIX] google_calendar: show a better error in case of bad email format

### DIFF
--- a/addons/google_calendar/i18n/google_calendar.pot
+++ b/addons/google_calendar/i18n/google_calendar.pot
@@ -370,3 +370,12 @@ msgstr ""
 #, python-format
 msgid "You will be redirected to Google to authorize access to your calendar!"
 msgstr ""
+
+#. module: google_calendar
+#. openerp-web
+#: code:addons/google_calendar/models/calendar.py:0
+#, python-format
+msgid ""
+"Email %s in event %s is not a valid address for Odoo. "
+"Please correct it from Google and try to sync again."
+msgstr ""


### PR DESCRIPTION
Google accepts some formats of the email address that Odoo does not. So if one of the attendees' emails is in a format that is invalid for Odoo, it fails to synchronize and the user has no way of knowing what went wrong.

Here is the error:
```
Odoo Server Error
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/src/odoo/odoo/http.py", line 685, in dispatch
    result = self._call_function(**self.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 361, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/http.py", line 349, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/src/odoo/odoo/http.py", line 908, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/src/odoo/odoo/http.py", line 533, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/src/odoo/addons/google_calendar/controllers/main.py", line 44, in sync_data
    need_refresh = request.env.user.sudo()._sync_google_calendar(GoogleCal)
  File "/home/odoo/src/odoo/addons/google_calendar/models/res_users.py", line 96, in _sync_google_calendar
    synced_events = self.env['calendar.event']._sync_google2odoo(events - recurrences, default_reminders=default_reminders)
  File "/home/odoo/src/odoo/addons/google_calendar/models/google_sync.py", line 157, in _sync_google2odoo
    odoo_values = [
  File "/home/odoo/src/odoo/addons/google_calendar/models/google_sync.py", line 158, in <listcomp>
    dict(self._odoo_values(e, default_reminders), need_sync=False)
  File "/home/odoo/src/odoo/addons/google_calendar/models/calendar.py", line 67, in _odoo_values
    attendee_commands, partner_commands = self._odoo_attendee_commands(google_event)
  File "/home/odoo/src/odoo/addons/google_calendar/models/calendar.py", line 120, in _odoo_attendee_commands
    partner = self.env.user.partner_id if attendee.get('self') else self.env['res.partner'].find_or_create(attendee.get('email'))
  File "/home/odoo/src/odoo/addons/mail/models/res_partner.py", line 56, in find_or_create
    parsed_name, parsed_email = self._parse_partner_name(email)
  File "/home/odoo/src/odoo/odoo/addons/base/models/res_partner.py", line 715, in _parse_partner_name
    name = text[:text.index(email)].replace('"', '').replace('<', '').strip()
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: substring not found
```

The solution is to show a better error to the user for these cases.

opw-3167274

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
