### PR TITLE
[FIX] web_editor: expected singleton in attachment

### DIFF
--- a/addons/web_editor/models/assets.py
+++ b/addons/web_editor/models/assets.py
@@ -129,7 +129,8 @@ class Assets(models.AbstractModel):
                 attachment = self._get_custom_attachment(url)
             else:
                 attachment = custom_attachments.filtered(lambda r: r.url == url)
-            return attachment and base64.b64decode(attachment.datas) or False
+            return attachment and len(attachment) == 1 and base64.b64decode(attachment.datas) or len(
+                attachment) > 1 and base64.b64decode(attachment[0].datas) or False
 
         # If the file is not yet customized, the content is found by reading
         # the local file


### PR DESCRIPTION
Expected singleton in _get_content_from_url() method because when duplicate css or js files with the same URL in the database it will give the singleton error.

see: https://tinyurl.com/2nklx5r2

so, I have conditionally sent 1 attachment per request.

sentry - 3853699392

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
