### PR TITLE
[FIX] website: make wysiwyg fonts independent from iframe fonts

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -221,6 +221,7 @@
             'web_editor/static/src/scss/bootstrap_overridden.scss',
             'web/static/src/scss/pre_variables.scss',
             'web/static/lib/bootstrap/scss/_variables.scss',
+            'website/static/src/scss/website.wysiwyg.fonts.scss',
             'website/static/src/scss/website.wysiwyg.scss',
             'website/static/src/scss/website.edit_mode.scss',
             'website/static/src/js/editor/editor.js',
@@ -259,6 +260,12 @@
             'website/static/src/js/editor/widget_link.js',
             'website/static/src/js/widgets/link_popover_widget.js',
             'website/static/src/xml/website.cookies_bar.xml',
+        ],
+        # TODO: in master, we should revisit this and probably opt-in what is
+        # to be added in the iframe instead of excluding what should not be.
+        'website.assets_wysiwyg_inside': [
+            ('include', 'website.assets_wysiwyg'),
+            ('remove', 'website/static/src/scss/website.wysiwyg.fonts.scss'),
         ],
         'web_editor.assets_media_dialog': [
             'website/static/src/components/media_dialog/image_selector.js',

--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -37,6 +37,9 @@ class WebsiteBackend(http.Controller):
 
     @http.route('/website/iframefallback', type="http", auth='user', website=True)
     def get_iframe_fallback(self):
+        # TODO adapt in master (done like this as a fix in stable)
+        view = request.env.ref('website.iframefallback')
+        view.arch = view.arch.replace('"website.assets_wysiwyg"', '"website.assets_wysiwyg_inside"')
         return request.render('website.iframefallback')
 
     @http.route('/website/check_new_content_access_rights', type="json", auth='user')

--- a/addons/website/static/src/js/content/website_root_instance.js
+++ b/addons/website/static/src/js/content/website_root_instance.js
@@ -11,7 +11,7 @@ const prom = createPublicRoot(WebsiteRoot).then(rootInstance => {
     if (window.frameElement) {
         let prepare = Promise.resolve();
         if (window.frameElement.dataset.loadWysiwyg === 'true') {
-            prepare = loadWysiwyg(['website.assets_wysiwyg']);
+            prepare = loadWysiwyg(['website.assets_wysiwyg_inside']);
         }
         prepare.then(() => {
             window.dispatchEvent(new CustomEvent('PUBLIC-ROOT-READY', {detail: {rootInstance}}));

--- a/addons/website/static/src/scss/website.wysiwyg.fonts.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.fonts.scss
@@ -1,0 +1,13 @@
+
+@each $font-name, $font-config in $o-theme-font-configs {
+    $url: map-get($font-config, 'url');
+    @if $url {
+        @import url("https://fonts.googleapis.com/css?family=#{unquote($url)}&display=swap");
+    } @else {
+        $name: map-get($font-config, 'name');
+        $attachment: map-get($font-config, 'attachment');
+        @if $attachment {
+            @import url("/web/content/#{$attachment}/google-font-#{unquote($name)}");
+        }
+    }
+}

--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -1,17 +1,4 @@
 
-@each $font-name, $font-config in $o-theme-font-configs {
-    $url: map-get($font-config, 'url');
-    @if $url {
-        @import url("https://fonts.googleapis.com/css?family=#{unquote($url)}&display=swap");
-    } @else {
-        $name: map-get($font-config, 'name');
-        $attachment: map-get($font-config, 'attachment');
-        @if $attachment {
-            @import url("/web/content/#{$attachment}/google-font-#{unquote($name)}");
-        }
-    }
-}
-
 #oe_snippets {
     top: 0;
     .oe-toolbar {


### PR DESCRIPTION
Since the edited page is within an iframe, the built-in fonts used by the wysiwyg are also loaded inside the page within the iframe, which causes them to replace the one used when viewing the page as a visitor if it happens to be one of the fallback fonts.

This commit avoids that by giving a distinct `font-family` to the fonts used by the wysiwyg.

task-3080104
