### PR TITLE
[IMP] l10n_es: update fiscal position REAGYP

### DIFF
--- a/addons/l10n_es/data/account_fiscal_position_template_data.xml
+++ b/addons/l10n_es/data/account_fiscal_position_template_data.xml
@@ -3841,6 +3841,17 @@
             <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
             <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
         </record>
+         <record id="fptt_reagyp_a_4b_3" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_reagyp_a"/>
+            <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva0_s_bc"/>
+            <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva12_agr"/>
+        </record>
+        <record id="fptt_reagyp_a_4b_4" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="fp_reagyp_a"/>
+            <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva0_s_bc"/>
+            <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
+        </record>
+
         <record id="fptt_reagyp_gp_4b_1" model="account.fiscal.position.tax.template">
             <field name="position_id" ref="fp_reagyp_gp"/>
             <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>


### PR DESCRIPTION
According to the new regulations in Spain, the tax position of REAGYP - Agriculture, has become obsolete since it must also map two other taxes. This PR adds the new mapping to this fiscal position.

Task-id:3180994


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
