### PR TITLE
[FIX] survey: fix 0 as random picker

### DIFF
--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -292,6 +292,6 @@ class TestSurveyInternals(common.TestSurveyCommon):
         invalid_records = page_without_description + text_box_1 + numerical_box \
             + matrix + simple_choice_2 + simple_choice_3 + text_box_3
         question_and_page_ids = my_survey.question_and_page_ids
-        returned_questions_and_pages = my_survey._get_pages_and_questions_to_show()
+        returned_questions_and_pages = my_survey._get_pages_and_questions_to_show(question_and_page_ids)
 
         self.assertEqual(question_and_page_ids - invalid_records, returned_questions_and_pages)

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -168,7 +168,13 @@
             t-att-data-timer="timer_start"
             t-att-data-time-limit-minutes="time_limit_minutes"/>
         <t t-if="survey.questions_layout == 'one_page'">
-            <t t-foreach='survey.question_and_page_ids' t-as='question'>
+            <t t-if="survey.questions_selection == 'random'">
+                <t t-set="questions_and_pages" t-value="survey._get_visible_pages_and_questions()"/>
+            </t>
+            <t t-else="">
+                <t t-set="questions_and_pages" t-value="survey.question_and_page_ids"/>
+            </t>
+            <t t-foreach='questions_and_pages' t-as='question'>
                 <h2 t-if="question.is_page" t-field='question.title' class="o_survey_title pb16 text-break" />
                 <div t-if="question.is_page" t-field='question.description' class="text-break"/>
                 <t t-if="not question.is_page and question in answer.predefined_question_ids" t-call="survey.question_container"/>


### PR DESCRIPTION
When setting 0 as the number of question to pick randomly,
it currently shows all questions in the survey.
Instead, it should show none of them.

Task-3165424