### PR TITLE
[FIX] hr_recruitment: no refuse reason on archive

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -556,9 +556,6 @@ class Applicant(models.Model):
         applicant_active = self.filtered(lambda applicant: applicant.active)
         if applicant_active:
             applicant_active.reset_applicant()
-        applicant_inactive = self.filtered(lambda applicant: not applicant.active)
-        if applicant_inactive:
-            return applicant_inactive.archive_applicant()
         return res
 
 


### PR DESCRIPTION
The refuse reason wizard would open whether you clicked on the Refuse button or on the archive action. But archiving doesn't necessarily mean that the applicant has been refused.

task-3172203
