### PR TITLE
[FIX] snailmail: don't delete letter we trying to resend

### DIFF
--- a/addons/snailmail/wizard/snailmail_letter_format_error.py
+++ b/addons/snailmail/wizard/snailmail_letter_format_error.py
@@ -20,7 +20,9 @@ class SnailmailLetterFormatError(models.TransientModel):
             ('error_code', '=', 'FORMAT_ERROR'),
         ])
         for letter in letters_to_resend:
-            letter.attachment_id.unlink()
+            old_attachment = letter.attachment_id
+            letter.attachment_id = False
+            old_attachment.unlink()
             letter.write({'cover': self.snailmail_cover})
             letter.snailmail_print()
 


### PR DESCRIPTION
## Current behaviour
When trying the resend a snailmail that had a format error, by adding a cover we get an error that a record we trying to access is deleted.

## Expected behaviour
We shouldn't delete the letter that we are trying to resend.

## Steps to reproduce
- Install Invoicing
- Add an IAP account with some credits
- Create a contact with a reallllyyyy long address, to overfill the fields.
- Create an invoice for that customer, try to print/send a snailmail
- It should fail without a message, then scroll down to the red paperplane, add the cover and update resend, you get an error about the missing record.

## Reason for the problem
This legacy code, so maybe in the past it used to work a bit differently. When trying to resend the letter, we are unlinking it's attachment (reasons for that are unknown to me), which is linked with a `Many2One` with letter with a cascading delete, so we end up deleting the `snailmail_letter` that we are iterating over, then when trying to write, it throws the error.

## Fix
Remove the link between the attachment and the letter before the deletion
of the `attachment_id`, so the letter is not being deleted.

## Affected versions
- 14.0
- 15.0
- saas-15.2
- 16.0
- saas-16.1
- master
---
opw-3111774

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
