### PR TITLE
[FIX] web: correct timeout/delay in mobile tests

### DIFF
--- a/addons/web/static/tests/mobile/views/fields/many2one_barcode_field_tests.js
+++ b/addons/web/static/tests/mobile/views/fields/many2one_barcode_field_tests.js
@@ -84,14 +84,13 @@ QUnit.module("Fields", (hooks) => {
         setupViewRegistries();
 
         patchWithCleanup(AutoComplete, {
-            delay: 0,
+            timeout: 0,
         });
 
         // simulate a environment with a camera/webcam
         patchWithCleanup(
             browser,
             Object.assign({}, browser, {
-                setTimeout: (fn) => fn(),
                 navigator: {
                     userAgent: "Chrome/0.0.0 (Linux; Android 13; Odoo TestSuite)",
                     mediaDevices: {

--- a/addons/web/static/tests/mobile/views/list_view_tests.js
+++ b/addons/web/static/tests/mobile/views/list_view_tests.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { makeFakeUserService } from "@web/../tests/helpers/mock_services";
 import { click, getFixture, patchWithCleanup, triggerEvents } from "@web/../tests/helpers/utils";
 import { getMenuItemTexts, toggleActionMenu } from "@web/../tests/search/helpers";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { ListRenderer } from "@web/views/list/list_renderer";
 
 let serverData;
 let fixture;
@@ -31,9 +31,8 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
             },
         };
 
-        patchWithCleanup(browser, {
-            setTimeout: (fn) => fn() || true,
-            clearTimeout: () => {},
+        patchWithCleanup(ListRenderer, {
+            LONG_TOUCH_THRESHOLD: 0,
         });
     });
 

--- a/addons/web/static/tests/views/fields/many2one_barcode_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_barcode_field_tests.js
@@ -72,14 +72,13 @@ QUnit.module("Fields", (hooks) => {
         setupViewRegistries();
 
         patchWithCleanup(AutoComplete, {
-            delay: 0,
+            timeout: 0,
         });
 
         // simulate a environment with a camera/webcam
         patchWithCleanup(
             browser,
             Object.assign({}, browser, {
-                setTimeout: (fn) => fn(),
                 navigator: {
                     userAgent: "Chrome/0.0.0 (Linux; Android 13; Odoo TestSuite)",
                     mediaDevices: {


### PR DESCRIPTION
Mobile tests targeting touch related (and more specifically long-touch) use cases often set the timeout/delay/threshold to 0 to avoid slowing down unnecessarily the test suite's run.

This commit is divided in two parts:
- using the correct property to control the timing
- cleanup the unnecessary patching of `setTimeout()` method following the fix above.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
