### PR TITLE
Change in domain leaf semantics (1, "=", 1) and fix expression.OR method

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -538,7 +538,7 @@ class AccountReportExpression(models.Model):
                 ('id', 'not in', self.ids),
             ], limit=1)
             if not other_expression_using_tag:
-                aml_using_tag = self.env['account.move.line'].sudo().search([('tax_tag_ids', 'in', tag.id)], limit=1)
+                aml_using_tag = self.env['account.move.line'].sudo().search([('tax_tag_ids', '=', tag.id)], limit=1)
                 if aml_using_tag:
                     tags_to_archive += tag
                 else:

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -117,8 +117,8 @@ def update_taxes_from_templates(cr, chart_template_xmlid):
         Checks if the tags are still used in taxes or move lines. If not we delete it.
         """
         for tag in tags:
-            tax_using_tag = env['account.tax.repartition.line'].sudo().search([('tag_ids', 'in', tag.id)], limit=1)
-            aml_using_tag = env['account.move.line'].sudo().search([('tax_tag_ids', 'in', tag.id)], limit=1)
+            tax_using_tag = env['account.tax.repartition.line'].sudo().search([('tag_ids', '=', tag.id)], limit=1)
+            aml_using_tag = env['account.move.line'].sudo().search([('tax_tag_ids', '=', tag.id)], limit=1)
             report_expr_using_tag = tag._get_related_tax_report_expressions()
             if not (aml_using_tag or tax_using_tag or report_expr_using_tag):
                 tag.unlink()

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -101,7 +101,7 @@
     <record id="account_analytic_line_rule_billing_user" model="ir.rule">
         <field name="name">account.analytic.line.billing.user</field>
         <field name="model_id" ref="analytic.model_account_analytic_line"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
@@ -220,14 +220,14 @@
     <record id="account_move_see_all" model="ir.rule">
         <field name="name">All Journal Entries</field>
         <field ref="model_account_move" name="model_id"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
     <record id="account_move_line_see_all" model="ir.rule">
         <field name="name">All Journal Items</field>
         <field ref="model_account_move_line" name="model_id"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
@@ -251,7 +251,7 @@
     <record id="account_move_rule_group_readonly" model="ir.rule">
         <field name="name">Readonly Move</field>
         <field name="model_id" ref="model_account_move"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_readonly'))]"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
@@ -261,7 +261,7 @@
     <record id="account_move_line_rule_group_readonly" model="ir.rule">
         <field name="name">Readonly Move Line</field>
         <field name="model_id" ref="model_account_move_line"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_readonly'))]"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_create" eval="False"/>
@@ -273,21 +273,21 @@
     <record id="account_move_rule_group_invoice" model="ir.rule">
         <field name="name">Readonly Move</field>
         <field name="model_id" ref="model_account_move"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
     <record id="account_move_line_rule_group_invoice" model="ir.rule">
         <field name="name">Readonly Move Line</field>
         <field name="model_id" ref="model_account_move_line"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
     <record id="account_invoice_send_rule_group_invoice" model="ir.rule">
         <field name="name">Readonly Invoice Send and Print</field>
         <field name="model_id" ref="model_account_invoice_send"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -108,7 +108,7 @@
                                         <span role="separator">Reconciliation</span>
                                     </div>
                                     <div>
-                                        <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_account_reconcile_model', 'use_domain': ['|', ('match_journal_ids', '=', False), ('match_journal_ids', 'in', active_id)]}" groups="account.group_account_manager">Reconciliation Models</a>
+                                        <a role="menuitem" type="object" name="open_action_with_context" context="{'action_name': 'action_account_reconcile_model', 'use_domain': ['|', ('match_journal_ids', '=', False), ('match_journal_ids', '=', active_id)]}" groups="account.group_account_manager">Reconciliation Models</a>
                                     </div>
                                 </div>
                             </div>

--- a/addons/account_payment/security/ir_rules.xml
+++ b/addons/account_payment/security/ir_rules.xml
@@ -7,7 +7,7 @@
         <field name="name">Access every transaction</field>
         <field name="model_id" ref="payment.model_payment_transaction"/>
         <!-- Reset the domain defined by payment.transaction_user_rule -->
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 
@@ -17,7 +17,7 @@
         <field name="name">Access every token</field>
         <field name="model_id" ref="payment.model_payment_token"/>
         <!-- Reset the domain defined by payment.token_user_rule -->
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
     </record>
 

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -175,7 +175,7 @@ export class AnalyticDistribution extends Component {
         if (limit) {
             args['limit'] = limit;
         }
-        if (domain.length === 1 && domain[0][0] === "id") {
+        if (domain.length === 1 && domain[0] instanceof Array && domain[0][0] === "id") {
             //batch these orm calls
             return await this.props.record.model.orm.read("account.analytic.account", domain[0][2], args.fields, {});
         }

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -24,19 +24,19 @@ class ResUsers(models.Model):
                  selection=[('new', 'Never Connected'), ('active', 'Confirmed')])
 
     def _search_state(self, operator, value):
-        negative = operator in expression.NEGATIVE_TERM_OPERATORS
+        is_negative_op = operator in expression.NEGATIVE_TERM_OPERATORS
 
         # In case we have no value
         if not value:
-            return expression.TRUE_DOMAIN if negative else expression.FALSE_DOMAIN
+            return [is_negative_op]
 
         if operator in ['in', 'not in']:
             if len(value) > 1:
-                return expression.FALSE_DOMAIN if negative else expression.TRUE_DOMAIN
+                return [not is_negative_op]
             if value[0] == 'new':
-                comp = '!=' if negative else '='
+                comp = '!=' if is_negative_op else '='
             if value[0] == 'active':
-                comp = '=' if negative else '!='
+                comp = '=' if is_negative_op else '!='
             return [('log_ids', comp, False)]
 
         if operator in ['=', '!=']:
@@ -46,7 +46,7 @@ class ResUsers(models.Model):
 
             return [('log_ids', operator, False)]
 
-        return expression.TRUE_DOMAIN
+        return [True]
 
     def _compute_state(self):
         for user in self:

--- a/addons/auth_totp/security/security.xml
+++ b/addons/auth_totp/security/security.xml
@@ -18,7 +18,7 @@
         <record id="api_key_public" model="ir.rule">
             <field name="name">Public users can't interact with keys at all</field>
             <field name="model_id" ref="model_auth_totp_device"/>
-            <field name="domain_force">[(0, '=', 1)]</field>
+            <field name="domain_force">[False]</field>
             <field name="groups" eval="[Command.link(ref('base.group_public'))]"/>
         </record>
         <record id="api_key_user" model="ir.rule">
@@ -33,7 +33,7 @@
         <record id="api_key_admin" model="ir.rule">
             <field name="name">Administrators can view user keys to revoke them</field>
             <field name="model_id" ref="model_auth_totp_device"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
         </record>
 </odoo>

--- a/addons/bus/tests/test_assetsbundle.py
+++ b/addons/bus/tests/test_assetsbundle.py
@@ -17,12 +17,9 @@ class BusWebTests(odoo.tests.HttpCase):
         db_name = self.env.registry.db_name
         bundle_xml_ids = ('web.assets_common', 'web.assets_backend')
 
-        domain = []
-        for bundle in bundle_xml_ids:
-            domain = expression.OR([
-                domain,
-                [('name', 'ilike', bundle + '%')]
-            ])
+        domain = expression.OR([
+            [('name', 'ilike', bundle + '%')] for bundle in bundle_xml_ids
+        ])
         # start from a clean slate
         self.env['ir.attachment'].search(domain).unlink()
         self.env.registry._clear_cache()

--- a/addons/calendar/security/calendar_security.xml
+++ b/addons/calendar/security/calendar_security.xml
@@ -12,14 +12,14 @@
         <record id="calendar_event_rule_employee" model="ir.rule">
             <field ref="model_calendar_event" name="model_id"/>
             <field name="name">All Calendar Event for employees</field>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field eval="[(4,ref('base.group_user'))]" name="groups"/>
         </record>
 
         <record id="calendar_attendee_rule_my" model="ir.rule">
             <field name="name">Own attendees</field>
             <field ref="model_calendar_attendee" name="model_id"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
 

--- a/addons/calendar/security/calendar_security.xml
+++ b/addons/calendar/security/calendar_security.xml
@@ -5,7 +5,7 @@
         <record id="calendar_event_rule_my" model="ir.rule">
             <field name="name">Own events</field>
             <field ref="model_calendar_event" name="model_id"/>
-            <field name="domain_force">[('partner_ids', 'in', user.partner_id.id)]</field>
+            <field name="domain_force">[('partner_ids', '=', user.partner_id.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
 
@@ -26,7 +26,7 @@
         <record id="calendar_event_rule_private" model="ir.rule">
             <field ref="model_calendar_event" name="model_id"/>
             <field name="name">Private events</field>
-            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', 'in', user.partner_id.id)]</field>
+            <field name="domain_force">['|', ('privacy', '!=', 'private'), '&amp;', ('privacy', '=', 'private'), '|', ('user_id', '=', user.id), ('partner_ids', '=', user.partner_id.id)]</field>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -306,7 +306,7 @@ class TestCalendar(SavepointCaseWithUserDemo):
             # check that every attendee receive a (single) mail for the event
             for partner in partners:
                 mail = self.env['mail.message'].sudo().search([
-                    ('notified_partner_ids', 'in', partner.id),
+                    ('notified_partner_ids', '=', partner.id),
                     ])
                 self.assertEqual(len(mail), 1)
 

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -318,7 +318,7 @@
                 <field name="show_as"/>
                 <field name="categ_ids"/>
                 <field name="description"/>
-                <filter string="My Meetings" help="My Meetings" name="mymeetings" domain="[('partner_ids.user_ids', 'in', [uid])]"/>
+                <filter string="My Meetings" help="My Meetings" name="mymeetings" domain="[('partner_ids.user_ids', '=', uid)]"/>
                 <separator/>
                 <filter string="Date" name="filter_start_date" date="start"/>
                 <separator/>

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -53,7 +53,7 @@ class Team(models.Model):
     # alias: improve fields coming from _inherits, use inherited to avoid replacing them
     alias_user_id = fields.Many2one(
         'res.users', related='alias_id.alias_user_id', readonly=False, inherited=True,
-        domain=lambda self: [('groups_id', 'in', self.env.ref('sales_team.group_sale_salesman_all_leads').id)])
+        domain=lambda self: [('groups_id', '=', self.env.ref('sales_team.group_sale_salesman_all_leads').id)])
     # properties
     lead_properties_definition = fields.PropertiesDefinition('Lead Properties')
 

--- a/addons/crm/security/crm_security.xml
+++ b/addons/crm/security/crm_security.xml
@@ -34,14 +34,14 @@
     <record id="crm_rule_all_lead" model="ir.rule">
         <field name="name">All Leads</field>
         <field ref="model_crm_lead" name="model_id"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
     <record id="crm_activity_report_rule_all_activities" model="ir.rule">
         <field name="name">All Activities</field>
         <field ref="model_crm_activity_report" name="model_id"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 

--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -60,7 +60,7 @@ class DataRecycleModel(models.Model):
     # User Notifications for Manual clean
     notify_user_ids = fields.Many2many(
         'res.users', string='Notify Users',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('base.group_system').id)],
+        domain=lambda self: [('groups_id', '=', self.env.ref('base.group_system').id)],
         default=lambda self: self.env.user,
         help='List of users to notify when there are new records to recycle')
     notify_frequency = fields.Integer(string='Notify', default=1)

--- a/addons/event/models/mail_template.py
+++ b/addons/event/models/mail_template.py
@@ -18,5 +18,5 @@ class MailTemplate(models.Model):
         method to filtrate the mail templates.
         """
         if self.env.context.get('filter_template_on_event'):
-            args = expression.AND([[('model', '=', 'event.registration')], args])
+            args = expression.AND([[('model', '=', 'event.registration')], args or [True]])
         return super(MailTemplate, self)._name_search(name, args, operator, limit, name_get_uid)

--- a/addons/event_crm/views/crm_lead_views.xml
+++ b/addons/event_crm/views/crm_lead_views.xml
@@ -36,7 +36,7 @@
         <field name="name">Leads</field>
         <field name="res_model">crm.lead</field>
         <field name="view_mode">tree,kanban,graph,pivot,calendar,form,activity</field>
-        <field name="domain">[('registration_ids', 'in', active_id)]</field>
+        <field name="domain">[('registration_ids', '=', active_id)]</field>
         <field name="context">{'create': False}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -33,7 +33,7 @@ class FleetVehicle(models.Model):
     active = fields.Boolean('Active', default=True, tracking=True)
     manager_id = fields.Many2one(
         'res.users', 'Fleet Manager',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('fleet.fleet_group_manager').id)],
+        domain=lambda self: [('groups_id', '=', self.env.ref('fleet.fleet_group_manager').id)],
     )
     company_id = fields.Many2one(
         'res.company', 'Company',

--- a/addons/gamification/data/gamification_challenge_data.xml
+++ b/addons/gamification/data/gamification_challenge_data.xml
@@ -22,7 +22,7 @@
             <field name="computation_mode">count</field>
             <field name="display_mode">boolean</field>
             <field name="model_id" ref="base.model_res_company"/>
-            <field name="domain">[('user_ids', 'in', [user.id]), ('name', '=', 'YourCompany')]</field>
+            <field name="domain">[('user_ids', '=', user.id), ('name', '=', 'YourCompany')]</field>
             <field name="condition">lower</field>
             <field name="action_id" ref="base.action_res_company_form"/>
             <field name="res_id_field">user.company_id.id</field>
@@ -33,7 +33,7 @@
             <field name="computation_mode">count</field>
             <field name="display_mode">boolean</field>
             <field name="model_id" ref="base.model_res_company"/>
-            <field name="domain">[('user_ids', 'in', [user.id]),('logo', '!=', False)]</field>
+            <field name="domain">[('user_ids', '=', user.id),('logo', '!=', False)]</field>
             <field name="action_id" ref="base.action_res_company_form"/>
             <field name="res_id_field">user.company_id.id</field>
         </record>

--- a/addons/gamification/security/gamification_security.xml
+++ b/addons/gamification/security/gamification_security.xml
@@ -24,7 +24,7 @@
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="False"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="goal_global_multicompany" model="ir.rule">

--- a/addons/gamification/security/gamification_security.xml
+++ b/addons/gamification/security/gamification_security.xml
@@ -12,7 +12,7 @@
                 '|',
                     ('user_id','=',user.id),
                     '&amp;',
-                        ('challenge_id.user_ids','in',user.id),
+                        ('challenge_id.user_ids','=',user.id),
                         ('challenge_id.visibility_mode','=','ranking')]</field>
         </record>
 

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -65,7 +65,7 @@ class Meeting(models.Model):
         lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)
         upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)
         return [
-            ('partner_ids.user_ids', 'in', self.env.user.id),
+            ('partner_ids.user_ids', '=', self.env.user.id),
             ('stop', '>', lower_bound),
             ('start', '<', upper_bound),
             # Do not sync events that follow the recurrence, they are already synced at recurrence creation

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -270,7 +270,7 @@ class GoogleSync(models.AbstractModel):
         """
         domain = self._get_sync_domain()
         if not full_sync:
-            is_active_clause = (self._active_name, '=', True) if self._active_name else expression.TRUE_LEAF
+            is_active_clause = (self._active_name, '=', True) if self._active_name else True
             domain = expression.AND([domain, [
                 '|',
                     '&', ('google_id', '=', False), is_active_clause,

--- a/addons/google_calendar/security/google_calendar_security.xml
+++ b/addons/google_calendar/security/google_calendar_security.xml
@@ -23,7 +23,7 @@
         <record id="google_calendar_token_system_access" model="ir.rule">
             <field name="name">Google Calendar manage all tokens</field>
             <field name="model_id" ref="model_google_calendar_credentials"/>
-            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('base.group_system'))]"/>
         </record>
     </data>

--- a/addons/google_calendar/security/google_calendar_security.xml
+++ b/addons/google_calendar/security/google_calendar_security.xml
@@ -3,7 +3,7 @@
         <record id="google_calendar_not_own_token_rule" model="ir.rule">
             <field name="name">Google Calendar NOT own token access rule</field>
             <field name="model_id" ref="model_google_calendar_credentials"/>
-            <field name="domain_force">[('user_ids', 'not in', user.id)]</field>
+            <field name="domain_force">[('user_ids', '!=', user.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_create" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -13,7 +13,7 @@
         <record id="google_calendar_own_token_rule" model="ir.rule">
             <field name="name">Google Calendar own token access rule</field>
             <field name="model_id" ref="model_google_calendar_credentials"/>
-            <field name="domain_force">[('user_ids', 'in', user.id)]</field>
+            <field name="domain_force">[('user_ids', '=', user.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_create" eval="0"/>
             <field name="perm_write" eval="1"/>

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -370,7 +370,7 @@ class HrEmployeePrivate(models.Model):
             department_id = vals['department_id'] if vals.get('department_id') else self[:1].department_id.id
             # When added to a department or changing user, subscribe to the channels auto-subscribed by department
             self.env['mail.channel'].sudo().search([
-                ('subscription_department_ids', 'in', department_id)
+                ('subscription_department_ids', '=', department_id)
             ])._subscribe_users_automatically()
         return res
 

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -47,21 +47,21 @@ class ResCompany(models.Model):
                 if start_date == company.overtime_start_date and \
                     (vals.get('overtime_company_threshold') != company.overtime_company_threshold) or\
                     (vals.get('overtime_employee_threshold') != company.overtime_employee_threshold):
-                    search_domain = OR([search_domain, [('employee_id.company_id', '=', company.id)]])
+                    search_domain = [('employee_id.company_id', '=', company.id)]
                 # If we enabled the overtime with a start date
                 elif not company.overtime_start_date and start_date:
-                    search_domain = OR([search_domain, [
+                    search_domain = [
                         ('employee_id.company_id', '=', company.id),
-                        ('check_in', '>=', start_date)]])
+                        ('check_in', '>=', start_date)]
                 # If we move the start date into the past
                 elif start_date and company.overtime_start_date > start_date:
-                    search_domain = OR([search_domain, [
+                    search_domain = [
                         ('employee_id.company_id', '=', company.id),
                         ('check_in', '>=', start_date),
-                        ('check_in', '<=', company.overtime_start_date)]])
+                        ('check_in', '<=', company.overtime_start_date)]
                 # If we move the start date into the future
                 elif start_date and company.overtime_start_date < start_date:
-                    delete_domain = OR([delete_domain, [
+                    delete_domain = OR([delete_domain or [], [
                         ('company_id', '=', company.id),
                         ('date', '<', start_date)]])
 

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -56,7 +56,7 @@
         <record id="hr_attendance_rule_attendance_manager" model="ir.rule">
             <field name="name">attendance officer: full access</field>
             <field name="model_id" ref="model_hr_attendance"/>
-            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4,ref('hr_attendance.group_hr_attendance_user'))]"/>
         </record>
 
@@ -93,7 +93,7 @@
         <record id="hr_attendance_rule_attendance_overtime_manager" model="ir.rule">
             <field name="name">attendance officer: full access</field>
             <field name="model_id" ref="model_hr_attendance_overtime"/>
-            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4,ref('hr_attendance.group_hr_attendance_user'))]"/>
         </record>
 

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -66,7 +66,7 @@ class Contract(models.Model):
     visa_expire = fields.Date('Visa Expire Date', related="employee_id.visa_expire", readonly=False)
 
     def _get_hr_responsible_domain(self):
-        return "[('share', '=', False), ('company_ids', 'in', company_id), ('groups_id', 'in', %s)]" % self.env.ref('hr.group_hr_user').id
+        return "[('share', '=', False), ('company_ids', '=', company_id), ('groups_id', '=', %s)]" % self.env.ref('hr.group_hr_user').id
 
     hr_responsible_id = fields.Many2one('res.users', 'HR Responsible', tracking=True,
         help='Person responsible for validating the employee\'s contracts.', domain=_get_hr_responsible_domain)

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -40,7 +40,7 @@
             <field name="name">HR Contract: Contract Manager</field>
             <field name="model_id" ref="model_hr_contract"/>
             <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_manager'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="ir_rule_hr_contract_multi_company" model="ir.rule">

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -891,7 +891,7 @@ class HrExpenseSheet(models.Model):
     employee_id = fields.Many2one('hr.employee', string="Employee", required=True, readonly=True, tracking=True, states={'draft': [('readonly', False)]}, default=_default_employee_id, check_company=True, domain= lambda self: self.env['hr.expense']._get_employee_id_domain())
     address_id = fields.Many2one('res.partner', compute='_compute_from_employee_id', store=True, readonly=False, copy=True, string="Employee Home Address", check_company=True)
     payment_mode = fields.Selection(related='expense_line_ids.payment_mode', readonly=True, string="Paid By", tracking=True)
-    user_id = fields.Many2one('res.users', 'Manager', compute='_compute_from_employee_id', store=True, readonly=True, copy=False, states={'draft': [('readonly', False)]}, tracking=True, domain=lambda self: [('groups_id', 'in', self.env.ref('hr_expense.group_hr_expense_team_approver').id)])
+    user_id = fields.Many2one('res.users', 'Manager', compute='_compute_from_employee_id', store=True, readonly=True, copy=False, states={'draft': [('readonly', False)]}, tracking=True, domain=lambda self: [('groups_id', '=', self.env.ref('hr_expense.group_hr_expense_team_approver').id)])
     total_amount = fields.Monetary('Total Amount', currency_field='currency_id', compute='_compute_amount', store=True, tracking=True)
     untaxed_amount = fields.Monetary('Untaxed Amount', currency_field='currency_id', compute='_compute_amount', store=True)
     total_amount_taxes = fields.Monetary('Taxes', currency_field='currency_id', compute='_compute_amount', store=True)

--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -4,7 +4,7 @@
         <record id="ir_rule_hr_expense_manager" model="ir.rule">
             <field name="name">Manager Expense</field>
             <field name="model_id" ref="model_hr_expense"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[
                 (4, ref('account.group_account_user')),
                 (4, ref('hr_expense.group_hr_expense_user'))]"/>
@@ -30,7 +30,7 @@
         <record id="ir_rule_hr_expense_sheet_manager" model="ir.rule">
             <field name="name">Manager Expense Sheet</field>
             <field name="model_id" ref="model_hr_expense_sheet"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[
                 (4, ref('account.group_account_user')),
                 (4, ref('hr_expense.group_hr_expense_user'))]"/>

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -15,7 +15,7 @@ class HrEmployeeBase(models.AbstractModel):
     leave_manager_id = fields.Many2one(
         'res.users', string='Time Off',
         compute='_compute_leave_manager', store=True, readonly=False,
-        domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
+        domain="[('share', '=', False), ('company_ids', '=', company_id)]",
         help='Select the user responsible for approving "Time Off" of this employee.\n'
              'If empty, the approval is done by an Administrator or Approver (determined in settings/users).')
     remaining_leaves = fields.Float(

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -60,9 +60,9 @@ class HolidaysType(models.Model):
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
     responsible_ids = fields.Many2many(
         'res.users', 'hr_leave_type_res_users_rel', 'hr_leave_type_id', 'res_users_id', string='Responsible Time Off Officer',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('hr_holidays.group_hr_holidays_user').id),
+        domain=lambda self: [('groups_id', '=', self.env.ref('hr_holidays.group_hr_holidays_user').id),
                              ('share', '=', False),
-                             ('company_ids', 'in', self.env.company.id)],
+                             ('company_ids', '=', self.env.company.id)],
                              auto_join=True,
         help="Choose the Time Off Officer who will be notified to approve allocation or Time Off request")
     leave_validation_type = fields.Selection([

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -31,12 +31,9 @@ class CalendarLeaves(models.Model):
                     raise ValidationError(_('Two public holidays cannot overlap each other for the same working hours.'))
 
     def _get_domain(self, time_domain_dict):
-        domain = []
-        for date in time_domain_dict:
-            domain = expression.OR([domain, [
-                    ('date_to', '>', date['date_from']),
-                    ('date_from', '<', date['date_to'])]
-            ])
+        domain = expression.OR([
+            [('date_to', '>', date['date_from']), ('date_from', '<', date['date_to'])]
+            for date in time_domain_dict])
         return expression.AND([domain, [('state', '!=', 'refuse'), ('active', '=', True)]])
 
     def _get_time_domain_dict(self):

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -100,7 +100,7 @@
     <record id="hr_leave_rule_user_read" model="ir.rule">
         <field name="name">Time Off All Approver read</field>
         <field name="model_id" ref="model_hr_leave"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="perm_write" eval="True"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_unlink" eval="True"/>
@@ -128,7 +128,7 @@
     <record id="hr_leave_rule_manager" model="ir.rule">
         <field name="name">Time Off Administrator</field>
         <field name="model_id" ref="model_hr_leave"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('group_hr_holidays_manager'))]"/>
     </record>
 
@@ -179,7 +179,7 @@
     <record id="hr_leave_allocation_rule_officer_read" model="ir.rule">
         <field name="name">Allocations: see all time off: read all</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="perm_create" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_unlink" eval="False"/>
@@ -215,14 +215,14 @@
     <record id="hr_leave_allocation_rule_manager" model="ir.rule">
         <field name="name">Allocations: administrator: no limit</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('group_hr_holidays_manager'))]"/>
     </record>
 
     <record id="resource_leaves_base_user" model="ir.rule">
         <field name="name">Time Off Resources: Approver</field>
         <field name="model_id" ref="model_resource_calendar_leaves"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="perm_create" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_unlink" eval="False"/>
@@ -233,7 +233,7 @@
     <record id="resource_leaves_holidays_user" model="ir.rule">
         <field name="name">Time Off Resources: All Approver</field>
         <field name="model_id" ref="model_resource_calendar_leaves"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
     </record>
 
@@ -269,7 +269,7 @@
     <record id="hr_leave_report_rule_group_holiday_user" model="ir.rule">
         <field name="name">Time Off Summary / Report: All Approver</field>
         <field name="model_id" ref="model_hr_leave_report"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="perm_create" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_unlink" eval="False"/>

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -44,7 +44,7 @@ class Applicant(models.Model):
     categ_ids = fields.Many2many('hr.applicant.category', string="Tags")
     company_id = fields.Many2one('res.company', "Company", compute='_compute_company', store=True, readonly=False, tracking=True)
     user_id = fields.Many2one(
-        'res.users', "Recruiter", compute='_compute_user', domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
+        'res.users', "Recruiter", compute='_compute_user', domain="[('share', '=', False), ('company_ids', '=', company_id)]",
         tracking=True, store=True, readonly=False)
     date_closed = fields.Datetime("Hire Date", compute='_compute_date_closed', store=True, readonly=False, tracking=True)
     date_open = fields.Datetime("Assigned", readonly=True)
@@ -93,7 +93,7 @@ class Applicant(models.Model):
     source_id = fields.Many2one(ondelete='set null')
     interviewer_ids = fields.Many2many('res.users', 'hr_applicant_res_users_interviewers_rel',
         string='Interviewers', index=True, tracking=True,
-        domain="[('share', '=', False), ('company_ids', 'in', company_id)]")
+        domain="[('share', '=', False), ('company_ids', '=', company_id)]")
     linkedin_profile = fields.Char('LinkedIn Profile')
     application_status = fields.Selection([
         ('ongoing', 'Ongoing'),

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -34,7 +34,7 @@ class Job(models.Model):
     manager_id = fields.Many2one(
         'hr.employee', related='department_id.manager_id', string="Department Manager",
         readonly=True, store=True)
-    user_id = fields.Many2one('res.users', "Recruiter", domain="[('share', '=', False), ('company_ids', 'in', company_id)]", tracking=True)
+    user_id = fields.Many2one('res.users', "Recruiter", domain="[('share', '=', False), ('company_ids', '=', company_id)]", tracking=True)
     hr_responsible_id = fields.Many2one(
         'res.users', "HR Responsible", tracking=True,
         help="Person responsible of validating the employee's contracts.")
@@ -46,7 +46,7 @@ class Job(models.Model):
     color = fields.Integer("Color Index")
     is_favorite = fields.Boolean(compute='_compute_is_favorite', inverse='_inverse_is_favorite')
     favorite_user_ids = fields.Many2many('res.users', 'job_favorite_user_rel', 'job_id', 'user_id', default=_get_default_favorite_user_ids)
-    interviewer_ids = fields.Many2many('res.users', string='Interviewers', domain="[('share', '=', False), ('company_ids', 'in', company_id)]")
+    interviewer_ids = fields.Many2many('res.users', string='Interviewers', domain="[('share', '=', False), ('company_ids', '=', company_id)]")
     extended_interviewer_ids = fields.Many2many('res.users', 'hr_job_extended_interviewer_res_users', compute='_compute_extended_interviewer_ids', store=True)
 
     activities_overdue = fields.Integer(compute='_compute_activities')

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -51,8 +51,8 @@
         <field name="model_id" ref="model_hr_applicant"/>
         <field name="domain_force">[
             '|',
-                ('job_id.interviewer_ids', 'in', user.id),
-                ('interviewer_ids', 'in', user.id),
+                ('job_id.interviewer_ids', '=', user.id),
+                ('interviewer_ids', '=', user.id),
         ]</field>
         <field name="perm_create" eval="False"/>
         <field name="perm_unlink" eval="False"/>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -132,7 +132,7 @@
         <field name="inherit_id" ref="hr.view_job_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='department_id']" position="after">
-                <filter string="My Favorites" name="my_favorite_jobs" domain="[('favorite_user_ids', 'in', uid)]"/>
+                <filter string="My Favorites" name="my_favorite_jobs" domain="[('favorite_user_ids', '=', uid)]"/>
                 <separator/>
             </xpath>
         </field>
@@ -297,8 +297,8 @@
         <field name="context">{'create': False}</field>
         <field name="domain">[
             '|',
-                ('interviewer_ids', 'in', uid),
-                ('extended_interviewer_ids', 'in', uid),
+                ('interviewer_ids', '=', uid),
+                ('extended_interviewer_ids', '=', uid),
         ]</field>
     </record>
     <menuitem name="By Job Positions" parent="menu_crm_case_categ0_act_job"

--- a/addons/hr_recruitment_skills/security/hr_recruitment_skills_security.xml
+++ b/addons/hr_recruitment_skills/security/hr_recruitment_skills_security.xml
@@ -6,8 +6,8 @@
         <field name="model_id" ref="model_hr_applicant_skill"/>
         <field name="domain_force">[
             '|',
-                ('applicant_id.job_id.interviewer_ids', 'in', user.id),
-                ('applicant_id.interviewer_ids', 'in', user.id),
+                ('applicant_id.job_id.interviewer_ids', '=', user.id),
+                ('applicant_id.interviewer_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_interviewer'))]"/>
     </record>

--- a/addons/hr_skills/security/hr_skills_security.xml
+++ b/addons/hr_skills/security/hr_skills_security.xml
@@ -4,7 +4,7 @@
     <record id="hr_resume_rule_employee" model="ir.rule">
         <field name="name">Resume: employee: read all</field>
         <field name="model_id" ref="model_hr_resume_line"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="perm_create" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_unlink" eval="False"/>
@@ -14,7 +14,7 @@
     <record id="hr_resume_rule_employee_hr_user" model="ir.rule">
         <field name="name">Resume: HR user: all</field>
         <field name="model_id" ref="model_hr_resume_line"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('hr.group_hr_user'))]"/>
     </record>
 
@@ -29,7 +29,7 @@
     <record id="hr_skill_rule_employee" model="ir.rule">
         <field name="name">Employee skill: employee: read all</field>
         <field name="model_id" ref="model_hr_employee_skill"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="perm_create" eval="False"/>
         <field name="perm_write" eval="False"/>
         <field name="perm_unlink" eval="False"/>
@@ -39,7 +39,7 @@
     <record id="hr_skill_rule_hr_user" model="ir.rule">
         <field name="name">Employee skill: HR user: read all</field>
         <field name="model_id" ref="model_hr_employee_skill"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('hr.group_hr_user'))]"/>
     </record>
 

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -39,7 +39,7 @@ class AccountAnalyticLine(models.Model):
         domain = [('allow_timesheets', '=', True)]
         if not self.user_has_groups('hr_timesheet.group_timesheet_manager'):
             return expression.AND([domain,
-                ['|', ('privacy_visibility', '!=', 'followers'), ('message_partner_ids', 'in', [self.env.user.partner_id.id])]
+                ['|', ('privacy_visibility', '!=', 'followers'), ('message_partner_ids', '=', self.env.user.partner_id.id)]
             ])
         return domain
 

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -119,7 +119,7 @@
         <record id="timesheet_analysis_report_manager" model="ir.rule">
             <field name="name">Timesheets Analysis Report manager</field>
             <field name="model_id" ref="model_timesheets_analysis_report"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_timesheet_manager')), (4, ref('project.group_project_manager'))]"/>
         </record>
     </data>

--- a/addons/hr_timesheet/security/hr_timesheet_security.xml
+++ b/addons/hr_timesheet/security/hr_timesheet_security.xml
@@ -40,7 +40,7 @@
                     ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
                     ('task_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
                 ('project_id.privacy_visibility', '=', 'portal'),
-                ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
+                ('project_id.collaborator_ids.partner_id', '=', user.partner_id.id),
             ]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="True"/>
@@ -57,8 +57,8 @@
                 ('project_id', '!=', False),
                 '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', '=', user.partner_id.id),
+                    ('task_id.message_partner_ids', '=', user.partner_id.id)
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>
@@ -70,7 +70,7 @@
                 ('project_id', '!=', False),
                 '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', '=', user.partner_id.id)
             ]</field>
             <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]" />
         </record>
@@ -99,8 +99,8 @@
                 ('user_id', '=', user.id),
                 '|', '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', '=', user.partner_id.id),
+                    ('task_id.message_partner_ids', '=', user.partner_id.id)
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_user'))]"/>
         </record>
@@ -111,7 +111,7 @@
             <field name="domain_force">[
                 '|',
                     ('project_id.privacy_visibility', '!=', 'followers'),
-                    ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                    ('project_id.message_partner_ids', '=', user.partner_id.id)
             ]</field>
             <field name="groups" eval="[(4, ref('group_hr_timesheet_approver'))]"/>
         </record>

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -28,7 +28,7 @@
     <record id="hr_timesheet_attendance_report_rule_manager" model="ir.rule">
         <field name="name">Timesheet attendance Report: Administrator</field>
         <field name="model_id" ref="model_hr_timesheet_attendance_report"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('hr_timesheet.group_timesheet_manager'))]"/>
     </record>
 </odoo>

--- a/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
+++ b/addons/hr_timesheet_attendance/security/hr_timesheet_attendance_report_security.xml
@@ -20,7 +20,7 @@
             ('project_id', '!=', False),
             '|',
                 ('project_id.privacy_visibility', '!=', 'followers'),
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id])
+                ('project_id.message_partner_ids', '=', user.partner_id.id)
         ]</field>
         <field name="groups" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/>
     </record>

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -331,7 +331,7 @@ class ImLivechatChannelRule(models.Model):
             return False
         # first, search the country specific rules (the first match is returned)
         if country_id: # don't include the country in the research if geoIP is not installed
-            domain = [('country_ids', 'in', [country_id]), ('channel_id', '=', channel_id)]
+            domain = [('country_ids', '=', country_id), ('channel_id', '=', channel_id)]
             rule = _match(self.search(domain))
             if rule:
                 return rule

--- a/addons/im_livechat/views/mail_channel_views.xml
+++ b/addons/im_livechat/views/mail_channel_views.xml
@@ -129,7 +129,7 @@
             <field name="name">Sessions</field>
             <field name="res_model">mail.channel</field>
             <field name="view_mode">tree,form</field>
-            <field name="domain">[('livechat_channel_id', 'in', [active_id]), ('has_message', '=', True)]</field>
+            <field name="domain">[('livechat_channel_id', '=', active_id), ('has_message', '=', True)]</field>
             <field name="context">{
                 'search_default_livechat_channel_id': [active_id],
                 'default_livechat_channel_id': active_id,

--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -137,12 +137,12 @@ class LinkTracker(models.Model):
         """Check that the link trackers are unique."""
         # build a query to fetch all needed link trackers at once
         search_query = expression.OR([
-            expression.AND([
-                [('url', '=', tracker.url)],
-                [('campaign_id', '=', tracker.campaign_id.id)],
-                [('medium_id', '=', tracker.medium_id.id)],
-                [('source_id', '=', tracker.source_id.id)],
-            ])
+            [
+                ('url', '=', tracker.url),
+                ('campaign_id', '=', tracker.campaign_id.id),
+                ('medium_id', '=', tracker.medium_id.id),
+                ('source_id', '=', tracker.source_id.id),
+            ]
             for tracker in self
         ])
 

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -109,11 +109,11 @@ class LoyaltyReward(models.Model):
         if self.discount_product_ids:
             domain = [('id', 'in', self.discount_product_ids.ids)]
         if self.discount_product_category_id:
-            domain = expression.OR([domain, [('categ_id', 'child_of', self.discount_product_category_id.id)]])
+            domain = expression.OR([domain or [False], [('categ_id', 'child_of', self.discount_product_category_id.id)]])
         if self.discount_product_tag_id:
-            domain = expression.OR([domain, [('all_product_tag_ids', '=', self.discount_product_tag_id.id)]])
+            domain = expression.OR([domain or [False], [('all_product_tag_ids', '=', self.discount_product_tag_id.id)]])
         if self.discount_product_domain and self.discount_product_domain != '[]':
-            domain = expression.AND([domain, ast.literal_eval(self.discount_product_domain)])
+            domain = expression.AND([domain or [True], ast.literal_eval(self.discount_product_domain)])
         return domain
 
     @api.depends('discount_product_ids', 'discount_product_category_id', 'discount_product_tag_id', 'discount_product_domain')

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -111,7 +111,7 @@ class LoyaltyReward(models.Model):
         if self.discount_product_category_id:
             domain = expression.OR([domain, [('categ_id', 'child_of', self.discount_product_category_id.id)]])
         if self.discount_product_tag_id:
-            domain = expression.OR([domain, [('all_product_tag_ids', 'in', self.discount_product_tag_id.id)]])
+            domain = expression.OR([domain, [('all_product_tag_ids', '=', self.discount_product_tag_id.id)]])
         if self.discount_product_domain and self.discount_product_domain != '[]':
             domain = expression.AND([domain, ast.literal_eval(self.discount_product_domain)])
         return domain

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -120,11 +120,11 @@ class LoyaltyRule(models.Model):
         if self.product_ids:
             domain = [('id', 'in', self.product_ids.ids)]
         if self.product_category_id:
-            domain = expression.OR([domain, [('categ_id', 'child_of', self.product_category_id.id)]])
+            domain = expression.OR([domain or [False], [('categ_id', 'child_of', self.product_category_id.id)]])
         if self.product_tag_id:
-            domain = expression.OR([domain, [('all_product_tag_ids', '=', self.product_tag_id.id)]])
+            domain = expression.OR([domain or [False], [('all_product_tag_ids', '=', self.product_tag_id.id)]])
         if self.product_domain and self.product_domain != '[]':
-            domain = expression.AND([domain, ast.literal_eval(self.product_domain)])
+            domain = expression.AND([domain or [True], ast.literal_eval(self.product_domain)])
         return domain
 
     def _get_valid_products(self):

--- a/addons/loyalty/models/loyalty_rule.py
+++ b/addons/loyalty/models/loyalty_rule.py
@@ -122,7 +122,7 @@ class LoyaltyRule(models.Model):
         if self.product_category_id:
             domain = expression.OR([domain, [('categ_id', 'child_of', self.product_category_id.id)]])
         if self.product_tag_id:
-            domain = expression.OR([domain, [('all_product_tag_ids', 'in', self.product_tag_id.id)]])
+            domain = expression.OR([domain, [('all_product_tag_ids', '=', self.product_tag_id.id)]])
         if self.product_domain and self.product_domain != '[]':
             domain = expression.AND([domain, ast.literal_eval(self.product_domain)])
         return domain

--- a/addons/loyalty/wizard/loyalty_generate_wizard.py
+++ b/addons/loyalty/wizard/loyalty_generate_wizard.py
@@ -36,7 +36,7 @@ class LoyaltyGenerateWizard(models.TransientModel):
         if self.customer_ids:
             domain = [('id', 'in', self.customer_ids.ids)]
         if self.customer_tag_ids:
-            domain = expression.OR([domain, [('category_id', 'in', self.customer_tag_ids.ids)]])
+            domain = expression.OR([domain or [False], [('category_id', 'in', self.customer_tag_ids.ids)]])
         return self.env['res.partner'].search(domain)
 
     @api.depends('customer_ids', 'customer_tag_ids', 'mode')

--- a/addons/lunch/controllers/main.py
+++ b/addons/lunch/controllers/main.py
@@ -109,7 +109,7 @@ class LunchController(http.Controller):
 
         alert_domain = expression.AND([
             [('available_today', '=', True)],
-            [('location_ids', 'in', user_location.id)],
+            [('location_ids', '=', user_location.id)],
             [('mode', '=', 'alert')],
         ])
 

--- a/addons/lunch/models/lunch_product.py
+++ b/addons/lunch/models/lunch_product.py
@@ -87,7 +87,7 @@ class LunchProduct(models.Model):
         supported_operators = ['in', 'not in', '=', '!=']
 
         if not operator in supported_operators:
-            return expression.TRUE_DOMAIN
+            return [True]
 
         if isinstance(value, int):
             value = [value]

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -49,7 +49,7 @@ class LunchSupplier(models.Model):
     country_id = fields.Many2one('res.country', related='partner_id.country_id', readonly=False)
     company_id = fields.Many2one('res.company', related='partner_id.company_id', readonly=False, store=True)
 
-    responsible_id = fields.Many2one('res.users', string="Responsible", domain=lambda self: [('groups_id', 'in', self.env.ref('lunch.group_lunch_manager').id)],
+    responsible_id = fields.Many2one('res.users', string="Responsible", domain=lambda self: [('groups_id', '=', self.env.ref('lunch.group_lunch_manager').id)],
                                      default=lambda self: self.env.user,
                                      help="The responsible is the person that will order lunch for everyone. It will be used as the 'from' when sending the automatic email.")
 

--- a/addons/lunch/security/lunch_security.xml
+++ b/addons/lunch/security/lunch_security.xml
@@ -28,7 +28,7 @@
             <field name="name">lunch.cashmove: do see other people's cashmove</field>
             <field name="model_id" ref="model_lunch_cashmove"/>
             <field name="groups" eval="[(4, ref('group_lunch_manager'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
         <record id="lunch_order_rule_delete" model="ir.rule">
             <field name="name">lunch.order: Only new and cancelled order lines deleted.</field>
@@ -54,7 +54,7 @@
         <record id="lunch_order_rule_write_manager" model="ir.rule">
             <field name="name">manager can do whatever</field>
             <field name="model_id" ref="lunch.model_lunch_order"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="perm_read" eval="0"/>
             <field name="perm_create" eval="0"/>
             <field name="perm_unlink" eval="0"/>

--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -216,7 +216,7 @@ class DiscussController(http.Controller):
 
     @http.route('/mail/starred/messages', methods=['POST'], type='json', auth='user')
     def discuss_starred_messages(self, max_id=None, min_id=None, limit=30, **kwargs):
-        return request.env['mail.message']._message_fetch(domain=[('starred_partner_ids', 'in', [request.env.user.partner_id.id])], max_id=max_id, min_id=min_id, limit=limit).message_format()
+        return request.env['mail.message']._message_fetch(domain=[('starred_partner_ids', '=', request.env.user.partner_id.id)], max_id=max_id, min_id=min_id, limit=limit).message_format()
 
     # --------------------------------------------------------------------------
     # Thread API (channel/chatter common)

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -452,7 +452,7 @@ class MailActivity(models.Model):
                 domain = expression.AND([domain, [('id', 'in', allowed_ids)]])
             else:
                 # force void result if no allowed ids found
-                domain = expression.AND([domain, [(0, '=', 1)]])
+                domain = expression.AND([domain, [False]])
 
         return super(MailActivity, self)._read_group_raw(
             domain=domain, fields=fields, groupby=groupby, offset=offset,

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -176,7 +176,7 @@ class Channel(models.Model):
         if self.env.user._is_public():
             guest = self.env['mail.guest']._get_guest_from_context()
             if not guest:
-                return expression.FALSE_DOMAIN if is_in else expression.TRUE_DOMAIN
+                return [not is_in]
             user_domain = [('guest_id', '=', guest.id)]
         else:
             user_domain = [('partner_id', '=', self.env.user.partner_id.id)]
@@ -760,8 +760,8 @@ class Channel(models.Model):
         all_needed_members_domain = expression.OR([
             [('channel_id.channel_type', '!=', 'channel')],
             [('rtc_inviting_session_id', '!=', False)],
-            [('partner_id', '=', current_partner.id) if current_partner else expression.FALSE_LEAF],
-            [('guest_id', '=', current_guest.id) if current_guest else expression.FALSE_LEAF],
+            [('partner_id', '=', current_partner.id) if current_partner else False],
+            [('guest_id', '=', current_guest.id) if current_guest else False],
         ])
         all_needed_members = self.env['mail.channel.member'].search(expression.AND([[('channel_id', 'in', self.ids)], all_needed_members_domain]), order='id')
         all_needed_members.partner_id.mail_partner_format()  # prefetch in batch

--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -1115,7 +1115,7 @@ class Channel(models.Model):
         domain = expression.AND([
                         [('name', 'ilike', search)],
                         [('channel_type', '=', 'channel')],
-                        [('channel_partner_ids', 'in', [self.env.user.partner_id.id])]
+                        [('channel_partner_ids', '=', self.env.user.partner_id.id)]
                     ])
         channels = self.search(domain, limit=limit)
         return [{

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -242,8 +242,8 @@ class Message(models.Model):
     @api.model
     def _search_starred(self, operator, operand):
         if operator == '=' and operand:
-            return [('starred_partner_ids', 'in', [self.env.user.partner_id.id])]
-        return [('starred_partner_ids', 'not in', [self.env.user.partner_id.id])]
+            return [('starred_partner_ids', '=', self.env.user.partner_id.id)]
+        return [('starred_partner_ids', '!=', self.env.user.partner_id.id)]
 
     # ------------------------------------------------------
     # CRUD / ORM
@@ -771,7 +771,7 @@ class Message(models.Model):
         """ Unstar messages for the current partner. """
         partner_id = self.env.user.partner_id.id
 
-        starred_messages = self.search([('starred_partner_ids', 'in', partner_id)])
+        starred_messages = self.search([('starred_partner_ids', '=', partner_id)])
         starred_messages.write({'starred_partner_ids': [Command.unlink(partner_id)]})
 
         ids = [m.id for m in starred_messages]

--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -79,7 +79,7 @@ class MailBlackListMixin(models.AbstractModel):
         self._cr.execute(query % self._table)
         res = self._cr.fetchall()
         if not res:
-            return [(0, '=', 1)]
+            return [False]
         return [('id', 'in', [r[0] for r in res])]
 
     @api.depends('email_normalized')

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -245,7 +245,7 @@ class Partner(models.Model):
         # get the channels and groups
         channels |= self.env['mail.channel'].search([
             ('channel_type', 'in', ('channel', 'group')),
-            ('channel_partner_ids', 'in', [self.id]),
+            ('channel_partner_ids', '=', self.id),
         ])
         # get the pinned direct messages
         channels |= self.env['mail.channel'].search([
@@ -276,9 +276,9 @@ class Partner(models.Model):
         ])
         if channel_id:
             channel = self.env['mail.channel'].search([('id', '=', int(channel_id))])
-            domain = expression.AND([domain, [('channel_ids', 'not in', channel.id)]])
+            domain = expression.AND([domain, [('channel_ids', '!=', channel.id)]])
             if channel.group_public_id:
-                domain = expression.AND([domain, [('user_ids.groups_id', 'in', channel.group_public_id.id)]])
+                domain = expression.AND([domain, [('user_ids.groups_id', '=', channel.group_public_id.id)]])
         query = self.env['res.partner']._search(domain, order='name, id')
         query.order = 'LOWER("res_partner"."name"), "res_partner"."id"'  # bypass lack of support for case insensitive order in search()
         query.limit = int(limit)
@@ -297,7 +297,7 @@ class Partner(models.Model):
         search_dom = expression.OR([[('name', 'ilike', search)], [('email', 'ilike', search)]])
         search_dom = expression.AND([[('active', '=', True), ('type', '!=', 'private')], search_dom])
         if channel_id:
-            search_dom = expression.AND([[('channel_ids', 'in', channel_id)], search_dom])
+            search_dom = expression.AND([[('channel_ids', '=', channel_id)], search_dom])
         domain_is_user = expression.AND([[('user_ids', '!=', False), ('user_ids.active', '=', True)], search_dom])
         priority_conditions = [
             expression.AND([domain_is_user, [('partner_share', '=', False)]]),  # Search partners that are internal users

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -47,7 +47,7 @@ class Users(models.Model):
         inbox_group_id = self.env['ir.model.data']._xmlid_to_res_id('mail.group_mail_notification_type_inbox')
 
         self.filtered_domain([
-            ('groups_id', 'in', inbox_group_id), ('notification_type', '!=', 'inbox')
+            ('groups_id', '=', inbox_group_id), ('notification_type', '!=', 'inbox')
         ]).notification_type = 'inbox'
         self.filtered_domain([
             ('groups_id', 'not in', inbox_group_id), ('notification_type', '=', 'inbox')

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -24,7 +24,7 @@
             <field name="name">Mail.channel: admin full access</field>
             <field name="model_id" ref="model_mail_channel"/>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="ir_rule_mail_channel_member_group_user" model="ir.rule">
@@ -52,7 +52,7 @@
             <field name="name">mail.channel.member: admin can manipulate all entries</field>
             <field name="model_id" ref="model_mail_channel_member"/>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="ir_rule_mail_notifications_group_user" model="ir.rule">
@@ -107,7 +107,7 @@
         <record id="mail_template_editor_rule" model="ir.rule">
             <field name="name">Mail Template Editors - Edit All Templates</field>
             <field name="model_id" ref="model_mail_template"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[Command.link(ref('group_mail_template_editor')), Command.link(ref('base.group_system'))]"/>
             <field name="perm_create" eval="True"/>
             <field name="perm_read" eval="False"/>
@@ -119,7 +119,7 @@
             <field name="name">Administrators can access all User Settings.</field>
             <field name="model_id" ref="model_res_users_settings"/>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>
@@ -152,7 +152,7 @@
             <field name="name">Administrators can access all User Settings volumes.</field>
             <field name="model_id" ref="model_res_users_settings_volumes"/>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="True"/>

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -15,7 +15,7 @@
                         ('channel_type', '=', 'channel'),
                         '|',
                             ('group_public_id', '=', False),
-                            ('group_public_id', 'in', [g.id for g in user.groups_id])]
+                            ('group_public_id', 'in', user.groups_id.ids)]
             </field>
             <field name="perm_create" eval="False"/>
         </record>
@@ -40,7 +40,7 @@
                         ('channel_id.channel_type', '=', 'channel'),
                         '|',
                             ('channel_id.group_public_id', '=', False),
-                            ('channel_id.group_public_id', 'in', [g.id for g in user.groups_id])]
+                            ('channel_id.group_public_id', 'in', user.groups_id.ids)]
             </field>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>

--- a/addons/mail/tests/test_mail_channel_as_guest.py
+++ b/addons/mail/tests/test_mail_channel_as_guest.py
@@ -26,7 +26,7 @@ class TestMailPublicPage(HttpCase):
 
     def test_mail_channel_public_page_as_guest(self):
         self.start_tour(self.channel.invitation_url, "mail/static/tests/tours/mail_channel_as_guest_tour.js")
-        guest = self.env['mail.guest'].search([('channel_ids', 'in', self.channel.id)], limit=1, order='id desc')
+        guest = self.env['mail.guest'].search([('channel_ids', '=', self.channel.id)], limit=1, order='id desc')
         self.start_tour(self.channel.invitation_url, self.tour, cookies={guest._cookie_name: f"{guest.id}{guest._cookie_separator}{guest.access_token}"})
 
     def test_mail_channel_public_page_as_internal(self):

--- a/addons/mail/views/mail_message_views.xml
+++ b/addons/mail/views/mail_message_views.xml
@@ -110,7 +110,7 @@
                     <field name="parent_id"/>
                     <filter string="Has Mentions"
                             name="filter_has_mentions"
-                            domain="[('partner_ids.user_ids', 'in', [uid])]"/>
+                            domain="[('partner_ids.user_ids', '=', uid)]"/>
                     <separator/>
                     <filter string="Need Action"
                             name="message_needaction" help="Unread messages"

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1154,7 +1154,7 @@ class MailComposer(models.TransientModel):
         :return: an Odoo domain (list of leaves) """
         self.ensure_one()
         if isinstance(self.res_domain, (str, bool)) and not self.res_domain:
-            return expression.FALSE_DOMAIN
+            return [False]
         try:
             domain = self.res_domain
             if isinstance(self.res_domain, str):

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -65,7 +65,7 @@ class MailGroup(models.Model):
     moderation_rule_count = fields.Integer(string='Moderated emails count', compute='_compute_moderation_rule_count')
     moderation_rule_ids = fields.One2many('mail.group.moderation', 'mail_group_id', string='Moderated Emails')
     moderator_ids = fields.Many2many('res.users', 'mail_group_moderator_rel', string='Moderators',
-                                     domain=lambda self: [('groups_id', 'in', self.env.ref('base.group_user').id)])
+                                     domain=lambda self: [('groups_id', '=', self.env.ref('base.group_user').id)])
     moderation_notify = fields.Boolean(
         string='Automatic notification',
         help='People receive an automatic notification about their message being waiting for moderation.')

--- a/addons/mail_group/security/mail_group_security.xml
+++ b/addons/mail_group/security/mail_group_security.xml
@@ -36,7 +36,7 @@
     <record id="mail_group_rule_administrator" model="ir.rule">
         <field name="name">Mail Group: Administrator have access to all mail group</field>
         <field name="model_id" ref="model_mail_group"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('mail_group.group_mail_group_manager'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>
@@ -98,7 +98,7 @@
     <record id="mail_group_message_rule_administrator" model="ir.rule">
         <field name="name">Mail Group Message: Administrator have access to all messages</field>
         <field name="model_id" ref="model_mail_group_message"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('mail_group.group_mail_group_manager'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>
@@ -118,7 +118,7 @@
     <record id="mail_group_member_rule_administrator" model="ir.rule">
         <field name="name">Mail Group Member: Administrator have access to all members</field>
         <field name="model_id" ref="model_mail_group_member"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('mail_group.group_mail_group_manager'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>
@@ -138,7 +138,7 @@
     <record id="mail_group_moderation_rule_administrator" model="ir.rule">
         <field name="name">Mail Group Moderation: Administrator have access to all moderation rules</field>
         <field name="model_id" ref="model_mail_group_moderation"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('mail_group.group_mail_group_manager'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>

--- a/addons/mail_group/security/mail_group_security.xml
+++ b/addons/mail_group/security/mail_group_security.xml
@@ -7,14 +7,14 @@
             '|',
             '|',
             '|',
-                ('moderator_ids', 'in', user.id),
+                ('moderator_ids', '=', user.id),
                 ('access_mode', '=', 'public'),
                 '&amp;',
                     ('access_mode', '=', 'groups'),
-                    ('access_group_id', 'in', [g.id for g in user.groups_id]),
+                    ('access_group_id', 'in', user.groups_id.ids),
                 '&amp;',
                     ('access_mode', '=', 'members'),
-                    ('member_partner_ids', 'in', [user.partner_id.id]),
+                    ('member_partner_ids', '=', user.partner_id.id),
             ]
         </field>
         <field name="groups" eval="[(4, ref('base.group_user')), (4, ref('base.group_portal')), (4, ref('base.group_public'))]"/>
@@ -26,7 +26,7 @@
     <record id="mail_group_rule_write_all" model="ir.rule">
         <field name="name">Mail Group: Moderator have write access on their group</field>
         <field name="model_id" ref="model_mail_group"/>
-        <field name="domain_force">[('moderator_ids', 'in', user.id)]</field>
+        <field name="domain_force">[('moderator_ids', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="perm_create" eval="False"/>
         <field name="perm_read" eval="False"/>
@@ -52,11 +52,11 @@
                 '|',
                 '|',
                 '|',
-                    ('mail_group_id.moderator_ids', 'in', user.id),
+                    ('mail_group_id.moderator_ids', '=', user.id),
                     ('mail_group_id.access_mode', '=', 'public'),
                     '&amp;',
                         ('mail_group_id.access_mode', '=', 'groups'),
-                        ('mail_group_id.access_group_id', 'in', [g.id for g in user.groups_id]),
+                        ('mail_group_id.access_group_id', 'in', user.groups_id.ids),
                     '&amp;',
                         ('mail_group_id.access_mode', '=', 'members'),
                         ('mail_group_id.member_partner_ids', 'in', [user.partner_id.id]),
@@ -75,18 +75,18 @@
                 '&amp;',
                     '|',
                         ('moderation_status', '=', 'accepted'),
-                        ('mail_group_id.moderator_ids', 'in', user.id),
+                        ('mail_group_id.moderator_ids', '=', user.id),
                     '|',
                     '|',
                     '|',
-                        ('mail_group_id.moderator_ids', 'in', user.id),
+                        ('mail_group_id.moderator_ids', '=', user.id),
                         ('mail_group_id.access_mode', '=', 'public'),
                         '&amp;',
                             ('mail_group_id.access_mode', '=', 'groups'),
-                            ('mail_group_id.access_group_id', 'in', [g.id for g in user.groups_id]),
+                            ('mail_group_id.access_group_id', 'in', user.groups_id.ids),
                         '&amp;',
                             ('mail_group_id.access_mode', '=', 'members'),
-                            ('mail_group_id.member_partner_ids', 'in', [user.partner_id.id]),
+                            ('mail_group_id.member_partner_ids', '=', user.partner_id.id),
             ]
         </field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
@@ -108,7 +108,7 @@
     <record id="mail_group_member_rule_user" model="ir.rule">
         <field name="name">Mail Group Member: Members are accessible only by moderators</field>
         <field name="model_id" ref="model_mail_group_member"/>
-        <field name="domain_force">[('mail_group_id.moderator_ids', 'in', user.id)]</field>
+        <field name="domain_force">[('mail_group_id.moderator_ids', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>
@@ -128,7 +128,7 @@
     <record id="mail_group_moderation_rule_user" model="ir.rule">
         <field name="name">Mail Group Moderation: Moderation rules are accessible only by moderators</field>
         <field name="model_id" ref="model_mail_group_moderation"/>
-        <field name="domain_force">[('mail_group_id.moderator_ids', 'in', user.id)]</field>
+        <field name="domain_force">[('mail_group_id.moderator_ids', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -421,7 +421,7 @@ class MaintenanceTeam(models.Model):
         default=lambda self: self.env.company)
     member_ids = fields.Many2many(
         'res.users', 'maintenance_team_users_rel', string="Team Members",
-        domain="[('company_ids', 'in', company_id)]")
+        domain="[('company_ids', '=', company_id)]")
     color = fields.Integer("Color Index", default=0)
     request_ids = fields.One2many('maintenance.request', 'maintenance_team_id', copy=False)
     equipment_ids = fields.One2many('maintenance.equipment', 'maintenance_team_id', copy=False)

--- a/addons/maintenance/security/maintenance.xml
+++ b/addons/maintenance/security/maintenance.xml
@@ -29,14 +29,14 @@
     <record id="equipment_request_rule_admin_user" model="ir.rule">
         <field name="name">Administrator of maintenance requests</field>
         <field name="model_id" ref="model_maintenance_request"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('group_equipment_manager'))]"/>
     </record>
 
     <record id="equipment_rule_admin_user" model="ir.rule">
         <field name="name">Equipment administrator</field>
         <field name="model_id" ref="model_maintenance_equipment"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('group_equipment_manager'))]"/>
     </record>
 

--- a/addons/maintenance/security/maintenance.xml
+++ b/addons/maintenance/security/maintenance.xml
@@ -15,14 +15,14 @@
     <record id="equipment_request_rule_user" model="ir.rule">
         <field name="name">Users are allowed to access their own maintenance requests</field>
         <field name="model_id" ref="model_maintenance_request"/>
-        <field name="domain_force">['|', ('message_partner_ids', 'in', [user.partner_id.id]), ('user_id', '=', user.id)]</field>
+        <field name="domain_force">['|', ('message_partner_ids', '=', user.partner_id.id), ('user_id', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
 
     <record id="equipment_rule_user" model="ir.rule">
         <field name="name">Users are allowed to access equipment they follow</field>
         <field name="model_id" ref="model_maintenance_equipment"/>
-        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
 

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -122,7 +122,7 @@ class MassMailController(http.Controller):
         if not mail or not consteq(token, mail._generate_mail_recipient_token()):
             raise BadRequest()
 
-        request.env['mailing.trace'].sudo().set_opened(domain=[('mail_mail_id_int', 'in', [mail_id])])
+        request.env['mailing.trace'].sudo().set_opened(domain=[('mail_mail_id_int', '=', mail_id)])
         response = werkzeug.wrappers.Response()
         response.mimetype = 'image/gif'
         response.data = base64.b64decode(b'R0lGODlhAQABAIAAANvf7wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==')

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -3,7 +3,6 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.osv import expression
 
 
 class MassMailingContactListRel(models.Model):
@@ -99,7 +98,7 @@ class MassMailingContact(models.Model):
             [active_list_id] = self._context['default_list_ids']
             contacts = self.env['mailing.contact.subscription'].search([('list_id', '=', active_list_id)])
             return [('id', 'in', [record.contact_id.id for record in contacts if record.opt_out == value])]
-        return expression.FALSE_DOMAIN if value else expression.TRUE_DOMAIN
+        return [not value]
 
     @api.depends('subscription_list_ids')
     @api.depends_context('default_list_ids')

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -179,19 +179,19 @@ class MassMailingList(models.Model):
 
     def action_view_contacts_opt_out(self):
         action = self.env["ir.actions.actions"]._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
-        action['domain'] = [('list_ids', 'in', self.id)]
+        action['domain'] = [('list_ids', '=', self.id)]
         action['context'] = {'default_list_ids': self.ids, 'create': False, 'search_default_filter_opt_out': 1}
         return action
 
     def action_view_contacts_blacklisted(self):
         action = self.env["ir.actions.actions"]._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
-        action['domain'] = [('list_ids', 'in', self.id)]
+        action['domain'] = [('list_ids', '=', self.id)]
         action['context'] = {'default_list_ids': self.ids, 'create': False, 'search_default_filter_blacklisted': 1}
         return action
 
     def action_view_contacts_bouncing(self):
         action = self.env["ir.actions.actions"]._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
-        action['domain'] = [('list_ids', 'in', self.id)]
+        action['domain'] = [('list_ids', '=', self.id)]
         action['context'] = {'default_list_ids': self.ids, 'create': False, 'search_default_filter_bounce': 1}
         return action
 

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -132,7 +132,7 @@ class Meeting(models.Model):
         lower_bound = fields.Datetime.subtract(fields.Datetime.now(), days=day_range)
         upper_bound = fields.Datetime.add(fields.Datetime.now(), days=day_range)
         return [
-            ('partner_ids.user_ids', 'in', self.env.user.id),
+            ('partner_ids.user_ids', '=', self.env.user.id),
             ('stop', '>', lower_bound),
             ('start', '<', upper_bound),
             # Do not sync events that follow the recurrence, they are already synced at recurrence creation

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -463,7 +463,7 @@ class MicrosoftSync(models.AbstractModel):
         """
         domain = self._get_microsoft_sync_domain()
         if not full_sync:
-            is_active_clause = (self._active_name, '=', True) if self._active_name else expression.TRUE_LEAF
+            is_active_clause = (self._active_name, '=', True) if self._active_name else True
             domain = expression.AND([domain, [
                 '|',
                 '&', ('ms_universal_event_id', '=', False), is_active_clause,

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -250,11 +250,11 @@ class MicrosoftSync(models.AbstractModel):
         # To map existing recurrences with events to update, we must use the universal id
         # (also known as ICalUId in the Microsoft API), as 'seriesMasterId' attribute of events
         # is specific to the Microsoft user calendar.
-        ms_recurrence_ids = list({x.seriesMasterId for x in recurrents})
+        ms_recurrence_ids = {x.seriesMasterId for x in recurrents}
         ms_recurrence_uids = {r.id: r.iCalUId for r in microsoft_events if r.id in ms_recurrence_ids}
 
         recurrences = self.env['calendar.recurrence'].search([
-            ('ms_universal_event_id', 'in', ms_recurrence_uids.values())
+            ('ms_universal_event_id', 'in', list(ms_recurrence_uids.values()))
         ])
         for recurrent_master_id in ms_recurrence_ids:
             recurrence_id = recurrences.filtered(

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -187,7 +187,7 @@ class MrpProduction(models.Model):
     user_id = fields.Many2one(
         'res.users', 'Responsible', default=lambda self: self.env.user,
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
-        domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)])
+        domain=lambda self: [('groups_id', '=', self.env.ref('mrp.group_mrp_user').id)])
     company_id = fields.Many2one(
         'res.company', 'Company', default=lambda self: self.env.company,
         index=True, required=True)

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -99,5 +99,5 @@ class MrpProductionSplitLine(models.TransientModel):
     quantity = fields.Float('Quantity To Produce', digits='Product Unit of Measure', required=True)
     user_id = fields.Many2one(
         'res.users', 'Responsible',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)])
+        domain=lambda self: [('groups_id', '=', self.env.ref('mrp.group_mrp_user').id)])
     date = fields.Datetime('Schedule Date')

--- a/addons/note/models/res_users.py
+++ b/addons/note/models/res_users.py
@@ -17,7 +17,7 @@ class Users(models.Model):
         users = super().create(vals_list)
         user_group_id = self.env['ir.model.data']._xmlid_to_res_id('base.group_user')
         # for new employee, create his own 5 base note stages
-        users.filtered_domain([('groups_id', 'in', [user_group_id])])._create_note_stages()
+        users.filtered_domain([('groups_id', '=', user_group_id)])._create_note_stages()
         return users
 
     @api.model

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -473,7 +473,7 @@ class PaymentProvider(models.Model):
                 domain, [
                     '|',
                     ('available_country_ids', '=', False),
-                    ('available_country_ids', 'in', [partner.country_id.id]),
+                    ('available_country_ids', '=', partner.country_id.id),
                 ]
             ])
 
@@ -498,7 +498,7 @@ class PaymentProvider(models.Model):
                 domain, [
                     '|',
                     ('available_currency_ids', '=', False),
-                    ('available_currency_ids', 'in', [currency.id]),
+                    ('available_currency_ids', '=', currency.id),
                 ]
             ])
 

--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -117,7 +117,7 @@ class PhoneMixin(models.AbstractModel):
             self._cr.execute(query, (pattern, term) * len(phone_fields))
         res = self._cr.fetchall()
         if not res:
-            return [(0, '=', 1)]
+            return [False]
         return [('id', 'in', [r[0] for r in res])]
 
     @api.depends(lambda self: self._phone_get_sanitize_triggers())
@@ -181,7 +181,7 @@ class PhoneMixin(models.AbstractModel):
         self._cr.execute(query % self._table)
         res = self._cr.fetchall()
         if not res:
-            return [(0, '=', 1)]
+            return [False]
         return [('id', 'in', [r[0] for r in res])]
 
     def _assert_phone_field(self):

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -22,7 +22,7 @@
         <field name="name">Point Of Sale Bank Statement Accountant</field>
         <field name="model_id" ref="account.model_account_bank_statement" />
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
     </record>
     <record id="rule_pos_bank_statement_line_user" model="ir.rule">
         <field name="name">Point Of Sale Bank Statement Line POS User</field>
@@ -34,7 +34,7 @@
         <field name="name">Point Of Sale Bank Statement Line Accountant</field>
         <field name="model_id" ref="account.model_account_bank_statement_line" />
         <field name="groups" eval="[(4, ref('account.group_account_invoice'))]"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
     </record>
     <record id="rule_pos_multi_company" model="ir.rule">
         <field name="name">Point Of Sale Order</field>

--- a/addons/point_of_sale/wizard/pos_payment.xml
+++ b/addons/point_of_sale/wizard/pos_payment.xml
@@ -7,7 +7,7 @@
             <form string="Pay Order">
                 <group>
                     <field name="config_id" invisible="1" />
-                    <field name="payment_method_id" domain="[('config_ids', 'in', config_id)]"/>
+                    <field name="payment_method_id" domain="[('config_ids', '=', config_id)]"/>
                     <field name="amount" />
                     <field name="payment_name"/>
                 </group>

--- a/addons/pos_sale/security/pos_sale_security.xml
+++ b/addons/pos_sale/security/pos_sale_security.xml
@@ -3,7 +3,7 @@
     <record id="pos_sale_rule_pos_channel_pos_manager" model="ir.rule">
         <field name="name">POS Sales Team</field>
         <field name="model_id" ref="sales_team.model_crm_team"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('point_of_sale.group_pos_manager'))]"/>
     </record>
 </odoo>

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -123,8 +123,8 @@ class TestVariants(ProductVariantsCommon):
         for ptav in sofa_size_s + sofa_size_m:
             products = self.env['product.product'].search([
                 ('product_tmpl_id', '=', test_template.id),
-                ('product_template_attribute_value_ids', 'in', ptav.id),
-                ('product_template_attribute_value_ids', 'in', sofa_attr1_v2.id)
+                ('product_template_attribute_value_ids', '=', ptav.id),
+                ('product_template_attribute_value_ids', '=', sofa_attr1_v2.id)
             ])
             self.assertEqual(len(products), 1)
 
@@ -162,8 +162,8 @@ class TestVariants(ProductVariantsCommon):
             for value_2 in sofa_size_s + sofa_size_m + sofa_size_l:
                 products = self.env['product.product'].search([
                     ('product_tmpl_id', '=', test_template.id),
-                    ('product_template_attribute_value_ids', 'in', value_1.id),
-                    ('product_template_attribute_value_ids', 'in', value_2.id)
+                    ('product_template_attribute_value_ids', '=', value_1.id),
+                    ('product_template_attribute_value_ids', '=', value_2.id)
                 ])
                 self.assertEqual(len(products), 1)
 

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -283,7 +283,7 @@ class Project(models.Model):
     def _search_is_favorite(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise NotImplementedError(_('Operation not supported'))
-        return [('favorite_user_ids', 'in' if (operator == '=') == value else 'not in', self.env.uid)]
+        return [('favorite_user_ids', operator, self.env.uid)]
 
     def _compute_is_favorite(self):
         for project in self:
@@ -2730,7 +2730,7 @@ class ProjectTags(models.Model):
 
     def _get_project_tags_domain(self, domain, project_id):
         tag_ids = list(self.with_user(SUPERUSER_ID)._search(
-            ['|', ('task_ids.project_id', '=', project_id), ('project_ids', 'in', project_id)]))
+            ['|', ('task_ids.project_id', '=', project_id), ('project_ids', '=', project_id)]))
         return expression.AND([domain, [('id', 'in', tag_ids)]])
 
     @api.model

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2123,8 +2123,8 @@ class Task(models.Model):
         tasks = self
         recurrence_update = vals.pop('recurrence_update', 'this')
         if recurrence_update != 'this':
-            recurrence_domain = []
             if recurrence_update == 'subsequent':
+                recurrence_domain = [False]
                 for task in self:
                     recurrence_domain = expression.OR([recurrence_domain, ['&', ('recurrence_id', '=', task.recurrence_id.id), ('create_date', '>=', task.create_date)]])
             else:

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -248,7 +248,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
         * A domain that only contains fields that are specific to `project.task.burndown.chart.report`
         * A domain that only contains fields that are specific to `project.task`
 
-        Fields that are not part of the constraint are replaced by either a `FALSE_LEAF` or a `TRUE_LEAF` in order
+        Fields that are not part of the constraint are replaced by either a `False` or a `True` in order
         to ensure the complete domain evaluation. See `remove_domain_leaf` for more details.
 
         :param domain: The domain that has been passed to the read_group.

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -63,7 +63,7 @@
     <record model="ir.rule" id="project_project_manager_rule">
         <field name="name">Project: project manager: see all</field>
         <field name="model_id" ref="model_project_project"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
 
@@ -114,7 +114,7 @@
     <record model="ir.rule" id="task_type_manager_rule">
         <field name="name">Project/Task Type: manager sees all</field>
         <field name="model_id" ref="model_project_task_type"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
 
@@ -256,14 +256,14 @@
     <record model="ir.rule" id="report_project_task_manager_rule">
         <field name="name">Tasks Analysis: project visibility Manager</field>
         <field name="model_id" ref="model_report_project_task_user"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
 
     <record id="update_visibility_project_admin" model="ir.rule">
         <field name="name">Project updates : Project user can see all project updates</field>
         <field name="model_id" ref="project.model_project_update"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
 
@@ -283,7 +283,7 @@
     <record model="ir.rule" id="burndown_chart_project_manager_rule">
         <field name="name">Burndown chart: project visibility User</field>
         <field name="model_id" ref="model_project_task_burndown_chart_report"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
 
@@ -309,7 +309,7 @@
     <record id="milestone_visibility_project_admin" model="ir.rule">
         <field name="name">Project/Milestone: Project manager can see all project milestones</field>
         <field name="model_id" ref="project.model_project_milestone"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
     </record>
 </data>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -72,7 +72,7 @@
         <field name="model_id" ref="model_project_project"/>
         <field name="domain_force">['|',
                                         ('privacy_visibility', '!=', 'followers'),
-                                        ('message_partner_ids', 'in', [user.partner_id.id])
+                                        ('message_partner_ids', '=', user.partner_id.id)
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
@@ -92,11 +92,11 @@
                     ('project_id', '!=', False),
                     '|',
                         ('project_id.privacy_visibility', '!=', 'followers'),
-                        ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                        ('project_id.message_partner_ids', '=', user.partner_id.id),
                 '|',
-                    ('message_partner_ids', 'in', [user.partner_id.id]),
+                    ('message_partner_ids', '=', user.partner_id.id),
                     # to subscribe check access to the record, follower is not enough at creation
-                    ('user_ids', 'in', user.id)
+                    ('user_ids', '=', user.id)
         ]</field>
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
@@ -106,7 +106,7 @@
         <field name="model_id" ref="model_project_task"/>
         <field name="domain_force">[
             '|', ('project_id', '!=', False),
-                 ('user_ids', 'in', user.id),
+                 ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
     </record>
@@ -154,7 +154,7 @@
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|', '|', ('project_id', '!=', False),
                       ('parent_id', '!=', False),
-                 ('user_ids', 'in', user.id),
+                 ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -208,7 +208,7 @@
             '|',
                 ('project_id.message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
                 ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-            ('project_id.collaborator_ids.partner_id', 'in', [user.partner_id.id]),
+            ('project_id.collaborator_ids.partner_id', '=', user.partner_id.id),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="False"/>
@@ -230,7 +230,7 @@
         '|',
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('project_id.message_partner_ids', '=', user.partner_id.id),
                 '|',
                     ('user_id', '=', user.id),
                     ('project_id.user_id', '=', user.id)
@@ -245,10 +245,10 @@
         '|',
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('project_id.message_partner_ids', '=', user.partner_id.id),
                 '|',
-                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('user_ids', 'in', user.id),
+                    ('task_id.message_partner_ids', '=', user.partner_id.id),
+                    ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -274,8 +274,8 @@
         '|',
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
-                ('user_ids', 'in', user.id),
+                ('project_id.message_partner_ids', '=', user.partner_id.id),
+                ('user_ids', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4,ref('project.group_project_user'))]"/>
     </record>
@@ -300,7 +300,7 @@
         '|',
             ('project_id.privacy_visibility', '!=', 'followers'),
             '|',
-                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                ('project_id.message_partner_ids', '=', user.partner_id.id),
                 ('project_id.user_id', '=', user.id),
         ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_dynamic_group_list.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_dynamic_group_list.js
@@ -28,7 +28,7 @@ export class ProjectTaskKanbanDynamicGroupList extends KanbanDynamicGroupList {
             return super._loadGroups(...arguments);
         }
         const previousDomain = this.domain;
-        this.domain = Domain.and([[['user_ids', 'in', session.uid]], previousDomain]).toList({});
+        this.domain = Domain.and([[['user_ids', '=', session.uid]], previousDomain]).toList({});
         const result = await super._loadGroups(...arguments);
         this.domain = previousDomain;
         return result;

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -249,18 +249,18 @@ class TestProjectSharing(TestProjectSharingCommon):
         self.task_portal.with_user(self.user_portal).write({'stage_id': self.project_portal.type_ids[-1].id})
 
     def test_orm_method_with_true_false_domain(self):
-        """ Test orm method overriden in project for project sharing works with TRUE_LEAF/FALSE_LEAF
+        """ Test orm method overriden in project for project sharing works with True/False
 
             Test Case
             =========
             1) Share a project in edit mode for portal user
-            2) Search the portal task contained in the project shared by using a domain with TRUE_LEAF
+            2) Search the portal task contained in the project shared by using a domain with True
             3) Check the task is found with the `search` method
-            4) filter the task with `TRUE_DOMAIN` and check if the task is always returned by `filtered_domain` method
-            5) filter the task with `FALSE_DOMAIN` and check if no task is returned by `filtered_domain` method
-            6) Search the task with `FALSE_LEAF` and check no task is found with `search` method
-            7) Call `read_group` method with `TRUE_LEAF` in the domain and check if the task is found
-            8) Call `read_group` method with `FALSE_LEAF` in the domain and check if no task is found
+            4) filter the task with `[True]` domain and check if the task is always returned by `filtered_domain` method
+            5) filter the task with `[False]` domain and check if no task is returned by `filtered_domain` method
+            6) Search the task with `False` and check no task is found with `search` method
+            7) Call `read_group` method with `True` in the domain and check if the task is found
+            8) Call `read_group` method with `False` in the domain and check if no task is found
         """
         domain = [('id', '=', self.task_portal.id)]
         self.project_portal.write({
@@ -270,23 +270,23 @@ class TestProjectSharing(TestProjectSharingCommon):
         })
         task = self.env['project.task'].with_user(self.user_portal).search(
             expression.AND([
-                expression.TRUE_DOMAIN,
+                [True],
                 domain,
             ])
         )
         self.assertTrue(task, 'The task should be found.')
-        self.assertEqual(task, task.filtered_domain(expression.TRUE_DOMAIN), 'The task found should be kept since the domain is truly')
-        self.assertFalse(task.filtered_domain(expression.FALSE_DOMAIN), 'The task should not be found since the domain is falsy')
+        self.assertEqual(task, task.filtered_domain([True]), 'The task found should be kept since the domain is truly')
+        self.assertFalse(task.filtered_domain([False]), 'The task should not be found since the domain is falsy')
         task = self.env['project.task'].with_user(self.user_portal).search(
             expression.AND([
-                expression.FALSE_DOMAIN,
+                [False],
                 domain,
             ]),
         )
         self.assertFalse(task, 'No task should be found since the domain contained a falsy tuple.')
 
         task_read_group = self.env['project.task'].read_group(
-            expression.AND([expression.TRUE_DOMAIN, domain]),
+            expression.AND([[True], domain]),
             ['id'],
             [],
         )
@@ -294,7 +294,7 @@ class TestProjectSharing(TestProjectSharingCommon):
         self.assertEqual(task_read_group[0]['id'], self.task_portal.id, 'The task should be found with the read_group method containing a truly tuple.')
 
         task_read_group = self.env['project.task'].read_group(
-            expression.AND([expression.FALSE_DOMAIN, domain]),
+            expression.AND([[False], domain]),
             ['id'],
             [],
         )

--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -136,9 +136,9 @@
             <form string="Project Sharing: Task" class="o_form_project_tasks">
                 <header>
                     <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : &quot;[('user_ids', 'in', [uid])]&quot;}" data-hotkey="q" groups="base.group_user"/>
+                            attrs="{'invisible' : &quot;[('user_ids', '=', uid)]&quot;}" data-hotkey="q" groups="base.group_user"/>
                     <button name="action_unassign_me" string="Unassign Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : &quot;[('user_ids', 'not in', [uid])]&quot;}" data-hotkey="q"/>
+                            attrs="{'invisible' : &quot;[('user_ids', '!=', uid)]&quot;}" data-hotkey="q"/>
                     <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}" />
                 </header>
                 <sheet string="Task">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -65,7 +65,7 @@
                     <field name="company_id" groups="base.group_multi_company"/>
                 </field>
                 <field name="description" position="after">
-                    <filter string="My Tasks" name="my_tasks" domain="[('user_ids', 'in', uid)]"/>
+                    <filter string="My Tasks" name="my_tasks" domain="[('user_ids', '=', uid)]"/>
                 </field>
                 <filter name="stage" position="after">
                     <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
@@ -615,7 +615,7 @@
                     <field name="stage_id" groups="project.group_project_stages"/>
                     <field name="partner_id" string="Customer" filter_domain="[('partner_id', 'child_of', self)]"/>
                     <filter string="My Projects" name="own_projects" domain="[('user_id', '=', uid)]"/>
-                    <filter string="My Favorites" name="my_projects" domain="[('favorite_user_ids', 'in', uid)]"/>
+                    <filter string="My Favorites" name="my_projects" domain="[('favorite_user_ids', '=', uid)]"/>
                     <filter string="Unassigned" name="unassigned_projects" domain="[('user_id', '=', False)]"/>
                     <separator/>
                     <filter string="Late Milestones" name="late_milestones" domain="[('is_milestone_exceeded', '=', True)]" groups="project.group_project_milestone"/>
@@ -1075,8 +1075,8 @@
                     <field name="parent_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <header>
-                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', 'in', uid), ('user_ids', '!=', [])]&quot;}" data-hotkey="q"/>
-                        <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', 'in', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight" attrs="{'invisible' : &quot;['|', ('user_ids', '=', uid), ('user_ids', '!=', [])]&quot;}" data-hotkey="q"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" attrs="{'invisible': &quot;['|', ('user_ids', '=', uid), ('user_ids', '=', [])]&quot;}" data-hotkey="q"/>
                         <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False), ('stage_id', '=', False)]}"/>
                         <field name="personal_stage_type_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '!=', False)]}" domain="[('user_id', '=', uid)]" string="Personal Stage"/>
                     </header>
@@ -1715,7 +1715,7 @@
             <field name="view_mode">kanban,tree,form,calendar,pivot,graph,activity</field>
             <field name="context">{'all_task': 0, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('user_ids', 'in', uid)]</field>
+            <field name="domain">[('user_ids', '=', uid)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -85,7 +85,7 @@ class ProductProduct(models.Model):
                         ('move_dest_ids', '=', False),
                         ('orderpoint_id.warehouse_id', 'in', warehouse_ids)
             ]])
-            domain = expression.OR([domain, wh_domain])
+            domain = expression.OR([domain or [False], wh_domain])
         return domain
 
 

--- a/addons/rating/views/rating_rating_views.xml
+++ b/addons/rating/views/rating_rating_views.xml
@@ -230,7 +230,7 @@
                     <field name="res_name" filter_domain="[('res_name','ilike',self)]"/>
                     <field name="res_id"/>
                     <field name="parent_res_name" filter_domain="[('parent_res_name','ilike',self)]"/>
-                    <filter string="My Ratings" name="my_ratings" domain="[('rated_partner_id.user_ids', 'in', [uid])]"/>
+                    <filter string="My Ratings" name="my_ratings" domain="[('rated_partner_id.user_ids', '=', uid)]"/>
                     <separator/>
                     <filter string="Satisfied" name="rating_happy" domain="[('rating_text', '=', 'top')]"/>
                     <filter string="Okay" name="rating_okay" domain="[('rating_text', '=', 'ok')]"/>

--- a/addons/sale/security/ir_rules.xml
+++ b/addons/sale/security/ir_rules.xml
@@ -50,7 +50,7 @@
     <record id="sale_order_see_all" model="ir.rule">
         <field name="name">All Orders</field>
         <field ref="model_sale_order" name="model_id"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
@@ -64,7 +64,7 @@
     <record id="sale_order_report_see_all" model="ir.rule">
         <field name="name">All Orders Analysis</field>
         <field ref="model_sale_report" name="model_id"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
@@ -78,7 +78,7 @@
     <record id="sale_order_line_see_all" model="ir.rule">
         <field name="name">All Orders Lines</field>
         <field ref="model_sale_order_line" name="model_id"/>
-        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
@@ -92,7 +92,7 @@
     <record id="account_invoice_report_rule_see_all" model="ir.rule">
         <field name="name">All Invoices Analysis</field>
         <field name="model_id" ref="model_account_invoice_report"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
 
@@ -102,7 +102,7 @@
         <field name="name">Access every payment transaction</field>
         <field name="model_id" ref="payment.model_payment_transaction"/>
         <!-- Reset the domain defined by payment.transaction_user_rule -->
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
     </record>
 
@@ -110,7 +110,7 @@
         <field name="name">Access every payment token</field>
         <field name="model_id" ref="payment.model_payment_token"/>
         <!-- Reset the domain defined by payment.token_user_rule -->
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
     </record>
 

--- a/addons/sale_stock/security/sale_stock_security.xml
+++ b/addons/sale_stock/security/sale_stock_security.xml
@@ -11,7 +11,7 @@
         <record id="stock_picking_rule_portal" model="ir.rule">
             <field name="name">Portal Follower Transfers</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
-            <field name="domain_force">['|', '|', ('message_partner_ids', 'in', [user.partner_id.id]), ('partner_id', '=', user.partner_id.id), ('sale_id.partner_id', '=', user.partner_id.id)]</field>
+            <field name="domain_force">['|', '|', ('message_partner_ids', '=', user.partner_id.id), ('partner_id', '=', user.partner_id.id), ('sale_id.partner_id', '=', user.partner_id.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
     </data>

--- a/addons/sale_timesheet/__init__.py
+++ b/addons/sale_timesheet/__init__.py
@@ -7,7 +7,7 @@ from . import report
 
 
 def uninstall_hook(env):
-    env.ref("account.account_analytic_line_rule_billing_user").write({'domain_force': "[(1, '=', 1)]"})
+    env.ref("account.account_analytic_line_rule_billing_user").write({'domain_force': "[True]"})
 
 def _sale_timesheet_post_init(env):
     products = env['product.template'].search([('detailed_type', '=', 'service'), ('invoice_policy', '=', 'order'), ('service_type', '=', 'manual')])

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -78,13 +78,13 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
     def _get_search_domain(self, search_in, search):
         search_domain = super()._get_search_domain(search_in, search)
         if search_in in ('sol', 'all'):
-            search_domain = expression.OR([search_domain, [('so_line', 'ilike', search)]])
+            search_domain = expression.OR([search_domain or [False], [('so_line', 'ilike', search)]])
         if search_in in ('so', 'all'):
-            search_domain = expression.OR([search_domain, [('so_line.order_id.name', 'ilike', search)]])
+            search_domain = expression.OR([search_domain or [False], [('so_line.order_id.name', 'ilike', search)]])
         if search_in in ('invoice', 'all'):
             invoices = request.env['account.move'].sudo().search([('name', 'ilike', search)])
             domain = request.env['account.analytic.line']._timesheet_get_sale_domain(invoices.mapped('invoice_line_ids.sale_line_ids'), invoices)
-            search_domain = expression.OR([search_domain, domain])
+            search_domain = expression.OR([search_domain or [False], domain])
         return search_domain
 
     def _get_groupby_mapping(self):

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -23,7 +23,7 @@ class AccountAnalyticLine(models.Model):
 
     def _default_sale_line_domain(self):
         domain = super(AccountAnalyticLine, self)._default_sale_line_domain()
-        return expression.OR([domain, [('qty_delivered_method', '=', 'timesheet')]])
+        return expression.OR([domain or [False], [('qty_delivered_method', '=', 'timesheet')]])
 
     timesheet_invoice_type = fields.Selection(TIMESHEET_INVOICE_TYPES, string="Billable Type",
             compute='_compute_timesheet_invoice_type', compute_sudo=True, store=True, readonly=True)

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -82,6 +82,10 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: 'div[name="timesheet_ids"] td.o_field_x2many_list_row_add a[role="button"]',
     content: 'Click on Add a line to create a new timesheet into the task.',
 }, {
+    trigger: '.o_field_x2many div[name="name"] input',
+    content: 'Enter a description for this timesheet',
+    run: 'text work',
+}, {
     trigger: 'div[name="unit_amount"] input',
     content: 'Enter one hour for this timesheet',
     run: 'text 1',

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -58,7 +58,7 @@ class CrmTeam(models.Model):
         team = self.env['crm.team']
         teams = self.env['crm.team'].search([
             ('company_id', 'in', valid_cids),
-             '|', ('user_id', '=', user.id), ('member_ids', 'in', [user.id])
+             '|', ('user_id', '=', user.id), ('member_ids', '=', user.id)
         ])
         if teams and domain:
             filtered_teams = teams.filtered_domain(domain)

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -31,7 +31,7 @@
         <record id="crm_rule_all_salesteam" model="ir.rule">
             <field name="name">All Salesteam</field>
             <field ref="sales_team.model_crm_team" name="model_id"/>
-            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
         </record>
 

--- a/addons/sms/security/sms_security.xml
+++ b/addons/sms/security/sms_security.xml
@@ -4,6 +4,6 @@
         <field name="name">SMS Template: system group granted all</field>
         <field name="model_id" ref="sms.model_sms_template"/>
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
     </record>
 </odoo>

--- a/addons/spreadsheet_account/models/account.py
+++ b/addons/spreadsheet_account/models/account.py
@@ -43,7 +43,7 @@ class AccountMove(models.Model):
     def _build_spreadsheet_formula_domain(self, formula_params):
         code = formula_params["code"]
         if not code:
-            return expression.FALSE_DOMAIN
+            return [False]
         company_id = formula_params["company_id"] or self.env.company.id
         company = self.env["res.company"].browse(company_id)
         start, end = self._get_date_period_boundaries(
@@ -116,7 +116,7 @@ class AccountMove(models.Model):
             company_id = args["company_id"] or self.env.company.id
             domain = self._build_spreadsheet_formula_domain(args)
             # remove this when _search always returns a Query object
-            if domain == expression.FALSE_DOMAIN:
+            if expression.is_false(domain):
                 results.append({"credit": 0, "debit": 0})
                 continue
             MoveLines = self.env["account.move.line"].with_company(company_id)

--- a/addons/spreadsheet_account/tests/test_debit_credit.py
+++ b/addons/spreadsheet_account/tests/test_debit_credit.py
@@ -860,7 +860,7 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
                 "view_mode": "list",
                 "views": [[False, "list"]],
                 "target": "current",
-                "domain": [(0, "=", 1)],
+                "domain": [False],
                 "name": "Journal items for account prefix ",
             },
         )

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -379,7 +379,7 @@ class Picking(models.Model):
         readonly=True, store=True, index=True)
     user_id = fields.Many2one(
         'res.users', 'Responsible', tracking=True,
-        domain=lambda self: [('groups_id', 'in', self.env.ref('stock.group_stock_user').id)],
+        domain=lambda self: [('groups_id', '=', self.env.ref('stock.group_stock_user').id)],
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
         default=lambda self: self.env.user)
     move_line_ids = fields.One2many('stock.move.line', 'picking_id', 'Operations')

--- a/addons/survey/security/survey_security.xml
+++ b/addons/survey/security/survey_security.xml
@@ -28,7 +28,7 @@
         <record id="survey_survey_rule_survey_manager" model="ir.rule">
             <field name="name">Survey: manager: all</field>
             <field name="model_id" ref="survey.model_survey_survey"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -38,7 +38,7 @@
         <record id="survey_survey_rule_survey_user_read" model="ir.rule">
             <field name="name">Survey: officer: read all</field>
             <field name="model_id" ref="survey.model_survey_survey"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_user'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -59,7 +59,7 @@
         <record id="survey_question_rule_survey_manager" model="ir.rule">
             <field name="name">Survey question: manager: all</field>
             <field name="model_id" ref="survey.model_survey_question"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -69,7 +69,7 @@
         <record id="survey_question_rule_survey_user_read" model="ir.rule">
             <field name="name">Survey question: officer: read all</field>
             <field name="model_id" ref="survey.model_survey_question"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_user'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -90,7 +90,7 @@
         <record id="survey_question_answer_rule_survey_manager" model="ir.rule">
             <field name="name">Survey question answer: manager: all</field>
             <field name="model_id" ref="survey.model_survey_question_answer"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -100,7 +100,7 @@
         <record id="survey_question_answer_rule_survey_user_read" model="ir.rule">
             <field name="name">Survey question answer: officer: read all</field>
             <field name="model_id" ref="survey.model_survey_question_answer"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_user'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -122,7 +122,7 @@
         <record id="survey_user_input_rule_survey_manager" model="ir.rule">
             <field name="name">Survey user input: manager: all</field>
             <field name="model_id" ref="survey.model_survey_user_input"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -132,7 +132,7 @@
         <record id="survey_user_input_rule_survey_user_read" model="ir.rule">
             <field name="name">Survey user input: officer: read all</field>
             <field name="model_id" ref="survey.model_survey_user_input"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_user'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -153,7 +153,7 @@
         <record id="survey_user_input_line_rule_survey_manager" model="ir.rule">
             <field name="name">Survey user input line: manager: all</field>
             <field name="model_id" ref="survey.model_survey_user_input_line"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -163,7 +163,7 @@
         <record id="survey_user_input_line_rule_survey_user_read" model="ir.rule">
             <field name="name">Survey user input line: officer: read all</field>
             <field name="model_id" ref="survey.model_survey_user_input_line"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_survey_user'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>

--- a/addons/survey/tests/test_survey_security.py
+++ b/addons/survey/tests/test_survey_security.py
@@ -171,9 +171,9 @@ class TestAccess(common.TestSurveyCommon):
 
         # Read: nope
         with self.assertRaises(AccessError):
-            self.env['survey.user_input'].search([('survey_id', 'in', [self.survey.id])])
+            self.env['survey.user_input'].search([('survey_id', '=', self.survey.id)])
         with self.assertRaises(AccessError):
-            self.env['survey.user_input.line'].search([('survey_id', 'in', [self.survey.id])])
+            self.env['survey.user_input.line'].search([('survey_id', '=', self.survey.id)])
         with self.assertRaises(AccessError):
             self.env['survey.user_input'].browse(self.answer_0.ids).read(['state'])
         with self.assertRaises(AccessError):
@@ -200,9 +200,9 @@ class TestAccess(common.TestSurveyCommon):
 
         # Read: nope
         with self.assertRaises(AccessError):
-            self.env['survey.user_input'].search([('survey_id', 'in', [self.survey.id])])
+            self.env['survey.user_input'].search([('survey_id', '=', self.survey.id)])
         with self.assertRaises(AccessError):
-            self.env['survey.user_input.line'].search([('survey_id', 'in', [self.survey.id])])
+            self.env['survey.user_input.line'].search([('survey_id', '=', self.survey.id)])
         with self.assertRaises(AccessError):
             self.env['survey.user_input'].browse(self.answer_0.ids).read(['state'])
         with self.assertRaises(AccessError):
@@ -229,9 +229,9 @@ class TestAccess(common.TestSurveyCommon):
 
         # Read: nope
         with self.assertRaises(AccessError):
-            self.env['survey.user_input'].search([('survey_id', 'in', [self.survey.id])])
+            self.env['survey.user_input'].search([('survey_id', '=', self.survey.id)])
         with self.assertRaises(AccessError):
-            self.env['survey.user_input.line'].search([('survey_id', 'in', [self.survey.id])])
+            self.env['survey.user_input.line'].search([('survey_id', '=', self.survey.id)])
         with self.assertRaises(AccessError):
             self.env['survey.user_input'].browse(self.answer_0.ids).read(['state'])
         with self.assertRaises(AccessError):

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -12,7 +12,7 @@
     <record id="mail_test_ticket_rule_portal" model="ir.rule">
         <field name="name">Portal Mail Test Ticket</field>
         <field name="model_id" ref="test_mail.model_mail_test_ticket"/>
-        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
@@ -26,7 +26,7 @@
     <record id="mail_test_ticket_mc_rule_portal" model="ir.rule">
         <field name="name">Portal Mail Test Ticket Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_ticket_mc"/>
-        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
@@ -34,7 +34,7 @@
     <record id="mail_test_container_rule_portal" model="ir.rule">
         <field name="name">Portal Mail Test Container</field>
         <field name="model_id" ref="test_mail.model_mail_test_container"/>
-        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 
@@ -48,7 +48,7 @@
     <record id="mail_test_container_mc_rule_portal" model="ir.rule">
         <field name="name">Portal Mail Test Container Multi Company</field>
         <field name="model_id" ref="test_mail.model_mail_test_container_mc"/>
-        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -462,7 +462,7 @@ class AdvancedResponsibleNotifiedTest(TestMailCommon):
         mail_message = self.env['mail.message'].search([
             ('model', '=', 'mail.test.track'),
             ('res_id', '=', sub.id),
-            ('partner_ids', 'in', partner.id),
+            ('partner_ids', '=', partner.id),
         ])
         self.assertEqual(1, len(mail_message))
 

--- a/addons/test_mail_full/security/ir_rule_data.xml
+++ b/addons/test_mail_full/security/ir_rule_data.xml
@@ -10,7 +10,7 @@
     <record id="mail_test_rating_rule_portal" model="ir.rule">
         <field name="name">TestRating: Portal should follow</field>
         <field name="model_id" ref="test_mail_full.model_mail_test_rating"/>
-        <field name="domain_force">[('message_partner_ids', 'in', [user.partner_id.id])]</field>
+        <field name="domain_force">[('message_partner_ids', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
 

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -6,16 +6,13 @@ import base64
 import json
 
 from odoo import _, _lt, api, fields, models
-from odoo.osv.expression import AND, TRUE_DOMAIN, normalize_domain
+from odoo.osv.expression import AND, is_true
 from odoo.tools import date_utils, lazy
 from odoo.tools.misc import get_lang
 from odoo.exceptions import UserError
 from collections import defaultdict
 
 SEARCH_PANEL_ERROR_MESSAGE = _lt("Too many items to display.")
-
-def is_true_domain(domain):
-    return normalize_domain(domain) == TRUE_DOMAIN
 
 
 class lazymapping(defaultdict):
@@ -241,7 +238,7 @@ class Base(models.AbstractModel):
         enable_counters = kwargs.get('enable_counters')
         only_counters = kwargs.get('only_counters')
         extra_domain = kwargs.get('extra_domain', [])
-        no_extra = is_true_domain(extra_domain)
+        no_extra = is_true(extra_domain)
         model_domain = kwargs.get('model_domain', [])
         count_domain = AND([model_domain, extra_domain])
 
@@ -678,7 +675,7 @@ class Base(models.AbstractModel):
                     if enable_counters:
                         count = self.search_count(search_count_domain)
                     if not expand:
-                        if enable_counters and is_true_domain(local_extra_domain):
+                        if enable_counters and is_true(local_extra_domain):
                             inImage = count
                         else:
                             inImage = self.search(search_domain, limit=1)

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -660,7 +660,7 @@ class Base(models.AbstractModel):
                 if enable_counters or not expand:
                     search_domain = AND([
                             model_domain,
-                            [(field_name, 'in', record_id)],
+                            [(field_name, '=', record_id)],
                         ])
                     local_extra_domain = extra_domain
                     if group_by and group_domain:

--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -109,15 +109,8 @@ export class Domain {
     }
 }
 
-/** @type {Condition} */
-const TRUE_LEAF = [1, "=", 1];
-/** @type {Condition} */
-const FALSE_LEAF = [0, "=", 1];
-const TRUE_DOMAIN = new Domain([TRUE_LEAF]);
-const FALSE_DOMAIN = new Domain([FALSE_LEAF]);
-
-Domain.TRUE = TRUE_DOMAIN;
-Domain.FALSE = FALSE_DOMAIN;
+Domain.TRUE = new Domain([true]);
+Domain.FALSE = new Domain([false]);
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -134,6 +127,9 @@ function toAST(domain) {
             case "&":
             case "|":
                 return { type: 1 /* String */, value: elem };
+            case true:
+            case false:
+                return { type: 2, value: elem };
             default:
                 return {
                     type: 10 /* Tuple */,

--- a/addons/web/static/src/legacy/debug_manager.js
+++ b/addons/web/static/src/legacy/debug_manager.js
@@ -6,6 +6,7 @@ import { formatDateTime, parseDateTime } from "@web/core/l10n/dates";
 import { formatMany2one } from "@web/views/fields/formatters";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { isModifierAlwaysTrue } from "@web/views/utils";
 
 import { Component, onWillStart, useState } from "@odoo/owl";
 
@@ -119,7 +120,8 @@ class SetDefaultDialog extends Component {
                 if (modifierData) {
                     const evaluatedModifiers = modifierData.evaluatedModifiers[stateId];
                     invisibleOrReadOnly =
-                        evaluatedModifiers.invisible || evaluatedModifiers.readonly;
+                        isModifierAlwaysTrue(evaluatedModifiers.invisible) ||
+                        isModifierAlwaysTrue(evaluatedModifiers.readonly);
                 }
                 const fieldInfo = fields[fieldName];
                 const valueDisplayed = this.display(fieldInfo, fieldsValues[fieldName]);

--- a/addons/web/static/src/legacy/js/core/domain.js
+++ b/addons/web/static/src/legacy/js/core/domain.js
@@ -5,13 +5,11 @@ var collections = require("web.collections");
 var pyUtils = require("web.py_utils");
 var py = window.py; // look py.js
 
-const TRUE_LEAF = [1, '=', 1];
-const FALSE_LEAF = [0, '=', 1];
-const TRUE_DOMAIN = [TRUE_LEAF];
-const FALSE_DOMAIN = [FALSE_LEAF];
-
-function compare(a, b) {
-    return JSON.stringify(a) === JSON.stringify(b);
+function isTrueLeaf(leaf) {
+    return JSON.stringify(leaf) === '[1,"=",1]';
+}
+function isFalseLeaf(leaf) {
+    return JSON.stringify(leaf) === '[0,"=",1]';
 }
 
 /**
@@ -69,7 +67,7 @@ var Domain = collections.Tree.extend({
             // for the syntax 'parent.field'.
 
             let fieldValue;
-            if (compare(this._data, FALSE_LEAF) || compare(this._data, TRUE_LEAF)) {
+            if (isFalseLeaf(this._data) || isTrueLeaf(this._data)) {
                 fieldValue = this._data[0];
             } else {
                 var parentField = this._data[0].split('.');
@@ -406,15 +404,15 @@ var Domain = collections.Tree.extend({
                     if (node.operators.length !== 1) {
                         throw new Error('Wrong condition to convert in domain');
                     }
-                    var right = astToStackValue(node.expressions[0]);
-                    var left = astToStackValue(node.expressions[1]);
+                    var field = astToStackValue(node.expressions[0]);
+                    var value = astToStackValue(node.expressions[1]);
                     var operator = node.operators[0];
                     switch (operator) {
                         case 'is': operator = '='; break;
                         case 'is not': operator = '!='; break;
                         case '==': operator = '='; break;
                     }
-                    return [[right, operator, left]];
+                    return [[field, operator, value]];
                 default:
                     throw "Condition cannot be transformed into domain";
             }
@@ -423,11 +421,6 @@ var Domain = collections.Tree.extend({
         return astToStack(ast);
     },
 });
-
-Domain.TRUE_LEAF = TRUE_LEAF;
-Domain.FALSE_LEAF = FALSE_LEAF;
-Domain.TRUE_DOMAIN = TRUE_DOMAIN;
-Domain.FALSE_DOMAIN = FALSE_DOMAIN;
 
 return Domain;
 });

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -93,6 +93,7 @@ var session = require('web.session');
 var utils = require('web.utils');
 var viewUtils = require('web.viewUtils');
 var localStorage = require('web.local_storage');
+const { isModifierAlwaysTrue } = require('@web/views/utils');
 
 var _t = core._t;
 
@@ -4050,7 +4051,7 @@ var BasicModel = AbstractModel.extend({
         if (fieldInfo) {
             var rawModifiers = fieldInfo.modifiers || {};
             var modifiers = this._evalModifiers(record, _.pick(rawModifiers, 'readonly'));
-            return modifiers.readonly && !fieldInfo.force_save;
+            return isModifierAlwaysTrue(modifiers.readonly) && !fieldInfo.force_save;
         } else {
             return false;
         }

--- a/addons/web/static/src/legacy/js/views/search_panel_model_extension.js
+++ b/addons/web/static/src/legacy/js/views/search_panel_model_extension.js
@@ -5,6 +5,7 @@
     import { sortBy } from "web.utils";
     import Domain from "web.Domain";
     import pyUtils from "web.py_utils";
+    import { isModifierAlwaysTrue } from "@web/views/utils";
 
     // DefaultViewTypes is the list of view types for which the searchpanel is
     // present by default (if not explicitly stated in the "view_types" attribute
@@ -416,7 +417,7 @@
             let hasCategoryWithCounters = false;
             let hasFilterWithDomain = false;
             this.config.archNodes.forEach(({ attrs, tag }, index) => {
-                if (tag !== "field" || attrs.invisible === "1") {
+                if (tag !== "field" || attrs.invisible && isModifierAlwaysTrue(JSON.parse(attrs.invisible))) {
                     return;
                 }
                 const type = attrs.select === "multi" ? "filter" : "category";

--- a/addons/web/static/src/legacy/js/widgets/model_field_selector_popover.js
+++ b/addons/web/static/src/legacy/js/widgets/model_field_selector_popover.js
@@ -356,9 +356,9 @@ var ModelFieldSelectorPopover = Widget.extend({
                 }
             } else if (field && chain.length === 0) { // Last node fetched
                 return Promise.resolve();
-            } else if (!field && fieldName === "1") { // TRUE_LEAF
+            } else if (!field && fieldName === "1") { // True leaf
                 this._validate(true);
-            } else if (!field && fieldName === "0") { // FALSE_LEAF
+            } else if (!field && fieldName === "0") { // False leaf
                 this._validate(true);
             } else { // Wrong node chain
                 this._validate(false);

--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -5,6 +5,7 @@ import { _lt } from "@web/core/l10n/translation";
 import { evaluateExpr } from "@web/core/py_js/py";
 import { XMLParser } from "@web/core/utils/xml";
 import { DEFAULT_INTERVAL, DEFAULT_PERIOD } from "@web/search/utils/dates";
+import { isModifierAlwaysTrue } from "@web/views/utils";
 
 const ALL = _lt("All");
 const DEFAULT_LIMIT = 200;
@@ -111,7 +112,7 @@ export class SearchArchParser extends XMLParser {
         this.pushGroup("field");
         const preField = { type: "field" };
         const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
-        if (modifiers.invisible === true) {
+        if (isModifierAlwaysTrue(modifiers.invisible)) {
             preField.invisible = true;
         }
         if (node.hasAttribute("domain")) {
@@ -221,7 +222,7 @@ export class SearchArchParser extends XMLParser {
             }
         }
         const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
-        if (modifiers.invisible === true) {
+        if (isModifierAlwaysTrue(modifiers.invisible)) {
             preSearchItem.invisible = true;
             const fieldName = preSearchItem.fieldName;
             if (fieldName && !this.fields[fieldName]) {
@@ -290,7 +291,7 @@ export class SearchArchParser extends XMLParser {
                 continue;
             }
             const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
-            if (modifiers.invisible === true) {
+            if (isModifierAlwaysTrue(modifiers.invisible)) {
                 continue;
             }
             const attrs = {};

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -71,7 +71,7 @@ WithSearch.props = {
     comparison: { validate: () => true, optional: true }, // fix problem with validation with type: [Object, null]
     // Issue OWL: https://github.com/odoo/owl/issues/910
     context: { type: Object, optional: true },
-    domain: { type: Array, element: [String, Array], optional: true },
+    domain: { type: Array, element: [Boolean, String, Array], optional: true },
     groupBy: { type: Array, element: String, optional: true },
     orderBy: { type: Array, element: String, optional: true },
 

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 import {
     archParseBoolean,
     evalDomain,
+    isModifierAlwaysTrue,
     getClassNameFromDecoration,
     X2M_TYPES,
 } from "@web/views/utils";
@@ -220,8 +221,9 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         props: {},
         rawAttrs: {},
         options: evaluateExpr(node.getAttribute("options") || "{}"),
-        alwaysInvisible: modifiers.invisible === true || modifiers.column_invisible === true,
+        alwaysInvisible: isModifierAlwaysTrue(modifiers.invisible) || isModifierAlwaysTrue(modifiers.column_invisible),
     };
+
     if (node.getAttribute("domain")) {
         fieldInfo.domain = node.getAttribute("domain");
     }

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -38,7 +38,7 @@ export async function loadSubViews(
             continue; // what follows only concerns x2many fields
         }
         const fieldInfo = activeFields[fieldName];
-        if (fieldInfo.modifiers.invisible === true) {
+        if (fieldInfo.alwaysInvisible) {
             continue; // no need to fetch the sub view if the field is always invisible
         }
 

--- a/addons/web/static/src/views/graph/graph_arch_parser.js
+++ b/addons/web/static/src/views/graph/graph_arch_parser.js
@@ -2,7 +2,7 @@
 
 import { XMLParser } from "@web/core/utils/xml";
 import { GROUPABLE_TYPES } from "@web/search/utils/misc";
-import { archParseBoolean } from "@web/views/utils";
+import { archParseBoolean, isModifierAlwaysTrue } from "@web/views/utils";
 
 const MODES = ["bar", "line", "pie"];
 const ORDERS = ["ASC", "DESC", "asc", "desc", null];
@@ -51,7 +51,7 @@ export class GraphArchParser extends XMLParser {
                         archInfo.fieldAttrs[fieldName].string = string;
                     }
                     const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
-                    if (modifiers.invisible === true) {
+                    if (isModifierAlwaysTrue(modifiers.invisible)) {
                         if (!archInfo.fieldAttrs[fieldName]) {
                             archInfo.fieldAttrs[fieldName] = {};
                         }

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -11,7 +11,7 @@ import { useSortable } from "@web/core/utils/sortable";
 import { sprintf } from "@web/core/utils/strings";
 import { session } from "@web/session";
 import { isAllowedDateField } from "@web/views/relational_model";
-import { isNull, isRelational } from "@web/views/utils";
+import { isNull, isRelational, isModifierAlwaysTrue } from "@web/views/utils";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { useBounceButton } from "@web/views/view_hook";
 import { ColumnProgress } from "@web/views/view_components/column_progress";
@@ -189,7 +189,7 @@ export class KanbanRenderer extends Component {
         const { modifiers, type } = groupByField;
         return Boolean(
             !(modifiers && "readonly" in modifiers
-                ? modifiers.readonly
+                ? isModifierAlwaysTrue(modifiers.readonly)
                 : fields[groupByField.name].readonly) &&
                 (isAllowedDateField(groupByField) || MOVABLE_RECORD_TYPES.includes(type))
         );

--- a/addons/web/static/src/views/legacy_utils.js
+++ b/addons/web/static/src/views/legacy_utils.js
@@ -110,7 +110,7 @@ export function mapActiveFieldsToFieldsInfo(activeFields, fields, viewType, env)
             fieldInfo.limit = FieldComponent.limit;
         }
 
-        if (fieldDescr.modifiers && fieldDescr.modifiers.invisible === true) {
+        if (fieldDescr.alwaysInvisible) {
             fieldInfo.__no_fetch = true;
         }
 

--- a/addons/web/static/src/views/pivot/pivot_arch_parser.js
+++ b/addons/web/static/src/views/pivot/pivot_arch_parser.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { XMLParser } from "@web/core/utils/xml";
-import { archParseBoolean } from "@web/views/utils";
+import { archParseBoolean, isModifierAlwaysTrue } from "@web/views/utils";
 
 export class PivotArchParser extends XMLParser {
     parse(arch) {
@@ -43,7 +43,7 @@ export class PivotArchParser extends XMLParser {
                         archInfo.fieldAttrs[fieldName].string = node.getAttribute("string");
                     }
                     const modifiers = JSON.parse(node.getAttribute("modifiers") || "{}");
-                    if (modifiers.invisible === true) {
+                    if (isModifierAlwaysTrue(modifiers.invisible)) {
                         archInfo.fieldAttrs[fieldName].isInvisible = true;
                         break;
                     }

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -115,6 +115,24 @@ export function evalDomain(modifier, evalContext) {
 }
 
 /**
+ * Return True if the domain will be always evaluate as true
+ *
+ * @param {Array[] | boolean} modifier
+ * @returns {boolean}
+ */
+export function isModifierAlwaysTrue(modifier) {
+    if (!modifier) {
+        return false;
+    }
+    if (modifier === true || modifier === 1) {
+        return true;
+    }
+    if (modifier.length === 1 && modifier[0] === true) {
+        return true;
+    }
+}
+
+/**
  * @param {Element} rootNode
  * @returns {ViewActiveActions}
  */

--- a/addons/web/static/tests/core/model_field_selector_tests.js
+++ b/addons/web/static/tests/core/model_field_selector_tests.js
@@ -352,7 +352,7 @@ QUnit.module("Components", (hooks) => {
         );
     });
 
-    QUnit.test("create a field chain with value 1 i.e. TRUE_LEAF", async (assert) => {
+    QUnit.test("create a field chain with value 1 i.e. True leaf", async (assert) => {
         assert.expect(1);
 
         //create the field selector with domain value ["1"]
@@ -372,7 +372,7 @@ QUnit.module("Components", (hooks) => {
         );
     });
 
-    QUnit.test("create a field chain with value 0 i.e. FALSE_LEAF", async (assert) => {
+    QUnit.test("create a field chain with value 0 i.e. False leaf", async (assert) => {
         assert.expect(1);
 
         //create the field selector with domain value ["0"]

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1694,7 +1694,7 @@ export class MockServer {
                 if (enableCounters || !expand) {
                     const searchDomain = new Domain([
                         ...modelDomain,
-                        [fieldName, "in", record.id],
+                        [fieldName, "=", record.id],
                     ]).toList();
                     let localExtraDomain = extraDomain;
                     if (groupBy && groupDomain) {

--- a/addons/web/static/tests/legacy/core/domain_tests.js
+++ b/addons/web/static/tests/legacy/core/domain_tests.js
@@ -138,12 +138,12 @@ QUnit.module('core', {}, function () {
 
     QUnit.test("compute true domain", function (assert) {
         assert.expect(1);
-        assert.ok(new Domain(Domain.TRUE_DOMAIN).compute({}));
+        assert.ok(new Domain([true]).compute({}));
     });
 
     QUnit.test("compute false domain", function (assert) {
         assert.expect(1);
-        assert.notOk(new Domain(Domain.FALSE_DOMAIN).compute({}));
+        assert.notOk(new Domain([false]).compute({}));
     });
 
     QUnit.test("arrayToString", function (assert) {

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1079,7 +1079,7 @@ var MockServer = Class.extend({
                 if (enableCounters || !expand) {
                     const searchDomain = Domain.prototype.normalizeArray([
                         ...modelDomain,
-                        [fieldName, "in", record.id]
+                        [fieldName, "=", record.id]
                     ]);
                     let localExtraDomain = extraDomain;
                     if (groupBy && groupDomain) {

--- a/addons/web/static/tests/legacy/views/abstract_model_tests.js
+++ b/addons/web/static/tests/legacy/views/abstract_model_tests.js
@@ -2,7 +2,6 @@ odoo.define('web.abstract_model_tests', function (require) {
     "use strict";
 
     const AbstractModel = require('web.AbstractModel');
-    const Domain = require('web.Domain');
 
     QUnit.module('LegacyViews', {}, function () {
         QUnit.module('AbstractModel');
@@ -105,11 +104,11 @@ odoo.define('web.abstract_model_tests', function (require) {
                 SampleModel: Model,
             });
 
-            await model.load({ domain: Domain.FALSE_DOMAIN, });
+            await model.load({ domain: [false], });
 
             const beforeReload = model.get(null, { withSampleData: true });
 
-            const reloaded = model.reload(null, { domain: Domain.TRUE_DOMAIN });
+            const reloaded = model.reload(null, { domain: [true] });
             const duringReload = model.get(null, { withSampleData: true });
 
             await reloaded;

--- a/addons/web/static/tests/legacy/widgets/model_field_selector_tests.js
+++ b/addons/web/static/tests/legacy/widgets/model_field_selector_tests.js
@@ -281,7 +281,7 @@ QUnit.module('ModelFieldSelector', {
         fieldSelector.destroy();
     });
 
-    QUnit.test("create a field chain with value 1 i.e. TRUE_LEAF", async function (assert) {
+    QUnit.test("create a field chain with value 1 i.e. True leaf", async function (assert) {
         assert.expect(1);
 
         var $target = $("#qunit-fixture");
@@ -301,7 +301,7 @@ QUnit.module('ModelFieldSelector', {
         fieldSelector.destroy();
     });
 
-    QUnit.test("create a field chain with value 0 i.e. FALSE_LEAF", async function (assert) {
+    QUnit.test("create a field chain with value 0 i.e. False leaf", async function (assert) {
         assert.expect(1);
 
         var $target = $("#qunit-fixture");

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -749,7 +749,7 @@ QUnit.module("Views", (hooks) => {
 
             const expectedDomains = [
                 ["&", ["date", ">=", "2016-12-01"], ["date", "<=", "2016-12-31"]],
-                [[0, "=", 1]],
+                [false],
             ];
             const fakeActionService = {
                 start() {

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -19,7 +19,6 @@ from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.tools.json import scriptsafe as json_scriptsafe
 from odoo.tools.safe_eval import safe_eval
-from odoo.osv.expression import FALSE_DOMAIN
 from odoo.addons.http_routing.models import ir_http
 from odoo.addons.http_routing.models.ir_http import _guess_mimetype
 from odoo.addons.portal.controllers.portal import _build_url_w_params
@@ -38,7 +37,7 @@ def sitemap_qs2dom(qs, route, field='name'):
         if len(needles) == 1:
             dom = [(field, 'ilike', needles[0])]
         else:
-            dom = FALSE_DOMAIN
+            dom = [False]
     return dom
 
 

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -24,7 +24,7 @@ from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
 from odoo.http import request
 from odoo.modules.module import get_resource_path, get_manifest
-from odoo.osv.expression import AND, OR, FALSE_DOMAIN, get_unaccent_wrapper
+from odoo.osv.expression import AND, OR, is_false, get_unaccent_wrapper
 from odoo.tools.translate import _
 from odoo.tools import escape_psql, pycompat
 
@@ -1140,7 +1140,7 @@ class Website(models.Model):
                     if query:
                         r = "".join([x[1] for x in rule._trace[1:] if not x[0]])  # remove model converter from route
                         query = sitemap_qs2dom(query, r, self.env[converter.model]._rec_name)
-                        if query == FALSE_DOMAIN:
+                        if is_false(query):
                             continue
 
                     for rec in converter.generate(self.env, args=val, dom=query):

--- a/addons/website/security/website_security.xml
+++ b/addons/website/security/website_security.xml
@@ -54,7 +54,7 @@
     <record id="website_group_system_edit_all_views" model="ir.rule">
         <field name="name">Administration Settings: Manage all views</field>
         <field name="model_id" ref="base.model_ir_ui_view"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="True"/>

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -66,7 +66,7 @@
         <field name="name">Partners</field>
         <field name="res_model">res.partner</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('visitor_ids', 'in', [active_id])]</field>
+        <field name="domain">[('visitor_ids', '=', active_id)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
               No partner linked for this visitor

--- a/addons/website_crm/views/crm_lead_views.xml
+++ b/addons/website_crm/views/crm_lead_views.xml
@@ -19,7 +19,7 @@
         <field name="name">Leads</field>
         <field name="res_model">crm.lead</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('visitor_ids', 'in', [active_id])]</field>
+        <field name="domain">[('visitor_ids', '=', active_id)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
               No lead linked for this visitor

--- a/addons/website_crm_iap_reveal/security/ir_rules.xml
+++ b/addons/website_crm_iap_reveal/security/ir_rules.xml
@@ -3,7 +3,7 @@
     <record id="ir_rule_crm_reveal_rule_all" model="ir.rule">
         <field name="name">CRM Reveal Rules: All Rules</field>
         <field name="model_id" ref="model_crm_reveal_rule"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
     <record id="ir_rule_crm_reveal_rule_salesman" model="ir.rule">
@@ -16,7 +16,7 @@
     <record id="ir_rule_crm_reveal_view_all" model="ir.rule">
         <field name="name">CRM Reveal Views: All Views</field>
         <field name="model_id" ref="model_crm_reveal_view"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
     </record>
     <record id="ir_rule_crm_reveal_view_salesman" model="ir.rule">

--- a/addons/website_crm_partner_assign/security/ir_rule.xml
+++ b/addons/website_crm_partner_assign/security/ir_rule.xml
@@ -25,7 +25,7 @@
     <record id="ir_rule_crm_partner_report_assign_all" model="ir.rule">
          <field name="name">CRM partner assign report: All Assignations</field>
          <field name="model_id" ref="model_crm_partner_report_assign"/>
-         <field name="domain_force">[(1, '=', 1)]</field>
+         <field name="domain_force">[True]</field>
          <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_all_leads'))]"/>
      </record>
 

--- a/addons/website_customer/controllers/main.py
+++ b/addons/website_customer/controllers/main.py
@@ -59,7 +59,7 @@ class WebsiteCustomer(http.Controller):
         tag_id = post.get('tag_id')
         if tag_id:
             tag_id = unslug(tag_id)[1] or 0
-            domain += [('website_tag_ids', 'in', tag_id)]
+            domain += [('website_tag_ids', '=', tag_id)]
 
         # group by industry, based on customers found with the search(domain)
         industries = Partner.sudo().read_group(domain, ["id", "industry_id"], groupby="industry_id", orderby="industry_id")

--- a/addons/website_event/views/event_registration_views.xml
+++ b/addons/website_event/views/event_registration_views.xml
@@ -4,7 +4,7 @@
         <field name="name">Registrations</field>
         <field name="res_model">event.registration</field>
         <field name="view_mode">kanban,tree,form</field>
-        <field name="domain">[('visitor_id', 'in', [active_id])]</field>
+        <field name="domain">[('visitor_id', '=', active_id)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No registration linked to this visitor

--- a/addons/website_event_questions/security/security.xml
+++ b/addons/website_event_questions/security/security.xml
@@ -14,7 +14,7 @@
     <record id="ir_rule_event_question_event_user" model="ir.rule">
         <field name="name">Event Question: event user: read all</field>
         <field name="model_id" ref="website_event_questions.model_event_question"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('event.group_event_registration_desk'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>
@@ -35,7 +35,7 @@
     <record id="ir_rule_event_question_answer_event_user" model="ir.rule">
         <field name="name">Event Question Answer: event user: read all</field>
         <field name="model_id" ref="website_event_questions.model_event_question_answer"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('event.group_event_registration_desk'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -4,7 +4,7 @@
         <field name="name">Visitors Wishlist</field>
         <field name="res_model">website.visitor</field>
         <field name="view_mode">kanban,tree,form,graph</field>
-        <field name="domain">[('event_track_wishlisted_ids', 'in', [active_id])]</field>
+        <field name="domain">[('event_track_wishlisted_ids', '=', active_id)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Wait for visitors to add this track to their list of favorites
@@ -311,7 +311,7 @@
         <field name="name">Wishlisted Tracks</field>
         <field name="res_model">event.track</field>
         <field name="view_mode">kanban,tree,form</field>
-        <field name="domain">[('wishlist_visitor_ids', 'in', [active_id])]</field>
+        <field name="domain">[('wishlist_visitor_ids', '=', active_id)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No track favorited by this visitor

--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -389,7 +389,7 @@ class Post(models.Model):
         user = self.env.user
         # Won't impact sitemap, search() in converter is forced as public user
         if self.env.is_admin():
-            return [(1, '=', 1)]
+            return [True]
 
         req = """
             SELECT p.id

--- a/addons/website_forum/security/website_forum_security.xml
+++ b/addons/website_forum/security/website_forum_security.xml
@@ -20,7 +20,7 @@
     <record id="website_forum_create_website_designer" model="ir.rule">
         <field name="name">Website forum: Website designer can create private forum</field>
         <field name="model_id" ref="model_forum_forum"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('website.group_website_designer'))]"/>
         <field name="perm_unlink" eval="0"/>
         <field name="perm_write" eval="0"/>
@@ -30,7 +30,7 @@
     <record id="website_forum_private" model="ir.rule">
         <field name="name">Website forum: All access for manager</field>
         <field name="model_id" ref="model_forum_forum"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
     </record>
 
@@ -49,7 +49,7 @@
     <record id="website_forum_private_post" model="ir.rule">
         <field name="name">Website forum post : All access for manager</field>
         <field name="model_id" ref="model_forum_post"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
     </record>
 
@@ -68,7 +68,7 @@
     <record id="website_forum_private_tag" model="ir.rule">
         <field name="name">Website forum tag : Manager user can access to all tags</field>
         <field name="model_id" ref="model_forum_tag"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('base.group_erp_manager'))]"/>
     </record>
 </odoo>

--- a/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
+++ b/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
@@ -24,7 +24,7 @@
     <record id="hr_job_officer" model="ir.rule">
         <field name="name">Job Positions: HR Officer</field>
         <field name="model_id" ref="hr.model_hr_job"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/addons/website_sale_delivery/models/res_country.py
+++ b/addons/website_sale_delivery/models/res_country.py
@@ -27,7 +27,7 @@ class ResCountry(models.Model):
 
         states = self.env['res.country.state']
         if mode == 'shipping':
-            dom = ['|', ('country_ids', 'in', self.id), ('country_ids', '=', False), ('website_published', '=', True)]
+            dom = ['|', ('country_ids', '=', self.id), ('country_ids', '=', False), ('website_published', '=', True)]
             delivery_carriers = self.env['delivery.carrier'].sudo().search(dom)
 
             for carrier in delivery_carriers:

--- a/addons/website_sale_wishlist/security/website_sale_wishlist_security.xml
+++ b/addons/website_sale_wishlist/security/website_sale_wishlist_security.xml
@@ -11,7 +11,7 @@
         <record id="all_product_wishlist_rule" model="ir.rule">
             <field name="name">See all wishlist</field>
             <field name="model_id" ref="model_product_wishlist"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('sales_team.group_sale_manager'))]"/>
         </record>
 

--- a/addons/website_slides/data/gamification_data.xml
+++ b/addons/website_slides/data/gamification_data.xml
@@ -142,7 +142,7 @@
         <field name="condition">higher</field>
         <field name="domain">[
             ('completed', '=', True),
-            (0, '=', 1)
+            False
         ]</field>
         <field name="batch_mode">True</field>
         <field name="batch_distinctive_field" ref="website_slides.field_slide_slide_partner__partner_id"/>

--- a/addons/website_slides/security/website_slides_security.xml
+++ b/addons/website_slides/security/website_slides_security.xml
@@ -26,7 +26,7 @@
         <record id="rule_slide_channel_global" model="ir.rule">
             <field name="name">Channel: always visible (sub rules exist)</field>
             <field name="model_id" ref="model_slide_channel"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="rule_slide_channel_visibility_public_user" model="ir.rule">
@@ -61,7 +61,7 @@
         <record id="rule_slide_channel_officer_r" model="ir.rule">
             <field name="name">Channel: officer: read all</field>
             <field name="model_id" ref="model_slide_channel"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_officer'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -82,7 +82,7 @@
         <record id="rule_slide_channel_manager" model="ir.rule">
             <field name="name">Channel: manager: crud all</field>
             <field name="model_id" ref="model_slide_channel"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -105,7 +105,7 @@
         <record id="rule_slide_slide_global" model="ir.rule">
             <field name="name">Slide: always visible (sub rules exist)</field>
             <field name="model_id" ref="model_slide_slide"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="rule_slide_slide_public_user" model="ir.rule">
@@ -156,7 +156,7 @@
         <record id="rule_slide_slide_officer_r" model="ir.rule">
             <field name="name">Slide: officer: read all</field>
             <field name="model_id" ref="model_slide_slide"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_officer'))]"/>
             <field name="perm_unlink" eval="0"/>
             <field name="perm_write" eval="0"/>
@@ -178,7 +178,7 @@
         <record id="rule_slide_slide_manager" model="ir.rule">
             <field name="name">Slide: manager: crud all</field>
             <field name="model_id" ref="model_slide_slide"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -201,7 +201,7 @@
         <record id="rule_slide_channel_partner_manager" model="ir.rule">
             <field name="name">Channel Partner: manager: crud all</field>
             <field name="model_id" ref="model_slide_channel_partner"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -224,7 +224,7 @@
         <record id="rule_slide_slide_partner_manager" model="ir.rule">
             <field name="name">Slide Partner: manager: crud all</field>
             <field name="model_id" ref="model_slide_slide_partner"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_manager'))]"/>
             <field name="perm_unlink" eval="1"/>
             <field name="perm_write" eval="1"/>
@@ -247,7 +247,7 @@
         <record id="rule_slide_slide_resource_officer_read" model="ir.rule">
             <field name="name">Resource: officer: read all</field>
             <field name="model_id" ref="model_slide_slide_resource"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_officer'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="False"/>
@@ -269,7 +269,7 @@
         <record id="rule_slide_slide_resource_downloadable_manager" model="ir.rule">
             <field name="name">Resource: manager: crud all</field>
             <field name="model_id" ref="model_slide_slide_resource"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[(4, ref('group_website_slides_manager'))]"/>
             <field name="perm_read" eval="1"/>
             <field name="perm_write" eval="1"/>

--- a/addons/website_slides/tests/test_security.py
+++ b/addons/website_slides/tests/test_security.py
@@ -281,7 +281,7 @@ class TestAccessFeatures(common.SlidesCase):
 
     @mute_logger('odoo.models', 'odoo.addons.base.models.ir_rule')
     def test_channel_auto_subscription(self):
-        user_employees = self.env['res.users'].search([('groups_id', 'in', self.ref('base.group_user'))])
+        user_employees = self.env['res.users'].search([('groups_id', '=', self.ref('base.group_user'))])
 
         channel = self.env['slide.channel'].with_user(self.user_officer).create({
             'name': 'Test',

--- a/addons/website_slides_forum/security/website_slides_forum_security.xml
+++ b/addons/website_slides_forum/security/website_slides_forum_security.xml
@@ -14,7 +14,7 @@
                 ('slide_channel_ids.website_published', '=', True),
                 '|',
                     ('slide_channel_ids.visibility', 'in', ('public','connected')),
-                    ('slide_channel_ids.partner_ids', 'in', user.partner_id.id)
+                    ('slide_channel_ids.partner_ids', '=', user.partner_id.id)
             ]
         </field>
         <field name="groups" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
@@ -40,7 +40,7 @@
                 ('forum_id.slide_channel_ids.website_published', '=', True),
                 '|',
                     ('forum_id.slide_channel_ids.visibility', 'in', ('public','connected')),
-                    ('forum_id.slide_channel_ids.partner_ids', 'in', user.partner_id.id)
+                    ('forum_id.slide_channel_ids.partner_ids', '=', user.partner_id.id)
             ]
         </field>
         <field name="groups" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>
@@ -66,7 +66,7 @@
                 ('forum_id.slide_channel_ids.website_published', '=', True),
                 '|',
                     ('forum_id.slide_channel_ids.visibility', 'in', ('public','connected')),
-                    ('forum_id.slide_channel_ids.partner_ids', 'in', user.partner_id.id)
+                    ('forum_id.slide_channel_ids.partner_ids', '=', user.partner_id.id)
             ]
         </field>
         <field name="groups" eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"/>

--- a/addons/website_slides_forum/security/website_slides_forum_security.xml
+++ b/addons/website_slides_forum/security/website_slides_forum_security.xml
@@ -22,7 +22,7 @@
     <record id="website_slides_forum_website_slides_officer" model="ir.rule">
         <field name="name">Website forum: website slides officer can access all forum</field>
         <field name="model_id" ref="website_forum.model_forum_forum"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('website_slides.group_website_slides_officer'))]"/>
     </record>
 
@@ -48,7 +48,7 @@
     <record id="website_slides_forum_website_slides_officer_post" model="ir.rule">
         <field name="name">Website forum post: website slides officer can access all post</field>
         <field name="model_id" ref="website_forum.model_forum_post"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('website_slides.group_website_slides_officer'))]"/>
     </record>
 
@@ -74,7 +74,7 @@
     <record id="website_slides_forum_website_slides_officer_tag" model="ir.rule">
         <field name="name">Website slides forum tag: website slides officer can access all tag</field>
         <field name="model_id" ref="website_forum.model_forum_tag"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="domain_force">[True]</field>
         <field name="groups" eval="[(4, ref('website_slides.group_website_slides_officer'))]"/>
     </record>
 </odoo>

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -8,7 +8,7 @@ from odoo.tools.safe_eval import safe_eval, time
 from odoo.tools.misc import find_in_path
 from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version
 from odoo.http import request
-from odoo.osv.expression import NEGATIVE_TERM_OPERATORS, FALSE_DOMAIN
+from odoo.osv.expression import NEGATIVE_TERM_OPERATORS
 
 import io
 import logging
@@ -137,7 +137,7 @@ class IrActionsReport(models.Model):
         elif isinstance(value, bool) or value is None:
             return [('model', operator, value)]
         else:
-            return FALSE_DOMAIN
+            return [False]
 
     def _get_readable_fields(self):
         return super()._get_readable_fields() | {

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -526,9 +526,9 @@ class IrAttachment(models.Model):
         # add res_field=False in domain if not present; the arg[0] trick below
         # works for domain items and '&'/'|'/'!' operators too
         discard_binary_fields_attachments = False
-        if not any(arg[0] in ('id', 'res_field') for arg in args):
+        if not expression.domain_has_field_names(args, ['id', 'res_field']):
             discard_binary_fields_attachments = True
-            args.insert(0, ('res_field', '=', False))
+            args = expression.AND([[('res_field', '=', False)], args])
 
         ids = super(IrAttachment, self)._search(args, offset=offset, limit=limit, order=order,
                                                 count=False, access_rights_uid=access_rights_uid)

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -81,9 +81,10 @@ class IrRule(models.Model):
         # searching on (records, group_rules) filters out some of the records)
         group_rules = all_rules.filtered(lambda r: r.groups and r.groups & self.env.user.groups_id)
         group_domains = expression.OR([
-            safe_eval(r.domain_force, eval_context) if r.domain_force else []
+            safe_eval(r.domain_force or "[False]", eval_context)
             for r in group_rules
         ])
+
         # if all records get returned, the group rules are not failing
         if Model.search_count(expression.AND([[('id', 'in', for_records.ids)], group_domains])) == len(for_records):
             group_rules = self.browse(())

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -890,10 +890,11 @@ class Partner(models.Model):
         """ Override search() to always show inactive children when searching via ``child_of`` operator. The ORM will
         always call search() with a simple domain of the form [('parent_id', 'in', [ids])]. """
         # a special ``domain`` is set on the ``child_ids`` o2m to bypass this logic, as it uses similar domain expressions
-        if len(args) == 1 and len(args[0]) == 3 and args[0][:2] == ('parent_id','in') \
-                and args[0][2] != [False]:
+        if (len(args) == 1 and isinstance(args[0], (tuple, list))
+                and args[0][:2] == ('parent_id', 'in')
+                and args[0][2] != [False]):
             self = self.with_context(active_test=False)
-        return super(Partner, self)._search(args, offset=offset, limit=limit, order=order,
+        return super()._search(args, offset=offset, limit=limit, order=order,
                                             count=count, access_rights_uid=access_rights_uid)
 
     @api.model

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -888,7 +888,7 @@ class Partner(models.Model):
     @api.model
     def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
         """ Override search() to always show inactive children when searching via ``child_of`` operator. The ORM will
-        always call search() with a simple domain of the form [('parent_id', 'in', [ids])]. """
+        always call search() with a simple domain of the form [('parent_id', 'in', ids)]. """
         # a special ``domain`` is set on the ``child_ids`` o2m to bypass this logic, as it uses similar domain expressions
         if (len(args) == 1 and isinstance(args[0], (tuple, list))
                 and args[0][:2] == ('parent_id', 'in')

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -182,9 +182,9 @@ class Groups(models.Model):
             else:
                 sub_where = expression.OR([group_domain, category_domain])
             if operator in expression.NEGATIVE_TERM_OPERATORS:
-                where = expression.AND([where, sub_where])
+                where = expression.AND([where or [True], sub_where])
             else:
-                where = expression.OR([where, sub_where])
+                where = expression.OR([where or [False], sub_where])
         return where
 
     @api.model

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -428,7 +428,7 @@ class Users(models.Model):
     @api.depends('groups_id')
     def _compute_share(self):
         user_group_id = self.env['ir.model.data']._xmlid_to_res_id('base.group_user')
-        internal_users = self.filtered_domain([('groups_id', 'in', [user_group_id])])
+        internal_users = self.filtered_domain([('groups_id', '=', user_group_id)])
         internal_users.share = False
         (self - internal_users).share = True
 
@@ -708,7 +708,7 @@ class Users(models.Model):
     @tools.ormcache('self.id')
     def _get_company_ids(self):
         # use search() instead of `self.company_ids` to avoid extra query for `active_test`
-        domain = [('active', '=', True), ('user_ids', 'in', self.id)]
+        domain = [('active', '=', True), ('user_ids', '=', self.id)]
         return self.env['res.company'].search(domain)._ids
 
     @api.model

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -44,7 +44,7 @@
         <record model="ir.rule" id="ir_default_system_rule">
             <field name="name">Defaults: alter all defaults</field>
             <field name="model_id" ref="model_ir_default"/>
-            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
             <field name="perm_read" eval="False"/>
         </record>
@@ -109,7 +109,7 @@
         <record id="ir_filters_admin_all_rights_rule" model="ir.rule">
             <field name="name">ir.filters.admin.all.rights</field>
             <field name="model_id" ref="model_ir_filters"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[Command.link(ref('base.group_erp_manager'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="True"/>
@@ -169,7 +169,7 @@
             <field name="model_id" ref="model_res_company"/>
             <field eval="False" name="global"/>
             <field name="groups" eval="[Command.set([ref('base.group_erp_manager')])]"/>
-            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="domain_force">[True]</field>
         </record>
 
         <record id="res_users_identity_check" model="ir.rule">
@@ -196,7 +196,7 @@
         <record id="api_key_public" model="ir.rule">
             <field name="name">Public users can't interact with keys at all</field>
             <field name="model_id" ref="model_res_users_apikeys"/>
-            <field name="domain_force">[(0, '=', 1)]</field>
+            <field name="domain_force">[False]</field>
             <field name="groups" eval="[Command.link(ref('base.group_public'))]"/>
         </record>
         <record id="api_key_user" model="ir.rule">
@@ -211,7 +211,7 @@
         <record id="api_key_admin" model="ir.rule">
             <field name="name">Administrators can view user keys to revoke them</field>
             <field name="model_id" ref="model_res_users_apikeys"/>
-            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="domain_force">[True]</field>
             <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
         </record>
     </data>

--- a/odoo/addons/base/tests/test_acl.py
+++ b/odoo/addons/base/tests/test_acl.py
@@ -204,7 +204,7 @@ class TestIrRule(TransactionCaseWithUserDemo):
         self.assertTrue(partners, "Demo user should see some partner.")
 
         # same with domain 1=1
-        rule1.domain_force = "[(1,'=',1)]"
+        rule1.domain_force = "[True]"
         partners = partners_demo.search([])
         self.assertTrue(partners, "Demo user should see some partner.")
 
@@ -226,12 +226,12 @@ class TestIrRule(TransactionCaseWithUserDemo):
         self.assertTrue(partners, "Demo user should see some partner.")
 
         # same with domains 1=1 and blank
-        rule1.domain_force = "[(1,'=',1)]"
+        rule1.domain_force = "[True]"
         partners = partners_demo.search([])
         self.assertTrue(partners, "Demo user should see some partner.")
 
         # same with domains 1=1 and 1=1
-        rule2.domain_force = "[(1,'=',1)]"
+        rule2.domain_force = "[True]"
         partners = partners_demo.search([])
         self.assertTrue(partners, "Demo user should see some partner.")
 
@@ -248,7 +248,7 @@ class TestIrRule(TransactionCaseWithUserDemo):
         self.assertTrue(partners, "Demo user should see some partner.")
 
         # same with domains 1=1, 1=1 and 1=1
-        rule3.domain_force = "[(1,'=',1)]"
+        rule3.domain_force = "[True]"
         partners = partners_demo.search([])
         self.assertTrue(partners, "Demo user should see some partner.")
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -819,6 +819,12 @@ class TestExpression(SavepointCaseWithUserDemo):
         false = [False]
         true = [True]
         normal = [('foo', '=', 'bar')]
+        # OR with nothing
+        expr = expression.OR([])
+        self.assertEqual(expr, false)
+        # OR with empty leaf
+        expr = expression.OR([[]])
+        self.assertEqual(expr, true)
         # OR with single FALSE_LEAF
         expr = expression.OR([false])
         self.assertEqual(expr, false)

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -44,10 +44,10 @@ class TestExpression(SavepointCaseWithUserDemo):
 
         # On a one2many or many2many field, `in` should be read `contains` (and
         # `not in` should be read `doesn't contain`.
-        with_a = self._search(partners, [('category_id', 'in', [cat_a.id])])
+        with_a = self._search(partners, [('category_id', '=', cat_a.id)])
         self.assertEqual(a + ab, with_a, "Search for category_id in cat_a failed.")
 
-        with_b = self._search(partners, [('category_id', 'in', [cat_b.id])])
+        with_b = self._search(partners, [('category_id', '=', cat_b.id)])
         self.assertEqual(b + ab, with_b, "Search for category_id in cat_b failed.")
 
         # Partners with the category A or the category B.
@@ -55,11 +55,11 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertEqual(a + b + ab, with_a_or_b, "Search for category_id contains cat_a or cat_b failed.")
 
         # Show that `contains list` is really `contains element or contains element`.
-        with_a_or_with_b = self._search(partners, ['|', ('category_id', 'in', [cat_a.id]), ('category_id', 'in', [cat_b.id])])
+        with_a_or_with_b = self._search(partners, ['|', ('category_id', '=', cat_a.id), ('category_id', '=', cat_b.id)])
         self.assertEqual(a + b + ab, with_a_or_with_b, "Search for category_id contains cat_a or contains cat_b failed.")
 
         # If we change the OR in AND...
-        with_a_and_b = self._search(partners, [('category_id', 'in', [cat_a.id]), ('category_id', 'in', [cat_b.id])])
+        with_a_and_b = self._search(partners, [('category_id', '=', cat_a.id), ('category_id', '=', cat_b.id)])
         self.assertEqual(ab, with_a_and_b, "Search for category_id contains cat_a and cat_b failed.")
 
         # Partners without category A and without category B.
@@ -68,18 +68,18 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertTrue(c in without_a_or_b, "Search for category_id doesn't contain cat_a or cat_b failed (2).")
 
         # Show that `doesn't contain list` is really `doesn't contain element and doesn't contain element`.
-        without_a_and_without_b = self._search(partners, [('category_id', 'not in', [cat_a.id]), ('category_id', 'not in', [cat_b.id])])
+        without_a_and_without_b = self._search(partners, [('category_id', '!=', cat_a.id), ('category_id', '!=', cat_b.id)])
         self.assertFalse(without_a_and_without_b & (a + b + ab), "Search for category_id doesn't contain cat_a and cat_b failed (1).")
         self.assertTrue(c in without_a_and_without_b, "Search for category_id doesn't contain cat_a and cat_b failed (2).")
 
         # We can exclude any partner containing the category A.
-        without_a = self._search(partners, [('category_id', 'not in', [cat_a.id])])
+        without_a = self._search(partners, [('category_id', '!=', cat_a.id)])
         self.assertTrue(a not in without_a, "Search for category_id doesn't contain cat_a failed (1).")
         self.assertTrue(ab not in without_a, "Search for category_id doesn't contain cat_a failed (2).")
         self.assertLessEqual(b + c, without_a, "Search for category_id doesn't contain cat_a failed (3).")
 
         # (Obviously we can do the same for cateory B.)
-        without_b = self._search(partners, [('category_id', 'not in', [cat_b.id])])
+        without_b = self._search(partners, [('category_id', '!=', cat_b.id)])
         self.assertTrue(b not in without_b, "Search for category_id doesn't contain cat_b failed (1).")
         self.assertTrue(ab not in without_b, "Search for category_id doesn't contain cat_b failed (2).")
         self.assertLessEqual(a + c, without_b, "Search for category_id doesn't contain cat_b failed (3).")
@@ -262,7 +262,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         res_0 = self._search(Currency, [])
         res_1 = self._search(Currency, [('name', 'not like', 'probably_unexisting_name')])
         self.assertEqual(res_0, res_1)
-        res_2 = self._search(Currency, [('id', 'not in', [non_currency_id])])
+        res_2 = self._search(Currency, [('id', '!=', non_currency_id)])
         self.assertEqual(res_0, res_2)
         res_3 = self._search(Currency, [('id', 'not in', [])])
         self.assertEqual(res_0, res_3)
@@ -287,7 +287,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertEqual(one, res_4)
         # res_5 = Partner.search([('id', 'in', one)]) # TODO make it permitted, just like for child_of
         # self.assertEqual(one, res_5)
-        res_6 = self._search(Partner, [('id', 'in', [one.id])])
+        res_6 = self._search(Partner, [('id', '=', one.id)])
         self.assertEqual(one, res_6)
         res_7 = self._search(Partner, [('name', '=', one.name)])
         self.assertEqual(one, res_7)
@@ -299,10 +299,6 @@ class TestExpression(SavepointCaseWithUserDemo):
 
         # testing equality with name
         partners = self._search(Partner, [('parent_id', '=', 'Pepper Street')])
-        self.assertTrue(partners)
-
-        # testing the in operator with name
-        partners = self._search(Partner, [('parent_id', 'in', 'Pepper Street')])
         self.assertTrue(partners)
 
         # testing the in operator with a list of names
@@ -382,7 +378,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         # existing value belongs to them.
         res_0 = self._search(Partner, [('parent_id', 'not like', 'probably_unexisting_name')]) # get all rows, included null parent_id
         self.assertEqual(res_0, all_partners)
-        res_1 = self._search(Partner, [('parent_id', 'not in', [non_partner_id])]) # get all rows, included null parent_id
+        res_1 = self._search(Partner, [('parent_id', '!=', non_partner_id)]) # get all rows, included null parent_id
         self.assertEqual(res_1, all_partners)
         res_2 = self._search(Partner, [('parent_id', '!=', False)]) # get rows with not null parent_id, deprecated syntax
         self.assertEqual(res_2, with_parent)
@@ -397,7 +393,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         # give the whole set of ids.
         res_5 = self._search(Partner, [('parent_id', 'like', 'probably_unexisting_name')])
         self.assertFalse(res_5)
-        res_6 = self._search(Partner, [('parent_id', 'in', [non_partner_id])])
+        res_6 = self._search(Partner, [('parent_id', '=', non_partner_id)])
         self.assertFalse(res_6)
         res_7 = self._search(Partner, [('parent_id', '=', False)])
         self.assertEqual(res_7, without_parent)
@@ -412,7 +408,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         # i.e. not ... in ... must be the same as ... not in ... .
         res_10 = self._search(Partner, ['!', ('parent_id', 'like', 'probably_unexisting_name')])
         self.assertEqual(res_0, res_10)
-        res_11 = self._search(Partner, ['!', ('parent_id', 'in', [non_partner_id])])
+        res_11 = self._search(Partner, ['!', ('parent_id', '=', non_partner_id)])
         self.assertEqual(res_1, res_11)
         res_12 = self._search(Partner, ['!', ('parent_id', '=', False)])
         self.assertEqual(res_2, res_12)
@@ -540,8 +536,10 @@ class TestExpression(SavepointCaseWithUserDemo):
         u1b = Users.create({'login': 'dbo2', 'partner_id': p1}).id
         u2 = Users.create({'login': 'rpo', 'partner_id': p2}).id
 
-        res = self._search(Partner, [('user_ids', 'in', u1a)])
-        self.assertEqual([p1], res.ids, "o2m IN accept single int on right side")
+        res = self._search(Partner, [('user_ids', '=', u1a)])
+        self.assertEqual([p1], res.ids, "o2m = accept single int on right side")
+        res = self._search(Partner, [('user_ids', 'in', [u1a])])
+        self.assertEqual([p1], res.ids, "o2m IN accept a list of int on right side")
         res = self._search(Partner, [('user_ids', '=', 'Dédé Boitaclou')])
         self.assertEqual([p1], res.ids, "o2m NOT IN matches none on the right side")
         res = self._search(Partner, [('user_ids', 'in', [10000])])
@@ -549,7 +547,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         res = self._search(Partner, [('user_ids', 'in', [u1a,u2])])
         self.assertEqual([p1,p2], res.ids, "o2m IN matches any on the right side")
         all_ids = self._search(Partner, []).ids
-        res = self._search(Partner, [('user_ids', 'not in', u1a)])
+        res = self._search(Partner, [('user_ids', 'not in', [u1a])])
         self.assertEqual(set(all_ids) - set([p1]), set(res.ids), "o2m NOT IN matches none on the right side")
         res = self._search(Partner, [('user_ids', '!=', 'Dédé Boitaclou')])
         self.assertEqual(set(all_ids) - set([p1]), set(res.ids), "o2m NOT IN matches none on the right side")
@@ -584,7 +582,7 @@ class TestExpression(SavepointCaseWithUserDemo):
 
         # search the currency via its rates one2many (the one2many must point back at the currency)
         currency_rate1 = self._search(CurrencyRate, [('currency_id', 'not like', 'probably_unexisting_name')])
-        currency_rate2 = self._search(CurrencyRate, [('id', 'not in', [non_currency_id])])
+        currency_rate2 = self._search(CurrencyRate, [('id', '!=', non_currency_id)])
         self.assertEqual(currency_rate1, currency_rate2)
         currency_rate3 = self._search(CurrencyRate, [('id', 'not in', [])])
         self.assertEqual(currency_rate1, currency_rate3)
@@ -594,7 +592,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         self.assertEqual(res_3, default_currency)
         res_4 = self._search(Currency, [('rate_ids', 'in', default_currency.rate_ids[0].ids)]) # currencies having first rate of main currency
         self.assertEqual(res_4, default_currency)
-        res_5 = self._search(Currency, [('rate_ids', 'in', default_currency.rate_ids[0].id)]) # currencies having first rate of main currency
+        res_5 = self._search(Currency, [('rate_ids', '=', default_currency.rate_ids[0].id)]) # currencies having first rate of main currency
         self.assertEqual(res_5, default_currency)
         # res_6 = Currency.search([('rate_ids', 'in', [default_currency.rate_ids[0].name])])
         # res_7 = Currency.search([('rate_ids', '=', default_currency.rate_ids[0].name)])
@@ -606,7 +604,7 @@ class TestExpression(SavepointCaseWithUserDemo):
 
         # get the currencies referenced by some currency rates using a weird negative domain
         res_10 = self._search(Currency, [('rate_ids', 'not like', 'probably_unexisting_name')])
-        res_11 = self._search(Currency, [('rate_ids', 'not in', [non_currency_id])])
+        res_11 = self._search(Currency, [('rate_ids', '!=', non_currency_id)])
         self.assertEqual(res_10, res_11)
         res_12 = self._search(Currency, [('rate_ids', '!=', False)])
         self.assertEqual(res_10, res_12)

--- a/odoo/addons/base/wizard/base_partner_merge_views.xml
+++ b/odoo/addons/base/wizard/base_partner_merge_views.xml
@@ -56,7 +56,7 @@
                             </p>
                             <group col="2">
                                 <field name="dst_partner_id"
-                                    domain="[('id', 'in', partner_ids or False)]"
+                                    domain="[('id', 'in', partner_ids)]"
                                     attrs="{'required': [('state', '=', 'selection')]}"
                                     context="{'partner_show_db_id': True}"
                                     options="{'always_reload': True}"/>

--- a/odoo/addons/test_access_rights/security.xml
+++ b/odoo/addons/test_access_rights/security.xml
@@ -5,7 +5,7 @@
             <field name="domain_force">[
                 '|',
                     ('message_partner_ids', 'child_of', [user.partner_id.commercial_partner_id.id]),
-                    ('message_partner_ids', 'in', [user.partner_id.id])
+                    ('message_partner_ids', '=', user.partner_id.id)
             ]</field>
             <field name="groups" eval="[Command.link(ref('base.group_portal'))]"/>
     </record>

--- a/odoo/addons/test_access_rights/tests/test_feedback.py
+++ b/odoo/addons/test_access_rights/tests/test_feedback.py
@@ -263,7 +263,7 @@ Contact your administrator to request access if necessary.""" % (self.record.dis
         self.env.ref('base.group_no_one').write({'users': [Command.link(self.user.id)]})
         self.env.ref('base.group_user').write({'users': [Command.link(self.user.id)]})
         self._make_rule('rule 0', '[("val", "=", 42)]', global_=True)
-        self._make_rule('rule 1', '[(1, "=", 1)]', global_=True)
+        self._make_rule('rule 1', '[True]', global_=True)
         with self.assertRaises(AccessError) as ctx:
             self.record.write({'val': 1})
         self.assertEqual(
@@ -283,8 +283,8 @@ Contact your administrator to request access if necessary.""" % (self.record.dis
         self.env.ref('base.group_no_one').write({'users': [Command.link(self.user.id)]})
         self.env.ref('base.group_user').write({'users': [Command.link(self.user.id)]})
         self._make_rule('rule 0', '[("val", "=", 42)]', global_=True)
-        self._make_rule('rule 1', '[(1, "=", 1)]', global_=True)
-        self._make_rule('rule 2', '[(0, "=", 1)]')
+        self._make_rule('rule 1', '[True]', global_=True)
+        self._make_rule('rule 2', '[False]')
         self._make_rule('rule 3', '[("val", "=", 55)]')
         with self.assertRaises(AccessError) as ctx:
             self.record.write({'val': 1})

--- a/odoo/addons/test_access_rights/tests/test_ir_rules.py
+++ b/odoo/addons/test_access_rights/tests/test_ir_rules.py
@@ -57,7 +57,7 @@ class TestRules(TransactionCase):
             'name': 'Forbid public group',
             'model_id': self.browse_ref('test_access_rights.model_test_access_right_some_obj').id,
             'groups': [Command.set([self.browse_ref('base.group_public').id])],
-            'domain_force': "[(0, '=', 1)]"
+            'domain_force': "[False]"
         })
 
         browse2 = env['test_access_right.some_obj'].browse(self.id2)

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -192,7 +192,7 @@ class Message(models.Model):
         self.env.cr.execute(query, (value,))
         ids = [t[0] for t in self.env.cr.fetchall()]
         # return domain with an implicit AND
-        return [('id', 'in', ids), (1, '=', 1)]
+        return [('id', 'in', ids), True]
 
     @api.depends('size')
     def _compute_double_size(self):

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2224,12 +2224,12 @@ class TestFields(TransactionCaseWithUserDemo):
 
         # makes sure that line.move_id is flushed before search
         line = self.env['test_new_api.move_line'].create({'move_id': move1.id})
-        moves = self.env['test_new_api.move'].search([('line_ids', 'in', line.id)])
+        moves = self.env['test_new_api.move'].search([('line_ids', '=', line.id)])
         self.assertEqual(moves, move1)
 
         # makes sure that line.move_id is flushed before search
         line.move_id = move2
-        moves = self.env['test_new_api.move'].search([('line_ids', 'in', line.id)])
+        moves = self.env['test_new_api.move'].search([('line_ids', '=', line.id)])
         self.assertEqual(moves, move2)
 
     def test_73_relational_inverse(self):

--- a/odoo/addons/test_search_panel/tests/test_search_panel_select_range.py
+++ b/odoo/addons/test_search_panel/tests/test_search_panel_select_range.py
@@ -300,7 +300,7 @@ class TestSelectRange(odoo.tests.TransactionCase):
         # no counters, no expand, and hierarchization
         result = self.SourceModel.search_panel_select_range(
             'folder_id',
-            search_domain=[(0, '=', 1)],
+            search_domain=[False],
         )
         self.assertEqual(
             result,

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -300,8 +300,8 @@ def AND(domains):
     result = []
     count = 0
     for domain in domains:
-        domain = daomin and normalize_domain(domain)
-        if not domain or domain == [True]:
+        domain = normalize_domain(domain)
+        if domain == [True]:
             continue
         if domain == [False]:
             return [False]
@@ -315,8 +315,8 @@ def OR(domains):
     result = []
     count = 0
     for domain in domains:
-        domain = domain and normalize_domain(domain)
-        if not domain or domain == [False]:
+        domain = normalize_domain(domain)
+        if domain == [False]:
             continue
         if domain == [True]:
             return [True]

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -390,6 +390,7 @@ def _quote(to_quote):
     return to_quote
 
 
+NORMALIZE_DOMAIN_RIGHT_IN = (list, tuple, Query)
 def normalize_leaf(element):
     """ Normalizes the leaf of the domain whether it is an operator, a boolea
         and a leaf in the form of a triplet (tuple/list).
@@ -426,10 +427,10 @@ def normalize_leaf(element):
             warnings.warn(f"The domain leaf operator '{element}' should use a lowercase operator.", UserWarning)
         else:
             raise ValueError(f"Invalide operator in domain leaf {element!r}.")
-    if isinstance(right, bool) and operator in ('in', 'not in'):
+    if operator in ('in', 'not in') and not isinstance(right, NORMALIZE_DOMAIN_RIGHT_IN):
         warnings.warn(f"The domain term '{element}' should use the '=' or '!=' operator.", UserWarning)
         operator = '=' if operator == 'in' else '!='
-    if isinstance(right, (list, tuple)) and operator in ('=', '!='):
+    if operator in ('=', '!=') and isinstance(right, (list, tuple)):
         warnings.warn(f"The domain term '{element}' should use the 'in' or 'not in' operator.", UserWarning)
         operator = 'in' if operator == '=' else 'not in'
     return left, operator, right

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2231,7 +2231,7 @@ class Form(object):
         inherited_modifiers = ['invisible']
         fvg['fields'].setdefault('id', {'type': 'id'})
         # pre-resolve modifiers & bind to arch toplevel
-        modifiers = fvg['modifiers'] = {'id': {'required': [FALSE_LEAF], 'readonly': [TRUE_LEAF]}}
+        modifiers = fvg['modifiers'] = {'id': {'required': [False], 'readonly': [True]}}
         contexts = fvg['contexts'] = {}
         order = fvg['fields_ordered'] = []
         field_level = fvg['tree'].xpath('count(ancestor::field)')
@@ -2252,8 +2252,8 @@ class Form(object):
 
             node_modifiers = {}
             for modifier, domain in json.loads(f.get('modifiers', '{}')).items():
-                if isinstance(domain, int):
-                    node_modifiers[modifier] = [TRUE_LEAF] if domain else [FALSE_LEAF]
+                if isinstance(domain, (int, bool)):
+                    node_modifiers[modifier] = [bool(domain)]
                 elif isinstance(domain, str):
                     node_modifiers[modifier] = normalize_domain(safe_eval(domain, eval_context))
                 else:
@@ -2264,7 +2264,7 @@ class Form(object):
                 for modifier in inherited_modifiers:
                     if modifier in ancestor_modifiers:
                         domain = ancestor_modifiers[modifier]
-                        ancestor_domain = ([TRUE_LEAF] if domain else [FALSE_LEAF]) if isinstance(domain, int) else normalize_domain(domain)
+                        ancestor_domain = ([bool(domain)]) if isinstance(domain, (int, bool)) else normalize_domain(domain)
                         node_domain = node_modifiers.get(modifier, [])
                         # Combine the field modifiers with his ancestor modifiers with an OR connector
                         # e.g. A field is invisible if its own invisible modifier is True
@@ -2277,8 +2277,8 @@ class Form(object):
                 # e.g. a field is readonly if all occurences of the field are readonly in the view.
                 for modifier in set(node_modifiers.keys()).union(modifiers[fname].keys()):
                     modifiers[fname][modifier] = expression.AND([
-                        modifiers[fname].get(modifier, [FALSE_LEAF]),
-                        node_modifiers.get(modifier, [FALSE_LEAF]),
+                        modifiers[fname].get(modifier, [False]),
+                        node_modifiers.get(modifier, [False]),
                     ])
             else:
                 modifiers[fname] = node_modifiers
@@ -2357,6 +2357,9 @@ class Form(object):
                 e1 = stack.pop()
                 e2 = stack.pop()
                 stack.append(e1 or e2)
+            elif isinstance(it, bool):
+                stack.append(it)
+                continue
             elif isinstance(it, tuple):
                 if it == TRUE_LEAF:
                     stack.append(True)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2265,7 +2265,7 @@ class Form(object):
                     if modifier in ancestor_modifiers:
                         domain = ancestor_modifiers[modifier]
                         ancestor_domain = ([bool(domain)]) if isinstance(domain, (int, bool)) else normalize_domain(domain)
-                        node_domain = node_modifiers.get(modifier, [])
+                        node_domain = node_modifiers.get(modifier, [False])
                         # Combine the field modifiers with his ancestor modifiers with an OR connector
                         # e.g. A field is invisible if its own invisible modifier is True
                         # OR if one of its ancestor invisible modifier is True


### PR DESCRIPTION
This pr is to be reviewed commit by commit. It stems from task opw-2495504 following which a series of changes were established with the framework-py team.

[IMP] all: domain leaf semantics (1, "=", 1) is replaced by a boolean
[FIX] all: fix misinterpretation of empty domain in expression.OR
[IMP] web: adapt js for boolean in domain and no pre-processing
[IMP] all: better normalization and warnings for wrong domain operator