### PR TITLE
[FIX] web: popover service: prevent the crash when undefined target 

### DIFF
--- a/addons/web/static/src/core/popover/popover_container.js
+++ b/addons/web/static/src/core/popover/popover_container.js
@@ -13,7 +13,12 @@ class PopoverController extends Component {
         onWillUnmount(this.onWillUnmount);
     }
     onMounted() {
-        this.targetObserver.observe(this.target.parentElement, { childList: true });
+        if (!this.target.parentElement) {
+            //The target disapeared before the call of onMounted
+            this.onTargetMutate();
+        } else {
+            this.targetObserver.observe(this.target.parentElement, { childList: true });
+        }
     }
     onWillUnmount() {
         this.targetObserver.disconnect();

--- a/addons/web/static/tests/core/popover/popover_service_tests.js
+++ b/addons/web/static/tests/core/popover/popover_service_tests.js
@@ -128,6 +128,28 @@ QUnit.test("close callback", async (assert) => {
     assert.verifySteps(["close"]);
 });
 
+QUnit.test("do not crash and close if target parent does not exist", async (assert) => {
+    assert.expect(3);
+
+    // This target does not have any parent, it simulate the case where the element disapeared
+    // from the DOM before the onMounted of the component is called
+    const dissapearedTarget = document.createElement("div");
+
+    assert.containsOnce(fixture, ".o_popover_container");
+
+    class Comp extends Component {}
+    Comp.template = xml`<div id="comp">in popover</div>`;
+
+    function onClose() {
+        assert.step("close");
+    }
+
+    popovers.add(dissapearedTarget, Comp, {}, { onClose });
+    await nextTick();
+
+    assert.verifySteps(["close"]);
+});
+
 QUnit.test("sub component triggers close", async (assert) => {
     assert.containsOnce(fixture, ".o_popover_container");
 


### PR DESCRIPTION
Steps to reproduce:
- In debug mode
- Go to a cancelled invoice in Accounting
- Click to the "Reset to draft" button in a fast timing (before the `PopoverContainer` is mounted).

When hovering an element, a tooltip appears. If the element disappears before the `onMounted` of the `PopoverContainer`, then the popover causes a crash because the target element does not exists anymore.

Recorded scenario in the python training:
![popover](https://user-images.githubusercontent.com/109217759/220384105-09b225d7-2bfd-4f59-bc12-f7a7b865ce39.gif)


