### PR TITLE
[FIX] website_sale_comparison: fix ensure_one in add_to_compare view

### DIFF
--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -4,7 +4,7 @@
     <template id="add_to_compare" inherit_id="website_sale.products_item" name="Comparison List" priority="22">
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
-            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
+            <t t-set="product_variant_id" t-value="product and product._get_first_possible_variant_id()"/>
             <button t-if="product_variant_id and categories" type="button" role="button" class="d-none d-md-inline-block btn btn-outline-primary bg-white o_add_compare" title="Compare" aria-label="Compare" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist"><span class="fa fa-exchange"></span></button>
         </xpath>
     </template>


### PR DESCRIPTION
In `website_sale_wishlist.add_to_wishlist` website template, an additional filtering step was added in odoo#88276 that can possibly make it so that here `product` is an empty recordset. Therefore subsequently calling `_get_first_possible_variant_id()` fails as the method calls `ensure_one()`.
The change adds a check to make sure the call is skipped if `product` is an empty recordset.

opw-3168984


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
