### PR TITLE
[FIX] calendar: activate events color matching with many attendees

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -101,7 +101,7 @@ export class AttendeeCalendarModel extends CalendarModel {
                     record.attendeeId = attendee;
                     // Colors are linked to the partner_id but in this case we want it linked
                     // to attendeeId
-                    record.colorIndex = attendee;
+                    record.colorIndex = attendee.toString();
                     if (attendeeInfo) {
                         record.attendeeStatus = attendeeInfo.status;
                         record.isAlone = attendeeInfo.is_alone;


### PR DESCRIPTION
Before this commit, when the ids of attendees were too big, there were no color matchings available, i.e., all the events had the same color on Odoo Calendar. Now, this id is treated as a string to avoid this problem and show the events with different event colors for each attendee.

Task-id: 3199864

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
