### PR TITLE
[FIX] base,project: access followed task in follower-only project

### DIFF
--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -85,6 +85,13 @@ class TestCRUDVisibilityFollowers(TestAccessRights):
         self.task.invalidate_model()
         self.task.with_user(self.env.user).name
 
+    @users('Internal user')
+    def test_task_allowed_read_internal_read(self):
+        self.task.message_subscribe(partner_ids=[self.env.user.partner_id.id])
+        self.task.flush_model()
+        self.task.invalidate_model()
+        self.task.with_user(self.env.user).name
+
     @users('Internal user', 'Portal user')
     def test_task_no_write(self):
         with self.assertRaises(AccessError, msg="%s should not be able to write on the task" % self.env.user.name):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -3364,7 +3364,7 @@ class Properties(Field):
         convert_to_record / convert_to_read.
         """
         definition_records_map = {
-            record: record[self.definition_record][self.definition_record_field]
+            record: record[self.definition_record].sudo()[self.definition_record_field]
             for record in records
         }
 


### PR DESCRIPTION
This task fixes the issue where a user cannot see a followed task in a project with visibility follower.

This is due to the properties set on the project.

Steps to reproduce:
- Create a project with visibility: followers
- Add a task in the project
- Add a Project User as follower of the task, and assign the task to this user
- Connect as the Project User, go on My tasks
- Open the tasks

Current behavior:
```
Due to security restrictions, you are not allowed to access 'Project'
(project.project) records.

This restriction is due to the following rules:
- Project: employees: following required for follower-only project

Contact your administrator to request access if necessary.
```

Expected Behavior:
No traceback, see the followed task.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
