### PR TITLE
[FIX] base_import: replace field-name with fieldPath for importing records

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -164,7 +164,7 @@ export class BaseImportModel {
         const startRow = this.importOptions.skip;
         const importRes = {
             ids: [],
-            fields: this.columns.map((e) => Boolean(e.fieldInfo) && e.fieldInfo.name),
+            fields: this.columns.map((e) => Boolean(e.fieldInfo) && e.fieldInfo.fieldPath),
             columns: this.columns.map((e) => e.name.trim().toLowerCase()),
             hasError: false,
         };


### PR DESCRIPTION
While trying to import data from CSV files it generates KeyError for relational fields from other models.

Ex. Stock.Move.Line:`price_unit` field which is related by `invoice_line_ids` in Account.Move. It was being read directly as`price_unit` from Account.Move model instead of `invoice_line_ids/price_unit`.

see: 
[](url)
![task1_pr](https://user-images.githubusercontent.com/121081895/220833352-86abc8ca-8af5-4171-8093-9bece3c67083.png)


sentry-3940359612

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
