### PR TITLE
Remove leftover unnecessary metaclasses

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -7,18 +7,7 @@ from odoo.addons.hw_drivers.main import drivers, iot_devices
 from odoo.tools.lru import LRU
 
 
-class DriverMetaClass(type):
-    def __new__(cls, clsname, bases, attrs):
-        newclass = super(DriverMetaClass, cls).__new__(cls, clsname, bases, attrs)
-        if hasattr(newclass, 'priority'):
-            newclass.priority += 1
-        else:
-            newclass.priority = 0
-        drivers.append(newclass)
-        return newclass
-
-
-class Driver(Thread, metaclass=DriverMetaClass):
+class Driver(Thread):
     """
     Hook to register the driver into the drivers list
     """
@@ -38,6 +27,14 @@ class Driver(Thread, metaclass=DriverMetaClass):
 
         # Least Recently Used (LRU) Cache that will store the idempotent keys already seen.
         self._iot_idempotent_ids_cache = LRU(500)
+
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+        if hasattr(cls, 'priority'):
+            cls.priority += 1
+        else:
+            cls.priority = 0
+        drivers.append(cls)
 
     @classmethod
     def supported(cls, device):

--- a/addons/hw_drivers/interface.py
+++ b/addons/hw_drivers/interface.py
@@ -10,14 +10,7 @@ from odoo.addons.hw_drivers.main import drivers, interfaces, iot_devices
 _logger = logging.getLogger(__name__)
 
 
-class InterfaceMetaClass(type):
-    def __new__(cls, clsname, bases, attrs):
-        new_interface = super(InterfaceMetaClass, cls).__new__(cls, clsname, bases, attrs)
-        interfaces[clsname] = new_interface
-        return new_interface
-
-
-class Interface(Thread, metaclass=InterfaceMetaClass):
+class Interface(Thread):
     _loop_delay = 3  # Delay (in seconds) between calls to get_devices or 0 if it should be called only once
     _detected_devices = {}
     connection_type = ''
@@ -25,6 +18,10 @@ class Interface(Thread, metaclass=InterfaceMetaClass):
     def __init__(self):
         super(Interface, self).__init__()
         self.drivers = sorted([d for d in drivers if d.connection_type == self.connection_type], key=lambda d: d.priority, reverse=True)
+
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+        interfaces[cls.__name__] = cls
 
     def run(self):
         while self.connection_type and self.drivers:

--- a/odoo/addons/base/tests/test_test_suite.py
+++ b/odoo/addons/base/tests/test_test_suite.py
@@ -16,12 +16,12 @@ from odoo.tests.result import OdooTestResult
 
 _logger = logging.getLogger(__name__)
 
-from odoo.tests import MetaCase
-
 
 # this is mainly to ensure that simple tests will continue to work even if BaseCase should be used
 # this only works if doClassCleanup is available on testCase because of the vendoring of suite.py.
-class TestTestSuite(TestCase, metaclass=MetaCase):
+class TestTestSuite(TestCase):
+    test_tags = {'standard', 'at_install'}
+    test_module = 'base'
 
     def test_test_suite(self):
         """ Check that OdooSuite handles unittest.TestCase correctly. """

--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -17,7 +17,6 @@ class TestSetTags(TransactionCase):
 
         fc = FakeClass()
 
-        self.assertTrue(hasattr(fc, 'test_tags'))
         self.assertEqual(fc.test_tags, {'at_install', 'standard'})
         self.assertEqual(fc.test_module, 'base')
 
@@ -29,7 +28,6 @@ class TestSetTags(TransactionCase):
 
         fc = FakeClass()
 
-        self.assertTrue(hasattr(fc, 'test_tags'))
         self.assertEqual(fc.test_tags, {'at_install', 'standard'})
         self.assertEqual(fc.test_module, 'base')
 

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -105,7 +105,7 @@ def make_suite(module_names, position='at_install'):
         for t in get_module_test_cases(m)
         if position_tag.check(t) and config_tags.check(t)
     )
-    return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
+    return OdooSuite(sorted(tests, key=lambda t: getattr(t, 'test_sequence', 0)))
 
 
 def run_suite(suite):

--- a/odoo/tests/tag_selector.py
+++ b/odoo/tests/tag_selector.py
@@ -52,7 +52,7 @@ class TagsSelector(object):
             return False
 
         test_module = test.test_module
-        test_class = test.test_class
+        test_class = test.__class__.__name__
         test_tags = test.test_tags | {test_module}  # module as test_tags deprecated, keep for retrocompatibility,
         test_method = test._testMethodName
         test_module_path = test.__module__.removeprefix('odoo.addons').replace('.', '/') + '.py'


### PR DESCRIPTION
Test cases, fields, and hw_drivers are still unnecessarily using metaclasses where `__init_subclass__` does the job just fine (arguably better).

This leaves `Model` as the only class using a metaclass, and there it's pretty legit: the metaclass(es) directly alter the structure of the class and autodecorate its methods. Some of it could be in `__init_subclass__` but not all, which would not remove the metaclass, and thus makes the migration pretty unnecessary.