### PR TITLE
[FIX] hr_org_chart: fix organization chart alignment

### DIFF
--- a/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
+++ b/addons/hr_org_chart/static/src/xml/hr_org_chart.xml
@@ -85,7 +85,7 @@
         <div class="alert alert-info" role="alert">
             <p><b>No hierarchy position.</b></p>
             <p>This employee has no manager or subordinate.</p>
-            <p>In order to get an organigram, set a manager and save the record.</p>
+            <p class="mb-0">In order to get an organigram, set a manager and save the record.</p>
         </div>
     </t>
 


### PR DESCRIPTION
In this commit, when user open employee form the organization chart is
aligned vertically centered which was not correctly aligned before.

task-3183804
