### PR TITLE
[IMP] l10n_de: miss configured account

### DIFF
--- a/addons/l10n_de_skr03/data/template/account.account-de_skr03.csv
+++ b/addons/l10n_de_skr03/data/template/account.account-de_skr03.csv
@@ -281,7 +281,7 @@
 "account_1376","1376","Receivables from typical silent partners","l10n_de.tag_de_asset_bs_B_II_4","asset_current","False","","Forderungen gegen typisch stille Gesellschafter"
 "account_1377","1377","Receivables from typical silent partners - remaining term up to 1 year","l10n_de.tag_de_asset_bs_B_II_4","asset_current","False","","Forderungen gegen typisch stille Gesellschafter - Restlaufzeit bis 1 Jahr"
 "account_1378","1378","Receivables from typical silent partners - remaining term greater than 1 year","l10n_de.tag_de_asset_bs_B_II_4","asset_non_current","False","","Forderungen gegen typisch stille Gesellschafter - Restlaufzeit größer 1 Jahr"
-"account_1380","1380","Cost centre reconciliation account","l10n_de.tag_de_pl_06","asset_current","False","","Überleitungskonto Kostenstelle"
+"account_1380","1380","Cost centre reconciliation account","l10n_de.tag_de_asset_bs_B_II_4","asset_current","False","","Überleitungskonto Kostenstelle"
 "account_1381","1381","Receivables from GmbH shareholders","l10n_de.tag_de_asset_bs_B_II_4","asset_current","False","","Forderungen gegen GmbH-Gesellschafter"
 "account_1382","1382","Receivables from GmbH shareholders - remaining term up to 1 year","l10n_de.tag_de_asset_bs_B_II_4","asset_current","False","","Forderungen gegen GmbH-Gesellschafter - Restlaufzeit bis 1 Jahr"
 "account_1383","1383","Receivables from GmbH shareholders - remaining term greater than 1 year","l10n_de.tag_de_asset_bs_B_II_4","asset_non_current","False","","Forderungen gegen GmbH-Gesellschafter - Restlaufzeit größer 1 Jahr"


### PR DESCRIPTION
By checking the script checking if all the account supposed to be in the BS are. The account 1380 seems to be miss configured

task-id: 3041738


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
