### PR TITLE
[FIX] mrp,project,purchase,stock,base: deny usage of user not in picked company

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -26,6 +26,7 @@ class MrpProduction(models.Model):
     _date_name = 'date_planned_start'
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _order = 'priority desc, date_planned_start asc,id'
+    _check_company_auto = True
 
     @api.model
     def _get_default_picking_type(self):
@@ -218,7 +219,8 @@ class MrpProduction(models.Model):
     user_id = fields.Many2one(
         'res.users', 'Responsible', default=lambda self: self.env.user,
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
-        domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)])
+        domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)],
+        check_company=True)
     company_id = fields.Many2one(
         'res.company', 'Company', default=lambda self: self.env.company,
         index=True, required=True)

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -311,7 +311,7 @@ class Project(models.Model):
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks',
                                domain=['|', ('stage_id.fold', '=', False), ('stage_id', '=', False)])
     color = fields.Integer(string='Color Index')
-    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True)
+    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True, check_company=True)
     alias_enabled = fields.Boolean(string='Use Email Alias', compute='_compute_alias_enabled', readonly=False)
     alias_id = fields.Many2one('mail.alias', string='Alias', ondelete="restrict", required=True,
         help="Internal email associated with this project. Incoming emails are automatically synchronized "

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -23,6 +23,7 @@ class PurchaseOrder(models.Model):
     _inherit = ['portal.mixin', 'mail.thread', 'mail.activity.mixin']
     _description = "Purchase Order"
     _order = 'priority desc, id desc'
+    _check_company_auto = True
 
     @api.depends('order_line.price_total')
     def _amount_all(self):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -256,6 +256,7 @@ class Picking(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = "Transfer"
     _order = "priority desc, scheduled_date asc, id desc"
+    _check_company_auto = True
 
     name = fields.Char(
         'Reference', default='/',
@@ -352,7 +353,7 @@ class Picking(models.Model):
         'res.users', 'Responsible', tracking=True,
         domain=lambda self: [('groups_id', 'in', self.env.ref('stock.group_stock_user').id)],
         states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
-        default=lambda self: self.env.user)
+        default=lambda self: self.env.user, check_company=True)
     move_line_ids = fields.One2many('stock.move.line', 'picking_id', 'Operations')
     move_line_ids_without_package = fields.One2many('stock.move.line', 'picking_id', 'Operations without package', domain=['|',('package_level_id', '=', False), ('picking_type_entire_packs', '=', False)])
     move_line_nosuggest_ids = fields.One2many(

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -134,6 +134,7 @@ class Partner(models.Model):
     _inherit = ['format.address.mixin', 'avatar.mixin']
     _name = "res.partner"
     _order = "display_name"
+    _check_company_auto = True
 
     def _default_category(self):
         return self.env['res.partner.category'].browse(self._context.get('category_id'))
@@ -172,7 +173,7 @@ class Partner(models.Model):
                                "Anywhere else, time values are computed according to the time offset of your web client.")
 
     tz_offset = fields.Char(compute='_compute_tz_offset', string='Timezone offset', invisible=True)
-    user_id = fields.Many2one('res.users', string='Salesperson',
+    user_id = fields.Many2one('res.users', string='Salesperson', check_company=True,
       help='The internal user in charge of this contact.')
     vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Complete it if the contact is subjected to government taxes. Used in some legal statements.")
     same_vat_partner_id = fields.Many2one('res.partner', string='Partner with same Tax ID', compute='_compute_same_vat_partner_id', store=False)


### PR DESCRIPTION
Actual Behavior
================

When in a company A setup, we are allowed to pick user from company B

Expected Behavior
=================

A company shouldn't be able to pick a user from another company.

How to reproduce
===============

1. Create a multicompany instance
2. Create multiple users, each with access only to a specific company.
3. Go into any app, except sales and CRM, and change any field that contains user, and change the user e.g. these app: 
- Contacts - Employees - Accounting - Manufacturing - Inventory

When applying `check_company=True` to the `user_id` in each model fixes the issue in question

([linked pr](https://github.com/odoo/enterprise/pull/34909))

opw-3053345