### PR TITLE
[FIX] requirements: adapt psycopg2 for windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,8 @@ Pillow==9.0.1  # min version = 7.0.0 (Focal with security backports)
 polib==1.1.0
 psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
 psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
-psycopg2==2.8.6; sys_platform == 'win32' or python_version >= '3.8'
+psycopg2==2.8.6; sys_platform != 'win32' and python_version >= '3.8'
+psycopg2==2.9.5; sys_platform == 'win32'  # No 2.8.6 wheel for win and python > 3.9
 pydot==1.4.1
 pyopenssl==19.0.0
 PyPDF2==1.26.0


### PR DESCRIPTION
As our documentation about source install on Windows recommends to install the latest python version, we need to adapt the requirements because there is no Windows wheel package for `psycopg2` version 2.8.6 that fits the latest python versions.

See:
https://www.odoo.com/documentation/16.0/administration/install/install.html#python https://pypi.org/project/psycopg2/2.8.6/#files
https://pypi.org/project/psycopg2/2.9.5/#files

Closes #105547
