### PR TITLE
[FIX] base_import: Fix relational fields not being correctly mapped

### DIFF
--- a/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
+++ b/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
@@ -6,7 +6,7 @@
                 <p>
                     <t t-if="props.errors[0].value">No matching records found for the following name </t>
                     <t t-else="">Multiple errors occurred </t>
-                      in field <b t-esc="props.fieldInfo.name"/>:
+                      in field <b t-esc="props.fieldInfo.label"/>:
                 </p>
                 <ul>
                     <t t-foreach="props.errors" t-as="error" t-key="error_index">

--- a/addons/base_import/static/src/import_data_content/import_data_content.scss
+++ b/addons/base_import/static/src/import_data_content/import_data_content.scss
@@ -14,6 +14,10 @@
     .o_import_preview {
         width: fit-content;
     }
+
+    td {
+        vertical-align: top;
+    }
 }
 
 @mixin o-import-sprite-icon($x: 0, $y: 0) {

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -74,7 +74,7 @@
                                             t-att-data-tooltip-info="getTooltipDetails(column.fieldInfo)"
                                         ></i>
                                         <span class="ps-5">
-                                            <t t-esc="column.fieldInfo.string" />
+                                            <t t-esc="column.fieldInfo.label" />
                                         </span>
                                     </t>
                                     <span t-else="" class="text-warning">To import, select a field...</span>

--- a/addons/base_import/static/src/import_data_options/import_data_options.js
+++ b/addons/base_import/static/src/import_data_options/import_data_options.js
@@ -62,14 +62,18 @@ export class ImportDataOptions extends Component {
                 "import_skip_records",
             ].includes(ev.target.value)
         ) {
-            this.props.onOptionChanged(ev.target.value, ev.target.value, this.props.fieldInfo.name);
+            this.props.onOptionChanged(
+                ev.target.value,
+                ev.target.value,
+                this.props.fieldInfo.fieldPath
+            );
         } else {
             const value = {
                 fallback_value: ev.target.value,
                 field_model: this.currentModel,
                 field_type: this.props.fieldInfo.type,
             };
-            this.props.onOptionChanged("fallback_values", value, this.props.fieldInfo.name);
+            this.props.onOptionChanged("fallback_values", value, this.props.fieldInfo.fieldPath);
         }
     }
 }

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -904,8 +904,8 @@ QUnit.module("Base Import Tests", (hooks) => {
         );
         // Check that errors have been sorted and grouped
         assert.strictEqual(
-            target.querySelector(".o_import_report p").textContent.trim(),
-            "Multiple errors occurred  in field foo:"
+            target.querySelector(".o_import_report p").textContent.trim().toLowerCase(),
+            "multiple errors occurred  in field foo:"
         );
         assert.strictEqual(
             target.querySelector(".o_import_report li:first-child").textContent.trim(),


### PR DESCRIPTION
**Moved PR [here](https://github.com/odoo/odoo/pull/113975) to change source branch from master to saas-16.1.**


This commit fixes a couple of issues linked to relational fields:

- When previewing a file with relational fields/ids, they were not correctly mapped to their respective fields in the selects, the fields were also not correctly mapped in the arguments given for the import.
- The select label was also only showing the name of the last sub-field while it should show the full path ("External ID" vs "Company / External ID").
- Some errors were not correctly displayed: wrong field name, not in a column when it should be.

Task ID: 3210337
opw-3203704 + opw-3192403

-----
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)