### PR TITLE
[FIX] mrp: improve bom_line check

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -868,6 +868,14 @@ msgid "BoM line product %s should not be the same as BoM product."
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/models/mrp_bom.py:0
+#, python-format
+msgid ""
+"BoM line product '%(line_product)s' is used as finished product in another "
+"BoM which '%(finished_product)s' is used as component"
+msgstr ""
+
+#. module: mrp
 #: model:product.product,name:mrp.product_product_computer_desk_bolt
 #: model:product.template,name:mrp.product_product_computer_desk_bolt_product_template
 msgid "Bolt"


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “P1” And “P2”
- Create a BoM for “P1”:
    - Component: 1 unit of “P2”
- Create a BoM for “P2”:
    - Component: 1 unit of “P1”
- Try to print the Bom & structure of “P1” or “P2”

**Problem:**
An infinite loop is triggered with a timeout

It's weird to use wood to make a table and use a table to make wood.

opw-3200969
