### PR TITLE
[FIX] datetime picker to work in arabic

### DIFF
--- a/addons/web/static/lib/tempusdominus/tempusdominus.js
+++ b/addons/web/static/lib/tempusdominus/tempusdominus.js
@@ -2160,7 +2160,7 @@ var TempusDominusBootstrap4 = function ($) {
 
         TempusDominusBootstrap4.prototype._fillHours = function _fillHours() {
             var table = this.widget.find('.timepicker-hours table'),
-                currentHour = this._viewDate.clone().startOf('d'),
+                currentHour = this._viewDate.clone().startOf('d').locale('en'),
                 html = [];
             var row = $('<tr>');
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix datetime picker when working arabic
Current behavior before PR:
when you change time from time picker in arabic language change event does not fire
Desired behavior after PR is merged:
time(hoiurs, minutes, seconds) should be changed



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
