### PR TITLE
[IMP] point_of_sale: display config name in config

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -59,4 +59,11 @@ export class Navbar extends LegacyComponent {
         }
         return 0;
     }
+
+    get configName() {
+        if (this.env.pos) {
+            return this.env.pos.config.name;
+        }
+        return "Shop";
+    }
 }

--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -6,6 +6,10 @@
             <div t-if="pos.tempScreen" class="block-top-header" />
             <div class="pos-branding">
                 <img t-if="!env.isMobile" class="pos-logo" t-on-click="() => debug.toggleWidget()" src="/point_of_sale/static/src/img/logo.png" alt="Logo" />
+                <div class="cash-move-button">
+                    <i class="fa fa-building" aria-hidden="true"></i>
+                    <span style="padding-left: 10px;"><t t-esc="configName"/></span>
+                </div>
                 <div t-if="props.showCashMoveButton" class="cash-move-button" t-on-click="onCashMoveButtonClick">
                     <i class="fa fa-money" aria-hidden="true"></i>
                     <span style="padding-left: 10px;">Cash In/Out</span>


### PR DESCRIPTION
When in the front-end part of the config, it is not possible to know in which PoS you are logged in. The information is now displayed in the navbar of the config.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
