### PR TITLE
[FIX] web: html field layout without label

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -324,8 +324,11 @@ export class FormCompiler extends ViewCompiler {
                     ? child.getAttribute("nolabel") !== "1"
                     : true;
                 slotContent = this.compileNode(child, { ...params, currentSlot: mainSlot }, false);
-                if (slotContent && addLabel && !isOuterGroup && !isTextNode(slotContent)) {
+                const shouldExpand = slotContent && !isOuterGroup && !isTextNode(slotContent);
+                if (shouldExpand && (addLabel || sequence === 1)) {
                     itemSpan = itemSpan === 1 ? itemSpan + 1 : itemSpan;
+                }
+                if (shouldExpand && addLabel) {
                     const fieldName = child.getAttribute("name");
                     const fieldId = slotContent.getAttribute("id") || fieldName;
                     const props = {


### PR DESCRIPTION
When we create a model with Studio with the option 'Notes' enabled, the notes field in the form view is squashed on the left side of the form

Steps to reproduce:
1. Install Studio
2. Toggle Studio and create a new app
3. Enter any app name and click on next
4. Give a name to the model and click on next
5. Enable Notes and click on CREATE YOUR APP
6. Close Studio
7. The notes field is squashed on the left side of the form

Solution:
Increment the itemSpan when the field uses a label or if it is the first element of the group

opw-3098985