### PR TITLE
[FIX] website_sale: avoid wrong pricelist on recurring products

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -480,7 +480,7 @@ class ProductTemplate(models.Model):
         for product, data in zip(self, results_data):
             categ_ids = product.public_categ_ids.filtered(lambda c: not c.website_id or c.website_id == current_website)
             if with_price:
-                combination_info = product._get_combination_info(only_template=True)
+                combination_info = product._get_combination_info(only_template=True, pricelist=current_website.get_current_pricelist())
                 data['price'], list_price = self._search_render_results_prices(
                     mapping, combination_info
                 )


### PR DESCRIPTION
Recurring products may have variants, that have different prices.
On search preview the minimal price is shown.
However, on multi-pricelist setup, the current pricelist was reset to first
pricelist [1].

Fix it by passing pricelist argument to `_get_combination_info`

STEPS

1. Create a subscription product with variants.
2. Create two pricelists ( Time based pricing ) for this product
3. Go to the website > Select one of the pricelist
4. Search product in search bar > You can see price from
another pricelist (if you don't, try another pricelist on the step 3.).

[1]: https://github.com/odoo/enterprise/blob/e9b2ea5c27382f58564f991af501e6a52c6a5193/website_sale_subscription/models/product_template.py#L95-L98

opw-3185013
