### PR TITLE
[FIX] *: errors on command.(un)link

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -790,7 +790,7 @@ class Meeting(models.Model):
         self.ensure_one()
         partner = self.env['res.partner'].browse(partner_id)
         if partner not in self.partner_ids:
-            self.write({'partner_ids': [(4, partner.id)]})
+            self.with_context(active_test=False).write({'partner_ids': [(4, partner.id)]})
 
     def action_mass_deletion(self, recurrence_update_setting):
         self.ensure_one()

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -115,7 +115,8 @@ class RecurrenceRule(models.Model):
             # Remove old attendees. Sometimes, several partners have the same email.
             if email_normalize(odoo_attendee_email) not in emails:
                 attendees = existing_attendees.exists().filtered(lambda att: att.email == email_normalize(odoo_attendee_email))
-                self.calendar_event_ids.write({'need_sync': False, 'partner_ids': [Command.unlink(att.partner_id.id) for att in attendees]})
+                self.calendar_event_ids.with_context(active_test=False).write(
+                    {'need_sync': False, 'partner_ids': [Command.unlink(att.partner_id.id) for att in attendees]})
 
         # Update the recurrence values
         old_event_values = self.base_event_id and self.base_event_id.read(base_event_time_fields)[0]

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -749,7 +749,7 @@ class Message(models.Model):
         partner_id = self.env.user.partner_id.id
 
         starred_messages = self.search([('starred_partner_ids', 'in', partner_id)])
-        starred_messages.write({'starred_partner_ids': [Command.unlink(partner_id)]})
+        starred_messages.with_contex(active_test=False).write({'starred_partner_ids': [Command.unlink(partner_id)]})
 
         ids = [m.id for m in starred_messages]
         self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.message/toggle_star', {
@@ -765,9 +765,9 @@ class Message(models.Model):
         self.check_access_rule('read')
         starred = not self.starred
         if starred:
-            self.sudo().write({'starred_partner_ids': [Command.link(self.env.user.partner_id.id)]})
+            self.sudo().with_contex(active_test=False).write({'starred_partner_ids': [Command.link(self.env.user.partner_id.id)]})
         else:
-            self.sudo().write({'starred_partner_ids': [Command.unlink(self.env.user.partner_id.id)]})
+            self.sudo().with_contex(active_test=False).write({'starred_partner_ids': [Command.unlink(self.env.user.partner_id.id)]})
 
         self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.message/toggle_star', {
             'message_ids': [self.id],

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2474,10 +2474,10 @@ class Task(models.Model):
         return super(Task, self)._message_post_after_hook(message, msg_vals)
 
     def action_assign_to_me(self):
-        self.write({'user_ids': [(4, self.env.user.id)]})
+        self.with_contex(active_test=False).write({'user_ids': [(4, self.env.user.id)]})
 
     def action_unassign_me(self):
-        self.write({'user_ids': [Command.unlink(self.env.uid)]})
+        self.with_contex(active_test=False).write({'user_ids': [Command.unlink(self.env.uid)]})
 
     # If depth == 1, return only direct children
     # If depth == 3, return children to third generation

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -214,7 +214,7 @@ class TestProjectSharing(TestProjectSharingCommon):
             1) add many assignees in a task
             2) check the portal user can read no assignee in this task. Should have an AccessError exception
         """
-        self.task_cow.write({'user_ids': [Command.link(self.user_projectmanager.id)]})
+        self.task_cow.with_contex(active_test=False).write({'user_ids': [Command.link(self.user_projectmanager.id)]})
         with self.assertRaises(AccessError, msg="Should not accept the portal user to access to a task he does not follow it and its project."):
             self.task_cow.with_user(self.user_portal).read(['portal_user_names'])
         self.assertEqual(len(self.task_cow.user_ids), 2, '2 users should be assigned in this task.')


### PR DESCRIPTION
If the field may contain inactive records, it needs to be written with active_test=False

```py
>>> from odoo import Command
>>> p1 = self.env['res.partner'].create({'name':'P1'})
>>> p2 = self.env['res.partner'].create({'name':'P2'})
>>> p3 = self.env['res.partner'].create({'name':'P3', 'active':False})
>>> c = self.env['res.partner.category'].create({'name':'C', 'partner_ids': [Command.set([p1.id, p2.id, p3.id])]})
>>> c.partner_ids.mapped('name')
['P1', 'P2']
>>> c.with_context(active_test=False).partner_ids.mapped('name')
['P1', 'P2', 'P3']

>>> c.write({'partner_ids': [Command.unlink(p2.id)]})
>>> c.with_context(active_test=False).partner_ids.mapped('name')
['P1']  # expected p1, p3

>>> c.write({'partner_ids': [Command.set([p1.id, p3.id])]})
>>> c.write({'partner_ids': [Command.link(p2.id)]})
>>> c.with_context(active_test=False).partner_ids.mapped('name')
['P1', 'P2']  # expected p1, p2, p3
```