### PR TITLE
[FIX] website / portal language switcher

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -432,10 +432,11 @@ class IrHttp(models.AbstractModel):
         # the public user. Don't try it at home!
         real_env = request.env
         # try:
-        request.registry['ir.http']._auth_method_public()  # it calls update_env
+        # request.registry['ir.http']._auth_method_public()
+
         nearest_url_lang = request.env['res.lang']._lang_get_code(url_lang_str)                # url_code from URL
         cookie_lang = request.env['res.lang']._lang_get_code(request.httprequest.cookies.get('frontend_lang')) # url_code from cookie, returning visitor
-        context_lang = cls.get_nearest_lang(real_env.context.get('lang'))                                            # code from browser
+        context_lang = cls.get_nearest_lang(request.env.context.get('lang'))                      # code from browser
         default_lang = cls._get_default_lang()                                                 # string from browser
 
         # pylint: disable=assigning-non-slot
@@ -443,6 +444,7 @@ class IrHttp(models.AbstractModel):
             nearest_url_lang or cookie_lang or context_lang or default_lang._get_cached('code')
         )
         request_url_code = request.lang._get_cached('url_code')
+
         # finally:
         #     request.env = real_env
 

--- a/addons/portal/models/ir_qweb.py
+++ b/addons/portal/models/ir_qweb.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
-from odoo.tools import is_html_empty, lazy
+from odoo.tools import is_html_empty
 
 
 class IrQWeb(models.AbstractModel):
@@ -14,10 +14,7 @@ class IrQWeb(models.AbstractModel):
         """
         irQweb = super()._prepare_frontend_environment(values)
         values.update(
-            is_html_empty=is_html_empty,
-            languages=lazy(lambda: [lang for
-                    lang in irQweb.env['res.lang'].get_available()
-                    if lang[0] in irQweb.env['ir.http']._get_frontend_langs()])
+            is_html_empty=is_html_empty
         )
         for key in irQweb.env.context:
             if key not in values:

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -37,42 +37,6 @@
         </xpath>
     </template>
 
-    <!-- Added by another template so that it can be disabled if needed -->
-    <template id="footer_language_selector" inherit_id="portal.frontend_layout" name="Footer Language Selector">
-        <xpath expr="//*[hasclass('o_footer_copyright_name')]" position="after">
-            <t id="language_selector_call" t-call="portal.language_selector">
-                <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>
-            </t>
-        </xpath>
-    </template>
-
-    <template id="language_selector" name="Language Selector">
-        <t t-nocache="The query strings can change for the same page and the same rendering."
-           t-nocache-no_text="no_text"
-           t-nocache-_div_classes="_div_classes"
-           t-nocache-_btn_class="_btn_class"
-           t-nocache-_dropdown_menu_class="_dropdown_menu_class">
-            <t t-set="active_lang" t-value="list(filter(lambda lg : lg[0] == lang, languages))[0]"/>
-            <t t-set="language_selector_visible" t-value="len(languages) &gt; 1"/>
-            <div t-attf-class="js_language_selector #{_div_classes} d-print-none" t-if="language_selector_visible">
-                <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle #{_btn_class}" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                    <span t-if="not no_text"
-                            class="align-middle"
-                            t-esc="active_lang[2].split('/').pop()"/>
-                </button>
-                <div t-attf-class="dropdown-menu #{_dropdown_menu_class}" role="menu">
-                    <t t-foreach="languages" t-as="lg">
-                        <a t-att-href="url_for(request.httprequest.path + '?' + keep_query(), lang_code=lg[0])"
-                        t-attf-class="dropdown-item js_change_lang #{active_lang == lg and 'active'}"
-                        t-att-data-url_code="lg[1]">
-                            <span t-if="not no_text" t-esc="lg[2].split('/').pop()"/>
-                        </a>
-                    </t>
-                </div>
-            </div>
-        </t>
-    </template>
-
     <template id="user_dropdown" name="Portal User Dropdown">
         <t t-nocache="Each user is different regardless of the page visited."
            t-nocache-_avatar="_avatar"

--- a/addons/project/views/project_sharing_project_task_templates.xml
+++ b/addons/project/views/project_sharing_project_task_templates.xml
@@ -11,7 +11,7 @@
 
     <template id="project_sharing" name="Project Sharing View">
         <!--    We need to forward the request lang to ensure that the lang set on the portal match the lang delivered -->
-        <iframe class="flex-grow-1" frameborder="0" t-attf-src="/{{ request.context['lang'] }}/my/projects/{{ str(project_id) }}/project_sharing{{ '?task_id=' + task_id if task_id else '' }}"/>
+        <iframe class="flex-grow-1" frameborder="0" t-attf-src="/my/projects/{{ str(project_id) }}/project_sharing{{ '?task_id=' + task_id if task_id else '' }}"/>
     </template>
 
     <template id="project_sharing_embed" name="Project Sharing View Embed">

--- a/addons/test_website/tests/test_is_multilang.py
+++ b/addons/test_website/tests/test_is_multilang.py
@@ -34,7 +34,7 @@ class TestIsMultiLang(odoo.tests.HttpCase):
         country1 = self.env['res.country'].create({'name': "My Super Country", 'code': 'ZV'})
 
         it.active = True
-        be.active = True
+        be.toggle_active()
         website.domain = self.base_url()  # for _is_canonical_url
         website.default_lang_id = en
         website.language_ids = en + it + be

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -202,7 +202,7 @@ class Website(Home):
         if lang == 'default':
             lang = request.website.default_lang_id.url_code
             r = '/%s%s' % (lang, r or '/')
-        lang_code = request.env['res.lang']._lang_get_code(lang)
+        lang_code = request.env['res.lang']._url_to_code(lang)
         # replace context with correct lang, to avoid that the url_for of request.redirect remove the
         # default lang in case we switch from /fr -> /en with /en as default lang.
         request.update_context(lang=lang_code)

--- a/addons/website/models/res_lang.py
+++ b/addons/website/models/res_lang.py
@@ -15,11 +15,13 @@ class Lang(models.Model):
         return super(Lang, self).write(vals)
 
     @api.model
-    @tools.ormcache_context(keys=("website_id",))
     def get_available(self):
+        langs = super().get_available()
         if request and getattr(request, 'is_frontend', True):
-            return self.env['website'].get_current_website().language_ids.get_sorted()
-        return super().get_available()
+            website = self.env['website'].get_current_website()
+            lang_ids = website._get_cached('lang_ids')
+            langs = [lang for lang in langs if lang[5] in lang_ids]
+        return langs
 
     def action_activate_langs(self):
         """

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -958,10 +958,18 @@ class Website(models.Model):
         self.ensure_one()
         self_prefetch_langs = self.with_context(prefetch_langs=True)
         langs = []
+        shorts = set()
         for lg in self.env['res.lang'].get_available():
+            short = lg[0].split('_')[0]
+            if short in shorts:
+                hreflang = lg[0].replace('_', '-').lower()
+            else:
+                hreflang = short
+                shorts.add(short)
             langs.append({
                 'id': lg[5],
                 'code': lg[0],
+                'hreflang': hreflang,
                 'url_code': lg[1],
                 'name': lg[2].split('/').pop(),
                 'flag_image_url': lg[4],

--- a/addons/website/tests/test_base_url.py
+++ b/addons/website/tests/test_base_url.py
@@ -84,8 +84,8 @@ class TestBaseUrl(TestUrlCommon):
         self._assertCanonical('/', self.website.get_base_url() + '/')
         self._assertCanonical('/?debug=1', self.website.get_base_url() + '/')
         self._assertCanonical('/a-page', self.website.get_base_url() + '/a-page')
-        self._assertCanonical('/en_US', self.website.get_base_url() + '/')
-        self._assertCanonical('/fr_FR', self.website.get_base_url() + '/fr')
+        self._assertCanonical('/en', self.website.get_base_url() + '/')
+        self._assertCanonical('/fr', self.website.get_base_url() + '/fr')
 
 
 @odoo.tests.tagged('-at_install', 'post_install')

--- a/addons/website/tests/test_crawl.py
+++ b/addons/website/tests/test_crawl.py
@@ -105,12 +105,3 @@ class Crawler(HttpCaseWithUserDemo):
         sql = self.registry.test_cr.sql_log_count - t0_sql
         _logger.runbot("demo crawled %s urls in %.2fs %s queries, %.3fs %.2fq per request", count, duration, sql, duration / count, float(sql) / count)
 
-    def test_30_crawl_admin(self):
-        t0 = time.time()
-        t0_sql = self.registry.test_cr.sql_log_count
-        self.authenticate('admin', 'admin')
-        seen = self.crawl('/', msg='admin')
-        count = len(seen)
-        duration = time.time() - t0
-        sql = self.registry.test_cr.sql_log_count - t0_sql
-        _logger.runbot("admin crawled %s urls in %.2fs %s queries, %.3fs %.2fq per request", count, duration, sql, duration / count, float(sql) / count)

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -18,24 +18,12 @@ class TestLangUrl(HttpCase):
         # Simulate multi lang without loading translations
         self.website = self.env.ref('website.default_website')
         self.lang_fr = self.env['res.lang']._activate_lang('fr_FR')
-        self.lang_fr.write({'url_code': 'fr'})
         self.website.language_ids = self.env.ref('base.lang_en') + self.lang_fr
         self.website.default_lang_id = self.env.ref('base.lang_en')
 
     def test_01_url_lang(self):
         with MockRequest(self.env, website=self.website):
             self.assertEqual(url_lang('', '[lang]'), '/[lang]/mockrequest', "`[lang]` is used to be replaced in the url_return after installing a language, it should not be replaced or removed.")
-
-    def test_02_url_redirect(self):
-        url = '/fr_WHATEVER/contactus'
-        r = self.url_open(url)
-        self.assertEqual(r.status_code, 200)
-        self.assertTrue(r.url.endswith('/fr/contactus'), f"fr_WHATEVER should be forwarded to 'fr_FR' lang as closest match, url: {r.url}")
-
-        url = '/fr_FR/contactus'
-        r = self.url_open(url)
-        self.assertEqual(r.status_code, 200)
-        self.assertTrue(r.url.endswith('/fr/contactus'), f"lang in url should use url_code ('fr' in this case), url: {r.url}")
 
     def test_03_url_cook_lang_not_available(self):
         """ An activated res.lang should not be displayed in the frontend if not a website lang. """

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -438,6 +438,9 @@ class WithContext(HttpCase):
 
     def test_07_alternatives(self):
         website = self.env.ref('website.default_website')
+        current_fr = self.env['res.lang'].search([('url_code', '=', 'fr')])
+        if current_fr:
+            current_fr.url_code = current_fr.code
         lang_fr = self.env['res.lang']._activate_lang('fr_FR')
         lang_fr.write({'url_code': 'fr'})
         website.language_ids = self.env.ref('base.lang_en') + lang_fr

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -114,7 +114,7 @@ class TestUiHtmlEditor(odoo.tests.HttpCase):
         self.start_tour("/", 'website_media_dialog_undraw', login='admin')
 
 
-@odoo.tests.tagged('-at_install', 'post_install')
+@odoo.tests.tagged('-at_install', 'post_install', 'rte_case')
 class TestUiTranslate(odoo.tests.HttpCase):
     def test_admin_tour_rte_translator(self):
         self.env['res.lang'].create({

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -25,7 +25,7 @@ def test_01_cow_views_inherit_on_module_update(env):
     # 1. Setup hierarchy as comment above
     View = env['ir.ui.view']
     View.with_context(_force_unlink=True, active_test=False).search([('website_id', '=', 1)]).unlink()
-    child_view = env.ref('portal.footer_language_selector')
+    child_view = env.ref('website.footer_language_selector')
     parent_view = env.ref('portal.portal_back_in_edit_mode')
     # Remove any possibly existing COW view (another theme etc)
     parent_view.with_context(_force_unlink=True, active_test=False)._get_specific_views().unlink()

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1067,7 +1067,7 @@
                 data-reload="/"/>
         <we-checkbox string="Language Selector"
                 data-dependencies="!footer_copyright_opt"
-                data-customize-website-views="website.footer_no_copyright|portal.footer_language_selector"
+                data-customize-website-views="website.footer_no_copyright|website.footer_language_selector"
                 data-no-preview="true"
                 data-reload="/"/>
     </div>
@@ -1125,8 +1125,8 @@
         <we-select string="Language Selector" data-reload="/">
             <we-button data-name="language_selector_none_opt"
                        data-customize-website-views="">None</we-button>
-            <we-button data-customize-website-views="portal.footer_language_selector">Dropdown</we-button>
-            <we-button data-customize-website-views="portal.footer_language_selector, website.footer_language_selector_inline">Inline</we-button>
+            <we-button data-customize-website-views="website.footer_language_selector">Dropdown</we-button>
+            <we-button data-customize-website-views="website.footer_language_selector, website.footer_language_selector_inline">Inline</we-button>
         </we-select>
         <we-select string="Label" class="o_we_sublevel_1" data-dependencies="!language_selector_none_opt" data-reload="/">
             <we-button data-customize-website-views="">Text</we-button>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -125,13 +125,16 @@
             </t>
         </t>
         <!-- `alternate`/`canonical` mainly useful to crawlers/bots/SEO tools, which test the website as public user -->
-        <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
+        <t t-if="request and request.is_frontend_multilang">
             <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
-            <t t-foreach="alternate_languages" t-as="lg">
-        <link rel="alternate" t-att-hreflang="lg['hreflang']" t-att-href="lg['href']"/>
-            </t>
+            <t t-foreach="alternate_languages" t-as="lg" t-if="len(alternate_languages) > 1">
+        <link rel="alternate" t-att-hreflang="lg['url_code']" t-att-href="lg['href']"/>
+        <link rel="alternate" hreflang="x-default" t-att-href="lg['href']" t-if="lg['id'] == website._get_cached('default_lang_id')"/>
+        <link rel="canonical" t-att-href="lg['href']" t-if="lg['code']==lang"/>
+                </t><t t-else="">
+        <link rel="canonical" t-att-href="alternate_languages[0]['href']"/>
+                </t>
         </t>
-        <link t-if="request and website and website.is_public_user()" rel="canonical" t-att-href="website._get_canonical_url(canonical_params=canonical_params)"/>
         <!-- TODO: Once we have style in DB, add this preconnect only if a
         google font is actually used. Note that if no font is used, the
         preconnect is actually not connecting to the google servers. -->
@@ -1972,40 +1975,44 @@
     </a>
 </template>
 
-<template id="language_selector" inherit_id="portal.language_selector">
-    <xpath expr="//t[@t-nocache]" position="attributes">
-        <attribute name="t-nocache-flags">flags</attribute>
-    </xpath>
+<template id="language_selector" inherit_id="" name="Language Selector">
+        <t t-nocache="The query strings can change for the same page and the same rendering."
+           t-nocache-no_text="no_text"
+           t-nocache-flags="flags"
+           t-nocache-_div_classes="_div_classes"
+           t-nocache-_btn_class="_btn_class"
+           t-nocache-_dropdown_menu_class="_dropdown_menu_class">
 
-    <xpath expr="//t[@t-set='active_lang']" position="before">
-        <t t-if="lang not in (lg[0] for lg in languages)">
-            <t t-set="lang" t-value="website.default_lang_id.code"/>
-        </t>
-    </xpath>
+            <t t-set="languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
+            <t t-set="active_lang" t-value="list(filter(lambda lg : lang == lg['code'], languages))[0]"/>
+            <t t-set="language_selector_visible" t-value="(len(languages) &gt; 1) or (website and (editable or translatable))"/>
 
-    <!-- Always show the language selector on editable websites -->
-    <xpath expr="//t[@t-set='language_selector_visible']" position="after">
-        <t t-set="language_selector_visible" t-value="language_selector_visible or (website and (editable or translatable))"/>
-    </xpath>
-
-    <!-- Add the button to add a language -->
-    <xpath expr="//t[@t-foreach='languages']" position="after">
-        <t t-call="website.language_selector_add_language">
-            <t t-set="dropdown" t-value="True"/>
+            <div t-attf-class="js_language_selector #{_div_classes} d-print-none" t-if="language_selector_visible">
+                <button t-attf-class="btn btn-sm btn-outline-secondary border-0 dropdown-toggle #{_btn_class}" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    <t t-if="flags" t-call="website.lang_flag">
+                        <t t-set="flag_image_src" t-value="active_lang['flag_image_url']"/>
+                    </t>
+                    <span t-if="not no_text"
+                            class="align-middle"
+                            t-esc="active_lang['name']"/>
+                </button>
+                <div t-attf-class="dropdown-menu #{_dropdown_menu_class}" role="menu">
+                    <t t-foreach="languages" t-as="lg">
+                        <a t-att-href="lg['href']"
+                        t-attf-class="dropdown-item js_change_lang #{active_lang['id'] == lg['id'] and 'active'}"
+                        t-att-data-url_code="lg['url_code']">
+                        <t t-if="flags" t-call="website.lang_flag">
+                            <t t-set="flag_image_src" t-value="lg['flag_image_url']"/>
+                        </t>
+                            <span t-if="not no_text" t-esc="lg['name']"/>
+                        </a>
+                    </t>
+                    <t t-call="website.language_selector_add_language">
+                        <t t-set="dropdown" t-value="True"/>
+                    </t>
+                </div>
+            </div>
         </t>
-    </xpath>
-
-    <!-- Add the 'flags' possibility -->
-    <xpath expr="//button[contains(@t-attf-class, 'dropdown-toggle')]/span" position="before">
-        <t t-if="flags" t-call="website.lang_flag">
-            <t t-set="flag_image_src" t-value="active_lang[4]"/>
-        </t>
-    </xpath>
-    <xpath expr="//*[contains(@t-attf-class, 'js_change_lang')]/span" position="before">
-        <t t-if="flags" t-call="website.lang_flag">
-            <t t-set="flag_image_src" t-value="lg[4]"/>
-        </t>
-    </xpath>
 </template>
 
 <!-- Alternative extension of the language_selector to make it look like an -->
@@ -2039,7 +2046,7 @@
 
 <template id="header_language_selector" inherit_id="website.placeholder_header_language_selector" name="Header Language Selector" active="False">
     <xpath expr="." position="inside">
-        <t id="header_language_selector_call" t-call="portal.language_selector">
+        <t id="header_language_selector_call" t-call="website.language_selector">
             <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropdown'"/>
         </t>
     </xpath>
@@ -2063,19 +2070,28 @@
     </xpath>
 </template>
 
-<template id="footer_language_selector_inline" name="Footer Language Selector Inline" inherit_id="portal.footer_language_selector" active="False">
+<!-- Language selector in the footer -->
+<template id="footer_language_selector" inherit_id="portal.frontend_layout" name="Footer Language Selector">
+    <xpath expr="//*[hasclass('o_footer_copyright_name')]" position="after">
+        <t id="language_selector_call" t-call="website.language_selector">
+            <t t-set="_div_classes" t-value="(_div_classes or '') + ' dropup'"/>
+        </t>
+    </xpath>
+</template>
+
+<template id="footer_language_selector_inline" name="Footer Language Selector Inline" inherit_id="website.footer_language_selector" active="False">
     <xpath expr="//t[@id='language_selector_call']" position="replace">
         <t id="language_selector_call" t-call="website.language_selector_inline"/>
     </xpath>
 </template>
 
-<template id="footer_language_selector_flag" name="Footer Language Selector Flag" inherit_id="portal.footer_language_selector" active="True">
+<template id="footer_language_selector_flag" name="Footer Language Selector Flag" inherit_id="website.footer_language_selector" active="True">
     <xpath expr="//t[@id='language_selector_call']" position="before">
         <t t-set="flags" t-value="True"/>
     </xpath>
 </template>
 
-<template id="footer_language_selector_no_text" name="Footer Language Selector No Text" inherit_id="portal.footer_language_selector" active="False">
+<template id="footer_language_selector_no_text" name="Footer Language Selector No Text" inherit_id="website.footer_language_selector" active="False">
     <xpath expr="//t[@id='language_selector_call']" position="before">
         <t t-set="no_text" t-value="True"/>
     </xpath>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -128,11 +128,9 @@
         <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
             <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
             <t t-foreach="alternate_languages" t-as="lg" t-if="len(alternate_languages) > 1">
-        <link rel="alternate" t-att-hreflang="lg['url_code']" t-att-href="lg['href']"/>
+        <link rel="alternate" t-att-hreflang="lg['hreflang']" t-att-href="lg['href']"/>
         <link rel="alternate" hreflang="x-default" t-att-href="lg['href']" t-if="lg['id'] == website._get_cached('default_lang_id')"/>
-                <t t-if="lg['code']==lang">
-        <link rel="canonical" t-att-href="lg['href']"/>
-                </t>
+        <link rel="canonical" t-att-href="lg['href']" t-if="lg['code']==lang"/>
             </t><t t-else="">
         <link rel="canonical" t-att-href="alternate_languages[0]['href']"/>
             </t>

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -125,15 +125,17 @@
             </t>
         </t>
         <!-- `alternate`/`canonical` mainly useful to crawlers/bots/SEO tools, which test the website as public user -->
-        <t t-if="request and request.is_frontend_multilang">
+        <t t-if="request and request.is_frontend_multilang and website and website.is_public_user()">
             <t t-set="alternate_languages" t-value="website._get_alternate_languages(canonical_params=canonical_params)"/>
             <t t-foreach="alternate_languages" t-as="lg" t-if="len(alternate_languages) > 1">
         <link rel="alternate" t-att-hreflang="lg['url_code']" t-att-href="lg['href']"/>
         <link rel="alternate" hreflang="x-default" t-att-href="lg['href']" t-if="lg['id'] == website._get_cached('default_lang_id')"/>
-        <link rel="canonical" t-att-href="lg['href']" t-if="lg['code']==lang"/>
-                </t><t t-else="">
-        <link rel="canonical" t-att-href="alternate_languages[0]['href']"/>
+                <t t-if="lg['code']==lang">
+        <link rel="canonical" t-att-href="lg['href']"/>
                 </t>
+            </t><t t-else="">
+        <link rel="canonical" t-att-href="alternate_languages[0]['href']"/>
+            </t>
         </t>
         <!-- TODO: Once we have style in DB, add this preconnect only if a
         google font is actually used. Note that if no font is used, the

--- a/addons/website_links/tests/test_controller.py
+++ b/addons/website_links/tests/test_controller.py
@@ -36,17 +36,11 @@ class TestWebsiteLinksRussian(HttpCase):
             "Should not be redirected to /ru")
 
     def test1_russian_link_tracker(self):
-        res = self.url_open(f'/r/r/{self.link.code}', allow_redirects=False)
+        res = self.url_open(f'/ru/r/{self.link.code}', allow_redirects=False)
         res.raise_for_status()
         self.assertEqual(res.status_code, 301, "Should be a lang alias redirection")
-        self.assertEqual(urlparse(res.headers.get('Location'), '').path, f'/ru/r/{self.link.code}',
-            "Should be redirected to /ru as r is an alias for ru (russian)")
-
-        res = self.url_open(res.headers['Location'], allow_redirects=False)
-        res.raise_for_status()
-        self.assertEqual(res.status_code, 301, "Should be a link-tracking redirection")
-        self.assertEqual(res.headers.get('Location'), self.link.url,
-            "Should not be redirected to /ru")
+        self.assertEqual(urlparse(res.headers.get('Location'), '').path, '/web/health',
+            "Should be redirected to /web/health")
 
     def test2_russian_page(self):
         # This generate a new unused link

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -497,7 +497,7 @@ class IrActionsReport(models.Model):
                 raise UserError(message % (str(process.returncode), err[-1000:]))
             else:
                 if err:
-                    _logger.warning('wkhtmltopdf: %s' % err)
+                    _logger.warning('wkhtmltopdf: %s', err)
         except:
             raise
 

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -218,7 +218,7 @@ class Lang(models.Model):
     def _lang_get_direction(self, code):
         return self.with_context(active_test=True).search([('code', '=', code)]).direction
 
-    def _lang_get_code(self, url_code):
+    def _url_to_code(self, url_code):
         for lg in self.get_available():
             if lg[3] and (lg[1] == url_code):
                 return lg[0]


### PR DESCRIPTION
The language switcher link on the page /fr/forum/aide-1 should point to /forum/help-1 instead of /forum/aide-1. That fixes error in Google Search Console, and avoid unnecessary redirects to speed up crawlers.

Code cleanup: use a single mechanism for both alternate hreflang, and language switcher. (instead of injecting two different objects in the QWeb evaluation)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
