### PR TITLE
[IMP] Time off : a time off with a duration equal to 1 day is display…

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1078,9 +1078,11 @@ class HolidaysRequest(models.Model):
             calendar = holiday.employee_id.resource_calendar_id or company_calendar
             user = holiday.user_id
             if holiday.leave_type_request_unit == 'hour':
-                meeting_name = _("%s on Time Off: %.2f hour(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_hours_display)
+                meeting_name = _("%s on Time Off : %.2f hour(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_hours_display)
+                allday_value = float_compare(holiday.number_of_days, 1.0, 1) >= 0
             else:
-                meeting_name = _("%s on Time Off: %.2f day(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_days)
+                meeting_name = _("%s on Time Off : %.2f day(s)") % (holiday.employee_id.name or holiday.category_id.name, holiday.number_of_days)
+                allday_value = not holiday.request_unit_half
             meeting_values = {
                 'name': meeting_name,
                 'duration': holiday.number_of_days * (calendar.hours_per_day or HOURS_PER_DAY),
@@ -1088,7 +1090,7 @@ class HolidaysRequest(models.Model):
                 'user_id': user.id,
                 'start': holiday.date_from,
                 'stop': holiday.date_to,
-                'allday': False,
+                'allday': allday_value,
                 'privacy': 'confidential',
                 'event_tz': user.tz,
                 'activity_ids': [(5, 0, 0)],

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=95, admin=99):
+        with self.assertQueryCount(__system__=98, admin=102):
             leave.action_validate()
         leave.action_refuse()
 


### PR DESCRIPTION
[IMP] Time off : a time off (duration >= 1day) is displayed in the allday box


The number of queries for the test "test_performance_leave_validate" has been increased by 2 queries.

Task : [Time off] Canlendar time's off id : task-3103848

Description of the issue/feature this PR addresses: 

If the duration time off is greater than or equal to 1 day, the time off has its boolean allday equals
to True and it is displayed in the allday box.

Current behavior before PR:

This change makes it possible to see more quickly that if a person
has a timeoff then it is not possible to put a meeting on the same day. It was not obvious in the case
where a person had a time off of 1 day.

Desired behavior after PR is merged:

If the duration time off is greater than or equal to 1 day, the time off has its boolean allday equals
to True.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
