### PR TITLE
[FIX] mrp: correct dilevered quantity for non Unit kits

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -454,9 +454,12 @@ class StockMove(models.Model):
                 return 0.0
         if qty_ratios:
             # Now that we have every ratio by components, we keep the lowest one to know how many kits we can produce
-            # with the quantities delivered of each component. We use the floor division here because a 'partial kit'
-            # doesn't make sense.
-            return min(qty_ratios) // 1
+            # with the quantities delivered of each component.
+            if kit_bom.product_uom_id == self.env.ref('uom.product_uom_unit'):
+                # We use the floor division here because a 'partial kit' doesn't make sense.
+                return min(qty_ratios) // 1
+            else:
+                return float_round(min(qty_ratios), precision_rounding=kit_bom.product_uom_id.rounding)
         else:
             return 0.0
 


### PR DESCRIPTION
Steps to reproduce:
- create a Kit with product and component unit type as KG
- create and confirm an SO of 10.7 kg of that product
- set the quantity and validate the delivery

Bug:
the delivered quantity on the sale order is rounded down the rounding down is applied to group component into kits but it shouldn't apply to product with non discrete unit

Fix:
only round down kits with unit_type: "Unit"

opw-3122197

