### PR TITLE
[FIX] stock_account: fix the issue with changing the name of all the …

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -71,15 +71,15 @@ class AccountMove(models.Model):
         # Create additional COGS lines for customer invoices.
         self.env['account.move.line'].create(self._stock_account_prepare_anglo_saxon_out_lines_vals())
 
-        # Post entries.
-        posted = super()._post(soft)
-
         # The invoice reference is set during the super call
         for layer in stock_valuation_layers:
             description = f"{layer.account_move_line_id.move_id.display_name} - {layer.product_id.display_name}"
             layer.description = description
             layer.account_move_id.ref = description
             layer.account_move_id.line_ids.write({'name': description})
+
+        # Post entries.
+        posted = super()._post(soft)
 
         # Reconcile COGS lines in case of anglo-saxon accounting with perpetual valuation.
         posted._stock_account_anglo_saxon_reconcile_valuation()


### PR DESCRIPTION
The issue:
Creating a purchase order with all/most product cost method set to something other than standard, then creating a bill, change the quantity on any product, then confirm it. you will notice all the journal items that has a product with cost method is not standard, their name changed to be the same as the one that has it's quantity changed.

The fix:
after investigating the issue, I found that in the override of write method for account move line, there's a spepcific condtition checkes wheter the move has been posted before or not (l.move_id.posted_before), and because in the _post method in the account_move we post the move then we check for the valuation layer, then call the write method (for account move line). so it seems like the move has been already posted but this is the first time posting this move. As a fix, I did change the order of posting the move.

opw-3184297
