### PR TITLE
[FIX] base: fix the computed field that depends on a properties field

### DIFF
--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -151,6 +151,7 @@ class Message(models.Model):
         string='Properties',
         definition='discussion.attributes_definition',
     )
+    is_attributes_empty = fields.Boolean(string='Is Attribute Empty', compute='_compute_is_attributes_empty')
 
     @api.constrains('author', 'discussion')
     def _check_author(self):
@@ -181,6 +182,14 @@ class Message(models.Model):
     def _compute_size(self):
         for message in self:
             message.size = len(message.body or '')
+
+    @api.depends('attributes')
+    def _compute_is_attributes_empty(self):
+        for message in self:
+            message.is_attributes_empty = all(
+                property.get('definition_deleted')
+                for property in message.attributes
+            )
 
     def _search_size(self, operator, value):
         if operator not in ('=', '!=', '<', '<=', '>', '>=', 'in', 'not in'):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6460,6 +6460,19 @@ class BaseModel(metaclass=MetaModel):
         # and depends on line.a, but line.b is not in the form view)
         record._update_cache(changed_values, validate=False)
 
+        # update the cache of the definition record to make the onchange
+        # work on properties fields
+        for name in changed_values:
+            field = self._fields.get(name)
+            if field and field.type == "properties":
+                # update the cache of the definition record
+                definitions = copy.deepcopy(changed_values[name])
+                for definition in definitions:
+                    definition.pop('value', None)
+                    definition.pop('definition_changed', None)
+                definitions = [definition for definition in definitions if not definition.get('definition_deleted')]
+                record[field.definition_record]._update_cache({field.definition_record_field: definitions})
+
         # update snapshot0 with changed values
         for name in names:
             snapshot0.fetch(name)


### PR DESCRIPTION
Bug
===
In Knowledge, we have a computed field, that depends on the properties field. Because the cache of the parent is not updated, in `convert_to_record`, when we get the definition, we got the old value.

Because of that, the computed field is never triggered.

Task-3213639