### PR TITLE
[FIX] pos_{coupon,discount}: properly handle a mix of discounts

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -311,10 +311,9 @@ odoo.define('pos_coupon.pos', function (require) {
         },
         _getRegularOrderlines: function () {
             const orderlines = _order_super.get_orderlines.apply(this, arguments);
-            const is_discount_product = (line) => this.pos.config.discount_product_id && line.product.id === this.pos.config.discount_product_id[0];
             const is_gift_card_product = (line) => this.pos.config.gift_card_product_id && line.product.id === this.pos.config.gift_card_product_id[0];
             const is_tips_product = (line) => this.pos.config.tip_product_id && line.product.id === this.pos.config.tip_product_id[0];
-            return orderlines.filter((line) => !line.is_program_reward && !line.refunded_orderline_id && !is_discount_product(line) && !is_gift_card_product(line) && !is_tips_product(line));
+            return orderlines.filter((line) => !line.is_program_reward && !line.refunded_orderline_id && !is_gift_card_product(line) && !is_tips_product(line));
         },
         _getRewardLines: function () {
             const orderlines = _order_super.get_orderlines.apply(this, arguments);

--- a/addons/pos_discount/static/src/js/DiscountButton.js
+++ b/addons/pos_discount/static/src/js/DiscountButton.js
@@ -5,6 +5,7 @@ odoo.define('pos_discount.DiscountButton', function(require) {
     const ProductScreen = require('point_of_sale.ProductScreen');
     const { useListener } = require('web.custom_hooks');
     const Registries = require('point_of_sale.Registries');
+    const round_pr = require('web.utils').round_precision;
 
     class DiscountButton extends PosComponent {
         constructor() {
@@ -52,6 +53,15 @@ odoo.define('pos_discount.DiscountButton', function(require) {
                     base_to_discount = order.get_total_with_tax();
                 }
             }
+            base_to_discount -= round_pr(lines.filter(
+                function (orderline) {
+                    return orderline.is_program_reward;
+                }
+            ).reduce((function(sum, orderLine) {
+                return sum + orderLine.get_price_without_tax();
+            }), 0), this.env.pos.currency.rounding);
+
+
             var discount = - pc / 100.0 * base_to_discount;
 
             if( discount < 0 ){

--- a/addons/pos_discount/static/src/js/models.js
+++ b/addons/pos_discount/static/src/js/models.js
@@ -15,7 +15,12 @@ odoo.define('pos_discount.models', function (require) {
     order:  product_model.order,
     domain: function(self) {return [['id', '=', self.config.discount_product_id[0]]];},
     context: product_model.context,
-    loaded: product_model.loaded,
+    loaded: function(self, products){
+        if (products.length) {
+            products[0].taxes_id = [];
+        }
+        product_model.loaded(self, products);
+    }
   }]);
 
 });


### PR DESCRIPTION
There are two types of discounts: *global discount* (pos_discount module) and *discount on total amount* (pos_coupon). The two don't work well together.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
