### PR TITLE
[FIX] partner_autocomplete: show confirmation dialog on blur

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -38,7 +38,7 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
         );
     }
 
-    async onSelect(option) {
+    async onSelect(option, params) {
         if (option.partner_gid) {  // Checks that it is a partner autocomplete option
             const data = await this.partner_autocomplete.getCreateData(Object.getPrototypeOf(option));
             let context = {
@@ -55,7 +55,7 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
             return this.openMany2X({ context });
         }
         else {
-            return super.onSelect(option);
+            return super.onSelect(option, params);
         }
     }
 

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -8,6 +8,7 @@ import {
     getFixture,
     patchWithCleanup,
     triggerEvent,
+    editInput,
 } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { loadJS } from "@web/core/assets";
@@ -345,5 +346,16 @@ QUnit.module('partner_autocomplete', {
         for (const [fieldName, expectedValue] of Object.entries(expectedValues)) {
             assert.strictEqual(target.querySelector(`[name=${fieldName}] input`).value, expectedValue, `${fieldName} should be filled`);
         }
+    });
+
+    QUnit.test("Show confirmation dialog on input blur", async function (assert) {
+        assert.expect(1);
+        await makeView(makeViewParams);
+        const input = target.querySelector("[name=parent_id] input.o-autocomplete--input.o_input");
+        await triggerEvent(input, null, "focus");
+        await click(input);
+        await editInput(input, null, "go");
+        await triggerEvent(input, null, "blur");
+        assert.containsOnce(target, ".modal-open");
     });
 });


### PR DESCRIPTION
Make the res_partner_many2one behave similarly to the many2one field
during blur where a confirmation dialog is shown.

TASK-ID: 3205625

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
