### PR TITLE
[FIX] event: access right for admins of event app

### DIFF
--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -13,7 +13,7 @@
 "access_ir_model_data_group_erp_manager","ir_model_data group_erp_manager","model_ir_model_data","group_erp_manager",1,1,1,1
 "access_ir_model_fields_group_erp_manager","ir_model_fields group_erp_manager","model_ir_model_fields","group_erp_manager",1,1,1,1
 "access_ir_model_fields_selection_group_erp_manager","ir_model_fields_selection group_erp_manager","model_ir_model_fields_selection","group_erp_manager",1,1,1,1
-"access_ir_model_user","ir_model_all","model_ir_model",base.group_user,0,0,0,0
+"access_ir_model_user","ir_model_all","model_ir_model",base.group_user,1,0,0,0
 "access_ir_model_data_user","ir_model_data user","model_ir_model_data",base.group_user,0,0,0,0
 "access_ir_model_fields_user","ir_model_fields all","model_ir_model_fields",base.group_user,0,0,0,0
 "access_ir_model_fields_selection_user","ir_model_fields_selection all","model_ir_model_fields_selection",base.group_user,0,0,0,0


### PR DESCRIPTION
1. Install [Events]

2. On [Settings], create an admin for Events (uncheck all other rights)

3. Click on Events, enter an event

3. Click on [Communication] tab, and try adding a line

Issue: accessing ir.model is blocked from commit 5dc4cff60a557e14b08440c227423291c407899b

Solution: partial revert

Impacted versions: 15 - master

opw-3163138
