### PR TITLE
[FIX] web: Dropdown mouseenter without hovering capability

### DIFF
--- a/addons/web/static/src/core/browser/browser.js
+++ b/addons/web/static/src/core/browser/browser.js
@@ -27,6 +27,7 @@ export const browser = Object.assign({}, owl.browser, {
     cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
     console: window.console,
     history: window.history,
+    matchMedia: window.matchMedia.bind(window),
     navigator: navigator,
     open: window.open.bind(window),
     XMLHttpRequest: window.XMLHttpRequest,

--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -47,3 +47,7 @@ export function hasTouch() {
 export function maxTouchPoints() {
     return browser.navigator.maxTouchPoints || 1;
 }
+
+export function hasNoHoveringCapability() {
+    return browser.matchMedia("(any-hover: none)").matches;
+}

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -5,6 +5,7 @@ import { usePosition } from "../position/position_hook";
 import { useDropdownNavigation } from "./dropdown_navigation_hook";
 import { ParentClosingMode } from "./dropdown_item";
 import { localization } from "../l10n/localization";
+import { hasNoHoveringCapability } from "@web/core/browser/feature_detection";
 
 const { Component, core, hooks, useState, QWeb } = owl;
 const { EventBus } = core;
@@ -257,6 +258,9 @@ export class Dropdown extends Component {
      * NB: only if its siblings dropdown group is opened and if not a sub dropdown.
      */
     onTogglerMouseEnter() {
+        if (hasNoHoveringCapability()) {
+            return;
+        }
         if (this.state.groupIsOpen && !this.state.open) {
             this.togglerRef.el.focus();
             this.open();

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -437,6 +437,9 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.test(
         "siblings dropdowns: when one is open, others can be toggled on mouse-enter",
         async (assert) => {
+            patchWithCleanup(browser, {
+                matchMedia: () => ({ matches: false }),
+            });
             assert.expect(13);
             const beforeOpenProm = makeDeferred();
             class Parent extends owl.Component {
@@ -580,6 +583,9 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("siblings dropdowns: toggler focused on mouseenter", async (assert) => {
+        patchWithCleanup(browser, {
+            matchMedia: () => ({ matches: false }),
+        });
         class Parent extends owl.Component {}
         Parent.template = owl.tags.xml`
         <div>


### PR DESCRIPTION
Ref.
https://www.w3.org/TR/mediaqueries-4/#mf-interaction

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
