### PR TITLE
[FIX] web: wrap overflow of multiline text fields

### DIFF
--- a/addons/web/static/src/views/fields/text/text_field.scss
+++ b/addons/web/static/src/views/fields/text/text_field.scss
@@ -5,3 +5,7 @@
         overflow-y: hidden;
     }
 }
+
+div > .o_field_text {
+    word-wrap: anywhere;
+}


### PR DESCRIPTION
Readonly multiline text fields in a form group break the view if the content is long

Steps to reproduce:
1. Install Studio, CRM and Events
2. Go to CRM and open lead 'Modern Open Space'
3. Trigger Studio and add a multiline text field 'URL' in the left group of the form
4. Close Studio and enter a long url in the new field
5. Go to Events and open any event
6. Trigger Studio and add a many2one field 'Opportunity' linked to Lead/Opportunity in the left group of the form
7. Add a related field 'Related URL' linked to Opportunity -> URL
8. Close Studio and set the Opportunity to 'Modern Open Space'
9. The 'Related URL' field should update and the url entered exceeds the borders of the group

Solution:
Wrap the content of o_field_text classes

opw-3191298