### PR TITLE
[FIX] website: fix click on link in edit mode

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -378,7 +378,7 @@ export class WebsitePreview extends Component {
             } else if (href && target !== '_blank' && !isEditing && this._isTopWindowURL(linkEl)) {
                 ev.preventDefault();
                 this.router.redirect(href);
-            } else if (this.iframe.el.contentWindow.location.pathname !== new URL(href).pathname) {
+            } else if (this.iframe.el.contentWindow.location.pathname !== new URL(href).pathname && !isEditing) {
                 this.websiteService.websiteRootInstance = undefined;
             }
         });


### PR DESCRIPTION
Since commit [1], the `websiteRootInstance` is set to `undefined` only
in some specific cases instead of at every page unload, in order to
avoid weird edition behaviors. These cases include clicking on links
leading somewhere else than the current page (i.e. other page or other
website (so the anchors are not concerned)).

However, the edit mode was not taken into account when adding these link
cases, which means that clicking on such links while being in edit mode
will set `websiteRootInstance` to `undefined`, breaking the editor (i.e.
some options will not be applied when clicking on them).

This commit adds a check looking if we are not in edit mode when we
click on links, before setting `websiteRootInstance` to `undefined`.

Steps to reproduce:
- In edit mode, on the Home page, go in the footer and click on any link
(except "Contact Us") under "Useful Links" or on the house icon in the
Social Media snippet.
- Change the footer height with the Height option.
=> The option is applied correctly (because the link stays on the same
page).
- Click on "Contact Us" or another Social Media icon.
- Try to change the footer height again.
=> The preview works but when we leave it, we see that the option was
not applied.
- Drop a snippet and click on it.
=> Infinite loading.

[1]: https://github.com/odoo/odoo/commit/e47a9900e4a7842774d33a332b325e1f08c3ca45

opw-3196324