### PR TITLE
[IMP] account: don't generate unaddressable root account

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -991,12 +991,12 @@ class AccountRoot(models.Model):
                    LEFT(code,2) AS name,
                    ASCII(code) AS parent_id,
                    company_id
-            FROM account_account WHERE code IS NOT NULL
+            FROM account_account WHERE code != ''
             UNION ALL
             SELECT DISTINCT ASCII(code) AS id,
                    LEFT(code,1) AS name,
                    NULL::int AS parent_id,
                    company_id
-            FROM account_account WHERE code IS NOT NULL
+            FROM account_account WHERE code != ''
             )''' % (self._table,)
         )


### PR DESCRIPTION
In the ORM computation for account_account's root_id field, the root_id will be set to NULL in the db if the code doesn't evaluate to True in Python. This means that if the code is the empty string `''`, the corresponding root_id will be False and the account will not be shown under any root subsections in the chart of accounts, only the All section (which makes sense). In normal use empty codes can't happen because the UI doesn't allow it. The database does, which means it can occur in certain corner cases.

The account root view computation is inconsistent with the ORM computation and it will generate an empty account root with id 0 for an account with an empty code `''`. This account root can't be referenced by an account because if the root_id is False, there is no reference and if the root_id is 0, you'll get a traceback when loading the chart of accounts. A read_group call will be done that filters on non-NULL root id's (like 0) in account_account, but the ORM will then interpret that 0 value as False. This means the read_group call ends up returning a boolean instead of a tuple for that line, which causes a traceback when the tuple is expected.

So to summarize, this change prevents an account root that can't be referenced from being generated in the obscure corner case where the code is `''`. It aligns the logic of the account root view computation with that of the ORM computation.

I didn't keep the check on NULL from the original query, because the code is a required field.