### PR TITLE
[FIX] purchase_stock: avoid memory error computing on_time_rate

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -5,6 +5,7 @@ from datetime import timedelta, datetime, time
 from collections import defaultdict
 
 from odoo import api, fields, models
+from odoo.tools import split_every
 
 
 class ResPartner(models.Model):
@@ -17,24 +18,31 @@ class ResPartner(models.Model):
 
     @api.depends('purchase_line_ids')
     def _compute_on_time_rate(self):
-        order_lines = self.env['purchase.order.line'].search([
+        order_line_ids = self.env['purchase.order.line']._search([
             ('partner_id', 'in', self.ids),
             ('date_order', '>', fields.Date.today() - timedelta(365)),
             ('qty_received', '!=', 0),
-            ('order_id.state', 'in', ['done', 'purchase'])
-        ]).filtered(lambda l: l.product_id.sudo().product_tmpl_id.type != 'service')
+            ('order_id.state', 'in', ['done', 'purchase'])])
+
         lines_qty_done = defaultdict(lambda: 0)
-        moves = self.env['stock.move'].search([
-            ('purchase_line_id', 'in', order_lines.ids),
-            ('state', '=', 'done')]).filtered(lambda m: m.date.date() <= m.purchase_line_id.date_planned.date())
-        for move, qty_done in zip(moves, moves.mapped('quantity_done')):
-            lines_qty_done[move.purchase_line_id.id] += qty_done
         partner_dict = {}
-        for line in order_lines:
-            on_time, ordered = partner_dict.get(line.partner_id, (0, 0))
-            ordered += line.product_uom_qty
-            on_time += lines_qty_done[line.id]
-            partner_dict[line.partner_id] = (on_time, ordered)
+
+        for order_lines in split_every(1000, order_line_ids, self.env['purchase.order.line'].browse):
+            order_lines = order_lines.filtered(lambda l: l.product_id.sudo().product_tmpl_id.type != 'service')
+            moves = self.env['stock.move'].search([
+                ('purchase_line_id', 'in', order_lines.ids),
+                ('state', '=', 'done')]).filtered(lambda m: m.date.date() <= m.purchase_line_id.date_planned.date())
+            for move, qty_done in zip(moves, moves.mapped('quantity_done')):
+                lines_qty_done[move.purchase_line_id.id] += qty_done
+            for line in order_lines:
+                on_time, ordered = partner_dict.get(line.partner_id, (0, 0))
+                ordered += line.product_uom_qty
+                on_time += lines_qty_done[line.id]
+                partner_dict[line.partner_id] = (on_time, ordered)
+
+            order_lines.invalidate_cache()
+            moves.invalidate_cache()
+
         seen_partner = self.env['res.partner']
         for partner, numbers in partner_dict.items():
             seen_partner |= partner


### PR DESCRIPTION
The compute of `on_time_rate` loads all the purchase order lines and all the stock moves related to the partners in context. The number of loaded records could be very high and results in an out of memory error.

opw-3142152
The db in the ticket has almost 950K PO lines for a single partner.

The fix is needed for later versions as well.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
