### PR TITLE
[REF] *: field should not use isReadonly

### DIFF
--- a/addons/web/static/src/views/fields/boolean/boolean_field.js
+++ b/addons/web/static/src/views/fields/boolean/boolean_field.js
@@ -15,11 +15,7 @@ export class BooleanField extends Component {
     };
 
     get isReadonly() {
-        return (
-            !this.props.record.isInEdition ||
-            this.props.record.isReadonly(this.props.name) ||
-            this.props.readonly
-        );
+        return this.props.readonly;
     }
 
     /**

--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
@@ -1,14 +1,19 @@
 /** @odoo-module **/
 
-import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { evalDomain } from "@web/views/utils";
 import { booleanField, BooleanField } from "../boolean/boolean_field";
 
 export class BooleanToggleField extends BooleanField {
     static template = "web.BooleanToggleField";
+    static props = {
+        ...BooleanField.props,
+        readonlyFromModifiers: { type: Array | Boolean, optional: true },
+    };
 
     get isReadonly() {
-        return this.props.record.isReadonly(this.props.name);
+        return evalDomain(this.props.readonlyFromModifiers, this.props.record.evalContext) || false;
     }
 
     async onChange(newValue) {
@@ -28,6 +33,9 @@ export const booleanToggleField = {
     ...booleanField,
     component: BooleanToggleField,
     displayName: _lt("Toggle"),
+    extractProps: (fieldInfo) => ({
+        readonlyFromModifiers: fieldInfo.modifiers.readonly,
+    }),
 };
 
 registry.category("fields").add("boolean_toggle", booleanToggleField);

--- a/addons/web/static/src/views/fields/color/color_field.js
+++ b/addons/web/static/src/views/fields/color/color_field.js
@@ -1,14 +1,15 @@
 /** @odoo-module **/
 
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 import { registry } from "@web/core/registry";
+import { evalDomain } from "@web/views/utils";
 import { standardFieldProps } from "../standard_field_props";
-
-import { Component, useState, onWillUpdateProps } from "@odoo/owl";
 
 export class ColorField extends Component {
     static template = "web.ColorField";
     static props = {
         ...standardFieldProps,
+        readonlyFromModifiers: { type: Array | Boolean, optional: true },
     };
 
     setup() {
@@ -22,13 +23,16 @@ export class ColorField extends Component {
     }
 
     get isReadonly() {
-        return this.props.record.isReadonly(this.props.name);
+        return evalDomain(this.props.readonlyFromModifiers, this.props.record.evalContext) || false;
     }
 }
 
 export const colorField = {
     component: ColorField,
     supportedTypes: ["char"],
+    extractProps: ({ modifiers }) => ({
+        readonlyFromModifiers: modifiers.readonly,
+    }),
 };
 
 registry.category("fields").add("color", colorField);

--- a/addons/web/static/src/views/fields/priority/priority_field.js
+++ b/addons/web/static/src/views/fields/priority/priority_field.js
@@ -4,13 +4,14 @@ import { useCommand } from "@web/core/commands/command_hook";
 import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
 import { standardFieldProps } from "../standard_field_props";
-
+import { evalDomain } from "@web/views/utils";
 import { Component, useState } from "@odoo/owl";
 
 export class PriorityField extends Component {
     static template = "web.PriorityField";
     static props = {
         ...standardFieldProps,
+        readonlyFromModifiers: { type: Array | Boolean, optional: true },
     };
 
     setup() {
@@ -54,7 +55,7 @@ export class PriorityField extends Component {
             : this.options.findIndex((o) => o[0] === this.props.value);
     }
     get isReadonly() {
-        return this.props.record.isReadonly(this.props.name);
+        return evalDomain(this.props.readonlyFromModifiers, this.props.record.evalContext) || false;
     }
 
     getTooltip(value) {
@@ -91,6 +92,9 @@ export const priorityField = {
     component: PriorityField,
     displayName: _lt("Priority"),
     supportedTypes: ["selection"],
+    extractProps: ({ modifiers }) => ({
+        readonlyFromModifiers: modifiers.readonly,
+    }),
 };
 
 registry.category("fields").add("priority", priorityField);

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.js
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.js
@@ -1,14 +1,15 @@
 /** @odoo-module **/
 
+import { Component } from "@odoo/owl";
 import { useCommand } from "@web/core/commands/command_hook";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { sprintf } from "@web/core/utils/strings";
-import { _lt } from "@web/core/l10n/translation";
-import { standardFieldProps } from "../standard_field_props";
+import { evalDomain } from "@web/views/utils";
 import { formatSelection } from "../formatters";
-import { Component } from "@odoo/owl";
+import { standardFieldProps } from "../standard_field_props";
 
 export class StateSelectionField extends Component {
     static template = "web.StateSelectionField";
@@ -19,6 +20,7 @@ export class StateSelectionField extends Component {
     static props = {
         ...standardFieldProps,
         hideLabel: { type: Boolean, optional: true },
+        readonlyFromModifiers: { type: Array | Boolean, optional: true },
     };
     static defaultProps = {
         hideLabel: false,
@@ -67,7 +69,7 @@ export class StateSelectionField extends Component {
         );
     }
     get isReadonly() {
-        return this.props.record.isReadonly(this.props.name);
+        return evalDomain(this.props.readonlyFromModifiers, this.props.record.evalContext) || false;
     }
 
     statusColor(value) {
@@ -91,8 +93,9 @@ export const stateSelectionField = {
     component: StateSelectionField,
     displayName: _lt("Label Selection"),
     supportedTypes: ["selection"],
-    extractProps: ({ options }) => ({
+    extractProps: ({ options, modifiers }) => ({
         hideLabel: !!options.hide_label,
+        readonlyFromModifiers: modifiers.readonly,
     }),
 };
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -14,7 +14,7 @@ import { useSortable } from "@web/core/utils/sortable";
 import { getTabableElements } from "@web/core/utils/ui";
 import { Field } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
-import { getClassNameFromDecoration } from "@web/views/utils";
+import { evalDomain, getClassNameFromDecoration } from "@web/views/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useBounceButton } from "@web/views/view_hook";
 import { Widget } from "@web/views/widgets/widget";
@@ -25,10 +25,10 @@ import {
     onPatched,
     onWillPatch,
     onWillUpdateProps,
+    useEffect,
     useExternalListener,
     useRef,
     useState,
-    useEffect,
 } from "@odoo/owl";
 
 const formatters = registry.category("formatters");
@@ -781,7 +781,7 @@ export class ListRenderer extends Component {
             if (
                 record.isInEdition &&
                 this.props.list.editedRecord &&
-                this.props.list.editedRecord.isReadonly(column.name)
+                this.getCellReadonly(column, this.props.list.editedRecord)
             ) {
                 classNames.push("text-muted");
             } else {
@@ -793,8 +793,8 @@ export class ListRenderer extends Component {
 
     getCellReadonly(column, record) {
         return (
-            record.isReadonly(column.name) ||
-            (column.relatedPropertyField && record.selected && record.model.multiEdit)
+            (column.relatedPropertyField && record.selected && record.model.multiEdit) ||
+            evalDomain(column.modifiers.readonly, record.evalContext)
         );
     }
 

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -5,6 +5,7 @@ import { ComponentAdapter } from 'web.OwlCompatibility';
 import { registry } from "@web/core/registry";
 import { _lt } from "@web/core/l10n/translation";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { evalDomain } from "@web/views/utils";
 import { getWysiwygClass } from 'web_editor.loader';
 import { QWebPlugin } from '@web_editor/js/backend/QWebPlugin';
 import { TranslationButton } from "@web/views/fields/translation_button";
@@ -141,7 +142,12 @@ export class HtmlField extends Component {
                         // Ensure all external links are opened in a new tab.
                         retargetLinks(this.readonlyElementRef.el);
 
-                        const hasReadonlyModifiers = Boolean(this.props.record.isReadonly(this.props.name));
+                        const hasReadonlyModifiers =
+                            evalDomain(
+                                this.props.readonlyFromModifiers,
+                                this.props.record.evalContext
+                            ) || false;
+
                         if (!hasReadonlyModifiers) {
                             const $el = $(this.readonlyElementRef.el);
                             $el.off('.checklistBinding');
@@ -630,13 +636,14 @@ HtmlField.props = {
     isInlineStyle: { type: Boolean, optional: true },
     wrapper: { type: String, optional: true },
     wysiwygOptions: { type: Object },
+    readonlyFromModifiers: { type: Array | Boolean, optional: true },
 };
 
 export const htmlField = {
     component: HtmlField,
     displayName: _lt("Html"),
     supportedTypes: ["html"],
-    extractProps: ({ attrs, options }) => {
+    extractProps: ({ attrs, options, modifiers }) => {
         const wysiwygOptions = {
             placeholder: attrs.placeholder,
             noAttachment: options['no-attachment'],
@@ -682,6 +689,7 @@ export const htmlField = {
             wrapper: options.wrapper,
 
             wysiwygOptions,
+            readonlyFromModifiers: modifiers.readonly,
         };
     },
 };


### PR DESCRIPTION
In many field composents, we need to know if the field modifier is readonly or not. So we use the function record.isReadonly(fieldname) to get the information. This one is false if we have several times the same <field> defined in a view. We will only listen to the modfier.readonly of the last occurrence. To solve this problem and allow the use of several fields in the same view with different modifiers, we will have to extract the readonlyModifiers and evaluate it in the field component.

Part of task: 3179751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
