### PR TITLE
[FIX] web_editor: wrap content of html field

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -1,6 +1,6 @@
 .oe_form_field_html {
     position: relative;
-    word-wrap: break-word;
+    word-wrap: anywhere;
 
     .note-editable {
         min-height: 330px;


### PR DESCRIPTION
Html fields added with studio break the form layout when the content overflows the column

Steps to reproduce:
1. Install Contacts & Studio
2. Open any contact form and toggle Studio
3. Add an html field under the address
4. Close Studio
5. Fill the content of the new html field without space, the content overflows out of the form

Solution:
Break the content of html fields anywhere

opw-3150450