### PR TITLE
[FIX] account: invoice currency bug

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -145,7 +145,7 @@ export class TaxTotalsComponent extends Component {
     }
 
     _format(amount) {
-        return formatMonetary(amount, { currencyId: this.currencyId });
+        return formatMonetary(amount, { currencyId: this.currencyId[0] });
     }
 
     _computeTotalsFormat() {


### PR DESCRIPTION
Before this PR, when something was changed on an invoice, the currency symbol disappeared and reappeared when there was a save.

The currency was not well set when information was changed so that every time the currency disappeared.

task-id: 3211813

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
