### PR TITLE
[FIX] base/account: VAT label in company view

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -687,3 +687,13 @@ class ResCompany(models.Model):
                 company.early_pay_discount_computation = 'excluded'
             else:
                 company.early_pay_discount_computation = 'included'
+
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        """ This is already done in base, but with accounting installed we want to use the account_fiscal_country_id instead """
+        arch, view = super()._get_view(view_id, view_type, **options)
+        company = self.env.company
+        if company.account_fiscal_country_id.vat_label:
+            for node in arch.xpath("//field[@name='vat']"):
+                node.attrib["string"] = company.account_fiscal_country_id.vat_label
+        return arch, view

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -667,3 +667,13 @@ class ResPartner(models.Model):
         :return: an array of ir.model.fields for which the user should provide values.
         """
         return []
+
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        """ This is already done in base, but with accounting installed we want to use the account_fiscal_country_id instead """
+        arch, view = super()._get_view(view_id, view_type, **options)
+        company = self.env.company
+        if company.account_fiscal_country_id.vat_label:
+            for node in arch.xpath("//field[@name='vat']"):
+                node.attrib["string"] = company.account_fiscal_country_id.vat_label
+        return arch, view

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -336,3 +336,12 @@ class Company(models.Model):
             main_company = self.env['res.company'].sudo().search([], limit=1, order="id")
 
         return main_company
+
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        company = self.env.company
+        if company.country_id.vat_label:
+            for node in arch.xpath("//field[@name='vat']"):
+                node.attrib["string"] = company.country_id.vat_label
+        return arch, view


### PR DESCRIPTION
In the same way that we are displaying the vat label depending on the currently selected company's country on the partner view, we will now do the same thing on the company view.
Also, when account is installed, we will use the fiscal country id to select the label instead.

Task id #3217791

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
