### PR TITLE
[FIX] account: avoid unnecessary exchange move for cash basis

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5400,7 +5400,7 @@ class AccountMoveLine(models.Model):
 
         # Fix cash basis entries.
         is_cash_basis_needed = self[0].account_internal_type in ('receivable', 'payable')
-        if is_cash_basis_needed:
+        if is_cash_basis_needed and exchange_diff_move_vals['line_ids']:
             _add_cash_basis_lines_to_exchange_difference_vals(self, exchange_diff_move_vals)
 
         # ==========================================================================


### PR DESCRIPTION
If you have an unreconciled invoice created before activating cash basis, registering a payment will create an exchange move and mess up the tax report.

Steps to reproduce (on a clean db with demo data and accounting): 
-Activate cash basis in accounting settings and set up the taxes
 'Tax Eligibility' field to 'Based on Payment'.
-Register a payment for an invoice created before the setting was
 activated.
->An exchange move in the 'Exchange Difference' journal has been created
  and the tax report for this tax is wrong, the tax line from the
  invoice has been counted twice.

Fix:
Create a cash basis exchange move only if there is an exchange move needed.

opw-3142889
