### PR TITLE
[FIX] stock: update location in SML when it changes in SM

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -111,10 +111,8 @@ class StockMoveLine(models.Model):
     @api.depends('move_id', 'move_id.location_id', 'move_id.location_dest_id')
     def _compute_location_id(self):
         for line in self:
-            if not line.location_id:
-                line.location_id = line.move_id.location_id or line.picking_id.location_id
-            if not line.location_dest_id:
-                line.location_dest_id = line.move_id.location_dest_id or line.picking_id.location_dest_id
+            line.location_id = line.move_id.location_id or line.location_id or line.picking_id.location_id
+            line.location_dest_id = line.move_id.location_dest_id or line.location_dest_id or line.picking_id.location_dest_id
 
     def _search_picking_type_id(self, operator, value):
         return [('picking_id.picking_type_id', operator, value)]


### PR DESCRIPTION
Steps to reproduce the bug:
- Create two warehouses: “WH1” and “WH2”
- Create a storable product “P1”
- go to inventory overview > Receipts:
    - Create a picking:
        - add “P1” as product
        - Set the Qty done to 1
- The location  “WH/stock” is set in the `stock.move.line`
- Change the dest location in the picking to “WH2/stock”

Problem:
the dest location is not updated on the `stock.move.line`


opw-3148993

https://user-images.githubusercontent.com/78867936/223172876-cbf6a47d-0c70-4899-a40c-65551f7cd497.mp4

