### PR TITLE
[FIX] uom: allow to unarchive a uom

### DIFF
--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -142,7 +142,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">uom.category</field>
         <field name="view_mode">tree,form</field>
-        <field name="context">{'allow_to_change_reference': 1}</field>
+        <field name="context">{'allow_to_change_reference': 1, 'active_test': False}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Add a new unit of measure category


### PR DESCRIPTION
Before this commit, it was not possible to unarchive a uom.uom after saving, since it was hidden in the uom category view and there is no menu anymore for uom.uom.

Steps to reproduce:
- go to uom category, archive a line
- save
- try to unarchive it

opw-3188272


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
