### PR TITLE
[FIX] account: allow different invoice currency than journal currency

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -796,7 +796,8 @@ class AccountMove(models.Model):
     def _compute_currency_id(self):
         for invoice in self:
             currency = (
-                invoice.statement_line_id.foreign_currency_id
+                invoice.currency_id
+                or invoice.statement_line_id.foreign_currency_id
                 or invoice.journal_id.currency_id
                 or invoice.journal_id.company_id.currency_id
             )


### PR DESCRIPTION

Before this commit, the currency was recomputed to the one set on the invoice journal when you try to change it on the invoice resulting with no change of the currency. This could also cause issues when you create an invoice from a sale order with another currency (unbalanced entry).

Now the currency of a journal entry stays the same if it was already set before and is not computed again.

opw-3203781

