### PR TITLE
[FIX] partner_autocomplete: field as title is too short

### DIFF
--- a/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
+++ b/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
@@ -30,3 +30,8 @@
         }
     }
 }
+
+// Same rule as .oe_title .o_field_char
+.o_form_view .o_form_editable .oe_title .o_field_field_partner_autocomplete {
+    width: 100%;
+}


### PR DESCRIPTION
Before this commit when the partner autocomplete field was used the form title css rules defined in o_field_char were missing.

So now the width: 100% is also applied when the partner autocomplete is a title and takes the whole available space.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
