### PR TITLE
[FIX] website_forum: increase forum post title width

### DIFF
--- a/addons/website_forum/views/website_pages_views.xml
+++ b/addons/website_forum/views/website_pages_views.xml
@@ -17,7 +17,7 @@
                 <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                 <label for="name"/>
                 <h1>
-                    <field name="name" placeholder="e.g. When should I plant my tomatoes?"/>
+                    <field name="name" class="w-100" placeholder="e.g. When should I plant my tomatoes?"/>
                 </h1>
                 <group>
                     <group name="forum_details">


### PR DESCRIPTION
before this commit, in the forum post form view,
the title field has small width and thus the title
 was not easily readable for the end users.

 after this commit, the title field width will
 be increased and title will become easily readable.

Before
![Screenshot from 2023-03-07 21-26-43](https://user-images.githubusercontent.com/27989791/223516590-051531d5-0f96-429d-bb1e-f51a58235909.png)


After:
![Screenshot from 2023-03-07 21-26-23](https://user-images.githubusercontent.com/27989791/223516638-4fdffc86-a999-4b4b-bb9d-9e3874310d3d.png)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
