### PR TITLE
[FIX] project: move property fields to the end of the list view

### DIFF
--- a/addons/project/views/project_sharing_views.xml
+++ b/addons/project/views/project_sharing_views.xml
@@ -234,7 +234,6 @@
         <field name="priority">999</field>
         <field name="arch" type="xml">
             <search position="inside"/>
-            <field name="task_properties" position="replace"></field>
         </field>
     </record>
 

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1533,9 +1533,9 @@
                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                         attrs="{'invisible': ['|', ('rating_active', '=', False), ('rating_last_text', '=', 'none')]}"
                         class="fw-bold" widget="badge" optional="hide" groups="project.group_project_rating"/>
-                    <field name="task_properties"/>
                 </field>
                 <tree position="inside">
+                    <field name="task_properties"/>
                     <field name="recurrence_id" invisible="1" />
                 </tree>
                 <xpath expr="//field[@name='partner_id']" position="after">

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -80,9 +80,6 @@
             <field name="inherit_id" ref="view_task_search_form_project_fsm_base"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <field name="description" position="after">
-                    <field string="Properties" name="task_properties"/>
-                </field>
                 <filter name="date_last_stage_update" position="after">
                     <filter string="Deadline" name="date_deadline" date="date_deadline"/>
                 </filter>
@@ -98,6 +95,9 @@
             <field name="inherit_id" ref="view_task_search_form_project_base"></field>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
+                <field name="description" position="after">
+                    <field string="Properties" name="task_properties"/>
+                </field>
                 <filter name="inactive" position="before">
                     <filter string="Unread Messages" name="message_needaction" domain="[('message_needaction', '=', True)]" groups="mail.group_mail_notification_type_inbox"/>
                     <separator/>


### PR DESCRIPTION
Property fields introduced in https://github.com/odoo/odoo/pull/112005 were at the wrong spot in project.task list and search views, which is causing issues.

This PR moves them to the right place.

Enterprise: https://github.com/odoo/enterprise/pull/37899