### PR TITLE
[FIX] account: fiscal country compute

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -176,7 +176,8 @@ class ResCompany(models.Model):
     @api.depends('country_id')
     def compute_account_tax_fiscal_country(self):
         for record in self:
-            record.account_fiscal_country_id = record.country_id
+            if not record.account_fiscal_country_id:
+                record.account_fiscal_country_id = record.country_id
 
     @api.depends('account_fiscal_country_id')
     def _compute_account_enabled_tax_country_ids(self):

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -366,7 +366,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
             return cls.env['account.account.tag'].create({
                 'name': name,
                 'applicability': 'taxes',
-                'country_id': cls.env.company.country_id.id
+                'country_id': cls.env.company.account_fiscal_country_id.id
             })
 
         cls.tax_tag_invoice_base = create_tag('Invoice Base tag')


### PR DESCRIPTION
The fiscal country was changed each time the user modified his
company's country. This caused problems (in particular at onboarding)
because it was not done transparently for the user.

After this commit, the fiscal country will behave like this:
- When we install Invoicing/Accounting, it is set by default to company's country
- When we install CoA, it is set to the CoA's country, if there is one (override above setting)
- It is **no longer automatically changed** when the company's country changes.

Task: 3221792