### PR TITLE
[FIX] sale: bad error message when invoicing sales order

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -685,12 +685,12 @@ class SaleOrder(models.Model):
         return UserError(_(
             "There is nothing to invoice!\n\n"
             "Reason(s) of this behavior could be:\n"
-            "- You should deliver your products before invoicing them: Click on the \"truck\" icon "
-            "(top-right of your screen) and follow instructions.\n"
             "- You should modify the invoicing policy of your product: Open the product, go to the "
             "\"Sales\" tab and modify invoicing policy from \"delivered quantities\" to \"ordered "
             "quantities\". For Services, you should modify the Service Invoicing Policy to "
             "'Prepaid'."
+            "- You should manually set the quantities in the \"Delivered\" column to the expected"
+            " value."
         ))
 
     def _get_invoiceable_lines(self, final=False):


### PR DESCRIPTION
When trying to invoice undelivered quantities the error message was somewhat misleading:
- it indicates as a possible solution an stock app feature even when stock is not installed;
- do not present to manually change the delivered quantities as a possible solution. After this commit the message will be more appropriated depending of the state of apps installed.

opw - 3206001

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
