### PR TITLE
[IMP] project: improve performance to portal task list view

### DIFF
--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -164,7 +164,7 @@
                                 <td>
                                     <t t-set="assignees" t-value="task.sudo().user_ids"/>
                                     <div t-if="assignees" class="row flex-nowrap ps-3">
-                                        <img class="rounded-circle o_portal_contact_img me-2" t-attf-src="#{image_data_uri(assignees[:1].avatar_1024)}" alt="User" style="width: 20px; height: 20px;"/>
+                                        <img class="rounded-circle o_portal_contact_img me-2" t-attf-src="#{image_data_uri(assignees[:1].avatar_128)}" alt="User" style="width: 20px; height: 20px;"/>
                                         <span t-out="'%s%s' % (assignees[:1].name, ' + %s others' % len(assignees[1:]) if len(assignees.user_ids) > 1 else '')" t-att-title="'\n'.join(assignees[1:].mapped('name'))"/>
                                     </div>
                                 </td>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR improves the load times when users consult the portal list view of Tasks

Current behavior before PR:
When a user has many tasks assigned or created the load times in portal view could be so long due to the large size of avatar images

Desired behavior after PR is merged:
The load time could be substantially reduced

Comparison:
![image](https://user-images.githubusercontent.com/90717087/224076949-9b4bfc1a-00ed-4d9e-b43a-98dbd7f09dd5.png)

![image](https://user-images.githubusercontent.com/90717087/224077133-63f732b9-aa9c-4ef3-bca4-f962df1966f4.png)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
