### PR TITLE
[IMP] point_of_sale: improve customer list in mobile view

### DIFF
--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -2087,46 +2087,48 @@ td {
     opacity: 0.3;
 }
 
-@media screen and (max-width: 768px) {
-    .pos .partnerlist-screen .partner-details-box {
+@media screen and (max-width: 767px) {
+    .partner-list thead {
+        display: none;
+    }
+
+    .partner-list-contents {
+        margin-top: 10px;
+    }
+
+    .partner-line {
         display: flex;
         flex-wrap: wrap;
+        align-items: center;
+        padding: 12px 24px;
     }
-    .pos .partnerlist-screen .partner-details-left{
-        width: auto;
-        float: none;
-        flex-grow: 1;
+    .partner-line td {
+        flex-basis: 100%;
+        padding: 5px;
     }
-    .pos .partnerlist-screen .partner-details-right{
-        width: auto;
-        float: none;
-        flex-grow: 1;
-    }
-    .pos .partnerlist-screen .partner-detail{
+    .partner-line-email {
+        order: 2;
         display: flex;
         flex-direction: column;
+        gap: 8px;
     }
-    .pos .partnerlist-screen .partner-details input,
-    .pos .partnerlist-screen .partner-details select
-    {
-        width: 100%;
+    .edit-partner-button-cell {
+        order: 3;
+        margin-top: 10px;
     }
-    .pos .partnerlist-screen .partner-details input.partner-name {
-        width: 100%;
+    .partner-list-contents {
+        margin-top: 10px;
     }
-    .pos .partnerlist-screen .partner-detail > .label{
-        width: auto;
-        text-align: left;
+
+    .partner-list td {
+        padding: 8px 0px !important;
     }
-    .pos .partnerlist-screen .partner-list td {
-        overflow: hidden;
-        white-space: nowrap;
+
+    .partner-line-last-column-placeholder {
+        display: none;
     }
+    
 }
-
-
-
-
 
 /*  ********* The OrderWidget  ********* */
 

--- a/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerLine.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerLine.xml
@@ -16,10 +16,10 @@
                     <span> unselect </span>
                 </div>
             </td>
-            <td t-if="!env.isMobile">
+            <td>
                 <t t-esc="props.partner.address" />
             </td>
-            <td class="partner-line-email" t-if="!env.isMobile">
+            <td class="partner-line-email">
                 <div t-if="props.partner.phone">
                     <i class="fa fa-fw fa-phone"/><t t-esc="props.partner.phone"/>
                 </div>
@@ -29,10 +29,6 @@
                 <div t-if="props.partner.email" class="email-field">
                     <i class="fa fa-fw fa-paper-plane-o"/><t t-esc="props.partner.email" />
                 </div>
-            </td>
-            <td t-if="env.isMobile">
-                <t t-esc="props.partner.zip or ''" />
-                <span t-if="highlight"><br/></span>
             </td>
             <td class="partner-line-balance" t-if="props.isBalanceDisplayed"></td>
             <td class="edit-partner-button-cell">


### PR DESCRIPTION
Prior to this commit, data in the customer list of the POS were partially omitted or lost outside of the screen if the resolution was under 768px and/or in portrait mode.

Now, when the screen is under 768px, each data/values in each column for each row are stacked on top of each other.

Task-3223287
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
