### PR TITLE
[IMP] l10n_it_edi: DatiFattureCollegate, down payment and credit notes

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -148,9 +148,17 @@
                 </DatiBollo>
                 <ImportoTotaleDocumento t-esc="format_monetary(document_total, currency)"/>
             </DatiGeneraliDocumento>
-            <DatiOrdineAcquisto t-if="record.ref">
+            <DatiOrdineAcquisto t-if="record.ref and not record.reversed_entry_id">
                 <IdDocumento t-esc="format_alphanumeric(record.ref[:20])"/>
             </DatiOrdineAcquisto>
+            <DatiFattureCollegate t-if="record.reversed_entry_id">
+                <IdDocumento t-esc="format_alphanumeric(record.reversed_entry_id.name[-20:])"/>
+                <Data t-if="record.reversed_entry_id.date" t-esc="format_date(record.reversed_entry_id.date)"/>
+            </DatiFattureCollegate>
+            <DatiFattureCollegate t-foreach="downpayment_moves" t-as="downpayment_move">
+                <IdDocumento t-esc="format_alphanumeric(downpayment_move.name[-20:])"/>
+                <Data t-if="downpayment_move.date" t-esc="format_date(downpayment_move.date)"/>
+            </DatiFattureCollegate>
             <DatiDDT t-if="record.l10n_it_ddt_id">
                 <NumeroDDT t-esc="format_alphanumeric(record.l10n_it_ddt_id.name[-20:])"/>
                 <DataDDT t-esc="format_date(record.l10n_it_ddt_id.date)"/>

--- a/addons/l10n_it_edi_sdicoop/tests/test_edi_reverse_charge_xml.py
+++ b/addons/l10n_it_edi_sdicoop/tests/test_edi_reverse_charge_xml.py
@@ -212,8 +212,21 @@ class TestItEdiReverseCharge(TestItEdi):
                 "//DatiPagamento/DettaglioPagamento/DataScadenzaPagamento": "<DataScadenzaPagamento/>",
             },
             xpaths_file={
-                "//DatiGeneraliDocumento/Numero": "<Numero/>",
-                "//DatiGeneraliDocumento/ImportoTotaleDocumento": "<ImportoTotaleDocumento>-1808.91</ImportoTotaleDocumento>",
+                "//DatiGenerali": f"""
+                    <DatiGenerali>
+                        <DatiGeneraliDocumento>
+                            <TipoDocumento>TD18</TipoDocumento>
+                            <Divisa>EUR</Divisa>
+                            <Data>2022-03-24</Data>
+                            <Numero/>
+                            <ImportoTotaleDocumento>-1808.91</ImportoTotaleDocumento>
+                        </DatiGeneraliDocumento>
+                        <DatiFattureCollegate>
+                            <IdDocumento>{self.reverse_charge_bill.name}</IdDocumento>
+                            <Data>{self.reverse_charge_bill.invoice_date}</Data>
+                        </DatiFattureCollegate>
+                    </DatiGenerali>
+                """,
                 "//DatiPagamento/DettaglioPagamento/DataScadenzaPagamento": "<DataScadenzaPagamento/>",
                 "(//DettaglioLinee/PrezzoUnitario)[1]": "<PrezzoUnitario>-800.400000</PrezzoUnitario>",
                 "(//DettaglioLinee/PrezzoUnitario)[2]": "<PrezzoUnitario>-800.400000</PrezzoUnitario>",


### PR DESCRIPTION
If the invoice has a deduction line for a down payment, the EDI generated XML file should have a reference to it in the DatiFattureCollegate. We take the reference from the related sales order.

Same goes for credit notes: they should have a reference to the original invoice. We take the reference from the move's `reversed_entry_id` field

Task link: https://www.odoo.com/web#id=3210485&model=project.task
Task-3210485

![image](https://user-images.githubusercontent.com/1665365/224184265-489089a7-91f1-4f43-b50a-581a6795bcee.png)