### PR TITLE
[FIX] calendar: take user default when computing `end` of an event

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -130,7 +130,8 @@ class Meeting(models.Model):
         'Start', required=True, tracking=True, default=fields.Date.today,
         help="Start date of an event, without time for full days events")
     stop = fields.Datetime(
-        'Stop', required=True, tracking=True, default=lambda self: fields.Datetime.today() + timedelta(hours=1),
+        'Stop', required=True, tracking=True,
+        default=lambda self: fields.Datetime.today() + timedelta(hours=self.default_get(['duration']).get('duration', 1)),
         compute='_compute_stop', readonly=False, store=True,
         help="Stop date of an event, without time for full days events")
     display_time = fields.Char('Event Time', compute='_compute_display_time')


### PR DESCRIPTION
## Current behaviour
If the user set a user default for the duration of calendar event to 30min. When creating a new event, the end time that is computed is always start + 1h. It doesn't take the set default duration by the user.

## Expected behaviour
The user set defaults should be taken into account when calculating the end time of an event.

## Steps to reproduce
- Install Calendar
- Activate Developer Mode
- Add a User Default for "duration (calendar.event)" of 0.5 (so it's 30min)
- In Calendar, create a new event, see that the duration is 1h after start, ignoring the duration of 30min.

## Reason for the problem
There is a default of end field that is today + timedelta(hours=1)

## Fix
Remove that default, so the `_compute_dates` can be triggered and correctly calculate the end date, taking into consideration the duration.

## Affected versions
- 15.0
- saas-15.2
- 16.0
- saas-16.1
- master
---
opw-3186435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
