### PR TITLE
[FIX] base: validation for size in char fields

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -28562,6 +28562,13 @@ msgid "Translatable"
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/ir_model.py:0
+#, python-format
+msgid "Translatable field cannot have a size"
+msgstr ""
+
+#. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_model_fields_search
 msgid "Translate"
 msgstr ""

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -583,6 +583,12 @@ class IrModelFields(models.Model):
                 msg = _("Field names can only contain characters, digits and underscores (up to 63).")
                 raise ValidationError(msg)
 
+    @api.constrains('size', 'translate')
+    def _check_size(self):
+        for rec in self:
+            if rec.ttype == 'char' and rec.translate and rec.size > 0:
+                raise ValidationError(_("Translatable field cannot have a size"))
+
     _sql_constraints = [
         ('name_unique', 'UNIQUE(model, name)', "Field names must be unique per model."),
         ('size_gt_zero', 'CHECK (size>=0)', 'Size of the field cannot be negative.'),


### PR DESCRIPTION
This issue was caught in Sentry.
When Translatable attribute is enabled for Char fields and if we set Size attribute to greater than 0 it will raise Error.

![image](https://user-images.githubusercontent.com/121081841/224320752-4d73c2ba-e205-406e-9485-6a6f0471673b.png)


sentry-3983578232



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
