### PR TITLE
[IMP] TimeOff-Calendar : Working hours appear in Calendar app

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -290,7 +290,7 @@ class Meeting(models.Model):
         for event in self:
             event.user_can_edit = self.env.user in event.partner_ids.user_ids + event.user_id
 
-    @api.depends('attendee_ids')
+    @api.depends('partner_ids')
     def _compute_invalid_email_partner_ids(self):
         for event in self:
             event.invalid_email_partner_ids = event.partner_ids.filtered(

--- a/addons/calendar/static/src/views/fields/attendee_tags_list.xml
+++ b/addons/calendar/static/src/views/fields/attendee_tags_list.xml
@@ -15,6 +15,12 @@
             </div>
         </xpath>
 
+        <xpath expr="//div[hasclass('o_tag_badge_text')]" position="after">
+            <div t-if="tag.noEmail" title="no email" class="ms-1">
+                <i class="fa fa-exclamation-triangle position-relative" role="img"/>
+            </div>
+        </xpath>
+
         <xpath expr="//span[hasclass('o_m2m_avatar_empty')]" position="attributes">
             <attribute name="class" remove="text-center" separator=" "/>
         </xpath>

--- a/addons/calendar/static/src/views/fields/many2many_attendee.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.js
@@ -1,5 +1,3 @@
-/** @odoo-module **/
-
 import { registry } from "@web/core/registry";
 import {
     Many2ManyTagsAvatarField,
@@ -36,11 +34,18 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
 
     get tags() {
         const partnerIds = this.specialData.data;
+        const noEmailPartnerIds = this.props.record.data.invalid_email_partner_ids
+            ? this.props.record.data.invalid_email_partner_ids.records
+            : [];
         const tags = super.tags.map((tag) => {
             const partner = partnerIds.find((partner) => tag.resId === partner.id);
+            const noEmail = noEmailPartnerIds.find((partner) => (tag.resId == partner.resId));
             if (partner) {
                 tag.status = partner.status;
                 tag.statusIcon = ICON_BY_STATUS[partner.status];
+            }
+            if (noEmail) {
+                tag.noEmail = true;
             }
             return tag;
         });

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -116,6 +116,8 @@
                     <field name="res_id" invisible="1" />
                     <field name="active" invisible="1"/>
                     <field name="user_can_edit" invisible="1"/>
+                    <field name="invalid_email_partner_ids" invisible="1"/> <!-- this field will be used in
+                        many2many_attendees widget -->
                     <div class="oe_title mb-3">
                         <div>
                             <label for="name"/>
@@ -239,10 +241,6 @@
                                     readonly="not user_can_edit"
                                 />
                             </div>
-                            <div class="alert alert-warning o_form_header mt-2" colspan="2" invisible="not invalid_email_partner_ids" role="status">
-                                <p><strong>The following attendees have invalid email addresses and won't receive any email notifications:</strong></p>
-                                <field name="invalid_email_partner_ids" widget="many2manyattendee" class="oe_inline"/>
-                            </div>
                         </group>
                     </group>
                     <notebook>
@@ -298,6 +296,8 @@
                     <field name="recurrence_update" invisible="1"/>
                     <field name="videocall_source" invisible="1"/>
                     <field name="access_token" invisible="1"/>
+                    <field name="invalid_email_partner_ids" invisible="1"/> <!-- this field will be used in
+                        many2many_attendees widget -->
                     <div class="o_row">
                         <h1 class="w-100"><field name="name" nolabel="1" placeholder="Add title" colspan="2"/></h1>
                     </div>

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -306,9 +306,12 @@ class HrEmployeeBase(models.AbstractModel):
         return working_now
 
     def _get_calendar_periods(self, start, stop):
-        # This method can be overridden in other modules where it's possible
-        # to have different resource calendars for an employee depending on the
-        # date.
+        """
+        :param datetime start: the start of the period
+        :param datetime stop: the stop of the period
+        This method can be overridden in other modules where it's possible to have different resource calendars for an
+        employee depending on the date.
+        """
         calendar_periods_by_employee = {}
         for employee in self:
             calendar = employee.resource_calendar_id or employee.company_id.resource_calendar_id

--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -12,7 +12,7 @@ class Partner(models.Model):
 
     def _compute_employees_count(self):
         for partner in self:
-            partner.employees_count = len(partner.employee_ids.filtered(lambda e: e.company_id in self.env.companies))
+            partner.employees_count = len(partner.sudo().employee_ids.filtered(lambda e: e.company_id in self.env.companies))
 
     def action_open_employees(self):
         self.ensure_one()

--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models, _
 
 

--- a/addons/hr_calendar/__init__.py
+++ b/addons/hr_calendar/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/hr_calendar/__manifest__.py
+++ b/addons/hr_calendar/__manifest__.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Display Working Hours in Calendar",
+    'version': '1.0',
+    'category': 'Human Resources/Employees',
+    'depends': ['hr', 'calendar'],
+    'auto_install': True,
+    'data': [
+        'views/calendar_views_calendarApp.xml'
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'hr_calendar/static/src/**/*',
+        ],
+        'web.qunit_suite_tests': [
+            'hr_calendar/static/tests/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/hr_calendar/models/__init__.py
+++ b/addons/hr_calendar/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import calendar_event
+from . import res_partner

--- a/addons/hr_calendar/models/calendar_event.py
+++ b/addons/hr_calendar/models/calendar_event.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from pytz import UTC
+
+from odoo import api, fields, models
+
+from odoo.addons.resource.models.utils import Intervals, sum_intervals, timezone_datetime
+
+
+class CalendarEvent(models.Model):
+    _inherit = "calendar.event"
+
+    unavailable_partner_ids = fields.Many2many('res.partner', compute='_compute_unavailable_partner_ids')
+
+    @api.depends('partner_ids', 'start', 'stop', 'allday')
+    def _compute_unavailable_partner_ids(self):
+        event_intervals = self._get_events_interval()
+
+        # Event without start and stop are skipped, except all day event: their interval is computed
+        # based on company calendar's interval.
+        for event, event_interval in event_intervals.items():
+            start = event_interval._items[0][0]
+            stop = event_interval._items[0][1]
+            if not event.partner_ids:
+                event.unavailable_partner_ids = []
+                continue
+            schedule_by_partner = event.partner_ids._get_schedule(start, stop, merge=False)
+            event.unavailable_partner_ids = event._check_employees_availability_for_event(
+                schedule_by_partner, event_interval)
+
+    @api.model
+    def get_unusual_days(self, date_from, date_to=None):
+        return self.env.user.employee_id._get_unusual_days(date_from, date_to)
+
+    def _get_events_interval(self):
+        """
+        Calculate the interval of an event based on its start, stop, and allday values. If an event is scheduled for the
+        entire day, its interval will correspond to the work interval defined by the company's calendar.
+        """
+        start = min(self.mapped('start')).replace(hour=0, minute=0, second=0, tzinfo=UTC)
+        stop = max(self.mapped('stop')).replace(hour=23, minute=59, second=59, tzinfo=UTC)
+        if not start or not stop:
+            return {}
+        company_calendar = self.env.company.resource_calendar_id
+        global_interval = company_calendar._work_intervals_batch(start, stop)[False]
+        interval_by_event = {}
+        for event in self:
+            event_interval = Intervals([(
+                timezone_datetime(event.start),
+                timezone_datetime(event.stop),
+                self.env['resource.calendar']
+            )])
+            if event.allday:
+                interval_by_event[event] = event_interval & global_interval
+            elif event.start and event.stop:
+                interval_by_event[event] = event_interval
+        return interval_by_event
+
+    def _check_employees_availability_for_event(self, schedule_by_partner, event_interval):
+        unavailable_partners = []
+        for partner, schedule in schedule_by_partner.items():
+            common_interval = schedule & event_interval
+            if sum_intervals(common_interval) != sum_intervals(event_interval):
+                unavailable_partners.append(partner.id)
+        return unavailable_partners

--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -1,0 +1,113 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from pytz import UTC, timezone
+from datetime import datetime
+from collections import defaultdict
+from functools import reduce
+
+from odoo import api, models
+
+from odoo.osv import expression
+from odoo.addons.resource.models.utils import Intervals
+
+
+class Partner(models.Model):
+    _inherit = ['res.partner']
+
+    def _get_employees_from_attendees(self, everybody=False):
+        domain = [
+            ('company_id', 'in', self.env.companies.ids),
+            ('work_contact_id', '!=', False),
+        ]
+        if not everybody:
+            domain = expression.AND([
+                domain,
+                [('work_contact_id', 'in', self.ids)]
+            ])
+        return dict(self.env['hr.employee'].sudo()._read_group(domain, groupby=['work_contact_id'], aggregates=['id:recordset']))
+
+    def _get_schedule(self, start_period, stop_period, everybody=False, merge=True):
+        """
+        This method implements the general case where employees might have different resource calendars at different
+        times, even though this is not the case with only this module installed.
+        This way it will work with these other modules by just overriding
+        `_get_calendar_periods`.
+
+        :param datetime start_period: the start of the period
+        :param datetime stop_period: the stop of the period
+        :param boolean everybody: represents the "everybody" filter on calendar
+        :param boolean merge: specifies if calendar's work_intervals needs to be merged
+        :return: schedule (merged or not) by partner
+        :rtype: defaultdict
+        """
+        employees_by_partner = self._get_employees_from_attendees(everybody)
+        if not employees_by_partner:
+            return {}
+        interval_by_calendar = defaultdict()
+        calendar_periods_by_employee = defaultdict(list)
+        employees_by_calendar = defaultdict(list)
+
+        # Compute employee's calendars's period and order employee by his involved calendars
+        employees = sum(employees_by_partner.values(), start=self.env['hr.employee'])
+        calendar_periods_by_employee = employees._get_calendar_periods(start_period, stop_period)
+        for employee, calendar_periods in calendar_periods_by_employee.items():
+            for (start, stop, calendar) in calendar_periods:
+                employees_by_calendar[calendar].append(employee)
+
+        # Compute all work intervals per calendar
+        for calendar, employees in employees_by_calendar.items():
+            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=employees, tz=timezone(calendar.tz))
+            del work_intervals[False]
+            # Merge all employees intervals to avoid to compute it multiples times
+            if merge:
+                interval_by_calendar[calendar] = reduce(Intervals.__and__, work_intervals.values())
+            else:
+                interval_by_calendar[calendar] = work_intervals
+
+        # Compute employee's schedule based own his calendar's periods
+        schedule_by_employee = defaultdict(list)
+        for employee, calendar_periods in calendar_periods_by_employee.items():
+            employee_interval = Intervals([])
+            for (start, stop, calendar) in calendar_periods:
+                interval = Intervals([(start, stop, self.env['resource.calendar'])])
+                if merge:
+                    calendar_interval = interval_by_calendar[calendar]
+                else:
+                    calendar_interval = interval_by_calendar[calendar][employee.id]
+                employee_interval = employee_interval | (calendar_interval & interval)
+            schedule_by_employee[employee] = employee_interval
+
+        # Compute partner's schedule equals to the union between his employees's schedule
+        schedules = defaultdict()
+        for partner, employees in employees_by_partner.items():
+            partner_schedule = Intervals([])
+            for employee in employees:
+                if schedule_by_employee[employee]:
+                    partner_schedule = partner_schedule | schedule_by_employee[employee]
+            schedules[partner] = partner_schedule
+        return schedules
+
+    @api.model
+    def get_working_hours_for_all_attendees(self, attendee_ids, date_from, date_to, everybody=False):
+
+        start_period = datetime.fromisoformat(date_from).replace(hour=0, minute=0, second=0, tzinfo=UTC)
+        stop_period = datetime.fromisoformat(date_to).replace(hour=23, minute=59, second=59, tzinfo=UTC)
+
+        schedule_by_partner = self.env['res.partner'].browse(attendee_ids)._get_schedule(start_period, stop_period, everybody)
+        if not schedule_by_partner:
+            return []
+        return self._interval_to_business_hours(reduce(Intervals.__and__, schedule_by_partner.values()))
+
+    def _interval_to_business_hours(self, working_intervals):
+        # This is the format expected by the fullcalendar library to do the overlay
+        return [{
+            "daysOfWeek": [interval[0].weekday() + 1],
+            "startTime":  interval[0].astimezone(timezone(self.env.user.tz)).strftime("%H:%M"),
+            "endTime": interval[1].astimezone(timezone(self.env.user.tz)).strftime("%H:%M"),
+        } for interval in working_intervals] if working_intervals else [{
+            # 7 is used a dummy value to gray the full week
+            # Returning an empty list would leave the week uncolored
+            "daysOfWeek": [7],
+            "startTime":  datetime.today().strftime("00:00"),
+            "endTime": datetime.today().strftime("00:00"),
+        }]

--- a/addons/hr_calendar/static/src/calendar/calendar_model.js
+++ b/addons/hr_calendar/static/src/calendar/calendar_model.js
@@ -1,0 +1,36 @@
+import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attendee_calendar_model";
+import { serializeDate } from "@web/core/l10n/dates";
+import { patch } from "@web/core/utils/patch";
+
+patch(AttendeeCalendarModel.prototype, {
+    setup() {
+        super.setup(...arguments)
+        this.data.workingHours = {};
+    },
+
+    get workingHours() {
+        return this.data.workingHours;
+    },
+
+    async updateData(data) {
+        await super.updateData(...arguments)
+        data.workingHours = await this.fetchWorkingHours(data);
+    },
+
+    async fetchWorkingHours(data){
+        if (this.meta.scale !== "day" && this.meta.scale !== "week"){
+            return [];
+        }
+        const attendeeFilters = data.filterSections.partner_ids;
+        const activeAttendeeIds = attendeeFilters.filters
+            .filter((filter) => filter.type !== "all" && filter.value && filter.active)
+            .map((filter) => filter.value);
+        const allFilter = attendeeFilters.filters.find((filter) => filter.type === "all");
+        return this.orm.call("res.partner", "get_working_hours_for_all_attendees", [
+            activeAttendeeIds,
+            serializeDate(data.range.start),
+            serializeDate(data.range.end),
+            allFilter?.active
+        ]);
+    },
+});

--- a/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -1,0 +1,17 @@
+import { AttendeeCalendarCommonRenderer } from "@calendar/views/attendee_calendar/common/attendee_calendar_common_renderer";
+import { patch } from "@web/core/utils/patch";
+import { onWillUpdateProps } from "@odoo/owl";
+
+patch(AttendeeCalendarCommonRenderer.prototype, {
+	setup() {
+		super.setup(...arguments);
+		onWillUpdateProps(() => {
+			this.fc.api.setOption("businessHours", this.props.model.workingHours)
+		});
+	},
+	get options() {
+		return Object.assign(super.options, {
+			businessHours: this.props.model.workingHours,
+		});
+	},
+});

--- a/addons/hr_calendar/static/src/views/fields/attendee_tags_list.xml
+++ b/addons/hr_calendar/static/src/views/fields/attendee_tags_list.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="hr_calendar.AttendeeTagsList" t-inherit="calendar.AttendeeTagsList" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('o_tag_badge_text')]" position="after">
+            <div t-if="tag.unavailableIcon" title="unavailable" class="ms-1">
+                <i class="fa fa-moon-o position-relative" role="img"/>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/hr_calendar/static/src/views/fields/many2many_attendees.js
+++ b/addons/hr_calendar/static/src/views/fields/many2many_attendees.js
@@ -1,0 +1,16 @@
+import { Many2ManyAttendee } from "@calendar/views/fields/many2many_attendee";
+import { patch } from "@web/core/utils/patch";
+patch(Many2ManyAttendee.prototype, {
+    get tags() {
+        const tags = super.tags;
+        if (this.props.record.data.unavailable_partner_ids) {
+            const unavailablePartnerIds = this.props.record.data.unavailable_partner_ids.records;
+            for (const tag of tags) {
+                if (unavailablePartnerIds.find((partner) => (tag.resId == partner.resId))) {
+                    tag.unavailableIcon = true;
+                }
+            }
+        }
+        return tags;
+    }
+})

--- a/addons/hr_calendar/static/tests/helpers/mock_server/mock_server.js
+++ b/addons/hr_calendar/static/tests/helpers/mock_server/mock_server.js
@@ -1,0 +1,11 @@
+import { patch } from "@web/core/utils/patch";
+import { MockServer } from "@web/../tests/helpers/mock_server";
+
+patch(MockServer.prototype, {
+    async _performRPC(route, args) {
+        if (args.method === "get_working_hours_for_all_attendees") {
+            return [];
+        }
+        return super._performRPC(route, args);
+    },
+});

--- a/addons/hr_calendar/tests/__init__.py
+++ b/addons/hr_calendar/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_working_hours

--- a/addons/hr_calendar/tests/common.py
+++ b/addons/hr_calendar/tests/common.py
@@ -1,0 +1,128 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+
+
+class TestHrCalendarCommon(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.tz = 'Europe/Brussels'
+
+        cls.company_A, cls.company_B = cls.env['res.company'].create([
+            {
+                'name': 'Test company A',
+            },
+            {
+                'name': 'Test company B',
+            },
+        ])
+        cls.env.user.company_id = cls.company_A
+
+        cls.calendar_35h, cls.calendar_28h, cls.calendar_35h_night = cls.env['resource.calendar'].create([
+            {
+                'tz': "Europe/Brussels",
+                'name': '35h calendar',
+                'hours_per_day': 7.0,
+                'attendance_ids': [
+                    (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Monday Evening', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                ],
+            },
+            {
+                'tz': "Europe/Brussels",
+                'name': '28h calendar',
+                'attendance_ids': [
+                    (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                ],
+            },
+            {
+                'tz': "Europe/Brussels",
+                'name': 'night calendar',
+                'attendance_ids': [
+                    (0, 0, {'name': 'Monday Evening', 'dayofweek': '0', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                ],
+            },
+        ])
+
+        cls.partnerA, cls.partnerB, cls.partnerC, cls.partnerD = cls.env['res.partner'].create([
+            {
+                'name': "Partner A",
+            },
+            {
+                'name': "Partner B",
+            },
+            {
+                'name': "Partner C",
+            },
+            {
+                'name': "Partner D",
+            },
+        ])
+
+        cls.employeeA, cls.employeeA_company_B, cls.employeeB, cls.employeeC, cls.employeeD = cls.env['hr.employee'].create([
+            {
+                'name': "Partner A - Company A - Calendar 35h",
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': cls.calendar_35h.id,
+                'work_contact_id': cls.partnerA.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner A - Company B - Calendar 28h",
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': cls.calendar_28h.id,
+                'work_contact_id': cls.partnerA.id,
+                'company_id': cls.company_B.id,
+            },
+            {
+                'name': "Partner B - Calendar 28h",
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': cls.calendar_28h.id,
+                'work_contact_id': cls.partnerB.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner C - Calendar 35h night",
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': cls.calendar_35h_night.id,
+                'work_contact_id': cls.partnerC.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner D - Calendar 35h No contract",
+                'tz': "Europe/Brussels",
+                'resource_calendar_id': cls.calendar_35h.id,
+                'work_contact_id': cls.partnerD.id,
+                'company_id': cls.company_A.id,
+            },
+        ])

--- a/addons/hr_calendar/tests/test_working_hours.py
+++ b/addons/hr_calendar/tests/test_working_hours.py
@@ -1,0 +1,236 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from datetime import datetime
+from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon
+
+
+@tagged('work_hours')
+class TestWorkingHours(TestHrCalendarCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if 'hr.contract' in cls.env:
+            cls.skipTest(cls,
+                "hr_contract module is installed. To test these features you need to install test_hr_contract_calendar")
+
+    def test_working_hours_2_emp_same_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_working_hours_2_emp_different_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # Nothing on monday due to partnerB's calendar : calendar_28h
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_working_hours_3_emp_different_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerB.id, self.partnerC.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # Nothing on monday due to partnerB's calendar : calendar_28h
+        # Nothing before 15:00 due to partnerC's calendar : calendar_35h_night
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '15:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '15:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '15:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '15:00', 'endTime': '16:00'}
+        ])
+
+    def test_working_hours_2_emp_same_calendar_hours_different_timezone(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+        calendar_35h_london_tz = self.calendar_35h.copy()
+        calendar_35h_london_tz.tz = 'Europe/London'
+        self.employeeD.resource_calendar_id = calendar_35h_london_tz
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        # calendar_35h_london_tz.tz = UTC, calendar_35h.tz = UTC +1
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [1], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [2], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '14:00', 'endTime': '16:00'},
+        ])
+
+    def test_multi_companies_2_employees_1_selected_company(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [ ] A
+        employee A company B ---> 28h               [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the 28h's schedule
+        """
+        self.env.user.company_id = self.company_B
+        self.env.user.company_ids = [self.company_B.id]
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_multi_companies_2_employees_2_selected_companies(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [X] A    <- main company
+        employee A company B ---> 28h               [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the 35h's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_multi_companies_2_employees_2_selected_companies_union_between_schedules(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [X] A    <- main company
+        employee A company B ---> 35h night         [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the union between 35h's and 35h night's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        self.employeeA_company_B.resource_calendar_id = self.calendar_35h_night
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
+        ])
+
+    def test_multi_companies_2_employees_1_partner_1_selected_companies(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee B1 company A ---> 28h               [X] A    <- main company
+        employee B2 company A ---> 35h night         [ ] B
+
+        OUTPUT:
+        =======
+        The schedule will be the union between 28h's and 35h night's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.env['hr.employee'].create({
+            'name': "Partner B2 - Calendar 35h night",
+            'tz': "Europe/Brussels",
+            'resource_calendar_id': self.calendar_35h_night.id,
+            'work_contact_id': self.partnerB.id,
+            'company_id': self.company_A.id,
+        })
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat(),
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '15:00', 'endTime': '22:00'},
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
+        ])

--- a/addons/hr_calendar/views/calendar_views_calendarApp.xml
+++ b/addons/hr_calendar/views/calendar_views_calendarApp.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo>
+    <record id="view_calendar_event_calendar" model="ir.ui.view">
+        <field name="name">view.calendar.event.calendar.inherit.calendar</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_calendar"/>
+        <field name="arch" type="xml">
+            <xpath expr="//calendar" position="attributes">
+                <attribute name="show_unusual_days">True</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_calendar_event_form_quick_create" model="ir.ui.view">
+        <field name="name">view.calendar.event.calendar.quick.create.inherit.calendar</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form_quick_create"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='stop']" position="after">
+                <field name="unavailable_partner_ids" invisible="1" /> <!-- this field will be used in
+                    many2many_attendees widget -->
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_calendar_event_form" model="ir.ui.view">
+        <field name="name">view.calendar.event.calendar.inherit.calendar</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='stop']" position="after">
+                <field name="unavailable_partner_ids" invisible="1" /> <!-- this field will be used in
+                    many2many_attendees widget -->
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -140,6 +140,10 @@ class Employee(models.Model):
         return res
 
     def _get_calendar_periods(self, start, stop):
+        """
+        :param datetime start: the start of the period
+        :param datetime stop: the stop of the period
+        """
         calendar_periods_by_employee = defaultdict(list)
         contracts_by_employee = self.env['hr.contract'].sudo()._read_group(domain=[
             '|',
@@ -157,12 +161,20 @@ class Employee(models.Model):
             for contract in contracts:
                 calendar_tz = timezone(contract.resource_calendar_id.tz)
                 utc = timezone('UTC')
-                date_start = datetime.combine(contract.date_start, time(0, 0, 0)).replace(tzinfo=calendar_tz).astimezone(utc)
+                date_start = datetime.combine(
+                    contract.date_start,
+                    time(0, 0, 0)
+                ).replace(tzinfo=calendar_tz).astimezone(utc)
                 if contract.date_end:
-                    date_end = datetime.combine(contract.date_end + relativedelta(days=1), time(0, 0, 0)).replace(tzinfo=calendar_tz).astimezone(utc)
+                    date_end = datetime.combine(
+                        contract.date_end + relativedelta(days=1),
+                        time(0, 0, 0)
+                    ).replace(tzinfo=calendar_tz).astimezone(utc)
                 else:
                     date_end = stop
-                calendar_periods_by_employee[employee].append((max(date_start, start), min(date_end, stop), contract.resource_calendar_id))
+                calendar_periods_by_employee[employee].append(
+                    (max(date_start, start), min(date_end, stop), contract.resource_calendar_id)
+                )
         return calendar_periods_by_employee
 
     @api.model

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -23,3 +23,4 @@ from . import test_past_accruals
 from . import test_allocations
 from . import test_multicompany
 from . import test_timeoff_event
+from . import test_working_hours

--- a/addons/hr_holidays/tests/test_working_hours.py
+++ b/addons/hr_holidays/tests/test_working_hours.py
@@ -1,0 +1,142 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from odoo.addons.hr_calendar.tests.common import TestHrCalendarCommon
+
+from odoo.tests import tagged
+
+
+@tagged('work_hours')
+class TestWorkingHours(TestHrCalendarCommon):
+    """ Test global leaves for a whole company, conflict resolutions """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if 'hr.contract' in cls.env:
+            cls.skipTest(cls,
+                "hr_contract module is installed. To test these features you need to install hr_holidays_contract"
+            )
+
+        cls.leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Unpaid Time Off',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'no_validation',
+        })
+
+    def test_multi_companies_2_employees_2_selected_companies_holidays(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [X] A    <- main company
+        employee A company B ---> 28h               [X] B
+        employee A company A take a day off for monday and tuesday.
+        OUTPUT:
+        =======
+        The schedule will be : off on monday, following 28h schedule on tuesday and the union for the rest of the week.
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        self.env['hr.leave'].create({
+            'name': 'holiday from monday to tuesday',
+            'employee_id': self.employeeA.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': datetime(2023, 12, 25),
+            'request_date_to': datetime(2023, 12, 26, 23, 59, 59),
+        })
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_multi_companies_2_employees_2_selected_companies_company_holidays(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [X] A    <- main company
+        employee A company B ---> 28h               [X] B
+        Company A give a day off for everyone on monday and tuesday.
+        OUTPUT:
+        =======
+        The schedule will be : off on monday, following 28h schedule on tuesday and the union for the rest of the week.
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        self.env['hr.leave'].create({
+            'name': 'holiday from monday to tuesday',
+            'holiday_type': 'company',
+            'mode_company_id': self.company_A.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': datetime(2023, 12, 25),
+            'request_date_to': datetime(2023, 12, 26, 23, 59, 59),
+        })
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_multi_companies_2_employees_2_selected_companies_global_holidays(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee A company A ---> 35h               [X] A    <- main company
+        employee A company B ---> 28h               [X] B
+        Global leave for calendar 35h on monday and tuesday.
+        OUTPUT:
+        =======
+        The schedule will be : off on monday, following 28h schedule on tuesday and the union for the rest of the week.
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        self.env['resource.calendar.leaves'].create({
+            'name': 'Global Time Off',
+            'date_from': datetime(2023, 12, 25),
+            'date_to': datetime(2023, 12, 26, 23, 59, 59),
+            'calendar_id': self.calendar_35h.id,
+        })
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])

--- a/addons/test_hr_contract_calendar/__init__.py
+++ b/addons/test_hr_contract_calendar/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/test_hr_contract_calendar/__manifest__.py
+++ b/addons/test_hr_contract_calendar/__manifest__.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Bridge module calendar, contract",
+    'version': '1.0',
+    'category': 'Human Resources/Employees',
+    'summary': "display working hours from employee's contracts",
+    'depends': ['hr_contract', 'hr_calendar'],
+    'license': 'LGPL-3',
+}

--- a/addons/test_hr_contract_calendar/tests/__init__.py
+++ b/addons/test_hr_contract_calendar/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_working_hours

--- a/addons/test_hr_contract_calendar/tests/common.py
+++ b/addons/test_hr_contract_calendar/tests/common.py
@@ -1,0 +1,181 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import common
+from datetime import datetime
+
+
+class TestHrContractCalendarCommon(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.user.tz = 'Europe/Brussels'
+
+        cls.company_A, cls.company_B = cls.env['res.company'].create([
+            {
+                'name': 'Test company A',
+            },
+            {
+                'name': 'Test company B',
+            },
+        ])
+        cls.env.user.company_id = cls.company_A
+        cls.calendar_35h, cls.calendar_28h, cls.calendar_35h_night = cls.env['resource.calendar'].create([
+            {
+                'tz': "Europe/Brussels",
+                'name': '35h calendar',
+                'hours_per_day': 7.0,
+                'attendance_ids': [
+                    (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Monday Evening', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                ],
+            },
+            {
+                'tz': "Europe/Brussels",
+                'name': '28h calendar',
+                'attendance_ids': [
+                    (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                    (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'}),
+                ],
+            },
+            {
+                'tz': "Europe/Brussels",
+                'name': 'night calendar',
+                'attendance_ids': [
+                    (0, 0, {'name': 'Monday Evening', 'dayofweek': '0', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Tuesday Evening', 'dayofweek': '1', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Wednesday Evening', 'dayofweek': '2', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Thursday Evening', 'dayofweek': '3', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                    (0, 0, {'name': 'Friday Evening', 'dayofweek': '4', 'hour_from': 15, 'hour_to': 22, 'day_period': 'afternoon'}),
+                ],
+            },
+        ])
+        cls.partnerA, cls.partnerB, cls.partnerC, cls.partnerD, cls.partnerE = cls.env['res.partner'].create([
+            {
+                'name': "Partner A",
+            },
+            {
+                'name': "Partner B",
+            },
+            {
+                'name': "Partner C",
+            },
+            {
+                'name': "Partner D",
+            },
+            {
+                'name': "Partner E",
+            },
+        ])
+
+        cls.employeeA, cls.employeeB, cls.employeeB_company_B,\
+        cls.employeeC, cls.employeeD, cls.employeeE = cls.env['hr.employee'].create([
+            {
+                'name': "Partner A - Calendar 35h",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerA.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner B - Company A - Calendar 28h",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerB.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner B - Company B - Calendar 35h night",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerB.id,
+                'company_id': cls.company_B.id,
+            },
+            {
+                'name': "Partner C - Calendar 35h night",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerC.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner D - Calendar 35h",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerD.id,
+                'company_id': cls.company_A.id,
+            },
+            {
+                'name': "Partner E - No calendar",
+                'tz': "Europe/Brussels",
+                'work_contact_id': cls.partnerE.id,
+                'company_id': cls.company_A.id,
+            },
+        ])
+        cls.contractA, cls.contractB, cls.contractB_company_B,\
+        cls.contractC, cls.contractD = cls.env['hr.contract'].create([
+            {
+                'date_start': datetime(2023, 12, 1),
+                'name': 'Contract Employee A start december',
+                'resource_calendar_id': cls.calendar_35h.id,
+                'wage': 5000.0,
+                'employee_id': cls.employeeA.id,
+                'state': 'close',
+                'company_id': cls.company_A.id,
+            },
+            {
+                'date_start': datetime(2023, 12, 1),
+                'date_end': datetime(2024, 3, 5),
+                'name': 'Contract Employee B start december end february',
+                'resource_calendar_id': cls.calendar_28h.id,
+                'wage': 5000.0,
+                'employee_id': cls.employeeB.id,
+                'state': 'close',
+                'company_id': cls.company_A.id,
+            },
+            {
+                'date_start': datetime(2023, 12, 1),
+                'name': 'Contract Employee A start december',
+                'resource_calendar_id': cls.calendar_35h_night.id,
+                'wage': 5000.0,
+                'employee_id': cls.employeeB_company_B.id,
+                'state': 'close',
+                'company_id': cls.company_B.id,
+            },
+            {
+                'date_start': datetime(2023, 12, 28),
+                'name': 'Contract Employee C start december',
+                'resource_calendar_id': cls.calendar_35h_night.id,
+                'wage': 5000.0,
+                'employee_id': cls.employeeC.id,
+                'state': 'close',
+                'company_id': cls.company_A.id,
+            },
+            {
+                'date_start': datetime(2023, 12, 1),
+                'name': 'Contract Employee D start december',
+                'resource_calendar_id': cls.calendar_35h.id,
+                'wage': 5000.0,
+                'employee_id': cls.employeeD.id,
+                'state': 'close',
+                'company_id': cls.company_A.id,
+            },
+        ])

--- a/addons/test_hr_contract_calendar/tests/test_working_hours.py
+++ b/addons/test_hr_contract_calendar/tests/test_working_hours.py
@@ -1,0 +1,190 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import tagged
+from datetime import datetime
+from odoo.addons.test_hr_contract_calendar.tests.common import TestHrContractCalendarCommon
+
+
+@tagged('work_hours')
+class TestWorkingHours(TestHrContractCalendarCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_working_hours_2_emp_same_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [1], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_working_hours_2_emp_contract_start(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.contractB.date_start = datetime(2023, 12, 28)
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        # Nothing on monday, tuesday and wednesday due to contractB. (start : thursday 2023/12/28)
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_working_hours_2_emp_contract_stop(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        self.contractB.date_end = datetime(2023, 12, 28)
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        # Nothing on monday due to calendarB.
+        # Nothing on Friday due to contractB (stop : thursday 2023/12/28)
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_working_hours_3_emp_different_calendar(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerB.id, self.partnerC.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        # Nothing on monday due to partnerB's calendar : calendar_2
+        # Nothing before 15:00 due to partnerC's calendar : calendar_3
+        # Nothing on tuesday and wednesday due to contractC. (start : thursday 2023/12/28)
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [4], 'startTime': '15:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '15:00', 'endTime': '16:00'},
+        ])
+
+    def test_working_hours_2_emp_same_calendar_different_timezone(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        calendar_35h_london_tz = self.calendar_35h.copy()
+        calendar_35h_london_tz.tz = 'Europe/London'
+        self.contractD.resource_calendar_id = calendar_35h_london_tz
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerD.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        # calendar_35h_london_tz.tz = UTC, calendar_35h.tz = UTC +1
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [1], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [2], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [3], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [4], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '14:00', 'endTime': '16:00'},
+            {'daysOfWeek': [5], 'startTime': '09:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '14:00', 'endTime': '16:00'}
+        ])
+
+    def test_working_hours_with_employee_without_contract(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id, self.partnerE.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        # Employee E doesn't have a contract
+        self.assertEqual(work_hours, [{'daysOfWeek': [7], 'startTime': '00:00', 'endTime': '00:00'}])
+
+    def test_working_hours_one_employee_with_two_contracts(self):
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id]
+
+        # Contract from november
+        self.env['hr.contract'].create({
+            'date_start': datetime(2023, 11, 1),
+            'date_end': datetime(2023, 11, 30),
+            'name': 'Contract november',
+            'resource_calendar_id': self.calendar_35h_night.id,
+            'wage': 5000.0,
+            'employee_id': self.employeeA.id,
+            'state': 'close',
+        })
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerA.id],
+            datetime(2023, 11, 27).isoformat(),
+            datetime(2023, 12, 3).isoformat()
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '15:00', 'endTime': '22:00'},
+            {'daysOfWeek': [2], 'startTime': '15:00', 'endTime': '22:00'},
+            {'daysOfWeek': [3], 'startTime': '15:00', 'endTime': '22:00'},
+            {'daysOfWeek': [4], 'startTime': '15:00', 'endTime': '22:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '16:00'},
+        ])
+
+    def test_multi_companies_2_employees_2_selected_companies(self):
+        """
+        INPUT:
+        ======
+        Employees                                   Companies
+        employee B1 company A ---> 28h               [X] A    <- main company
+        employee B2 company A ---> 35h night         [X] B
+
+        OUTPUT:
+        =======
+        The schedule will be the union between 28h's and 35h night's schedule
+        """
+        self.env.user.company_id = self.company_A
+        self.env.user.company_ids = [self.company_A.id, self.company_B.id]
+
+        # to check if the resource calendar on the contract takes priority
+        self.employeeB.resource_calendar_id = self.calendar_35h.id
+
+        work_hours = self.env['res.partner'].get_working_hours_for_all_attendees(
+            [self.partnerB.id],
+            datetime(2023, 12, 25).isoformat(),
+            datetime(2023, 12, 31).isoformat()
+        )
+        self.assertEqual(work_hours, [
+            {'daysOfWeek': [1], 'startTime': '15:00', 'endTime': '22:00'},
+            {'daysOfWeek': [2], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [2], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [3], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [3], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [4], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [4], 'startTime': '13:00', 'endTime': '22:00'},
+            {'daysOfWeek': [5], 'startTime': '08:00', 'endTime': '12:00'},
+            {'daysOfWeek': [5], 'startTime': '13:00', 'endTime': '22:00'},
+        ])


### PR DESCRIPTION
Before, working hours don't appear in Candar app
if in Calendar app, you load the calendar of someone else, their working hours will appear. In calendar when you see your calendar, the working hours don't appear If you selected more than one calendar, the working hours displayed is the intersection of all working hours

task : [Time Off - Calendar] Working Hours 3169246

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
