### PR TITLE
[FIX] web_editor: history manipulations should be reversible

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -499,8 +499,8 @@ export class OdooEditor extends EventTarget {
      *              node from its oid.
      * @returns {Node}
      */
-    unserializeNode(node, idToNodeMap) {
-        return unserializeNode(node, idToNodeMap);
+    unserializeNode(node, idToNodeMap, store) {
+        return unserializeNode(node, idToNodeMap, store);
     }
 
     automaticStepActive(label) {
@@ -561,7 +561,7 @@ export class OdooEditor extends EventTarget {
         // Map to reference nodes existing in the previous registered state
         // of the editable.
         const idToNodeMap = new Map();
-        this.unserializeNode(this._serializedEditable, idToNodeMap);
+        this.unserializeNode(this._serializedEditable, idToNodeMap, true);
         this.idSet(this.editable);
         // Map<parent.oid, Set<childNode>> used to register mutations that add
         // a child node to a parent. If a parent is added, then a child is added
@@ -906,7 +906,7 @@ export class OdooEditor extends EventTarget {
                     toremove.remove();
                 }
             } else if (record.type === 'add') {
-                let node = this.unserializeNode(record.node);
+                let node = this.unserializeNode(record.node, this._idToNodeMap);
                 if (this._collabClientId) {
                     const fakeNode = document.createElement('fake-el');
                     fakeNode.appendChild(node);
@@ -1050,7 +1050,7 @@ export class OdooEditor extends EventTarget {
                     break;
                 }
                 case 'remove': {
-                    let nodeToRemove = this.unserializeNode(mutation.node);
+                    let nodeToRemove = this.unserializeNode(mutation.node, this._idToNodeMap);
                     if (this._collabClientId) {
                         const fakeNode = document.createElement('fake-el');
                         fakeNode.appendChild(nodeToRemove);

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -477,11 +477,11 @@ export class OdooEditor extends EventTarget {
     }
 
     serializeNode(node, mutatedNodes) {
-        return this._collabClientId ? serializeNode(node, mutatedNodes) : node;
+        return serializeNode(node, mutatedNodes);
     }
 
     unserializeNode(node) {
-        return this._collabClientId ? unserializeNode(node) : node;
+        return unserializeNode(node);
     }
 
     automaticStepActive(label) {
@@ -822,7 +822,7 @@ export class OdooEditor extends EventTarget {
                     toremove.remove();
                 }
             } else if (record.type === 'add') {
-                let node = this.idFind(record.oid) || this.unserializeNode(record.node);
+                let node = this.unserializeNode(record.node);
                 if (this._collabClientId) {
                     const fakeNode = document.createElement('fake-el');
                     fakeNode.appendChild(node);
@@ -966,9 +966,8 @@ export class OdooEditor extends EventTarget {
                     break;
                 }
                 case 'remove': {
-                    let nodeToRemove = this.idFind(mutation.id);
-                    if (!nodeToRemove) {
-                        nodeToRemove = this.unserializeNode(mutation.node);
+                    let nodeToRemove = this.unserializeNode(mutation.node);
+                    if (this._collabClientId) {
                         const fakeNode = document.createElement('fake-el');
                         fakeNode.appendChild(nodeToRemove);
                         DOMPurify.sanitize(fakeNode, { IN_PLACE: true });
@@ -976,8 +975,8 @@ export class OdooEditor extends EventTarget {
                         if (!nodeToRemove) {
                             continue;
                         }
-                        this.idSet(nodeToRemove);
                     }
+                    this.idSet(nodeToRemove);
                     if (mutation.nextId && this.idFind(mutation.nextId)) {
                         const node = this.idFind(mutation.nextId);
                         node && node.before(nodeToRemove);

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/serialize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/serialize.js
@@ -28,7 +28,13 @@ export function serializeNode(node, nodesToStripFromChildren = new Set()) {
     return result;
 }
 
-export function unserializeNode(obj) {
+/**
+ * @param {Object} node Serialized node.
+ * @param {Map} idToNodeMap optional - Map to reference every unserialized
+ *              node from its oid.
+ * @returns {Node}
+ */
+export function unserializeNode(obj, idToNodeMap) {
     let result = undefined;
     if (obj.nodeType === Node.TEXT_NODE) {
         result = document.createTextNode(obj.textValue);
@@ -37,11 +43,14 @@ export function unserializeNode(obj) {
         for (const key in obj.attributes) {
             result.setAttribute(key, obj.attributes[key]);
         }
-        obj.children.forEach(child => result.append(unserializeNode(child)));
+        obj.children.forEach(child => result.append(unserializeNode(child, idToNodeMap)));
     } else {
         console.warn('unknown node type');
     }
     result.oid = obj.oid;
+    if (idToNodeMap) {
+        idToNodeMap.set(result.oid, result);
+    }
     return result;
 }
 

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3658,7 +3658,7 @@ X[]
                     `),
                 });
             });
-            it('should guarantee the same content after doing historyRevert and historyApply of a step', async () => {
+            it('should guarantee the same content after doing historyRevert and historyApply of a step (1)', async () => {
                 // Hand crafted scenario to demonstrate problematic cases
                 await testEditor(BasicEditor, {
                     contentBefore: '<h1>start</h1>',
@@ -3690,7 +3690,43 @@ X[]
                     `),
                 });
             });
-            it('should guarantee the same content before a step, after doing historyRevert of that step', async () => {
+            it('should guarantee the same content after doing historyRevert and historyApply of a step (2)', async () => {
+                // Hand crafted scenario to demonstrate problematic cases
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>start</h1>',
+                    stepFunction: async editor => {
+                        const p = document.createElement('P');
+                        const br = document.createElement('BR');
+                        const h1 = document.createElement('H1');
+                        editor.editable.append(h1);
+                        editor.historyStep();
+                        h1.append(br);
+                        editor.editable.append(p);
+                        p.append(br);
+                        p.remove();
+                        editor.editable.append(p);
+                        editor.historyStep();
+                        const step = editor._historySteps.at(-1);
+                        // Validate target content
+                        editor.clean();
+                        chai.expect(editor.editable.innerHTML).to.equal(unformat(`
+                            <h1>start</h1>
+                            <h1></h1>
+                            <p><br></p>
+                        `));
+                        editor.observerUnactive('reversibility');
+                        editor.historyRevert(step, {sideEffect: false});
+                        editor.historyApply(step.mutations);
+                        editor.observerActive('reversibility');
+                    },
+                    contentAfter: unformat(`
+                        <h1>start</h1>
+                        <h1></h1>
+                        <p><br></p>
+                    `),
+                });
+            });
+            it('should guarantee the same content before a step, after doing historyRevert of that step (1)', async () => {
                 // Hand crafted scenario to demonstrate problematic cases
                 await testEditor(BasicEditor, {
                     contentBefore: '<h1>start</h1>',
@@ -3714,6 +3750,72 @@ X[]
                         h1.append(br);
                         br.remove();
                         h1.remove();
+                        editor.historyStep();
+                        const step = editor._historySteps.at(-1);
+                        editor.observerUnactive('reversibility');
+                        editor.historyRevert(step, {sideEffect: false});
+                        editor.observerActive('reversibility');
+                    },
+                    contentAfter: unformat(`
+                        <h1>start</h1>
+                        <p><br></p>
+                    `),
+                });
+            });
+            it('should guarantee the same content before a step, after doing historyRevert of that step (2)', async () => {
+                // Hand crafted scenario to demonstrate problematic cases
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>start</h1>',
+                    stepFunction: async editor => {
+                        const h1 = document.createElement('H1');
+                        const p = document.createElement('P');
+                        const br = document.createElement('BR');
+                        p.append(br);
+                        editor.editable.append(p);
+                        editor.editable.append(h1);
+                        editor.historyStep();
+                        // Validate target content
+                        editor.clean();
+                        chai.expect(editor.editable.innerHTML).to.equal(unformat(`
+                            <h1>start</h1>
+                            <p><br></p>
+                            <h1></h1>
+                        `));
+                        p.remove();
+                        h1.append(br);
+                        editor.historyStep();
+                        const step = editor._historySteps.at(-1);
+                        editor.observerUnactive('reversibility');
+                        editor.historyRevert(step, {sideEffect: false});
+                        editor.observerActive('reversibility');
+                    },
+                    contentAfter: unformat(`
+                        <h1>start</h1>
+                        <p><br></p>
+                        <h1></h1>
+                    `),
+                });
+            });
+            it('should guarantee the same content before a step, after doing historyRevert of that step (3)', async () => {
+                // Hand crafted scenario to demonstrate problematic cases
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>start</h1>',
+                    stepFunction: async editor => {
+                        const p = document.createElement('P');
+                        const br = document.createElement('BR');
+                        p.append(br);
+                        editor.editable.append(p);
+                        editor.historyStep();
+                        // Validate target content
+                        editor.clean();
+                        chai.expect(editor.editable.innerHTML).to.equal(unformat(`
+                            <h1>start</h1>
+                            <p><br></p>
+                        `));
+                        br.remove();
+                        p.remove();
+                        editor.editable.append(p);
+                        p.append(br);
                         editor.historyStep();
                         const step = editor._historySteps.at(-1);
                         editor.observerUnactive('reversibility');


### PR DESCRIPTION
### [FIX] web_editor: history manipulations should be reversible
Impacted Versions:
15.0+

Mutations that `add` nodes should always register a serialization of those nodes
at the moment the mutation occured, because their children could be modified
while they are not observed by the editor in a later step. If the DOM instances
of those nodes is used instead, it would result in a different DOM state when
the mutations are reverted.

1. Example without using serialization:

Let A be a node in the DOM observed by a MutationObserver (MO).
Let B, C be nodes outside of the DOM (not observed).

Execute operations:
```
DOM operation 1: "Add C to A", mutations:
- M1: Add C to A

DOM operation 2: "Add C to B", mutations:
- M2: Remove C from A
- Add C to B // that mutation has not been observed as B is not inside the DOM

DOM operation 3: "Add B to the DOM", mutations:
- M3: Add B to the DOM
```

Revert Steps:
```
- M3: Remove B from the DOM
- M2: Add C to A // consequently, C has been removed to B outside of the DOM
- M1: Remove C from A
```

Apply Steps:
```
- M1: Add C to A
- M2: Remove C from A
- M3: Add B to the DOM // B does not contain C
```

Conclusion:
We are missing a mutation from the operation 2 that was not registered, so when
we reapply the steps, C is missing from B.

2. How to reproduce in Odoo:
- Start an editor (without collaborative mode, since it already uses
  serialization). More specifically, `OdooEditor._collabClientId` should be
  falsy.
- The editable value should be the following, where `[]` is the cursor position:
```
<h1>text[]</h1>
```
- Type `Enter` (`oEnter` command)
- manually call `historyRevert` and `historyApply` on the last registered step
  of the editor

Current behavior:
- The result after those operations is:
```
<h1>text</h1>
<p></p>
```
The moved children are not properly re-added to their original parent.

Expected behavior:
```
<h1>text</h1>
<p><br></p>
```
The moved children are properly re-added to their original parent.

Fix:
Force the serialization of nodes in mutations used for history steps, and always
unserialize them instead of using cached nodes in `_idToNodeMap`, when the
mutation `add` nodes, in order to recover the configuration that they had when
the mutation was handled. This is not perfect because mutations are handled in
batches, and when we handle them, the nodes configuration is the result of the
entire batch, not the configuration when the mutation occured.

### [FIX] web_editor: ObserverApply serializations convergence
In `observerApply`, mutations that `add` or `remove` nodes are stored with a
serialization of the added/removed node during the handling of the mutation,
from the value it has AFTER the entire batch of mutations currently being
processed.

However, for removed nodes, that serialization is only used when reverting the
step, to converge towards the state of the editable BEFORE the entire batch of
mutations was applied. Therefore, removed nodes should be serialized using that
state. Since observerApply will only be called after the mutations took place,
we have to register the state of the editor periodically to have access to that
"BEFORE" state. Good places to do it are: when calling `observerActive`, before
starting the observer, and during the handling of `observerApply` (to prepare
the state for the next time it will be called).

```
SERIALIZED_BEFORE
                  <- removed.serialize from BEFORE
                        added.serialize from AFTER ->
                                                      LIVE_CONTENT_AFTER

historyRevert
              `remove` => `add`    using the serialized value to converge
                                   towards SERIALIZED_BEFORE
              `add`    => `remove` no need to use the serialization

historyApply
              `remove` => `remove` no need to use the serialization
              `add`    => `add`    use the serialized value to converge towards
                                   what LIVE_CONTENT_AFTER was during the
                                   serialization.
```

Currently, a set of `mutatedNodes` is being used during `observerApply` to keep
track of nodes that are added to a parent that was also added during the same
batch. Since when the serialization occur, the parent has the child node (since
it is its final state after all mutations are applied), we have to prevent the
child from being serialized with it or else it will be duplicated if we revert
the mutations then apply them back.

However the current implementation is incomplete in the sense that it does not
keep track of the parent to which the child is added (the child node could be
added to another parent first (B), and still count in `mutatedNodes` for the
serialization of the parent (A).

In fact, what should happen is that mutatedNodes should only concern the parent
to which they are added/removed to/from. Using a Map linking a set of
mutatedNodes to each parent is thus more appropriate.

Furthermore, mutatedNodes for a specific added parent should only be the
children added (and not removed) after that parent, not those before.

```
add    A      | should not be serialized with B
add    B to A | should count as a mutatedNode for A added previously
add    C      |
add    B to C | should not count as a mutatedNode when serializing A
add    B to A |
remove A      |
add    A      | should be serialized with B at that mutation

<A><B/></A><C/>
```

Finally, `mutatedNodes` should also be tracked for removed nodes, indeed:
the reverse of `remove` is `add`, so if we have a remove child mutation,
followed by a remove parent mutation, if we revert it, we get add a parent
followed by add its child (same situation as before).

The reversed logic applies for mutatedNodes that should be taken into account
for the serialization of removed parents: only mutations of removed childs that
are not added back occuring before the removal of the parent should count.

```
<A><B/></A>

remove A        | should be serialized with B at that mutation
add    A        |
remove B from A | should count as a mutatedNode for A removed afterwards
remove A        | should not be serialized with B
```

### [FIX] web_editor: keep original reference of unserialized node
Since some Odoo modules (like website) may want to keep references to nodes in
the editor, the serialization/unserialization done in the editor should try to
preserve the reference to those nodes (and not replace them by a new instance of
the "same node" after unserializing its previous state).

This commit make it so that `unserializeNode` uses instances of nodes
registered (by their oid) in a Map if possible, to avoid creating new nodes as
much as possible.

Task-3227060