### PR TITLE
[FIX] web_editor: on pasting nested list should convert to another

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3246,6 +3246,17 @@ export class OdooEditor extends EventTarget {
                 node.before(fontNode);
                 node.replaceChildren(...fontNode.childNodes);
                 fontNode.appendChild(node);
+            } else if (node.nodeName === 'IMG' && node.getAttribute('aria-roledescription') === 'checkbox') {
+                const checklist = closestElement(node, 'ul');
+                const closestLi = closestElement(node, 'li');
+                if (checklist) {
+                    checklist.classList.add('o_checklist');
+                    if (node.getAttribute('alt') === 'checked') {
+                        closestLi.classList.add('o_checked');
+                    }
+                    node.remove();
+                    node = checklist;
+                }
             }
             // Remove all illegal attributes and classes from the node, then
             // clean its children.

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -180,9 +180,21 @@ export const editorCommands = {
 
         // In case the html inserted starts with a list and will be inserted within
         // a list, unwrap the list elements from the list.
-        if (closestElement(selection.anchorNode, 'UL, OL') &&
-            (container.firstChild.nodeName === 'UL' || container.firstChild.nodeName === 'OL')) {
-            container.replaceChildren(...container.firstChild.childNodes);
+        const isList = node => ['UL', 'OL'].includes(node.nodeName);
+        const hasSingleChild = container.childNodes.length === 1;
+        if (
+            closestElement(selection.anchorNode, 'UL, OL') &&
+            isList(container.firstChild)
+        ) {
+            unwrapContents(container.firstChild);
+        }
+        // Similarly if the html inserted ends with a list.
+        if (
+            closestElement(selection.focusNode, 'UL, OL') &&
+            isList(container.lastChild) &&
+            !hasSingleChild
+        ) {
+            unwrapContents(container.lastChild);
         }
 
         startNode = startNode || editor.document.getSelection().anchorNode;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -312,6 +312,11 @@ export const editorCommands = {
                     }
                 }
             }
+            // Ensure that all adjacent paragraph elements are converted to
+            // <li> when inserting in a list.
+            if (block.nodeName === "LI" && paragraphRelatedElements.includes(nodeToInsert.nodeName)) {
+                setTagName(nodeToInsert, "LI");
+            }
             if (insertBefore) {
                 currentNode.before(nodeToInsert);
                 insertBefore = false;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -54,6 +54,7 @@ import {
     lastLeaf,
     firstLeaf,
     paragraphRelatedElements,
+    convertList,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
@@ -231,11 +232,25 @@ export const editorCommands = {
         } else if (container.childElementCount > 1) {
             // Grab the content of the first child block and isolate it.
             if (shouldUnwrap(container.firstChild) && !isSelectionAtStart) {
+                // Unwrap the deepest nested first <li> element in the
+                // container to extract and paste the text content of the list.
+                if (container.firstChild.nodeName === 'LI') {
+                    const deepestBlock = closestBlock(firstLeaf(container.firstChild));
+                    splitAroundUntil(deepestBlock, container.firstChild);
+                    container.firstElementChild.replaceChildren(...deepestBlock.childNodes);
+                }
                 containerFirstChild.replaceChildren(...container.firstElementChild.childNodes);
                 container.firstElementChild.remove();
             }
             // Grab the content of the last child block and isolate it.
             if (shouldUnwrap(container.lastChild) && !isSelectionAtEnd) {
+                // Unwrap the deepest nested last <li> element in the container
+                // to extract and paste the text content of the list.
+                if (container.lastChild.nodeName === 'LI') {
+                    const deepestBlock = closestBlock(lastLeaf(container.lastChild));
+                    splitAroundUntil(deepestBlock, container.lastChild);
+                    container.lastElementChild.replaceChildren(...deepestBlock.childNodes);
+                }
                 containerLastChild.replaceChildren(...container.lastElementChild.childNodes);
                 container.lastElementChild.remove();
             }
@@ -259,6 +274,9 @@ export const editorCommands = {
         // element if it's a block then we insert the content in the right places.
         let currentNode = startNode;
         let lastChildNode = false;
+        const currentList = currentNode && closestElement(currentNode, 'UL, OL');
+        const mode = currentList && getListMode(currentList);
+
         const _insertAt = (reference, nodes, insertBefore) => {
             for (const child of (insertBefore ? nodes.reverse() : nodes)) {
                 reference[insertBefore ? 'before' : 'after'](child);
@@ -287,7 +305,7 @@ export const editorCommands = {
                 // If we arrive here, the o_enter index should always be 0.
                 const parent = currentNode.nextSibling.parentElement;
                 const index = [...parent.childNodes].indexOf(currentNode.nextSibling);
-                currentNode.nextSibling.parentElement.oEnter(index);
+                parent.oEnter(index);
             }
         }
 
@@ -341,10 +359,20 @@ export const editorCommands = {
             ) {
                 nodeToInsert = setTagName(nodeToInsert, block.nodeName);
             }
+            let convertedList;
+            if (
+                currentList &&
+                (
+                    (nodeToInsert.nodeName === 'LI' && nodeToInsert.classList.contains('oe-nested')) ||
+                    isList(nodeToInsert)
+                )
+            ) {
+                convertedList = convertList(nodeToInsert, mode);
+            }
             if (currentNode.tagName !== 'BR' && isShrunkBlock(currentNode)) {
                 currentNode.remove();
             }
-            currentNode = nodeToInsert;
+            currentNode = convertedList || nodeToInsert;
         }
 
         currentNode = lastChildNode || currentNode;
@@ -364,7 +392,7 @@ export const editorCommands = {
             currentNode = currentNode.nextSibling;
             lastPosition = getDeepestPosition(...rightPos(currentNode));
         } else {
-            lastPosition = [...paragraphRelatedElements, 'LI'].includes(currentNode.nodeName)
+            lastPosition = [...paragraphRelatedElements, 'LI', 'UL', 'OL'].includes(currentNode.nodeName)
                 ? rightPos(lastLeaf(currentNode))
                 : rightPos(currentNode);
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/toggleList.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/toggleList.js
@@ -1,14 +1,12 @@
 /** @odoo-module **/
 import {
     childNodeIndex,
-    getListMode,
     isBlock,
     preserveCursor,
-    setTagName,
-    toggleClass,
     insertListAfter,
     getAdjacents,
     closestElement,
+    toggleList,
 } from '../utils/utils.js';
 
 Text.prototype.oToggleList = function (offset, mode) {
@@ -67,32 +65,8 @@ HTMLParagraphElement.prototype.oToggleList = function (offset, mode = 'UL') {
 };
 
 HTMLLIElement.prototype.oToggleList = function (offset, mode) {
-    const pnode = this.closest('ul, ol');
-    if (!pnode) return;
     const restoreCursor = preserveCursor(this.ownerDocument);
-    const listMode = getListMode(pnode) + mode;
-    if (['OLCL', 'ULCL'].includes(listMode)) {
-        pnode.classList.add('o_checklist');
-        for (let li = pnode.firstElementChild; li !== null; li = li.nextElementSibling) {
-            if (li.style.listStyle != 'none') {
-                li.style.listStyle = null;
-                if (!li.style.all) li.removeAttribute('style');
-            }
-        }
-        setTagName(pnode, 'UL');
-    } else if (['CLOL', 'CLUL'].includes(listMode)) {
-        toggleClass(pnode, 'o_checklist');
-        setTagName(pnode, mode);
-    } else if (['OLUL', 'ULOL'].includes(listMode)) {
-        setTagName(pnode, mode);
-    } else {
-        // toggle => remove list
-        let node = this;
-        while (node) {
-            node = node.oShiftTab(offset);
-        }
-    }
-
+    toggleList(this, mode, offset);
     restoreCursor();
     return false;
 };

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -286,6 +286,23 @@ class Sanitize {
                 node = paragraph;
             }
 
+            // If node is UL or OL and its parent is UL or OL, nest it in an LI
+            // with class 'oe-nested'.
+            if (
+                ['UL', 'OL'].includes(node.nodeName) &&
+                ['UL', 'OL'].includes(node.parentNode.nodeName)
+            ) {
+                const restoreCursor = shouldPreserveCursor(node, this.root) && preserveCursor(this.root.ownerDocument);
+                const li = document.createElement('li');
+                node.parentNode.insertBefore(li, node);
+                li.appendChild(node);
+                li.classList.add('oe-nested');
+                node = li;
+                if (restoreCursor) {
+                    restoreCursor();
+                }
+            }
+
             // Ensure a zero width space is present inside the FA element.
             if (isFontAwesome(node) && node.textContent !== '\u200B') {
                 node.textContent = '\u200B';

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1974,6 +1974,7 @@ export function commonParentGet(node1, node2, root = undefined) {
 }
 
 export function getListMode(pnode) {
+    if (!["UL", "OL"].includes(pnode.tagName)) return;
     if (pnode.tagName == 'OL') return 'OL';
     return pnode.classList.contains('o_checklist') ? 'CL' : 'UL';
 }
@@ -1997,6 +1998,57 @@ export function insertListAfter(afterNode, mode, content = []) {
         }),
     );
     return list;
+}
+
+export function toggleList(node, mode, offset = 0) {
+    let pnode = node.closest('ul, ol');
+    if (!pnode) return;
+    const listMode = getListMode(pnode) + mode;
+    if (['OLCL', 'ULCL'].includes(listMode)) {
+        pnode.classList.add('o_checklist');
+        for (let li = pnode.firstElementChild; li !== null; li = li.nextElementSibling) {
+            if (li.style.listStyle !== 'none') {
+                li.style.listStyle = null;
+                if (!li.style.all) li.removeAttribute('style');
+            }
+        }
+        pnode = setTagName(pnode, 'UL');
+    } else if (['CLOL', 'CLUL'].includes(listMode)) {
+        toggleClass(pnode, 'o_checklist');
+        pnode = setTagName(pnode, mode);
+    } else if (['OLUL', 'ULOL'].includes(listMode)) {
+        pnode = setTagName(pnode, mode);
+    } else {
+        // toggle => remove list
+        let currNode = node;
+        while (currNode) {
+            currNode = currNode.oShiftTab(offset);
+        }
+        return;
+    }
+    return pnode;
+}
+
+/**
+ * Converts a list element and its nested elements to the specified list mode.
+ *
+ * @param {HTMLUListElement|HTMLOListElement|HTMLLIElement} node - HTML element
+ * representing a list or list item.
+ * @param {string} toMode - Target list mode
+ * @returns {HTMLUListElement|HTMLOListElement|HTMLLIElement} node - Modified
+ * list element after conversion.
+ */
+export function convertList(node, toMode) {
+    if (!["UL", "OL", "LI"].includes(node.nodeName)) return;
+    const listMode = getListMode(node);
+    if (listMode && toMode !== listMode) {
+        node = toggleList(node, toMode);
+    }
+    for (const child of node.childNodes) {
+        convertList(child, toMode);
+    }
+
+    return node;
 }
 
 export function toggleClass(node, className) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -327,6 +327,29 @@ describe('Paste', () => {
                     contentAfter: '<ul><li><h1>Google</h1></li><li><h1>Test</h1></li><li><h1>test2[]</h1></li></ul>',
                 });
             });
+            it('should paste checklist from gdoc', async () => {
+                await testEditor(BasicEditor, {
+                    removeCheckIds: true,
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <b style="font-weight:normal;" id="docs-internal-guid-5c9e50d3-7fff-c129-6dcc-e76588942722">
+                                <ul style="margin-top:0;margin-bottom:0;padding-inline-start:28px;">
+                                    <li dir="ltr" role="checkbox" aria-checked="false" style="list-style-type:none;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1">
+                                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAA1ElEQVR4Ae3bMQ4BURSFYY2xBuwQ7BIkTGxFRj9Oo9RdkXn5TvL3L19u+2ZmZmZmZhVbpH26pFcaJ9IrndMudb/CWadHGiden1bll9MIzqd79SUd0thY20qga4NA50qgoUGgoRJo/NL/V/N+QIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIEyFeEZyXQpUGgUyXQrkGgTSVQl/qGcG5pnkq3Sn0jOMv0k3Vpm05pmNjfsGPalFyOmZmZmdkbSS9cKbtzhxMAAAAASUVORK5CYII=" width="17.599999999999998px" height="17.599999999999998px" alt="unchecked" aria-roledescription="checkbox" style="margin-right:3px;" />
+                                        <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;display:inline-block;vertical-align:top;margin-top:0;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Abc</span></p>
+                                    </li>
+                                    <li dir="ltr" role="checkbox" aria-checked="false" style="list-style-type:none;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1">
+                                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABICAYAAABV7bNHAAAA1ElEQVR4Ae3bMQ4BURSFYY2xBuwQ7BIkTGxFRj9Oo9RdkXn5TvL3L19u+2ZmZmZmZhVbpH26pFcaJ9IrndMudb/CWadHGiden1bll9MIzqd79SUd0thY20qga4NA50qgoUGgoRJo/NL/V/N+QIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIEyFeEZyXQpUGgUyXQrkGgTSVQl/qGcG5pnkq3Sn0jOMv0k3Vpm05pmNjfsGPalFyOmZmZmdkbSS9cKbtzhxMAAAAASUVORK5CYII=" width="17.599999999999998px" height="17.599999999999998px" alt="checked" aria-roledescription="checkbox" style="margin-right:3px;" />
+                                        <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;display:inline-block;vertical-align:top;margin-top:0;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">def</span></p>
+                                    </li>
+                                </ul>
+                            </b>
+                        `));
+                    },
+                    contentAfter: `<ul class="o_checklist"><li>Abc</li><li class="o_checked">def[]</li></ul>`,
+                });
+            });
         });
     });
     describe('Simple text', () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1911,6 +1911,30 @@ describe('Paste', () => {
                     `),
                 });
             });
+            it('should convert multiple paragraphs into a checklist', async () => {
+                await testEditor(BasicEditor, {
+                    removeCheckIds: true,
+                    contentBefore: `<ul class="o_checklist"><li>[]<br></li></ul>`,
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <p>abc</p>
+                            <p>def</p>
+                            <p>ghi</p>
+                            <p>jkl</p>
+                            <p>mno</p>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul class="o_checklist">
+                            <li>abc</li>
+                            <li>def</li>
+                            <li>ghi</li>
+                            <li>jkl</li>
+                            <li>mno[]</li>
+                        </ul>
+                    `),
+                });
+            });
         });
     });
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1935,6 +1935,65 @@ describe('Paste', () => {
                     `),
                 });
             });
+            it('should insert a list and a p tag inside a new list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>[]<br></li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><li>abc</li><li>def</li></ul><p>ghi</p>');
+                    },
+                    contentAfter: '<ul><li>abc</li><li>def</li><li>ghi[]</li></ul>',
+                });
+            });
+            it('should insert content ending with a list inside a new list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>[]<br></li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<p>abc</p><ul><li>def</li><li>ghi</li></ul>');
+                    },
+                    contentAfter: '<ul><li>abc</li><li>def</li><li>ghi[]</li></ul>',
+                });
+            });
+            it('should convert a mixed list containing a paragraph into a checklist', async () => {
+                await testEditor(BasicEditor, {
+                    removeCheckIds: true,
+                    contentBefore: `<ul class="o_checklist"><li>[]<br></li></ul>`,
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ul>
+                                <li>abc</li>
+                                <li>def</li>
+                                <li>ghi</li>
+                            </ul>
+                            <p>jkl</p>
+                            <ol>
+                                <li>mno</li>
+                                <li>pqr</li>
+                                <li>stu</li>
+                            </ol>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul class="o_checklist">
+                            <li>abc</li>
+                            <li>def</li>
+                            <li>ghi</li>
+                            <li>jkl</li>
+                            <li>mno</li>
+                            <li>pqr</li>
+                            <li>stu[]</li>
+                        </ul>
+                    `),
+                });
+            });
+            it('should not unwrap a list twice when pasting on new list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>[]<br></li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<ul><ul><li>abc</li><li>def</li></ul></ul>');
+                    },
+                    contentAfter: '<ul><li class="oe-nested"><ul><li>abc</li><li>def[]</li></ul></li></ul>',
+                });
+            });
         });
     });
 

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1824,7 +1824,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<ul><li>abc</li><li>def</li><li>ghi</li></ul>');
                     },
-                    contentAfter: '<p>12</p><ul><li>abc</li><li>def</li><li>ghi</li></ul><p>[]34</p>',
+                    contentAfter: '<p>12</p><ul><li>abc</li><li>def</li><li>ghi[]</li></ul><p>34</p>',
                 });
             });
             it('should paste the text of an li into another li', async () => {
@@ -1992,6 +1992,289 @@ describe('Paste', () => {
                         await pasteHtml(editor, '<ul><ul><li>abc</li><li>def</li></ul></ul>');
                     },
                     contentAfter: '<ul><li class="oe-nested"><ul><li>abc</li><li>def[]</li></ul></li></ul>',
+                });
+            });
+            it('should paste a nested list into another list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ol><li>Alpha</li><li>[]<br></li></ol>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ul>
+                                <li>abc</li>
+                                <li>def</li>
+                                <li class="oe-nested">
+                                    <ul>
+                                        <li>123</li>
+                                        <li>456</li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ol>
+                            <li>Alpha</li>
+                            <li>abc</li>
+                            <li>def</li>
+                            <li class="oe-nested">
+                                <ol>
+                                    <li>123</li>
+                                    <li>456[]</li>
+                                </ol>
+                            </li>
+                        </ol>
+                    `),
+                });
+            });
+            it('should paste a nested list into another list (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>Alpha</li><li>[]<br></li></ul>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ol>
+                                <li class="oe-nested">
+                                    <ul>
+                                        <li class="oe-nested">
+                                            <ol>
+                                                <li class="oe-nested">
+                                                    <ul class="o_checklist">
+                                                        <li>abc</li>
+                                                    </ul>
+                                                </li>
+                                                <li>def</li>
+                                            </ol>
+                                        </li>
+                                        <li>ghi</li>
+                                    </ul>
+                                </li>
+                                <li>jkl</li>
+                            </ol>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul>
+                            <li>Alpha</li>
+                            <li class="oe-nested">
+                                <ul>
+                                    <li class="oe-nested">
+                                        <ul>
+                                            <li class="oe-nested">
+                                                <ul>
+                                                    <li>abc</li>
+                                                </ul>
+                                            </li>
+                                            <li>def</li>
+                                        </ul>
+                                    </li>
+                                    <li>ghi</li>
+                                </ul>
+                            </li>
+                            <li>jkl[]</li>
+                        </ul>
+                    `),
+                });
+            });
+            it('should convert a mixed list into a ordered list', async () => {
+                await testEditor(BasicEditor, {
+                    removeCheckIds: true,
+                    contentBefore: `<ol><li>[]<br></li></ol>`,
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(
+                            `<ul>
+                                <li>ab</li>
+                                <li>cd</li>
+                                <li class="oe-nested">
+                                    <ol>
+                                        <li>ef</li>
+                                        <li>gh</li>
+                                        <li class="oe-nested">
+                                            <ul class="o_checklist">
+                                                <li>ij</li>
+                                                <li>kl</li>
+                                            </ul>
+                                        </li>
+                                    </ol>
+                                </li>
+                            </ul>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ol>
+                            <li>ab</li>
+                            <li>cd</li>
+                            <li class="oe-nested">
+                                <ol>
+                                    <li>ef</li>
+                                    <li>gh</li>
+                                    <li class="oe-nested">
+                                        <ol>
+                                            <li>ij</li>
+                                            <li>kl[]</li>
+                                        </ol>
+                                    </li>
+                                </ol>
+                            </li>
+                        </ol>
+                    `),
+                });
+            });
+            it('should convert a mixed list starting with bullet list into a bullet list', async () => {
+                await testEditor(BasicEditor, {
+                    removeCheckIds: true,
+                    contentBefore: `<ul><li>[]<br></li></ul>`,
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ul>
+                                <li>ab</li>
+                                <li>cd</li>
+                                <li class="oe-nested">
+                                    <ol>
+                                        <li>ef</li>
+                                        <li>gh</li>
+                                        <li class="oe-nested">
+                                            <ul class="o_checklist">
+                                                <li>ij</li>
+                                                <li>kl</li>
+                                            </ul>
+                                        </li>
+                                    </ol>
+                                </li>
+                            </ul>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul>
+                            <li>ab</li>
+                            <li>cd</li>
+                            <li class="oe-nested">
+                                <ul>
+                                    <li>ef</li>
+                                    <li>gh</li>
+                                    <li class="oe-nested">
+                                        <ul>
+                                            <li>ij</li>
+                                            <li>kl[]</li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    `),
+                });
+            });
+            it('should paste a mixed list starting with deeply nested bullet list into a bullet list', async () => {
+                await testEditor(BasicEditor, {
+                    removeCheckIds: true,
+                    contentBefore: `<ul><li>[]<br></li></ul>`,
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ul>
+                                <li class="oe-nested">
+                                    <ul>
+                                        <li class="oe-nested">
+                                            <ul>
+                                                <li class="oe-nested">
+                                                    <ul>
+                                                        <li>ab</li>
+                                                        <li>cd</li>
+                                                    </ul>
+                                                </li>
+                                                <li>ef</li>
+                                                <li>gh</li>
+                                            </ul>
+                                        </li>
+                                        <li>ij</li>
+                                        <li>kl</li>
+                                    </ul>
+                                </li>
+                                <li>mn</li>
+                                <li>op</li>
+                            </ul>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul>
+                            <li class="oe-nested">
+                                <ul>
+                                    <li class="oe-nested">
+                                        <ul>
+                                            <li class="oe-nested">
+                                                <ul>
+                                                    <li>ab</li>
+                                                    <li>cd</li>
+                                                </ul>
+                                            </li>
+                                            <li>ef</li>
+                                            <li>gh</li>
+                                        </ul>
+                                    </li>
+                                    <li>ij</li>
+                                    <li>kl</li>
+                                </ul>
+                            </li>
+                            <li>mn</li>
+                            <li>op[]</li>
+                        </ul>
+                    `),
+                });
+            });
+            it('should paste a deeply nested list copied outside from odoo', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li>[]<br></li></ul>',
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ol>
+                                <li>ab</li>
+                                <ol>
+                                    <li>cd</li>
+                                    <li>ef</li>
+                                    <ul>
+                                        <li>gh</li>
+                                        <li>ij</li>
+                                    </ul>
+                                    <ol>
+                                        <li>kl</li>
+                                        <li>mn</li>
+                                    </ol>
+                                </ol>
+                                <ul>
+                                    <li>op</li>
+                                    <li>qr</li>
+                                    <ol>
+                                        <li>st</li>
+                                        <li>uv</li>
+                                    </ol>
+                                </ul>
+                            </ol>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul>
+                            <li>ab</li>
+                            <li class="oe-nested">
+                                <ul>
+                                    <li>cd</li>
+                                    <li>ef</li>
+                                    <li class="oe-nested">
+                                        <ul>
+                                            <li>gh</li>
+                                            <li>ij</li>
+                                            <li>kl</li>
+                                            <li>mn</li>
+                                        </ul>
+                                    </li>
+                                    <li>op</li>
+                                    <li>qr</li>
+                                    <li class="oe-nested">
+                                        <ul>
+                                            <li>st</li>
+                                            <li>uv[]</li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    `),
                 });
             });
         });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -9,6 +9,7 @@ import {
     pasteText,
     pasteHtml,
     pasteOdooEditorHtml,
+    unformat,
 } from "../utils.js";
 import {CLIPBOARD_WHITELISTS} from "../../src/OdooEditor.js";
 
@@ -1869,6 +1870,45 @@ describe('Paste', () => {
                         await pasteHtml(editor, '<ul><li>123</li><li>456</li></ul>');
                     },
                     contentAfter: '<ul><li>123</li><li>456[]abc</li><li>def</li><li>ghi</li></ul>',
+                });
+            });
+            it('should correctly paste nested UL or OL elements copied from GDocs', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: `<p>[]<br></p>`,
+                    stepFunction:  async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <ul>
+                                <li>abc</li>
+                                <li>def</li>
+                                <ul>
+                                    <li>ghi</li>
+                                    <li>jkl</li>
+                                </ul>
+                                <ol>
+                                    <li>mno</li>
+                                    <li>pqr</li>
+                                </ol>
+                            </ul>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <ul>
+                            <li>abc</li>
+                            <li>def</li>
+                            <li class="oe-nested">
+                                <ul>
+                                    <li>ghi</li>
+                                    <li>jkl</li>
+                                </ul>
+                            </li>
+                            <li class="oe-nested">
+                                <ol>
+                                    <li>mno</li>
+                                    <li>pqr[]</li>
+                                </ol>
+                            </li>
+                        </ul>
+                    `),
                 });
             });
         });


### PR DESCRIPTION
Current behavior before PR:

1. When we attempt to paste an H1 element into a P element, the H1 element gets converted to a P element.
2. When pasting from GDocs, nested UL or OL is a direct child of its parent UL or OL, rather than being child of LI with class `oe-nested`.
3. Copy/pasting multiple paragraphs into a list does not convert it to list.
4. When pasting content that begins with a list and includes other tags below it into a new list, only the list is pasted, resulting in a loss of the other content.
5. Copy/pasting one list over another bullets does not get transformed.
6. When copying a checklist from Google Docs, the check options are pasted as images.

Desired behavior after PR is merged:

1. When we attempt to paste an H1 element onto a P element, the H1 element will remain as an H1 element.
2. When pasting from GDocs, nested UL or OL are contained within an LI element with class `oe-nested`.
3. Copy/pasting multiple paragraphs into a list gets converted to list.
4. Pasting content with a list and other tags should no longer result in the loss of content.
5. Copy/pasting one list over another bullets get transformed.
6. Check options copied as image from Google Docs will no longer be pasted as images; instead the images should be removed and class `o_checklist` should be add to the closest list.

task-2956048

Co-authored-by: Deependra Solanki <deso@odoo.com>

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
