### PR TITLE
[FIX] web: decoration on a many2one field

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -27,7 +27,7 @@
             <t t-else="">
                 <a
                     t-if="value"
-                    class="o_form_uri"
+                    t-attf-class="o_form_uri #{classFromDecoration}"
                     t-att-href="value ? `#id=${value[0]}&amp;model=${relation}` : '#'"
                     t-on-click.prevent="onClick"
                 >

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -776,6 +776,25 @@ QUnit.module("Fields", (hooks) => {
     );
 
     QUnit.test(
+        "using a many2one widget must take into account the decorations",
+        async function (assert) {
+            await makeView({
+                type: "list",
+                resModel: "partner",
+                serverData,
+                arch: `
+                <tree>
+                    <field name="user_id" decoration-danger="int_field > 9" widget="many2one"/>
+                    <field name="int_field"/>
+                </tree>`,
+            });
+
+            assert.containsOnce(target, ".o_list_many2one a.text-danger");
+            assert.containsN(target, ".o_data_row", 3);
+        }
+    );
+
+    QUnit.test(
         "onchanges on many2ones trigger when editing record in form view",
         async function (assert) {
             assert.expect(10);


### PR DESCRIPTION
Before this commit, in a list view, the style of a decoration on a m2o widget was ignored. For example, when applying the danger decoration, we want the m2o field to be in red.

How to reproduce:
Go to a list view with a field having the many2one widget and a danger-decoration. Have a line that respects the decoration condition.

Before this commit:
All text on the line is red except the many2one text

After this commit:
All text on the line is in red

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
