### PR TITLE
[FIX] hr: cannot create a new employee on the application

### DIFF
--- a/addons/hr/models/mail_channel.py
+++ b/addons/hr/models/mail_channel.py
@@ -17,7 +17,7 @@ class Channel(models.Model):
         for channel in self:
             new_members[channel.id] = list(
                 set(new_members[channel.id]) |
-                set((channel.subscription_department_ids.member_ids.user_id.partner_id - channel.channel_partner_ids).ids)
+                set((channel.subscription_department_ids.member_ids.user_id.partner_id.filtered(lambda p: p.active) - channel.channel_partner_ids).ids)
             )
         return new_members
 


### PR DESCRIPTION
Steps:
1. Create Employee A that related with user A / partner A in Sales department
2. Create a channel Sales, set Auto Subscribe Departments as Sales department
3. Archive Employee A / user A / partner A
4. Create a application B in Sales department and click button Create Employee
5. An error occurred: duplicate key value violates unique constraint "mail_channel_partner_partner_unique"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
