### PR TITLE
[FIX] website: avoid saving modified menu if they are deleted

### DIFF
--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -228,6 +228,9 @@ export class EditMenuDialog extends Component {
             }
         ],
         { context: { lang: this.website.currentWebsite.metadata.lang } });
+        if (this.props.delete && this.toDelete.length) {
+            this.props.delete(this.toDelete);
+        }
         if (this.props.save) {
             this.props.save();
         } else {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -432,6 +432,16 @@ export class WysiwygAdapterComponent extends ComponentAdapter {
             case 'edit_menu':
                 return this.dialogs.add(EditMenuDialog, {
                     rootID: params[0],
+                    delete: (toDelete) => {
+                        this.widget.odooEditor.observerUnactive();
+                        const menuEl = this.widget.$editable[0].querySelector(`[data-content_menu_id="${params[0]}"]`);
+                        for (const deleteId of toDelete) {
+                            for (const itemEl of menuEl.querySelectorAll(`[data-oe-id="${deleteId}"]`)) {
+                                itemEl.remove();
+                            }
+                        }
+                        this.widget.odooEditor.observerActive();
+                    },
                     save: () => {
                         const snippetsMenu = this.widget.snippetsMenu;
                         snippetsMenu.trigger_up('request_save', {reload: true, _toMutex: true});


### PR DESCRIPTION
If a mega menu is deleted while it is dirty, an error popup appears
because stored translations cannot be retrieved during the update of
the now-missing `website.menu` record.

This commit avoids this problem by making sure that the deleted menues
are actually removed from the page before the save operation happens.

Steps to reproduce:
- Add a mega menu to the Event's sub-menu.
- Save the page.
- Edit the page.
- Make the mega menu dirty e.g. by changing some text inside it.
- Select another Event's menu entry.
- Edit the menu and delete the mega menu.

=> An error popup was displayed.

opw-3209228
