### PR TITLE
[FIX] product, sale: use defaults when creating product from sale order

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -335,7 +335,13 @@ class ProductProduct(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        products = super(ProductProduct, self.with_context(create_product_product=True)).create(vals_list)
+        ctx = dict(self.env.context)
+        if 'default_description_sale' in ctx and ctx.get('default_description_sale') is None:
+            ctx.pop('default_description_sale')
+        if 'default_lst_price' in ctx and ctx.get('default_lst_price') == 0:
+            ctx.pop('default_lst_price')
+        ctx['create_product_product'] = True
+        products = super(ProductProduct, self.with_context(ctx)).create(vals_list)
         # `_get_variant_id_for_combination` depends on existing variants
         self.clear_caches()
         return products

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -472,7 +472,7 @@
                                             'uom':product_uom,
                                             'company_id': parent.company_id,
                                             'default_lst_price': price_unit,
-                                            'default_description_sale': name
+                                            'default_description_sale': name or None
                                         }"
                                         domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                         widget="product_configurator"
@@ -492,7 +492,7 @@
                                           'uom':product_uom,
                                           'company_id': parent.company_id,
                                           'default_list_price': price_unit,
-                                          'default_description_sale': name
+                                          'default_description_sale': name or None
                                       }"
                                       domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
                                       widget="product_configurator"/>


### PR DESCRIPTION
Creating a product from the sale order lines doesn't use the user-defined defaults

Steps to reproduce:
1. Install Sales
2. Go to Settings > Technical > Actions > User-defined Defaults
3. Create a new default for field "Sales Description (product.template)" with value "test template"
4. Go to Sales and create a new quotation
5. In the order lines, create a new product P
6. Open the product form (with the quick edit button for example)
7. Open the Sales tab, the Sales Description should be "test template" but it is empty

Solution:
If we do not give any description_sale or lst_price when quick creating a product in a sale order, we remove the default keys added in the context for those fields so that we can use the values of `ir.default`

Problem:
When we do not enter any description or price in the order line for the creation of a new product, `default_description_sale` and `default_lst_price` will be present in the context with falsy values. `default_get` will therefore use those values for the creation of the new product, overlooking the values set in `ir.default`

opw-3171508