### PR TITLE
[FIX] web: fileName not updating in attachment form

### DIFF
--- a/addons/web/static/src/views/fields/binary/binary_field.js
+++ b/addons/web/static/src/views/fields/binary/binary_field.js
@@ -8,24 +8,17 @@ import { standardFieldProps } from "../standard_field_props";
 import { FileUploader } from "../file_handler";
 import { _lt } from "@web/core/l10n/translation";
 
-import { Component, onWillUpdateProps, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 export class BinaryField extends Component {
     setup() {
         this.notification = useService("notification");
-        this.state = useState({
-            fileName: this.props.record.data[this.props.fileNameField] || "",
-        });
-        onWillUpdateProps((nextProps) => {
-            this.state.fileName = nextProps.record.data[nextProps.fileNameField] || "";
-        });
     }
 
     get fileName() {
-        return this.state.fileName || this.props.value || "";
+        return this.props.record.data[this.props.fileNameField] || this.props.value || "";
     }
 
     update({ data, name }) {
-        this.state.fileName = name || "";
         const { fileNameField, record } = this.props;
         const changes = { [this.props.name]: data || false };
         if (fileNameField in record.fields && record.data[fileNameField] !== name) {

--- a/addons/web/static/src/views/fields/binary/binary_field.xml
+++ b/addons/web/static/src/views/fields/binary/binary_field.xml
@@ -51,7 +51,7 @@
         <t t-elif="props.record.resId and props.value">
             <a class="o_form_uri" href="#" t-on-click.prevent="onFileDownload">
                 <span class="fa fa-download me-2" />
-                <t t-if="state.fileName" t-esc="state.fileName" />
+                <t t-if="fileName" t-esc="fileName" />
             </a>
         </t>
     </t>


### PR DESCRIPTION
__Current behavior before PR:__
The issue appears in the `ir.attachment` form (Settings > Technical > Database Structure > Attachments). When clicking on the previous/next attachment the filename displayed on the field **File Content (base64)** does not change. This has the consequence that when downloading the file, it has the wrong filename.

__Description of the fix:__
This commit removes the useless `fileName` state from the class `BinaryField`. This field should have always been equal to `this.props.record.data[this.props.fileNameField]` anyway.

opw-3223755