### PR TITLE
[FIX]crm: wrong stages shown when filtering by team_id

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -900,7 +900,7 @@ class Lead(models.Model):
         # - OR ('team_ids', '=', team_id), ('fold', '=', False) if team_id: add team columns that are not folded
         team_id = self._context.get('default_team_id')
         if team_id:
-            search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_id', '=', False), ('team_id', '=', team_id)]
+            search_domain = ['&', ('id', 'in', stages.ids), '|', ('team_id', '=', False), ('team_id', '=', team_id)]
         else:
             search_domain = ['|', ('id', 'in', stages.ids), ('team_id', '=', False)]
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when filtering leads by team_id the kanban view shows stages from all teams instead of the one filtered by

Current behavior before PR:
wrong stages shown when filtering leads in kanban view

Desired behavior after PR is merged:
correct stages show in kanban view when filtering by team_id



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
