### PR TITLE
[FIX] base: updating translation too restrictive

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3005,13 +3005,17 @@ class BaseModel(metaclass=MetaModel):
         installed_lang = set(code for code, _ in self.env['res.lang'].get_installed())
         missing_languages = set(translations) - installed_lang
         if missing_languages:
-            raise UserError(
-                _("The following language is not activated: %(missing_names)s",
-                missing_names=', '.join(missing_languages))
-            )
+            for missing_language in missing_languages:
+                del translations[missing_language]
+            _logger.warning(
+                "Translation(s) of '%s' ignored for "
+                "the following language(s) that are not activated: %s",
+                str(self._fields['display_name']), missing_languages)
+
+        if not translations:
+            return
 
         field = self._fields[field_name]
-
         if not field.translate:
             return False  # or raise error
 


### PR DESCRIPTION
Steps to reproduce:
- Add multiple languages to a database
- Add a record with a translation in all language
- Remove one of the languages
- Try to duplicate the record

What happened ?:

The duplication of the record calls _update_field_translations and fails. This happens because the absence of a language is blocking, however, the previous languages are not removed from the database. Therefore the duplication try to retranslate the new record.

The fix:

Make the condition non-blocking but remove the useless translation on the fly. It remains impossible to translate into a non-activated language.
Also, changed the exception into a warming message with more precisions

