### PR TITLE
[IMP] core: improve the Graph class

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_expression
 from . import test_float
 from . import test_format_address_mixin
 from . import test_func
+from . import test_graph
 from . import test_http_case
 from . import test_image
 from . import test_avatar_mixin

--- a/odoo/addons/base/tests/test_graph.py
+++ b/odoo/addons/base/tests/test_graph.py
@@ -1,0 +1,339 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import time
+import logging
+from unittest.mock import patch
+from typing import Iterable, List, Dict
+
+from odoo.tests.common import BaseCase, TransactionCase
+from odoo.modules.graph import PackageGraph
+from odoo.modules.module import _DEFAULT_MANIFEST
+from odoo.tools import mute_logger
+
+_logger = logging.getLogger(__name__)
+
+class TestGraph(BaseCase):
+    @mute_logger('odoo.modules.graph')
+    def _test_graph_order(
+            self,
+            dependency: Dict[str, List[str]],
+            modules_list: Iterable[Iterable[str]],
+            expected: List[str]
+    ) -> None:
+        """
+        Test the order of the modules that need to be loaded
+
+        :param dependency: A dictionary of module dependency: {module_a: [module_b, module_c]}
+        :param modules_list: [['module_a', 'module_b'], ['module_c'], ...]
+            module_a and module_b will be added in the first round
+            module_c will be added in the second round
+            ...
+        :param expected: expected graph order
+        """
+        manifests = {
+            name: {**_DEFAULT_MANIFEST.copy(), **{'depends': depends}}
+            for name, depends in dependency.items()
+        }
+        with patch('odoo.modules.graph.PackageGraph._update_from_database'), \
+                patch('odoo.modules.module.get_manifest', lambda name: manifests.get(name, {})):
+            graph = PackageGraph(None)
+            graph_legacy = GraphLegacy()
+
+            for modules in modules_list:
+                graph.add(modules)
+                graph_legacy.add_modules(None, modules)
+
+            names = list(p.name for p in graph)
+            names_legacy = list(p.name for p in graph_legacy)
+
+            self.assertListEqual(names, expected)
+            self.assertListEqual(names_legacy, expected)
+
+    def test_graph_order_1(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'module2': ['module1'],
+            'module3': ['module1'],
+            'module4': ['module2', 'module3'],
+            'module5': ['module2', 'module4'],
+        }
+        # modules are in random order
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+        # module 5's depends is missing
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module1', 'module2', 'module3', 'module5']],
+            ['base', 'module1', 'module2', 'module3']
+        )
+        # module 6's manifest is missing
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module1', 'module2', 'module3', 'module4', 'module5', 'module6']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+        # three adding rounds
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module1', 'module2', 'module3'], ['module4', 'module5']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+
+    def test_graph_order_2(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'module2': ['module1'],
+            'module3': ['module1'],
+            'module4': ['module3'],
+            'module5': ['module2'],
+        }
+        # module4 and module5 have the same depth but don't have shared depends
+        # they should be ordered by name
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+
+    def test_graph_order_3(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'module2': ['module1'],
+            # depends loop
+            'module3': ['module1', 'module5'],
+            'module4': ['module2', 'module3'],
+            'module5': ['module2', 'module4'],
+        }
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
+            ['base', 'module1', 'module2']
+        )
+
+
+class TestGraphAll(TransactionCase):
+    @mute_logger('odoo.modules.graph')
+    def test_graph_order_all(self):
+        self.env['ir.module.module'].update_list()
+        modules = self.env['ir.module.module'].search([]).mapped('name')
+        for module in modules:  # cache manifest for fair performance comparison
+            odoo.modules.module.get_manifest(module)
+
+        graph = PackageGraph(self.cr)
+        graph_legacy = GraphLegacy()
+
+        time0 = time.time()
+        graph.add(modules)
+        names = list(p.name for p in graph)
+        time1 = time.time()
+
+        time0_legacy = time.time()
+        graph_legacy.add_modules(self.cr, modules)
+        names_legacy = list(g.name for g in graph_legacy)
+        time1_legacy = time.time()
+
+        self.assertListEqual(names, names_legacy)
+        _logger.info('\nCurrent Graph order time: %s\nLegacy Graph order time: %s', time1 - time0, time1_legacy - time0_legacy)
+
+
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+""" Modules dependency graph. """
+
+import itertools
+# import logging
+
+import odoo
+import odoo.tools as tools
+
+# _logger = logging.getLogger(__name__)
+
+class GraphLegacy(dict):
+    """ Modules dependency graph.
+
+    The graph is a mapping from module name to Nodes.
+
+    """
+
+    def add_node(self, name, info):
+        max_depth, father = 0, None
+        for d in info['depends']:
+            n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
+            if n.depth >= max_depth:
+                father = n
+                max_depth = n.depth
+        if father:
+            return father.add_child(name, info)
+        else:
+            return Node(name, self, info)
+
+    def update_from_db(self, cr):
+        return
+        # if not len(self):
+        #     return
+        # # update the graph with values from the database (if exist)
+        # ## First, we set the default values for each package in graph
+        # additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in
+        #                    self.keys()}
+        # ## Then we get the values from the database
+        # cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
+        #            '  FROM ir_module_module'
+        #            ' WHERE name IN %s', (tuple(additional_data),)
+        #            )
+        #
+        # ## and we update the default values with values from the database
+        # additional_data.update((x['name'], x) for x in cr.dictfetchall())
+        #
+        # for package in self.values():
+        #     for k, v in additional_data[package.name].items():
+        #         setattr(package, k, v)
+
+    def add_module(self, cr, module, force=None):
+        self.add_modules(cr, [module], force)
+
+    def add_modules(self, cr, module_list, force=None):
+        if force is None:
+            force = []
+        packages = []
+        len_graph = len(self)
+        for module in module_list:
+            info = odoo.modules.module.get_manifest(module)
+            if info and info['installable']:
+                packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
+            # elif module != 'studio_customization':
+            #     _logger.warning('module %s: not installable, skipped', module)
+
+        dependencies = dict([(p, info['depends']) for p, info in packages])
+        current, later = set([p for p, info in packages]), set()
+
+        while packages and current > later:
+            package, info = packages[0]
+            deps = info['depends']
+
+            # if all dependencies of 'package' are already in the graph, add 'package' in the graph
+            if all(dep in self for dep in deps):
+                if not package in current:
+                    packages.pop(0)
+                    continue
+                later.clear()
+                current.remove(package)
+                node = self.add_node(package, info)
+                # for kind in ('init', 'demo', 'update'):
+                #     if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
+                #         setattr(node, kind, True)
+            else:
+                later.add(package)
+                packages.append((package, info))
+            packages.pop(0)
+
+        self.update_from_db(cr)
+
+        for package in later:
+            unmet_deps = [p for p in dependencies[package] if p not in self]
+            # _logger.info('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
+
+        return len(self) - len_graph
+
+
+    def __iter__(self):
+        level = 0
+        done = set(self.keys())
+        while done:
+            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
+            for name, module in level_modules:
+                done.remove(name)
+                yield module
+            level += 1
+
+    def __str__(self):
+        return '\n'.join(str(n) for n in self if n.depth == 0)
+
+class Node(object):
+    """ One module in the modules dependency graph.
+
+    Node acts as a per-module singleton. A node is constructed via
+    Graph.add_module() or Graph.add_modules(). Some of its fields are from
+    ir_module_module (set by Graph.update_from_db()).
+
+    """
+    def __new__(cls, name, graph, info):
+        if name in graph:
+            inst = graph[name]
+        else:
+            inst = object.__new__(cls)
+            graph[name] = inst
+        return inst
+
+    def __init__(self, name, graph, info):
+        self.name = name
+        self.graph = graph
+        self.info = info or getattr(self, 'info', {})
+        if not hasattr(self, 'children'):
+            self.children = []
+        if not hasattr(self, 'depth'):
+            self.depth = 0
+
+    @property
+    def data(self):
+        return self.info
+
+    def add_child(self, name, info):
+        node = Node(name, self.graph, info)
+        node.depth = self.depth + 1
+        if node not in self.children:
+            self.children.append(node)
+        for attr in ('init', 'update', 'demo'):
+            if hasattr(self, attr):
+                setattr(node, attr, True)
+        self.children.sort(key=lambda x: x.name)
+        return node
+
+    def __setattr__(self, name, value):
+        super(Node, self).__setattr__(name, value)
+        if name in ('init', 'update', 'demo'):
+            tools.config[name][self.name] = 1
+            for child in self.children:
+                setattr(child, name, value)
+        if name == 'depth':
+            for child in self.children:
+                setattr(child, name, value + 1)
+
+    def __iter__(self):
+        return itertools.chain(
+            self.children,
+            itertools.chain.from_iterable(self.children)
+        )
+
+    def __str__(self):
+        return self._pprint()
+
+    def _pprint(self, depth=0):
+        s = '%s\n' % self.name
+        for c in self.children:
+            s += '%s`-> %s' % ('   ' * depth, c._pprint(depth+1))
+        return s
+
+    def should_have_demo(self):
+        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
+
+    @property
+    def parents(self):
+        if self.depth == 0:
+            return []
+
+        return (
+            node for node in self.graph.values()
+            if node.depth < self.depth
+            if self in node.children
+        )
+
+
+

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -44,7 +44,7 @@ class TestModuleManifest(BaseCase):
             'data': [],
             'demo': [],
             'demo_xml': [],
-            'depends': [],
+            'depends': ['base'],
             'description': '',
             'external_dependencies': {},
             'icon': '/base/static/description/icon.png',

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -3,187 +3,136 @@
 
 """ Modules dependency graph. """
 
-import itertools
 import logging
+from typing import Set, Dict, Iterable, Iterator
 
 import odoo
 import odoo.tools as tools
 
 _logger = logging.getLogger(__name__)
 
-class Graph(dict):
-    """ Modules dependency graph.
 
-    The graph is a mapping from module name to Nodes.
-
+class Package:
     """
-
-    def add_node(self, name, info):
-        max_depth, father = 0, None
-        for d in info['depends']:
-            n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
-            if n.depth >= max_depth:
-                father = n
-                max_depth = n.depth
-        if father:
-            return father.add_child(name, info)
-        else:
-            return Node(name, self, info)
-
-    def update_from_db(self, cr):
-        if not len(self):
-            return
-        # update the graph with values from the database (if exist)
-        ## First, we set the default values for each package in graph
-        additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in self.keys()}
-        ## Then we get the values from the database
-        cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
-                   '  FROM ir_module_module'
-                   ' WHERE name IN %s',(tuple(additional_data),)
-                   )
-
-        ## and we update the default values with values from the database
-        additional_data.update((x['name'], x) for x in cr.dictfetchall())
-
-        for package in self.values():
-            for k, v in additional_data[package.name].items():
-                setattr(package, k, v)
-
-    def add_module(self, cr, module, force=None):
-        self.add_modules(cr, [module], force)
-
-    def add_modules(self, cr, module_list, force=None):
-        if force is None:
-            force = []
-        packages = []
-        len_graph = len(self)
-        for module in module_list:
-            info = odoo.modules.module.get_manifest(module)
-            if info and info['installable']:
-                packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
-            elif module != 'studio_customization':
-                _logger.warning('module %s: not installable, skipped', module)
-
-        dependencies = dict([(p, info['depends']) for p, info in packages])
-        current, later = set([p for p, info in packages]), set()
-
-        while packages and current > later:
-            package, info = packages[0]
-            deps = info['depends']
-
-            # if all dependencies of 'package' are already in the graph, add 'package' in the graph
-            if all(dep in self for dep in deps):
-                if not package in current:
-                    packages.pop(0)
-                    continue
-                later.clear()
-                current.remove(package)
-                node = self.add_node(package, info)
-                for kind in ('init', 'demo', 'update'):
-                    if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
-                        setattr(node, kind, True)
-            else:
-                later.add(package)
-                packages.append((package, info))
-            packages.pop(0)
-
-        self.update_from_db(cr)
-
-        for package in later:
-            unmet_deps = [p for p in dependencies[package] if p not in self]
-            _logger.info('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
-
-        return len(self) - len_graph
-
-
-    def __iter__(self):
-        level = 0
-        done = set(self.keys())
-        while done:
-            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
-            for name, module in level_modules:
-                done.remove(name)
-                yield module
-            level += 1
-
-    def __str__(self):
-        return '\n'.join(str(n) for n in self if n.depth == 0)
-
-class Node(object):
-    """ One module in the modules dependency graph.
-
-    Node acts as a per-module singleton. A node is constructed via
-    Graph.add_module() or Graph.add_modules(). Some of its fields are from
-    ir_module_module (set by Graph.update_from_db()).
-
+    Python package for the Odoo module with the same name
     """
-    def __new__(cls, name, graph, info):
-        if name in graph:
-            inst = graph[name]
-        else:
-            inst = object.__new__(cls)
-            graph[name] = inst
-        return inst
-
-    def __init__(self, name, graph, info):
+    def __init__(self, name: str) -> None:
+        # manifest data
         self.name = name
-        self.graph = graph
-        self.info = info or getattr(self, 'info', {})
-        if not hasattr(self, 'children'):
-            self.children = []
-        if not hasattr(self, 'depth'):
-            self.depth = 0
+        self.manifest = odoo.modules.module.get_manifest(name) or {}
 
-    @property
-    def data(self):
-        return self.info
+        # ir_module_module data             # column_name
+        self.id = None                      # id
+        self.state = 'uninstalled'          # state
+        self.dbdemo = False                 # demo
+        self.installed_version = None       # latest_version
 
-    def add_child(self, name, info):
-        node = Node(name, self.graph, info)
-        node.depth = self.depth + 1
-        if node not in self.children:
-            self.children.append(node)
-        for attr in ('init', 'update', 'demo'):
-            if hasattr(self, attr):
-                setattr(node, attr, True)
-        self.children.sort(key=lambda x: x.name)
-        return node
+        # info for upgrade
+        self.load_state = None               # the state when loaded to packages
+        self.load_version = None             # the version when loaded to packages
 
-    def __setattr__(self, name, value):
-        super(Node, self).__setattr__(name, value)
-        if name in ('init', 'update', 'demo'):
-            tools.config[name][self.name] = 1
-            for child in self.children:
-                setattr(child, name, value)
-        if name == 'depth':
-            for child in self.children:
-                setattr(child, name, value + 1)
+        # dependency
+        self.depends: Set[Package] = set()
+        self._depth_loop = False            # detects dependency loops
 
-    def __iter__(self):
-        return itertools.chain(
-            self.children,
-            itertools.chain.from_iterable(self.children)
-        )
+    @tools.lazy_property
+    def depth(self) -> int:
+        """ Return the longest distance from self to module 'base' along dependencies. """
+        if self._depth_loop:
+            raise RecursionError
+        self._depth_loop = True
+        depth = max(package.depth for package in self.depends) + 1 if self.depends else 0
+        self._depth_loop = False
+        return depth
 
-    def __str__(self):
-        return self._pprint()
+    def demo_installable(self) -> bool:
+        return all(p.dbdemo for p in self.depends)
 
-    def _pprint(self, depth=0):
-        s = '%s\n' % self.name
-        for c in self.children:
-            s += '%s`-> %s' % ('   ' * depth, c._pprint(depth+1))
-        return s
 
-    def should_have_demo(self):
-        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
+class PackageGraph:
+    """
+    Sorted Python packages for Odoo modules with the same names ordered by (package.depth, package.name)
+    """
 
-    @property
-    def parents(self):
-        if self.depth == 0:
-            return []
+    def __init__(self, cr) -> None:
+        self._packages: Dict[str, Package] = {}
+        self._cr = cr
 
-        return (
-            node for node in self.graph.values()
-            if node.depth < self.depth
-            if self in node.children
-        )
+    def __contains__(self, name: str) -> bool:
+        return name in self._packages
+
+    def __getitem__(self, name: str) -> Package:
+        return self._packages[name]
+
+    def __iter__(self) -> Iterator[Package]:
+        return iter(sorted(self._packages.values(), key=lambda package: (package.depth, package.name)))
+
+    def __len__(self) -> int:
+        return len(self._packages)
+
+    def __bool__(self) -> bool:
+        return bool(self._packages)
+
+    def add(self, names: Iterable[str]) -> None:
+        for name in names:
+            package = self._packages[name] = Package(name)
+            if not package.manifest.get('installable'):
+                message = None if name == 'studio_customization' else 'not_installable'
+                self._remove(name, message)
+
+        self._update_depends(names)
+        self._check_depth(names)
+        self._update_from_database(names)
+
+    def _update_depends(self, names: Iterable[str]) -> None:
+        for name in names:
+            package = self._packages.get(name)
+            if package is not None:
+                try:
+                    package.depends = set(self._packages[dep] for dep in package.manifest['depends'])
+                except KeyError:
+                    self._remove(name, 'missing_depends')
+
+    def _check_depth(self, names: Iterable[str]) -> None:
+        for name in names:
+            package = self._packages.get(name)
+            try:
+                package and package.depth
+            except RecursionError:
+                self._remove(name, 'depends_loop')
+
+    def _update_from_database(self, names: Iterable[str]) -> None:
+        names = tuple(name for name in names if name in self._packages)
+        if not names:
+            return
+        # update packages with values from the database (if exist)
+        query = '''
+            SELECT name, id, state, demo, latest_version AS installed_version
+            FROM ir_module_module
+            WHERE name IN %s
+        '''
+        self._cr.execute(query, [names])
+        for name, id_, state, demo, installed_version in self._cr.fetchall():
+            package = self._packages[name]
+            package.id = id_
+            package.state = state
+            package.dbdemo = demo
+            package.installed_version = installed_version
+            package.load_version = installed_version
+            package.load_state = state
+
+    def _remove(self, name: str, reason: str = None) -> None:
+        package = self._packages.pop(name, None)
+        if package is not None:
+            if reason:
+                logger, message = self._REMOVE_MESSAGES.get(reason, (_logger.debug, reason))
+                logger('module %s: %s', name, message)
+            for other, other_package in list(self._packages.items()):
+                if package in other_package.depends:
+                    self._remove(other, reason)
+
+    _REMOVE_MESSAGES = {
+        'depends_loop': (_logger.warning, 'in a dependency loop, skipped'),
+        'not_installable': (_logger.warning, 'not installable, skipped'),
+        'missing_depends': (_logger.info, 'some depends are not loaded, skipped'),
+    }

--- a/odoo/modules/migration.py
+++ b/odoo/modules/migration.py
@@ -81,8 +81,7 @@ class MigrationManager(object):
             }
 
         for pkg in self.graph:
-            if not (hasattr(pkg, 'update') or pkg.state == 'to upgrade' or
-                    getattr(pkg, 'load_state', None) == 'to upgrade'):
+            if pkg.load_state != 'to upgrade':
                 continue
 
             self.migrations[pkg.name] = {
@@ -103,9 +102,11 @@ class MigrationManager(object):
             'post': '[%s>]',
             'end': '[$%s]',
         }
-        state = pkg.state if stage in ('pre', 'post') else getattr(pkg, 'load_state', None)
 
-        if not (hasattr(pkg, 'update') or state == 'to upgrade') or state == 'to install':
+        if not (
+                (stage in ('pre', 'post') and pkg.state == 'to upgrade') or
+                (stage == 'end' and pkg.load_state == 'to upgrade')
+        ):
             return
 
         def convert_version(version):
@@ -144,9 +145,9 @@ class MigrationManager(object):
                 key=os.path.basename,
             )
 
-        installed_version = getattr(pkg, 'load_version', pkg.installed_version) or ''
+        installed_version = pkg.load_version or ''
         parsed_installed_version = parse_version(installed_version)
-        current_version = parse_version(convert_version(pkg.data['version']))
+        current_version = parse_version(convert_version(pkg.manifest['version']))
 
         def compare(version):
             if version == "0.0.0" and parsed_installed_version < current_version:

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -33,7 +33,7 @@ _DEFAULT_MANIFEST = {
     'data': [],
     'demo': [],
     'demo_xml': [],
-    'depends': [],
+    'depends': ['base'],
     'description': '',
     'external_dependencies': {},
     #icon: f'/{module}/static/description/icon.png',  # automatic
@@ -314,6 +314,12 @@ def load_manifest(module, mod_path=None):
     if not manifest.get('license'):
         manifest['license'] = 'LGPL-3'
         _logger.warning("Missing `license` key in manifest for %r, defaulting to LGPL-3", module)
+
+    if module == 'base':
+        manifest['depends'] = []
+    elif not manifest['depends']:
+        # prevent the hack `'depends': []` except 'base' module
+        manifest['depends'] = _DEFAULT_MANIFEST['depends'].copy()
 
     # auto_install is either `False` (by default) in which case the module
     # is opt-in, either a list of dependencies in which case the module is

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -522,8 +522,6 @@ class configmanager(object):
         )
 
         self.options['init'] = opt.init and dict.fromkeys(opt.init.split(','), 1) or {}
-        self.options['demo'] = (dict(self.options['init'])
-                                if not self.options['without_demo'] else {})
         self.options['update'] = opt.update and dict.fromkeys(opt.update.split(','), 1) or {}
         self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()


### PR DESCRIPTION
The object of this commit is
1. decouple the graph.py and loading.py. graph.py is only used to determine the
   loading order
2. simplify graph.py to improve the readability and time complexity

Changes:
config:
the tools.config['demo'] is removed, because
1. it didn't work as it described before
2. we only support 2 modes and `tools.config['demo']` is not needed
    a. `bool(tools.config['without_demo']) is True` : don't install demo
    b. `bool(tools.config['without_demo']) is False`: install demo when
       `package.demo_installable() is True`

each package/pkg/node of the graph:
before:
1. manifest dict can be get from `package.data` and `package.info`
2. `package.init`, `package.update` contains the config for install/upgrade
3. `package.demo` contains the config for demo when upgrade/install
4. `package.load_state` and `package.load_version` are only available when a
   module is updated when loading
5. `package.should_have_demo()` returns if the loading.py should install demo
   for the package

after:
1. manifest dict can only be get from `package.manifest`
2. `package.init`, `package.update` are removed since they only have part of
   install/upgrade info comparing with the `package.state`
3. `package.demo` is removed since we directly get the demo config from
   `tool.config['without_demo']`
4. `package.load_state` and `package.load_version` are always available
5. `package.demo_installable()` returns if the package's demo can be installed

manifest:
before:
If `depends: []` or undefined `depends` in a manifest, the module installed
before all module with `depends: ['base']` but after the 'base' module
after:
the hack `depends: []` or undefined `depends` will be changed to
`depends: ['base']` in manifest
