### PR TITLE
[IMP] hr_holidays: improve stress days display

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar/time_off_calendar_controller.js
@@ -112,7 +112,7 @@ export const TimeOffCalendarController = CalendarController.extend({
                 args: [this.model.data.start_date, this.model.data.end_date],
                 context: this.context,
             }).then((stressDays) => {
-                this.$el.find('td.fc-day').toArray().forEach((td) => {
+                this.$el.find('td.fc-day-top').toArray().forEach((td) => {
                     if (stressDays[td.dataset.date]) {
                         td.classList.add('hr_stress_day_' + stressDays[td.dataset.date]);
                     }

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -47,7 +47,14 @@
 
     @for $size from 1 through length($o-colors) {
         .hr_stress_day_#{$size - 1} {
-            background-color: lighten(nth($o-colors, $size), 25%) !important;
+            .fc-day-number {
+                color: darken(nth($o-colors, $size), 20%) !important;
+            }
+            &.fc-today {
+                .fc-day-number {
+                    color: lighten(nth($o-colors, $size), 20%) !important;
+                }
+            }
         }
     }
 }
@@ -62,6 +69,15 @@
         list-style: none;
         padding-left: 0;
         margin: 0px;
+    }
+}
+
+.o_timeoff_legend {
+    .o_timeoff_legend_stressday {
+        display: inline-block;
+        width: 30px;
+        text-align: center;
+        color: $o-brand-odoo;
     }
 }
 

--- a/addons/hr_holidays/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays/static/src/xml/time_off_calendar.xml
@@ -65,6 +65,7 @@
                 <img src="/hr/static/src/img/icons/plain.svg" width="30px"/><span>Validated</span><br/>
                 <img src="/hr/static/src/img/icons/hatched.svg" width="30px"/><span>To Approve</span><br/>
                 <img src="/hr/static/src/img/icons/line.svg" width="30px"/><span>Refused</span><br/>
+                <span class="o_timeoff_legend_stressday">13</span><span>Stress Day</span>
             </div>
         </t>
     </t>


### PR DESCRIPTION
Before this commit stress days were displayed as colored rectangles on the calendar which made it ambiguous compared to leaves. After this commit the stress day have the number colored instead and the signification has been added to the legend on the side.

task-3226525