### PR TITLE
[FIX] mass_mailing: access campaign when having a favorite filter

### DIFF
--- a/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
+++ b/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
@@ -63,8 +63,9 @@ export class FieldMany2OneMailingFilter extends Many2OneField {
         const recordDomain = new Domain(this.props.record.data[this.props.domain_field] || []).toString();
         const filterDomain = new Domain(this.props.record.data.mailing_filter_domain || []).toString();
         el.classList.toggle('d-none', recordDomain === '[]');
+        const $inputModelField = document.querySelector(`input#${this.props.model_field}`);
         this.filter.canSaveFilter = !this.props.record.data.mailing_filter_id
-            || !document.querySelector(`input#${this.props.model_field}`).value.length
+            || $inputModelField && !$inputModelField.value.length
             || this.state.isFloating
             || filterDomain !== recordDomain;
     }


### PR DESCRIPTION
Steps to reproduce:

  - Install `Marketing Automation` module
  - Go to Marketing Automation and create a new Campaign
  - Add any filter, then add it to the favorite filters
  - Add an activity
  - Start the campaign

Issue:

  Traceback raised.

Cause:

  Checking if value of the input `model_field` is set (to know if we can
  display the add filter to favorite feature) while there is no input on
  the DOM since the field is in `readonly` mode.

Solution:

  Do not check input value if the input field is not in the DOM.

opw-3210419