### PR TITLE
[IMP] hr_expense,sale: analytic distribution compute

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -309,13 +309,13 @@ class HrExpense(models.Model):
     @api.depends('product_id', 'account_id')
     def _compute_analytic_distribution(self):
         for expense in self:
-            distribution = self.env['account.analytic.distribution.model']._get_distribution({
-                'product_id': expense.product_id.id,
-                'product_categ_id': expense.product_id.categ_id.id,
-                'account_prefix': expense.account_id.code,
-                'company_id': expense.company_id.id,
-            })
-            expense.analytic_distribution = distribution or expense.analytic_distribution
+            if not expense.analytic_distribution:
+                expense.analytic_distribution = self.env['account.analytic.distribution.model']._get_distribution({
+                    'product_id': expense.product_id.id,
+                    'product_categ_id': expense.product_id.categ_id.id,
+                    'account_prefix': expense.account_id.code,
+                    'company_id': expense.company_id.id,
+                })
 
     @api.constrains('payment_mode')
     def _check_payment_mode(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -894,7 +894,7 @@ class SaleOrderLine(models.Model):
     @api.depends('order_id.partner_id', 'product_id')
     def _compute_analytic_distribution(self):
         for line in self:
-            if not line.display_type and line.state == 'draft':
+            if not line.display_type and line.state == 'draft' and not line.analytic_distribution:
                 distribution = line.env['account.analytic.distribution.model']._get_distribution({
                     "product_id": line.product_id.id,
                     "product_categ_id": line.product_id.categ_id.id,
@@ -902,7 +902,7 @@ class SaleOrderLine(models.Model):
                     "partner_category_id": line.order_id.partner_id.category_id.ids,
                     "company_id": line.company_id.id,
                 })
-                line.analytic_distribution = distribution or line.analytic_distribution
+                line.analytic_distribution = distribution
 
     @api.depends('product_id', 'state', 'qty_invoiced', 'qty_delivered')
     def _compute_product_updatable(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -503,6 +503,9 @@ class TestSalesTeam(SaleCommon):
 
         self.assertEqual(sol.analytic_distribution, {str(analytic_account_super.id): 100}, "The analytic distribution should be set to Super Account")
         sol.write({'product_id': great_product.id})
+        self.assertEqual(sol.analytic_distribution, {str(analytic_account_super.id): 100}, "The analytic distribution should remain to Super Account")
+        sol.write({'analytic_distribution': False})
+        sol.write({'product_id': great_product.id})
         self.assertEqual(sol.analytic_distribution, {str(analytic_account_great.id): 100}, "The analytic distribution should be set to Great Account")
 
         so_no_analytic_account = self.env['sale.order'].create({


### PR DESCRIPTION
When the proper conditions are met for an analytic distribution model to be used either in a sale order line or in an expense line, we want to import the analytic distribution model only if the user has not previously already encoded an analytic distribution. Continuity of this improvement (Purchase flow): https://github.com/odoo/odoo/pull/111630

Steps to encounter the improvement:
 - create an analytic distribution model in Accounting app with a specific customer and product
 - create a sale order and specify an analytic distribution
 - change sale order by applying the specific customer and product of step 1

 Result:
 - the analytic distribution is not changed because it was already provided by the user at step 2

task: 3167148




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
