### PR TITLE
[FIX] mrp: manage mrp_operation picking type

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -162,6 +162,13 @@ class ProductProduct(models.Model):
         else:
             return super(ProductProduct, self).get_components()
 
+    def _get_description(self, picking_type_id):
+        self.ensure_one()
+        if picking_type_id.code == 'mrp_operation':
+            return self._get_description_or_name()
+
+        return super()._get_description(picking_type_id)
+
     def action_used_in_bom(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_form_action")

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -228,19 +228,23 @@ class Product(models.Model):
         self.ensure_one()
         return self.ids
 
+    def _get_description_or_name(self):
+        return html2plaintext(self.description) if not is_html_empty(self.description) else self.name
+
     def _get_description(self, picking_type_id):
         """ return product receipt/delivery/picking description depending on
         picking type passed as argument.
         """
         self.ensure_one()
         picking_code = picking_type_id.code
-        description = html2plaintext(self.description) if not is_html_empty(self.description) else self.name
+        description = self._get_description_or_name()
         if picking_code == 'incoming':
             return self.description_pickingin or description
         if picking_code == 'outgoing':
             return self.description_pickingout or self.name
         if picking_code == 'internal':
             return self.description_picking or description
+        return description
 
     def _get_domain_locations(self):
         '''


### PR DESCRIPTION
mrp_operation picking type is not handle by default in stock module get_description function. 
Override the function to handle it if mrp_operation exist (via mrp module)

Add default return to stock get_description function

Copy for 14.0: https://github.com/odoo/odoo/pull/115310

opw-3232811

Description of the issue/feature this PR addresses:
Handle "mrp_operation" picking type in get description

Current behavior before PR:
Unable to confirm MO with "mrp_operation" picking type for stock move

Desired behavior after PR is merged:
Able to confirm MO with "mrp_operation" picking type for stock move



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
