### PR TITLE
[FIX] account: allow change journal on entry form

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -675,7 +675,8 @@ class AccountMove(models.Model):
         highest_name = self[0]._get_last_sequence(lock=False) if self else False
 
         for move in self:
-            if not highest_name and move == self[0] and not move.posted_before and move.date and (not move.name or move.name == '/'):
+            if not highest_name and move == self[0] and not move.posted_before and move.date and \
+                    ((not move.name or move.name == '/') or move.move_type == 'entry'):
                 # In the form view, we need to compute a default sequence so that the user can edit
                 # it. We only check the first move as an approximation (enough for new in form view)
                 move._set_next_sequence()

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -382,6 +382,20 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             move_form.journal_id = journal
         self.assertEqual(move.name, 'AJ/2021/10/0001')
 
+    @freeze_time('2021-10-01 00:00:00')
+    def test_change_journal_account_move(self):
+        """Changing the journal should change the name of the move"""
+        journal = self.env['account.journal'].create({
+            'name': 'awesome journal',
+            'type': 'general',
+            'code': 'AJ',
+        })
+        move = self.env['account.move']
+        with Form(move) as move_form:
+            self.assertEqual(move_form.name, 'MISC/2021/10/0001')
+            move_form.journal_id = journal
+            self.assertEqual(move_form.name, 'AJ/2021/10/0001')
+
 
 @tagged('post_install', '-at_install')
 class TestSequenceMixinDeletion(TestSequenceMixinCommon):


### PR DESCRIPTION
Before this commit, on a new journal entry, the change
of the journal was not reflected on the name of the
move. Unless by saving it, then changing journal and
saving it again.

opw-3220764
