### PR TITLE
[FIX] account: prevent compute when default values are set

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -671,7 +671,7 @@ class AccountPayment(models.Model):
 
     def new(self, values=None, origin=None, ref=None):
         payment = super(AccountPayment, self.with_context(is_payment=True)).new(values, origin, ref)
-        if not payment.journal_id:  # might not be computed because declared by inheritance
+        if not payment.journal_id and not self.env.context.get('default_journal_id'):  # might not be computed because declared by inheritance
             payment.move_id._compute_journal_id()
         return payment
 


### PR DESCRIPTION
Steps to reproduce:
- In the Accounting Dashboard / Bank / three dots
- Click on "New - Internal Transfer"

Issue:
- The internal transfer field is not ticked

Cause:
The payment has yet no journal_id so we trigger manually the `_compute_journal_id` which in turn trigger the `_compute_is_internal_transfer` (depends on `journal_id`). -> `is_internal_transfer` is set to False

Solution:
Prevent the call to the compute if the journal_id has default value in the context context set in the `open_payments_action`
https://github.com/odoo/odoo/blob/ae71a4c255e995b5d232cb837e2879454bf30a52/addons/account/models/account_journal_dashboard.py#L557-L560

opw-3142646