### PR TITLE
[FIX] web: invoice lines overflow

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1226,3 +1226,7 @@
     clear: both;
     justify-content: space-between;
 }
+
+.o_field_widget.o_field_section_and_note_one2many{
+    display: block;
+}


### PR DESCRIPTION
When opening the form view of a sales or purchase invoice in firefox, if there are many columns in the lines or little horizontal space, an overflow problem occurred.

This fix makes the form display correctly.

@moduon MT-2408 OPW-3201461

Description of the issue/feature this PR addresses:

Current behavior before PR:

![image](https://user-images.githubusercontent.com/22261939/225582916-70f6428f-2f5c-4d28-9fa6-10bb327c7afc.png)


Desired behavior after PR is merged:

![image](https://user-images.githubusercontent.com/22261939/225583361-a4642272-db5d-47cd-b543-9a0fc2b7f85f.png)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
