### PR TITLE
[FIX] point_of_sale: prevent list index out of range when user is the superuser

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -10,7 +10,7 @@ import psycopg2
 import pytz
 import re
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, _, SUPERUSER_ID
 from odoo.tools import float_is_zero, float_round, float_repr, float_compare
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv.expression import AND
@@ -37,7 +37,7 @@ class PosOrder(models.Model):
     def _order_fields(self, ui_order):
         process_line = partial(self.env['pos.order.line']._order_line_fields, session_id=ui_order['pos_session_id'])
         return {
-            'user_id':      ui_order['user_id'] or False,
+            'user_id':      ui_order.get('user_id') or SUPERUSER_ID if SUPERUSER_ID else False,
             'session_id':   ui_order['pos_session_id'],
             'lines':        [process_line(l) for l in ui_order['lines']] if ui_order['lines'] else False,
             'pos_reference': ui_order['name'],

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import timedelta
 from itertools import groupby
 
-from odoo import api, fields, models, _, Command
+from odoo import api, fields, models, _, Command, SUPERUSER_ID
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools import float_is_zero, float_compare
 from odoo.osv.expression import AND, OR
@@ -1790,9 +1790,11 @@ class PosSession(models.Model):
         }
 
     def _get_pos_ui_res_users(self, params):
-        user = self.env['res.users'].search_read(**params['search_params'])[0]
-        user['role'] = 'manager' if any(id == self.config_id.group_pos_manager_id.id for id in user['groups_id']) else 'cashier'
-        del user['groups_id']
+        user = self.env['res.users'].search_read(**params['search_params'])
+        if user and user[0].get('id') != SUPERUSER_ID:
+            user = user[0]
+            user['role'] = 'manager' if any(id == self.config_id.group_pos_manager_id.id for id in user['groups_id']) else 'cashier'
+            del user['groups_id']
         return user
 
     def _loader_params_product_pricelist(self):


### PR DESCRIPTION
This issue was caught in Sentry.
when user click on the start session button, _get_pos_ui_res_users() method is called, it raises error because it does not get the id of the user if the user is the superuser.

see:
![Screenshot from 2023-03-16 18-25-56](https://user-images.githubusercontent.com/120459810/225623590-b5254a77-3267-4e97-b0c1-8db6f7b82b24.png)


sentry-3961892296

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
