### PR TITLE
[FIX] mail: invalidate the cache of the documents

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1126,7 +1126,7 @@ class Message(models.Model):
         for record in self:
             model = model or record.model
             res_id = res_id or record.res_id
-            if issubclass(self.pool[model], self.pool['mail.thread']):
+            if self.pool.get(model) and issubclass(self.pool.get(model), self.pool['mail.thread']):
                 self.env[model].browse(res_id).invalidate_recordset(fnames)
 
     def _get_search_domain_share(self):


### PR DESCRIPTION
If applied, this commit will solve the keyError for _invalidate_documents.

Before this commit:
============================================
KeyError 'rating' or 'False' occurs when a user tries to send a message and
 _invalidate_documents() takes the parameter model equal to 'rating' or 'False'.
but the model 'rating' is not available in the database and It will be accessed by the self.pool[model].

After this commit:
============================================
Solved the issue when the model 'rating' is not available or the model is 'False' while sending a message.

sentry - 3956327451

see - https://tinyurl.com/2zu47adg

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
