### PR TITLE
[FIX] web: pivot reset groupBy filter

### DIFF
--- a/addons/web/static/src/js/views/pivot/pivot_model.js
+++ b/addons/web/static/src/js/views/pivot/pivot_model.js
@@ -496,6 +496,7 @@ var PivotModel = AbstractModel.extend({
         temp = this.data.expandedColGroupBys;
         this.data.expandedColGroupBys = this.data.expandedRowGroupBys;
         this.data.expandedRowGroupBys = temp;
+        this.flipped = !this.flipped;
 
         function twistKey(key) {
             return JSON.stringify(JSON.parse(key).reverse());
@@ -575,6 +576,7 @@ var PivotModel = AbstractModel.extend({
         this.initialDomain = params.domain;
         this.initialRowGroupBys = params.context.pivot_row_groupby || params.rowGroupBys;
         this.defaultGroupedBy = params.groupedBy;
+        this.flipped = false;
 
         this.fields = params.fields;
         this.modelName = params.modelName;
@@ -638,7 +640,7 @@ var PivotModel = AbstractModel.extend({
             this.data.domain = this.initialDomain;
         }
         if ('groupBy' in params) {
-            this.data.groupedBy = params.groupBy.length ? params.groupBy : this.defaultGroupedBy;
+            this.data.groupedBy = params.groupBy.length ? params.groupBy : this.flipped ? this.defaultGroupedBy : this.initialRowGroupBys;
         }
         if ('timeRanges' in params) {
             this.data.timeRanges = params.timeRanges;


### PR DESCRIPTION
To reproduce
============
- on any app with pivot view
- set a groupBy, then remove it it doesn't bring back the default display

Problem
=======
when removing the groupBy filter, we take last groupBy value instead of the initial ones

Solution
========
use `initialRowGroupBys` when `params.groupBy` is empty

opw-3215313