### PR TITLE
[FIX] core,account: prevent reading fake binary fields over rpc

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -276,7 +276,7 @@ class AccountMove(models.Model):
         states={'posted': [('readonly', True)], 'cancel': [('readonly', True)]},
         check_company=True,
     )
-    needed_terms = fields.Binary(compute='_compute_needed_terms')
+    needed_terms = fields.Binary(compute='_compute_needed_terms', exportable=False)
     needed_terms_dirty = fields.Boolean(compute='_compute_needed_terms')
 
     # === Partner fields === #
@@ -476,7 +476,7 @@ class AccountMove(models.Model):
         help='Use this field to encode the total amount of the invoice.\n'
              'Odoo will automatically create one invoice line with default values to match it.',
     )
-    quick_encoding_vals = fields.Binary(compute='_compute_quick_encoding_vals')
+    quick_encoding_vals = fields.Binary(compute='_compute_quick_encoding_vals', exportable=False)
 
     # === Misc Information === #
     narration = fields.Html(
@@ -546,7 +546,7 @@ class AccountMove(models.Model):
     duplicated_ref_ids = fields.Many2many(comodel_name='account.move', compute='_compute_duplicated_ref_ids')
 
     # used to display the various dates and amount dues on the invoice's PDF
-    payment_term_details = fields.Binary(compute="_compute_payment_term_details")
+    payment_term_details = fields.Binary(compute="_compute_payment_term_details", exportable=False)
     show_payment_term_details = fields.Boolean(compute="_compute_show_payment_term_details")
     show_discount_details = fields.Boolean(compute="_compute_show_payment_term_details")
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -347,12 +347,12 @@ class AccountMoveLine(models.Model):
     )
 
     # === Invoice sync fields === #
-    term_key = fields.Binary(compute='_compute_term_key')
-    tax_key = fields.Binary(compute='_compute_tax_key')
-    compute_all_tax = fields.Binary(compute='_compute_all_tax')
+    term_key = fields.Binary(compute='_compute_term_key', exportable=False)
+    tax_key = fields.Binary(compute='_compute_tax_key', exportable=False)
+    compute_all_tax = fields.Binary(compute='_compute_all_tax', exportable=False)
     compute_all_tax_dirty = fields.Boolean(compute='_compute_all_tax')
-    epd_key = fields.Binary(compute='_compute_epd_key')
-    epd_needed = fields.Binary(compute='_compute_epd_needed')
+    epd_key = fields.Binary(compute='_compute_epd_key', exportable=False)
+    epd_needed = fields.Binary(compute='_compute_epd_needed', exportable=False)
     epd_dirty = fields.Boolean(compute='_compute_epd_needed')
 
     # === Analytic fields === #

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2866,6 +2866,8 @@ class BaseModel(metaclass=MetaModel):
         def valid(fname):
             """ determine whether user has access to field ``fname`` """
             field = self._fields.get(fname)
+            if not field.exportable:
+                return None
             if field and field.groups:
                 return self.user_has_groups(field.groups)
             else:
@@ -2874,7 +2876,7 @@ class BaseModel(metaclass=MetaModel):
         if not fields:
             fields = [name for name in self._fields if valid(name)]
         else:
-            invalid_fields = {name for name in fields if not valid(name)}
+            invalid_fields = {name for name in fields if valid(name) is False}
             if invalid_fields:
                 _logger.info('Access Denied by ACLs for operation: %s, uid: %s, model: %s, fields: %s',
                              operation, self._uid, self._name, ', '.join(invalid_fields))


### PR DESCRIPTION
Since Odoo 16 [1] account module uses some non-storable computed Binary fields to compute and access structured data. Those data is not transformed into binary data and is not supposed to be used outside of server environment. There are still use cases when ORM tries to process such fields as normal Binary fields. For example, on using export wizard [2].

This commit fixes similar problem on reading `account.move` record via rpc.

STEPS: create `account.move` record and read it via an RPC call [3]

```
account_move_id = 666
models.execute_kw(db, uid, password, 'account.move', 'read', [account_move_id])
```

SOLUTION

1. Add missing `exportable=False` to the fake Binary fields
2. Add `call_kw=True` context on calling method via rpc
3. Block access to non-exportable fields when `call_kw` context is presented

[1]:
https://github.com/odoo/odoo/commit/d8d47f9ff8554f4b39487fd2f13c153c7d6f958d [2]: https://github.com/odoo/odoo/commit/c925ecb2a22750524020f0d111888fd76eedb0cb [3]: https://www.odoo.com/documentation/16.0/developer/api/external_api.html

opw-3099975

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
