### PR TITLE
[FIX] web: Break too long names in kanban cards

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -123,6 +123,7 @@
         }
 
         .o_kanban_record_bottom {
+
             .oe_kanban_bottom_left,
             .oe_kanban_bottom_right {
                 display: flex;
@@ -131,6 +132,7 @@
             }
             .oe_kanban_bottom_left {
                 flex: 1 1 auto;
+                max-width: 80%;
 
                 > * {
                     margin-right: 6px;
@@ -140,6 +142,11 @@
                 .o_priority_star {
                     margin-top: 1px;
                     font-size: 18px;
+                }
+
+                span {
+                    max-width: 80%;
+                    overflow-wrap: break-word;
                 }
             }
             .oe_kanban_bottom_right {


### PR DESCRIPTION
**Moved to https://github.com/odoo/odoo/pull/117579 as this fix need to target 16.0**

[FIX] web: Break too long names in kanban cards

Behaviour before PR:
In kanban view, the cards UI is broken when there are too long words without spaces or breaks in the bottom half of the cards.

Desired behaviour after PR:
The words are broken so it fits in the cards without breaking the UI.


Task: 3083665

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
