### PR TITLE
[FIX] website_sale: fix the display of previous product price in product

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1160,9 +1160,9 @@
                     itemprop="listPrice"
                 />
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
-                <del t-if="product.compare_list_price">
-                    <span t-field="product.compare_list_price"
-                        groups="website_sale.group_product_price_comparison"
+                <t t-set="template_price_vals" t-value="product._get_sales_prices(website.pricelist_id)"/>
+                <del t-if="product.id in template_price_vals and 'base_price' in template_price_vals[product.id]">
+                    <span t-esc="template_price_vals[product.id]['base_price']"
                         t-options='{
                            "widget": "monetary",
                            "display_currency": product.currency_id,
@@ -1176,9 +1176,9 @@
                        "display_currency": product.currency_id,
                 }'/>
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
-                <del t-if="product.compare_list_price">
-                    <span t-field="product.compare_list_price"
-                        groups="website_sale.group_product_price_comparison"
+                <t t-set="template_price_vals" t-value="product._get_sales_prices(website.pricelist_id)"/>
+                <del t-if="product.id in template_price_vals and 'base_price' in template_price_vals[product.id]">
+                    <span t-esc="template_price_vals[product.id]['base_price']"
                         t-options='{
                             "widget": "monetary",
                             "display_currency": product.currency_id,


### PR DESCRIPTION
Steps to reproduce the bug:

- We need website and website_sale.
- Navigate to the settings > Website > Shop - Products.
- And under here we are gonna set Display Product Prices to be Tax Included, and we are going to activate Comparison Price.
- Now go to any product and we are gonna add a price, and a Compare to Price, after this, make sure we have set taxes for the product.
- Finally go to the frontend and go to the eCommerce shop, If we look here, the prices should be good, but If we go to an specific product, we can see that there are some differences.

Issue:

The problem is that we are not displaying the calculated price with the taxes applied, as we have selected previously. Instead we are using directly the `compare_list_price`, which is the price we have selected without taxes.

Solution:

Following the same behavior we used for the view of all the products, we can use the same method to calculate the price with taxes applied and display them in the product page.

opw-3216965