### PR TITLE
[IMP] web: add clipboard service

### DIFF
--- a/addons/web/static/src/core/clipboard/clipboard_service.js
+++ b/addons/web/static/src/core/clipboard/clipboard_service.js
@@ -1,0 +1,42 @@
+/** @odoo-module **/
+
+import { registry } from "../registry";
+import { browser } from "@web/core/browser/browser";
+
+/**
+ *  @typedef {{
+ *      writeText(
+ *          String: text,
+ *          options?: ...       TODO
+ *      ): () => void;
+ *  }}
+ */
+
+export const clipboardService = {
+
+    /** @returns {void} */
+    start(env) {
+
+        function writeText(text, options = {}) {
+            setTimeout(async () => { // Use a timeout for the Safari write to clipboard to work
+                try {
+                    await browser.navigator.clipboard.writeText(text);
+                    env.services.notification.add(env._t("Link copied to clipboard."), {type: "success"});
+                    if (options.onSuccess) {
+                        options.onSuccess();
+                    }
+                } catch (error) {
+                    env.services.notification.add(env._t("Error copying to clipboard."), {type: "danger"});
+                    console.error('Error copying to clipboard:', error);
+                    if (options.onError) {
+                        options.onError();
+                    }
+                }
+            });
+        }
+
+        return { writeText };
+    },
+};
+
+registry.category("services").add("clipboard", clipboardService);


### PR DESCRIPTION
In Odoo, there are multiple ways to write to/read the clipboard
(using the browser, the clipboardJS lib, the copyButton widget, ...).
Each time, there is duplicated code to write/read with the differents
success/failure handling.
When using the browsers clipboard, there is also the clipboard
permissions to handle and depending on the browser, we need
specific code for the write/read action to work.

To avoid the duplicated code, the browsers specificities, and
the permissions handling, which are highly traceback prone,
I propose to add a clipboard service in Odoo to have a reliable,
concised and generalized way to use the clipboard through all
Odoo apps.