### PR TITLE
[IMP] web: Add 'delay' param for draggable hooks

### DIFF
--- a/addons/web/static/src/core/utils/sortable.js
+++ b/addons/web/static/src/core/utils/sortable.js
@@ -202,5 +202,7 @@ export const useSortable = makeDraggableHook({
         current.placeHolder = current.element.cloneNode(false);
 
         addCleanup(() => current.placeHolder.remove());
+
+        return pick(current, "element", "group");
     },
 });


### PR DESCRIPTION
This commit introduces a "delay" parameter used to drag elements on a long mousedown instead of a short one.

This is coupled with the "tolerance" parameter to define the area in which the mousedown is considered uninterrupted.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
