### PR TITLE
[FIX] translate: cannot translate code outside of addons

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -472,7 +472,7 @@ class GettextAlias(object):
                 if not module:
                     path = inspect.getfile(frame)
                     path_info = odoo.modules.get_resource_from_path(path)
-                    module = path_info[0] if path_info else None
+                    module = path_info[0] if path_info else 'base'
                 return code_translations.get_python_translations(module, lang).get(source, source)
             else:
                 _logger.debug('no translation language detected, skipping translation for "%r" ', source)
@@ -510,7 +510,7 @@ class _lt:
         frame = inspect.currentframe().f_back
         path = inspect.getfile(frame)
         path_info = odoo.modules.get_resource_from_path(path)
-        self._module = path_info[0] if path_info else None
+        self._module = path_info[0] if path_info else 'base'
 
     def __str__(self):
         # Call _._get_translation() like _() does, so that we have the same number


### PR DESCRIPTION
before this commit, code in files for Odoo core which are outside of root_path/addons/
  e.g. odoo/models.py, odoo/service/model.py
cannot be translated. Because the translation tool thinks they don't belong to any module

after this commit, by reusing the same logic while exporting these code translations,
they will be translated by using po files of the 'base' module


---


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

Video:

https://user-images.githubusercontent.com/43790414/226787361-51950d5c-0463-4f62-a9f4-8501dc067b0b.mp4




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
