### PR TITLE
[FIX] payment_flutterwave: prevent key error 'event' in webhook in virtual card

### DIFF
--- a/addons/payment_flutterwave/controllers/main.py
+++ b/addons/payment_flutterwave/controllers/main.py
@@ -45,7 +45,7 @@ class FlutterwaveController(http.Controller):
         data = request.get_json_data()
         _logger.info("Notification received from Flutterwave with data:\n%s", pprint.pformat(data))
 
-        if data['event'] == 'charge.completed':
+        if data.get('event') == 'charge.completed':
             try:
                 # Check the origin of the notification.
                 tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(


### PR DESCRIPTION
KeyError "event" occurs when we try to access the Flutterware webhook because,
in a virtual card debit or OTP request, the key "event" is not available.

Traceback on sentry:

![KeyError-event-online-saas](https://user-images.githubusercontent.com/98319223/226598066-6a628295-aca5-4ecb-8722-9fb898d52deb.png)


This commit ensures that a key error will not be generated if "event"
is not available in the data.

sentry-4022514095


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
