### PR TITLE
[FIX] purchase,sale: packaging warning

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1237,24 +1237,6 @@ class PurchaseOrderLine(models.Model):
         if self.product_id and self.product_qty and self.product_uom:
             self.product_packaging_id = self.product_id.packaging_ids.filtered('purchase')._find_suitable_product_packaging(self.product_qty, self.product_uom) or self.product_packaging_id
 
-    @api.onchange('product_packaging_id')
-    def _onchange_product_packaging_id(self):
-        if self.product_packaging_id and self.product_qty:
-            newqty = self.product_packaging_id._check_qty(self.product_qty, self.product_uom, "UP")
-            if float_compare(newqty, self.product_qty, precision_rounding=self.product_uom.rounding) != 0:
-                return {
-                    'warning': {
-                        'title': _('Warning'),
-                        'message': _(
-                            "This product is packaged by %(pack_size).2f %(pack_name)s. You should purchase %(quantity).2f %(unit)s.",
-                            pack_size=self.product_packaging_id.qty,
-                            pack_name=self.product_id.uom_id.name,
-                            quantity=newqty,
-                            unit=self.product_uom.name
-                        ),
-                    },
-                }
-
     @api.onchange('product_packaging_id', 'product_uom', 'product_qty')
     def _onchange_update_product_packaging_qty(self):
         if not self.product_packaging_id:
@@ -1263,6 +1245,22 @@ class PurchaseOrderLine(models.Model):
             packaging_uom = self.product_packaging_id.product_uom_id
             packaging_uom_qty = self.product_uom._compute_quantity(self.product_qty, packaging_uom)
             self.product_packaging_qty = float_round(packaging_uom_qty / self.product_packaging_id.qty, precision_rounding=packaging_uom.rounding)
+            if self.product_qty:
+                newqty = self.product_packaging_id._check_qty(self.product_qty, self.product_uom, "UP")
+                if float_compare(newqty, self.product_qty, precision_rounding=self.product_uom.rounding) != 0:
+                    return {
+                        'warning': {
+                            'title': _('Warning'),
+                            'message': _(
+                                "This product is packaged by %(pack_size).2f %(pack_name)s. You should purchase %(quantity).2f %(unit)s.",
+                                pack_size=self.product_packaging_id.qty,
+                                pack_name=self.product_id.uom_id.name,
+                                quantity=newqty,
+                                unit=self.product_uom.name
+                            ),
+                        },
+                    }
+
 
     @api.onchange('product_packaging_qty')
     def _onchange_product_packaging_qty(self):

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -520,7 +520,14 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
 
         with Form(po) as po_form:
             with po_form.order_line.edit(0) as line:
-                line.product_qty = 8
+                with self.assertLogs(level="WARNING") as log_catcher:
+                    line.product_qty = 8
+
+        self.assertEqual(len(log_catcher.output), 1, "Exactly one warning should be logged")
+        self.assertIn(
+            'This product is packaged by 10.00 Units. You should purchase 10.00 Units.',
+            log_catcher.output[0],
+        )
 
         self.assertEqual(po.picking_ids.move_lines.product_uom_qty, 8)
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -412,24 +412,6 @@ class SaleOrderLine(models.Model):
         if self.product_id and self.product_uom_qty and self.product_uom:
             self.product_packaging_id = self.product_id.packaging_ids.filtered('sales')._find_suitable_product_packaging(self.product_uom_qty, self.product_uom) or self.product_packaging_id
 
-    @api.onchange('product_packaging_id')
-    def _onchange_product_packaging_id(self):
-        if self.product_packaging_id and self.product_uom_qty:
-            newqty = self.product_packaging_id._check_qty(self.product_uom_qty, self.product_uom, "UP")
-            if float_compare(newqty, self.product_uom_qty, precision_rounding=self.product_uom.rounding) != 0:
-                return {
-                    'warning': {
-                        'title': _('Warning'),
-                        'message': _(
-                            "This product is packaged by %(pack_size).2f %(pack_name)s. You should sell %(quantity).2f %(unit)s.",
-                            pack_size=self.product_packaging_id.qty,
-                            pack_name=self.product_id.uom_id.name,
-                            quantity=newqty,
-                            unit=self.product_uom.name
-                        ),
-                    },
-                }
-
     @api.onchange('product_packaging_id', 'product_uom', 'product_uom_qty')
     def _onchange_update_product_packaging_qty(self):
         if not self.product_packaging_id:
@@ -438,6 +420,21 @@ class SaleOrderLine(models.Model):
             packaging_uom = self.product_packaging_id.product_uom_id
             packaging_uom_qty = self.product_uom._compute_quantity(self.product_uom_qty, packaging_uom)
             self.product_packaging_qty = float_round(packaging_uom_qty / self.product_packaging_id.qty, precision_rounding=packaging_uom.rounding)
+            if self.product_uom_qty:
+                newqty = self.product_packaging_id._check_qty(self.product_uom_qty, self.product_uom, "UP")
+                if float_compare(newqty, self.product_uom_qty, precision_rounding=self.product_uom.rounding) != 0:
+                    return {
+                        'warning': {
+                            'title': _('Warning'),
+                            'message': _(
+                                "This product is packaged by %(pack_size).2f %(pack_name)s. You should sell %(quantity).2f %(unit)s.",
+                                pack_size=self.product_packaging_id.qty,
+                                pack_name=self.product_id.uom_id.name,
+                                quantity=newqty,
+                                unit=self.product_uom.name
+                            ),
+                        },
+                    }
 
     @api.onchange('product_packaging_qty')
     def _onchange_product_packaging_qty(self):

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1372,7 +1372,14 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
 
         with Form(so) as so_form:
             with so_form.order_line.edit(0) as line:
-                line.product_uom_qty = 8
+                with self.assertLogs(level="WARNING") as log_catcher:
+                    line.product_uom_qty = 8
+
+        self.assertEqual(len(log_catcher.output), 1, "Exactly one warning should be logged")
+        self.assertIn(
+            'This product is packaged by 10.00 Units. You should sell 10.00 Units.',
+            log_catcher.output[0],
+        )
 
         self.assertEqual(so.picking_ids.move_lines.product_uom_qty, 8)
 


### PR DESCRIPTION
Steps to reproduce the issue:
- Enable packaging in settings
- Generate packaging for each product
- Create a sales order including the packaging

Bug:
Version 14: When you modify the quantities of the product a warning message is displayed. If the quantities are not the same as the packaging, each time you modify it.
the warning message will be displayed.

Version 15+: If the quantities are not the same as the packaging, the first time you modify it. the warning message will be displayed. Nevertheless, the following modifications
will not generate a warning message.

Fix:
trigger check on quantity change

opw-3136245

