### PR TITLE
[IMP] web: clarify "Archive" modals

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -319,7 +319,8 @@ export class FormController extends Component {
                 description: this.env._t("Archive"),
                 callback: () => {
                     const dialogProps = {
-                        body: this.env._t("Are you sure that you want to archive all this record?"),
+                        body: this.env._t("Are you sure that you want to archive this record?"),
+                        confirmLabel: this.env._t("Archive"),
                         confirm: () => this.model.root.archive(),
                         cancel: () => {},
                     };

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -265,6 +265,7 @@ export class ListController extends Component {
                         body: this.env._t(
                             "Are you sure that you want to archive all the selected records?"
                         ),
+                        confirmLabel: this.env._t("Archive"),
                         confirm: () => {
                             this.toggleArchiveState(true);
                         },


### PR DESCRIPTION
Removing the "Oks" from the "Archive" modals to
clarify what confirming the action will do.

Also fixing a wording error in the form controller archive modal.

Task-3241064