### PR TITLE
[IMP] *: remove "French spacing"

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1414,11 +1414,11 @@ class AccountMove(models.Model):
         partner_id = record.partner_id.commercial_partner_id
         if not partner_id.credit_limit or updated_credit <= partner_id.credit_limit:
             return ''
-        msg = _('%s has reached its Credit Limit of : %s\nTotal amount due ',
+        msg = _('%s has reached its Credit Limit of: %s\nTotal amount due',
                 partner_id.name,
                 formatLang(self.env, partner_id.credit_limit, currency_obj=record.company_id.currency_id))
         if include:
-            msg += _('(including this document) ')
+            msg += _(' (including this document)')
         msg += ': %s' % formatLang(self.env, updated_credit, currency_obj=record.company_id.currency_id)
         return msg
 

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -89,7 +89,7 @@ class AccountTax(models.Model):
                "This allows more freedom on how to search the 'name' compared to 'filter_domain'."
                "See '_search_name' and '_parse_name_search' for why this is not possible with 'filter_domain'.")
     type_tax_use = fields.Selection(TYPE_TAX_USE, string='Tax Type', required=True, default="sale",
-        help="Determines where the tax is selectable. Note : 'None' means a tax can't be used by itself, however it can still be used in a group. 'adjustment' is used to perform tax adjustment.")
+        help="Determines where the tax is selectable. Note: 'None' means a tax can't be used by itself, however it can still be used in a group. 'adjustment' is used to perform tax adjustment.")
     tax_scope = fields.Selection([('service', 'Services'), ('consu', 'Goods')], string="Tax Scope", help="Restrict the use of taxes to a type of product.")
     amount_type = fields.Selection(default='percent', string="Tax Computation", required=True,
         selection=[('group', 'Group of Taxes'), ('fixed', 'Fixed'), ('percent', 'Percentage of Price'), ('division', 'Percentage of Price Tax Included')],

--- a/addons/account/views/bill_preview_template.xml
+++ b/addons/account/views/bill_preview_template.xml
@@ -126,7 +126,7 @@
                                     </div>
                                 </div>
                                 <div class="mt-4">
-                                    <p>Please use the following communication for your payment : <b><t t-out="invoice_ref"/></b></p>
+                                    <p>Please use the following communication for your payment: <b><t t-out="invoice_ref"/></b></p>
                                     <p>Payment terms: 30 Days</p>
                                 </div>
                             </div>

--- a/addons/account_check_printing/models/account_journal.py
+++ b/addons/account_check_printing/models/account_journal.py
@@ -67,7 +67,7 @@ class AccountJournal(models.Model):
         """ Create a check sequence for the journal """
         for journal in self:
             journal.check_sequence_id = self.env['ir.sequence'].sudo().create({
-                'name': journal.name + _(" : Check Number Sequence"),
+                'name': journal.name + _(": Check Number Sequence"),
                 'implementation': 'no_gap',
                 'padding': 5,
                 'number_increment': 1,

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -229,7 +229,7 @@ class AccountPayment(models.Model):
         }
 
     def _check_get_pages(self):
-        """ Returns the data structure used by the template : a list of dicts containing what to print on pages.
+        """ Returns the data structure used by the template: a list of dicts containing what to print on pages.
         """
         stub_pages = self._check_make_stub_pages() or [False]
         pages = []

--- a/addons/account_edi/data/cron.xml
+++ b/addons/account_edi/data/cron.xml
@@ -1,6 +1,6 @@
 <odoo noupdate="1">
     <record id="ir_cron_edi_network" model="ir.cron">
-        <field name="name">EDI : Perform web services operations</field>
+        <field name="name">EDI: Perform web services operations</field>
         <field name="model_id" ref="model_account_edi_document"/>
         <field name="state">code</field>
         <field name="code">model._cron_process_documents_web_services(job_count=20)</field>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_nlcius.py
@@ -60,7 +60,7 @@ class AccountEdiXmlUBLNL(models.AbstractModel):
         vals_list = super()._get_invoice_line_allowance_vals_list(line)
         # [BR-NL-32] Use of Discount reason code ( AllowanceChargeReasonCode ) is not recommended.
         # [BR-EN-34] Use of Charge reason code ( AllowanceChargeReasonCode ) is not recommended.
-        # Careful ! [BR-42]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance reason (BT-139)
+        # Careful! [BR-42]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance reason (BT-139)
         # or an Invoice line allowance reason code (BT-140).
         for vals in vals_list:
             if vals.get('allowance_charge_reason'):

--- a/addons/account_test/data/accounting_assert_test_data.xml
+++ b/addons/account_test/data/accounting_assert_test_data.xml
@@ -114,7 +114,7 @@ if result:
 
     <record model="accounting.assert.test" id="account_test_07">
         <field name="sequence">8</field>
-        <field name="name">Test 7 : Closing balance on bank statements</field>
+        <field name="name">Test 7: Closing balance on bank statements</field>
         <field name="desc">Check on bank statement that the Closing Balance = Starting Balance + sum of statement lines</field>
         <field name="code_exec"><![CDATA[column_order = ['name','difference']
 cr.execute("SELECT s.balance_start+sum(m.amount)-s.balance_end_real as difference, s.name from account_bank_statement s inner join account_bank_statement_line m on m.statement_id=s.id group by s.id, s.balance_start, s.balance_end_real,s.name having abs(s.balance_start+sum(m.amount)-s.balance_end_real) > 0.000000001;")
@@ -126,7 +126,7 @@ if result:
     <!-- TODO account.period has been removed -->
     <!-- <record model="accounting.assert.test" id="account_test_08">
         <field name="sequence">9</field>
-        <field name="name">Test 8 : Accounts and partners on account moves</field>
+        <field name="name">Test 8: Accounts and partners on account moves</field>
         <field name="desc">Check that general accounts and partners on account moves are active</field>
         <field name="code_exec"><![CDATA[column_order=['partner_name','partner_active','account_name','move_line_id','period']
 res = []

--- a/addons/auth_totp_mail/__manifest__.py
+++ b/addons/auth_totp_mail/__manifest__.py
@@ -4,9 +4,9 @@
 2FA Invite mail
 ===============
 Allow the users to invite another user to use Two-Factor authentication
-by sending an email to the target user. This email redirect them to :
+by sending an email to the target user. This email redirects them to:
 - the users security settings if the user is internal.
-- the portal security settings page if the user is not internal. 
+- the portal security settings page if the user is not internal.
     """,
     'depends': ['auth_totp', 'mail'],
     'category': 'Extra Tools',

--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -282,7 +282,7 @@
     <t t-set="recurrent" t-value="object.recurrence_id and not ctx.get('calendar_template_ignore_recurrence')" />
     <p>
         Hello <t t-out="object.common_name or ''">Gemini Furniture</t>,<br/><br/>
-        This is a reminder for the below event :
+        This is a reminder for the below event:
     </p>
     <div style="text-align: center; padding: 16px 0px 16px 0px;">
         <a t-attf-href="/calendar/{{ 'recurrence' if recurrent else 'meeting' }}/accept?token={{ object.access_token }}&amp;id={{ object.event_id.id }}"

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1483,7 +1483,7 @@ class Lead(models.Model):
         for opportunity in opportunities:
             for message in opportunity.message_ids:
                 if message.subject:
-                    subject = _("From %(source_name)s : %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
+                    subject = _("From %(source_name)s: %(source_subject)s", source_name=opportunity.name, source_subject=message.subject)
                 else:
                     subject = _("From %(source_name)s", source_name=opportunity.name)
                 message.write({

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     // Choose the element that is not going to be moved by the previous step.
     trigger: ".o_opportunity_kanban .o_kanban_group:nth-child(2) .o_kanban_record:not(.o_updating) .o-mail-ActivityButton",
     extra_trigger: ".o_opportunity_kanban",
-    content: Markup(_t("Looks like nothing is planned. :(<br><br><i>Tip : Schedule activities to keep track of everything you have to do!</i>")),
+    content: Markup(_t("Looks like nothing is planned. :(<br><br><i>Tip: Schedule activities to keep track of everything you have to do!</i>")),
     position: "bottom",
 }, {
     trigger: ".o-mail-ActivityListPopover button:contains(Schedule an activity)",

--- a/addons/event_crm/models/event_lead_rule.py
+++ b/addons/event_crm/models/event_lead_rule.py
@@ -77,8 +77,8 @@ class EventLeadRule(models.Model):
     lead_creation_basis = fields.Selection([
         ('attendee', 'Per Attendee'), ('order', 'Per Order')],
         string='Create', default='attendee', required=True,
-        help='Per Attendee : A Lead is created for each Attendee (B2C).\n'
-             'Per Order : A single Lead is created per Ticket Batch/Sale Order (B2B)')
+        help='Per Attendee: A Lead is created for each Attendee (B2C).\n'
+             'Per Order: A single Lead is created per Ticket Batch/Sale Order (B2B)')
     lead_creation_trigger = fields.Selection([
         ('create', 'Attendees are created'),
         ('confirm', 'Attendees are confirmed'),

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -5,7 +5,7 @@
             <field name="sequence">17</field>
         </record>
         <record id="fleet_group_user" model="res.groups">
-            <field name="name">Officer : Manage all vehicles</field>
+            <field name="name">Officer: Manage all vehicles</field>
             <field name="category_id" ref="base.module_category_human_resources_fleet"/>
             <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -354,7 +354,7 @@
         <field name="view_mode">kanban,tree,form,pivot,activity</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
-            Ready to manage your fleet more efficiently ?
+            Ready to manage your fleet more efficiently?
           </p><p>
             Let's create your first vehicle.
           </p>

--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -337,7 +337,7 @@
                     <span t-out="object.name or ''">Joel Willis</span>!
                 </p>
                 <p>
-                    You just reached a new rank : <strong t-out="object.rank_id.name or ''">Newbie</strong>
+                    You just reached a new rank: <strong t-out="object.rank_id.name or ''">Newbie</strong>
                 </p>
                 <t t-if="object.next_rank_id.name">
                     <p>Continue your work to become a <strong t-out="object.next_rank_id.name or ''">Student</strong>!</p>

--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -708,7 +708,7 @@ class Challenge(models.Model):
                     (first_user, second_user, third_user) = challenge._get_topN_users(MAX_VISIBILITY_RANKING)
                     if first_user:
                         challenge._reward_user(first_user, challenge.reward_first_id)
-                        message_body += _("<br/>Special rewards were sent to the top competing users. The ranking for this challenge is :")
+                        message_body += _("<br/>Special rewards were sent to the top competing users. The ranking for this challenge is:")
                         message_body += reward_message % {
                             'rank': 1,
                             'user_name': first_user.name,

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard_views.xml
@@ -18,7 +18,7 @@
                         </span>
                     </span>
                     <span attrs="{'invisible': [('has_timesheet', '=', True)]}">
-                        Are you sure you want to delete these employees ?
+                        Are you sure you want to delete these employees?
                     </span>
                     <footer attrs="{'invisible': [('has_timesheet', '=', False)]}">
                         <button string="Archive Employees" type="object" name="action_archive" class="btn btn-primary"

--- a/addons/l10n_be/__manifest__.py
+++ b/addons/l10n_be/__manifest__.py
@@ -20,16 +20,16 @@ Wizards provided by this module:
     * Partner VAT Intra: Enlist the partners with their related VAT and invoiced
       amounts. Prepares an XML file format.
 
-        **Path to access :** Invoicing/Reporting/Legal Reports/Belgium Statements/Partner VAT Intra
+        **Path to access:** Invoicing/Reporting/Legal Reports/Belgium Statements/Partner VAT Intra
     * Periodical VAT Declaration: Prepares an XML file for Vat Declaration of
       the Main company of the User currently Logged in.
 
-        **Path to access :** Invoicing/Reporting/Legal Reports/Belgium Statements/Periodical VAT Declaration
+        **Path to access:** Invoicing/Reporting/Legal Reports/Belgium Statements/Periodical VAT Declaration
     * Annual Listing Of VAT-Subjected Customers: Prepares an XML file for Vat
       Declaration of the Main company of the User currently Logged in Based on
       Fiscal year.
 
-        **Path to access :** Invoicing/Reporting/Legal Reports/Belgium Statements/Annual Listing Of VAT-Subjected Customers
+        **Path to access:** Invoicing/Reporting/Legal Reports/Belgium Statements/Annual Listing Of VAT-Subjected Customers
 
     """,
     'author': 'Noviat, Odoo S.A.',

--- a/addons/l10n_ch/__manifest__.py
+++ b/addons/l10n_ch/__manifest__.py
@@ -6,7 +6,7 @@ Swiss localization
 ==================
 This module defines a chart of account for Switzerland (Swiss PME/KMU 2015), taxes and enables the generation of ISR and QR-bill when you print an invoice or send it by mail.
 
-An ISR will be generated if you specify the information it needs :
+An ISR will be generated if you specify the information it needs:
     - The bank account you expect to be paid on must be set, and have a valid postal reference.
     - Your invoice must have been set assigned a bank account to receive its payment
       (this can be done manually, but a default value is automatically set if you have defined a bank account).
@@ -23,7 +23,7 @@ The generation of the ISR and QR-bill is automatic if you meet the previous crit
 
 Here is how it works:
     - Printing the invoice will trigger the download of three files: the invoice, its ISR and its QR-bill
-    - Clicking the 'Send by mail' button will attach three files to your draft mail : the invoice, the ISR and the QR-bill.
+    - Clicking the 'Send by mail' button will attach three files to your draft mail: the invoice, the ISR and the QR-bill.
     """,
     'version': '11.0',
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_fi/__manifest__.py
+++ b/addons/l10n_fi/__manifest__.py
@@ -8,7 +8,7 @@
 This is the Odoo module to manage the accounting in Finland.
 ============================================================
 
-After installing this module, you'll have access to :
+After installing this module, you'll have access to:
     * Finnish chart of account
     * Fiscal positions
     * Invoice Payment Reference Types (Finnish Standard Reference & Finnish Creditor Reference (RF))

--- a/addons/l10n_id_efaktur/__manifest__.py
+++ b/addons/l10n_id_efaktur/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '1.0',
     'description': """
         E-Faktur Menu(Indonesia)
-        Format : 010.000-16.00000001
+        Format: 010.000-16.00000001
         * 2 (dua) digit pertama adalah Kode Transaksi
         * 1 (satu) digit berikutnya adalah Kode Status
         * 3 (tiga) digit berikutnya adalah Kode Cabang

--- a/addons/l10n_latam_base/__manifest__.py
+++ b/addons/l10n_latam_base/__manifest__.py
@@ -37,7 +37,7 @@ Rules when creating a new partner: We will only see the identification types tha
 
 * If the partner have not country address set: Will show the generic identification types plus the ones defined in the partner's related company country (If the partner has not specific company then will show the identification types related to the current user company)
 
-* If the partner has country address : will show the generic identification types plus the ones defined for the country of the partner.
+* If the partner has country address: will show the generic identification types plus the ones defined for the country of the partner.
 
 When creating a new company, will set to the related partner always the related country is_vat identification type.
 

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -322,9 +322,9 @@ class MailRenderMixin(models.AbstractModel):
                         _('Only users belonging to the "%(group_name)s" group can modify dynamic templates.',
                            group_name=group.name)
                     ) from e
-                _logger.info("Failed to render template : %s", template_src, exc_info=True)
+                _logger.info("Failed to render template: %s", template_src, exc_info=True)
                 raise UserError(
-                    _("Failed to render QWeb template : %(template_src)s)",
+                    _("Failed to render QWeb template: %(template_src)s)",
                       template_src=template_src)
                     ) from e
             results[record.id] = render_result
@@ -376,9 +376,9 @@ class MailRenderMixin(models.AbstractModel):
                 )
                 results[record.id] = render_result
             except Exception as e:
-                _logger.info("Failed to render template : %s", view_ref, exc_info=True)
+                _logger.info("Failed to render template: %s", view_ref, exc_info=True)
                 raise UserError(
-                    _("Failed to render template : %(view_ref)s", view_ref=view_ref)
+                    _("Failed to render template: %(view_ref)s", view_ref=view_ref)
                 ) from e
 
         return results
@@ -444,7 +444,7 @@ class MailRenderMixin(models.AbstractModel):
             except Exception as e:
                 _logger.info("Failed to render inline_template: \n%s", str(template_txt), exc_info=True)
                 raise UserError(
-                    _("Failed to render inline_template template : %(template_txt)s)",
+                    _("Failed to render inline_template template: %(template_txt)s)",
                       template_txt=template_txt)
                 ) from e
 

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- equiment.request : views -->
+    <!-- equiment.request: views -->
     <record id="hr_equipment_request_view_search" model="ir.ui.view">
         <field name="name">equipment.request.search</field>
         <field name="model">maintenance.request</field>
@@ -149,7 +149,7 @@
                                     <b class="o_kanban_record_title"><field name="name"/></b>
                                 </div>
                                 <div class="o_kanban_record_body">
-                                    <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by : <field name="owner_user_id"/><br/></span>
+                                    <span name="owner_user_id" t-if="record.owner_user_id.raw_value">Requested by: <field name="owner_user_id"/><br/></span>
                                     <span class="oe_grey" t-if="record.equipment_id.raw_value"><field name="equipment_id"/><br/></span>
                                     <span t-if="record.category_id.raw_value"><field name="category_id"/></span>
                                 </div>
@@ -228,7 +228,7 @@
         </field>
     </record>
 
-    <!-- equiment.request : actions -->
+    <!-- equiment.request: actions -->
     <record id="hr_equipment_request_action" model="ir.actions.act_window">
         <field name="name">Maintenance Requests</field>
         <field name="res_model">maintenance.request</field>
@@ -325,7 +325,7 @@
         </field>
     </record>
 
-    <!-- equiment : views -->
+    <!-- equiment: views -->
     <record id="hr_equipment_view_form" model="ir.ui.view">
         <field name="name">equipment.form</field>
         <field name="model">maintenance.equipment</field>
@@ -544,7 +544,7 @@
         </field>
     </record>
 
-    <!-- equiment : actions -->
+    <!-- equiment: actions -->
     <record id="hr_equipment_action_from_category_form" model="ir.actions.act_window">
         <field name="name">Equipment</field>
         <field name="res_model">maintenance.equipment</field>
@@ -565,7 +565,7 @@
         </field>
     </record>
 
-    <!-- equipment.category : views -->
+    <!-- equipment.category: views -->
     <record id="hr_equipment_category_view_form" model="ir.ui.view">
         <field name="name">equipment.category.form</field>
         <field name="model">maintenance.equipment.category</field>
@@ -675,7 +675,7 @@
         </field>
     </record>
 
-    <!-- equipment.category : actions -->
+    <!-- equipment.category: actions -->
     <record id="hr_equipment_category_action" model="ir.actions.act_window">
         <field name="name">Equipment Categories</field>
         <field name="res_model">maintenance.equipment.category</field>
@@ -688,7 +688,7 @@
         </field>
     </record>
 
-    <!-- equipment.stage : views -->
+    <!-- equipment.stage: views -->
     <record id="hr_equipment_stage_view_search" model="ir.ui.view">
         <field name="name">equipment.stage.search</field>
         <field name="model">maintenance.stage</field>
@@ -729,7 +729,7 @@
         </field>
     </record>
 
-    <!-- equipment.stages : actions -->
+    <!-- equipment.stages: actions -->
     <record id="hr_equipment_stage_action" model="ir.actions.act_window">
         <field name="name">Stages</field>
         <field name="res_model">maintenance.stage</field>
@@ -925,7 +925,7 @@
         </field>
     </record>
 
-    <!-- equipment.team : actions -->
+    <!-- equipment.team: actions -->
     <record id="maintenance_team_action_settings" model="ir.actions.act_window">
         <field name="name">Teams</field>
         <field name="res_model">maintenance.team</field>

--- a/addons/mass_mailing_sms/wizard/sms_composer.py
+++ b/addons/mass_mailing_sms/wizard/sms_composer.py
@@ -42,7 +42,7 @@ class SMSComposer(models.TransientModel):
             trace_values['trace_status'] = 'cancel'
         else:
             if self.mass_sms_allow_unsubscribe:
-                sms_values['body'] = '%s\n%s' % (sms_values['body'] or '', _('STOP SMS : %s', self._get_unsubscribe_url(record.id, trace_code, sms_values['number'])))
+                sms_values['body'] = '%s\n%s' % (sms_values['body'] or '', _('STOP SMS: %s', self._get_unsubscribe_url(record.id, trace_code, sms_values['number'])))
         return trace_values
 
     def _get_optout_record_ids(self, records, recipients_info):

--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -388,7 +388,7 @@
             <img src="/mass_mailing_themes/static/src/img/theme_vip/vip_banner_part2.png" alt="Cover" class="img-fluid w-100 mx-auto"/>
         </div>
         <div class="s_discount2 o_mail_block_discount2 o_mail_snippet_general pt32 pb32" data-snippet="s_coupon_code" data-name="Promo Code" style="background-color: rgb(36, 37, 48) !important; text-align: center; padding-left: 15px; padding-right: 15px;">
-            <p style="text-align: center;">Here's your coupon code* :</p>
+            <p style="text-align: center;">Here's your coupon code*:</p>
             <table border="0" cellpadding="0" cellspacing="0" align="center" class="border" style="background-color: rgb(36, 37, 48) !important; border-collapse: collapse; border-color: rgb(198, 150, 120) !important;">
                 <tr>
                     <td width="50" height="50" align="center" class="o_mail_no_resize" style="min-width: 50px; max-width: 5.6rem; width: 50px !important; background-color: rgb(198, 150, 120) !important; text-align: center;"><i class="fa fa-2x fa-ticket" style="color: rgb(36, 37, 48) !important;"/>​</td>

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -32,8 +32,8 @@ class StockWarehouse(models.Model):
         ('pbm', 'Pick components and then manufacture (2 steps)'),
         ('pbm_sam', 'Pick components, manufacture and then store products (3 steps)')],
         'Manufacture', default='mrp_one_step', required=True,
-        help="Produce : Move the components to the production location\
-        directly and start the manufacturing process.\nPick / Produce : Unload\
+        help="Produce: Move the components to the production location\
+        directly and start the manufacturing process.\nPick / Produce: Unload\
         the components from the Stock to Input location first, and then\
         transfer it to the Production location.")
 

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -68,7 +68,7 @@
                             <p colspan="2" class="oe_grey oe_edit_only" attrs="{'invisible': [('type','!=','phantom')]}">
                             <ul>
                                 A BoM of type Kit is not produced with a manufacturing order.<br/>
-                                Instead, it is used to decompose a BoM into its components when :
+                                Instead, it is used to decompose a BoM into its components when:
                                 <li>
                                     it is added as a component in a manufacturing order
                                 </li>

--- a/addons/partner_autocomplete/data/cron.xml
+++ b/addons/partner_autocomplete/data/cron.xml
@@ -1,6 +1,6 @@
 <odoo>
     <record id="ir_cron_partner_autocomplete" model="ir.cron">
-        <field name="name">Partner Autocomplete : Sync with remote DB</field>
+        <field name="name">Partner Autocomplete: Sync with remote DB</field>
         <field name="model_id" ref="model_res_partner_autocomplete_sync"/>
         <field name="state">code</field>
         <field name="code">model.start_sync()</field>

--- a/addons/point_of_sale/README.md
+++ b/addons/point_of_sale/README.md
@@ -17,7 +17,7 @@ Work with the hardware you already have
 Odoo's POS is a web application that can run on any device that can display
 websites with little to no setup required.
 
-### Touchscreen or Keyboard ?
+### Touchscreen or Keyboard?
 
 The Point of Sale works perfectly on any kind of touch enabled device, whether
 it's multi-touch tablets like an iPad or keyboardless resistive touchscreen

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -83,8 +83,8 @@ class PricelistItem(models.Model):
         required=True,
         help="Base price for computation.\n"
              "Sales Price: The base price will be the Sales Price.\n"
-             "Cost Price : The base price will be the cost price.\n"
-             "Other Pricelist : Computation of the base price based on another Pricelist.")
+             "Cost Price: The base price will be the cost price.\n"
+             "Other Pricelist: Computation of the base price based on another Pricelist.")
     base_pricelist_id = fields.Many2one('product.pricelist', 'Other Pricelist', check_company=True)
 
     compute_price = fields.Selection(
@@ -197,7 +197,7 @@ class PricelistItem(models.Model):
     def _check_date_range(self):
         for item in self:
             if item.date_start and item.date_end and item.date_start >= item.date_end:
-                raise ValidationError(_('%s : end date (%s) should be greater than start date (%s)', item.display_name, format_datetime(self.env, item.date_end), format_datetime(self.env, item.date_start)))
+                raise ValidationError(_('%s: end date (%s) should be greater than start date (%s)', item.display_name, format_datetime(self.env, item.date_end), format_datetime(self.env, item.date_start)))
         return True
 
     @api.constrains('price_min_margin', 'price_max_margin')

--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -957,7 +957,7 @@ class PurchaseOrderLine(models.Model):
     qty_invoiced = fields.Float(compute='_compute_qty_invoiced', string="Billed Qty", digits='Product Unit of Measure', store=True)
 
     qty_received_method = fields.Selection([('manual', 'Manual')], string="Received Qty Method", compute='_compute_qty_received_method', store=True,
-        help="According to product configuration, the received quantity can be automatically computed by mechanism :\n"
+        help="According to product configuration, the received quantity can be automatically computed by mechanism:\n"
              "  - Manual: the quantity is set manually on the line\n"
              "  - Stock Moves: the quantity comes from confirmed pickings\n")
     qty_received = fields.Float("Received Qty", compute='_compute_qty_received', inverse='_inverse_qty_received', compute_sudo=True, store=True, digits='Product Unit of Measure')

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -40,7 +40,7 @@
                     <p t-field="o.date_approve" class="m-0"/>
                 </div>
                 <div t-elif="o.date_order" class="col-3 bm-2">
-                    <strong >Order Deadline:</strong>
+                    <strong>Order Deadline:</strong>
                     <p t-field="o.date_order" class="m-0"/>
                 </div>
             </div>

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -13,8 +13,8 @@
                              t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                     </div>
                     <t t-if="o.address_id != o.partner_invoice_id">
-                        <strong>Shipping address :</strong>
-                        <div t-field="o.address_id" 
+                        <strong>Shipping address:</strong>
+                        <div t-field="o.address_id"
                              t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
                     </t>
                 </t>

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -197,7 +197,7 @@ class SaleOrderLine(models.Model):
         string="Method to update delivered qty",
         compute='_compute_qty_delivered_method',
         store=True, precompute=True,
-        help="According to product configuration, the delivered quantity can be automatically computed by mechanism :\n"
+        help="According to product configuration, the delivered quantity can be automatically computed by mechanism:\n"
              "  - Manual: the quantity is set manually on the line\n"
              "  - Analytic From expenses: the quantity is the quantity sum from posted expenses\n"
              "  - Timesheet: the quantity is the sum of hours recorded on tasks linked to this sale line\n"

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -455,6 +455,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         sale_order.invoice_ids.invoice_line_ids.quantity = 3
         self.assertEqual(
             sale_order.invoice_ids.partner_credit_warning,
-            "partner_a has reached its Credit Limit of : $\xa01,000.00\n"
-            "Total amount due (including this document) : $\xa01,500.00"
+            "partner_a has reached its Credit Limit of: $\xa01,000.00\n"
+            "Total amount due (including this document): $\xa01,500.00"
         )

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -17,14 +17,14 @@
                                 <div class="o_kanban_record_headings">
                                     <strong class="o_kanban_record_title"><t t-esc="record.name.value"/></strong>
                                 </div>
-                                <span class="badge rounded-pill"><strong>Min qty :</strong><t t-esc="record.product_min_qty.value"/></span>
+                                <span class="badge rounded-pill"><strong>Min qty:</strong><t t-esc="record.product_min_qty.value"/></span>
                             </div>
                             <div class="o_kanban_record_bottom">
                                 <div class="oe_kanban_bottom_left">
                                     <span><t t-esc="record.product_id.value"/></span>
                                 </div>
                                 <div class="oe_kanban_bottom_right">
-                                    <span class="badge rounded-pill"><strong>Max qty :</strong><t t-esc="record.product_max_qty.value"/></span>
+                                    <span class="badge rounded-pill"><strong>Max qty:</strong><t t-esc="record.product_max_qty.value"/></span>
                                 </div>
                             </div>
                         </div>

--- a/addons/stock/views/stock_template.xml
+++ b/addons/stock/views/stock_template.xml
@@ -20,13 +20,13 @@
             <t t-if="move.state != 'done'">
                 <t t-if="'product_uom_qty' in vals">
                     <li>
-                        Quantity : <t t-esc="move.product_uom_qty"/> -&gt; <t t-esc="float(vals.get('product_uom_qty'))"/>
+                        Quantity: <t t-esc="move.product_uom_qty"/> -&gt; <t t-esc="float(vals.get('product_uom_qty'))"/>
                     </li>
                 </t>
             </t>
             <t t-if="'qty_done' in vals">
                 <li>
-                    Quantity : <t t-esc="move.qty_done"/> -&gt; <t t-esc="float(vals.get('qty_done'))"/>
+                    Quantity: <t t-esc="move.qty_done"/> -&gt; <t t-esc="float(vals.get('qty_done'))"/>
                 </li>
             </t>
             <t t-if="'location_id' in vals">
@@ -49,7 +49,7 @@
             </t>
             <t t-if="'lot_name' in vals">
                 <li>
-                    Lot/Serial :
+                    Lot/Serial:
                     <t t-if="move.lot_id">
                         <t t-esc="move.lot_id.name"/> -&gt;
                     </t>
@@ -58,7 +58,7 @@
             </t>
             <t t-if="'package_name' in vals">
                 <li>
-                    Source Package :
+                    Source Package:
                     <t t-if="move.package_id">
                         <t t-esc="move.package_id.name"/> -&gt;
                     </t>
@@ -67,7 +67,7 @@
             </t>
             <t t-if="'result_package_name' in vals">
                 <li>
-                    Destination Package :
+                    Destination Package:
                     <t t-if="move.result_package_id">
                         <t t-esc="move.result_package_id.name"/> -&gt;
                     </t>
@@ -76,7 +76,7 @@
             </t>
             <t t-if="'owner_name' in vals">
                 <li>
-                    Owner :
+                    Owner:
                     <t t-if="move.owner_id">
                         <t t-esc="move.owner_id.name"/> -&gt;
                     </t>

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -322,11 +322,11 @@ class StockLandedCostLine(models.Model):
         SPLIT_METHOD,
         string='Split Method',
         required=True,
-        help="Equal : Cost will be equally divided.\n"
-             "By Quantity : Cost will be divided according to product's quantity.\n"
-             "By Current cost : Cost will be divided according to product's current cost.\n"
-             "By Weight : Cost will be divided depending on its weight.\n"
-             "By Volume : Cost will be divided depending on its volume.")
+        help="Equal: Cost will be equally divided.\n"
+             "By Quantity: Cost will be divided according to product's quantity.\n"
+             "By Current cost: Cost will be divided according to product's current cost.\n"
+             "By Weight: Cost will be divided depending on its weight.\n"
+             "By Volume: Cost will be divided depending on its volume.")
     account_id = fields.Many2one('account.account', 'Account', domain=[('deprecated', '=', False)])
     currency_id = fields.Many2one('res.currency', related='cost_id.currency_id')
 

--- a/addons/test_base_import/models/test_base_import.py
+++ b/addons/test_base_import/models/test_base_import.py
@@ -8,81 +8,81 @@ def model(suffix_name):
 
 class Char(models.Model):
     _name = model('char')
-    _description = 'Tests : Base Import Model, Character'
+    _description = 'Tests: Base Import Model, Character'
 
     value = fields.Char()
 class CharRequired(models.Model):
     _name = model('char.required')
-    _description = 'Tests : Base Import Model, Character required'
+    _description = 'Tests: Base Import Model, Character required'
 
     value = fields.Char(required=True)
 
 class CharReadonly(models.Model):
     _name = model('char.readonly')
-    _description = 'Tests : Base Import Model, Character readonly'
+    _description = 'Tests: Base Import Model, Character readonly'
 
     value = fields.Char(readonly=True)
 
 class CharStates(models.Model):
     _name = model('char.states')
-    _description = 'Tests : Base Import Model, Character states'
+    _description = 'Tests: Base Import Model, Character states'
 
     value = fields.Char(readonly=True, states={'draft': [('readonly', False)]})
 
 class CharNoreadonly(models.Model):
     _name = model('char.noreadonly')
-    _description = 'Tests : Base Import Model, Character No readonly'
+    _description = 'Tests: Base Import Model, Character No readonly'
 
     value = fields.Char(readonly=True, states={'draft': [('invisible', True)]})
 
 class CharStillreadonly(models.Model):
     _name = model('char.stillreadonly')
-    _description = 'Tests : Base Import Model, Character still readonly'
+    _description = 'Tests: Base Import Model, Character still readonly'
 
     value = fields.Char(readonly=True, states={'draft': [('readonly', True)]})
 
 # TODO: complex field (m2m, o2m, m2o)
 class M2o(models.Model):
     _name = model('m2o')
-    _description = 'Tests : Base Import Model, Many to One'
+    _description = 'Tests: Base Import Model, Many to One'
 
     value = fields.Many2one(model('m2o.related'))
 
 class M2oRelated(models.Model):
     _name = model('m2o.related')
-    _description = 'Tests : Base Import Model, Many to One related'
+    _description = 'Tests: Base Import Model, Many to One related'
 
     value = fields.Integer(default=42)
 
 class M2oRequired(models.Model):
     _name = model('m2o.required')
-    _description = 'Tests : Base Import Model, Many to One required'
+    _description = 'Tests: Base Import Model, Many to One required'
 
     value = fields.Many2one(model('m2o.required.related'), required=True)
 
 class M2oRequiredRelated(models.Model):
     _name = model('m2o.required.related')
-    _description = 'Tests : Base Import Model, Many to One required related'
+    _description = 'Tests: Base Import Model, Many to One required related'
 
     value = fields.Integer(default=42)
 
 class O2m(models.Model):
     _name = model('o2m')
-    _description = 'Tests : Base Import Model, One to Many'
+    _description = 'Tests: Base Import Model, One to Many'
 
     name = fields.Char()
     value = fields.One2many(model('o2m.child'), 'parent_id')
 
 class O2mChild(models.Model):
     _name = model('o2m.child')
-    _description = 'Tests : Base Import Model, One to Many child'
+    _description = 'Tests: Base Import Model, One to Many child'
 
     parent_id = fields.Many2one(model('o2m'))
     value = fields.Integer()
 
 class PreviewModel(models.Model):
     _name = model('preview')
-    _description = 'Tests : Base Import Model Preview'
+    _description = 'Tests: Base Import Model Preview'
 
     name = fields.Char('Name')
     somevalue = fields.Integer(string='Some Value', required=True)

--- a/addons/utm/static/src/js/utm_campaign_kanban_examples.js
+++ b/addons/utm/static/src/js/utm_campaign_kanban_examples.js
@@ -13,7 +13,7 @@ const exampleData = {
     }, {
         name: _lt('Event-driven Flow'),
         columns: [_lt('Later'), _lt('This Month'), _lt('This Week'), _lt('Running'), _lt('Sent')],
-        description: _lt("Track incoming events (e.g. : Christmas, Black Friday, ...) and publish timely content."),
+        description: _lt("Track incoming events (e.g. Christmas, Black Friday, ...) and publish timely content."),
     }, {
         name: _lt('Soft-Launch Flow'),
         columns: [_lt('Pre-Launch'), _lt('Soft-Launch'), _lt('Deploy'), _lt('Report'), _lt('Done')],

--- a/addons/utm/views/utm_stage_views.xml
+++ b/addons/utm/views/utm_stage_views.xml
@@ -30,7 +30,7 @@
             <p class="o_view_nocontent_smiling_face">
             Create a stage for your campaigns
             </p><p>
-            Stages allow you to organize your workflow  (e.g. : plan, design, in progress,  done, …).
+            Stages allow you to organize your workflow  (e.g. plan, design, in progress, done, …).
             </p>
         </field>
     </record>

--- a/addons/web/static/src/views/list/list_confirmation_dialog.xml
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.xml
@@ -10,7 +10,7 @@
                         Among the <t t-esc="props.nbRecords"/> selected records,
                         <t t-esc="props.nbValidRecords"/> are valid for this update.<br/>
                     </t>
-                    Are you sure you want to perform the following update on those <t t-esc="props.nbValidRecords"/> records ?
+                    Are you sure you want to perform the following update on those <t t-esc="props.nbValidRecords"/> records?
                 </p>
                 <div class="table-responsive">
                     <table class="o_modal_changes">

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -11374,7 +11374,7 @@ QUnit.module("Views", (hooks) => {
             assert.strictEqual(
                 modalText,
                 "Among the 4 selected records, 2 are valid for this update. Are you sure you want to " +
-                    "perform the following update on those 2 records ? Field:int_fieldUpdate to:666"
+                    "perform the following update on those 2 records? Field:int_fieldUpdate to:666"
             );
             assert.strictEqual(
                 target.querySelector(".modal .o_modal_changes .o_field_widget").parentNode.style

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -221,7 +221,7 @@
                            </div>
                        </div>
                        <p>
-                           Please use the following communication for your payment : <b><span>
+                           Please use the following communication for your payment: <b><span>
                            INV/2020/07/0003</span></b>
                        </p>
                        <p name="payment_term">

--- a/addons/web_editor/static/src/js/common/ace.js
+++ b/addons/web_editor/static/src/js/common/ace.js
@@ -990,7 +990,7 @@ var ViewEditor = Widget.extend({
     _onResetClick: function () {
         var self = this;
         Dialog.confirm(this, _t("If you reset this file, all your customizations will be lost as it will be reverted to the default file."), {
-            title: _t("Careful !"),
+            title: _t("Careful!"),
             confirm_callback: function () {
                 self._resetResource(self._getSelectedResource());
             },

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -272,7 +272,7 @@ class WebsiteForm(http.Controller):
             # we create a mail.message to link them to the record
             record._message_log(
                 attachment_ids=[(6, 0, orphan_attachment_ids)],
-                body=Markup(_('<p>Attached files : </p>')),
+                body=Markup(_('<p>Attached files: </p>')),
                 message_type='comment',
             )
         elif model_name == 'mail.mail' and orphan_attachment_ids:

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -688,12 +688,12 @@ class Website(models.Model):
     @api.model
     def new_page(self, name=False, add_menu=False, template='website.default_page', ispage=True, namespace=None, page_values=None, menu_values=None):
         """ Create a new website page, and assign it a xmlid based on the given one
-            :param name : the name of the page
-            :param add_menu : if True, add a menu for that page
-            :param template : potential xml_id of the page to create
-            :param namespace : module part of the xml_id if none, the template module name is used
-            :param page_values : default values for the page to be created
-            :param menu_values : default values for the menu to be created
+            :param name: the name of the page
+            :param add_menu: if True, add a menu for that page
+            :param template: potential xml_id of the page to create
+            :param namespace: module part of the xml_id if none, the template module name is used
+            :param page_values: default values for the page to be created
+            :param menu_values: default values for the menu to be created
         """
         if namespace:
             template_module = namespace

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -256,7 +256,7 @@ class CrmLead(models.Model):
         fields = ['partner_name', 'phone', 'mobile', 'email_from', 'street', 'street2',
             'city', 'zip', 'state_id', 'country_id']
         if any([key not in fields for key in values]):
-            raise UserError(_("Not allowed to update the following field(s) : %s.") % ", ".join([key for key in values if not key in fields]))
+            raise UserError(_("Not allowed to update the following field(s): %s.") % ", ".join([key for key in values if not key in fields]))
         return self.sudo().write(values)
 
     @api.model

--- a/addons/website_event_track/data/event_track_demo.xml
+++ b/addons/website_event_track/data/event_track_demo.xml
@@ -202,7 +202,7 @@
         <field name="user_id" ref="base.user_admin"/>
     </record>
     <record id="event_track19" model="event.track">
-        <field name="name">Advanced lead management : tips and tricks from the fields</field>
+        <field name="name">Advanced lead management: tips and tricks from the fields</field>
         <field name="is_published" eval="True"/>
         <field name="event_id" ref="event.event_0"/>
         <field name="date" eval="(DateTime.now() + timedelta(days=3, hours=1, minutes=5)).strftime('%Y-%m-%d %H:%M:%S')"></field>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -508,7 +508,7 @@
             <div class="container">
                 <h1 class="py-4 text-white d-inline-block">All Users</h1>
                 <div class="py-4 float-end">
-                    <strong class="mb-3 text-white me-2">Rank by :</strong>
+                    <strong class="mb-3 text-white me-2">Rank by:</strong>
                     <div class="mb-3 btn-group">
                         <a t-attf-class="btn btn-secondary #{ 'active' if group_by == 'week' else ''}"
                             t-att-href="'/profile/users?' + keep_query('search', group_by='week')">This week</a>

--- a/addons/website_slides/static/src/xml/slide_quiz_create.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz_create.xml
@@ -12,7 +12,7 @@
                     </div>
                 </div>
                 <div class="text-muted mb-2">
-                    <span>Select the correct answer below :</span>
+                    <span>Select the correct answer below:</span>
                 </div>
                 <div class="list-group">
                     <t t-if="widget.question.answers" >

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -72,7 +72,7 @@
                             <div class="p-2 w-100">
                                 <h5 class="mt-0 mb-1" t-esc="certificate.survey_id.title"/>
                                 <div t-if="user.id == uid">
-                                    <small class="fw-bold">Score : <span t-esc="certificate.scoring_percentage"/> %</small>
+                                    <small class="fw-bold">Score: <span t-esc="certificate.scoring_percentage"/> %</small>
                                     <div class="float-end">
                                         <a role="button" class="float-end" t-att-href="'/survey/%s/get_certification' % certificate.survey_id.id">
                                             <i class="fa fa-download" aria-label="Download certification" title="Download Certification"/>

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -234,8 +234,8 @@ class Partner(models.Model):
         ], string='Address Type',
         default='contact',
         help="- Contact: Use this to organize the contact details of employees of a given company (e.g. CEO, CFO, ...).\n"
-             "- Invoice Address : Preferred address for all invoices. Selected by default when you invoice an order that belongs to this company.\n"
-             "- Delivery Address : Preferred address for all deliveries. Selected by default when you deliver an order that belongs to this company.\n"
+             "- Invoice Address: Preferred address for all invoices. Selected by default when you invoice an order that belongs to this company.\n"
+             "- Delivery Address: Preferred address for all deliveries. Selected by default when you deliver an order that belongs to this company.\n"
              "- Private: Private addresses are only visible by authorized users and contain sensitive data (employee home addresses, ...).\n"
              "- Other: Other address for the company (e.g. subsidiary, ...)")
     # address fields

--- a/odoo/addons/base/report/ir_module_report_templates.xml
+++ b/odoo/addons/base/report/ir_module_report_templates.xml
@@ -29,19 +29,19 @@
                         </table>
                         <span t-field="o.description"/>
                         <div>
-                            <strong>Reports :</strong>
+                            <strong>Reports:</strong>
                         </div>
                         <span t-field="o.reports_by_module"/>
                         <div>
-                            <strong>Menu :</strong>
+                            <strong>Menu:</strong>
                         </div>
                         <span t-field="o.menus_by_module"/>
                         <div>
-                            <strong>View :</strong>
+                            <strong>View:</strong>
                         </div>
                         <span t-field="o.views_by_module"/>
                         <div>
-                            <strong>Dependencies :</strong>
+                            <strong>Dependencies:</strong>
                         </div>
                         <div t-foreach="o.dependencies_id" t-as="dependency_id">
                             <span t-field="dependency_id.name"/> - <span t-field="dependency_id.module_id.state"/>


### PR DESCRIPTION
According to Wiktionary, French spacing is "the archaic practice (though still current in French) of inserting a space around colons, semicolons, question marks, and exclamation marks". This is not standard practice in English and most languages of the world.

The purpose of this commit is to start purging the code from this typo, as it may reflect poorly on the software for some people.

Enterprise: https://github.com/odoo/enterprise/pull/38542