### PR TITLE
[Fix] to allow Odoo to work on Postgres Version 15.0 and above

### DIFF
--- a/doc/cla/corporate/sundaebytes.md
+++ b/doc/cla/corporate/sundaebytes.md
@@ -1,0 +1,16 @@
+Trinidad and Tobago, 2023-10-03
+
+SundaeBytes agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Kwasi Edwards kwasiedwards@gmail.com   https://github.com/kwasi-dev
+
+List of contributors:
+Kwasi Edwards kwasiedwards@gmail.com   https://github.com/kwasi-dev
+Kwasi Edwards kwasi.edwards@sundaebytes.com https://github.com/sundaebytes
+Kwasi Edwards kwasi_edwards2@hotmail.com https://github.com/kwasi-dev

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -133,6 +133,14 @@ def _create_empty_database(name):
     except psycopg2.Error as e:
         _logger.warning("Unable to create PostgreSQL extensions : %s", e)
 
+    # restore legacy behaviour on pg15+
+    try:
+        db = odoo.sql_db.db_connect(name)
+        with db.cursor() as cr:
+            cr.execute("GRANT CREATE ON SCHEMA PUBLIC TO PUBLIC")
+    except psycopg2.Error as e:
+        _logger.warning("Unable to make public schema public-accessible: %s", e)
+
 @check_db_management_enabled
 def exp_create_database(db_name, demo, lang, user_password='admin', login='admin', country_code=None, phone=None):
     """ Similar to exp_create but blocking."""


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

From PostgreSQL's point of view, as of version 15.0 and above the default behavior is to constrain ordinary users to user-private schemas.  For every user needing to create non-temporary objects, it's advised that they create a schema with the same name as that user (Recall that the default search path starts with $user, which resolves to the user name. Therefore, if each user has a separate schema, they access their own schemas by default.) This pattern is a secure schema usage pattern.

See Section 5.9.6 https://www.postgresql.org/docs/current/ddl-schemas.html
and 
https://www.postgresql.org/docs/release/15.0/

Databases migrated from previous versions of postgresql will have the default public schema writable, but new odoo instances on postgresql version 15 and above do not work. To fix this We'd create a new schema in the database that's the same name as our database user after we create our empty database


**Current behavior before PR:**

Initializing a new Odoo database on Postgres version 15.0 and above with a user with only the LOGIN and CREATE DATABASE roles would result in an error 
`permission denied for schema public`

Because of this, no database tables are created on new databases using postgres V15.0 and above

Desired behavior after PR is merged:
Full functionality is restored by creating all tables in a schema that matches the database user



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
