### PR TITLE
[FIX] website_sale_digital: download digital files

### DIFF
--- a/addons/website_sale_digital/controllers/main.py
+++ b/addons/website_sale_digital/controllers/main.py
@@ -57,14 +57,9 @@ class WebsiteSaleDigital(CustomerPortal):
     ], type='http', auth='public')
     def download_attachment(self, attachment_id):
         # Check if this is a valid attachment id
-        attachment = request.env['ir.attachment'].sudo().search_read(
-            [('id', '=', int(attachment_id))],
-            ["name", "datas", "mimetype", "res_model", "res_id", "type", "url"]
-        )
+        attachment = request.env['ir.attachment'].sudo().search([('id', '=', int(attachment_id))])
 
-        if attachment:
-            attachment = attachment[0]
-        else:
+        if not attachment:
             return request.redirect(self.orders_page)
 
         # Check if the user has bought the associated product
@@ -85,4 +80,4 @@ class WebsiteSaleDigital(CustomerPortal):
         else:
             return request.redirect(self.orders_page)
 
-        return self.env['ir.binary']._get_stream_from(attachment).get_response(as_attachment=True)
+        return request.env['ir.binary']._get_stream_from(attachment).get_response(as_attachment=True)


### PR DESCRIPTION
To reproduce
============
- Create a service product and attach digital files
- Create a sale order for a portal user including this product and invoice/pay the s.o.
- Open the sale order from the portal as the selected user, then attempt to download the attached file.

Problem
=======
After introducing this improvement https://github.com/odoo/odoo/commit/c726d81d98a8fd95637c9135ea11476209123e98 we will search for the attachment on `ir.binary` but there was a typo where we look for the `env` variable in `self` where it doesn't exist.

Solution
========
Access to `env` from `request`

opw-3216900