### PR TITLE
[FIX] account: res partner bank bugprovement

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -46,6 +46,7 @@ class ResPartnerBank(models.Model):
              'usually happens when their emails are compromised. Once verified, you can activate the ability to send money.'
     )
     currency_id = fields.Many2one(tracking=True)
+    lock_trust_fields = fields.Boolean(compute='_compute_lock_trust_fields')
 
     @api.constrains('journal_id')
     def _check_journal_id(self):
@@ -95,6 +96,14 @@ class ResPartnerBank(models.Model):
         user_has_group_validate_bank_account = self.user_has_groups('account.group_validate_bank_account')
         for bank in self:
             bank.user_has_group_validate_bank_account = user_has_group_validate_bank_account
+
+    @api.depends('allow_out_payment')
+    def _compute_lock_trust_fields(self):
+        for bank in self:
+            if not bank._origin or not bank.allow_out_payment:
+                bank.lock_trust_fields = False
+            elif bank._origin and bank.allow_out_payment:
+                bank.lock_trust_fields = True
 
     def _build_qr_code_vals(self, amount, free_communication, structured_communication, currency, debtor_partner, qr_method=None, silent_errors=True):
         """ Returns the QR-code vals needed to generate the QR-code report link to pay this account with the given parameters,
@@ -260,6 +269,15 @@ class ResPartnerBank(models.Model):
             for field in tracking_fields:
                 # Group initial values by partner_id
                 account_initial_values[account][field] = account[field]
+
+        # Some fields should not be editable based on conditions. It is enforced in the view, but not in python which
+        # leaves them vulnerable to edits via the shell/... So we need to ensure that the user has the rights to edit
+        # these fields when writing too.
+        if ('acc_number' in vals or 'partner_id' in vals) and any(account.lock_trust_fields for account in self):
+            raise UserError(_("You cannot modify the account number or partner of an account that has been trusted."))
+
+        if 'allow_out_payment' in vals and not self.user_has_groups('account.group_validate_bank_account'):
+            raise UserError(_("You do not have the rights to trust or un-trust accounts."))
 
         res = super().write(vals)
 

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -82,9 +82,16 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <!-- Add a new setting that can be enabled to allow the user to "trust" a partner bank account -->
+    <record model="ir.module.category" id="account.module_category_accounting_bank">
+        <field name="name">Bank</field>
+        <field name="parent_id" ref="base.module_category_accounting"/>
+        <field name="sequence">50</field>
+    </record>
+
     <record id="group_validate_bank_account" model="res.groups">
         <field name="name">Validate bank account</field>
-        <field name="category_id" ref="base.module_category_usability"/>
+        <field name="category_id" ref="account.module_category_accounting_bank"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/account/views/res_partner_bank_views.xml
+++ b/addons/account/views/res_partner_bank_views.xml
@@ -17,15 +17,16 @@
                 </xpath>
 
                 <xpath expr="//field[@name='acc_number']" position="attributes">
-                    <attribute name="attrs">{'readonly': [('allow_out_payment', '=', True)]}</attribute>
+                    <attribute name="attrs">{'readonly': [('lock_trust_fields', '=', True)]}</attribute>
                 </xpath>
 
                 <xpath expr="//field[@name='partner_id']" position="attributes">
-                    <attribute name="attrs">{'readonly': [('allow_out_payment', '=', True)]}</attribute>
+                    <attribute name="attrs">{'readonly': [('lock_trust_fields', '=', True)]}</attribute>
                 </xpath>
 
                 <xpath expr="//field[@name='allow_out_payment']" position="replace">
                     <field name="user_has_group_validate_bank_account" invisible="1"/>
+                    <field name="lock_trust_fields" invisible="1"/>
                     <label for="allow_out_payment"/>
                     <div class="d-flex gap-2">
                         <field name="allow_out_payment" widget="boolean_toggle" attrs="{'readonly': [('user_has_group_validate_bank_account', '=', False)]}"/>
@@ -39,13 +40,13 @@
                         <div attrs="{'invisible': [('has_money_transfer_warning', '=', False)]}" class="mb-1">
                             <span class="text-danger">High risk</span>: <field name="money_transfer_service" nolabel="1" class="oe_inline"/> is a money transfer service and not a bank.
                             Double check if the account can be trusted by calling the vendor.<br/>
-                            <a href="https://www.odoo.com/documentation/master/applications/finance/accounting/payables/pay/trusted_accounts.html">Check why.</a>
+                            <a target="_blank" href="https://www.odoo.com/documentation/master/applications/finance/accounting/payables/pay/trusted_accounts.html">Check why.</a>
                         </div>
                         <field name="has_iban_warning" invisible="1"/>
                         <div attrs="{'invisible': [('has_iban_warning', '=', False)]}">
                             <span class="text-warning">Medium risk</span>: Iban <field name="sanitized_acc_number" nolabel="1" class="oe_inline fw-bold"/>
                             is not from the same country as the partner (<field name="partner_country_name" nolabel="1" class="oe_inline"/>).<br/>
-                            <a href="https://www.odoo.com/documentation/master/applications/finance/accounting/payables/pay/trusted_accounts.html">Check why it's risky.</a>
+                            <a target="_blank" href="https://www.odoo.com/documentation/master/applications/finance/accounting/payables/pay/trusted_accounts.html">Check why it's risky.</a>
                         </div>
                     </div>
                 </xpath>


### PR DESCRIPTION
Improve some aspects of the recent res partner bank improvement:
    - the url toward the docs open in a new tab
    - fix the account creation by disabling the readonly when trusted
      while the record isn't existing in the database yet
    - improve the visual of the setting by putting it in the accounting
      section

Note:
There is an issue with the boolean toggle which saves the record that is being fixed in task 3235962.
Without it the feature isn't working well.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
