### PR TITLE
[FIX] mrp: timesheet not splitting

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -686,7 +686,7 @@
             <field name="workorder_id" ref="mrp_workorder_1"/>
             <field name="loss_id" ref="block_reason7"/>
             <field name="date_start" eval="(datetime.now() - relativedelta(days=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
-            <field name="date_end" eval="(datetime.now() - relativedelta(days=2)).strftime('%Y-%m-%d %H:%M:%S')"/>
+            <field name="date_end" eval="(datetime.now() - relativedelta(days=4, hours=14)).strftime('%Y-%m-%d %H:%M:%S')"/>
         </record>
 
         <record id="mrp_workcenter_efficiency_1" model="mrp.workcenter.productivity">
@@ -695,6 +695,7 @@
             <field name="loss_id" ref="block_reason0"/>
             <field name="date_start" eval="(datetime.now() - timedelta(hours=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - timedelta(hours=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
+            <field name="duration">120</field>
         </record>
 
         <record id="mrp_workcenter_efficiency_2" model="mrp.workcenter.productivity">
@@ -703,6 +704,7 @@
             <field name="loss_id" ref="block_reason1"/>
             <field name="date_start" eval="(datetime.now() - timedelta(days=5, hours=4)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - timedelta(days=5, hours=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
+            <field name="duration">60</field>
         </record>
 
         <record id="mrp_workcenter_efficiency_3" model="mrp.workcenter.productivity">
@@ -710,7 +712,8 @@
             <field name="workorder_id" ref="mrp_workorder_2"/>
             <field name="loss_id" ref="block_reason7"/>
             <field name="date_start" eval="(datetime.now() - relativedelta(days=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
-            <field name="date_end" eval="(datetime.now() - relativedelta(days=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
+            <field name="date_end" eval="(datetime.now() - relativedelta(days=4, hours=16)).strftime('%Y-%m-%d %H:%M:%S')"/>
+            <field name="duration">120</field>
         </record>
 
         <record id="mrp_workcenter_efficiency_4" model="mrp.workcenter.productivity">

--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -643,11 +643,47 @@
         <!-- Run Scheduler -->
         <function model="procurement.group" name="run_scheduler"/>
 
+        <!-- Table Top MO's for workorders-->
+        <record id="mrp_production_5" model="mrp.production">
+            <field name="product_id" ref="product_product_computer_desk_head"/>
+            <field name="product_uom_id" ref="uom.product_uom_unit"/>
+            <field name="product_qty">2</field>
+            <field name="location_src_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_stock"/>
+        </record>
+
+        <record id="mrp_production_6" model="mrp.production">
+            <field name="product_id" ref="product_product_computer_desk_head"/>
+            <field name="product_uom_id" ref="uom.product_uom_unit"/>
+            <field name="product_qty">2</field>
+            <field name="location_src_id" ref="stock.stock_location_stock"/>
+            <field name="location_dest_id" ref="stock.stock_location_stock"/>
+        </record>
+
+        <!-- Work orders-->
+        <record id="mrp_workorder_1" model="mrp.workorder">
+            <field name="workcenter_id" ref="mrp_workcenter_3"/>
+            <field name="production_id" ref="mrp_production_5"/>
+            <field name="duration_expected">120</field>
+            <field name="name">Machine Assembly</field>
+            <field name="product_uom_id" ref="uom.product_uom_unit"/>
+            <field name="product_id" ref="product_product_computer_desk_head"/>
+        </record>
+
+        <record id="mrp_workorder_2" model="mrp.workorder">
+            <field name="workcenter_id" ref="mrp_workcenter_1"/>
+            <field name="production_id" ref="mrp_production_6"/>
+            <field name="duration_expected">60</field>
+            <field name="name">Drilling</field>
+            <field name="product_id" ref="product_product_computer_desk"/>
+            <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        </record>
 
         <!-- OEE -->
 
         <record id="mrp_workcenter_efficiency_0" model="mrp.workcenter.productivity">
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
+            <field name="workorder_id" ref="mrp_workorder_1"/>
             <field name="loss_id" ref="block_reason7"/>
             <field name="date_start" eval="(datetime.now() - relativedelta(days=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - relativedelta(days=2)).strftime('%Y-%m-%d %H:%M:%S')"/>
@@ -655,6 +691,7 @@
 
         <record id="mrp_workcenter_efficiency_1" model="mrp.workcenter.productivity">
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
+            <field name="workorder_id" ref="mrp_workorder_1"/>
             <field name="loss_id" ref="block_reason0"/>
             <field name="date_start" eval="(datetime.now() - timedelta(hours=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - timedelta(hours=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
@@ -662,6 +699,7 @@
 
         <record id="mrp_workcenter_efficiency_2" model="mrp.workcenter.productivity">
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
+            <field name="workorder_id" ref="mrp_workorder_1"/>
             <field name="loss_id" ref="block_reason1"/>
             <field name="date_start" eval="(datetime.now() - timedelta(days=5, hours=4)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - timedelta(days=5, hours=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
@@ -669,6 +707,7 @@
 
         <record id="mrp_workcenter_efficiency_3" model="mrp.workcenter.productivity">
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
+            <field name="workorder_id" ref="mrp_workorder_2"/>
             <field name="loss_id" ref="block_reason7"/>
             <field name="date_start" eval="(datetime.now() - relativedelta(days=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - relativedelta(days=3)).strftime('%Y-%m-%d %H:%M:%S')"/>
@@ -676,6 +715,7 @@
 
         <record id="mrp_workcenter_efficiency_4" model="mrp.workcenter.productivity">
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
+            <field name="workorder_id" ref="mrp_workorder_2"/>
             <field name="loss_id" ref="block_reason0"/>
             <field name="date_start" eval="(datetime.now() - timedelta(days=5,hours=5)).strftime('%Y-%m-%d %H:%M:%S')"/>
             <field name="date_end" eval="(datetime.now() - timedelta(days=5,hours=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
@@ -683,6 +723,7 @@
 
         <record id="mrp_workcenter_efficiency_5" model="mrp.workcenter.productivity">
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
+            <field name="workorder_id" ref="mrp_workorder_2"/>
             <field name="loss_id" ref="block_reason1"/>
             <field name="date_start" eval="(datetime.now() - timedelta(hours=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
         </record>

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -472,23 +472,21 @@ class MrpWorkcenterProductivity(models.Model):
         for wo in workorders:
             self._split(wo)
             return_created_ids = self._merge_timesheets(return_created_ids, wo)
-        return return_created_ids
+        return return_created_ids if len(return_created_ids) > 0 else self.env['mrp.workcenter.productivity'].browse()
 
     def write(self, vals_list):
-        self.ensure_one()
         if self.env.context.get('timesheet_splitting_merging'):
             return super().write(vals_list)
 
-        self.with_context(timesheet_splitting_merging=True)
         super().write(vals_list)
         if vals_list.get("workorder_id"):
             workorder = self.env['mrp.workorder'].browse(vals_list["workorder_id"])
         else:
             workorder = self.workorder_id
-        self._split(workorder)
-        self._merge_timesheets([], workorder)
+        if workorder:
+            self._split(workorder)
+            self._merge_timesheets([], workorder)
 
-        self.with_context(timesheet_splitting_merging=False)
         return True
 
     def _merge_timesheets(self, created_time_ids, workorder=None, ):

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -231,6 +231,18 @@ class TestMrpCommon(common2.TestStockCommon):
             'categ_id': cls.env.ref('product.product_category_all').id,
         })
 
+        cls.production = cls.env['mrp.production'].create({
+            'product_id': cls.laptop.id
+        })
+
+        cls.workorder_1 = cls.env['mrp.workorder'].create({
+            'production_id': cls.production.id,
+            'name': 'test',
+            'product_id': cls.laptop.id,
+            'product_uom_id': cls.env.ref("uom.product_uom_unit").id,
+            'workcenter_id': cls.workcenter_1.id,
+        })
+
     @classmethod
     def make_prods(cls, n):
         return [

--- a/addons/mrp/tests/test_oee.py
+++ b/addons/mrp/tests/test_oee.py
@@ -15,7 +15,8 @@ class TestOee(TestMrpCommon):
             'date_start': date_start,
             'date_end': date_end,
             'loss_id': loss_reason.id,
-            'description': loss_reason.name
+            'description': loss_reason.name,
+            'workorder_id': self.workorder_1.id
         })
 
     def test_wrokcenter_oee(self):
@@ -45,7 +46,7 @@ class TestOee(TestMrpCommon):
 
         # Check working state is normal or not.
         end_time = time_to_string_utc_datetime(time(10, 48, 39))
-        workcenter_productivity_1.write({'date_end': end_time})
+        workcenter_productivity_1[0].write({'date_end': end_time})
         self.assertEqual(self.workcenter_1.working_state, 'normal', "Wrong working state of workcenter.")
 
         # Process Defect time duration (1.33 min)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3032,7 +3032,7 @@ class TestMrpOrder(TestMrpCommon):
         action = mo.button_mark_done()
         backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
         backorder.save().action_backorder()
-        mo_backorder = mo.procurement_group_id.mrp_production_ids[-1]
+        mo_backorder = mo.procurement_group_id.mrp_production_ids[0]
         mo_backorder.button_plan()
 
         self.assertEqual(mo_backorder.workorder_ids[0].state, 'cancel')

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2460,20 +2460,19 @@ class TestMrpOrder(TestMrpCommon):
 
         # update real duration to amount above expected duration
         workorder.duration = real_duration_increased_above_expected
-        self.assertEqual(len(workorder.time_ids), 3, "Two more time tracking values should have been created")
-        self.assertEqual(workorder.time_ids[1].loss_type, 'productive', "Duration amount added under the expected duration should be productive time")
-        self.assertEqual(workorder.time_ids[2].loss_type, 'performance', "Duration amount added above expected duration should be performance (i.e. reduced) time")
-        self.assertEqual(workorder.time_ids[1].duration, expected_duration - real_duration_under_expected, "Added (productive) time should be expected duration - already existing duration")
-        self.assertEqual(workorder.time_ids[2].duration, real_duration_increased_above_expected - expected_duration, "Added (reduced) time should be total duration - expected duration")
+        self.assertEqual(len(workorder.time_ids), 2, "One more time tracking values should have been created")
+        # loss times should be inverted!!
+        self.assertEqual(workorder.time_ids[0].loss_type, 'performance', "The first timesheet should change from productive to performance")
+        self.assertEqual(workorder.time_ids[1].loss_type, 'productive', "Duration amount added before expected duration should be productive")
+        self.assertEqual(workorder.time_ids[0].duration, real_duration_increased_above_expected - expected_duration, "Added (reduced) time should be total duration - expected duration")
+        self.assertEqual(workorder.time_ids[1].duration, expected_duration, "Added (productive) time should be expected duration")
 
         # update real duration to amount below expected duration
         workorder.duration = real_duration_decreased
         # reducing time reverses the time_id order... so we reverse the check
-        self.assertEqual(len(workorder.time_ids), 2, "One time tracking values should have been deleted")
-        self.assertEqual(workorder.time_ids[1].loss_type, 'productive', "Original time tracking should be unchanged")
-        self.assertEqual(workorder.time_ids[1].duration, real_duration_under_expected, "Original time tracking should be unchanged")
+        self.assertEqual(len(workorder.time_ids), 1, "One time tracking value should have been deleted")
         self.assertEqual(workorder.time_ids[0].loss_type, 'productive', "Remaining time tracking should be productive")
-        self.assertEqual(workorder.time_ids[0].duration, real_duration_decreased - real_duration_under_expected, "Time tracking duration should have been reduced to reflect new shorter duration")
+        self.assertEqual(workorder.time_ids[0].duration, real_duration_decreased, "Time tracking duration should have been reduced to reflect new shorter duration")
 
     def test_propagate_quantity_on_backorders(self):
         """Create a MO for a product with several work orders.

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -78,6 +78,7 @@
                 <field name="time_ids" invisible="1"/>
                 <field name="working_state" invisible="1"/>
                 <field name="operation_id" invisible="1" domain="['|', ('bom_id', '=', production_bom_id), ('bom_id', '=', False)]" context="{'default_workcenter_id': workcenter_id, 'default_company_id': company_id}"/>
+                <field name="duration_editable" invisible="1"/>
                 <field name="name" string="Operation"/>
                 <field name="workcenter_id"/>
                 <field name="product_id" optional="show"/>
@@ -87,7 +88,7 @@
                 <field name="date_finished" optional="hide" attrs="{'readonly': [('state', 'in', ['progress', 'done', 'cancel'])]}"/>
                 <field name="duration_expected" widget="float_time" sum="expected duration"/>
                 <field name="duration" widget="mrp_timer"
-                  attrs="{'invisible': [('production_state','=', 'draft')], 'readonly': [('is_user_working', '=', True)]}" sum="real duration"/>
+                  attrs="{'invisible': [('production_state','=', 'draft')], 'readonly': ['|',('is_user_working', '=', True), ('duration_editable', '=', False)]}" sum="real duration"/>
                 <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-info="state not in ('progress', 'done', 'cancel')"
                   attrs="{'invisible': [('production_state', '=', 'draft')], 'column_invisible': [('parent.state', '=', 'draft')]}"/>
                 <button name="button_start" type="object" string="Start" class="btn-success"

--- a/addons/mrp_account/tests/test_analytic_account.py
+++ b/addons/mrp_account/tests/test_analytic_account.py
@@ -145,6 +145,7 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(len(mo.workorder_ids.wc_analytic_account_line_id), 0)
 
         # change duration to 120
+
         with mo_form.workorder_ids.edit(0) as line_edit:
             line_edit.duration = 120.0
         mo_form.save()


### PR DESCRIPTION
This bug was spotted in the wizard of the workorders allowing to create a timesheet manually.
The previous behaviour did not split the timesheet as it should.

For example: if the duration expected for the workorder is 60 min and if we create a timesheet of 70 min (supposing that no one timesheeted on the workorder),
the timesheets should be splitted in a 60 and a 10 one, with correct loss_ids.

The next step is to make sure that timesheet can merge together. For example, if an employee timesheet ends when another start, with the same productivity, those two should be merged as one

Theses steps must be done in the write and create from mrp.productivity

task id : 3216277

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
