### PR TITLE
[FIX] account: fix 'Total Rounded' with Half-up cash rounding

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1148,10 +1148,10 @@ class AccountMove(models.Model):
                 base_lines = move.invoice_line_ids.filtered(lambda line: line.display_type == 'product')
                 base_line_values_list = [line._convert_to_tax_base_line_dict() for line in base_lines]
 
+                sign = -1 if move.is_inbound(include_receipts=True) else 1
                 if move.id:
                     # The invoice is stored so we can add the early payment discount lines directly to reduce the
                     # tax amount without touching the untaxed amount.
-                    sign = -1 if move.is_inbound(include_receipts=True) else 1
                     base_line_values_list += [
                         {
                             **line._convert_to_tax_base_line_dict(),
@@ -1204,7 +1204,8 @@ class AccountMove(models.Model):
                 move.tax_totals = self.env['account.tax']._prepare_tax_totals(**kwargs)
                 rounding_line = move.line_ids.filtered(lambda l: l.display_type == 'rounding')
                 if rounding_line:
-                    amount_total_rounded = move.tax_totals['amount_total'] - rounding_line.balance
+                    amount_total_rounded = move.tax_totals['amount_total'] + sign * rounding_line.balance
+                    move.tax_totals['amount_total_rounded'] = amount_total_rounded
                     move.tax_totals['formatted_amount_total_rounded'] = formatLang(self.env, amount_total_rounded, currency_obj=move.currency_id) or ''
             else:
                 # Non-invoice moves don't support that field (because of multicurrency: all lines of the invoice share the same currency)

--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -732,3 +732,24 @@ class TestTaxTotals(AccountTestInvoicingCommon):
         ]
         run_case('round_per_line', lines, [16.60])
         run_case('round_globally', lines, [16.59])
+
+    def test_cash_rounding_amount_total_rounded(self):
+        tax_15 = self.env['account.tax'].create({
+            'name': "tax_15",
+            'amount_type': 'percent',
+            'amount': 15.0,
+        })
+        cash_rounding = self.env['account.cash.rounding'].create({
+            'name': 'Rounding HALF-UP',
+            'rounding': 1,
+            'strategy': 'biggest_tax',
+            'rounding_method': 'HALF-UP',
+        })
+
+        invoice = self.init_invoice('out_invoice', amounts=[378], taxes=tax_15)
+        invoice.invoice_cash_rounding_id = cash_rounding
+        self.assertEqual(invoice.tax_totals['amount_total_rounded'], 435)
+
+        bill = self.init_invoice('in_invoice', amounts=[378], taxes=tax_15)
+        bill.invoice_cash_rounding_id = cash_rounding
+        self.assertEqual(bill.tax_totals['amount_total_rounded'], 435)


### PR DESCRIPTION
### Steps to Reproduce

1. Activate Cash Roundings.
2. Create a half-up cash rounding with a precision of 1.
3. Create a new bill with a pre-tax amount of 378 and a tax rate of 15%
4. Apply the cash rounding to the bill and save.
5. Review the "Total Rounded" value.

Expected Results:
The 'Total Rounded' value should be 435.00

Actual Results:
The displayed 'Total Rounded' value is 434.40

Ticket links:
https://www.odoo.com/web#id=3235723&model=project.task
https://www.odoo.com/web#id=3236011&model=project.task
https://www.odoo.com/web#id=3277942&model=project.task

opw-3235723
opw-3236011
opw-3277942