### PR TITLE
[FIX] web: fix get_translations_for_webclient

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -45,6 +45,10 @@ export const localizationService = {
             multi_lang: multiLang,
         } = await response.json();
 
+        if (!userLocalization) {
+            throw new Error("Language (" + lang + ") is not available");
+        }
+
         // FIXME We flatten the result of the python route.
         // Eventually, we want a new python route to return directly the good result.
         const terms = {};

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -219,27 +219,28 @@ class IrHttp(models.AbstractModel):
             modules = self.pool._init_modules
         if not lang:
             lang = self._context.get("lang")
-        langs = self.env['res.lang']._lang_get(lang)
-        lang_params = None
-        if langs:
-            lang_params = {
-                "name": langs.name,
-                "direction": langs.direction,
-                "date_format": langs.date_format,
-                "time_format": langs.time_format,
-                "grouping": langs.grouping,
-                "decimal_point": langs.decimal_point,
-                "thousands_sep": langs.thousands_sep,
-                "week_start": langs.week_start,
-            }
-            lang_params['week_start'] = int(lang_params['week_start'])
-            lang_params['code'] = lang
+        res_lang = self.env['res.lang']._lang_get(lang)
+        if not res_lang:
+            return None, None
+
+        lang_params = {
+            'name': res_lang.name,
+            'direction': res_lang.direction,
+            'date_format': res_lang.date_format,
+            'time_format': res_lang.time_format,
+            'grouping': res_lang.grouping,
+            'decimal_point': res_lang.decimal_point,
+            'thousands_sep': res_lang.thousands_sep,
+            'week_start': int(res_lang.week_start),
+            'code': res_lang.code
+        }
 
         # Regional languages (ll_CC) must inherit/override their parent lang (ll), but this is
         # done server-side when the language is loaded, so we only need to load the user's lang.
-        translations_per_module = {}
-        for module in modules:
-            translations_per_module[module] = code_translations.get_web_translations(module, lang)
+        translations_per_module = {
+            module: code_translations.get_web_translations(module, res_lang.code)
+            for module in modules
+        }
 
         return translations_per_module, lang_params
 


### PR DESCRIPTION
before this commit:
when lang is an inactivated language, get_translations_for_webclient returns (translations_for_lang, None)
which is not consistent, and may trigger frontend error

after this commit:
get_translations_for_webclient will return (None, None)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
