### PR TITLE
[FIX] hr_expense: adding expenses to expense sheet error

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -767,7 +767,6 @@
                                    'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header',
                                    'default_company_id': company_id,
                                    'default_employee_id': employee_id,
-                                   'default_sheet_id': active_id,
                                    'default_payment_mode': payment_mode,
                                }"
                                attrs="{'readonly': [('is_editable', '=', False)]}" force_save="1">


### PR DESCRIPTION
Before this commit,
- create an expense
- click on create expense report button
- click on add expense in expense lines
- click on create
> the record does not exist error.

After, you can add expense to expense report via the lines without issue. The (not yet existing) expense sheet is not part of the context anymore.

task-id: 3245816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
