### PR TITLE
[FIX] mail: add tracking for binary fields

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -758,6 +758,13 @@ msgid "Anonymous"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
+#, python-format
+msgid "Value has changed"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,help:mail.field_mail_compose_message__no_auto_thread
 #: model:ir.model.fields,help:mail.field_mail_mail__no_auto_thread
 #: model:ir.model.fields,help:mail.field_mail_message__no_auto_thread

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -78,7 +78,7 @@ class MailTracking(models.Model):
                 'old_value_char': initial_value and initial_value.sudo().name_get()[0][1] or '',
                 'new_value_char': new_value and new_value.sudo().name_get()[0][1] or ''
             })
-        else:
+        elif col_info['type'] != 'binary':
             tracked = False
 
         if tracked:

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -175,12 +175,17 @@
                                     <li>
                                         <div class="o_Message_trackingValue" role="group">
                                             <div class="o_Message_trackingValueFieldName o_Message_trackingValueItem" t-esc="value.changed_field"/>
-                                            <t t-if="value.old_value">
-                                                <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>
+                                            <t t-if="value.old_value or value.new_value">
+                                                <t t-if="value.old_value">
+                                                    <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>
+                                                </t>
+                                                <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img"/>
+                                                <t t-if="value.new_value">
+                                                    <div class="o_Message_trackingValueNewValue o_Message_trackingValueItem" t-esc="value.new_value"/>
+                                                </t>
                                             </t>
-                                            <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img"/>
-                                            <t t-if="value.new_value">
-                                                <div class="o_Message_trackingValueNewValue o_Message_trackingValueItem" t-esc="value.new_value"/>
+                                            <t t-else="">
+                                                Value has changed
                                             </t>
                                         </div>
                                     </li>

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -54,6 +54,15 @@ class MailTestFieldType(models.Model):
         return super(MailTestFieldType, self).create(vals_list)
 
 
+class MailTestTrackBinary(models.Model):
+    _name = 'mail.test.track.binary'
+    _description = "Test tracking with binary field"
+    _inherit = ['mail.thread']
+
+    name = fields.Char()
+    picture = fields.Binary(tracking=True)
+
+
 class MailTestTrackCompute(models.Model):
     _name = 'mail.test.track.compute'
     _description = "Test tracking with computed fields"

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -21,6 +21,7 @@ access_mail_test_cc_portal,mail.test.cc.portal,model_mail_test_cc,base.group_por
 access_mail_test_cc_user,mail.test.cc.user,model_mail_test_cc,base.group_user,1,1,1,1
 access_mail_test_multi_company_user,mail.test.multi.company.user,model_mail_test_multi_company,base.group_user,1,1,1,1
 access_mail_test_multi_company_portal,mail.test.multi.company.portal,model_mail_test_multi_company,base.group_portal,1,0,0,0
+access_mail_test_track_binary,mail.test.track.binary,model_mail_test_track_binary,base.group_user,1,1,1,1
 access_mail_test_track_compute,mail.test.track.compute,model_mail_test_track_compute,base.group_user,1,1,1,1
 access_mail_test_track_selection_portal,mail.test.track.selection.portal,model_mail_test_track_selection,base.group_portal,0,0,0,0
 access_mail_test_track_selection_user,mail.test.track.selection.user,model_mail_test_track_selection,base.group_user,1,1,1,1

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -262,6 +262,32 @@ class TestTracking(TestMailCommon):
             ('container_id', 'many2one', False, container),
         ])
 
+    def test_tracked_binary(self):
+        # Test: Check that a tracked binary field creates trackings without values when modified
+        # no tracking at creation
+        record = self.env['mail.test.track.binary'].create({'name': ''})
+        self.flush_tracking()
+        self.assertEqual(len(record.message_ids), 1)
+        self.assertEqual(len(record.message_ids[0].tracking_value_ids), 0)
+
+        # tracking when setting the value
+        record.write({'picture': b'Y29vbF9waG90bw=='})
+        self.flush_tracking()
+        self.assertEqual(len(record.message_ids), 2)
+        self.assertEqual(len(record.message_ids[0].tracking_value_ids), 1)
+        self.assertTracking(record.message_ids[0], [
+            ('picture', 'char', False, False),
+        ])
+
+        # tracking when changing the value
+        record.write({'picture': b'YXdlc29tZV9waG90bw=='})
+        self.flush_tracking()
+        self.assertEqual(len(record.message_ids), 3)
+        self.assertEqual(len(record.message_ids[0].tracking_value_ids), 1)
+        self.assertTracking(record.message_ids[0], [
+            ('picture', 'char', False, False),
+        ])
+
     def test_tracked_compute(self):
         # no tracking at creation
         record = self.env['mail.test.track.compute'].create({})


### PR DESCRIPTION
Tracking on binary fields doesn't work as no message is added in the chatter when changing a binary field value

Steps to reproduce:
1. Install Sales and Studio
2. Open any quotation
3. Trigger Studio and add a signature field to the form
4. With debug mode enabled, edit the field (by clicking on MORE when the field is selected) and set the Enable Ordered Tracking to 1
5. Close Studio
6. Edit the signature and save
7. A tracking message should appear in the chatter but nothing happens

Solution:
Track binary field changes and notify the change (without the values)

Problem:
Fields of type binary are untracked by force in `create_tracking_values`

opw-3055108