### PR TITLE
[FIX] stock_picking_batch: check that the batch name is unique

### DIFF
--- a/addons/barcodes/i18n/barcodes.pot
+++ b/addons/barcodes/i18n/barcodes.pot
@@ -272,6 +272,12 @@ msgstr ""
 msgid "The barcode matching pattern"
 msgstr ""
 
+#. module: stock_picking_batch
+#: code:addons/stock_picking_batch/models/stock_picking_batch.py:0
+#, python-format
+msgid "The batch name must be unique! Please choose another one."
+msgstr ""
+
 #. module: barcodes
 #: model:ir.model.fields,help:barcodes.field_barcode_nomenclature__rule_ids
 msgid "The list of barcode rules"

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
 class StockPickingBatch(models.Model):
@@ -54,6 +54,13 @@ class StockPickingBatch(models.Model):
               - If manually set then scheduled date for all transfers in batch will automatically update to this date.
               - If not manually changed and transfers are added/removed/updated then this will be their earliest scheduled date
                 but this scheduled date will not be set for all transfers in batch.""")
+
+    @api.constrains('name')
+    def _check_name(self):
+        for batch in self:
+            if batch.name != 'New':
+                if self.search_count([('name', '=', batch.name)]) > 1:
+                    raise ValidationError(_('The batch name must be unique! Please choose another one.'))
 
     @api.depends('company_id', 'picking_type_id', 'state')
     def _compute_allowed_picking_ids(self):


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a batch > e.g, it will have the name "Batch/0001"
- Go to “Sequences” > Batch Transfer > change the next number to “1”
- Create a new batch

**Problem:**
it will have the same name as the first, while the batch name should be unique

opw-3232687

