### PR TITLE
[FIX] web: doAction doesn't convert to markup

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -484,7 +484,7 @@ function makeActionManager(env) {
         for (const key of specialKeys) {
             if (key in action) {
                 if (key === "help") {
-                    viewProps.noContentHelp = action.help;
+                    viewProps.noContentHelp = markup(action.help);
                 } else {
                     viewProps[key] = action[key];
                 }


### PR DESCRIPTION
Before:
When using the action_service's doAction method, the noContentHelp is not converted to markup, resulting in an ugly noContentHelp screen.

After:
No content screens look pretty