### PR TITLE
[IMP] web: Add ability to add hotkeys for order line controls.

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -213,9 +213,9 @@
                                 attrs="{'readonly': [('state', 'in', ('done', 'cancel'))]}">
                                 <tree string="Purchase Order Lines" editable="bottom">
                                     <control>
-                                        <create name="add_product_control" string="Add a product"/>
+                                        <create name="add_product_control" string="Add a product" hotkey="p"/>
                                         <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                        <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                        <create name="add_note_control" string="Add a note" hotkey="n" context="{'default_display_type': 'line_note'}"/>
                                     </control>
                                     <field name="display_type" invisible="1"/>
                                     <field name="currency_id" invisible="1"/>

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -448,9 +448,9 @@
                                     editable="bottom"
                                 >
                                     <control>
-                                        <create name="add_product_control" string="Add a product"/>
+                                        <create name="add_product_control" string="Add a product" hotkey="p"/>
                                         <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                        <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                        <create name="add_note_control" string="Add a note" hotkey="n" context="{'default_display_type': 'line_note'}"/>
                                     </control>
 
                                     <field name="sequence" widget="handle" />

--- a/addons/web/static/src/legacy/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_editable_renderer.js
@@ -72,6 +72,7 @@ ListRenderer.include({
                 }
                 this.creates.push({
                     context: child.attrs.context,
+                    hotkey: child.attrs.hotkey,
                     string: child.attrs.string,
                 });
             });
@@ -1246,6 +1247,7 @@ ListRenderer.include({
                 _.each(this.creates, function (create, index) {
                     var $a = $('<a href="#" role="button">')
                         .attr('data-context', create.context)
+                        .attr('data-hotkey', create.hotkey)
                         .text(create.string);
                     if (index > 0) {
                         $a.addClass('ml16');


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

As office staff, I would like to quickly amend orders using only the keyboard, but it is currently impossible to set hotkeys for "Add a product" and similar order line controls.

# Current behavior before PR:

No ability to add hotkeys for order line controls.

# Desired behavior after PR is merged:

Ability to add hotkeys for order line controls.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
