### PR TITLE
[FIX] l10n_ec:  prevent tax template deletion

### DIFF
--- a/addons/l10n_ec/i18n/l10n_ec.pot
+++ b/addons/l10n_ec/i18n/l10n_ec.pot
@@ -402,3 +402,12 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ec.selection__l10n_latam_document_type__internal_type__withhold
 msgid "Withhold"
 msgstr ""
+
+#. module: l10n_ec
+#. odoo-python
+#: code:addons/l10n_ec/models/account_tax.py:0
+#, python-format
+msgid ""
+"You cannot delete account template %s as it is used in another module.You "
+"can archieve it."
+msgstr ""

--- a/addons/l10n_ec/models/account_tax.py
+++ b/addons/l10n_ec/models/account_tax.py
@@ -1,8 +1,36 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import fields, models, api, _
+from odoo.exceptions import UserError
 
+ACCOUNT_TAX_TEMPLATES = ['l10n_ec.tax_vat_510_sup_01',
+'l10n_ec.tax_vat_510_sup_05',
+'l10n_ec.tax_vat_510_sup_06',
+'l10n_ec.tax_vat_510_sup_15',
+'l10n_ec.tax_vat_511_sup_03',
+'l10n_ec.tax_vat_512_sup_04',
+'l10n_ec.tax_vat_512_sup_05',
+'l10n_ec.tax_vat_512_sup_07',
+'l10n_ec.tax_vat_513_sup_01',
+'l10n_ec.tax_vat_514_sup_06',
+'l10n_ec.tax_vat_515_sup_03',
+'l10n_ec.tax_vat_516_sup_07',
+'l10n_ec.tax_vat_517_sup_02',
+'l10n_ec.tax_vat_517_sup_04',
+'l10n_ec.tax_vat_517_sup_05',
+'l10n_ec.tax_vat_517_sup_07',
+'l10n_ec.tax_vat_517_sup_15',
+'l10n_ec.tax_vat_518_sup_02',
+'l10n_ec.tax_vat_541_sup_02',
+'l10n_ec.tax_vat_542_sup_02',
+'l10n_ec.tax_vat_510_08_sup_01',
+'l10n_ec.tax_vat_545_sup_08',
+'l10n_ec.tax_vat_545_sup_08_vat0',
+'l10n_ec.tax_vat_545_sup_08_vat_exempt',
+'l10n_ec.tax_vat_545_sup_08_vat_not_charged',
+'l10n_ec.tax_vat_545_sup_09',
+]
 
 class AccountTax(models.Model):
 
@@ -51,3 +79,8 @@ class AccountTaxTemplate(models.Model):
         string="Code ATS",
         help="Tax Identification Code for the Simplified Transactional Annex",
     )
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_last_account_template(self):
+        if self.get_external_id()[self.id] in ACCOUNT_TAX_TEMPLATES:
+            raise UserError(_("You cannot delete account template %s as it is used in another module but you can archive it.") % self.name)


### PR DESCRIPTION
When we delete a tax template from the 'Account Tax Template' in 'l10n_ec'. which is identified by an ID stored in a CSV file, and then upgrade or install 'l10n_ec_edi', the system attempts to retrieve the tax template using the ID stored in the deleted template's CSV file. If the system cannot find the template, an exception is thrown indicating that the 'account.tax.template.csv' file cannot be processed because a required value is missing for the 'Chart Template' field (chart_template_id).

see: https://bit.ly/42AqpsN

This commit  solves this issue by adding a function '_unlink_except_last_account_template' that  prevents user from deleting tax templates whose id is stored in  account.tax.tamplate.csv.

sentry-3985837649