### PR TITLE
[FIX] event{._sms}: irrelevant template data display

### DIFF
--- a/addons/event/i18n/event.pot
+++ b/addons/event/i18n/event.pot
@@ -2964,6 +2964,12 @@ msgid "The stop date cannot be earlier than the start date."
 msgstr ""
 
 #. module: event
+#: code:addons/event/models/event_mail.py:0
+#, python-format
+msgid "There is no template data relevant to the notification type."
+msgstr ""
+
+#. module: event
 #: model_terms:event.event,description:event.event_0
 msgid ""
 "This event is also an opportunity to showcase our partners' case studies, "

--- a/addons/event_sms/i18n/event_sms.pot
+++ b/addons/event_sms/i18n/event_sms.pot
@@ -63,6 +63,12 @@ msgid "Send"
 msgstr ""
 
 #. module: event_sms
+#: code:addons/event_sms/models/event_mail.py:0
+#, python-format
+msgid "There is no template data relevant to the notification type."
+msgstr ""
+
+#. module: event_sms
 #: model:sms.template,body:event_sms.sms_template_data_event_reminder
 msgid ""
 "{{ object.event_id.organizer_id.name or object.event_id.company_id.name or "

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class EventTypeMail(models.Model):
@@ -66,8 +67,11 @@ class EventMailScheduler(models.Model):
         super().set_template_ref_model()
         mail_model = self.env['sms.template']
         if self.notification_type == 'sms':
-            record = mail_model.search([('model', '=', 'event.registration')], limit=1)
-            self.template_ref = "{},{}".format('sms.template', record.id) if record else False
+            template = mail_model.search([('model', '=', 'event.registration')], limit=1)
+            if template:
+                self.template_ref = "{},{}".format('sms.template', template.id)
+            else:
+                raise UserError(_("There is no template data relevant to the notification type."))
 
 
 class EventMailRegistration(models.Model):


### PR DESCRIPTION
1. Install Events
2. Click on the app
- click on any event
- Communication tab
- select [Social Post] (one without demo data) on Send column
- click on Template section to get the dropdown

Issue: what you see are not relevant to the Send section
Resolve by: Give some guidance to the user
Linked w: [PR#38684](https://github.com/odoo/enterprise/pull/38684)
Impacted version: 15.0 - master
opw-3103199
