### PR TITLE
[16.0][IMP] models: Enable usage of "special" field "__count" as part of order-by clause of "read_group" method.

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1968,6 +1968,8 @@ class BaseModel(metaclass=MetaModel):
             elif order_field in aggregated_fields:
                 order_split[0] = '"%s"' % order_field
                 orderby_terms.append(' '.join(order_split))
+            elif order_field == "__count":
+                 orderby_terms.append(' '.join(order_split))
             elif order_field not in self._fields:
                 raise ValueError("Invalid field %r on model %r" % (order_field, self._name))
             elif order_field == 'sequence':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The idea/suggestion behind this PR is to enable usage of special field ___count_ in the _order-by_ clause of the _read_group_ method.

Currently system does not recognize field ___count_ as part of the order-by clause, but it can be useful if it would. 
We can use that field as part of the result values, so maybe we could use it as part of the order-by as well.

What do you think?

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
