### PR TITLE
[FIX]  hr_expense:  add amount_currency in needed_terms

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -68,6 +68,7 @@ class AccountMove(models.Model):
                         "balance": balance,
                         "name": "",
                         "account_id": move.expense_sheet_id.expense_line_ids[0]._get_expense_account_destination(),
+                        "amount_currency": balance,
                     }
                 }
 


### PR DESCRIPTION
The computed value of 'AccountMove.needed_terms' is overridden in 'hr.expense'
 module where it does not add the 'amount_currency' key-value pair.
So, it will cause error.

![image](https://user-images.githubusercontent.com/121805291/227471604-999fe8fd-922b-45bf-86ac-3609499da588.png)


sentry - 4022475962

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
