### PR TITLE
Fix Ambiguous Column

### DIFF
--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -53,7 +53,7 @@ class User(models.Model):
         self.env['hr.leave'].flush(fnames=['user_id', 'state', 'date_from', 'date_to'])
         self.env.cr.execute('''SELECT res_users.%s FROM res_users
                             JOIN hr_leave ON hr_leave.user_id = res_users.id
-                            AND state in ('validate')
+                            AND res_users.state in ('validate')
                             AND res_users.active = 't'
                             AND date_from <= %%s AND date_to >= %%s''' % field, (now, now))
         return [r[0] for r in self.env.cr.fetchall()]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixed Ambiguous column error after migration Odoo 11 to Odoo 15 ,  in  data base query of function  _get_on_leave_ids inside model res_user inside hr_holidays app 

Current behavior before PR:

Getting error "psycopq2.errors.AmbiquousColumn:columnreference
"state" is ambiguous
LINE 3:
AND state in ('validate')"

product that exactly the query does not make clear which table the state column is referencing.
The error does not allow entering the employee module and occurs when accessing the database and does not allow updating applications.

This error is present in Other versions like 14.0 and 16.0 

Desired behavior after PR is merged:

The error no longer occurs, applications can be updated and the employee module can be accessed

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
