### PR TITLE
[FIX] web_editor: keep styles on enter

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2954,6 +2954,7 @@ export class OdooEditor extends EventTarget {
         // we only remove the attribute to ensure we don't break some style.
         // Otherwise we remove the entire inline element.
         for (const emptyElement of element.querySelectorAll('[oe-zws-empty-inline]')) {
+            const blockEl = closestBlock(emptyElement);
             if (isZWS(emptyElement)) {
                 if (emptyElement.classList.length > 0) {
                     emptyElement.removeAttribute('oe-zws-empty-inline');
@@ -2963,6 +2964,9 @@ export class OdooEditor extends EventTarget {
             } else {
                 cleanZWS(emptyElement);
                 emptyElement.removeAttribute('oe-zws-empty-inline');
+            }
+            if (blockEl) {
+                fillEmpty(blockEl);
             }
         }
         sanitize(element);

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2598,10 +2598,12 @@ export class OdooEditor extends EventTarget {
                 // and preserves the cursor position.
                 const sel = this.document.getSelection();
                 const restoreCursor = preserveCursor(this.document);
-                const emptyElement = closestElement(sel.anchorNode, '[oe-zws-empty-inline]');
+                const emptyElement = closestElement(sel.anchorNode, '[oe-zws-empty-inline], [oe-inline-line-break]');
                 if (emptyElement && !isZWS(emptyElement)) {
                     cleanZWS(emptyElement);
-                    emptyElement.removeAttribute('oe-zws-empty-inline');
+                    ['oe-zws-empty-inline', 'oe-inline-line-break'].forEach(attr => {
+                        emptyElement.removeAttribute(attr);
+                    });
                 }
                 restoreCursor();
                 // Check for url after user insert a space so we won't transform an incomplete url.
@@ -2955,17 +2957,21 @@ export class OdooEditor extends EventTarget {
         // If the element have a class,
         // we only remove the attribute to ensure we don't break some style.
         // Otherwise we remove the entire inline element.
-        for (const emptyElement of element.querySelectorAll('[oe-zws-empty-inline]')) {
+        for (const emptyElement of element.querySelectorAll('[oe-zws-empty-inline], [oe-inline-line-break]')) {
             const blockEl = closestBlock(emptyElement);
             if (isZWS(emptyElement)) {
                 if (emptyElement.classList.length > 0) {
-                    emptyElement.removeAttribute('oe-zws-empty-inline');
+                    ['oe-zws-empty-inline', 'oe-inline-line-break'].forEach(attr => {
+                        emptyElement.removeAttribute(attr);
+                    });
                 } else {
                     emptyElement.remove();
                 }
             } else {
                 cleanZWS(emptyElement);
-                emptyElement.removeAttribute('oe-zws-empty-inline');
+                ['oe-zws-empty-inline', 'oe-inline-line-break'].forEach(attr => {
+                    emptyElement.removeAttribute(attr);
+                });
             }
             if (blockEl) {
                 fillEmpty(blockEl);

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2593,6 +2593,16 @@ export class OdooEditor extends EventTarget {
                     insertText(selection, ev.data === null ? ev.dataTransfer.getData('text/plain') : ev.data);
                     selection.collapseToEnd();
                 }
+                // Removes zero-width spaces added at the time of Enter,
+                // and preserves the cursor position.
+                const sel = this.document.getSelection();
+                const restoreCursor = preserveCursor(this.document);
+                const emptyElement = closestElement(sel.anchorNode, '[oe-zws-empty-inline]');
+                if (emptyElement && !isZWS(emptyElement)) {
+                    cleanZWS(emptyElement);
+                    emptyElement.removeAttribute('oe-zws-empty-inline');
+                }
+                restoreCursor();
                 // Check for url after user insert a space so we won't transform an incomplete url.
                 if (
                     ev.data &&

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2560,6 +2560,7 @@ export class OdooEditor extends EventTarget {
                 this._compositionStep();
                 this.historyRollback();
                 ev.preventDefault();
+                getDeepRange(this.editable, { select: true });
                 if (this._applyCommand('oEnter') === UNBREAKABLE_ROLLBACK_CODE) {
                     this._applyCommand('oShiftEnter');
                 }
@@ -2692,6 +2693,7 @@ export class OdooEditor extends EventTarget {
             ev.stopPropagation();
         } else if (ev.shiftKey && ev.key === "Enter") {
             ev.preventDefault();
+            getDeepRange(this.editable, { select: true });
             this._applyCommand('oShiftEnter');
         } else if (IS_KEYBOARD_EVENT_UNDO(ev)) {
             // Ctrl-Z

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
@@ -9,6 +9,8 @@ import {
     getState,
     leftPos,
     splitTextNode,
+    closestElement,
+    isBlock,
 } from '../utils/utils.js';
 
 Text.prototype.oShiftEnter = function (offset) {
@@ -22,6 +24,11 @@ HTMLElement.prototype.oShiftEnter = function (offset) {
     const brEls = [brEl];
     if (offset >= this.childNodes.length) {
         this.appendChild(brEl);
+        if (!isBlock(closestElement(this)) && this.nextSibling) {
+            const zws = document.createTextNode('\u200B');
+            this.appendChild(zws);
+            this.setAttribute("oe-inline-line-break", "");
+        }
     } else {
         this.insertBefore(brEl, this.childNodes[offset]);
     }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1990,12 +1990,7 @@ export function unwrapContents(node) {
 export function fillEmpty(el) {
     const fillers = {};
     const blockEl = closestBlock(el);
-    if (isShrunkBlock(blockEl)) {
-        const br = document.createElement('br');
-        blockEl.appendChild(br);
-        fillers.br = br;
-    }
-    if (!isVisible(el) && !el.hasAttribute('oe-zws-empty-inline')) {
+    if (!isVisible(el)) {
         // As soon as there is actual content in the node, the zero-width space
         // is removed by the sanitize function.
         const zws = document.createTextNode('\u200B');
@@ -2007,6 +2002,11 @@ export function fillEmpty(el) {
             previousSibling.remove();
         }
         setSelection(zws, 0, zws, 0);
+    }
+    if (isShrunkBlock(blockEl)) {
+        const br = document.createElement('br');
+        blockEl.appendChild(br);
+        fillers.br = br;
     }
     return fillers;
 }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
@@ -1,4 +1,4 @@
-import { BasicEditor, testEditor } from '../utils.js';
+import { BasicEditor, testEditor, insertText } from '../utils.js';
 
 const setColor = (color, mode) => {
     return async editor => {
@@ -111,6 +111,67 @@ describe('applyColor', () => {
             stepFunction: setColor('','color'),
             stepFunction: setColor('','backgroundColor'),
             contentAfter: '<p>[abcabc]</p>',
+        });
+    });
+});
+
+describe('keep styles', () => {
+    it('should keep styles on enter', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[]</font></p>',
+            stepFunction: async editor => {
+                await editor.execCommand('oEnter');
+                await insertText(editor, 'x');
+                await editor.execCommand('oEnter');
+            },
+            contentAfterEdit: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
+                                '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">x</font></p>' +
+                                '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font></p>',
+        });
+        await testEditor(BasicEditor, {
+            contentBefore: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[]</font></h1>',
+            stepFunction: async editor => {
+                await editor.execCommand('oEnter');
+                await insertText(editor, 'x');
+                await editor.execCommand('oEnter');
+            },
+            contentAfterEdit: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
+                            '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">x</font></p>' +
+                            '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font></p>',
+        });
+    });
+    it('should split a paragraph and also keep styles on enter', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[]</font>cd</p>',
+            stepFunction: async editor => {
+                await editor.execCommand('oEnter');
+            },
+            contentAfterEdit: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
+                            '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font>cd</p>',
+        });
+        await testEditor(BasicEditor, {
+            contentBefore: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[]</font>cd</h1>',
+            stepFunction: async editor => {
+                await editor.execCommand('oEnter');
+            },
+            contentAfterEdit: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
+                                '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font>cd</h1>',
+        });
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[] </font>cd</p>',
+            stepFunction: async editor => {
+                await editor.execCommand('oEnter');
+            },
+            contentAfter: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
+                            '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">[]&nbsp;</font>cd</p>',
+        });
+        await testEditor(BasicEditor, {
+            contentBefore: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[] </font>cd</h1>',
+            stepFunction: async editor => {
+                await editor.execCommand('oEnter');
+            },
+            contentAfter: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
+                            '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">[]&nbsp;</font>cd</h1>'
         });
     });
 });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
@@ -46,7 +46,7 @@ describe('applyColor', () => {
             contentAfterEdit: '<p>[<font oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
                               '<p><font oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
                               '<p>]<font oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>',
-            contentAfter: '<p>[</p><p></p><p>]</p>',
+            contentAfter: '<p>[<br></p><p><br></p><p>]<br></p>',
         });
     });
     it('should apply a background color on empty selection', async () => {
@@ -56,7 +56,7 @@ describe('applyColor', () => {
             contentAfterEdit: '<p>[<font oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
                               '<p><font oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
                               '<p>]<font oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>',
-            contentAfter: '<p>[</p><p></p><p>]</p>',
+            contentAfter: '<p>[<br></p><p><br></p><p>]<br></p>',
         });
     });
     it('should not merge line on background color change', async () => {
@@ -127,6 +127,10 @@ describe('keep styles', () => {
             contentAfterEdit: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
                                 '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">x</font></p>' +
                                 '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font></p>',
+
+            contentAfter: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
+                            '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">x</font></p>' +
+                            '<p>[]<br></p>',
         });
         await testEditor(BasicEditor, {
             contentBefore: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[]</font></h1>',
@@ -138,6 +142,10 @@ describe('keep styles', () => {
             contentAfterEdit: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
                             '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">x</font></p>' +
                             '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font></p>',
+
+            contentAfter: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
+                            '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">x</font></p>' +
+                            '<p>[]<br></p>',
         });
     });
     it('should split a paragraph and also keep styles on enter', async () => {
@@ -148,6 +156,8 @@ describe('keep styles', () => {
             },
             contentAfterEdit: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
                             '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font>cd</p>',
+            contentAfter: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></p>' +
+                            '<p>[]cd</p>',
         });
         await testEditor(BasicEditor, {
             contentBefore: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[]</font>cd</h1>',
@@ -156,6 +166,8 @@ describe('keep styles', () => {
             },
             contentAfterEdit: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
                                 '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);" oe-zws-empty-inline="">[]\u200b</font>cd</h1>',
+            contentAfter: '<h1><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc</font></h1>' +
+                            '<h1>[]cd</h1>',
         });
         await testEditor(BasicEditor, {
             contentBefore: '<p><font style="color: rgb(0, 255, 0) background-color: rgb(255, 0, 0);">abc[] </font>cd</p>',

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2728,11 +2728,13 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abc[]</p>',
                         stepFunction: insertParagraphBreak,
+                        contentAfterEdit: '<p>abc</p><p placeholder="Type &quot;/&quot; for commands" class="oe-hint oe-command-temporary-hint">[]<br></p>',
                         contentAfter: '<p>abc</p><p>[]<br></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abc[] </p>',
                         stepFunction: insertParagraphBreak,
+                        contentAfterEdit: '<p>abc</p><p placeholder="Type &quot;/&quot; for commands" class="oe-hint oe-command-temporary-hint">[]<br></p>',
                         contentAfter: '<p>abc</p><p>[]<br></p>',
                     });
                 });
@@ -2866,6 +2868,7 @@ X[]
                         // That selection is equivalent to </b>[]
                         contentBefore: '<p><b>abc[]</b>def</p>',
                         stepFunction: insertParagraphBreak,
+                        contentAfterEdit: '<p><b>abc</b></p><p><b oe-zws-empty-inline="">[]\u200B</b>def</p>',
                         contentAfter: '<p><b>abc</b></p><p>[]def</p>',
                     });
                     await testEditor(BasicEditor, {
@@ -2873,6 +2876,7 @@ X[]
                         stepFunction: insertParagraphBreak,
                         // The space is converted to a non-breaking
                         // space so it is visible.
+                        contentAfterEdit: '<p><b>abc</b></p><p><b oe-zws-empty-inline="">[]\u200B</b>&nbsp;def</p>',
                         contentAfter: '<p><b>abc</b></p><p>[]&nbsp;def</p>',
                     });
                     await testEditor(BasicEditor, {
@@ -2881,6 +2885,7 @@ X[]
                         // The space is converted to a non-breaking
                         // space so it is visible (because it's before a
                         // <br>).
+                        contentAfterEdit: '<p><b>abc&nbsp;</b></p><p><b oe-zws-empty-inline="">[]\u200B</b>def</p>',
                         contentAfter: '<p><b>abc&nbsp;</b></p><p>[]def</p>',
                     });
                 });
@@ -2894,14 +2899,14 @@ X[]
                         // That selection is equivalent to []<b>
                         contentBefore: '<p><b>[]abc</b></p>',
                         stepFunction: insertParagraphBreak,
-                        contentAfter: '<p><br></p><p><b>[]abc</b></p>',
+                        contentAfterEdit: '<p><b oe-zws-empty-inline="">\u200B</b></p><p><b>[]abc</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>[] abc</b></p>',
                         stepFunction: insertParagraphBreak,
                         // The space should have been parsed away.
                         // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
-                        contentAfter: '<p><br></p><p><b>[] abc</b></p>',
+                        contentAfterEdit: '<p><b oe-zws-empty-inline="">\u200B</b></p><p><b>[] abc</b></p>',
                     });
                 });
                 it('should split a paragraph within a format node', async () => {
@@ -2935,13 +2940,13 @@ X[]
                         // That selection is equivalent to </b>[]
                         contentBefore: '<p><b>abc[]</b></p>',
                         stepFunction: insertParagraphBreak,
-                        contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
+                        contentAfterEdit: '<p><b>abc</b></p><p><b oe-zws-empty-inline="">[]\u200B</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>abc[] </b></p>',
                         stepFunction: insertParagraphBreak,
                         // The space should have been parsed away.
-                        contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
+                        contentAfterEdit: '<p><b>abc</b></p><p><b oe-zws-empty-inline="">[]\u200B</b></p>',
                     });
                 });
                 it('should insert line breaks outside the edges of an anchor in unbreakable', async () => {
@@ -3013,7 +3018,7 @@ X[]
                             '<p><span class="a">ab</span></p><p><span class="b">[]cd</span></p>',
                         stepFunction: insertParagraphBreak,
                         contentAfter:
-                            '<p><span class="a">ab</span></p><p><br></p><p><span class="b">[]cd</span></p>',
+                            '<p><span class="a">ab</span></p><p><span class="b">\u200B</span></p><p><span class="b">[]cd</span></p>',
                     });
                 });
                 it('should split a paragraph with a span with a bold in two', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3325,6 +3325,7 @@ X[]
                         // That selection is equivalent to </b>[]
                         contentBefore: '<p><b>abc[]</b>def</p>',
                         stepFunction: insertLineBreak,
+                        contentAfterEdit: '<p><b oe-inline-line-break="">abc<br>[]\u200B</b>def</p>',
                         // JW cAfter: '<p><b>abc[]<br></b>def</p>',
                         contentAfter: '<p><b>abc<br>[]</b>def</p>',
                     });
@@ -3335,15 +3336,23 @@ X[]
                         // it is visible (because it's after a <br>).
                         // Visually, the caret does show _after_ the line
                         // break.
+                        contentAfterEdit: '<p><b oe-inline-line-break="">abc<br>[]\u200B</b> def</p>',
                         // JW cAfter: '<p><b>abc[]<br></b>&nbsp;def</p>',
-                        contentAfter: '<p><b>abc<br>[]</b>&nbsp;def</p>',
+                        contentAfter: '<p><b>abc<br>[]</b> def</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>abc []</b>def</p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
+                        contentAfterEdit: '<p><b oe-inline-line-break="">abc&nbsp;<br>[]\u200B</b>def</p>',
                         contentAfter: '<p><b>abc&nbsp;<br>[]</b>def</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><b>abc[]</b><br><br></p>',
+                        stepFunction: insertLineBreak,
+                        contentAfterEdit: '<p><b oe-inline-line-break="">abc<br>[]\u200B</b><br><br></p>',
+                        contentAfter: '<p><b>abc<br>[]</b><br><br></p>',
                     });
                 });
                 it('should insert a <br> at the beginning of a format node', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2900,6 +2900,7 @@ X[]
                         contentBefore: '<p><b>[]abc</b></p>',
                         stepFunction: insertParagraphBreak,
                         contentAfterEdit: '<p><b oe-zws-empty-inline="">\u200B</b></p><p><b>[]abc</b></p>',
+                        contentAfter: '<p><br></p><p><b>[]abc</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>[] abc</b></p>',
@@ -2907,6 +2908,7 @@ X[]
                         // The space should have been parsed away.
                         // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
                         contentAfterEdit: '<p><b oe-zws-empty-inline="">\u200B</b></p><p><b>[] abc</b></p>',
+                        contentAfter: '<p><br></p><p><b>[] abc</b></p>',
                     });
                 });
                 it('should split a paragraph within a format node', async () => {
@@ -2941,12 +2943,14 @@ X[]
                         contentBefore: '<p><b>abc[]</b></p>',
                         stepFunction: insertParagraphBreak,
                         contentAfterEdit: '<p><b>abc</b></p><p><b oe-zws-empty-inline="">[]\u200B</b></p>',
+                        contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>abc[] </b></p>',
                         stepFunction: insertParagraphBreak,
                         // The space should have been parsed away.
                         contentAfterEdit: '<p><b>abc</b></p><p><b oe-zws-empty-inline="">[]\u200B</b></p>',
+                        contentAfter: '<p><b>abc</b></p><p>[]<br></p>',
                     });
                 });
                 it('should insert line breaks outside the edges of an anchor in unbreakable', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
@@ -6277,14 +6277,14 @@ describe('List', () => {
                                     await insertText(editor, 'b');
                                     await insertParagraphBreak(editor);
                                 },
-                                contentAfter: unformat(`
+                                contentAfterEdit: unformat(`
                                     <ul>
                                         <li>ab</li>
                                         <li class="oe-nested">
                                             <ul>
                                                 <li><font style="color: red;">cd</font></li>
-                                                <li>b</li>
-                                                <li>[]<br></li>
+                                                <li><font style="color: red;">b</font></li>
+                                                <li><font style="color: red;" oe-zws-empty-inline="">[]\u200b</font></li>
                                             </ul>
                                         </li>
                                         <li>ef</li>
@@ -6619,18 +6619,18 @@ describe('List', () => {
                                         await insertText(editor, '0');
                                         await insertParagraphBreak(editor);
                                     },
-                                    contentAfter: unformat(`
-                                    <ul class="o_checklist">
-                                        <li>ab</li>
-                                        <li class="oe-nested">
-                                            <ul class="o_checklist">
-                                                <li><font style="color: red;">cd</font></li>
-                                                <li>0</li>
-                                                <li>[]<br></li>
-                                            </ul>
-                                        </li>
-                                        <li class="o_checked">ef</li>
-                                    </ul>`),
+                                    contentAfterEdit: unformat(`
+                                        <ul class="o_checklist">
+                                            <li>ab</li>
+                                            <li class="oe-nested">
+                                                <ul class="o_checklist">
+                                                    <li><font style="color: red;">cd</font></li>
+                                                    <li><font style="color: red;">0</font></li>
+                                                    <li><font style="color: red;" oe-zws-empty-inline="">[]\u200b</font></li>
+                                                </ul>
+                                            </li>
+                                            <li class="o_checked">ef</li>
+                                        </ul>`),
                                 });
                             });
                         });
@@ -6714,18 +6714,18 @@ describe('List', () => {
                                         await insertText(editor, '0');
                                         await insertParagraphBreak(editor);
                                     },
-                                    contentAfter: unformat(`
-                                    <ul class="o_checklist">
-                                        <li class="o_checked">ab</li>
-                                        <li class="oe-nested">
-                                            <ul class="o_checklist">
-                                                <li class="o_checked"><font style="color: red;">cd</font></li>
-                                                <li>0</li>
-                                                <li>[]<br></li>
-                                            </ul>
-                                        </li>
-                                        <li class="o_checked">ef</li>
-                                    </ul>`),
+                                    contentAfterEdit: unformat(`
+                                        <ul class="o_checklist">
+                                            <li class="o_checked">ab</li>
+                                            <li class="oe-nested">
+                                                <ul class="o_checklist">
+                                                    <li class="o_checked"><font style="color: red;">cd</font></li>
+                                                    <li><font style="color: red;">0</font></li>
+                                                    <li><font style="color: red;" oe-zws-empty-inline="">[]\u200b</font></li>
+                                                </ul>
+                                            </li>
+                                            <li class="o_checked">ef</li>
+                                        </ul>`),
                                 });
                             });
                         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
@@ -6289,6 +6289,18 @@ describe('List', () => {
                                         </li>
                                         <li>ef</li>
                                     </ul>`),
+                                contentAfter: unformat(`
+                                    <ul>
+                                        <li>ab</li>
+                                        <li class="oe-nested">
+                                            <ul>
+                                                <li><font style="color: red;">cd</font></li>
+                                                <li><font style="color: red;">b</font></li>
+                                                <li>[]<br></li>
+                                            </ul>
+                                        </li>
+                                        <li>ef</li>
+                                    </ul>`),
                             });
                         });
                     });
@@ -6631,6 +6643,18 @@ describe('List', () => {
                                             </li>
                                             <li class="o_checked">ef</li>
                                         </ul>`),
+                                    contentAfter: unformat(`
+                                        <ul class="o_checklist">
+                                            <li>ab</li>
+                                            <li class="oe-nested">
+                                                <ul class="o_checklist">
+                                                    <li><font style="color: red;">cd</font></li>
+                                                    <li><font style="color: red;">0</font></li>
+                                                    <li>[]<br></li>
+                                                </ul>
+                                            </li>
+                                            <li class="o_checked">ef</li>
+                                        </ul>`),
                                 });
                             });
                         });
@@ -6722,6 +6746,18 @@ describe('List', () => {
                                                     <li class="o_checked"><font style="color: red;">cd</font></li>
                                                     <li><font style="color: red;">0</font></li>
                                                     <li><font style="color: red;" oe-zws-empty-inline="">[]\u200b</font></li>
+                                                </ul>
+                                            </li>
+                                            <li class="o_checked">ef</li>
+                                        </ul>`),
+                                    contentAfter: unformat(`
+                                        <ul class="o_checklist">
+                                            <li class="o_checked">ab</li>
+                                            <li class="oe-nested">
+                                                <ul class="o_checklist">
+                                                    <li class="o_checked"><font style="color: red;">cd</font></li>
+                                                    <li><font style="color: red;">0</font></li>
+                                                    <li>[]<br></li>
                                                 </ul>
                                             </li>
                                             <li class="o_checked">ef</li>


### PR DESCRIPTION
**Current behavior before PR:**

When the current line element has applied styles and enter is pressed, the newly generated line element doesn't contain the previous element styles.

**Desired behavior after PR is merged:**

Now, the current line element has applied styles, and enter is pressed, the newly generated line element will contain the same styles.

**Task**-2822187