### PR TITLE
15.0-base-xml_mimetype_magic

### DIFF
--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -185,6 +185,8 @@ if magic:
         # https://github.com/file/file/commit/1a08bb5c235700ba623ffa6f3c95938fe295b262
         if mimetype == 'image/svg':
             return 'image/svg+xml'
+        if mimetype == "text/xml":
+            return "application/xml"
         return mimetype
 else:
     guess_mimetype = _odoo_guess_mimetype


### PR DESCRIPTION
When using [magic from pypi](https://pypi.python.org/pypi/python-magic/), XML files are detected as `text/xml`.

This patch fixes the `/base:test_guess_mimetype.test_mimetype_xml` test in such scenarios. Makes XML type detection homogeneous in Odoo.

@moduon MT-1075

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
