### PR TITLE
[FIX] website: recover the application of options on anchor images

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -374,11 +374,13 @@ export class WebsitePreview extends Component {
                     },
                     reloadIframe: false,
                 });
-            } else if (href && target !== '_blank' && !isEditing && this._isTopWindowURL(linkEl)) {
-                ev.preventDefault();
-                browser.location.assign(href);
-            } else if (this.iframe.el.contentWindow.location.pathname !== new URL(href).pathname) {
-                this.websiteService.websiteRootInstance = undefined;
+            } else if (href && target !== '_blank' && !isEditing) {
+                if (this._isTopWindowURL(linkEl)) {
+                    ev.preventDefault();
+                    this.router.redirect(href);
+                } else if (this.iframe.el.contentWindow.location.pathname !== new URL(href).pathname) {
+                    this.websiteService.websiteRootInstance = undefined;
+                }
             }
         });
         this.iframe.el.contentDocument.addEventListener('keydown', ev => {


### PR DESCRIPTION
Steps to reproduce the bug:
- Go on the shop.
- Edit.
- Replace a `product.template` image by one of your own.
- Put a shape on the image.
=> When you click on a shape, it does not apply on the image.
Note : This behavior appears for other anchor images such as the logo.

Note that there is an event listener that detects clicks on the
document. The problem is that at the click on the image, the code will
detect that the current URL is different from the URL of the anchor
image that we want to access (`href`) so it will set the
`websiteRootInstance` to `undefined`. However, this mechanism should
not appear in edit mode. Indeed, in edit mode, it is impossible to
browse the different website pages.

The bug described earlier can now be understand like this: The shape is
never apply on the image as there is a promise that never resolved.
Indeed, the click on the shape will lead to a `_refreshPublicWidgets`
that will trigger up a `widgets_start_request`. This event will be
intercepted by the `wysiwg_adapter` and will call `_websiteRootEvent`.
Because the `websiteRootInstance` has been set to `undefined`,
`_websiteRootEvent` will never trigger the `widget_start_request` so it
will never be intercepted by `public_root.js`.

task-4720