### PR TITLE
[FIX] core: handling of NULLS clause

### DIFF
--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -60,6 +60,78 @@ class test_search(TransactionCase):
         id_desc_active_desc = Partner.search([('name', 'like', 'test_search_order%'), '|', ('active', '=', True), ('active', '=', False)], order="id desc, active desc")
         self.assertEqual([e, ab, b, a, d, c], list(id_desc_active_desc), "Search with 'ID DESC, ACTIVE DESC' order failed.")
 
+        a.ref = "ref1"
+        c.ref = "ref2"
+        ids = (a | b | c).ids
+        for order, result in [
+            ('ref', a | c | b),
+            ('ref desc', b | c | a),
+            ('ref asc nulls first', b | a | c),
+            ('ref asc nulls last', a | c | b),
+            ('ref desc nulls first', b | c | a),
+            ('ref desc nulls last', c | a | b)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+
+        # sorting by an m2o should alias to the natural order of the m2o
+        self.patch_order('res.country', 'code')
+        a.country_id, c.country_id = self.env['res.country'].create([{
+            'name': "Country 1",
+            'code': '01',
+        }, {
+            'name': 'Country 2',
+            'code': '02',
+        }])
+
+        for order, result in [
+            ('country_id', a | c | b),
+            ('country_id desc', b | c | a),
+            ('country_id asc nulls first', b | a | c),
+            ('country_id asc nulls last', a | c | b),
+            ('country_id desc nulls first', b | c | a),
+            ('country_id desc nulls last', c | a | b)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+
+        # NULLS applies to the m2o itself, not its sub-fields, so a null `code`
+        # will sort normally (larger than non-null codes)
+        b.country_id = self.env['res.country'].create({'name': "Country X"})
+
+        for order, result in [
+            ('country_id', a | c | b),
+            ('country_id desc', b | c | a),
+            ('country_id asc nulls first', a | c | b),
+            ('country_id asc nulls last', a | c | b),
+            ('country_id desc nulls first', b | c | a),
+            ('country_id desc nulls last', b | c | a)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+
+        # a field DESC should reverse the nested behaviour (and thus the inner
+        # NULLS clauses), but the outer NULLS clause still has no effect
+        self.patch_order('res.country', 'code NULLS FIRST')
+        for order, result in [
+            ('country_id', b | a | c),
+            ('country_id desc', c | a | b),
+            ('country_id asc nulls first', b | a | c),
+            ('country_id asc nulls last', b | a | c),
+            ('country_id desc nulls first', c | a | b),
+            ('country_id desc nulls last', c | a | b)
+        ]:
+            with self.subTest(order):
+                self.assertEqual(
+                    Partner.search([('id', 'in', ids)], order=order).mapped('name'),
+                    result.mapped('name'))
+
     def test_10_inherits_m2order(self):
         Users = self.env['res.users']
 


### PR DESCRIPTION
Allowance of NULLS clauses in #116464 was a bit optimistic, notably not handling how it affected the order-parsing code.

Fix that here: reuse `regex_order` to extract the bits from each part, rather than splitting the clause by hand.

Also apply `reverse_direction` to `NULLS`: given `a_id DESC` and `_fields[a_id].relation._order = 'xxx NULLS LAST'`, reversing the clause should order by `xxx DESC NULLS FIRST` to correctly flip the original: unlike the default, `NULLS` clause are not relative to the sorting order, they put the `NULL`-valued records at the specified location regardless.

Finally the NULLS-clause needs to be expanded by hand on m2o fields: propagating the clause through the join would yield unexpected and illogical results when mixing NULL m2o fields and non-NULL m2o fields with NULL `_order` fields (as they would get mixed rather than clearly layered / separated).

However because SQL nulls are ordered the usual way (`true > false`) the `NULLS` clause is fundamentally equivalent to sorting on the field being NULL (if `NULLS LAST`) or not (if `NULLS FIRST`). So we can prepend the expanded m2o's ordering with such a clause to get the correct behavior.
