### PR TITLE
[16.0][IMP] core: Introducing a new CLI command for database anonymization.

### DIFF
--- a/odoo/cli/__init__.py
+++ b/odoo/cli/__init__.py
@@ -15,5 +15,6 @@ from . import start
 from . import populate
 from . import tsconfig
 from . import neutralize
+from . import anonymize
 from . import genproxytoken
 from . import db

--- a/odoo/cli/anonymize.py
+++ b/odoo/cli/anonymize.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import optparse
+import sys
+
+import odoo
+
+from . import Command
+
+_logger = logging.getLogger(__name__)
+
+
+class Anonymize(Command):
+    """Anonymize a database"""
+
+    def run(self, args):
+        parser = odoo.tools.config.parser
+        group = optparse.OptionGroup(parser, "Anonymize", "Anonymize the database specified by the `-d` argument.")
+        group.add_option("--stdout", action="store_true", dest="to_stdout",
+                         help="Output the anonymization SQL instead of applying it")
+        parser.add_option_group(group)
+        opt = odoo.tools.config.parse_config(args)
+
+        dbname = odoo.tools.config['db_name']
+        if not dbname:
+            _logger.error('Anonymize command needs a database name. Use "-d" argument')
+            sys.exit(1)
+
+        if not opt.to_stdout:
+            _logger.info("Starting %s database anonymization", dbname)
+
+        try:
+            with odoo.sql_db.db_connect(dbname).cursor() as cursor:
+                installed_modules = odoo.modules.anonymize.get_installed_modules(cursor)
+                queries = odoo.modules.anonymize.get_anonymization_queries(installed_modules)
+                if opt.to_stdout:
+                    # pylint: disable=bad-builtin
+                    print('BEGIN;')
+                    for query in queries:
+                        # pylint: disable=bad-builtin
+                        print(query.rstrip(";") + ";")
+                    # pylint: disable=bad-builtin
+                    print("COMMIT;")
+                else:
+                    for query in queries:
+                        cursor.execute(query)
+                    _logger.info("Anonymization finished")
+        except Exception:
+            _logger.critical("An error occurred during the anonymization. THE DATABASE IS NOT ANONYMIZED!")
+            sys.exit(1)

--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -5,7 +5,7 @@
 
 """
 
-from . import db, graph, loading, migration, module, registry, neutralize
+from . import db, graph, loading, migration, module, registry, neutralize, anonymize
 
 from odoo.modules.loading import load_modules, reset_modules_state
 

--- a/odoo/modules/anonymize.py
+++ b/odoo/modules/anonymize.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+
+
+def get_installed_modules(cursor):
+    cursor.execute('''
+        SELECT name
+          FROM ir_module_module
+         WHERE state IN ('installed', 'to upgrade', 'to remove');
+    ''')
+    return [result[0] for result in cursor.fetchall()]
+
+
+def get_anonymization_queries(modules):
+    # neutralization for each module
+    for module in modules:
+        filename = odoo.modules.get_module_resource(module, 'data/anonymize.sql')
+        if filename:
+            with odoo.tools.misc.file_open(filename) as file:
+                yield file.read().strip()


### PR DESCRIPTION
Hi guys,

I have a proposition for a new `cli` command. I hope you'll like the idea ...

Just like with database neutralization we sometimes have a need to additionally anonymize some very sensitive module data from leaving production environment, but that can be conditioned depending on the target environment because, for example, we want to have one staging environment neutralized, but the other or all integration envs we want them neutralized and anonymized as well.

Cheers,
Petar

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
