### PR TITLE
[FIX] account: prevent account tag deletion

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -76,7 +76,7 @@ class AccountAccount(models.Model):
     note = fields.Text('Internal Notes', tracking=True)
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True,
         default=lambda self: self.env.company)
-    tag_ids = fields.Many2many('account.account.tag', 'account_account_account_tag', string='Tags', help="Optional tags you may want to assign for custom reporting")
+    tag_ids = fields.Many2many('account.account.tag', 'account_account_account_tag', string='Tags', help="Optional tags you may want to assign for custom reporting", ondelete='restrict')
     group_id = fields.Many2one('account.group', compute='_compute_account_group', store=True, readonly=True,
                                help="Account prefixes can determine account groups.")
     root_id = fields.Many2one('account.root', compute='_compute_account_root', store=True)

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -705,7 +705,7 @@ class AccountTaxRepartitionLine(models.Model):
         domain="[('deprecated', '=', False), ('company_id', '=', company_id), ('internal_type', 'not in', ('receivable', 'payable'))]",
         check_company=True,
         help="Account on which to post the tax amount")
-    tag_ids = fields.Many2many(string="Tax Grids", comodel_name='account.account.tag', domain=[('applicability', '=', 'taxes')], copy=True)
+    tag_ids = fields.Many2many(string="Tax Grids", comodel_name='account.account.tag', domain=[('applicability', '=', 'taxes')], copy=True, ondelete='restrict')
     invoice_tax_id = fields.Many2one(comodel_name='account.tax',
         ondelete='cascade',
         check_company=True,


### PR DESCRIPTION
When the user deletes an 'account tag' which is being used in 'Tax Report'. And 
after it when the user upgrades 'l10n_es_reports'. The report will try to 
retrieve the id's used in domain we will encounter error:
"Could not eval([('tax_tag_ids', 'in', [ref('l10n_es.mod_111_11'),
ref('l10n_es.mod_111_12')])]) for formula in {}".

Steps to reproduce:
1) Install 'l10n_es' .
2) In 'Accounting' delete  the 'Account Tags' which were created in 'l10n_es' by 
visiting 'Accounting/Configuration/Accounting/Account Tags'.
3) Now upgrade 'l10n_es_reports'.
By following above steps you will be able to produce error. 

see: https://bit.ly/3JTkaYo

To resolve this issue:
I override the unlink function so that it could prevent the deletion of account 
tags used in report and which are created in data file.

sentry-3935871751

