### PR TITLE
[IMP] stock: optimize move reservation

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -313,7 +313,5 @@ class StockMove(models.Model):
                         if existing_lots:
                             existing_lot = existing_lots.filtered_domain([('product_id', '=', line.product_id.id), ('name', '=', lot.lot_name)])
                             if existing_lot:
-                                available_quantity = move._get_available_quantity(move.location_id, lot_id=existing_lot, strict=True)
-                                if not float_is_zero(available_quantity, precision_rounding=line.product_id.uom_id.rounding):
-                                    move._update_reserved_quantity(qty, min(qty, available_quantity), move.location_id, existing_lot)
-                                    continue
+                                move._update_reserved_quantity(qty, move.location_id, lot_id=existing_lot)
+                                continue

--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -72,7 +72,7 @@ class StockMove(models.Model):
                     break
         return options
 
-    def _update_reserved_quantity(self, need, available_quantity, location_id, lot_id=None, package_id=None, owner_id=None, strict=True):
+    def _update_reserved_quantity(self, need, location_id, quant_ids=None, lot_id=None, package_id=None, owner_id=None, strict=True):
         if self.product_id.use_expiration_date:
-            return super(StockMove, self.with_context(with_expiration=self.date))._update_reserved_quantity(need, available_quantity, location_id, lot_id, package_id, owner_id, strict)
-        return super()._update_reserved_quantity(need, available_quantity, location_id, lot_id, package_id, owner_id, strict)
+            return super(StockMove, self.with_context(with_expiration=self.date))._update_reserved_quantity(need, location_id, quant_ids, lot_id, package_id, owner_id, strict)
+        return super()._update_reserved_quantity(need, location_id, quant_ids, lot_id, package_id, owner_id, strict)

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -534,10 +534,12 @@ class StockMoveLine(models.Model):
 
     def unlink(self):
         precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        quants_by_product = self.env['stock.quant']._get_quants_by_products_locations(self.product_id, self.location_id)
         for ml in self:
             # Unlinking a move line should unreserve.
             if not float_is_zero(ml.reserved_qty, precision_digits=precision) and ml.move_id and not ml.move_id._should_bypass_reservation(ml.location_id):
-                self.env['stock.quant']._update_reserved_quantity(ml.product_id, ml.location_id, -ml.reserved_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
+                quants = quants_by_product[ml.product_id.id]
+                quants._update_reserved_quantity(ml.product_id, ml.location_id, -ml.reserved_qty, lot_id=ml.lot_id, package_id=ml.package_id, owner_id=ml.owner_id, strict=True)
         moves = self.mapped('move_id')
         res = super(StockMoveLine, self).unlink()
         if moves:


### PR DESCRIPTION
This commit improves the performance of reservation by removing
the `get_available_quantity` and `update_reserved_quantity` inside
`_action_assign` which each does a search on quants with the same domain,
both of which are done per move to assign.

Instead the quants needed by the moves to reserve are fetched first and
are then filtered in memory for each move to reserve from.

A new function is provided `get_quants_per_product` which should be used
when reserving moves to fetch the relevant quants once and then call
`_update_reserved_quantity` on them which will filter them in memory.
This avoids searching for quants for every move.

Performance stats:

These stats are from the Odoo profiler on the `_action_assign` called
on a specific number of moves. For each number of moves the duration was
taken multiple times and the average was taken. The 10 moves durations
were quite random since the numbers were very small and could be considered
an outlier.

Before this commit:

| No. of Moves  | SQL Queries | Duration (s) |
| ------------- | ------------- | ------------|
| 10  | 70  | 0.044440283 |
| 100  | 633  | 0.398992664 |
| 1,000  | 4,518  | 6.264924025 |
| 10,000  | 46,954  | 79.76809310 |

After this commit:

| No. of Moves  | SQL Queries | Duration (s) |
| ------------- | ------------- | ------------|
| 10  | 62  | 0.062840558 |
| 100  | 540  | 0.323033646 |
| 1,000  | 3,893  | 4.062329989 |
| 10,000  | 39,259  | 49.92596793 |

Besides 10 moves duration, there's a general performance
improvement of 20% - 35%

Enterprise PR: https://github.com/odoo/enterprise/pull/40633

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
