### PR TITLE
[FIX] web_editor: backspace removes to much content

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -58,6 +58,7 @@ import {
     isZWS,
     getDeepestPosition,
     leftPos,
+    isNotEditableNode,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -1431,7 +1432,7 @@ export class OdooEditor extends EventTarget {
         });
         if (!range) return;
         let start = range.startContainer;
-        let end = range.endContainer;
+        let end = !isNotEditableNode(range.endContainer) ? range.endContainer: range.endContainer.previousSibling;
         // Let the DOM split and delete the range.
         const doJoin =
             (closestBlock(start) !== closestBlock(range.commonAncestorContainer) ||
@@ -1477,7 +1478,6 @@ export class OdooEditor extends EventTarget {
         // emptied it without removing it. Ensure it's gone.
         const isRemovableInvisible = (node, noBlocks = true) =>
             !isVisible(node, noBlocks) && !isUnremovable(node);
-        const endIsStart = end === start;
         while (end && isRemovableInvisible(end, false) && !end.contains(range.endContainer)) {
             const parent = end.parentNode;
             end.remove();
@@ -1487,7 +1487,7 @@ export class OdooEditor extends EventTarget {
         while (
             start &&
             isRemovableInvisible(start) &&
-            !(endIsStart && start.contains(range.startContainer))
+            !start.contains(range.startContainer)
         ) {
             const parent = start.parentNode;
             start.remove();
@@ -1513,7 +1513,7 @@ export class OdooEditor extends EventTarget {
             doJoin &&
             next &&
             !(next.previousSibling && next.previousSibling === joinWith) &&
-            this.editable.contains(next)
+            this.editable.contains(next) && !isNotEditableNode(next)
         ) {
             const restore = preserveCursor(this.document);
             this.observerFlush();

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -1486,6 +1486,15 @@ X[]
                         contentAfter: `<p>abc</p><p>[]def</p>`,
                     });
                 });
+                it('should not remove contenteditable="false" before the selected text', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: `<p>a</p><hr contenteditable="false"><p>[b</p><p>c]d</p>`,
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                        },
+                        contentAfter: `<p>a</p><hr contenteditable="false"><p>[]d</p>`,
+                    });
+                });
             });
             describe('Line breaks', () => {
                 describe('Single', () => {


### PR DESCRIPTION
**Current behavior before PR:**

When we select a text and a contentEditable='false' element is before it on hitting backspace it removes the contentEditable='false' element as well.

**Desired behavior after PR is merged:**

Now the contentEditable='false' element before it is not removed.

Task-3210083




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
