### PR TITLE
[FIX] project: fix description editable of task for portal user issue

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -22,7 +22,6 @@ from .project_update import STATUS_COLOR
 PROJECT_TASK_READABLE_FIELDS = {
     'id',
     'active',
-    'description',
     'priority',
     'kanban_state_label',
     'project_id',
@@ -49,6 +48,7 @@ PROJECT_TASK_READABLE_FIELDS = {
 
 PROJECT_TASK_WRITABLE_FIELDS = {
     'name',
+    'description',
     'partner_id',
     'partner_email',
     'date_deadline',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
In the website when task is open, portal user can't edit the description from the website. Portal user have only readonly access for description.

Current behavior before PR:
Portal user can't edit the description from website.

Desired behavior after PR is merged:
Portal user can directly edit the description from website.

Fix:
We have to provide write access to the description field for portal user. Therefore, we remove description field from PROJECT_TASK_READABLE_FIELDS and add it to the PROJECT_TASK_WRITABLE_FIELDS.

task-3217427

