### PR TITLE
[FIX] sale: Avoid discount reset if no pricelist

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -562,13 +562,13 @@ class SaleOrderLine(models.Model):
             ):
                 continue
 
-            line.discount = 0.0
-
             if not line.pricelist_item_id:
                 # No pricelist rule was found for the product
                 # therefore, the pricelist didn't apply any discount/change
                 # to the existing sales price.
                 continue
+
+            line.discount = 0.0
 
             line = line.with_company(line.company_id)
             pricelist_price = line._get_pricelist_price()

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -562,13 +562,13 @@ class SaleOrderLine(models.Model):
             ):
                 continue
 
+            line.discount = 0.0
+
             if not line.pricelist_item_id:
                 # No pricelist rule was found for the product
                 # therefore, the pricelist didn't apply any discount/change
                 # to the existing sales price.
                 continue
-
-            line.discount = 0.0
 
             line = line.with_company(line.company_id)
             pricelist_price = line._get_pricelist_price()


### PR DESCRIPTION
Product without pricelist and buy with "without_discount" pricelist will have its discount reset on save/confirm
Avoid this reset if the product has no pricelist for it

opw-3227722

Description of the issue/feature this PR addresses:
For recurrent product that not have pricelist link, when we add discounts while creating a new sale order:
- All discounts are reset out when we save the sale order.
- All discounts are reset out when we confirm the sale order.

Current behavior before PR:
Discount reset to 0 on save/confirm

Desired behavior after PR is merged:
Discount keep the input value from the user


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
