### PR TITLE
[FIX] web_editor, website: prevent deletion of used attachment

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -217,6 +217,7 @@ class Web_Editor(http.Controller):
         Returns a dict mapping attachments which would not be removed (if any)
         mapped to the views preventing their removal
         """
+        # deprecated for remove_with_new_check
         self._clean_context()
         Attachment = attachments_to_remove = request.env['ir.attachment']
         Views = request.env['ir.ui.view']
@@ -236,6 +237,54 @@ class Web_Editor(http.Controller):
 
             if views:
                 removal_blocked_by[attachment.id] = views.read(['name'])
+            else:
+                attachments_to_remove += attachment
+        if attachments_to_remove:
+            attachments_to_remove.unlink()
+        return removal_blocked_by
+
+    @http.route('/web_editor/attachment/remove_with_new_check', type='json', auth='user', website=True)
+    def remove_with_new_check(self, ids, **kwargs):
+        """ Removes a web-based image attachment if it is used by no view (template)
+
+        Returns a dict mapping attachments which would not be removed (if any)
+        mapped to a dict about what prevents their removal containing:
+        - matches: list of records that reference the attachment
+        - skippedModels: list of names of models that contain too many records
+        - accessModels: list of names of models that contain records that reference the attachment
+            but cannot be accessed by the user
+        """
+        # TODO In master: replace remove route
+        self._clean_context()
+        Attachment = attachments_to_remove = request.env['ir.attachment']
+
+        # views blocking removal of the attachment
+        removal_blocked_by = {}
+
+        for attachment in Attachment.browse(ids):
+            referrers = None if kwargs.get('force') else attachment._is_used_in_html_field()
+            if referrers:
+                matches = []
+                unique_url = set()
+                for items in referrers['matches']:
+                    if 'name' not in items._fields:
+                        continue
+                    fields = ['name', 'website_url'] if 'website_url' in items._fields else ['name']
+                    records = items.read(fields)
+                    if 'website_url' not in items._fields:
+                        # Fallback to backend url
+                        for record in records:
+                            record['website_url'] = '/web#model=%s&id=%s' % (items._name, record['id'])
+                    for record in records:
+                        if record['website_url'] in unique_url:
+                            continue
+                        unique_url.add(record['website_url'])
+                        matches.append(record)
+                removal_blocked_by[attachment.id] = {
+                    'matches': matches,
+                    'skippedModels': [{'name': request.env[model_name]._description} for model_name in referrers['skipped_models']],
+                    'accessModels': [{'name': request.env[model_name]._description} for model_name in referrers['access_models']],
+                }
             else:
                 attachments_to_remove += attachment
         if attachments_to_remove:

--- a/addons/web_editor/models/__init__.py
+++ b/addons/web_editor/models/__init__.py
@@ -6,6 +6,7 @@ from . import ir_qweb
 from . import ir_ui_view
 from . import ir_http
 from . import ir_translation
+from . import models
 
 from . import assets
 

--- a/addons/web_editor/models/models.py
+++ b/addons/web_editor/models/models.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class BaseModel(models.AbstractModel):
+    _inherit = 'base'
+
+    @api.model
+    def _get_examined_html_fields(self):
+        """ Returns an array of (model name, field name, domain, requires full
+            scan boolean) indicating which HTML field values should be
+            examined when using find_in_html_field.
+        """
+        return [('ir.ui.view', 'arch_db', [('type', '=', 'qweb')], True)]

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -257,6 +257,7 @@
     </t>
 
     <t t-name="wysiwyg.widgets.image.existing.error">
+        <!-- Deprecated for wysiwyg.widgets.image.existing.multierror -->
         <div class="form-text">
             <p>The image could not be deleted because it is used in the
                following pages or views:</p>
@@ -298,6 +299,38 @@
                     <div class="mr-auto o_notification_content"/>
                 </div>
             </div>
+        </div>
+    </t>
+
+    <t t-name="wysiwyg.widgets.image.existing.multierror">
+        <div class="form-text">
+            <p>The image could not be deleted.</p>
+            <t t-if="cause.matches.length">
+                <p>It is used in the following pages:</p>
+                <ul t-as="page" t-foreach="cause.matches">
+                    <li>
+                        <a t-att-href="page.website_url">
+                            <t t-esc="page.name"/>
+                        </a>
+                    </li>
+                </ul>
+            </t>
+            <t t-if="cause.accessModels.length">
+                <p>It is used in records to which you do not have access in the following models:</p>
+                <ul t-as="model" t-foreach="cause.accessModels">
+                    <li>
+                        <t t-esc="model.name"/>
+                    </li>
+                </ul>
+            </t>
+            <t t-if="cause.skippedModels.length">
+                <p>It might still be referenced in one of the following models that has many records:</p>
+                <ul t-as="model" t-foreach="cause.skippedModels">
+                    <li>
+                        <t t-esc="model.name"/>
+                    </li>
+                </ul>
+            </t>
         </div>
     </t>
 

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -1,0 +1,44 @@
+# -*- encoding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+SCAN_MAX_COUNT = 1000
+
+def find_in_html_field(env, html_escaped_likes):
+    """ Returns models where the likes appear inside HTML fields.
+
+        :param env: env
+        :param html_escaped_likes: array of string to include as values of
+               domain 'like'. Values must be HTML escaped.
+
+        :returns PNG image converted from given font
+    """
+    all_matches = []
+    big_models = []
+    sudo_models = []
+    for model_name, field_name, domain, requires_full_scan in env['base']._get_examined_html_fields():
+        if not requires_full_scan:
+            if model_name in big_models:
+                continue
+            if env[model_name].sudo().with_context(active_test=False).search_count([]) > SCAN_MAX_COUNT:
+                big_models.append(model_name)
+                continue
+        likes = [(field_name, 'like', like) for like in html_escaped_likes]
+        domain.extend([
+            *(['|'] * (len(likes) - 1)),
+            *likes,
+        ])
+        matches = env[model_name]
+        if matches.check_access_rights('read', raise_exception=False):
+            matches = matches.with_context(active_test=False).search(domain)
+            all_matches.append(matches)
+            continue
+        if model_name in sudo_models:
+            continue
+        sudo_matches = env[model_name].sudo().with_context(active_test=False).search(domain, limit=1)
+        if sudo_matches:
+            sudo_models.append(model_name)
+    return {
+        'matches': all_matches,
+        'skipped_models': big_models,
+        'access_models': sudo_models,
+    } if matches or big_models or sudo_models else None

--- a/addons/website/models/ir_model.py
+++ b/addons/website/models/ir_model.py
@@ -38,3 +38,10 @@ class BaseModel(models.AbstractModel):
         # dummy version of 'get_website_meta' above; this is a graceful fallback
         # for models that don't inherit from 'website.seo.metadata'
         return {}
+
+    def _get_examined_html_fields(self):
+        html_fields = super()._get_examined_html_fields()
+        table_to_model = {self.env[model_name]._table: model_name for model_name in self.env if self.env[model_name]._table}
+        for table, name in self.env['website']._get_html_fields():
+            html_fields.append((table_to_model.get(table), name, [], False))
+        return html_fields


### PR DESCRIPTION
The deletion of used attachments from the media dialog is prevented
since [1]. It is possible that it worked at the time, but that it
stopped working in [2] when the routes for attachments have been
updated.
Also, it only checked for the presence of attachments in views,
ignoring other HTML fields.

This commit fixes the existing mechanism and also limits the search on
views to QWeb views, and adds the check across other HTML fields.
The fields inside ir.action models and mail messages are explicitly
blacklisted, similarly to what exists in 15.0.
This commit also detects non-image attachments which are obtained
through the `/web/content/...` route.
It also adapts the link within the warning so that the website page of
the blocking object is reached if there is one, otherwise it falls back
onto the backend page of the object.

In 15.0, the list of fields should be obtained from `website`'s
`_get_html_fields` instead of duplicating its mechanism.

In 16.0, apply the same principle to the menu dependencies which were
restored by [3] and [4].

Steps to reproduce:
- Drop a Text - Image block on a website page/a product page.
- Upload an attachment in that block.
- Save.
- Edit another page.
- In the media dialog, delete the uploaded attachment.

=> Attachment is deleted and page contains a missing image/document.

[1]: https://github.com/odoo/odoo/commit/e78a3b18cc6c049a712d594ab70287c486447f0a
[2]: https://github.com/odoo/odoo/commit/6baf611df1064a3ae5f6368d3a35b3c3d7779543
[3]: https://github.com/odoo/odoo/commit/11db2f6ed81419ac724ff27ac95a4438d670cbd5
[4]: https://github.com/odoo/odoo/commit/6ac17b93437868cbefbe13448a6fcbb29953f221

task-3223788