### PR TITLE
[FIX] web: improve export dialog fields search

### DIFF
--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -3,6 +3,7 @@
 import { browser } from "@web/core/browser/browser";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { Dialog } from "@web/core/dialog/dialog";
+import { unique } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { useSortable } from "@web/core/utils/sortable";
@@ -21,22 +22,25 @@ DeleteExportListDialog.template = "web.DeleteExportListDialog";
 
 class ExportDataItem extends Component {
     setup() {
-        this.subFields = [];
         this.state = useState({
-            isExpanded: false,
+            isExpanded: this.subFields.length > 0 && this.props.isExpanded,
         });
     }
 
-    async onClick() {
-        if (this.props.isFieldExpandable(this.props.field)) {
-            this.subFields = await this.props.onClick(this.props.field.id);
-            this.state.isExpanded = this.props.isFieldExpanded(this.props.field.id);
+    get subFields() {
+        return this.props.getSubFields(this.props.field.id);
+    }
+
+    async loadExpandedContent(id) {
+        if (this.props.isFieldExpandable(id)) {
+            await this.props.onToggleExpandField(id);
+            this.state.isExpanded = !this.state.isExpanded;
         }
     }
 
-    onDoubleClick(fieldId) {
-        if (!this.props.isFieldExpandable(this.props.field) && !this.isFieldSelected(fieldId)) {
-            this.props.onAdd(fieldId);
+    onDoubleClick(id) {
+        if (!this.props.isFieldExpandable(id) && !this.isFieldSelected(id)) {
+            this.props.onAdd(id);
         }
     }
 
@@ -47,14 +51,15 @@ class ExportDataItem extends Component {
 ExportDataItem.template = "web.ExportDataItem";
 ExportDataItem.components = { ExportDataItem };
 ExportDataItem.props = {
-    field: { type: Object, optional: true },
     exportList: { type: Object, optional: true },
-    expandedContent: Function,
+    field: { type: Object, optional: true },
+    getSubFields: Function,
     isDebug: Boolean,
+    isExpanded: Boolean,
     isFieldExpandable: Function,
-    isFieldExpanded: Function,
-    onClick: Function,
     onAdd: Function,
+    onToggleExpandField: Function,
+    search: Array,
 };
 
 export class ExportDataDialog extends Component {
@@ -146,7 +151,30 @@ export class ExportDataDialog extends Component {
     }
 
     get rootFields() {
+        if (this.searchRef.el && this.searchRef.el.value) {
+            const rootFromSearchResults = this.fieldsAvailable.map((f) => {
+                if (f.parent) {
+                    const parentEl = this.knownFields[f.parent.id];
+                    return this.knownFields[parentEl.parent ? parentEl.parent.id : parentEl.id];
+                }
+                return this.knownFields[f.id];
+            });
+            return unique(rootFromSearchResults);
+        }
         return this.fieldsAvailable.filter(({ parent }) => !parent);
+    }
+
+    getSubFields(id) {
+        let subfieldsFromSearchResults = [];
+        const fieldsAvailable = this.fieldsAvailable;
+        const expandedFields = (this.expandedFields[id] && this.expandedFields[id].fields) || [];
+        if (this.searchRef.el && this.searchRef.el.value) {
+            subfieldsFromSearchResults = fieldsAvailable
+                .filter((f) => f.parent && this.knownFields[f.parent.id].parent)
+                .map((f) => f.parent);
+        }
+        const availableSubFields = unique([...fieldsAvailable, ...subfieldsFromSearchResults]);
+        return expandedFields.filter((a) => availableSubFields.some((b) => a.id === b.id));
     }
 
     updateSize() {
@@ -175,15 +203,7 @@ export class ExportDataDialog extends Component {
         }
     }
 
-    expandedContent(id) {
-        return this.isFieldExpanded(id) && this.expandedFields[id].fields;
-    }
-
-    isFieldExpanded(id) {
-        return this.expandedFields[id] && !this.expandedFields[id].hidden;
-    }
-
-    isFieldExpandable({ id }) {
+    isFieldExpandable(id) {
         return this.knownFields[id].children && id.split("/").length < 3;
     }
 
@@ -206,7 +226,6 @@ export class ExportDataDialog extends Component {
         if (id) {
             if (this.expandedFields[id]) {
                 // we don't make a new RPC if the value is already known
-                this.expandedFields[id].hidden = !this.expandedFields[id].hidden;
                 return this.expandedFields[id].fields;
             }
             parentField = this.knownFields[id];
@@ -225,7 +244,6 @@ export class ExportDataDialog extends Component {
             parentParams
         );
         for (const field of fields) {
-            field.label = field.string;
             field.parent = parentField;
             if (!this.knownFields[field.id]) {
                 this.knownFields[field.id] = field;
@@ -332,7 +350,9 @@ export class ExportDataDialog extends Component {
         this.state.search = fuzzyLookup(
             ev.target.value,
             this.fieldsAvailable || Object.values(this.knownFields),
-            (field) => field.string
+            // because fuzzyLookup gives an higher score if the string starts with the pattern,
+            // reversing the string makes the search more reliable in this context
+            (field) => field.string.split("/").reverse().join("/")
         );
     }
 

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.xml
@@ -12,9 +12,9 @@
     </t>
 
     <t t-name="web.ExportDataItem" owl="1">
-        <div t-att-data-field_id="props.field.id" t-attf-class="o_export_tree_item cursor-pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded mb-2' : '' }} {{ props.field.parent ? '' : 'pe-3'}}" role="treeitem" t-on-click.stop="onClick" t-on-dblclick="() => this.onDoubleClick(props.field.id)">
+        <div t-att-data-field_id="props.field.id" t-attf-class="o_export_tree_item cursor-pointer position-relative ps-4 {{ state.isExpanded ? 'o_expanded mb-2' : '' }} {{ props.field.parent ? '' : 'pe-3'}}" role="treeitem" t-on-click.stop="() => this.loadExpandedContent(props.field.id)" t-on-dblclick="() => this.onDoubleClick(props.field.id)">
             <div t-attf-class="o_tree_column d-flex align-items-center {{ props.field.required ? 'fw-bolder' : ''}}">
-                <span t-if="props.isFieldExpandable(props.field)" t-attf-class="ms-n3 float-start o_expand_parent small fa {{ state.isExpanded ? 'fa-chevron-down' : 'fa-chevron-right' }}" role="img" aria-label="Show sub-fields" title="Show sub-fields" />
+                <span t-if="props.isFieldExpandable(props.field.id)" t-attf-class="ms-n3 float-start o_expand_parent small fa {{ state.isExpanded ? 'fa-chevron-down' : 'fa-chevron-right' }}" role="img" aria-label="Show sub-fields" title="Show sub-fields" />
                 <span t-if="props.isDebug and props.field.id" class="overflow-hidden w-100" t-esc="`${props.field.string} (${props.field.id})`" />
                 <span t-else="" class="overflow-hidden w-100" t-esc="props.field.string" />
                 <span title="Select field" t-attf-class="fa fa-plus float-end m-1 o_add_field {{ isFieldSelected(props.field.id) ? 'o_inactive opacity-25' : '' }}" t-on-click.stop="(ev) => !this.isFieldSelected(this.props.field.id) and this.props.onAdd(this.props.field.id)" />
@@ -44,16 +44,17 @@
                     <div class="o_left_field_panel h-100 overflow-auto border">
                         <div class="o_field_tree_structure">
                             <t t-if="fieldsAvailable">
-                                <t t-foreach="rootFields" t-as="field" t-key="field.id">
+                                <t t-foreach="rootFields" t-as="field" t-key="field.id + '_' + state.search.length">
                                     <ExportDataItem
-                                        field="field"
-                                        expandedContent.bind="expandedContent"
-                                        isFieldExpanded.bind="isFieldExpanded"
                                         exportList="state.exportList"
+                                        field="field"
+                                        getSubFields.bind="getSubFields"
                                         isFieldExpandable.bind="isFieldExpandable"
                                         isDebug="isDebug"
-                                        onClick.bind="onToggleExpandField"
+                                        isExpanded="state.search.length > 0"
+                                        onToggleExpandField.bind="onToggleExpandField"
                                         onAdd.bind="onAddItemExportList"
+                                        search="state.search"
                                     />
                                 </t>
                             </t>

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog_tests.js
@@ -1026,4 +1026,44 @@ QUnit.module("ViewDialogs", (hooks) => {
             );
         }
     );
+
+    QUnit.test("Export dialog: search subfields", async function (assert) {
+        await makeView({
+            serverData,
+            type: "list",
+            resModel: "partner",
+            arch: `
+                <tree export_xlsx="1"><field name="foo"/></tree>`,
+            actionMenus: {},
+            mockRPC(route, args) {
+                if (route === "/web/export/formats") {
+                    return Promise.resolve([{ tag: "csv", label: "CSV" }]);
+                }
+                if (route === "/web/export/get_fields") {
+                    if (!args.parent_field) {
+                        return Promise.resolve(fetchedFields.root);
+                    }
+                    return Promise.resolve(fetchedFields[args.prefix]);
+                }
+            },
+        });
+
+        await openExportDataDialog();
+
+        const firstField = target.querySelector(
+            ".o_left_field_panel .o_export_tree_item:first-child"
+        );
+        await click(firstField);
+
+        // show then hide content for the 'partner_ids' field.
+        // this will load subfields and make them available to search
+        await click(firstField.querySelector(".o_export_tree_item"));
+        await click(firstField.querySelector(".o_export_tree_item"));
+        await editInput(target, ".o_export_search_input", "company");
+        assert.containsOnce(
+            target,
+            ".o_export_tree_item[data-field_id='activity_ids/partner_ids/company_ids']",
+            "subfield that was known has been found and is displayed"
+        );
+    });
 });


### PR DESCRIPTION
This commit fixes the search feature of the export dialog. Before this commit, it was impossible to display subfields that would match the search pattern, since the filter was only applied to look for fields at the 'root' of the available fields.

Now, it is possible to search and find subfields that matches the pattern, and they are displayed inside their expanded parent(s).

A test has been added and verify the search feature.

task-3245492