### PR TITLE
[FIX] point_of_sale: ProxyStatus trigger fixed

### DIFF
--- a/addons/point_of_sale/static/src/js/ChromeWidgets/ProxyStatus.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/ProxyStatus.js
@@ -1,6 +1,7 @@
 /** @odoo-module */
 
 import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/pos_hook";
 
 // Previously ProxyStatusWidget
 export class ProxyStatus extends Component {
@@ -13,6 +14,7 @@ export class ProxyStatus extends Component {
             status: initialProxyStatus.status,
             msg: initialProxyStatus.msg,
         });
+        this.pos = usePos();
         this.statuses = ["connected", "connecting", "disconnected", "warning"];
         this.index = 0;
 

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/ProxyStatus.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/ProxyStatus.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="ProxyStatus" owl="1">
-        <div class="oe_status js_proxy" t-on-click="() => this.trigger('connect-to-proxy')">
+        <div class="oe_status js_proxy" t-on-click="() => this.pos.connectToProxy()">
             <span t-if="state.msg and !env.isMobile" class="js_msg">
                 <t t-esc="state.msg" />
             </span>


### PR DESCRIPTION
Before, in point_of_sale when the IoT box was disconnected and the status button of the IoT Box top right was pressed an error was triggered. This PR solves this issue.

```
TypeError: v1.trigger is not a function
    at ProxyStatus.hdlr1 (eval at compile (http://10.30.64.95:8069/web/assets/debug/web.assets_common.js:21918:16), <anonymous>:16:25) (/web/static/lib/owl/owl.js:5480)
    at Object.mainEventHandler (http://10.30.64.95:8069/web/assets/debug/web.assets_common.js:22185:25) (/web/static/lib/owl/owl.js:5747)
    at HTMLDivElement.listener (http://10.30.64.95:8069/web/assets/debug/web.assets_common.js:16746:20) (/web/static/lib/owl/owl.js:308)
```

[task-3252747](https://www.odoo.com/web#cids=1&menu_id=4720&action=333&active_id=1737&model=project.task&view_type=form&id=3252747)