### PR TITLE
[IMP] web: allow to open a record in editable list

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -768,16 +768,6 @@ class AccountAccount(models.Model):
         if self.env['account.tax.repartition.line'].search([('account_id', 'in', self.ids)], limit=1):
             raise UserError(_('You cannot remove/deactivate the accounts "%s" which are set on a tax repartition line.', ', '.join(f"{a.code} - {a.name}" for a in self)))
 
-    def action_read_account(self):
-        self.ensure_one()
-        return {
-            'name': self.display_name,
-            'type': 'ir.actions.act_window',
-            'view_mode': 'form',
-            'res_model': 'account.account',
-            'res_id': self.id,
-        }
-
     def action_duplicate_accounts(self):
         for account in self.browse(self.env.context['active_ids']):
             account.copy()

--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -89,7 +89,7 @@
             <field name="name">account.account.list</field>
             <field name="model">account.account</field>
             <field name="arch" type="xml">
-                <tree editable="top" create="1" delete="1" multi_edit="1" string="Chart of accounts">
+                <tree editable="top" create="1" delete="1" multi_edit="1" string="Chart of accounts"  open_form_view="True">
                     <field name="company_id" column_invisible="True"/>
                     <field name="code"/>
                     <field name="name"/>
@@ -103,7 +103,6 @@
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                     <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
-                    <button name="action_read_account" type="object" string="Setup" class="float-end btn-secondary"/>
                 </tree>
             </field>
         </record>

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -70,7 +70,7 @@
             <field name="name">account.setup.opening.move.line.tree</field>
             <field name="model">account.account</field>
             <field name="arch" type="xml">
-                <tree editable="top" create="1" delete="1" decoration-muted="opening_debit == 0 and opening_credit == 0">
+                <tree editable="top" create="1" delete="1" decoration-muted="opening_debit == 0 and opening_credit == 0" open_form_view="True">
                     <field name="code"/>
                     <field name="name"/>
                     <field name="company_id" column_invisible="True"/>
@@ -82,7 +82,6 @@
                     <field name="tax_ids" optional="hide" widget="many2many_tags"/>
                     <field name="tag_ids" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
-                    <button name="action_read_account" type="object" string="Setup" class="float-end btn-secondary"/>
                 </tree>
             </field>
         </record>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -70,7 +70,7 @@
             <field name="name">project.task.type.tree</field>
             <field name="model">project.task.type</field>
             <field name="arch" type="xml">
-                <tree string="Task Stage" delete="0" sample="1" multi_edit="1">
+                <tree string="Task Stage" delete="0" sample="1" multi_edit="1" editable="bottom" open_form_view="True">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="fold" optional="show"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -368,7 +368,7 @@
                                    context="{'default_project_id': project_id, 'default_display_in_project': False, 'default_user_ids': user_ids, 'default_parent_id': id,
                                     'default_partner_id': partner_id, 'default_milestone_id': allow_milestones and milestone_id}"
                                    widget="subtasks_one2many">
-                                <tree editable="bottom" decoration-muted="state in ['1_done','1_canceled']">
+                                <tree editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True" force_save="1"/>
                                     <field name="sequence" widget="handle"/>
@@ -397,14 +397,13 @@
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                                     <field name="stage_id" optional="hide" context="{'default_project_id': project_id}"/>
-                                    <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link float-end"/>
                                 </tree>
                             </field>
                         </page>
                         <page name="task_dependencies" string="Blocked By" invisible="not allow_task_dependencies" groups="project.group_project_task_dependencies">
                             <field name="depend_on_ids" nolabel="1"
                                    context="{'default_project_id': project_id, 'search_view_ref' : 'project.view_task_search_form', 'search_default_project_id': project_id, 'tree_view_ref': 'project.open_view_all_tasks_list_view', 'search_default_open_tasks': 1}">
-                                <tree editable="bottom" decoration-muted="state in ['1_done','1_canceled']">
+                                <tree editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="parent_id" column_invisible="True" />
                                     <field name="subtask_count" column_invisible="True"/>
@@ -432,7 +431,6 @@
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                                     <field name="stage_id" optional="hide"/>
-                                    <button class="oe_link float-end" string="View Task" name="action_open_task" type="object"/>
                                 </tree>
                             </field>
                         </page>

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -17,6 +17,7 @@ import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { computeViewClassName } from "@web/views/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
+import { useService } from "@web/core/utils/hooks";
 
 import { Component } from "@odoo/owl";
 
@@ -123,6 +124,7 @@ export class X2ManyField extends Component {
             ];
             return selectCreate(p);
         };
+        this.action = useService("action");
     }
 
     get activeField() {
@@ -221,7 +223,23 @@ export class X2ManyField extends Component {
                 !this.props.readonly && ("editable" in params ? params.editable : editable);
             this.onAdd(params);
         };
+        const openFormView = props.editable ? archInfo.openFormView : false;
+        props.onOpenFormView = openFormView ? this.switchToForm.bind(this) : undefined;
         return props;
+    }
+
+    switchToForm(record) {
+        this.action.doAction(
+            {
+                type: "ir.actions.act_window",
+                views: [[false, "form"]],
+                res_id: record.resId,
+                res_model: this.list.resModel,
+            },
+            {
+                props: { resIds: this.list.resIds },
+            }
+        );
     }
 
     async onAdd({ context, editable } = {}) {

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -188,6 +188,10 @@ export class ListArchParser extends XMLParser {
                     ? archParseBoolean(node.getAttribute("multi_edit") || "")
                     : false;
 
+                treeAttr.openFormView = treeAttr.editable
+                    ? archParseBoolean(xmlDoc.getAttribute("open_form_view") || "")
+                    : false;
+
                 const limitAttr = node.getAttribute("limit");
                 treeAttr.limit = limitAttr && parseInt(limitAttr, 10);
 

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -47,6 +47,8 @@ export class ListController extends Component {
         this.rootRef = useRef("root");
 
         this.archInfo = this.props.archInfo;
+        const openFormView = this.props.editable ? this.archInfo.openFormView : false;
+        this.onOpenFormView = openFormView ? this.openRecord.bind(this) : undefined;
         this.activeActions = this.archInfo.activeActions;
         this.editable =
             this.activeActions.edit && this.props.editable ? this.archInfo.editable : false;

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -75,6 +75,7 @@
                     archInfo="archInfo"
                     allowSelectors="props.allowSelectors"
                     editable="editable"
+                    onOpenFormView="onOpenFormView" 
                     openRecord.bind="openRecord"
                     noContentHelp="props.info.noContentHelp"
                     onAdd.bind="createRecord"

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -269,7 +269,11 @@ export class ListRenderer extends Component {
                 return {
                     ...getPropertyFieldInfo(propertyField),
                     id: `${column.id}_${propertyField.name}`,
-                    column_invisible: combineModifiers(propertyField.column_invisible, column.column_invisible, 'OR'),
+                    column_invisible: combineModifiers(
+                        propertyField.column_invisible,
+                        column.column_invisible,
+                        "OR"
+                    ),
                     classNames: column.classNames,
                     optional: "hide",
                     type: "field",
@@ -437,6 +441,9 @@ export class ListRenderer extends Component {
         if (this.activeActions.onDelete || this.displayOptionalFields) {
             nbCols++;
         }
+        if (this.props.onOpenFormView) {
+            nbCols++;
+        }
         return nbCols;
     }
 
@@ -571,8 +578,9 @@ export class ListRenderer extends Component {
     get optionalFieldGroups() {
         const propertyGroups = {};
         const optionalFields = [];
-        const optionalColumns = this.allColumns.filter((col) =>
-            col.optional && !this.evalColumnInvisible(col.column_invisible));
+        const optionalColumns = this.allColumns.filter(
+            (col) => col.optional && !this.evalColumnInvisible(col.column_invisible)
+        );
         for (const col of optionalColumns) {
             const optionalField = {
                 label: col.label,
@@ -597,8 +605,9 @@ export class ListRenderer extends Component {
     }
 
     get hasOptionalFields() {
-        return this.allColumns.some((col) =>
-            col.optional && !this.evalColumnInvisible(col.column_invisible));
+        return this.allColumns.some(
+            (col) => col.optional && !this.evalColumnInvisible(col.column_invisible)
+        );
     }
 
     get displayOptionalFields() {
@@ -994,6 +1003,9 @@ export class ListRenderer extends Component {
             }
         }
         if (this.hasSelectors) {
+            colspan++;
+        }
+        if (this.props.onOpenFormView) {
             colspan++;
         }
         return colspan;
@@ -2122,6 +2134,7 @@ ListRenderer.props = [
     "cycleOnTab?",
     "allowSelectors?",
     "editable?",
+    "onOpenFormView?",
     "noContentHelp?",
     "nestedKeyOptionalFieldsData?",
     "onOptionalFieldsChanged?",

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -73,7 +73,7 @@
         }
 
         tbody > tr > td:not(.o_list_record_selector) {
-            &:not(.o_handle_cell):not(.o_list_button):not(.o_list_record_remove) {
+            &:not(.o_handle_cell):not(.o_list_button):not(.o_list_record_remove):not(.o_list_record_open_form_view) {
                 @include o-text-overflow(table-cell);
                 &.o_list_text {
                     white-space: pre-wrap;
@@ -148,7 +148,7 @@
             width: 40px !important; // Force to 40px regardless by the font-size
         }
 
-        .o_list_record_remove, .o_handle_cell {
+        .o_list_record_remove, .o_handle_cell, .o_list_record_open_form_view {
             width: 1px;  // to prevent the column to expand
         }
 
@@ -159,12 +159,16 @@
             }
         }
 
-        .o_list_record_remove button {
+        .o_list_record_remove button, .o_list_record_open_form_view button {
             padding: 0px;
             background: none;
             border-style: none;
             display: table-cell;
             cursor: pointer;
+        }
+
+        .o_list_record_remove button, button {
+            padding-top: 5px;
         }
 
         .o_keyboard_navigation {
@@ -259,8 +263,14 @@
             cursor: col-resize;
         }
 
+        .o_list_open_form_view {
+            width: 64px;
+            min-width: 64px
+        }
+
         .o_list_actions_header {
             width: 32px;
+            min-width: 32px
         }
 
         .o_data_row.o_list_no_open {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -147,7 +147,7 @@
                     <tr t-if="!group.list.isGrouped and props.editable and canCreate">
                         <td t-if="hasSelectors"/>
                         <td
-                            t-att-colspan="hasSelector ? nbCols - 1 : nbCols"
+                            t-att-colspan="hasSelectors ?  nbCols - 1 : nbCols"
                             class="o_group_field_row_add"
                         >
                             <a href="#"

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -41,7 +41,8 @@
                             </th>
                             <th t-else="" t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev)" t-att-class="{o_list_button: column.type === 'button_group'}"/>
                         </t>
-                        <th t-if="displayOptionalFields or activeActions.onDelete" t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header" style="width: 32px; min-width: 32px">
+                        <th t-if="props.onOpenFormView" t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view"/>
+                        <th t-if="displayOptionalFields or activeActions.onDelete" t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header">
                             <Dropdown t-if="displayOptionalFields"
                                 class="'o_optional_columns_dropdown text-center border-top-0'"
                                 togglerClass="'btn p-0'"
@@ -87,6 +88,7 @@
                             </td>
                             <td t-else=""/>
                         </t>
+                        <td t-if="props.onOpenFormView"/>
                         <td t-if="displayOptionalFields or activeActions.onDelete" />
                     </tr>
                 </tfoot>
@@ -264,6 +266,20 @@
                         <Widget t-props="column.props" record="record"/>
                     </td>
                 </t>
+            </t>
+
+            <t t-if="props.onOpenFormView">
+                <td class="o_list_record_open_form_view text-center"
+                    t-on-keydown.synthetic="(ev) => this.onCellKeydown(ev, group, record)"
+                    t-on-click.stop="() => props.onOpenFormView(record)"
+                    tabindex="-1"
+                >
+                    <button class="btn btn-link text-end"
+                        name="Open in form view"
+                        aria-label="Open in form view"
+                        tabindex="-1"
+                    >View</button>
+                </td>
             </t>
 
             <t t-set="useUnlink" t-value="'unlink' in activeActions" />

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -630,6 +630,54 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(["switch to form - resId: 1 activeIds: 1,2,3,4"]);
     });
 
+    QUnit.test("non-editable list with open_form_view", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree open_form_view="1"><field name="foo"/></tree>',
+        });
+        assert.containsNone(
+            target,
+            "td.o_list_record_open_form_view",
+            "button to open form view should not be present on non-editable list"
+        );
+    });
+
+    QUnit.test("editable list with open_form_view not set", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree editable="top"><field name="foo"/></tree>',
+        });
+        assert.containsNone(
+            target,
+            "td.o_list_record_open_form_view",
+            "button to open form view should not be present"
+        );
+    });
+
+    QUnit.test("editable list with open_form_view", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree editable="top" open_form_view="1"><field name="foo"/></tree>',
+            selectRecord: (resId, options) => {
+                assert.step(`switch to form - resId: ${resId} activeIds: ${options.activeIds}`);
+            },
+        });
+        assert.containsN(
+            target,
+            "td.o_list_record_open_form_view",
+            4,
+            "button to open form view should be present on each rows"
+        );
+        await click(target.querySelector("td.o_list_record_open_form_view"));
+        assert.verifySteps(["switch to form - resId: 1 activeIds: 1,2,3,4"]);
+    });
+
     QUnit.test(
         "export feature in list for users not in base.group_allow_export",
         async function (assert) {
@@ -4756,7 +4804,7 @@ QUnit.module("Views", (hooks) => {
                 25,
                 "Currency field should have a fixed width of 25px (see arch)"
             );
-            assert.strictEqual(target.querySelector(".o_list_actions_header").style.width, "32px");
+            assert.strictEqual(target.querySelector(".o_list_actions_header").offsetWidth, 32);
         }
     );
 

--- a/odoo/addons/base/rng/tree_view.rng
+++ b/odoo/addons/base/rng/tree_view.rng
@@ -49,6 +49,7 @@
             <rng:optional><rng:attribute name="sample"/></rng:optional>
             <rng:optional><rng:attribute name="action"/></rng:optional>
             <rng:optional><rng:attribute name="type"/></rng:optional>
+            <rng:optional><rng:attribute name="open_form_view"/></rng:optional>
             <rng:optional>
                 <rng:attribute name="limit">
                     <rng:data type="int"/>


### PR DESCRIPTION
With this revision, it's now possible to display a button to switch from an editable list view to a form view. It's possible by adding the attribute `open_form_view` to the `tree` element in the list definition. It works both with base and embedded list views.

Task-id 3063425
