### PR TITLE
[IMP] base: prevent adding Admin Rights to demo user

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -613,6 +613,9 @@ class Users(models.Model):
             added_groups = default_user.groups_id - old_groups
             if added_groups:
                 internal_users = self.env.ref('base.group_user').users - default_user
+                demo_user = self.env.ref('base.user_demo', raise_if_not_found=False)
+                if demo_user:
+                    internal_users = internal_users - demo_user
                 internal_users.write({'groups_id': [Command.link(gid) for gid in added_groups.ids]})
 
         if 'company_id' in values:


### PR DESCRIPTION
Before this commit : Demo user gets assigned administrator rights for most modules because the user right groups to be assigned to default user are synced with all internal users.

After this commit : Demo user does not get assigned administrator rights for most modules and only has basic user rights as the rights assigned to default user are no longer synced with demo user.

task - 3191519