### PR TITLE
[FIX] mass_mailing_event : get correct list of attendees

### DIFF
--- a/addons/mass_mailing_event/models/event_event.py
+++ b/addons/mass_mailing_event/models/event_event.py
@@ -16,7 +16,7 @@ class Event(models.Model):
             'target': 'current',
             'context': {
                 'default_mailing_model_id': self.env.ref('event.model_event_registration').id,
-                'default_mailing_domain': repr([('event_id', 'in', self.ids)])
+                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel')])
             },
         }
 


### PR DESCRIPTION
The list of attendees to contact for an event is wrong.

Steps to reproduce the error:
1- In the event app , have a canceled attendee
2- Send an email to attendees
bug : the email will be sent to canceled attendees as
well.

The problem was originated from the domain given by the inherited class ,
there was no condition on the state of the attendee.

opw-3240100