### PR TITLE
[FIX] calendar : change stop date for recurrent events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -883,7 +883,7 @@ class Meeting(models.Model):
                 if not start_update:
                     # Apply the same shift for start
                     start = base_time_values['start'] + (stop_update - self.stop)
-                    start_date = base_time_values['start_date'] + (stop_update.date() - self.stop.date())
+                    start_date = base_time_values['start'].date() + (stop_update.date() - self.stop.date())
                     update_dict.update({'start': start, 'start_date': start_date})
                 stop = base_time_values['stop'] + (stop_update - self.stop)
                 stop_date = base_time_values['stop'].date() + (stop_update.date() - self.stop.date())

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -386,6 +386,19 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
             (datetime(2019, 11, 9, 1, 0), datetime(2019, 11, 12, 18, 0)),
         ])
 
+    def test_shift_stop_all(self):
+        # testing the case where we only want to update the stop time
+        event = self.events[0]
+        event.write({
+            'recurrence_update': 'all_events',
+            'stop': event.stop + relativedelta(days=1),
+        })
+        self.assertEventDates(event.recurrence_id.calendar_event_ids, [
+            (datetime(2019, 10, 22, 1, 0), datetime(2019, 10, 25, 18, 0)),
+            (datetime(2019, 10, 29, 1, 0), datetime(2019, 11, 1, 18, 0)),
+            (datetime(2019, 11, 5, 1, 0), datetime(2019, 11, 8, 18, 0)),
+        ])
+
     def test_change_week_day_rrule(self):
         recurrence = self.events.recurrence_id
         recurrence.rrule = 'FREQ=WEEKLY;COUNT=3;BYDAY=WE' # from TU to WE


### PR DESCRIPTION
Changing end time for recurrent event will generate an error

Steps to reproduce the error :
1- Create an event in the calendar app  with recurrence on 2- Save and close
3- Edit this event again and select change all events at the top 4- change the ending time

The error was happening because the wrong key was accessed in a dictionary

opw-3236432

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
