### PR TITLE
[FIX] point_of_sale: IoT status button error fixed

### DIFF
--- a/addons/point_of_sale/static/src/js/ChromeWidgets/ProxyStatus.js
+++ b/addons/point_of_sale/static/src/js/ChromeWidgets/ProxyStatus.js
@@ -1,9 +1,14 @@
 /** @odoo-module */
 
+<<<<<<< HEAD
 import { Component, useState } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/pos_hook";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
+=======
+import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/pos_hook";
+>>>>>>> [FIX] point_of_sale: IoT status button error fixed
 
 // Previously ProxyStatusWidget
 export class ProxyStatus extends Component {
@@ -11,9 +16,28 @@ export class ProxyStatus extends Component {
 
     setup() {
         super.setup();
+<<<<<<< HEAD
         this.pos = usePos();
         const hardwareProxy = useService("hardware_proxy");
         this.connectionInfo = useState(hardwareProxy.connectionInfo);
+=======
+        const initialProxyStatus = this.env.proxy.get("status");
+        this.state = useState({
+            status: initialProxyStatus.status,
+            msg: initialProxyStatus.msg,
+        });
+        this.statuses = ["connected", "connecting", "disconnected", "warning"];
+        this.pos = usePos();
+        this.index = 0;
+
+        onMounted(() => {
+            this.env.proxy.on("change:status", this, this._onChangeStatus);
+        });
+
+        onWillUnmount(() => {
+            this.env.proxy.off("change:status", this, this._onChangeStatus);
+        });
+>>>>>>> [FIX] point_of_sale: IoT status button error fixed
     }
 
     get message() {

--- a/addons/point_of_sale/static/src/xml/ChromeWidgets/ProxyStatus.xml
+++ b/addons/point_of_sale/static/src/xml/ChromeWidgets/ProxyStatus.xml
@@ -3,8 +3,13 @@
 
     <t t-name="ProxyStatus" owl="1">
         <div class="oe_status js_proxy" t-on-click="() => this.pos.connectToProxy()">
+<<<<<<< HEAD
             <span t-if="this.message and !env.isMobile" class="js_msg">
                 <t t-esc="this.message" />
+=======
+            <span t-if="state.msg and !env.isMobile" class="js_msg">
+                <t t-esc="state.msg" />
+>>>>>>> [FIX] point_of_sale: IoT status button error fixed
             </span>
             <span t-if="connectionInfo.status === 'connected' and !this.message" class="js_connected oe_green">
                 <i class="fa fa-fw fa-sitemap" role="img" aria-label="Proxy Connected"


### PR DESCRIPTION
Before, when we were trying to check the status of an IoT Box which is disconnected by using its status button an error was triggered:

```
TypeError: v1.trigger is not a function
    at ProxyStatus.hdlr1 (eval at compile (http://10.30.64.95:8069/web/assets/debug/web.assets_common.js:21918:16), <anonymous>:16:25) (/web/static/lib/owl/owl.js:5480)
    at Object.mainEventHandler (http://10.30.64.95:8069/web/assets/debug/web.assets_common.js:22185:25) (/web/static/lib/owl/owl.js:5747)
    at HTMLDivElement.listener (http://10.30.64.95:8069/web/assets/debug/web.assets_common.js:16746:20) (/web/static/lib/owl/owl.js:308)
```

This PR solves that issue

[Task 3252747](https://www.odoo.com/web#id=3252747&cids=1&menu_id=4720&action=333&active_id=1737&model=project.task&view_type=form)
