### PR TITLE
[FIX] event: access issue for event admin to event templates

### DIFF
--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -55,7 +55,7 @@
                                    <tree string="Communication" editable="bottom">
                                        <field name="notification_type"/>
                                        <field name="template_model_id" invisible="1"/>
-                                       <field name="template_ref" options="{'model_field': 'template_model_id', 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                                       <field name="template_ref" options="{'hide_model': True, 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
                                        <field name="interval_nbr" attrs="{'readonly':[('interval_unit', '=', 'now')]}"/>
                                        <field name="interval_unit"/>
                                         <field name="interval_type"/>


### PR DESCRIPTION
1. Install Events

2. Settings - Users
- Ensure one has Admin:Settings, another Event:Administrator
- Click gear icon to set password

3. Try the step 4 with admin settings vs event admin

4. Click on the Event app
- [Configuration] - [Event Templates]
- Communication tab
- select any on Send column

Issue: It works not for Event Admin to edit the tab 
Resolve by: Workaround to access ir.model
Impacted version: 15.0 - master
opw-3103199
