### PR TITLE
[FIX] web: prevent traceback while integer number is out of range

### DIFF
--- a/addons/web/static/src/search/filter_menu/custom_filter_item.js
+++ b/addons/web/static/src/search/filter_menu/custom_filter_item.js
@@ -92,7 +92,11 @@ function parseField(field, value) {
     }
     const type = field.type === "id" ? "integer" : field.type;
     const parse = parsers.contains(type) ? parsers.get(type) : (v) => v;
-    return parse(value);
+    value = parse(value);
+    if (type === "integer" && value > 2147483647 || value < -2147483647) {
+        value = 0;
+    }
+    return value;
 }
 
 function formatField(field, value) {


### PR DESCRIPTION
When the user filters the record by ID from a custom filter and you write the number greater than and less than the range of integer (-2147483647 to 2147483647) then
an error occurs.

see: 
![NumericValueOutOfRange-value-7380435569-is-out-of-range-for-type-integer-LINE-1-ive-true-AND-FALSE-AND-res_partner-id-738043556-online-saas](https://user-images.githubusercontent.com/98956874/228844603-abd88c68-2d47-4aa6-8a10-cc2b07ea11fb.png)

Here we can check if the number is out of range then we set zero in place of that number.

sentry-3955015437