### PR TITLE
[FIX] web,sms : show SMS/Call links

### DIFF
--- a/addons/sms/static/src/components/sms_button/sms_button.xml
+++ b/addons/sms/static/src/components/sms_button/sms_button.xml
@@ -6,7 +6,7 @@
             t-att-title="title"
             t-att-href="'sms:'+props.value"
             t-on-click.prevent.stop="onClick"
-            class="ms-3 d-inline-flex align-items-center o_field_phone_sms"
+            class="ms-3 d-inline-flex align-items-center o_field_phone_sms text-nowrap"
         ><i class="fa fa-mobile"></i><small class="fw-bold ms-1">SMS</small></a>
     </t>
 

--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -23,7 +23,7 @@
             <a
                 t-if="props.value"
                 t-att-href="'tel:'+props.value"
-                class="o_phone_form_link ms-3 d-inline-flex align-items-center"
+                class="o_phone_form_link ms-3 d-inline-flex align-items-center text-nowrap"
             >
                 <i class="fa fa-phone"></i><small class="fw-bold ms-1">Call</small>
             </a>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The pr makes changes in the static content of web and sms modules. The wrapping behavior of text inside the anchor tags was being affected by the text-wrap class given to the div in which the input field and these texts were placed.

Steps to recreate:
1. Go to contacts.
2. Select any contact.
3. Use the internal link of their company to go to the company's page.
4. Click on any of the contacts given below the contact tab.
5. Hover the mouse over the phone field.
6. The text 'Call' and 'SMS' would be wrapped vertically.

Current behavior before PR:

The sms and phone icons along with their texts would get wrapped because of the text-wrap class on the input field which is higher in the HTML hierarchy.

Desired behavior after PR is merged:

This commit adds text-nowrap class to sms and phone anchor tags so that the text inside them does not get wrapped.

OPW-3240894


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
