### PR TITLE
[FIX] stock: improve stock.picking.batch unlink message

### DIFF
--- a/addons/stock_picking_batch/i18n/stock_picking_batch.pot
+++ b/addons/stock_picking_batch/i18n/stock_picking_batch.pot
@@ -815,7 +815,7 @@ msgstr ""
 #. module: stock_picking_batch
 #: code:addons/stock_picking_batch/models/stock_picking_batch.py:0
 #, python-format
-msgid "You cannot delete Done batch transfers."
+msgid "You cannot delete Done batch/wave transfers."
 msgstr ""
 
 #. module: stock_picking_batch

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -164,7 +164,7 @@ class StockPickingBatch(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_if_not_done(self):
         if any(batch.state == 'done' for batch in self):
-            raise UserError(_("You cannot delete Done batch transfers."))
+            raise UserError(_("You cannot delete Done batch/wave transfers."))
 
     def onchange(self, values, field_name, field_onchange):
         """Override onchange to NOT to update all scheduled_date on pickings when


### PR DESCRIPTION
before this commit, on deleting a done wave transfer the user error shown is You cannot delete Done
 batch transfers , even though it is wave transfer
 message says it as batch transfer

 after this commit, the message will show
 You cannot delete Done batch/wave transfers,
 so that it will fit for both batch and wave
 transfers.

close: https://github.com/odoo/odoo/issues/92220

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
