### PR TITLE
[FIX] project:  fix the internal user access rights for project

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -617,8 +617,11 @@
                     <field name="recurrence_id" invisible="1" />
                     <header>
                         <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
-                            attrs="{'invisible' : [('user_id', '!=', False)]}"/>
-                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False)]}"/>
+                            attrs="{'invisible' : [('user_id', '!=', False)]}" groups="project.group_project_user"/>
+                        <button name="action_assign_to_me" string="Assign to Me" type="object" class="oe_highlight"
+                            attrs="{'invisible' : [('user_id', '!=', False)]}" readonly="1" groups="!project.group_project_user"/>
+                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False)]}" groups="project.group_project_user"/>
+                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" attrs="{'invisible': [('project_id', '=', False)]}" readonly="1" groups="!project.group_project_user"/>
                     </header>
                     <div class="text-center alert alert-primary" role="alert" attrs="{'invisible': ['|', ('ribbon_message', '=', False), ('ribbon_message', '=', '')]}">
                         <field name="ribbon_message"/>
@@ -649,9 +652,11 @@
                     <widget name="web_ribbon" title="Archived" bg_color="bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <div class="oe_title pr-0">
                         <h1 class="d-flex flex-row justify-content-between">
-                            <field name="priority" widget="priority" class="mr-3"/>
+                            <field name="priority" widget="priority" class="mr-3" groups="project.group_project_user"/>
+                            <field name="priority" widget="priority" class="mr-3" readonly="1" groups="!project.group_project_user"/>
                             <field name="name" class="o_task_name text-truncate" placeholder="Task Title..." default_focus="1" />
-                            <field name="kanban_state" widget="state_selection" class="ml-auto"/>
+                            <field name="kanban_state" widget="state_selection" class="ml-auto" groups="project.group_project_user"/>
+                            <field name="kanban_state" widget="state_selection" class="ml-auto" readonly="1" groups="!project.group_project_user"/>
                         </h1>
                     </div>
                     <group>
@@ -666,7 +671,8 @@
                                 attrs="{'invisible' : [('allow_subtasks', '=', False)]}"
                             />
                             <field name="date_deadline" attrs="{'invisible': [('is_closed', '=', True)]}"/>
-                            <field name="recurring_task" attrs="{'invisible': [('allow_recurring_tasks', '=', False)]}" />
+                            <field name="recurring_task" attrs="{'invisible': [('allow_recurring_tasks', '=', False)]}" readonly="1" groups="!project.group_project_user"/>
+                            <field name="recurring_task" attrs="{'invisible': [('allow_recurring_tasks', '=', False)]}" groups="project.group_project_user"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                         </group>
                         <group>


### PR DESCRIPTION
Issue: When an internal user without access to the project app logs in, they can currently edit several fields (priority, kanban_state, recurring_task, stage_id, assign to me button) in the project task form view.

Current Behavior Before PR:
Internal users are able to edit the mentioned fields in the project task form view, even if they don't have access to the project app.

Fix:
With this PR, the mentioned fields will be set as read-only for internal users without access to the project app.

Task - 3229105


