### PR TITLE
[FIX] web_editor: change header style of mega menu fix

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -367,6 +367,7 @@ export const editorCommands = {
                 if (inLI && tagName === "P") {
                     inLI.oToggleList(0);
                 } else {
+                    block.classList.remove('h1', 'h2', 'h3', 'h4', 'h5', 'h6');
                     setTagName(block, tagName);
                 }
             } else {

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1832,11 +1832,13 @@ export function setTagName(el, newTagName) {
     while (el.firstChild) {
         n.append(el.firstChild);
     }
-    const closestLi = el.closest('li');
+    // For the case wherein a node is a direct child of LI,
+    // do not wrap it in <p> when converting it to normal.
+    const containerEl = el.tagName === 'LI' ? el : el.parentNode;
     if (el.tagName === 'LI' && newTagName !== 'p') {
         el.append(n);
-    } else if (closestLi && newTagName === 'p') {
-        closestLi.replaceChildren(...n.childNodes);
+    } else if (containerEl && containerEl.tagName === 'LI' && newTagName === 'p') {
+        containerEl.replaceChildren(...n.childNodes);
     } else {
         el.parentNode.replaceChild(n, el);
     }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
@@ -961,6 +961,13 @@ describe('setTagName', () => {
                 contentAfter: '<h1 class="text-uppercase">[abcd]</h1>',
             });
         });
+        it('should turn a inline elements within a div into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><font style="color: red;">a[b</font><span style="font-size: 12px;">c]d</span><font style="color: red;">ef</font><p>gh</p><font style="color: red;">ij</font><span style="font-size: 12px;">kl</span></div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<div><h1><font style="color: red;">a[b</font><span style="font-size: 12px;">c]d</span><font style="color: red;">ef</font></h1><p>gh</p><font style="color: red;">ij</font><span style="font-size: 12px;">kl</span></div>',
+            });
+        });
     });
     describe('to heading 2', () => {
         it('should turn a heading 1 into a heading 2', async () => {
@@ -1003,6 +1010,13 @@ describe('setTagName', () => {
                 contentBefore: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'h2'),
                 contentAfter: '<table><tbody><tr><td><h2>[a</h2></td><td><h2>b</h2></td><td><h2>c]</h2></td></tr></tbody></table>',
+            });
+        });
+        it('should turn a inline elements within a div into a heading 2', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><font style="color: red;">ab</font><span style="font-size: 12px;">cd</span><font style="color: red;">ef</font><p>gh</p><font style="color: red;">[ij</font><span style="font-size: 12px;">k]l</span></div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<div><font style="color: red;">ab</font><span style="font-size: 12px;">cd</span><font style="color: red;">ef</font><p>gh</p><h2><font style="color: red;">[ij</font><span style="font-size: 12px;">k]l</span></h2></div>',
             });
         });
     });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
@@ -889,11 +889,25 @@ describe('setTagName', () => {
                 contentAfter: `<ul><li>[abcd]</li></ul>`
             });
         });
+        it('should add paragraph tag to normal text in list when text is deeply nested', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<ul><li><div><h1>[abcd]</h1></div></li></ul>',
+                stepFunction: editor => editor.execCommand('setTag', 'p'),
+                contentAfter: '<ul><li><div><p>[abcd]</p></div></li></ul>',
+            });
+        });
         it('should turn three table cells with heading 1 to table cells with paragraph', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<table><tbody><tr><td><h1>[a</h1></td><td><h1>b</h1></td><td><h1>c]</h1></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'p'),
                 contentAfter: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
+            });
+        });
+        it('should turn a heading 4 with class h5 into a paragraph', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h4 class="text-uppercase h5">[abcd]</h4>',
+                stepFunction: editor => editor.execCommand('setTag', 'p'),
+                contentAfter: '<p class="text-uppercase">[abcd]</p>',
             });
         });
     });
@@ -938,6 +952,13 @@ describe('setTagName', () => {
                 contentBefore: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'h1'),
                 contentAfter: '<table><tbody><tr><td><h1>[a</h1></td><td><h1>b</h1></td><td><h1>c]</h1></td></tr></tbody></table>',
+            });
+        });
+        it('should turn a heading 4 with class h5 into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h4 class="text-uppercase h5">[abcd]</h4>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<h1 class="text-uppercase">[abcd]</h1>',
             });
         });
     });
@@ -1101,6 +1122,13 @@ describe('setTagName', () => {
                 contentBefore: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'blockquote'),
                 contentAfter: '<table><tbody><tr><td><blockquote>[a</blockquote></td><td><blockquote>b</blockquote></td><td><blockquote>c]</blockquote></td></tr></tbody></table>',
+            });
+        });
+        it('should turn a heading 4 with class h5 into a blockquote', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h4 class="h5">[abcd]</h4>',
+                stepFunction: editor => editor.execCommand('setTag', 'blockquote'),
+                contentAfter: '<blockquote>[abcd]</blockquote>',
             });
         });
     });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -35,6 +35,7 @@ const preserveCursor = OdooEditorLib.preserveCursor;
 const closestElement = OdooEditorLib.closestElement;
 const setSelection = OdooEditorLib.setSelection;
 const endPos = OdooEditorLib.endPos;
+const getCursorDirection = OdooEditorLib.getCursorDirection;
 
 var id = 0;
 const faZoomClassRegex = RegExp('fa-[0-9]x');
@@ -1261,8 +1262,17 @@ const Wysiwyg = Widget.extend({
                         anchorOffset = focusOffset = index;
                     }
                 } else {
-                    anchorNode = link;
-                    focusNode = link;
+                    const selectionDirection = getCursorDirection(selection.anchorNode, 0, selection.focusNode, 0);
+                    if (
+                        closestElement(selection.anchorNode, 'a') === link &&
+                        closestElement(selection.focusNode, 'a') === link
+                    ) {
+                        [anchorNode, focusNode] = selectionDirection
+                            ? [selection.anchorNode, selection.focusNode]
+                            : [selection.focusNode, selection.anchorNode];
+                    } else {
+                        [anchorNode, focusNode] = [link, link];
+                    }
                 }
                 if (!focusOffset) {
                     focusOffset = focusNode.childNodes.length || focusNode.length;


### PR DESCRIPTION
**Current behavior before PR:**

- Some website snippets contained elements with classes like h1, h2, h3, etc.
`setTag` function did not remove this classes when changing the tag, resulting
in no visual effect.
- Additionally, when fixing the `setTagName` function to avoid adding a `<p>`
tag when converting a tag to a `<p>` inside an `<li>`, it missed a scenario
where the element was deeply nested within the `<li>` tag. For instance, in a
case like `<li><div><h1>abcd</h1></div></li>`, the function failed to replace
the `<h1>`with a `<p>` tag.
- `destroyLinkTools` function sets the selection to entire link. However, in
case where a website snippet had a structure like
```<a><div><i class="fa-xxx>​</i><div><h4>Text</h4><font>Text</font></div></div></a>```
selecting the complete link caused problem. The toolbar couldn't be updated correctly, also
one could not change the a tag of a single element within the link.
- When a block node, such as `DIV` or `TD`, had inline childNodes it failed to
correctly change the tag of those inline nodes.

**Desired behavior after PR is merged:**

- Classes like h1, h2, h3, etc. are now removed when changing the tag.
- The `setTagName` function has been fixed to correctly replace a tag with a
`<p>` tag. when deeply nested inside an `<li>`.
- Fix `destroyLinkTools` such that now it select the anchorNode and the focus
node of selection instead of complete link.
- Fix `setTag` such that now it wrappes all the inlineNodes correctly into
newNode.

task-3245819