### PR TITLE
[FIX] website_slides_survey: fix uninstall_hook issue of missing argument

### DIFF
--- a/addons/website_slides_survey/__init__.py
+++ b/addons/website_slides_survey/__init__.py
@@ -4,10 +4,8 @@
 from . import models
 from . import controllers
 
-from odoo import api, SUPERUSER_ID
 
-def uninstall_hook(cr, registry):
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    dt = env.ref('website_slides.badge_data_certification_goal', raise_if_not_found=False)
-    if dt:
-        dt.domain = "[('completed', '=', True), (0, '=', 1)]"
+def uninstall_hook(env):
+    slide = env.ref('website_slides.badge_data_certification_goal', raise_if_not_found=False)
+    if slide:
+        slide.domain = "[('completed', '=', True), (0, '=', 1)]"


### PR DESCRIPTION
if applied, this commit will solve the issue of 'uninstall_hook() missing 1 required positional argument: registry' when uninstalling the module 'website_slides_survey'.
The updated code of the uninstall_hook method directly takes the 'env' as an argument so now no need to add the cr and registry as parameters.

ref commit - https://github.com/odoo/odoo/commit/b4a7996e967621aa090dc80346e6c3ef1d032dcf
sentry - 4050481635
see - https://tinyurl.com/2nxgnmqk