### PR TITLE
[FIX] stock: Show the right decimal accuracy in the product kanban view

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -161,7 +161,7 @@
                     <field name="show_on_hand_qty_status_button"/>
                 </xpath>
                 <xpath expr="//div[@name='product_lst_price']" position="after">
-                    <div t-if="record.show_on_hand_qty_status_button.raw_value">On hand: <field name="qty_available"/> <field name="uom_id"/></div>
+                    <div t-if="record.show_on_hand_qty_status_button.raw_value">On hand: <field name="qty_available" widget="float"/> <field name="uom_id"/></div>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Steps:
- Set the Decimal accuracy to 3
- Go to product kanban view

Issue: the decimal precision is not respected in the 'On Hand' property.

Solution(Discussed with GED):
- Adding widget="float" works but the compiler should automatically format the field based on its type
- This is considered as a hot fix and a task has been opened internally to fix that.


opw-3211928