### PR TITLE
[FIX] project: fix sub-tasks notebook shadow issue

### DIFF
--- a/addons/project/static/src/project_sharing/views/list/list_renderer.scss
+++ b/addons/project/static/src/project_sharing/views/list/list_renderer.scss
@@ -1,0 +1,3 @@
+.o_project_sharing .o_list_renderer {
+    --ListRenderer-thead-shadow: linear-gradient(180deg, rgba(0, 0, 0, 0.08), transparent);
+}


### PR DESCRIPTION
[FIX] project: fix sub-tasks notebook shadow issue

Description of the issue/feature this PR addresses:
In the website when task of project is open, sub tasks notebook has dark shadow
below the list. Shadow should be same as sub tasks list in backend.

Current behavior before PR:
Sub tasks notebook has dark shadow below the list in website.

Desired behavior after PR is merged:
Sub tasks notebook has same shadow as in backend project module.

causes:
in project sharing, gradient of 0.4 opacity is apply on shadow for dark mode in 
list_controller.dark.scss file so that shadow effect is shown in dark mode 
which is also apply on light mode therefore shadow is dark in light mode

Fix:
As all the list view in project sharing have same issue, so we create file in 
project and override the  css for shadow for light mode.

task-3217427
