### PR TITLE
[IMP] web_editor, website, *: allow columns on mobile snippets

### DIFF
--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -376,6 +376,7 @@
             <we-button data-select-count="4">4</we-button>
             <we-button data-select-count="5">5</we-button>
             <we-button data-select-count="6">6</we-button>
+            <we-button data-select-count="custom" data-name="custom_cols_opt">Custom</we-button>
         </we-select>
     </div>
 

--- a/addons/web_editor/static/src/js/common/column_layout_mixin.js
+++ b/addons/web_editor/static/src/js/common/column_layout_mixin.js
@@ -1,0 +1,99 @@
+/** @odoo-module **/
+
+export const ColumnLayoutMixin = {
+    /**
+     * Calculates the number of columns for the mobile or desktop version.
+     * If all elements don't have the same size, returns "custom".
+     *
+     * @private
+     * @param {HTMLCollection} columnEls - elements in the .row container
+     * @param {boolean} isMobile
+     * @returns {integer|string} number of columns or "custom"
+     */
+    _getNbColumns(columnEls, isMobile) {
+        if (!columnEls) {
+            return 0;
+        }
+        if (this._areColsCustomized(columnEls, isMobile)) {
+            return "custom";
+        }
+
+        const resolutionModifier = isMobile ? "" : "lg-";
+        const colRegex = new RegExp(`(?:^|\\s+)col-${resolutionModifier}(\\d{1,2})(?!\\S)`);
+        const colSize = parseInt(columnEls[0].className.match(colRegex)?.[1] || 12);
+        const offsetSize = this._getFirstItem(columnEls, isMobile).classList
+            .contains(`offset-${resolutionModifier}1`) ? 1 : 0;
+
+        return Math.floor((12 - offsetSize) / colSize);
+    },
+    /**
+     * Retrieves the mobile order class as a match array if there is one.
+     *
+     * @private
+     * @param {HTMLElement} el
+     * @returns {Array|null} class match ["o_we_mobile_order_XX", "XX"]
+     */
+    _getItemMobileOrder(el) {
+        return el.className.match(/\bo_we_mobile_order_([0-9]+)\b/);
+    },
+    /**
+     * Gets the first item, whether it has a mobile order class or not.
+     *
+     * @private
+     * @param {HTMLCollection} columnEls - elements in the .row container
+     * @param {boolean} isMobile
+     * @returns {HTMLElement} first HTMLElement in order
+     */
+    _getFirstItem(columnEls, isMobile) {
+        return isMobile && [...columnEls].find(el => el.classList.contains("o_we_mobile_order_0"))
+            || columnEls[0];
+    },
+    /**
+     * Adds the classes for mobile order.
+     *
+     * @private
+     * @param {HTMLCollection} columnEls - elements in the .row container
+     */
+    _addMobileOrders(columnEls) {
+        for (let i = 0; i < columnEls.length; i++) {
+            const mobileOrderClass = `o_we_mobile_order_${i}`;
+            columnEls[i].classList.add(mobileOrderClass);
+        }
+    },
+    /**
+     * Checks whether some columns were resized or were added offsets manually.
+     *
+     * @private
+     * @param {HTMLElement} columnEls
+     * @param {boolean} isMobile
+     * @returns {boolean}
+     */
+    _areColsCustomized(columnEls, isMobile) {
+        const resolutionModifier = isMobile ? "" : "lg-";
+        const colRegex = new RegExp(`(?:^|\\s+)col-${resolutionModifier}(\\d{1,2})(?!\\S)`);
+        const colSize = parseInt(columnEls[0].className.match(colRegex)?.[1] || 12);
+
+        // Cases where we know the columns sizes and/or offsets are NOT custom:
+        // - if all columns have an equal size AND
+        //     - if there are no offsets OR
+        //     - if, with 5 columns, there is exactly one offset-1 and it's on
+        //       the 1st item
+        // Any other case is custom.
+        const allColsSizesEqual = [...columnEls].every((columnEl) =>
+            parseInt(columnEl.className.match(colRegex)?.[1] || 12) === colSize);
+        if (!allColsSizesEqual) {
+            return true;
+        }
+        const offsetRegex = new RegExp(`(?:^|\\s+)offset-${resolutionModifier}[1-9][0-1]?(?!\\S)`);
+        const nbOffsets = [...columnEls]
+            .filter((columnEl) => columnEl.className.match(offsetRegex)).length;
+        if (nbOffsets === 0) {
+            return false;
+        }
+        if (nbOffsets === 1 && colSize === 2 && this._getFirstItem(columnEls, isMobile).className
+                .match(`offset-${resolutionModifier}1`)) {
+            return false;
+        }
+        return true;
+    },
+};

--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -223,7 +223,7 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
 
     for (const [i, columnEl] of [...columnEls].entries()) {
         // Removing padding and offset classes.
-        const regex = /^(pt|pb|col-|offset-)/;
+        const regex = /^(((pt|pb)\d{1,3}$)|col-lg-|offset-lg-)/;
         const toRemove = [...columnEl.classList].filter(c => {
             return regex.test(c);
         });

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import {SIZES, MEDIAS_BREAKPOINTS} from "@web/core/ui/ui_service";
 import {
     normalizeCSSColor,
     isCSSColor,
@@ -462,6 +463,18 @@ function _shouldEditableMediaBeEditable(mediaEl) {
         && nonEditableAncestorRootEl.parentElement
         && nonEditableAncestorRootEl.parentElement.isContentEditable;
 }
+/**
+ * Checks if the view of the targeted element is mobile.
+ *
+ * @param {HTMLElement} targetEl - target of the editor
+ * @returns {boolean}
+ */
+function _isMobileView(targetEl) {
+    const mobileViewThreshold = MEDIAS_BREAKPOINTS[SIZES.LG].minWidth;
+    const clientWidth = targetEl.ownerDocument.defaultView?.frameElement?.clientWidth ||
+        targetEl.ownerDocument.documentElement.clientWidth;
+    return clientWidth && clientWidth < mobileViewThreshold;
+}
 
 export default {
     COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES: COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES,
@@ -488,4 +501,5 @@ export default {
     addBackgroundImageAttributes: _addBackgroundImageAttributes,
     isBackgroundImageAttribute: _isBackgroundImageAttribute,
     shouldEditableMediaBeEditable: _shouldEditableMediaBeEditable,
+    isMobileView: _isMobileView,
 };

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2513,7 +2513,7 @@ var SnippetsMenu = Widget.extend({
             this.invisibleDOMMap = new Map();
             const $invisibleDOMPanelEl = $(this.invisibleDOMPanelEl);
             $invisibleDOMPanelEl.find('.o_we_invisible_entry').remove();
-            const isMobile = this.options.wysiwyg.websiteService?.context.isMobile;
+            const isMobile = this._isMobile();
             const invisibleSelector = `.o_snippet_invisible, ${isMobile ? '.o_snippet_mobile_invisible' : '.o_snippet_desktop_invisible'}`;
             const $selector = this.options.enableTranslation ? this.$body : globalSelector.all();
             let $invisibleSnippets = $selector.find(invisibleSelector).addBack(invisibleSelector);
@@ -3679,6 +3679,14 @@ var SnippetsMenu = Widget.extend({
         for (const el of tooltipTargetEls) {
             Tooltip.getInstance(el)?.hide();
         }
+    },
+    /**
+     * Returns whether the edited content is a mobile view content.
+     *
+     * @returns {boolean}
+     */
+    _isMobile() {
+        return weUtils.isMobileView(this.$body[0]);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4006,19 +4006,6 @@ const SnippetOptionWidget = Widget.extend({
      * @returns {Promise<boolean>|boolean}
      */
     _computeWidgetVisibility: async function (widgetName, params) {
-        const moveUpOrLeft = widgetName === 'move_up_opt' || widgetName === 'move_left_opt';
-        const moveDownOrRight = widgetName === 'move_down_opt' || widgetName === 'move_right_opt';
-
-        if (moveUpOrLeft || moveDownOrRight) {
-            // The arrows are not displayed if the target is in a grid and if
-            // not in mobile view.
-            const isMobileView = weUtils.isMobileView(this.$target[0]);
-            if (this.$target[0].classList.contains('o_grid_item') && !isMobileView) {
-                return false;
-            }
-            const firstOrLastChild = moveUpOrLeft ? ':first-child' : ':last-child';
-            return !this.$target.is(firstOrLastChild);
-        }
         return true;
     },
     /**
@@ -4698,16 +4685,6 @@ registry.sizing = SnippetOptionWidget.extend({
             // columns.
             const moveHandleEl = this.$overlay[0].querySelector('.o_move_handle');
             moveHandleEl.classList.toggle('d-none', isMobileView);
-
-            // Hiding/showing the arrows.
-            if (isGrid) {
-                const moveLeftArrowEl = this.$overlay[0].querySelector('.fa-angle-left');
-                const moveRightArrowEl = this.$overlay[0].querySelector('.fa-angle-right');
-                const showLeft = await this._computeWidgetVisibility('move_left_opt');
-                const showRight = await this._computeWidgetVisibility('move_right_opt');
-                moveLeftArrowEl.classList.toggle('d-none', !showLeft);
-                moveRightArrowEl.classList.toggle('d-none', !showRight);
-            }
 
             // Show/hide the buttons to send back/front a grid item.
             const bringFrontBackEls = this.$overlay[0].querySelectorAll('.o_front_back');
@@ -5577,6 +5554,30 @@ registry.SnippetMove = SnippetOptionWidget.extend({
         // Update the "Invisible Elements" panel as the order of invisible
         // snippets could have changed on the page.
         this.trigger_up("update_invisible_dom");
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * @override
+     */
+    async _computeWidgetVisibility(widgetName, params) {
+        const moveUpOrLeft = widgetName === "move_up_opt" || widgetName === "move_left_opt";
+        const moveDownOrRight = widgetName === "move_down_opt" || widgetName === "move_right_opt";
+
+        if (moveUpOrLeft || moveDownOrRight) {
+            // The arrows are not displayed if the target is in a grid and if
+            // not in mobile view.
+            const isMobileView = weUtils.isMobileView(this.$target[0]);
+            if (!isMobileView && this.$target[0].classList.contains("o_grid_item")) {
+                return false;
+            }
+            const firstOrLastChild = moveUpOrLeft ? ":first-child" : ":last-child";
+            return !this.$target.is(firstOrLastChild);
+        }
+        return this._super(...arguments);
     },
 });
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -31,7 +31,6 @@ import {
     getDataURLBinarySize,
 } from "@web_editor/js/editor/image_processing";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
-import {SIZES, MEDIAS_BREAKPOINTS} from "@web/core/ui/ui_service";
 import { pick } from "@web/core/utils/objects";
 import { _t } from "@web/core/l10n/translation";
 import {
@@ -4013,8 +4012,7 @@ const SnippetOptionWidget = Widget.extend({
         if (moveUpOrLeft || moveDownOrRight) {
             // The arrows are not displayed if the target is in a grid and if
             // not in mobile view.
-            const mobileViewThreshold = MEDIAS_BREAKPOINTS[SIZES.LG].minWidth;
-            const isMobileView = this.$target[0].ownerDocument.defaultView.frameElement.clientWidth < mobileViewThreshold;
+            const isMobileView = weUtils.isMobileView(this.$target[0]);
             if (this.$target[0].classList.contains('o_grid_item') && !isMobileView) {
                 return false;
             }
@@ -4683,8 +4681,7 @@ registry.sizing = SnippetOptionWidget.extend({
     async updateUIVisibility() {
         await this._super(...arguments);
 
-        const mobileViewThreshold = MEDIAS_BREAKPOINTS[SIZES.LG].minWidth;
-        const isMobileView = this.$target[0].ownerDocument.defaultView.frameElement.clientWidth < mobileViewThreshold;
+        const isMobileView = weUtils.isMobileView(this.$target[0]);
         const isGrid = this.$target[0].classList.contains('o_grid_item');
         if (this.$target[0].parentNode && this.$target[0].parentNode.classList.contains('row')) {
             // Hiding/showing the correct resize handles if we are in grid mode
@@ -5280,8 +5277,7 @@ registry.layout_column = SnippetOptionWidget.extend({
         await this._super(previewMode, widgetValue, params);
 
         const rowEl = this.$target[0];
-        const mobileViewThreshold = MEDIAS_BREAKPOINTS[SIZES.LG].minWidth;
-        const isMobileView = rowEl.ownerDocument.defaultView.frameElement.clientWidth < mobileViewThreshold;
+        const isMobileView = weUtils.isMobileView(rowEl);
         if (["row-gap", "column-gap"].includes(params.cssProperty) && !isMobileView) {
             // Reset the animation.
             this._removeGridPreview();
@@ -8025,10 +8021,7 @@ registry.BackgroundShape = SnippetOptionWidget.extend({
                 shapeToSelect = possibleShapes[1];
             }
             // Only show on mobile by default if toggled from mobile view
-            const mobileViewThreshold = MEDIAS_BREAKPOINTS[SIZES.LG].minWidth;
-            const isMobileView = this.$target[0].ownerDocument
-                .defaultView.frameElement.clientWidth < mobileViewThreshold;
-            const showOnMobile = isMobileView;
+            const showOnMobile = weUtils.isMobileView(this.$target[0]);
             this.trigger_up('snippet_edition_request', {exec: () => {
                 // options for shape will only be available after _toggleShape() returned
                 this._requestUserValueWidgets('bg_shape_opt')[0].enable();

--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -32,6 +32,14 @@
     transform: scale(-1);
 }
 
+@include media-breakpoint-down(lg) {
+    @for $i from 0 through 12 {
+        .o_we_mobile_order_#{$i} {
+            order: $i;
+        }
+    }
+}
+
 // GRID LAYOUT
 .o_grid_mode {
     @include media-breakpoint-down(lg) {
@@ -39,39 +47,46 @@
         row-gap: 0px !important;
         column-gap: 0px !important;
     }
-    @include media-breakpoint-up(lg) {
+    --grid-item-padding-y: 10px;
+    --grid-item-padding-x: 10px;
+
+    > * {
+        padding: var(--grid-item-padding-y) var(--grid-item-padding-x) !important;
+    }
+}
+
+@include media-breakpoint-up(lg) {
+    .o_grid_mode {
         display: grid !important;
         grid-auto-rows: 50px;
         grid-template-columns: repeat(12, 1fr);
         row-gap: 0px;
         column-gap: 0px;
-    }
-    --gutter-x: 0px;
-    --grid-item-padding-y: 10px;
-    --grid-item-padding-x: 10px;
 
-    > * {
-        width: 100%;
-        min-width: 0;
-        margin: 0 !important;
-        padding: var(--grid-item-padding-y) var(--grid-item-padding-x) !important;
-    }
-}
+        --gutter-x: 0px;
 
-.container-fluid > .o_grid_mode {
-    --gutter-x: 30px;
-}
-
-.o_grid_item_image {
-    > img, > .media_iframe_video {
-        width: 100% !important;
-        height: 100% !important;
-        object-fit: cover !important;
+        > * {
+            margin: 0 !important;
+            width: 100%;
+            min-width: 0;
+        }
     }
 
-    &.o_grid_item_image_contain > img,
-    > img[data-shape] {
-        object-fit: contain !important;
+    .container-fluid > .o_grid_mode {
+        --gutter-x: 30px;
+    }
+
+    .o_grid_item_image {
+        > img, > .media_iframe_video {
+            width: 100% !important;
+            height: 100% !important;
+            object-fit: cover !important;
+        }
+
+        &.o_grid_item_image_contain > img,
+        > img[data-shape] {
+            object-fit: contain !important;
+        }
     }
 }
 

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import Dialog from "@web/legacy/js/core/dialog";
 import weSnippetEditor from "@web_editor/js/editor/snippets.editor";
 import wSnippetOptions from "@website/js/editor/snippets.options";
+import wUtils from "@website/js/utils";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/utils/utils";
 import { renderToElement } from "@web/core/utils/render";
 const getDeepRange = OdooEditorLib.getDeepRange;
@@ -301,6 +302,12 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
      */
     _isValidSelection(sel) {
         return sel.rangeCount && [...this.getEditableArea()].some(el => el.contains(sel.anchorNode));
+    },
+    /**
+     * @override
+     */
+    _isMobile() {
+        return wUtils.isMobile(this);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -4015,6 +4015,15 @@ options.registry.Button = options.Class.extend({
     },
 });
 
+options.registry.layout_column.include({
+    /**
+     * @override
+     */
+    _isMobile() {
+        return wUtils.isMobile(this);
+    },
+});
+
 export default {
     UrlPickerUserValueWidget: UrlPickerUserValueWidget,
     FontFamilyPickerUserValueWidget: FontFamilyPickerUserValueWidget,

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2583,12 +2583,7 @@ options.registry.DeviceVisibility = options.Class.extend({
         }
 
         // Update invisible elements.
-        let isMobile;
-        this.trigger_up('service_context_get', {
-            callback: (ctx) => {
-                isMobile = ctx['isMobile'];
-            },
-        });
+        const isMobile = wUtils.isMobile(this);
         this.trigger_up('snippet_option_visibility_update', {show: widgetValue !== (isMobile ? 'no_mobile' : 'no_desktop')});
     },
     /**

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -416,6 +416,23 @@ export function generateGMapLink(dataset) {
         + '&ie=UTF8&iwloc=&output=embed';
 }
 
+/**
+ * Checks if the edited content is currently previewed as in a mobile device.
+ *
+ * @param {Object} self - context object ("this")
+ * @returns {boolean}
+ */
+function isMobile(self) {
+    let isMobile;
+    self.trigger_up("service_context_get", {
+        callback: (ctx) => {
+            isMobile = ctx["isMobile"];
+        },
+    });
+
+    return isMobile;
+}
+
 export default {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
@@ -427,4 +444,5 @@ export default {
     svgToPNG: svgToPNG,
     generateGMapIframe: generateGMapIframe,
     generateGMapLink: generateGMapLink,
+    isMobile: isMobile,
 };

--- a/addons/website/static/src/snippets/s_color_blocks_2/000.scss
+++ b/addons/website/static/src/snippets/s_color_blocks_2/000.scss
@@ -23,11 +23,6 @@
         padding-top: 8vw; // A flex item cannot have % padding top and bottom (even if it works on chrome)
         padding-bottom: 8vw; // Solution is vw units but we keep 8% as a fallback
     }
-    @include media-breakpoint-down(lg) {
-        [class*="col-lg-"] {
-            flex: 1 1 100%;
-        }
-    }
 
     img {
         max-width: 100%;

--- a/addons/website/static/src/snippets/s_process_steps/options.js
+++ b/addons/website/static/src/snippets/s_process_steps/options.js
@@ -2,7 +2,6 @@
 
 import options from '@web_editor/js/editor/snippets.options';
 import weUtils from '@web_editor/js/common/utils';
-import {SIZES, MEDIAS_BREAKPOINTS} from '@web/core/ui/ui_service';
 
 options.registry.StepsConnector = options.Class.extend({
     /**
@@ -80,9 +79,7 @@ options.registry.StepsConnector = options.Class.extend({
         // We don't use the service_context_get intentionally because the
         // connectors are hidden as soon as the page is smaller than 992px
         // (the BS lg breakpoint).
-        const mobileViewThreshold = MEDIAS_BREAKPOINTS[SIZES.LG].minWidth;
-        const isMobileView = this.$target[0].ownerDocument.documentElement.clientWidth <
-            mobileViewThreshold;
+        const isMobileView = weUtils.isMobileView(this.$target[0]);
         return !isMobileView && this._super(...arguments);
     },
     /**

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -1,0 +1,118 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+const columnCountOptSelector = ".snippet-option-layout_column we-select[data-name='column_count_opt']";
+const columnsSnippetRow = "iframe .s_three_columns .row";
+
+wTourUtils.registerWebsitePreviewTour("website_update_column_count", {
+    test: true,
+    url: "/",
+    edition: true,
+}, () => [
+wTourUtils.dragNDrop({
+    id: "s_three_columns",
+    name: "Columns",
+}),
+wTourUtils.clickOnSnippet({
+    id: "s_three_columns",
+    name: "Columns",
+}), {
+    content: "Open the columns count select",
+    trigger: columnCountOptSelector,
+}, {
+    content: "Set 5 columns on desktop",
+    trigger: `${columnCountOptSelector} we-button[data-select-count='5']`,
+}, {
+    content: "Check that there are now 5 items on 5 columns, and that it didn't change the mobile layout",
+    trigger: `${columnsSnippetRow}:has(.col-lg-2:nth-child(5):not(.col-2)):not(:has(:nth-child(6)))`,
+    isCheck: true,
+}, {
+    content: "Check that there is an offset on the 1st item to center the row on desktop, but not on mobile",
+    trigger: `${columnsSnippetRow} > .offset-lg-1:not(.offset-1):first-child`,
+    isCheck: true,
+}, {
+    content: "Open the columns count select",
+    trigger: columnCountOptSelector,
+}, {
+    content: "Set 2 columns on desktop",
+    trigger: `${columnCountOptSelector} we-button[data-select-count='2']`,
+}, {
+    content: "Check that there are still 5 items in the row and click on the last one",
+    trigger: `${columnsSnippetRow} > :nth-child(5)`,
+}, {
+    content: "Delete the item",
+    trigger: "we-title:contains('Column'):not(:contains('Columns')) .oe_snippet_remove",
+}, {
+    content: "Toggle mobile view",
+    trigger: ".o_we_website_top_actions [data-action='mobile']",
+}, {
+    content: "Check that there is 1 column on mobile and click on the selector",
+    trigger: `${columnCountOptSelector} we-toggler:contains('1')`,
+}, {
+    content: "Set 3 columns on mobile",
+    trigger: `${columnCountOptSelector} we-button[data-select-count='3']`,
+}, {
+    content: "Check that there are still 4 items but on rows of 3 columns",
+    trigger: `${columnsSnippetRow}:has(.col-lg-6.col-4:nth-child(4))`,
+    isCheck: true,
+},
+// As there is no practical way to resize the items through the handles, the
+// next step approximates part of what could be reached.
+{
+    content: "Add a fake resized class on mobile to the 2nd item",
+    trigger: `${columnsSnippetRow} > :nth-child(2)`,
+    run: ({ tip_widget }) => {
+        const secondItemEl = tip_widget.$anchor[0];
+        secondItemEl.classList.replace("col-4", "col-6");
+        // As this is a hardcoded class replacement, a click is needed to
+        // update the column count.
+        secondItemEl.previousElementSibling.click();
+    },
+}, {
+    content: "Check that the counter shows 'Custom'",
+    trigger: `${columnCountOptSelector} we-toggler:contains('Custom')`,
+    isCheck: true,
+}, {
+    content: "Click on the 2nd item",
+    trigger: `${columnsSnippetRow} > :nth-child(2)`,
+}, {
+    content: "Change the orders of the 2nd and 3rd items",
+    trigger: "iframe .o_overlay_move_options [data-name='move_right_opt']",
+}, {
+    content: "Check that the 1st item now has a class .o_we_mobile_order_0" +
+             "and that .o_we_mobile_order_1 is set on the 3rd item, and .o_we_mobile_order_2 on the 2nd",
+    trigger: `${columnsSnippetRow}:has(.o_we_mobile_order_0:first-child)`,
+    extra_trigger: `${columnsSnippetRow}:has(.o_we_mobile_order_2:nth-child(2) + .o_we_mobile_order_1:nth-child(3))`,
+    isCheck: true,
+}, {
+    content: "Toggle desktop view",
+    trigger: ".o_we_website_top_actions [data-action='mobile']",
+}, {
+    content: "Open the columns count select",
+    trigger: columnCountOptSelector,
+}, {
+    content: "Add 2 more items through the columns counter",
+    trigger: `${columnCountOptSelector} we-button[data-select-count='6']`,
+}, {
+    content: "Check that each item has a different mobile order from 0 to 5",
+    trigger: `${columnsSnippetRow}${[0, 1, 2, 3, 4, 5].map(n => `:has(.o_we_mobile_order_${n})`).join("")}`,
+    isCheck: true,
+}, {
+    content: "Click on the 6th item",
+    trigger: `${columnsSnippetRow} > :nth-child(6)`,
+}, {
+    // TODO: remove this step. It should not be needed, but the build fails
+    // without it.
+    content: "Wait for move arrows to appear",
+    trigger: "iframe .o_overlay_move_options [data-name='move_left_opt']:has(+ .d-none[data-name='move_right_opt'])",
+    isCheck: true,
+}, {
+    content: "Change the orders of the 5th and 6th items to override the mobile orders",
+    trigger: "iframe .o_overlay_move_options [data-name='move_left_opt']",
+}, {
+    content: "Check that there are no .o_we_mobile_order_X classes anymore",
+    trigger: `${columnsSnippetRow}:not(:has(.o_we_mobile_order_0))`,
+    isCheck: true,
+},
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -446,3 +446,6 @@ class TestUi(odoo.tests.HttpCase):
 
     def test_website_text_font_size(self):
         self.start_tour('/@/', 'website_text_font_size', login='admin', timeout=300)
+
+    def test_update_column_count(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_update_column_count', login="admin")

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -360,6 +360,7 @@
         <we-button data-select-count="4">4</we-button>
         <we-button data-select-count="5">5</we-button>
         <we-button data-select-count="6">6</we-button>
+        <we-button data-select-count="custom" data-name="custom_cols_opt">Custom</we-button>
     </we-select>
 </template>
 


### PR DESCRIPTION
*: mass_mailing

This PR introduces options for the flex column layout and the
horizontal resizing to be used on mobile and be independent from
the desktop layout (commit 3).

In the other commits, it also:
- introduces 2 utility functions `isMobile()` and `isMobileView()`,
respectively in website and web_editor, to check whether the view is
either mobile or desktop. (commit 1)
- moves logic from the method `_computeWidgetVisibility()` in the main
`SnippetOptionsWidget` to the overriding method in the `SnippetMove`
sub-widget instead. (commit 2)
- adds a test for the behavior of the column layout. (commit 3)

In particular, commit 3 makes it possible to:
- Have different number of columns on mobile and on desktop.
- Use different column widths and offsets for mobile and desktop.
- Reorder columns independently.

The behavior expected from the columns is:
- In the editor panel, Cols indicate the number of columns per row on
both mobile and desktop. The option is conditional of your environment:
you edit the number for the screen size of your current resolution.
- When columns have different sizes (either because it is the default
behavior of the snippet, or because the user resized some), the counter
should read "Custom". Same when the user changed some offsets.
- If manual modifications were made on width and offset, they are reset
on the current display if the number of elements is updated. This was
decided because an old, specific layout with custom offsets / width
doesn't work well with a different number of elements. (This is also the
default behavior before this PR with desktop-only modifications.)

The expected behavior when reordering is:
- On mobile, it should only affect the mobile layout.
- On desktop, it should affect both layouts.

In order to have a coherent feature on both mobile and desktop as well
as correct some nonideal but non blocking behaviors, the commit also
changes the following behaviors:
- When setting a columns count lower than the current number of items in
the `.row` container, extra items are now wrapped on the next flex-rows
(still within the container) instead of being deleted.
- When going from e.g. 3 to 5 columns (and as many items), the change
happens all at once instead of each item being visibly added one by one
on the next row, then brought back to the first row.
- The columns count automatically updates when resizing an item, instead
of updating only after you click somewhere else on the snippet.

task-3097045