### PR TITLE
[WIP][IMP] mail: compress old messages

### DIFF
--- a/addons/mail/data/ir_config_parameter.xml
+++ b/addons/mail/data/ir_config_parameter.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <data noupdate="1">
+    <record id="ir_config_mail_message_last_compressed_id" model="ir.config_parameter">
+        <field name="key">mail_message.last_compressed_id</field>
+        <field name="value">-1</field> <!-- The last mail_message id that was processed -->
+    </record>
+  </data>
+</odoo>

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -65,5 +65,17 @@
             <field name="code">model._send_notifications_cron()</field>
             <field name="state">code</field>
         </record>
+        
+        <record id="ir_cron_compress_messages" model="ir.cron">
+            <field name="name">Compress messages older than 1 year</field>
+            <field name="model_id" ref="model_mail_message"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">hours</field>
+            <field name="numbercall">-1</field>
+            <field name="code">model._cron_compress_messages(365, 25000)</field>
+            <field name="state">code</field>
+            <field name="active" eval="False"/>  <!-- opt-in for the user -->
+            <field name="doall" eval="False"/>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_link_preview
 from . import test_mail_activity
 from . import test_mail_composer
 from . import test_mail_full_composer
+from . import test_mail_message
 from . import test_mail_render
 from . import test_mail_template
 from . import test_mail_tools

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from markupsafe import Markup
+
+from odoo.tests.common import TransactionCase
+
+HTML_MSG_BODY_NO_STYLE = \
+"""<pre style="white-space:pre-wrap">*Hello*
+
+*World*</pre>"""
+HTML_MSG_BODY_NO_QUOTE_WITH_STYLE = """
+<p>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>Hello</strong></span>
+    <br>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>World</strong></span>
+</p>
+"""
+HTML_MSG_BODY_ONE_QUOTE_WITH_STYLE = """
+<p>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>Hello</strong></span>
+    <br>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>World</strong></span>
+    <blockquote data-o-mail-quote="1">
+        Some reply text
+    </blockquote>
+</p>
+"""
+HTML_MSG_BODY_NESTED_QUOTES_WITH_STYLE = """
+<p>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>Hello</strong></span>
+    <br>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>World</strong></span>
+    <blockquote data-o-mail-quote="1">
+        Some reply text
+        <blockquote data-o-mail-quote="1">
+            Another reply
+        </blockquote>
+    </blockquote>
+</p>
+"""
+HTML_MSG_BODY_MULTI_NESTED_QUOTES_WITH_STYLE = """
+<p>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>Hello</strong></span>
+    <br>
+    <span class="some_useless_style_that_takes_too_much_space"><strong>World</strong></span>
+    <blockquote data-o-mail-quote="1">
+        Some reply text
+        <blockquote data-o-mail-quote="1">
+            Another reply
+            <blockquote data-o-mail-quote="1">
+                Yet another reply
+            </blockquote>
+        </blockquote>
+    </blockquote>
+</p>
+"""
+
+HTML_BODY_TEMPLATES = [
+    HTML_MSG_BODY_NO_QUOTE_WITH_STYLE,
+    HTML_MSG_BODY_ONE_QUOTE_WITH_STYLE,
+    HTML_MSG_BODY_NESTED_QUOTES_WITH_STYLE,
+    HTML_MSG_BODY_MULTI_NESTED_QUOTES_WITH_STYLE,
+]
+
+class TestMailMessage(TransactionCase):
+
+    def test_compress_message_body(self):
+        some_partner = self.env.ref('base.res_partner_1')
+        messages = self.env['mail.message'].create([
+            {
+                'body': template,
+                'partner_ids': [(4, some_partner.id)],
+                'message_type': 'email',
+            }
+            for template in HTML_BODY_TEMPLATES
+        ])
+        self.env['ir.config_parameter'].sudo().set_param('mail_message.last_compressed_id', str(min(messages.ids) - 1))
+        messages._cron_compress_messages()
+        for message in messages:
+            self.assertEqual(message.body, Markup(HTML_MSG_BODY_NO_STYLE))
+        self.assertEqual(int(self.env['ir.config_parameter'].sudo().get_param('mail_message.last_compressed_id')), max(messages.ids))

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -291,7 +291,14 @@ TEXT_URL_REGEX = r'https?://[\w@:%.+&~#=/-]+(?:\?\S+)?'
 HTML_TAG_URL_REGEX = URL_REGEX + r'([^<>]*>([^<>]+)<\/)?'
 HTML_TAGS_REGEX = re.compile('<.*?>')
 HTML_NEWLINES_REGEX = re.compile('<(div|p|br|tr)[^>]*>|\n')
-
+HTML_ZERO_WIDTH_SPACE_ENTITIES = (
+    '&ZeroWidthSpace;',
+    '&NegativeThickSpace;',
+    '&NegativeMediumSpace;',
+    '&NegativeThinSpace;',
+    '&NegativeThinSpace;',
+    '&NegativeVeryThinSpace;',
+)
 
 def validate_url(url):
     if urls.url_parse(url).scheme not in ('http', 'https', 'ftp', 'ftps'):
@@ -388,10 +395,14 @@ def html2plaintext(html, body_id=None, encoding='utf-8'):
     html = html.replace('</p>', '\n')
     html = re.sub('<br\s*/?>', '\n', html)
     html = re.sub('<.*?>', ' ', html)
+    html = html.replace('&nbsp;', ' ')
     html = html.replace(' ' * 2, ' ')
     html = html.replace('&gt;', '>')
     html = html.replace('&lt;', '<')
     html = html.replace('&amp;', '&')
+
+    for entity in HTML_ZERO_WIDTH_SPACE_ENTITIES:
+        html = html.replace(entity, '')
 
     # strip all lines
     html = '\n'.join([x.strip() for x in html.splitlines()])


### PR DESCRIPTION
## Description
For large companies, the `mail_message` model can get quite large.
One of the primary culprit is the `body` field, which is an HTML field.

## Solution
Create a cron (inactive by default) that convert old
`mail_message.body` to plaintext and removes quotes from it's content.
Removing styling and html tags + the quotes reduces the space used to
store the body of the messages.

---
perf-3209468

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
