### PR TITLE
[FIX] web_editor, website: disable mega menu hover mode while editing

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1728,6 +1728,7 @@ var SnippetsMenu = Widget.extend({
         'clone_snippet': '_onCloneSnippet',
         'cover_update': '_onOverlaysCoverUpdate',
         'deactivate_snippet': '_onDeactivateSnippet',
+        'deactivate_snippet_if_any': '_onDeactivateSnippetIfAny',
         'drag_and_drop_stop': '_onSnippetDragAndDropStop',
         'drag_and_drop_start': '_onSnippetDragAndDropStart',
         'get_snippet_versions': '_onGetSnippetVersions',
@@ -1882,6 +1883,7 @@ var SnippetsMenu = Widget.extend({
         this.$document.on('mouseup.snippets_menu', '.dropdown-toggle', this._onClick);
 
         core.bus.on('deactivate_snippet', this, this._onDeactivateSnippet);
+        core.bus.on('deactivate_snippet_if_any', this, this._onDeactivateSnippetIfAny);
 
         // Adapt overlay covering when the window is resized / content changes
         var debouncedCoverUpdate = _.throttle(() => {
@@ -2041,6 +2043,7 @@ var SnippetsMenu = Widget.extend({
             }
         }
         core.bus.off('deactivate_snippet', this, this._onDeactivateSnippet);
+        core.bus.off('deactivate_snippet_if_any', this, this._onDeactivateSnippetIfAny);
         $(document.body).off('click', this._checkEditorToolbarVisibilityCallback);
         this.el.ownerDocument.body.classList.remove('editor_has_snippets');
     },
@@ -3625,6 +3628,23 @@ var SnippetsMenu = Widget.extend({
      */
     _onDeactivateSnippet: function () {
         this._activateSnippet(false);
+    },
+    /**
+     * Called when a child editor asks to deactivate the current snippet
+     * overlay if the active snippet fulfills a given condition.
+     *
+     * @private
+     * @param {OdooEvent} ev
+     * @param {Object} ev.data
+     * @param {function} ev.data.targetCondition
+     */
+    _onDeactivateSnippetIfAny(ev) {
+        for (const editor of this.snippetEditors) {
+            if (ev.data.targetCondition(editor.$target[0])) {
+                this._activateSnippet(false);
+                return;
+            }
+        }
     },
     /**
     * Called when a snippet will move in the page.

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -218,6 +218,7 @@
             'website/static/src/js/editor/editor.js',
             'website/static/src/js/editor/snippets.editor.js',
             'website/static/src/js/editor/snippets.options.js',
+            'website/static/src/js/editor/megamenu.js',
             'website/static/src/snippets/s_facebook_page/options.js',
             'website/static/src/snippets/s_image_gallery/options.js',
             'website/static/src/snippets/s_image_gallery/000.xml',

--- a/addons/website/static/src/js/editor/megamenu.js
+++ b/addons/website/static/src/js/editor/megamenu.js
@@ -1,0 +1,92 @@
+/** @odoo-module **/
+
+import core from 'web.core';
+import publicWidget from 'web.public.widget';
+
+publicWidget.registry.hoverableDropdown.include({
+    /**
+     * @override
+     */
+    start() {
+        if (this.editableMode) {
+            this._onPageClick = this._onPageClick.bind(this);
+            this.el.closest('#wrapwrap').addEventListener('click', this._onPageClick);
+        }
+        return this._super.apply(this, arguments);
+    },
+    /**
+     * @override
+     */
+    destroy() {
+        if (this.editableMode) {
+            this.el.closest('#wrapwrap').removeEventListener('click', this._onPageClick);
+        }
+        return this._super.apply(this, arguments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Hides all opened menues.
+     *
+     * @private
+     */
+    _hideMenues() {
+        core.bus.trigger('deactivate_snippet_if_any', {data: {
+            targetCondition: el => {
+                const headerEl = el.closest('header');
+                const shownMenuEl = headerEl.querySelector('.nav-item.dropdown.show');
+                return shownMenuEl && headerEl === this.el;
+            },
+        }});
+        for (const el of this.el.querySelectorAll('.nav-item.dropdown.show')) {
+            el.classList.remove('show');
+            for (const toggleEl of el.querySelectorAll('.dropdown-toggle')) {
+                toggleEl.setAttribute('aria-expanded', 'false');
+            }
+            for (const menuEl of el.querySelectorAll('.dropdown-menu')) {
+                menuEl.classList.remove('show');
+            }
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Called when the page is clicked anywhere.
+     * Closes the shown menu if the click is outside of it.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onPageClick(ev) {
+        if (ev.target.closest('.dropdown.show')) {
+            return;
+        }
+        this._hideMenues();
+    },
+    /**
+     * @override
+     */
+    _onMouseEnter(ev) {
+        if (this.editableMode && ev.target.classList.contains('o_mega_menu_toggle')) {
+            // Hide any other sub-menu.
+            this._hideMenues();
+        }
+        this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    _onMouseLeave(ev) {
+        if (this.editableMode) {
+            // Cancel handling from view mode.
+            return;
+        }
+        this._super(...arguments);
+    },
+});

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -927,7 +927,7 @@
             <we-button data-select-class="" data-name="header_dropdown_on_click_opt">On Click</we-button>
         </we-select>
 
-        <we-checkbox string="Show Sign In" data-customize-website-views="portal.user_sign_in" data-reload="/"/>
+        <we-checkbox string="Show Sign In" data-customize-website-views="portal.user_sign_in" data-reload="/" data-no-preview="true"/>
         <we-checkbox string="Call to Action" data-customize-website-views="website.header_call_to_action"
                      data-reset-view-arch="true" data-reload="/"/>
         <we-select string="Language Selector" data-reload="/">


### PR DESCRIPTION
When a mega menu "Sub Menus" are configured as "On Hover", it becomes very difficult to edit its content.

This commit changes the behavior of the "On Hover" while the page is being edited:
- it disables the hide on exit (`mouseleave`)
- it hides the menu when the page is clicked outside of the opened menu
- it deactivates the snippet selection if it was inside the menu that becomes hidden

This commit also disables the preview of the "Show Sign In" option which is not previewed anyway, so that it does not deselect the mega menu when hovering the options.

task-2825376
