### PR TITLE
[FIX] website_sale: properly handle empty product_images value

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2356,7 +2356,7 @@
                         </div>
                     </t>
                 </div>
-                <t t-if="len(product_images) > 1">
+                <t t-if="product_images and len(product_images) > 1">
                     <a class="carousel-control-prev" href="#o-carousel-product" role="button" data-bs-slide="prev">
                         <span class="fa fa-chevron-left fa-2x oe_unmovable" role="img" aria-label="Previous" title="Previous"/>
                     </a>


### PR DESCRIPTION
`product_images` might be equal to `None` somehow. This produces Internal Server Error on opening product page on website.

```
QWebException
Error while render the template
TypeError: object of type 'NoneType' has no len()
Template: website_sale.shop_product_carousel
Path: /t/div/div/t
Node: <t t-if="len(product_images) &gt; 1"/>
```

Fix it by checking value before using function `len`.

https://online.sentry.io/issues/4031760947/

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
