### PR TITLE
[FIX] mail: Fix discarded changes in relational fields on message

### DIFF
--- a/addons/mail/static/src/web/chatter.js
+++ b/addons/mail/static/src/web/chatter.js
@@ -296,11 +296,7 @@ export class Chatter extends Component {
 
     async reloadParentView() {
         if (this.props.webRecord) {
-            await this.props.webRecord.model.root.load(
-                { resId: this.props.threadId },
-                { keepChanges: true }
-            );
-            this.props.webRecord.model.notify();
+            await this.props.webRecord.model.root.save();
         }
     }
 


### PR DESCRIPTION
This commit modifies the behaviour of the auto-reload parent view that can be triggered by the chatter (on message posted in crm for example).
 The previous behavior was to load the data from the server
with keepChanges enabled and refresh the parent view (FormRenderer) which was problematic when working with relational fields like tags which changes were simply discarded when it happened. The behavior is now updated to simply auto-save the record when such reload is needed for the relational fields to be updated properly.

opw-3245717