### PR TITLE
[FIX] stock: add index on lot_id of stock.move.line

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -42,7 +42,7 @@ class StockMoveLine(models.Model):
     package_level_id = fields.Many2one('stock.package_level', 'Package Level', check_company=True)
     lot_id = fields.Many2one(
         'stock.production.lot', 'Lot/Serial Number',
-        domain="[('product_id', '=', product_id), ('company_id', '=', company_id)]", check_company=True)
+        domain="[('product_id', '=', product_id), ('company_id', '=', company_id)]", check_company=True, index=True)
     lot_name = fields.Char('Lot/Serial Number Name')
     result_package_id = fields.Many2one(
         'stock.quant.package', 'Destination Package',


### PR DESCRIPTION
Current behaviour before PR:
Slow

Desired behaviour after PR is merged:
Blazing Fast

---

The search in _find_delivery_ids_by_lot is slow in databases with many lots. Improvements were already made in commit [38bfbed] to speed up the method.

Adding an index speeds up the search call, which is the critical point in the recursive method, resulting in an overall improvement for the computed field delivery_ids on stock.production.lot.

[38bfbed]: https://github.com/odoo/odoo/commit/38bfbed7f7ab6dce60b4429b0db674e7d426e81b

opw-3201571