### PR TITLE
[FIX] stock: ignore archived rules during search

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -501,6 +501,7 @@ class ProcurementGroup(models.Model):
         """ Find a pull rule for the location_id, fallback on the parent
         locations if it could not be found.
         """
+        self = self.with_context(active_test=True)
         result = False
         location = location_id
         while (not result) and location:


### PR DESCRIPTION
In commit 1595c0e, the `Transaction` class was implemented to hold ORM data structures for a transaction. During one,  when there are pending computations and updates, the `flush` method is used. This method also defines the environment for said updates and computations but this environment has no guaranties in term of its content (e.g. context).

As such, no method should rely on a value in the environment that was not explicitly defined prior to its call.

This is the purpose of this commit for the `_get_rule` method. It ensures that the environment has `active_test = True`  in its context to make sure that no archived rule is used during the process.

opw-3232448
