### PR TITLE
[FIX] mail: handle notification for guests not users

### DIFF
--- a/addons/mail/static/src/core/messaging_service.js
+++ b/addons/mail/static/src/core/messaging_service.js
@@ -235,7 +235,7 @@ export class Messaging {
                     const command = rtcSessions[0][0];
                     this._updateRtcSessions(thread.id, sessionsData, command);
 
-                    if (invitedByUserId !== this.store.user?.user.id) {
+                    if (invitedByUserId && invitedByUserId !== this.store.user?.user?.id) {
                         this.notificationService.add(
                             sprintf(_t("You have been invited to #%s"), thread.displayName),
                             { type: "info" }
@@ -318,7 +318,7 @@ export class Messaging {
                         }
                         // move messages from Inbox to history
                         const partnerIndex = message.needaction_partner_ids.find(
-                            (p) => p === this.store.user.id
+                            (p) => p === this.store.user?.id
                         );
                         removeFromArray(message.needaction_partner_ids, partnerIndex);
                         removeFromArrayWithPredicate(
@@ -354,7 +354,7 @@ export class Messaging {
                         // knowledge of the channel
                         continue;
                     }
-                    if (this.store.user.id === partner_id) {
+                    if (partner_id && this.store.user?.id === partner_id) {
                         channel.serverLastSeenMsgBySelf = last_message_id;
                     }
                     const seenInfo = channel.seenInfos.find(


### PR DESCRIPTION
Some code in handle notification wrongly assumes `store.user` is set, as it reads `user.id`. This is correct when the user is authenticated as an internal user, but for guests this is incorrect.

This commit adapt code of handling notifications so that `store.user` can be undefined for guests.

Fix runbot issue 19978
