### PR TITLE
[IMP] mail: composer with html

### DIFF
--- a/addons/crm_livechat/static/tests/composer_tests.js
+++ b/addons/crm_livechat/static/tests/composer_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { afterNextRender, insertText, start, startServer } from "@mail/../tests/helpers/test_utils";
+import { insertText, start, startServer } from "@mail/../tests/helpers/test_utils";
 import { triggerHotkey } from "@web/../tests/helpers/utils";
 
 QUnit.module("composer");
@@ -18,9 +18,8 @@ QUnit.test("Can execute lead command", async function (assert) {
         },
     });
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "/lead great lead");
-    await afterNextRender(() => {
-        triggerHotkey("Enter");
-    });
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/lead great lead");
+    triggerHotkey("Enter");
+    triggerHotkey("Enter");
     assert.verifySteps(["execute_command_lead"]);
 });

--- a/addons/im_livechat/static/tests/composer_patch_tests.js
+++ b/addons/im_livechat/static/tests/composer_patch_tests.js
@@ -8,7 +8,7 @@ import {
     dragenterFiles,
     start,
 } from "@mail/../tests/helpers/test_utils";
-import { editInput, nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
+import { nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
 
 QUnit.module("composer (patch)");
 
@@ -35,7 +35,7 @@ QUnit.test("Attachment upload via drag and drop disabled", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsOnce($, ".o-mail-Composer");
-    dragenterFiles($(".o-mail-Composer-input")[0]);
+    dragenterFiles($(".o-mail-Composer")[0]);
     await nextTick();
     assert.containsNone($, ".o-mail-Dropzone");
 });
@@ -62,7 +62,8 @@ QUnit.test("Can execute help command on livechat channels", async (assert) => {
     });
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await editInput(document.body, ".o-mail-Composer-input", "/help");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/help");
+    triggerHotkey("Enter");
     triggerHotkey("Enter");
     await nextTick();
     assert.verifySteps(["execute_command_help"]);
@@ -112,7 +113,7 @@ QUnit.test('display canned response suggestions on typing ":"', async (assert) =
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    await insertText(".o-mail-Composer-input", ":");
+    await insertText(".o-mail-Composer .odoo-editor-editable", ":");
     assert.containsOnce($, ".o-mail-Composer-suggestionList .o-open");
 });
 
@@ -134,12 +135,12 @@ QUnit.test("use a canned response", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
-    await insertText(".o-mail-Composer-input", ":");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+    await insertText(".o-mail-Composer .odoo-editor-editable", ":");
     assert.containsOnce($, ".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
         "Hello! How are you? ",
         "canned response + additional whitespace afterwards"
     );
@@ -163,14 +164,17 @@ QUnit.test("use a canned response some text", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestion");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
-    await insertText(".o-mail-Composer-input", "bluhbluh ");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "bluhbluh ");
-    await insertText(".o-mail-Composer-input", ":");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "bluhbluh ");
+    assert.strictEqual(
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
+        "bluhbluh "
+    );
+    await insertText(".o-mail-Composer .odoo-editor-editable", ":");
     assert.containsOnce($, ".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
         "bluhbluh Hello! How are you? ",
         "previous content + canned response substitution + additional whitespace afterwards"
     );
@@ -194,19 +198,19 @@ QUnit.test("add an emoji after a canned response", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestion");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
-    await insertText(".o-mail-Composer-input", ":");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+    await insertText(".o-mail-Composer .odoo-editor-editable", ":");
     assert.containsOnce($, ".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
         "Hello! How are you? ",
         "previous content + canned response substitution + additional whitespace afterwards"
     );
     await click("button[aria-label='Emojis']");
     await click(".o-mail-Emoji:contains(😊)");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
         "Hello! How are you? 😊"
     );
 });

--- a/addons/im_livechat/static/tests/discuss_patch_tests.js
+++ b/addons/im_livechat/static/tests/discuss_patch_tests.js
@@ -113,7 +113,7 @@ QUnit.test("reaction button should not be present on livechat", async (assert) =
     });
     const { insertText, openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "Test");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
     await click(".o-mail-Composer-send");
     await click(".o-mail-Message");
     assert.containsNone($, "[title='Add a Reaction']");
@@ -179,7 +179,7 @@ QUnit.test(
         assert.strictEqual($(".o-mail-DiscussCategoryItem:eq(1)").text(), "Visitor 11");
         // post a new message on the last channel
         await click(".o-mail-DiscussCategoryItem:eq(1)");
-        await insertText(".o-mail-Composer-input", "Blabla");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Blabla");
         await click(".o-mail-Composer-send");
         assert.containsN($, ".o-mail-DiscussCategoryItem", 2);
         assert.strictEqual($(".o-mail-DiscussCategoryItem:eq(0)").text(), "Visitor 11");

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -59,7 +59,7 @@ For more specific needs, you may also assign custom-defined actions
 (technically: Server Actions) to be triggered for each incoming mail.
     """,
     'website': 'https://www.odoo.com/app/discuss',
-    'depends': ['base', 'base_setup', 'bus', 'web_tour'],
+    'depends': ['base', 'base_setup', 'bus', 'web_tour', 'web_editor'],
     'data': [
         'data/mail_groups.xml',
         'wizard/mail_blacklist_remove_views.xml',
@@ -121,6 +121,8 @@ For more specific needs, you may also assign custom-defined actions
             'mail/static/src/**/primary_variables.scss',
         ],
         'web.assets_backend': [
+            'web_editor/static/src/xml/editor.xml',
+
             # depends on BS variables, can't be loaded in assets_primary or assets_secondary
             'mail/static/src/scss/variables/derived_variables.scss',
             'mail/static/src/scss/*.scss',
@@ -177,6 +179,11 @@ For more specific needs, you may also assign custom-defined actions
             'web/static/src/legacy/js/services/session.js',
             'web/static/src/legacy/legacy_load_views.js',
             'web/static/src/legacy/utils.js',
+
+            ('include', 'web_editor.assets_wysiwyg'),
+            'web_editor/static/src/js/wysiwyg/dialog.js',
+            'web_editor/static/src/components/media_dialog/**/*',
+            'web_editor/static/src/js/frontend/loader.js',
 
             'mail/static/src/**/*',
             ('remove', 'mail/static/src/js/**/*'),

--- a/addons/mail/static/src/composer/composer.scss
+++ b/addons/mail/static/src/composer/composer.scss
@@ -30,28 +30,31 @@
     .o-mail-Composer-footer {
         grid-area: core-footer;
     }
-}
 
-.o-mail-Composer-actions button {
-    opacity: 75%;
-    &:hover {
-        background-color: rgba(0, 0, 0, 0.1);
-        opacity: 100%;
-    }
-}
-
-.o-mail-Composer-input {
-    padding-top: 10px; // carefully crafted to have the text in the middle in chat window
-    padding-bottom: 10px;
-    max-height: 100px;
-    resize: none;
-
-    .o-extended & {
-        max-height: 400px;
+    .o-mail-Composer-actions button {
+        opacity: 75%;
+        &:hover {
+            background-color: rgba(0, 0, 0, 0.1);
+            opacity: 100%;
+        }
     }
 
-    &::placeholder {
-        @include text-truncate();
+    .odoo-editor-editable {
+        border: 0;
+        padding-top: 10px !important;
+        padding-bottom: 10px !important;
+        padding-left: 0.75rem !important;
+        padding-right: 0.75rem !important;
+        max-height: 100px;
+
+        &::placeholder {
+            @include text-truncate();
+        }
+
+        p {
+            overflow-wrap: anywhere !important;
+            margin: 0;
+        }
     }
 }
 

--- a/addons/mail/static/src/composer/composer.xml
+++ b/addons/mail/static/src/composer/composer.xml
@@ -35,30 +35,11 @@
                         'border rounded-3 align-self-stretch flex-column' : extended,
                     }"
                 >
-                    <div class="position-relative flex-grow-1">
-                        <textarea class="o-mail-Composer-input form-control bg-view px-3 border-0 rounded-3 shadow-none overflow-auto"
-                            t-ref="textarea"
-                            style="height:40px;"
-                            t-on-keydown="onKeydown"
-                            t-on-focusin="onFocusin"
-                            t-on-focusout="() => this.props.composer.isFocused = false"
-                            t-on-click="(ev) => markEventHandled(ev, 'composer.onClickTextarea')"
-                            t-on-paste="onPaste"
-                            t-model="props.composer.textInputContent"
-                            t-att-placeholder="placeholder"
-                            t-att-readOnly="!state.active"
-                        />
-                        <!--
-                             This is an invisible textarea used to compute the composer
-                             height based on the text content. We need it to downsize
-                             the textarea properly without flicker.
-                        -->
-                        <textarea
-                            class="o-mail-Composer-fake position-absolute"
-                            t-model="props.composer.textInputContent"
-                            t-ref="fakeTextarea"
-                            disabled="1"
-                        />
+                    <div class="d-flex flex-column flex-grow-1" t-ref="wysiwygArea">
+                        <HtmlFieldWysiwygAdapterComponent Component="this.Wysiwyg"
+                            startWysiwyg.bind="this.startWysiwyg"
+                            editingValue="props.composer.wysiwygValue"
+                            widgetArgs="[this.wysiwygOptions()]" />
                     </div>
                     <div class="o-mail-Composer-actions d-flex bg-view"
                         t-att-class="{

--- a/addons/mail/static/src/composer/composer_model.js
+++ b/addons/mail/static/src/composer/composer_model.js
@@ -10,17 +10,11 @@ export class Composer {
         threadIds: new Set(),
     };
     /** @type {string} */
-    textInputContent;
+    wysiwygValue = undefined;
     /** @type {import("@mail/core/thread_model").Thread */
     thread;
-    /** @type {{ start: number, end: number, direction: "forward" | "backward" | "none"}}*/
-    selection = {
-        start: 0,
-        end: 0,
-        direction: "none",
-    };
-    /** @type {boolean} */
-    forceCursorMove;
+    /** @type {Range} */
+    range = undefined;
     /** @typedef {'message' | 'note' | false} */
     type;
     /** @type {import("@mail/core/store_service").Store} */
@@ -37,7 +31,8 @@ export class Composer {
             message.composer = this;
         }
         Object.assign(this, {
-            textInputContent: "",
+            wysiwygValue: "<p><br/></p>",
+            textContent: "",
             type: thread?.type === "chatter" ? false : "message",
             _store: store,
         });

--- a/addons/mail/static/src/core_ui/message.js
+++ b/addons/mail/static/src/core_ui/message.js
@@ -4,7 +4,7 @@ import { ImStatus } from "@mail/discuss_app/im_status";
 import { AttachmentList } from "@mail/attachments/attachment_list";
 import { MessageInReply } from "./message_in_reply";
 import { isEventHandled, markEventHandled } from "@mail/utils/misc";
-import { convertBrToLineBreak, htmlToTextContentInline } from "@mail/utils/format";
+import { htmlToTextContentInline } from "@mail/utils/format";
 import { MessageReactionMenu } from "@mail/core_ui/message_reaction_menu";
 import {
     Component,
@@ -427,16 +427,11 @@ export class Message extends Component {
     }
 
     enterEditMode() {
-        const messageContent = convertBrToLineBreak(this.props.message.body);
+        const messageBody = this.props.message.body;
         this.threadService.insertComposer({
             mentions: this.props.message.recipients,
             message: this.props.message,
-            textInputContent: messageContent,
-            selection: {
-                start: messageContent.length,
-                end: messageContent.length,
-                direction: "none",
-            },
+            wysiwygValue: messageBody,
         });
         this.state.isEditing = true;
     }

--- a/addons/mail/static/src/discuss/thread_service_patch.js
+++ b/addons/mail/static/src/discuss/thread_service_patch.js
@@ -10,17 +10,18 @@ patch(ThreadService.prototype, "discuss", {
     /**
      * @override
      * @param {import("@mail/core/thread_model").Thread} thread
+     * @param {string} textContent
      * @param {string} body
      */
-    async post(thread, body) {
-        if (thread.model === "discuss.channel" && body.startsWith("/")) {
-            const [firstWord] = body.substring(1).split(/\s/);
+    async post(thread, textContent, body) {
+        if (thread.model === "discuss.channel" && textContent.startsWith("/")) {
+            const [firstWord] = textContent.substring(1).split(/\s/);
             const command = commandRegistry.get(firstWord, false);
             if (
                 command &&
                 (!command.channel_types || command.channel_types.includes(thread.type))
             ) {
-                await this.executeCommand(thread, command, body);
+                await this.executeCommand(thread, command, textContent);
                 return;
             }
         }

--- a/addons/mail/static/src/discuss/typing/composer_patch.xml
+++ b/addons/mail/static/src/discuss/typing/composer_patch.xml
@@ -6,8 +6,5 @@
                 <Typing channel="thread" size="'medium'"/>
             </div>
         </xpath>
-        <xpath expr="//*[hasclass('o-mail-Composer-input')]" position="attributes">
-            <attribute name="t-on-input">onInput</attribute>
-        </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/js/tours/mail.js
+++ b/addons/mail/static/src/js/tours/mail.js
@@ -37,7 +37,7 @@ registry.category("web_tour.tours").add("mail_tour", {
             },
         },
         {
-            trigger: ".o-mail-Composer-input",
+            trigger: ".o-mail-Composer .odoo-editor-editable",
             content: Markup(
                 _t(
                     "<p><b>Write a message</b> to the members of the channel here.</p> <p>You can notify someone with <i>'@'</i> or link another channel with <i>'#'</i>. Start your message with <i>'/'</i> to get the list of possible commands.</p>"
@@ -47,7 +47,8 @@ registry.category("web_tour.tours").add("mail_tour", {
             width: 350,
             run: function (actions) {
                 var t = new Date().getTime();
-                actions.text("SomeText_" + t, this.$anchor);
+                actions.text("SomeText_" + t, this.$anchor.find("p"));
+                document.querySelector(".o-mail-Composer .odoo-editor-editable").click();
             },
         },
         {

--- a/addons/mail/static/src/utils/hooks.js
+++ b/addons/mail/static/src/utils/hooks.js
@@ -226,55 +226,6 @@ export function useMessageHighlight(duration = 2000) {
     return state;
 }
 
-export function useSelection({ refName, model, preserveOnClickAwayPredicate = () => false }) {
-    const ref = useRef(refName);
-    function onSelectionChange() {
-        if (document.activeElement && document.activeElement === ref.el) {
-            Object.assign(model, {
-                start: ref.el.selectionStart,
-                end: ref.el.selectionEnd,
-                direction: ref.el.selectionDirection,
-            });
-        }
-    }
-    function clear() {
-        if (!ref.el) {
-            return;
-        }
-        ref.el.selectionStart = ref.el.selectionEnd = ref.el.value.length;
-    }
-    onExternalClick(refName, async (ev) => {
-        if (await preserveOnClickAwayPredicate(ev)) {
-            return;
-        }
-        if (!ref.el) {
-            return;
-        }
-        clear();
-        Object.assign(model, {
-            start: ref.el.selectionStart,
-            end: ref.el.selectionEnd,
-            direction: ref.el.selectionDirection,
-        });
-    });
-    onMounted(() => {
-        document.addEventListener("selectionchange", onSelectionChange);
-    });
-    onWillUnmount(() => {
-        document.removeEventListener("selectionchange", onSelectionChange);
-    });
-    return {
-        clear,
-        restore() {
-            ref.el?.setSelectionRange(model.start, model.end, model.direction);
-        },
-        moveCursor(position) {
-            model.start = model.end = position;
-            ref.el.selectionStart = ref.el.selectionEnd = position;
-        },
-    };
-}
-
 /**
  * @param {string} refName
  * @param {ScrollPosition} [model] Model to store saved position.

--- a/addons/mail/static/tests/chat_window/chat_window_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_tests.js
@@ -66,7 +66,7 @@ QUnit.test(
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem");
-        await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
+        await insertText(".o-mail-ChatWindow .o-mail-Composer .odoo-editor-editable", "Test");
         await afterNextRender(() => triggerHotkey("control+Enter"));
         assert.containsOnce($, ".o-mail-Message");
     }
@@ -232,7 +232,7 @@ QUnit.test("chat window: close on ESCAPE", async (assert) => {
     });
     assert.containsOnce($, ".o-mail-ChatWindow");
 
-    $(".o-mail-Composer-input")[0].focus();
+    $(".o-mail-Composer .odoo-editor-editable")[0].focus();
     await afterNextRender(() => triggerHotkey("Escape"));
     assert.containsNone($, ".o-mail-ChatWindow");
     assert.verifySteps(["rpc:channel_fold/closed"]);
@@ -255,7 +255,7 @@ QUnit.test(
             ],
         });
         await start();
-        await insertText(".o-mail-Composer-input", "@");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "@");
         await afterNextRender(() => triggerHotkey("Escape"));
         assert.containsOnce($, ".o-mail-ChatWindow");
     }
@@ -296,7 +296,7 @@ QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]",
         document.activeElement,
         $(".o-mail-ChatWindow-header:contains(Channel_1)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 
     await click("button i[aria-label='Messages']");
@@ -308,7 +308,7 @@ QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]",
         document.activeElement,
         $(".o-mail-ChatWindow-header:contains(Channel_2)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 });
 
@@ -352,7 +352,7 @@ QUnit.test("open 3 different chat windows: not enough screen width", async (asse
         document.activeElement,
         $(".o-mail-ChatWindow-header:contains(Channel_3)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 });
 
@@ -397,11 +397,11 @@ QUnit.test(
             "should have enough space to open 2 chat windows simultaneously"
         );
         await start();
-        assert.containsN($, ".o-mail-ChatWindow .o-mail-Composer-input", 2);
+        assert.containsN($, ".o-mail-ChatWindow .o-mail-Composer .odoo-editor-editable", 2);
 
         $(".o-mail-ChatWindow-name:contains(MyTeam)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
             .focus();
         await afterNextRender(() => triggerHotkey("Escape"));
         assert.containsOnce($, ".o-mail-ChatWindow");
@@ -409,7 +409,7 @@ QUnit.test(
             document.activeElement,
             $(".o-mail-ChatWindow-name:contains(General)")
                 .closest(".o-mail-ChatWindow")
-                .find(".o-mail-Composer-input")[0]
+                .find(".o-mail-Composer .odoo-editor-editable")[0]
         );
     }
 );
@@ -431,7 +431,7 @@ QUnit.test("chat window: switch on TAB", async (assert) => {
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(channel1)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 
     await afterNextRender(() => triggerHotkey("Tab"));
@@ -439,7 +439,7 @@ QUnit.test("chat window: switch on TAB", async (assert) => {
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(channel1)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -451,7 +451,7 @@ QUnit.test("chat window: switch on TAB", async (assert) => {
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(channel2)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 
     await afterNextRender(() => triggerHotkey("Tab"));
@@ -460,7 +460,7 @@ QUnit.test("chat window: switch on TAB", async (assert) => {
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(channel1)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 });
 
@@ -518,18 +518,18 @@ QUnit.test("chat window: TAB cycle with 3 open chat windows [REQUIRE FOCUS]", as
     );
     await start();
     // FIXME: assumes ordering: MyProject, MyTeam, General
-    assert.containsN($, ".o-mail-ChatWindow .o-mail-Composer-input", 3);
+    assert.containsN($, ".o-mail-ChatWindow .o-mail-Composer .odoo-editor-editable", 3);
 
     $(".o-mail-ChatWindow-name:contains(MyProject)")
         .closest(".o-mail-ChatWindow")
-        .find(".o-mail-Composer-input")[0]
+        .find(".o-mail-Composer .odoo-editor-editable")[0]
         .focus();
     await afterNextRender(() => triggerHotkey("Tab"));
     assert.strictEqual(
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(MyTeam)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 
     await afterNextRender(() => triggerHotkey("Tab"));
@@ -537,7 +537,7 @@ QUnit.test("chat window: TAB cycle with 3 open chat windows [REQUIRE FOCUS]", as
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(General)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 
     await afterNextRender(() => triggerHotkey("Tab"));
@@ -545,7 +545,7 @@ QUnit.test("chat window: TAB cycle with 3 open chat windows [REQUIRE FOCUS]", as
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(MyProject)")
             .closest(".o-mail-ChatWindow")
-            .find(".o-mail-Composer-input")[0]
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
     );
 });
 
@@ -590,29 +590,10 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        assert.containsOnce($, ".o-mail-ChatWindow");
-        assert.containsN($, ".o-mail-Message", 2);
-        assert.containsOnce($, "hr + span:contains(New messages)");
-    }
-);
-
-QUnit.test(
-    "new message separator is shown in chat window of chat on receiving new message when there was no history",
-    async (assert) => {
-        const pyEnv = await startServer();
-        const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
-        const userId = pyEnv["res.users"].create({
-            name: "Foreigner user",
-            partner_id: partnerId,
-        });
-        const channelId = pyEnv["discuss.channel"].create({
-            channel_member_ids: [
-                Command.create({ partner_id: pyEnv.currentPartnerId }),
-                Command.create({ partner_id: partnerId }),
-            ],
-            channel_type: "chat",
-        });
-        const { env } = await start();
+        $(".o-mail-ChatWindow-name:contains(Demo)")
+            .closest(".o-mail-ChatWindow")
+            .find(".o-mail-Composer .odoo-editor-editable")[0]
+            .blur();
         // simulate receiving a message
         await afterNextRender(async () =>
             env.services.rpc("/mail/message/post", {
@@ -622,6 +603,8 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
+        assert.containsOnce($, ".o-mail-ChatWindow");
+        assert.containsN($, ".o-mail-Message", 3);
         assert.containsOnce($, "hr + span:contains(New messages)");
     }
 );
@@ -696,9 +679,9 @@ QUnit.test(
             });
         }
         await start();
-        await insertText(".o-mail-Composer-input", "WOLOLO");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "WOLOLO");
         await afterNextRender(() =>
-            triggerEvent(document.body, ".o-mail-Composer-input", "keydown", {
+            triggerEvent(document.body, ".o-mail-Composer .odoo-editor-editable", "keydown", {
                 key: "Enter",
             })
         );
@@ -785,7 +768,7 @@ QUnit.test("chat window: composer state conservation on toggle discuss", async (
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     // Set content of the composer of the chat window
-    await insertText(".o-mail-Composer-input", "XDU for the win !");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "XDU for the win !");
     assert.containsNone($, ".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard");
     // Set attachments of the composer
     const files = [
@@ -802,7 +785,10 @@ QUnit.test("chat window: composer state conservation on toggle discuss", async (
     ];
     inputFiles($(".o-mail-Composer-coreMain .o_input_file")[0], files);
     await waitUntil(".o-mail-AttachmentCard .fa-check", 2);
-    assert.strictEqual($(".o-mail-Composer-input").val(), "XDU for the win !");
+    assert.strictEqual(
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent,
+        "XDU for the win !"
+    );
 
     await openDiscuss();
     assert.containsNone($, ".o-mail-ChatWindow");
@@ -812,7 +798,10 @@ QUnit.test("chat window: composer state conservation on toggle discuss", async (
         res_model: "discuss.channel",
         views: [[false, "form"]],
     });
-    assert.strictEqual($(".o-mail-Composer-input").val(), "XDU for the win !");
+    assert.strictEqual(
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent,
+        "XDU for the win !"
+    );
     assert.containsN($, ".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard", 2);
 });
 
@@ -854,7 +843,7 @@ QUnit.test(
         ]);
         pyEnv["discuss.channel.member"].write([memberId], { seen_message_id: messageId });
         const { env } = await start();
-        $(".o-mail-Composer-input")[0].blur();
+        $(".o-mail-Composer .odoo-editor-editable")[0].blur();
         // simulate receiving a message
         await afterNextRender(() =>
             env.services.rpc("/mail/message/post", {
@@ -865,7 +854,7 @@ QUnit.test(
             })
         );
         assert.containsOnce($, "hr + span:contains(New messages)");
-        await afterNextRender(() => $(".o-mail-Composer-input")[0].focus());
+        await afterNextRender(() => $(".o-mail-Composer .odoo-editor-editable")[0].focus());
         assert.containsNone($, "hr + span:contains(New messages)");
     }
 );

--- a/addons/mail/static/tests/composer/suggested_recipients_test.js
+++ b/addons/mail/static/tests/composer/suggested_recipients_test.js
@@ -201,7 +201,7 @@ QUnit.test(
         });
         await openFormView("res.fake", fakeId);
         await click("button:contains(Log note)");
-        await insertText(".o-mail-Composer-input", "Dummy Message");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Dummy Message");
         await click(".o-mail-Composer-send");
     }
 );
@@ -220,7 +220,7 @@ QUnit.test(
         });
         await openFormView("res.fake", fakeId);
         await click("button:contains(Send message)");
-        await insertText(".o-mail-Composer-input", "Dummy Message");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Dummy Message");
         await click(".o-mail-Composer-send");
         assert.strictEqual($(".o-mail-Followers-counter").text(), "1");
     }

--- a/addons/mail/static/tests/crosstab/crosstab_tests.js
+++ b/addons/mail/static/tests/crosstab/crosstab_tests.js
@@ -22,7 +22,7 @@ QUnit.test("Messages are received cross-tab", async (assert) => {
     const tab2 = await start({ asTab: true });
     await tab1.openDiscuss(channelId);
     await tab2.openDiscuss(channelId);
-    await tab1.insertText(".o-mail-Composer-input", "Hello World!");
+    await tab1.insertText(".o-mail-Composer .odoo-editor-editable", "Hello World!");
     await tab1.click("button:contains(Send)");
     assert.containsOnce(tab1.target, ".o-mail-Message:contains(Hello World!)");
     assert.containsOnce(tab2.target, ".o-mail-Message:contains(Hello World!)");

--- a/addons/mail/static/tests/discuss/composer_tests.js
+++ b/addons/mail/static/tests/discuss/composer_tests.js
@@ -27,7 +27,7 @@ QUnit.test('do not send typing notification on typing "/" command', async (asser
         },
     });
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "/");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/");
     assert.verifySteps([], "No rpc done");
 });
 
@@ -44,9 +44,9 @@ QUnit.test(
             },
         });
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "/");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "/");
         await click(".o-mail-Composer-suggestion");
-        await insertText(".o-mail-Composer-input", " is user?");
+        await insertText(".o-mail-Composer .odoo-editor-editable", " is user?");
         assert.verifySteps([], "No rpc done");
     }
 );
@@ -60,16 +60,19 @@ QUnit.test("add an emoji after a command", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
-    await insertText(".o-mail-Composer-input", "/");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
         "/who ",
         "previous content + used command + additional whitespace afterwards"
     );
 
     await click("button[aria-label='Emojis']");
     await click(".o-mail-Emoji:contains(😊)");
-    assert.strictEqual($(".o-mail-Composer-input").val().replace(/\s/, " "), "/who 😊");
+    assert.strictEqual(
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
+        "/who 😊"
+    );
 });

--- a/addons/mail/static/tests/discuss/suggestion_tests.js
+++ b/addons/mail/static/tests/discuss/suggestion_tests.js
@@ -24,7 +24,7 @@ QUnit.test('display command suggestions on typing "/"', async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    await insertText(".o-mail-Composer-input", "/");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/");
     assert.containsOnce($, ".o-mail-Composer-suggestionList .o-open");
 });
 
@@ -34,11 +34,11 @@ QUnit.test("use a command for a specific channel type", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
-    await insertText(".o-mail-Composer-input", "/");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
         "/who ",
         "command + additional whitespace afterwards"
     );
@@ -55,10 +55,13 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
         assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-        assert.strictEqual($(".o-mail-Composer-input").val(), "");
-        await insertText(".o-mail-Composer-input", "bluhbluh ");
-        assert.strictEqual($(".o-mail-Composer-input").val(), "bluhbluh ");
-        await insertText(".o-mail-Composer-input", "/");
+        assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "bluhbluh ");
+        assert.strictEqual(
+            $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replaceAll(/\s/g, " "),
+            "bluhbluh "
+        );
+        await insertText(".o-mail-Composer .odoo-editor-editable", "/");
         assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
     }
 );

--- a/addons/mail/static/tests/discuss/typing/typing_tests.js
+++ b/addons/mail/static/tests/discuss/typing/typing_tests.js
@@ -243,7 +243,7 @@ QUnit.test("current partner notify is typing to other thread members", async (as
         },
     });
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "a");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "a");
     assert.verifySteps(["notify_typing:true"]);
 });
 
@@ -261,14 +261,14 @@ QUnit.test(
             },
         });
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "a");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "a");
         assert.verifySteps(["notify_typing:true"]);
 
         // simulate current partner typing a character for a long time.
         let totalTimeElapsed = 0;
         const elapseTickTime = SHORT_TYPING / 2;
         while (totalTimeElapsed < LONG_TYPING + SHORT_TYPING) {
-            await insertText(".o-mail-Composer-input", "a");
+            await insertText(".o-mail-Composer .odoo-editor-editable", "a");
             totalTimeElapsed += elapseTickTime;
             await advanceTime(elapseTickTime);
         }
@@ -290,7 +290,7 @@ QUnit.test(
             },
         });
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "a");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "a");
         assert.verifySteps(["notify_typing:true"]);
 
         await advanceTime(SHORT_TYPING);
@@ -312,7 +312,7 @@ QUnit.test(
             },
         });
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "a");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "a");
         assert.verifySteps(["notify_typing:true"]);
 
         await nextAnimationFrame();

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -266,7 +266,7 @@ QUnit.test("Message following a notification should not be squashed", async (ass
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await editInput(document.body, ".o-mail-Composer-input", "Hello world!");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Hello world!");
     await click(".o-mail-Composer button:contains(Send)");
     assert.containsOnce($, ".o-mail-Message-sidebar .o-mail-Message-avatarContainer");
 });
@@ -279,7 +279,7 @@ QUnit.test("Posting message should transform links.", async (assert) => {
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "test https://www.odoo.com/");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "test https://www.odoo.com/");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, "a[href='https://www.odoo.com/']");
 });
@@ -292,7 +292,7 @@ QUnit.test("Posting message should transform relevant data to emoji.", async (as
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "test :P :laughing:");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "test :P :laughing:");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, ".o-mail-Message-body:contains(test 😛 😆)");
 });
@@ -316,12 +316,12 @@ QUnit.test(
 
         await openDiscuss(channelId);
         // write 1 message
-        await editInput(document.body, ".o-mail-Composer-input", "abc");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "abc");
         await click(".o-mail-Composer button:contains(Send)");
 
         // write another message, but /mail/message/post is delayed by promise
         flag = true;
-        await editInput(document.body, ".o-mail-Composer-input", "def");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "def");
         await click(".o-mail-Composer button:contains(Send)");
         assert.containsN($, ".o-mail-Message", 2);
         assert.containsN($, ".o-mail-Message-header", 1); // just 1, because 2nd message is squashed
@@ -355,7 +355,7 @@ QUnit.test("Can use channel command /who", async (assert) => {
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "/who");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "/who");
     await click(".o-mail-Composer button:contains(Send)");
     assert.strictEqual($(".o_mail_notification").text(), "You are alone in this channel.");
 });
@@ -490,7 +490,7 @@ QUnit.test("reply to message from inbox (message linked to document)", async (as
                 assert.step("message_post");
                 assert.strictEqual(args.thread_model, "res.partner");
                 assert.strictEqual(args.thread_id, partnerId);
-                assert.strictEqual(args.post_data.body, "Test");
+                assert.strictEqual(args.post_data.body, "<p>Test</p>");
                 assert.strictEqual(args.post_data.message_type, "comment");
             }
         },
@@ -509,9 +509,9 @@ QUnit.test("reply to message from inbox (message linked to document)", async (as
     assert.hasClass($(".o-mail-Message"), "o-selected");
     assert.containsOnce($, ".o-mail-Composer");
     assert.containsOnce($, ".o-mail-Composer-coreHeader:contains(on: Refactoring)");
-    assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+    assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
 
-    await insertText(".o-mail-Composer-input", "Test");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
     await click(".o-mail-Composer-send");
     assert.verifySteps(["message_post"]);
     assert.containsNone($, ".o-mail-Composer");
@@ -537,7 +537,7 @@ QUnit.test("Can reply to starred message", async (assert) => {
     await openDiscuss("mail.box_starred");
     await click("[title='Reply']");
     assert.containsOnce($, ".o-mail-Composer-coreHeader:contains('RandomName')");
-    await insertText(".o-mail-Composer-input", "abc");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "abc");
     await click(".o-mail-Composer-send");
     assert.verifySteps(['Message posted on "RandomName"']);
     assert.containsOnce($, ".o-mail-Message");
@@ -566,7 +566,7 @@ QUnit.test("Can reply to history message", async (assert) => {
     await openDiscuss("mail.box_history");
     await click("[title='Reply']");
     assert.containsOnce($, ".o-mail-Composer-coreHeader:contains('RandomName')");
-    await insertText(".o-mail-Composer-input", "abc");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "abc");
     await click(".o-mail-Composer-send");
     assert.verifySteps(['Message posted on "RandomName"']);
     assert.containsOnce($, ".o-mail-Message");
@@ -1031,7 +1031,7 @@ QUnit.test("post a simple message", async (assert) => {
                 assert.step("message_post");
                 assert.strictEqual(args.thread_model, "discuss.channel");
                 assert.strictEqual(args.thread_id, channelId);
-                assert.strictEqual(args.post_data.body, "Test");
+                assert.strictEqual(args.post_data.body, "<p>Test</p>");
                 assert.strictEqual(args.post_data.message_type, "comment");
                 assert.strictEqual(args.post_data.subtype_xmlid, "mail.mt_comment");
             }
@@ -1040,15 +1040,15 @@ QUnit.test("post a simple message", async (assert) => {
     await openDiscuss(channelId);
     assert.containsOnce($, ".o-mail-Thread:contains(There are no messages in this conversation.)");
     assert.containsNone($, ".o-mail-Message");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
 
     // insert some HTML in editable
-    await insertText(".o-mail-Composer-input", "Test");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "Test");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "Test");
 
     await click(".o-mail-Composer-send");
     assert.verifySteps(["message_post"]);
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
     assert.containsOnce($, ".o-mail-Message");
     pyEnv["mail.message"].search([], { order: "id DESC" });
     const $message = $(".o-mail-Message");
@@ -1103,12 +1103,12 @@ QUnit.test("auto-focus composer on opening thread", async (assert) => {
     await click(".o-mail-DiscussCategoryItem:contains(General)");
     assert.hasClass($(".o-mail-DiscussCategoryItem:contains(General)"), "o-active");
     assert.containsOnce($, ".o-mail-Composer");
-    assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+    assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
 
     await click(".o-mail-DiscussCategoryItem:contains(Demo User)");
     assert.hasClass($(".o-mail-DiscussCategoryItem:contains(Demo User)"), "o-active");
     assert.containsOnce($, ".o-mail-Composer");
-    assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+    assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
 });
 
 QUnit.test(
@@ -1537,9 +1537,9 @@ QUnit.test(
         const channelId = pyEnv["discuss.channel"].create({ name: "test" });
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "Dummy Message");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Dummy Message");
         await click(".o-mail-Composer-send");
-        assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+        assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
     }
 );
 
@@ -1664,7 +1664,7 @@ QUnit.test("new messages separator [REQUIRE FOCUS]", async (assert) => {
 
     $(".o-mail-Discuss-content .o-mail-Thread")[0].scrollTop = 0;
     // composer is focused by default, we remove that focus
-    $(".o-mail-Composer-input")[0].blur();
+    $(".o-mail-Composer .odoo-editor-editable")[0].blur();
     // simulate receiving a message
     await afterNextRender(async () =>
         env.services.rpc("/mail/message/post", {
@@ -1680,7 +1680,7 @@ QUnit.test("new messages separator [REQUIRE FOCUS]", async (assert) => {
     messageList.scrollTop = messageList.scrollHeight - messageList.clientHeight;
     assert.containsOnce($, "hr + span:contains(New messages)");
 
-    await afterNextRender(() => $(".o-mail-Composer-input")[0].focus());
+    await afterNextRender(() => $(".o-mail-Composer .odoo-editor-editable")[0].focus());
     assert.containsNone($, "hr + span:contains(New messages)");
 });
 

--- a/addons/mail/static/tests/discuss_app/inbox_tests.js
+++ b/addons/mail/static/tests/discuss_app/inbox_tests.js
@@ -72,13 +72,13 @@ QUnit.test("reply: discard on pressing escape", async (assert) => {
     assert.containsOnce($, ".o-mail-Composer");
 
     // Escape on suggestion prompt does not stop replying
-    await insertText(".o-mail-Composer-input", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
     assert.containsOnce($, ".o-mail-Composer-suggestionList .o-open");
     await afterNextRender(() => triggerHotkey("Escape"));
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
     assert.containsOnce($, ".o-mail-Composer");
 
-    click(".o-mail-Composer-input").catch(() => {});
+    click(".o-mail-Composer .odoo-editor-editable").catch(() => {});
     await afterNextRender(() => triggerHotkey("Escape"));
     assert.containsNone($, ".o-mail-Composer");
 });
@@ -115,7 +115,7 @@ QUnit.test(
         assert.containsOnce($, ".o-mail-Message");
 
         await click("[title='Reply']");
-        await insertText(".o-mail-Composer-input", "Test");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
         await click(".o-mail-Composer-send");
         assert.verifySteps(["/mail/message/post"]);
     }
@@ -155,7 +155,7 @@ QUnit.test(
         await click("[title='Reply']");
         assert.strictEqual($(".o-mail-Composer-send").text().trim(), "Send");
 
-        await insertText(".o-mail-Composer-input", "Test");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
         await click(".o-mail-Composer-send");
         assert.verifySteps(["/mail/message/post"]);
     }

--- a/addons/mail/static/tests/discuss_app/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss_app/sidebar_tests.js
@@ -278,7 +278,7 @@ QUnit.test("sidebar: open pinned channel", async (assert) => {
     await openDiscuss();
     await click(".o-mail-DiscussCategoryItem:contains(General)");
     assert.strictEqual($(".o-mail-Discuss-threadName").val(), "General");
-    assert.containsOnce($, ".o-mail-Composer-input[placeholder='Message #General…']");
+    assert.containsOnce($, ".o-mail-Composer .odoo-editor-editable");
 });
 
 QUnit.test("sidebar: open channel and leave it", async (assert) => {
@@ -1073,7 +1073,7 @@ QUnit.test("chat should be sorted by last activity time [REQUIRE FOCUS]", async 
 
     // post a new message on the last channel
     await click($($chats[1]));
-    await insertText(".o-mail-Composer-input", "Blabla");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Blabla");
     await click(".o-mail-Composer-send");
     $chats = $(".o-mail-DiscussCategory-chat ~ .o-mail-DiscussCategoryItem");
     assert.strictEqual($chats.length, 2);

--- a/addons/mail/static/tests/emoji/emoji_tests.js
+++ b/addons/mail/static/tests/emoji/emoji_tests.js
@@ -68,7 +68,7 @@ QUnit.test("Basic keyboard navigation", async (assert) => {
         "codepoints"
     );
     await afterNextRender(() => triggerHotkey("Enter"));
-    assert.strictEqual($(".o-mail-Composer-input").val(), codepoints);
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, codepoints);
 });
 
 QUnit.test("recent category (basic)", async (assert) => {
@@ -118,7 +118,7 @@ QUnit.test("posting :wink: in message should impact recent", async (assert) => {
     const channelId = pyEnv["discuss.channel"].create({ name: "" });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":wink:");
+    await insertText(".o-mail-Composer .odoo-editor-editable", ":wink:");
     await click(".o-mail-Composer button[aria-label='Send']");
     await click("button[aria-label='Emojis']");
     assert.containsOnce(
@@ -133,7 +133,7 @@ QUnit.test("posting :snowman: in message should impact recent", async (assert) =
     const channelId = pyEnv["discuss.channel"].create({ name: "" });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", ":snowman:");
+    await insertText(".o-mail-Composer .odoo-editor-editable", ":snowman:");
     await click(".o-mail-Composer button[aria-label='Send']");
     await click("button[aria-label='Emojis']");
     assert.containsOnce(
@@ -165,6 +165,6 @@ QUnit.test(
             )
         );
         assert.containsOnce($, ".o-mail-EmojiPicker");
-        assert.strictEqual($(".o-mail-Composer-input").val(), "👺");
+        assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "👺");
     }
 );

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -43,6 +43,9 @@ function _createFakeDataTransfer(files) {
         dropEffect: "all",
         effectAllowed: "all",
         files,
+        getData: () => {
+            return files;
+        },
         items: [],
         types: ["Files"],
     };
@@ -533,13 +536,21 @@ function pasteFiles(el, files) {
  * @param {string} content
  * @param {Object} [param2 = {}]
  * @param {boolean} [param2.replace = false]
+ * @param {boolean} [param2.inComposer = false]
  */
-export async function insertText(selector, content, { replace = false } = {}) {
-    await afterNextRender(() => {
-        if (replace) {
+export async function insertText(selector, content, { replace = false, inComposer = false } = {}) {
+    if (replace) {
+        if (inComposer) {
+            document.querySelector(selector).innerText = "";
+        } else {
             document.querySelector(selector).value = "";
         }
-        document.querySelector(selector).focus();
+    }
+    document.querySelector(selector).focus();
+    if (content === "") {
+        return;
+    }
+    await afterNextRender(() => {
         for (const char of content) {
             document.execCommand("insertText", false, char);
             document

--- a/addons/mail/static/tests/messaging/messaging_tests.js
+++ b/addons/mail/static/tests/messaging/messaging_tests.js
@@ -80,7 +80,7 @@ QUnit.test(
         });
         const { openDiscuss, openFormView } = await start();
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "test https://www.odoo.com/");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "test https://www.odoo.com/");
         await click(".o-mail-Composer-send");
         // leaving discuss.
         await openFormView("res.partner", partnerId);

--- a/addons/mail/static/tests/suggestion/suggestion_tests.js
+++ b/addons/mail/static/tests/suggestion/suggestion_tests.js
@@ -45,7 +45,7 @@ QUnit.test('display partner mention suggestions on typing "@"', async (assert) =
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestion");
 
-    await insertText(".o-mail-Composer-input", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
     assert.containsN($, ".o-mail-Composer-suggestion", 3);
 });
 
@@ -73,11 +73,11 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
         assert.containsNone($, ".o-mail-Composer-suggestion");
-        await insertText(".o-mail-Composer-input", "first message");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "first message");
         triggerHotkey("Enter");
         await nextTick();
 
-        await insertText(".o-mail-Composer-input", "@");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "@");
         assert.containsN($, ".o-mail-Composer-suggestion", 3);
     }
 );
@@ -88,7 +88,7 @@ QUnit.test('display partner mention suggestions on typing "@" in chatter', async
     await openFormView("res.partner", pyEnv.currentPartnerId);
     await click("button:contains(Send message)");
     assert.containsNone($, ".o-mail-Composer-suggestion");
-    await insertText(".o-mail-Composer-input", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
     assert.containsOnce($, ".o-mail-Composer-suggestion:contains(Mitchell Admin)");
 });
 
@@ -107,7 +107,7 @@ QUnit.test("show other channel member in @ mention", async (assert) => {
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
     assert.containsOnce($, ".o-mail-Composer-suggestion:contains(TestPartner)");
 });
 
@@ -126,9 +126,12 @@ QUnit.test("select @ mention insert mention text in composer", async (assert) =>
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
     await click(".o-mail-Composer-suggestion:contains(TestPartner)");
-    assert.strictEqual($(".o-mail-Composer-input").val().trim(), "@TestPartner");
+    assert.strictEqual(
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.trim(),
+        "@TestPartner"
+    );
 });
 
 QUnit.test('display channel mention suggestions on typing "#"', async (assert) => {
@@ -140,7 +143,7 @@ QUnit.test('display channel mention suggestions on typing "#"', async (assert) =
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    await insertText(".o-mail-Composer-input", "#");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
     assert.containsOnce($, ".o-mail-Composer-suggestionList .o-open");
 });
 
@@ -153,12 +156,12 @@ QUnit.test("mention a channel", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
-    assert.strictEqual($(".o-mail-Composer-input").val(), "");
-    await insertText(".o-mail-Composer-input", "#");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
     assert.containsOnce($, ".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
-        $(".o-mail-Composer-input").val().replace(/\s/, " "),
+        $(".o-mail-Composer .odoo-editor-editable")[0].textContent.replace(/\s/, " "),
         "#General ",
         "mentioned channel + additional whitespace afterwards"
     );
@@ -181,9 +184,9 @@ QUnit.test("Channel suggestions do not crash after rpc returns", async (assert) 
     });
     await openDiscuss(channelId);
     pyEnv["discuss.channel"].create({ name: "foo" });
-    insertText(".o-mail-Composer-input", "#");
+    insertText(".o-mail-Composer .odoo-editor-editable", "#");
     await nextTick();
-    insertText(".o-mail-Composer-input", "f");
+    insertText(".o-mail-Composer .odoo-editor-editable", "f");
     await deferred;
     assert.verifySteps(["get_mention_suggestions"]);
 });

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -200,7 +200,7 @@ QUnit.test("thread is still scrolling after scrolling up then to bottom", async 
     await openDiscuss(channelId);
     $(".o-mail-Thread")[0].scrollTo({ top: $(".o-mail-Thread")[0].scrollHeight / 2 });
     $(".o-mail-Thread")[0].scrollTo({ top: $(".o-mail-Thread")[0].scrollHeight });
-    await insertText(".o-mail-Composer-input", "123");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "123");
     await click(".o-mail-Composer-send");
     assert.ok(isScrolledToBottom($(".o-mail-Thread")[0]));
 });
@@ -210,7 +210,7 @@ QUnit.test("mention a channel with space in the name", async (assert) => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General good boy" });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "#");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
@@ -222,7 +222,7 @@ QUnit.test('mention a channel with "&" in the name', async (assert) => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General & good" });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "#");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
@@ -259,6 +259,9 @@ QUnit.test(
             },
         });
         await click(".o_menu_systray i[aria-label='Messages']");
+        await click(".o-mail-NotificationItem");
+        $(".o-mail-Composer .odoo-editor-editable")[0].blur();
+
         await afterNextRender(async () =>
             env.services.rpc("/mail/message/post", {
                 context: { mockedUserId: userId },
@@ -269,7 +272,7 @@ QUnit.test(
         );
         assert.verifySteps(["rpc:channel_fetch"]);
 
-        $(".o-mail-Composer-input")[0].focus();
+        $(".o-mail-Composer .odoo-editor-editable")[0].focus();
         await waitUntil(".o-mail-Message");
         assert.verifySteps(["rpc:set_last_seen_message"]);
     }
@@ -297,7 +300,7 @@ QUnit.test(
             },
         });
         await openDiscuss(channelId);
-        $(".o-mail-Composer-input")[0].focus();
+        $(".o-mail-Composer .odoo-editor-editable")[0].focus();
         // simulate receiving a message
         await env.services.rpc("/mail/message/post", {
             context: { mockedUserId: userId },
@@ -450,7 +453,7 @@ QUnit.test(
         assert.containsOnce($, ".o-mail-Message");
         assert.containsNone($, "hr + span:contains(New messages)");
 
-        await insertText(".o-mail-Composer-input", "hey!");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "hey!");
         await afterNextRender(() => {
             // need to remove focus from text area to avoid set_last_seen_message
             $(".o-mail-Composer-send")[0].focus();
@@ -491,7 +494,7 @@ QUnit.test("new messages separator on receiving new message [REQUIRE FOCUS]", as
     assert.containsOnce($, ".o-mail-Message", "should have an initial message");
     assert.containsNone($, "hr + span:contains(New messages)");
 
-    $(".o-mail-Composer-input")[0].blur();
+    $(".o-mail-Composer .odoo-editor-editable")[0].blur();
     // simulate receiving a message
     await afterNextRender(() =>
         env.services.rpc("/mail/message/post", {
@@ -505,7 +508,7 @@ QUnit.test("new messages separator on receiving new message [REQUIRE FOCUS]", as
     assert.containsOnce($, "hr + span:contains(New messages)");
     assert.containsOnce($, ".o-mail-Thread-newMessage ~ .o-mail-Message:contains(hu)");
 
-    $(".o-mail-Composer-input")[0].focus();
+    $(".o-mail-Composer .odoo-editor-editable")[0].focus();
     await nextTick();
     assert.containsNone($, "hr + span:contains(New messages)");
 });
@@ -524,7 +527,7 @@ QUnit.test("no new messages separator on posting message (no message history)", 
     assert.containsNone($, ".o-mail-Message");
     assert.containsNone($, "hr + span:contains(New messages)");
 
-    await insertText(".o-mail-Composer-input", "hey!");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "hey!");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, ".o-mail-Message");
     assert.containsNone($, "hr + span:contains(New messages)");
@@ -545,8 +548,8 @@ QUnit.test("Mention a partner with special character (e.g. apostrophe ')", async
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "@");
-    await insertText(".o-mail-Composer-input", "Pyn");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Pyn");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce(
@@ -577,11 +580,11 @@ QUnit.test("mention 2 different partners that have the same name", async (assert
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "@");
-    await insertText(".o-mail-Composer-input", "Te");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Te");
     await click(".o-mail-Composer-suggestion:eq(0)");
-    await insertText(".o-mail-Composer-input", "@");
-    await insertText(".o-mail-Composer-input", "Te");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "@");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Te");
     await click(".o-mail-Composer-suggestion:eq(1)");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, ".o-mail-Message-body");
@@ -600,8 +603,8 @@ QUnit.test("mention a channel on a second line when the first line contains #", 
     const channelId = pyEnv["discuss.channel"].create({ name: "General good" });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "#blabla\n");
-    await insertText(".o-mail-Composer-input", "#");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#blabla\n");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
@@ -615,11 +618,11 @@ QUnit.test(
         const channelId = pyEnv["discuss.channel"].create({ name: "General good" });
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "#");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "#");
         await click(".o-mail-Composer-suggestion");
-        const text = $(".o-mail-Composer-input").val();
-        $(".o-mail-Composer-input").val(text.slice(0, -1));
-        await insertText(".o-mail-Composer-input", ", test");
+        const text = $(".o-mail-Composer .odoo-editor-editable")[0].textContent;
+        $(".o-mail-Composer .odoo-editor-editable").val(text.slice(0, -1));
+        await insertText(".o-mail-Composer .odoo-editor-editable", ", test");
         await click(".o-mail-Composer-send");
         assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
         assert.strictEqual($(".o_channel_redirect").text(), "#General good");
@@ -641,11 +644,11 @@ QUnit.test("mention 2 different channels that have the same name", async (assert
     ]);
     const { openDiscuss } = await start();
     await openDiscuss(channelId_1);
-    await insertText(".o-mail-Composer-input", "#");
-    await insertText(".o-mail-Composer-input", "m");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "m");
     await click(".o-mail-Composer-suggestion:eq(0)");
-    await insertText(".o-mail-Composer-input", "#");
-    await insertText(".o-mail-Composer-input", "m");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "#");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "m");
     await click(".o-mail-Composer-suggestion:eq(1)");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, ".o-mail-Message-body");
@@ -676,9 +679,9 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "email@odoo.com\n");
-        await insertText(".o-mail-Composer-input", "@");
-        await insertText(".o-mail-Composer-input", "Te");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "email@odoo.com\n");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "@");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Te");
         await click(".o-mail-Composer-suggestion");
         await click(".o-mail-Composer-send");
         assert.containsOnce(
@@ -743,10 +746,10 @@ QUnit.test(
         const { openDiscuss, env } = await start();
         await openDiscuss(channelId);
         // send a command that leads to receiving a transient message
-        await insertText(".o-mail-Composer-input", "/who");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "/who");
         await click(".o-mail-Composer-send");
         // composer is focused by default, we remove that focus
-        $(".o-mail-Composer-input")[0].blur();
+        $(".o-mail-Composer .odoo-editor-editable")[0].blur();
         // simulate receiving a message
         await afterNextRender(() =>
             env.services.rpc("/mail/message/post", {
@@ -769,9 +772,9 @@ QUnit.test(
         const channelId = pyEnv["discuss.channel"].create({ name: "test" });
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
-        await insertText(".o-mail-Composer-input", "Dummy Message");
+        await insertText(".o-mail-Composer .odoo-editor-editable", "Dummy Message");
         await click(".o-mail-Composer-send");
-        assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+        assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
     }
 );
 
@@ -895,7 +898,10 @@ QUnit.test(
         });
         await openDiscuss(channelId);
         // ensure focusout is triggered on composers' textarea
-        await triggerEvents($(".o-mail-Composer-input")[0], null, ["blur", "focusout"]);
+        await triggerEvents($(".o-mail-Composer .odoo-editor-editable")[0], null, [
+            "blur",
+            "focusout",
+        ]);
         await click("button:contains(Inbox)");
         const messageId = pyEnv["mail.message"].create({
             author_id: partnerId,

--- a/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_as_guest_tour.js
@@ -48,8 +48,11 @@ registry
             },
             {
                 content: "Write something in composer",
-                trigger: ".o-mail-Composer-input",
-                run: "text cheese",
+                trigger: ".o-mail-Composer .odoo-editor-editable",
+                run: function (actions) {
+                    actions.text("cheese", this.$anchor.find("p"));
+                    document.querySelector(".o-mail-Composer .odoo-editor-editable").click();
+                },
             },
             {
                 content: "Add one file in composer",

--- a/addons/mail/static/tests/tours/discuss_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_public_tour.js
@@ -37,8 +37,11 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/discuss_public_
         },
         {
             content: "Write something in composer",
-            trigger: ".o-mail-Composer-input",
-            run: "text cheese",
+            trigger: ".o-mail-Composer .odoo-editor-editable",
+            run: function (actions) {
+                actions.text("cheese", this.$anchor.find("p"));
+                document.querySelector(".o-mail-Composer .odoo-editor-editable").click();
+            },
         },
         {
             content: "Add one file in composer",

--- a/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
@@ -19,8 +19,11 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_full_compo
         },
         {
             content: "Write something in composer",
-            trigger: ".o-mail-Composer-input",
-            run: "text blahblah",
+            trigger: ".o-mail-Composer .odoo-editor-editable",
+            run: function (actions) {
+                actions.text("blahblah", this.$anchor.find("p"));
+                document.querySelector(".o-mail-Composer .odoo-editor-editable").click();
+            },
         },
         {
             content: "Add one file in composer",

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -14,7 +14,7 @@ import {
     waitUntil,
 } from "@mail/../tests/helpers/test_utils";
 
-import { editInput, triggerHotkey } from "@web/../tests/helpers/utils";
+import { triggerHotkey } from "@web/../tests/helpers/utils";
 import { file } from "web.test_utils";
 
 const { createFile } = file;
@@ -59,7 +59,7 @@ QUnit.test("can post a message on a record thread", async (assert) => {
                 const expected = {
                     context: args.context,
                     post_data: {
-                        body: "hey",
+                        body: "<p>hey</p>",
                         attachment_ids: [],
                         message_type: "comment",
                         partner_ids: [],
@@ -78,7 +78,7 @@ QUnit.test("can post a message on a record thread", async (assert) => {
     await click("button:contains(Send message)");
     assert.containsOnce($, ".o-mail-Composer");
 
-    await editInput(document.body, ".o-mail-Composer-input", "hey");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "hey");
     assert.containsNone($, ".o-mail-Message");
 
     await click(".o-mail-Composer button:contains(Send)");
@@ -97,7 +97,7 @@ QUnit.test("can post a note on a record thread", async (assert) => {
                     context: args.context,
                     post_data: {
                         attachment_ids: [],
-                        body: "hey",
+                        body: "<p>hey</p>",
                         message_type: "comment",
                         partner_ids: [],
                         subtype_xmlid: "mail.mt_note",
@@ -115,7 +115,7 @@ QUnit.test("can post a note on a record thread", async (assert) => {
     await click("button:contains(Log note)");
     assert.containsOnce($, ".o-mail-Composer");
 
-    await editInput(document.body, ".o-mail-Composer-input", "hey");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "hey");
     assert.containsNone($, ".o-mail-Message");
 
     await click(".o-mail-Composer button:contains(Send)");
@@ -159,7 +159,7 @@ QUnit.test("Composer toggle state is kept when switching from aside to bottom", 
         resId: partnerId,
         resModel: "res.partner",
     });
-    assert.containsOnce($, ".o-mail-Composer-input");
+    assert.containsOnce($, ".o-mail-Composer .odoo-editor-editable");
 });
 
 QUnit.test("Textarea content is kept when switching from aside to bottom", async (assert) => {
@@ -168,13 +168,13 @@ QUnit.test("Textarea content is kept when switching from aside to bottom", async
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     await openFormView("res.partner", partnerId);
     await click("button:contains(Send message)");
-    await editInput(document.body, ".o-mail-Composer-input", "Hello world !");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Hello world !");
     patchUiSize({ size: SIZES.LG });
     await waitFormViewLoaded(() => window.dispatchEvent(new Event("resize")), {
         resId: partnerId,
         resModel: "res.partner",
     });
-    assert.strictEqual($(".o-mail-Composer-input").val(), "Hello world !");
+    assert.strictEqual($(".o-mail-Composer .odoo-editor-editable")[0].textContent, "Hello world !");
 });
 
 QUnit.test("Composer type is kept when switching from aside to bottom", async (assert) => {
@@ -283,7 +283,7 @@ QUnit.test('post message with "CTRL-Enter" keyboard shortcut in chatter', async 
     assert.containsNone($, ".o-mail-Message");
 
     await click("button:contains(Send message)");
-    await insertText(".o-mail-Composer-input", "Test");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
     await afterNextRender(() => triggerHotkey("control+Enter"));
     assert.containsOnce($, ".o-mail-Message");
 });
@@ -404,11 +404,11 @@ QUnit.test("composer show/hide on log note/send message [REQUIRE FOCUS]", async 
 
     await click("button:contains(Send message)");
     assert.containsOnce($, ".o-mail-Composer");
-    assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+    assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
 
     await click("button:contains(Log note)");
     assert.containsOnce($, ".o-mail-Composer");
-    assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
+    assert.strictEqual(document.activeElement, $(".o-mail-Composer .odoo-editor-editable")[0]);
 
     await click("button:contains(Log note)");
     assert.containsNone($, ".o-mail-Composer");
@@ -432,7 +432,7 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async (assert) 
     assert.containsNone($, ".o-mail-Message");
 
     await click("button:contains(Send message)");
-    await insertText(".o-mail-Composer-input", "Test");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
     await triggerHotkey("Enter");
     assert.containsNone($, ".o-mail-Message");
 });
@@ -716,7 +716,7 @@ QUnit.test("post message on draft record", async (assert) => {
         views: [[false, "form"]],
     });
     await click("button:contains(Send message)");
-    await editInput(document.body, ".o-mail-Composer-input", "Test");
+    await insertText(".o-mail-Composer .odoo-editor-editable", "Test");
     await click(".o-mail-Composer button:contains(Send)");
     assert.containsOnce($, ".o-mail-Message");
     assert.containsOnce($, ".o-mail-Message:contains(Test)");

--- a/addons/mail/static/tests/web/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/web/chatter_topbar_tests.js
@@ -80,10 +80,7 @@ QUnit.test("log note toggling", async (assert) => {
 
     await click("button:contains(Log note)");
     assert.hasClass($("button:contains(Log note)"), "o-active");
-    assert.containsOnce(
-        $,
-        ".o-mail-Composer .o-mail-Composer-input[placeholder='Log an internal note...']"
-    );
+    assert.containsOnce($, ".o-mail-Composer .odoo-editor-editable");
 
     await click("button:contains(Log note)");
     assert.doesNotHaveClass($("button:contains(Log note)"), "o-active");
@@ -105,7 +102,7 @@ QUnit.test("send message toggling", async (assert) => {
 
     await click("button:contains(Send message)");
     assert.hasClass($("button:contains(Send message)"), "o-active");
-    assert.containsOnce($, ".o-mail-Composer-input[placeholder='Send a message to followers...']");
+    assert.containsOnce($, ".o-mail-Composer .odoo-editor-editable");
 
     await click("button:contains(Send message)");
     assert.doesNotHaveClass($("button:contains(Send message)"), "o-active");
@@ -130,12 +127,12 @@ QUnit.test("log note/send message switching", async (assert) => {
     await click("button:contains(Send message)");
     assert.hasClass($("button:contains(Send message)"), "o-active");
     assert.doesNotHaveClass($("button:contains(Log note)"), "o-active");
-    assert.containsOnce($, ".o-mail-Composer-input[placeholder='Send a message to followers...']");
+    assert.containsOnce($, ".o-mail-Composer .odoo-editor-editable");
 
     await click("button:contains(Log note)");
     assert.doesNotHaveClass($("button:contains(Send message)"), "o-active");
     assert.hasClass($("button:contains(Log note)"), "o-active");
-    assert.containsOnce($, ".o-mail-Composer-input[placeholder='Log an internal note...']");
+    assert.containsOnce($, ".o-mail-Composer .odoo-editor-editable");
 });
 
 QUnit.test("attachment counter without attachments", async (assert) => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -649,13 +649,14 @@ export class OdooEditor extends EventTarget {
         // -------
         // Toolbar
         // -------
-
-        if (this.options.toolbar) {
+        if (this.options.disableToolbar) {
+            this.toolbar = null;
+        } else if (this.options.toolbar) {
             this.setupToolbar(this.options.toolbar);
         }
         // placeholder hint
         if (editable.textContent === '' && this.options.placeholder) {
-            this._makeHint(editable.firstChild, this.options.placeholder, true);
+            this._makeHint(editable.firstChild, this.options.placeholder, this.options.isPlaceholderHintTemporary);
         }
     }
     /**
@@ -714,7 +715,7 @@ export class OdooEditor extends EventTarget {
         this._toRollback = false;
         // Placeholder hint.
         if (this.editable.textContent === '' && this.options.placeholder) {
-            this._makeHint(this.editable.firstChild, this.options.placeholder, true);
+            this._makeHint(this.editable.firstChild, this.options.placeholder, this.options.isPlaceholderHintTemporary);
         }
     }
 
@@ -3541,7 +3542,7 @@ export class OdooEditor extends EventTarget {
                     }
                 }
             }
-        } else if (ev.key === 'Tab') {
+        } else if (ev.key === 'Tab' && !this.options.disableTabAction) {
             // Tab
             const tabHtml = '<span class="oe-tabs" contenteditable="false">\u0009</span>\u200B';
             const sel = this.document.getSelection();
@@ -4007,14 +4008,16 @@ export class OdooEditor extends EventTarget {
         }
 
         const block = this.options.getPowerboxElement();
-        if (block) {
+        if (this.options.placeholder && this.options.isPlaceholderHintPriority){
+            this._makeHint(block, this.options.placeholder, this.options.isPlaceholderHintTemporary);
+        } else if (block) {
             this._makeHint(block, this.options._t('Type "/" for commands'), true);
         }
 
         // placeholder hint
         const sel = this.document.getSelection();
         if (this.editable.textContent.trim() === '' && this.options.placeholder && this.editable.firstChild && this.editable.firstChild.innerHTML && !this.editable.contains(sel.focusNode)) {
-            this._makeHint(this.editable.firstChild, this.options.placeholder, true);
+            this._makeHint(this.editable.firstChild, this.options.placeholder, this.options.isPlaceholderHintTemporary);
         }
     }
     _makeHint(block, text, temporary = false) {
@@ -4454,7 +4457,7 @@ export class OdooEditor extends EventTarget {
             if (fragment.hasChildNodes()) {
                 this._applyCommand('insert', fragment);
             }
-        } else if ((files.length || clipboardHtml) && targetSupportsHtmlContent) {
+        } else if ((files.length || clipboardHtml) && targetSupportsHtmlContent && !this.options.disbaleImagesOnPaste) {
             const clipboardElem = this._prepareClipboardData(clipboardHtml);
             // When copy pasting a table from the outside, a picture of the
             // table can be included in the clipboard as an image file. In that

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -168,10 +168,14 @@ const Wysiwyg = Widget.extend({
             _t: _t,
             toolbar: this.toolbar.$el[0],
             document: this.options.document,
+            disableToolbar: !!this.options.disableToolbar,
             autohideToolbar: !!this.options.autohideToolbar,
             isRootEditable: this.options.isRootEditable,
             onPostSanitize: this._setONotEditable.bind(this),
             placeholder: this.options.placeholder,
+            isPlaceholderHintTemporary: this.options.isPlaceholderHintTemporary === undefined ? true : this.options.isPlaceholderHintTemporary,
+            isPlaceholderHintPriority: !!this.options.isPlaceholderHintPriority,
+            disbaleImagesOnPaste: !! this.options.disbaleImagesOnPaste,
             powerboxFilters: this.options.powerboxFilters || [],
             showEmptyElementHint: this.options.showEmptyElementHint,
             controlHistoryFromDocument: this.options.controlHistoryFromDocument,
@@ -232,6 +236,7 @@ const Wysiwyg = Widget.extend({
             renderingClasses: ['o_dirty', 'o_transform_removal', 'oe_edited_link', 'o_menu_loading'],
             dropImageAsAttachment: options.dropImageAsAttachment,
             foldSnippets: !!options.foldSnippets,
+            disableTabAction: !!options.disableTabAction,
         }, editorCollaborationOptions));
 
         this.odooEditor.addEventListener('contentChanged', function () {
@@ -421,7 +426,7 @@ const Wysiwyg = Widget.extend({
             this._setONotEditable(this.odooEditor.editable);
         });
 
-        if (this.options.autohideToolbar) {
+        if (!this.options.disableToolbar && this.options.autohideToolbar) {
             if (this.odooEditor.isMobile) {
                 $(this.odooEditor.editable).before(this.toolbar.$el);
             } else {
@@ -1029,6 +1034,16 @@ const Wysiwyg = Widget.extend({
     focus: function () {
         if (this.odooEditor && !this.odooEditor.historyResetLatestComputedSelection(true)) {
             // If the editor don't have an history step to focus to,
+            if (this.odooEditor.editable.textContent.trim() === '') {
+                // If the editor is empty, we place the cursor at the beginning of the editor.
+                const range = document.createRange();
+                range.setStart(this.odooEditor.editable, 0);
+                range.collapse(true);
+                const selection = this.odooEditor.document.getSelection();
+                selection.removeAllRanges();
+                selection.addRange(range);
+                return;
+            }
             // We place the cursor after the end of the editor exiting content.
             const range = document.createRange();
             const elementToTarget = this.$editable[0].lastElementChild ? this.$editable[0].lastElementChild : this.$editable[0];

--- a/addons/website_livechat/static/tests/messaging_service_patch_tests.js
+++ b/addons/website_livechat/static/tests/messaging_service_patch_tests.js
@@ -35,6 +35,6 @@ QUnit.test("Should open chat window on send chat request to website visitor", as
         });
     });
     assert.containsOnce($, ".o-mail-ChatWindow");
-    assert.ok(document.activeElement, $(".o-mail-ChatWindow .o-mail-Composer-input")[0]);
+    assert.ok(document.activeElement, $(".o-mail-ChatWindow .o-mail-Composer")[0]);
     assert.strictEqual($(".o-mail-ChatWindow-name").text(), "Visitor #11");
 });


### PR DESCRIPTION
Functions missing at this moment:
1. Restore selection when switching channels;
2. Don't insert emoji to the selected place if the selection is discarded ( clicking outside of the composer );

These problems should be fixed by finding a better way to store the range.

Some hacky code can be removed after this PR
https://github.com/odoo/odoo/pull/118966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
