### PR TITLE
[FIX] point_of_sale: print Sales Details report with an empty session

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -119,7 +119,7 @@ class ReportSaleDetails(models.AbstractModel):
             is_cash_method = False
             for payment in payments:
                 account_payments = self.env['account.payment'].search([('pos_session_id', '=', session.id)])
-                if payment['session'] == session.id:
+                if payment.get('session') == session.id:
                     if not payment['cash']:
                         for account_payment in account_payments:
                             if payment['id'] == account_payment.pos_payment_method_id.id:


### PR DESCRIPTION
Steps to reproduce the error:
 1. open a session
 2. add an opening cash amount like 100 (don't add any order)
 3. close the session with 0 as the counted cash amount
 4. Go to Reporting > Sales Details > change the date to contain the session > Print

The problem is that inserted payment in the `if not is_cash_method` condition doesn't have `session`.

opw-3259068

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
