### PR TITLE
[FIX] portal : sync user's login with partner's email

### DIFF
--- a/addons/portal/tests/test_portal_wizard.py
+++ b/addons/portal/tests/test_portal_wizard.py
@@ -174,3 +174,15 @@ class TestPortalWizard(MailCommon):
         portal_user.with_company(company_1).action_grant_access()
 
         self.assertEqual(portal_user.user_id.company_id, company_2, 'Must create the user in the same company as the partner.')
+
+    def test_login_changed_granting_access(self):
+        """Test that the login is changed when the email is changed while granting access"""
+        partner1 = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'email': 'a@a.com',
+        })
+        portal_wizard1 = self.env['portal.wizard'].with_context(active_ids=[partner1.id]).create({})
+        portal_user1 = portal_wizard1.user_ids
+        portal_user1.email = 't@t.com'
+        portal_user1.action_grant_access()
+        self.assertEqual(portal_user1.user_id.login, 't@t.com', 'Login should be same as email')

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -129,8 +129,7 @@ class PortalWizardUser(models.TransientModel):
         group_public = self.env.ref('base.group_public')
 
         # update partner email, if a new one was introduced
-        if self.partner_id.email != self.email:
-            self.partner_id.write({'email': self.email})
+        self._update_partner_email()
 
         user_sudo = self.user_id.sudo()
 
@@ -243,3 +242,10 @@ class PortalWizardUser(models.TransientModel):
 
         if user:
             raise UserError(_('The contact "%s" has the same email has an existing user (%s).', self.partner_id.name, user.name))
+
+    def _update_partner_email(self):
+        """Update partner email on portal action, if a new one was introduced and is valid."""
+        email_normalized = email_normalize(self.email)
+        if email_normalize(self.partner_id.email) != email_normalized:
+            self.partner_id.write({'email': email_normalized})
+            self.user_id.login = email_normalized


### PR DESCRIPTION
The commit updates the login of the user if the partner email is different than user email when granting portal access.

Steps to reproduce the issue:

Go to Contacts and create contact with an email address;
Grant portal access to this email address;
An invitation email is automatically sent;
Revoke access and change the email address on the contact;
Grant portal access to this new email address;
An invitation email is automatically sent
Current Behaviour:
An invitation email is automatically sent to new email with previous login information.

Desired Behaviour:
An invitation email should be sent to new email with new login information.

OPW-3233276


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
