### PR TITLE
[FIX] account: prevent deletion of imported accounts

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -414,12 +414,16 @@ class AccountAccount(models.Model):
         with opening debit/credit. In that case, the auto-balance is postpone
         until the whole file has been imported.
         """
-        rslt = super(AccountAccount, self).load(fields, data)
-
         if 'import_file' in self.env.context:
+            # Never automatically delete imported accounts when upgrading modules.
+            rslt = super(AccountAccount, self.with_context(noupdate=True)).load(fields, data)
+
             companies = self.search([('id', 'in', rslt['ids'])]).mapped('company_id')
             for company in companies:
                 company._auto_balance_opening_move()
+        else:
+            rslt = super().load(fields, data)
+
         return rslt
 
     def _toggle_reconcile_to_true(self):


### PR DESCRIPTION
If accounts are imported through the UI via a CSV or XLSX file, an ir_model_data record will be created where noupdate is False by default. It will be linked to the current chart of accounts module. When that module is upgraded, the imported accounts (as well as any account move lines and other records referring to them) will get deleted.

This fix prevents that by seting noupdate to True if the accounts are imported from a file.

opw-3231987
