### PR TITLE
[FIX] mail: Display chat actions without hiding message time

### DIFF
--- a/addons/mail/static/src/components/message/message.scss
+++ b/addons/mail/static/src/components/message/message.scss
@@ -3,7 +3,7 @@
 // ------------------------------------------------------------------
 
 .o_Message_actionListContainer {
-    @include o-position-absolute($top: - map-get($spacers, 3), $right: 0);
+    @include o-position-absolute($top: - map-get($spacers, 4), $right: 0);
 
     &.o-squashed {
         @include o-position-absolute($top: - map-get($spacers, 4), $right: 0);


### PR DESCRIPTION
Hovering over the message pops up the action bubble and hides the time of the message. 

This issue happens because the CSS rule for the message bubble action element that has been set to a short distance to the message time, the solution is basically to update this margin distance to a bigger one.

Steps to reproduce:
1) Go to Odoo Enterprise and start a new chat
2) When passing the mouse hover over the message the action bubble appears and hides the message time

OPW: 3246957