### PR TITLE
[IMP] core: recurse in SQL

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -189,7 +189,7 @@ class PricelistItem(models.Model):
     #=== CONSTRAINT METHODS ===#
 
     @api.constrains('base_pricelist_id', 'pricelist_id', 'base')
-    def _check_recursion(self):
+    def _check_pricelist_recursion(self):
         if any(item.base == 'pricelist' and item.pricelist_id and item.pricelist_id == item.base_pricelist_id for item in self):
             raise ValidationError(_('You cannot assign the Main Pricelist as Other Pricelist in PriceList Item'))
 

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -752,8 +752,8 @@ class IrActionsServer(models.Model):
                 raise ValidationError(msg)
 
     @api.constrains('child_ids')
-    def _check_recursion(self):
-        if not self._check_m2m_recursion('child_ids'):
+    def _check_child_ids_recursion(self):
+        if not self._check_recursion('child_ids'):
             raise ValidationError(_('Recursion found in child server actions'))
 
     def _get_readable_fields(self):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -430,7 +430,7 @@ actual arch.
     def _check_000_inheritance(self):
         # NOTE: constraints methods are check alphabetically. Always ensure this method will be
         #       called before other constraint methods to avoid infinite loop in `_get_combined_arch`.
-        if not self._check_recursion(parent='inherit_id'):
+        if not self._check_recursion('inherit_id'):
             raise ValidationError(_('You cannot create recursive inherited views.'))
 
     _sql_constraints = [

--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -149,11 +149,11 @@ class TestGroups(TransactionCase):
         b = self.env['res.groups'].create({'name': 'B'})
         c = self.env['res.groups'].create({'name': 'G', 'implied_ids': [Command.set((a + b).ids)]})
         d = self.env['res.groups'].create({'name': 'D', 'implied_ids': [Command.set(c.ids)]})
-        self.assertTrue((a + b + c + d)._check_m2m_recursion('implied_ids'))
+        self.assertTrue((a + b + c + d)._check_recursion('implied_ids'))
 
         # create a cycle and check
         a.implied_ids = d
-        self.assertFalse(a._check_m2m_recursion('implied_ids'))
+        self.assertFalse(a._check_recursion('implied_ids'))
 
     def test_res_group_copy(self):
         a = self.env['res.groups'].with_context(lang='en_US').create({'name': 'A'})

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -2,14 +2,18 @@
 
 import os.path
 import tempfile
+import time
 from os.path import join as opj
 from unittest.mock import patch
+from logging import getLogger
 
 import odoo.addons
 from odoo.modules.module import load_manifest
 from odoo.modules.module import get_manifest
 from odoo.release import major_version
-from odoo.tests.common import BaseCase
+from odoo.tests.common import BaseCase, TransactionCase, warmup
+
+_logger = getLogger(__name__)
 
 
 class TestModuleManifest(BaseCase):
@@ -93,3 +97,93 @@ class TestModuleManifest(BaseCase):
             manifest = load_manifest(self.module_name)
         self.assertEqual(manifest['license'], 'LGPL-3')
         self.assertIn("Missing `license` key", capture.output[0])
+
+class TestIrModule(TransactionCase):
+
+    def downstream_dependencies_legacy(self, modules, known_deps=None,
+                                exclude_states=('uninstalled', 'uninstallable', 'to remove')):
+        """ Return the modules that directly or indirectly depend on the modules
+        in `self`, and that satisfy the `exclude_states` filter.
+        """
+        if not modules:
+            return modules
+        modules.flush_model(['name', 'state'])
+        modules.env['ir.module.module.dependency'].flush_model(['module_id', 'name'])
+        known_deps = known_deps or modules.browse()
+        query = """ SELECT DISTINCT m.id
+                        FROM ir_module_module_dependency d
+                        JOIN ir_module_module m ON (d.module_id=m.id)
+                        WHERE
+                            d.name IN (SELECT name from ir_module_module where id in %s) AND
+                            m.state NOT IN %s AND
+                            m.id NOT IN %s """
+        modules._cr.execute(query, (tuple(modules.ids), tuple(exclude_states), tuple(known_deps.ids or modules.ids)))
+        new_deps = modules.browse([row[0] for row in modules._cr.fetchall()])
+        missing_mods = new_deps - known_deps
+        known_deps |= new_deps
+        if missing_mods:
+            known_deps |= self.downstream_dependencies_legacy(missing_mods, known_deps, exclude_states)
+        return known_deps
+
+    def upstream_dependencies_legacy(self, modules, known_deps=None,
+                              exclude_states=('installed', 'uninstallable', 'to remove')):
+        """ Return the dependency tree of modules of the modules in `self`, and
+        that satisfy the `exclude_states` filter.
+        """
+        if not modules:
+            return modules
+        modules.flush_model(['name', 'state'])
+        modules.env['ir.module.module.dependency'].flush_model(['module_id', 'name'])
+        known_deps = known_deps or modules.browse()
+        query = """ SELECT DISTINCT m.id
+                    FROM ir_module_module_dependency d
+                    JOIN ir_module_module m ON (d.module_id=m.id)
+                    WHERE
+                        m.name IN (SELECT name from ir_module_module_dependency where module_id in %s) AND
+                        m.state NOT IN %s AND
+                        m.id NOT IN %s """
+        modules._cr.execute(query, (tuple(modules.ids), tuple(exclude_states), tuple(known_deps.ids or modules.ids)))
+        new_deps = modules.browse([row[0] for row in modules._cr.fetchall()])
+        missing_mods = new_deps - known_deps
+        known_deps |= new_deps
+        if missing_mods:
+            known_deps |= self.upstream_dependencies_legacy(missing_mods, known_deps, exclude_states)
+        return known_deps
+
+    @warmup
+    def test_downstream_dependencies(self):
+        module_base = self.env['ir.module.module'].search([('name', '=', 'base')])
+        t0 = time.time()
+        dependents_legacy = self.downstream_dependencies_legacy(module_base, exclude_states=('dummy',))
+        t1 = time.time()
+
+        t2 = time.time()
+        dependents = module_base.downstream_dependencies(exclude_states=('dummy',))
+        t3 = time.time()
+
+        if self.warm:
+            self.assertEqual(dependents_legacy, dependents)
+            _logger.info('legacy upstream_dependencies time %.6fs', t1 - t0)
+            _logger.info('current upstream_dependencies time %.6fs', t3 - t2)
+
+    @warmup
+    def test_upstream_dependencies(self):
+        module_industry_fsm_stock = self.env['ir.module.module'].search([('name', '=', 'industry_fsm_stock')])
+        if not module_industry_fsm_stock:  # the module with the deepest depth 16
+            return
+        module_base = self.env['ir.module.module'].search([('name', '=', 'base')])
+        t0 = time.time()
+        depends_legacy = self.upstream_dependencies_legacy(module_industry_fsm_stock, exclude_states=('dummy',))
+        t1 = time.time()
+
+        t2 = time.time()
+        depends = module_industry_fsm_stock.upstream_dependencies(exclude_states=('dummy',))
+        t3 = time.time()
+
+        if self.warm:
+            # the upstream_dependencies_legacy won't return the last layer of depends
+            # it should be treated as a bug since it against its definition
+            # but it is a safe bug, since the last layer of depends is always 'base' which should always be installed
+            self.assertEqual(depends_legacy | module_base, depends)
+            _logger.info('legacy upstream_dependencies time %.6fs', t1 - t0)
+            _logger.info('current upstream_dependencies time %.6fs', t3 - t2)

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -731,6 +731,10 @@ class TestPartnerRecursion(TransactionCase):
             self.p2.write({'child_ids': [Command.update(self.p3.id, {'parent_id': p3b.id}),
                                          Command.update(p3b.id, {'parent_id': self.p3.id})]})
 
+    def test_105_res_partner_recursion(self):
+        with self.assertRaises(ValidationError):
+            (self.p3 + self.p1).parent_id = self.p2
+
     def test_110_res_partner_recursion_multi_update(self):
         """ multi-write on several partners in same hierarchy must not trigger a false cycle detection """
         ps = self.p1 + self.p2 + self.p3

--- a/odoo/addons/base/wizard/base_module_uninstall.py
+++ b/odoo/addons/base/wizard/base_module_uninstall.py
@@ -21,7 +21,7 @@ class BaseModuleUninstall(models.TransientModel):
 
     def _get_modules(self):
         """ Return all the modules impacted by self. """
-        return self.module_id.downstream_dependencies(self.module_id)
+        return self.module_id.downstream_dependencies() | self.module_id
 
     @api.depends('module_id', 'show_all')
     def _compute_module_ids(self):


### PR DESCRIPTION
[IMP] core: refactor dependency
refactor upstream_dependency and downstream_dependency since they do a recursion
across python and SQL.
These methods are not performance bottlenecks, but it would be simpler to only
use RECURSIVE CTE to do everything in SQL when possible.

Behavior changes
1 for downstream_dependencies and upstream_dependencies
Before this commit:

when call `dd = module_a.downstream_dependencies(known_deps=module_a)`
the module_a will be included in the returned dd
when call `dd = module_a.downstream_dependencies()`
the module_a won't be included in the returned dd
It is too tricky and useless

After this commit:
know_deps is removed and when call `dd = module_a.downstream_dependencies()`
the module_a won't be included in the returned dd

2 for upstream_dependencies
Before this commit:
The result of upstream_dependencies won't include the last layer of depends
it should be treated as a bug since it is against its definition
but it is a safe bug, since the last layer of depends is always 'base' which
should always be installed

After this commit:
the module 'base' is actually always included in the result of
upstream_dependencies


[IMP] core: check recursion by sql
use RECURSIVE CTE to check recursion
avoid potential dead loop for check_recursion in test_105_res_partner_recursion
