### PR TITLE
[FIX] web: removing blocked pop-up warning

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -764,16 +764,6 @@ function makeActionManager(env) {
             env.services.router.redirect(url);
         } else {
             const w = browser.open(url, "_blank", "noreferrer");
-            if (!w || w.closed || typeof w.closed === "undefined") {
-                const msg = env._t(
-                    "A popup window has been blocked. You may need to change your " +
-                        "browser settings to allow popup windows for this page."
-                );
-                env.services.notification.add(msg, {
-                    sticky: true,
-                    type: "warning",
-                });
-            }
             if (options.onClose) {
                 options.onClose();
             }


### PR DESCRIPTION

Since https://github.com/odoo/odoo/pull/117205 , the blocked pop-up warning always shows. 

Choice to be made, 

The noreferrer is a nice to have. If we block calls to javascript: , there is no real need for the noreferrer to be added. The idea behind the original commit was to prevent the execution of arbitrary javascript on the odoo.com domain. In some context the url was controllable by an other user of the same db. basically leading to an XSS. 

Since we already block javascript: in the same commit. There is probably no need to also enforce the noreferrer. 

On the other hand, all the support browser already have a "blocked pop-up" warning. 

On chrome and edge: 
![chrome-pop-up](https://user-images.githubusercontent.com/105292262/230109248-05335f12-932a-448f-9f40-4b122abf3efa.gif)

On firefox 
![firefox-pop-up](https://user-images.githubusercontent.com/105292262/230109011-118ac81f-7c5b-4ec8-8774-b9c89fd90e31.png)


