### PR TITLE
[IMP] mail: display sender when different from author

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -47,7 +47,7 @@ class TestImLivechatMessage(TransactionCase):
             'attachment_ids': [],
             'author': {
                 'id': self.users[1].partner_id.id,
-                'name': "test1",
+                'name': self.users[1].partner_id.name,
             },
             'body': message.body,
             'date': message.date,
@@ -72,6 +72,10 @@ class TestImLivechatMessage(TransactionCase):
             'recipients': [],
             'record_name': "test1 Ernest Employee",
             'res_id': channel_livechat_1.id,
+            'sender': {
+                'id': self.users[0].partner_id.id,
+                'name': self.users[0].partner_id.name,
+            },
             'sms_ids': [],
             'starred_partner_ids': [],
             'subject': False,

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -5,7 +5,7 @@ from odoo import Command
 from odoo.tests.common import users, tagged, TransactionCase
 
 
-@tagged('post_install', '-at_install')
+@tagged('post_install', '-at_install', 'mail_thread')
 class TestImLivechatMessage(TransactionCase):
     def setUp(self):
         super().setUp()
@@ -47,7 +47,7 @@ class TestImLivechatMessage(TransactionCase):
             'attachment_ids': [],
             'author': {
                 'id': self.users[1].partner_id.id,
-                'name': self.users[1].partner_id.name,
+                'name': "test1",
             },
             'body': message.body,
             'date': message.date,
@@ -74,7 +74,7 @@ class TestImLivechatMessage(TransactionCase):
             'res_id': channel_livechat_1.id,
             'sender': {
                 'id': self.users[0].partner_id.id,
-                'name': self.users[0].partner_id.name,
+                'name': "Ernest Employee",
             },
             'sms_ids': [],
             'starred_partner_ids': [],

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -110,6 +110,7 @@ For more specific needs, you may also assign custom-defined actions
     ],
     'demo': [
         'data/mail_channel_demo.xml',
+        'data/res_partner_demo.xml',
     ],
     'installable': True,
     'application': True,

--- a/addons/mail/data/res_partner_demo.xml
+++ b/addons/mail/data/res_partner_demo.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo><data noupdate="1">
+    <record id="mail_guest_demo_0" model="mail.guest">
+        <field name="name">Mighty Guest</field>
+    </record>
+
+    <record id="mail_message_demo_partner_15_0" model="mail.message">
+        <field name="author_id" eval="False"/>
+        <field name="author_guest_id" eval="False"/>
+        <field name="body" type="html"><p>Hello! Here is an incoming email from a new email.</p></field>
+        <field name="create_uid" ref="base.user_root"/>
+        <field name="date" eval="(DateTime.today() - timedelta(days=5)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="email_from">albert@example.com</field>
+        <field name="message_type">email</field>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_address_15"/>
+        <field name="subtype_id" ref="mail.mt_comment"/>        
+    </record>
+    <record id="mail_message_demo_partner_15_1" model="mail.message">
+        <field name="author_id" ref="base.res_partner_address_15"/>
+        <field name="author_guest_id" eval="False"/>
+        <field name="body" type="html"><p>Hello! This is an incoming email from a partner.</p></field>
+        <field name="create_uid" ref="base.user_root"/>
+        <field name="date" eval="(DateTime.today() - timedelta(days=5)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="email_from">brandon.freeman55@example.com</field>
+        <field name="message_type">email</field>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_address_15"/>
+        <field name="subtype_id" ref="mail.mt_comment"/>        
+    </record>
+    <record id="mail_message_demo_partner_15_2" model="mail.message">
+        <field name="author_id" ref="base.partner_demo"/>
+        <field name="author_guest_id" eval="False"/>
+        <field name="body" type="html"><p>I add a comment, if I may.</p></field>
+        <field name="create_uid" ref="base.user_demo"/>
+        <field name="date" eval="(DateTime.today() - timedelta(days=4)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="email_from">mark.brown23@example.com</field>
+        <field name="message_type">comment</field>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_address_15"/>
+        <field name="subtype_id" ref="mail.mt_comment"/>    
+    </record>
+    <record id="mail_message_demo_partner_15_3" model="mail.message">
+        <field name="author_id" ref="base.partner_demo"/>
+        <field name="author_guest_id" eval="False"/>
+        <field name="body" type="html"><p>This is a comment posted by a cron on behalf of demo.</p></field>
+        <field name="create_uid" ref="base.user_root"/>
+        <field name="date" eval="(DateTime.today() - timedelta(days=3)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="email_from">mark.brown23@example.com</field>
+        <field name="message_type">comment</field>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_address_15"/>
+        <field name="subtype_id" ref="mail.mt_comment"/>    
+    </record>
+    <record id="mail_message_demo_partner_15_4" model="mail.message">
+        <field name="author_id" ref="base.partner_demo"/>
+        <field name="author_guest_id" eval="False"/>
+        <field name="body" type="html"><p>This is a comment by admin on behalf of demo.</p></field>
+        <field name="create_uid" ref="base.user_admin"/>
+        <field name="date" eval="(DateTime.today() - timedelta(days=3)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="email_from">mark.brown23@example.com</field>
+        <field name="message_type">comment</field>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_address_15"/>
+        <field name="subtype_id" ref="mail.mt_comment"/>    
+    </record>
+    <record id="mail_message_demo_partner_15_5" model="mail.message">
+        <field name="author_id" eval="False"/>
+        <field name="author_guest_id" ref="mail_guest_demo_0"/>
+        <field name="body" type="html"><p>This was posted by a guest.</p></field>
+        <field name="create_uid" ref="base.user_root"/>
+        <field name="date" eval="(DateTime.today() - timedelta(days=5)).strftime('%Y-%m-%d %H:%M:00')"/>
+        <field name="email_from" eval="False"/>
+        <field name="message_type">comment</field>
+        <field name="model">res.partner</field>
+        <field name="res_id" ref="base.res_partner_address_15"/>
+        <field name="subtype_id" ref="mail.mt_comment"/>    
+    </record>
+
+</data></odoo>

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7155,6 +7155,13 @@ msgid "Post your message on the thread"
 msgstr ""
 
 #. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/models/message_view.js:0
+#, python-format
+msgid "Posted on %s"
+msgstr ""
+
+#. module: mail
 #. odoo-python
 #: code:addons/mail/models/mail_thread.py:0
 #, python-format
@@ -8163,6 +8170,20 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_search
 #, python-format
 msgid "Sent"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/models/message_view.js:0
+#, python-format
+msgid "Sent by %s"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/models/message_view.js:0
+#, python-format
+msgid "Sent by %s on %s"
 msgstr ""
 
 #. module: mail
@@ -29479,6 +29500,13 @@ msgstr ""
 #: code:addons/mail/static/src/models_data/emoji_data.js:0
 #, python-format
 msgid "sent"
+msgstr ""
+
+#. module: mail
+#. odoo-javascript
+#: code:addons/mail/static/src/models/message_view.js:0
+#, python-format
+msgid "sent by %s"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -848,7 +848,7 @@ class Message(models.Model):
         for vals in vals_list:
             message_sudo = self.browse(vals['id']).sudo().with_prefetch(self.ids)
 
-            # author, sender
+            # author
             author = {
                 'id': message_sudo.author_id.id,
                 'name': message_sudo.author_id.name,
@@ -857,19 +857,17 @@ class Message(models.Model):
                 'id': message_sudo.author_guest_id.id,
                 'name': message_sudo.author_guest_id.name,
             } if message_sudo.author_guest_id else [('clear',)]
-            if message_sudo.author_guest_id:
-                sender = guestAuthor
-            # impersonation of post
-            elif message_sudo.author_id and message_sudo.message_type != 'email':
+            # sender: used to display impersonation, mainly for internal users
+            # e.g. when a template is used on behalf of someone else; mail gateway
+            # messages currently consider the author being the sender (as otherwise
+            # it will always be 'Sent by Odoobot')
+            if message_sudo.message_type == 'email':
+                sender = author
+            else:
                 sender = {
                     'id': message_sudo.create_uid.partner_id.id,
                     'name': message_sudo.create_uid.name,
                 }
-            # don't want to see "Sent by Odoobot"
-            elif message_sudo.author_id and message_sudo.message_type == 'email':
-                sender = author
-            else:
-                sender = [('clear',)]
 
             # other
             if message_sudo.model and message_sudo.res_id:
@@ -923,55 +921,53 @@ class Message(models.Model):
         return self.search(domain, limit=limit)
 
     def message_format(self, format_reply=True):
-        """ Get the message values in the format for web client. Since message
-        values can be broadcasted, computed fields MUST NOT BE READ and
-        broadcasted.
-
-        :returns list(dict). Example :
-        {
-            'attachment_ids': [
+        """ Get the message values in the format for web client. Since message values can be broadcasted,
+            computed fields MUST NOT BE READ and broadcasted.
+            :returns list(dict).
+             Example :
                 {
-                    'id': 45,
-                    'name': u'sample.png',
-                    'filename': u'sample.png'
-                    'file_type_icon': u'webimage',
-                }
-            ],
-            'author': { 'id': 3, 'name': 'Administrator' },
-            'body': HTML content of the message
-            'date': '2015-06-30 08:22:33',
-            'email_from': 'sacha@pokemon.com' # email address or False
-            'id': 59,
-            'is_discussion': False # only if the message is a discussion (subtype == discussion)
-            'is_note': True # only if the message is a note (subtype == note)
-            'is_notification': False # only if the message is a note but is a notification aka not linked to a document like assignation
-            'message_type': u'comment',
-            'model': u'res.partner',
-            'needaction_partner_ids': [], # list of partner ids
-            'parentMessage': {...}, # formatted message that this message is a reply to. Only present if format_reply is True
-            'partner_ids': [[7, "Sacha Du Bourg-Palette"]], # list of partner name_get
-            'record_name': u'Agrolait',
-            'res_id': 7,
-            'sender': { 'id': 3, 'name': 'Administrator' },
-            'subject': u'Subject','
-            'subtype_id': (1, u'Discussions'),
-            'trackingValues': [
-                {
-                    'changedField': "Customer",
-                    'id': 2965,
-                    'newValue': {
-                        'currencyId': "",
-                        'fieldType': 'char',
-                        'value': "Axelor",
+                    'body': HTML content of the message
+                    'model': u'res.partner',
+                    'record_name': u'Agrolait',
+                    'attachment_ids': [
+                        {
+                            'file_type_icon': u'webimage',
+                            'id': 45,
+                            'name': u'sample.png',
+                            'filename': u'sample.png'
+                        }
                     ],
-                    'oldValue': {
-                        'currencyId': "",
-                        'fieldType': 'char',
-                        'value': "",
+                    'needaction_partner_ids': [], # list of partner ids
+                    'res_id': 7,
+                    'trackingValues': [
+                        {
+                            'changedField': "Customer",
+                            'id': 2965,
+                            'newValue': {
+                                'currencyId': "",
+                                'fieldType': 'char',
+                                'value': "Axelor",
+                            ],
+                            'oldValue': {
+                                'currencyId': "",
+                                'fieldType': 'char',
+                                'value': "",
+                            ],
+                        }
                     ],
+                    'author_id': (3, u'Administrator'),
+                    'email_from': 'sacha@pokemon.com' # email address or False
+                    'subtype_id': (1, u'Discussions'),
+                    'date': '2015-06-30 08:22:33',
+                    'partner_ids': [[7, "Sacha Du Bourg-Palette"]], # list of partner name_get
+                    'message_type': u'comment',
+                    'id': 59,
+                    'subject': False
+                    'is_note': True # only if the message is a note (subtype == note)
+                    'is_discussion': False # only if the message is a discussion (subtype == discussion)
+                    'is_notification': False # only if the message is a note but is a notification aka not linked to a document like assignation
+                    'parentMessage': {...}, # formatted message that this message is a reply to. Only present if format_reply is True
                 }
-            ],
-        }
         """
         vals_list = self._message_format(self._get_message_format_fields(), format_reply=format_reply)
 

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -73,11 +73,6 @@
                                             <t t-esc="messageView.message.author.nameOrDisplayName"/>
                                         </t>
                                     </strong>
-                                    <span t-if="messageView.message.sender and messageView.message.sender !== messageView.message.author"
-                                          class="me-1 small fw-light">
-                                        sent by
-                                        <t t-esc="messageView.message.sender.name"/>
-                                    </span>
                                 </t>
                                 <t t-elif="messageView.message.guestAuthor">
                                     <strong class="o_Message_authorName me-2 text-truncate text-muted">
@@ -96,6 +91,7 @@
                                         Anonymous
                                     </strong>
                                 </t>
+                                <span t-if="messageView.senderView" class="me-1 small fw-light" t-esc="messageView.senderView"/>
                                 <t t-if="messageView.message.date">
                                     <small class="o_Message_date o_Message_headerDate text-muted opacity-50" t-att-class="{ 'o-message-selected': messageView.isSelected, 'me-2': !(messageView.isInChatWindowAndIsAlignedRight) }" t-att-title="messageView.dateEnriched">
                                         <span t-if="messageView.isShowingAuthorName">-</span> <t t-esc="messageView.dateFromNow"/>

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -73,6 +73,11 @@
                                             <t t-esc="messageView.message.author.nameOrDisplayName"/>
                                         </t>
                                     </strong>
+                                    <span t-if="messageView.message.sender and messageView.message.sender !== messageView.message.author"
+                                          class="me-1 small fw-light">
+                                        sent by
+                                        <t t-esc="messageView.message.sender.name"/>
+                                    </span>
                                 </t>
                                 <t t-elif="messageView.message.guestAuthor">
                                     <strong class="o_Message_authorName me-2 text-truncate text-muted">
@@ -92,7 +97,7 @@
                                     </strong>
                                 </t>
                                 <t t-if="messageView.message.date">
-                                    <small class="o_Message_date o_Message_headerDate text-muted opacity-50" t-att-class="{ 'o-message-selected': messageView.isSelected, 'me-2': !(messageView.isInChatWindowAndIsAlignedRight) }" t-att-title="messageView.message.datetime">
+                                    <small class="o_Message_date o_Message_headerDate text-muted opacity-50" t-att-class="{ 'o-message-selected': messageView.isSelected, 'me-2': !(messageView.isInChatWindowAndIsAlignedRight) }" t-att-title="messageView.dateEnriched">
                                         <span t-if="messageView.isShowingAuthorName">-</span> <t t-esc="messageView.dateFromNow"/>
                                     </small>
                                 </t>

--- a/addons/mail/static/src/models/message.js
+++ b/addons/mail/static/src/models/message.js
@@ -95,6 +95,9 @@ registerModel({
             if ('starred_partner_ids' in data && this.messaging.currentPartner) {
                 data2.isStarred = data.starred_partner_ids.includes(this.messaging.currentPartner.id);
             }
+            if ('sender' in data) {
+                data2.sender = data.sender;
+            }
             if ('subject' in data) {
                 data2.subject = data.subject;
             }
@@ -703,6 +706,7 @@ registerModel({
             },
         }),
         recipients: many('Partner'),
+        sender: one('Partner'),
         shortTime: attr({
             compute() {
                 if (!this.date) {

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -4,6 +4,7 @@ import { registerModel } from '@mail/model/model_core';
 import { attr, one } from '@mail/model/model_field';
 import { clear } from '@mail/model/model_field_command';
 import { isEventHandled, markEventHandled } from '@mail/utils/utils';
+import { sprintf } from "@web/core/utils/strings";
 
 registerModel({
     name: 'MessageView',
@@ -245,6 +246,34 @@ registerModel({
         */
         composerViewInEditing: one('ComposerView', {
             inverse: 'messageViewInEditing',
+        }),
+        /**
+         * Enriched date (contains the from, email-like)
+         */
+        dateEnriched: attr({
+            compute() {
+                if (!this.message) {
+                    return clear();
+                }
+                if (this.message.message_type === 'email' && this.message.email_from) {
+                    if (this.message.datetime) {
+                        return sprintf(
+                            this.env._t("Sent by %s on %s"),
+                            this.message.email_from,
+                            this.message.datetime
+                        );
+                    }
+                    else {
+                        return sprintf(
+                            this.env._t("Sent by %s"),
+                            this.message.email_from
+                        );
+                    }
+                }
+                return sprintf(
+                    this.env._t("Posted on %s"), this.message.datetime
+                );
+            },
         }),
         /**
          * States the time elapsed since date up to now.

--- a/addons/mail/static/src/models/message_view.js
+++ b/addons/mail/static/src/models/message_view.js
@@ -270,6 +270,9 @@ registerModel({
                         );
                     }
                 }
+                if (!this.message.datetime) {
+                    return clear();
+                }
                 return sprintf(
                     this.env._t("Posted on %s"), this.message.datetime
                 );
@@ -593,6 +596,23 @@ registerModel({
                 return this.message.author && this.message.author.isImStatusSet ? {} : clear();
             },
             inverse: 'messageViewOwner',
+        }),
+        /**
+         * Sender (impersonation note)
+         */
+        senderView: attr({
+            compute() {
+                if (this.messaging.currentGuest) {
+                    return false;
+                }
+                if (!this.message) {
+                    return clear();
+                }
+                if (!this.message.author || !this.message.sender || this.message.author === this.message.sender) {
+                    return false;
+                }
+                return sprintf(this.env._t("sent by %s"), this.message.sender.name);
+            },
         }),
     },
 });


### PR DESCRIPTION
PURPOSE

Display impersonation information when the sender of a message is either not
the real author, either was deduced through some secondary mechanism like
the Guest mechanism (token-based discussions) or the mailgateway (automatic
partner finding based on email).

USE CASES: IMPERSONATION

  * guest_author_id: when having a guest, it should be clear enough as it
    is used mainly for discussion channels, not really on classic chatter
    documents. Hence do nothing;
  * mail gateway: no author but email_from: chatter displays the email icon
    which is sufficient to indicate this comes from the outside world via
    the mail gateway:
  * author, and different from create user: if message is an email do not
    do anything specific, as otherwise it will be displayed 'sent by
    Odoobot' on a lot of post messages;
  * author, and different from create user, message is not an email: display
    'Sent by <sender>' after the author's name. This covers the template use
    case when it is sent on behalf of someone else, either by a real user,
    either by a cron;

USE CASES: DATE TOOLTIP

  * when message is of type 'email', enrich the date tooltip with 'Sent by
    <email_from> on <datetime>', to have this information available at
    hand without cluttering the UI;
  * otherwise, enrich the date tooltip with a 'Posted on <datetime>' indicating
    this is a classic post message;

Task-3267766