### PR TITLE
[FIX] hr_expense: posting the expense throws a traceback

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -68,6 +68,7 @@ class AccountMove(models.Model):
                         "balance": balance,
                         "name": "",
                         "account_id": move.expense_sheet_id.expense_line_ids[0]._get_expense_account_destination(),
+                        "amount_currency": balance,
                     }
                 }
 


### PR DESCRIPTION
The issue:
posting the expense throws a traceback because there's no amount_currency set on needed_terms field

The fix:
set the amount_currency field

opw-3240869