### PR TITLE
[FIX] web: Handle access rights in kanban avatar

### DIFF
--- a/addons/web/static/src/views/fields/access_rights_hook.js
+++ b/addons/web/static/src/views/fields/access_rights_hook.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import { useService } from "@web/core/utils/hooks";
+import { onWillStart } from "@odoo/owl";
+
+export function useAccessRights(model, permission) {
+    const result = {};
+    const userService = useService("user");
+    onWillStart(async () => {
+        result.value = await userService.checkAccessRight(model, permission);
+    });
+    return result;
+}

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -8,6 +8,7 @@ import {
 } from "@web/views/fields/many2many_tags/many2many_tags_field";
 import { TagsList } from "@web/core/tags_list/tags_list";
 import { AvatarMany2XAutocomplete } from "@web/views/fields/relational_utils";
+import { useAccessRights } from "../access_rights_hook";
 
 export class Many2ManyTagsAvatarField extends Many2ManyTagsField {
     static template = "web.Many2ManyTagsAvatarField";
@@ -151,7 +152,11 @@ export class KanbanMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
         isEditable: { type: Boolean, optional: true },
     };
     itemsVisible = 2;
-
+    hasAccess;
+    setup() {
+        super.setup();
+        this.hasAccess = useAccessRights(this.props.record.resModel, "write").value;
+    }
     get popoverProps() {
         const props = {
             ...this.props,

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -41,7 +41,7 @@
        owl="1">
         <xpath expr="//TagsList" position="attributes">
             <attribute name="popoverProps">popoverProps</attribute>
-            <attribute name="readonly">!props.isEditable</attribute>
+            <attribute name="readonly">!(props.isEditable and hasAccess)</attribute>
         </xpath>
     </t>
     <t t-name="web.Many2ManyTagsAvatarFieldPopover" t-inherit="web.Many2ManyTagsAvatarField" t-inherit-mode="primary" owl="1">

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
@@ -6,6 +6,7 @@ import { many2OneField, Many2OneField } from "../many2one/many2one_field";
 
 import { Component } from "@odoo/owl";
 import { AvatarMany2XAutocomplete } from "@web/views/fields/relational_utils";
+import { useAccessRights } from "../access_rights_hook";
 
 export class Many2OneAvatarField extends Component {
     static template = "web.Many2OneAvatarField";
@@ -61,11 +62,12 @@ export class KanbanMany2OneAvatarField extends Many2OneAvatarField {
         ...Many2OneAvatarField.props,
         isEditable: { type: Boolean, optional: true },
     };
+    hasAccess;
     setup() {
         super.setup();
         this.popover = usePopover();
+        this.hasAccess = useAccessRights(this.props.record.resModel, "write").value;
     }
-
     closePopover() {
         this.closePopoverFn();
         this.closePopoverFn = null;
@@ -79,7 +81,7 @@ export class KanbanMany2OneAvatarField extends Many2OneAvatarField {
         return props;
     }
     openPopover(ev) {
-        if (!this.props.isEditable) {
+        if (!(this.props.isEditable && this.hasAccess)) {
             return;
         }
         if (this.closePopoverFn) {

--- a/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
@@ -353,10 +353,16 @@ QUnit.module("Fields", (hooks) => {
             "user,false,list": '<tree><field name="display_name"/></tree>',
             "user,false,search": "<search/>",
         };
+        const accessRight = true;
         await makeView({
             type: "kanban",
             resModel: "partner",
             serverData,
+            mockRPC: (_, { method }) => {
+                if (method === "check_access_rights") {
+                    return accessRight;
+                }
+            },
             arch: `
                 <kanban>
                     <templates>
@@ -398,11 +404,16 @@ QUnit.module("Fields", (hooks) => {
 
     QUnit.test("widget many2one_avatar in kanban view", async function (assert) {
         assert.expect(5);
-
+        const accessRight = true;
         await makeView({
             type: "kanban",
             resModel: "partner",
             serverData,
+            mockRPC: (_, { method }) => {
+                if (method === "check_access_rights") {
+                    return accessRight;
+                }
+            },
             arch: `
                 <kanban>
                     <templates>
@@ -459,4 +470,50 @@ QUnit.module("Fields", (hooks) => {
             "should not have the quick assign icon"
         );
     });
+
+    QUnit.test(
+        "widget many2one_avatar in kanban view without access rights",
+        async function (assert) {
+            assert.expect(2);
+            const accessRight = false;
+            await makeView({
+                type: "kanban",
+                resModel: "partner",
+                serverData,
+                mockRPC: (_, { method }) => {
+                    if (method === "check_access_rights") {
+                        return accessRight;
+                    }
+                },
+                arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_global_click">
+                                <div class="oe_kanban_footer">
+                                    <div class="o_kanban_record_bottom">
+                                        <div class="oe_kanban_bottom_right">
+                                            <field name="user_id" widget="many2one_avatar"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            });
+            assert.strictEqual(
+                target.querySelector(
+                    ".o_kanban_record:nth-child(1) .o_field_many2one_avatar .o_m2o_avatar > img"
+                ).dataset.src,
+                "/web/image/user/17/avatar_128",
+                "should have correct avatar image"
+            );
+            assert.containsNone(
+                target,
+                ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > .o_quick_assign",
+                "should not have the quick assign icon"
+            );
+        }
+    );
 });


### PR DESCRIPTION
This commit creates a new useAccessRights hook which can be used by field components to check if the user has access to the specified model. This allows to hide features of the field that could only be used with the right access rights.
The bug that it fixes in this case is the add user icon that appears in the kanban many2many_tags_avatar_field for any user while it is not possible to use with insufficient access rights. Steps to reproduce: give minimal access rights to Marc Demo user, log in as Marc Demo, go to calendar, go to online appointments and check if the add user icon is available.

opw-3265086