### PR TITLE
[REF] web, *: remove module alias of legacy tests

### DIFF
--- a/addons/mail/static/tests/tours/discuss_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_public_tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { createFile, inputFiles } from "web.test_utils_file";
+import { createFile, inputFiles } from "@web/../tests/legacy/helpers/test_utils_file";
 
 registry.category("web_tour.tours").add("mail/static/tests/tours/discuss_public_tour.js", {
     test: true,

--- a/addons/mail/static/tests/tours/mail_channel_as_guest_tour.js
+++ b/addons/mail/static/tests/tours/mail_channel_as_guest_tour.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { createFile, inputFiles } from "web.test_utils_file";
+import { createFile, inputFiles } from "@web/../tests/legacy/helpers/test_utils_file";
 
 registry.category("web_tour.tours").add("mail/static/tests/tours/mail_channel_as_guest_tour.js", {
     test: true,

--- a/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { createFile, inputFiles } from "web.test_utils_file";
+import { createFile, inputFiles } from "@web/../tests/legacy/helpers/test_utils_file";
 
 import { registry } from "@web/core/registry";
 

--- a/addons/point_of_sale/static/tests/unit/popup_controller_tests.js
+++ b/addons/point_of_sale/static/tests/unit/popup_controller_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { AbstractAwaitablePopup } from "@point_of_sale/js/Popups/AbstractAwaitablePopup";
-import makeTestEnvironment from "web.test_env";
+import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
 import { click, getFixture, mount, nextTick, triggerEvent } from "@web/../tests/helpers/utils";
 import { clearRegistryWithCleanup, makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { registry } from "@web/core/registry";

--- a/addons/web/static/tests/core/datepicker_tests.js
+++ b/addons/web/static/tests/core/datepicker_tests.js
@@ -8,7 +8,7 @@ import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import ActionModel from "web.ActionModel";
 import CustomFilterItem from "web.CustomFilterItem";
 import { createComponent } from "web.test_utils";
-import { editSelect } from "web.test_utils_fields";
+import { editSelect } from "@web/../tests/legacy/helpers/test_utils_fields";
 import { registerCleanup } from "../helpers/cleanup";
 import { makeTestEnv } from "../helpers/mock_env";
 import { makeFakeLocalizationService } from "../helpers/mock_services";

--- a/addons/web/static/tests/helpers/legacy_env_utils.js
+++ b/addons/web/static/tests/helpers/legacy_env_utils.js
@@ -6,7 +6,7 @@ import { patch, unpatch } from "@web/core/utils/patch";
 import { makeLegacyDialogMappingService } from "@web/legacy/utils";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import core from "web.core";
-import makeTestEnvironment from "web.test_env";
+import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
 import { registerCleanup } from "./cleanup";
 import { makeTestEnv } from "./mock_env";
 import { patchWithCleanup } from "./utils";

--- a/addons/web/static/tests/legacy/component_extension_tests.js
+++ b/addons/web/static/tests/legacy/component_extension_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
     
-    import makeTestEnvironment from "web.test_env";
+    import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
     import testUtils from "web.test_utils";
     import { destroy, getFixture, mount } from "@web/../tests/helpers/utils";
     import { LegacyComponent } from "@web/legacy/legacy_component";

--- a/addons/web/static/tests/legacy/components/dropdown_menu_tests.js
+++ b/addons/web/static/tests/legacy/components/dropdown_menu_tests.js
@@ -2,7 +2,7 @@
     
     import DropdownMenu from "web.DropdownMenu";
     import testUtils from "web.test_utils";
-    import makeTestEnvironment  from "web.test_env";
+    import { makeTestEnvironment }  from "@web/../tests/legacy/helpers/test_env";
     import { mount } from "@web/../tests/helpers/utils";
     import { LegacyComponent } from "@web/legacy/legacy_component";
 

--- a/addons/web/static/tests/legacy/control_panel/control_panel_model_extension_tests.js
+++ b/addons/web/static/tests/legacy/control_panel/control_panel_model_extension_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
     
     import ActionModel from "web.ActionModel";
-    import makeTestEnvironment from "web.test_env";
+    import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
 
     function createModel(params = {}) {
         const archs = (params.arch && { search: params.arch, }) || {};

--- a/addons/web/static/tests/legacy/core/owl_dialog_tests.js
+++ b/addons/web/static/tests/legacy/core/owl_dialog_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
     
     import LegacyDialog from "web.Dialog";
-    import makeTestEnvironment from "web.test_env";
+    import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
     import Dialog from "web.OwlDialog";
     import testUtils from "web.test_utils";
 

--- a/addons/web/static/tests/legacy/core/popover_tests.js
+++ b/addons/web/static/tests/legacy/core/popover_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
     
-    import makeTestEnvironment from "web.test_env";
+    import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
     import Popover from "web.Popover";
     import testUtils from "web.test_utils";
     import { click, mount } from "@web/../tests/helpers/utils";

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1,10 +1,10 @@
-/** @odoo-module alias=web.MockServer **/
+/** @odoo-module **/
 
 import Class from "web.Class";
 import Domain from "web.Domain";
 import pyUtils from "web.py_utils";
 
-var MockServer = Class.extend({
+export var MockServer = Class.extend({
     /**
      * @constructor
      * @param {Object} data
@@ -2269,5 +2269,3 @@ var MockServer = Class.extend({
         }
     },
 });
-
-export default MockServer;

--- a/addons/web/static/tests/legacy/helpers/test_env.js
+++ b/addons/web/static/tests/legacy/helpers/test_env.js
@@ -1,8 +1,8 @@
-/** @odoo-module alias=web.test_env **/
+/** @odoo-module **/
     
     import Bus from "web.Bus";
     import session from "web.session";
-    import { makeTestEnvServices } from "@web/../tests/legacy/helpers/test_services";
+    import { makeTestEnvServices } from "./test_services";
     import { templates, setLoadXmlDefaultApp } from "@web/core/assets";
     import { renderToString } from "@web/core/utils/render";
     const { App, Component } = owl;
@@ -18,7 +18,7 @@
      * @param {Function} [providedRPC=null]
      * @returns {Proxy}
      */
-    function makeTestEnvironment(env = {}, providedRPC = null) {
+    export function makeTestEnvironment(env = {}, providedRPC = null) {
         if (!app) {
             app = new App(null, { templates, test: true });
             renderToString.app = app;
@@ -82,5 +82,3 @@
     QUnit.on('OdooBeforeTestHook', function () {
         Component.env = makeTestEnvironment();
     });
-
-    export default makeTestEnvironment;

--- a/addons/web/static/tests/legacy/helpers/test_services.js
+++ b/addons/web/static/tests/legacy/helpers/test_services.js
@@ -2,7 +2,7 @@
 
 import { buildQuery } from 'web.rpc';
 
-const testEnvServices = {
+export const testEnvServices = {
     getCookie() {},
     httpRequest(/* route, params = {}, readMethod = 'json' */) {
         return Promise.resolve('');
@@ -17,7 +17,7 @@ const testEnvServices = {
  * @param {Object} [env]
  * @returns {Object}
  */
-function makeTestEnvServices(env) {
+export function makeTestEnvServices(env) {
     return Object.assign({}, testEnvServices, {
         ajax: {
             rpc() {
@@ -31,8 +31,3 @@ function makeTestEnvServices(env) {
         ui: { activeElement: document }, // fake service
     }, env.services);
 }
-
-export {
-    makeTestEnvServices,
-    testEnvServices,
-};

--- a/addons/web/static/tests/legacy/helpers/test_utils.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils.js
@@ -11,17 +11,17 @@ odoo.define('web.test_utils', async function (require) {
      */
 
     const session = require('web.session');
-    const testUtilsCreate = require('web.test_utils_create');
-    const testUtilsControlPanel = require('web.test_utils_control_panel');
-    const testUtilsDom = require('web.test_utils_dom');
-    const testUtilsFields = require('web.test_utils_fields');
-    const testUtilsFile = require('web.test_utils_file');
-    const testUtilsForm = require('web.test_utils_form');
-    const testUtilsGraph = require('web.test_utils_graph');
-    const testUtilsKanban = require('web.test_utils_kanban');
-    const testUtilsMock = require('web.test_utils_mock');
-    const testUtilsModal = require('web.test_utils_modal');
-    const testUtilsPivot = require('web.test_utils_pivot');
+    const testUtilsCreate = require('@web/../tests/legacy/helpers/test_utils_create');
+    const testUtilsControlPanel = require('@web/../tests/legacy/helpers/test_utils_control_panel');
+    const testUtilsDom = require('@web/../tests/legacy/helpers/test_utils_dom');
+    const testUtilsFields = require('@web/../tests/legacy/helpers/test_utils_fields');
+    const testUtilsFile = require('@web/../tests/legacy/helpers/test_utils_file');
+    const testUtilsForm = require('@web/../tests/legacy/helpers/test_utils_form');
+    const testUtilsGraph = require('@web/../tests/legacy/helpers/test_utils_graph');
+    const testUtilsKanban = require('@web/../tests/legacy/helpers/test_utils_kanban');
+    const testUtilsMock = require('@web/../tests/legacy/helpers/test_utils_mock');
+    const testUtilsModal = require('@web/../tests/legacy/helpers/test_utils_modal');
+    const testUtilsPivot = require('@web/../tests/legacy/helpers/test_utils_pivot');
     const tools = require('web.tools');
 
 

--- a/addons/web/static/tests/legacy/helpers/test_utils_control_panel.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_control_panel.js
@@ -1,7 +1,7 @@
-/** @odoo-module alias=web.test_utils_control_panel **/
+/** @odoo-module **/
     
-    import { click, findItem, getNode, triggerEvent } from "web.test_utils_dom";
-    import { editInput, editSelect, editAndTrigger } from "web.test_utils_fields";
+    import { click, findItem, getNode, triggerEvent } from "./test_utils_dom";
+    import { editInput, editSelect, editAndTrigger } from "./test_utils_fields";
 
     //-------------------------------------------------------------------------
     // Exported functions
@@ -12,7 +12,7 @@
      * @param {(number|string)} menuFinder
      * @returns {Promise}
      */
-    async function toggleMenu(el, menuFinder) {
+    export async function toggleMenu(el, menuFinder) {
         const menu = findItem(el, `.dropdown > button`, menuFinder);
         await click(menu);
     }
@@ -22,7 +22,7 @@
      * @param {(number|string)} itemFinder
      * @returns {Promise}
      */
-    async function toggleMenuItem(el, itemFinder) {
+    export async function toggleMenuItem(el, itemFinder) {
         const item = findItem(el, `.o_menu_item > a`, itemFinder);
         await click(item);
     }
@@ -33,7 +33,7 @@
      * @param {(number|string)} optionFinder
      * @returns {Promise}
      */
-    async function toggleMenuItemOption(el, itemFinder, optionFinder) {
+    export async function toggleMenuItemOption(el, itemFinder, optionFinder) {
         const item = findItem(el, `.o_menu_item > a`, itemFinder);
         const option = findItem(item.parentNode, '.o_item_option > a', optionFinder);
         await click(option);
@@ -44,7 +44,7 @@
      * @param {(number|string)} itemFinder
      * @returns {boolean}
      */
-    function isItemSelected(el, itemFinder) {
+    export function isItemSelected(el, itemFinder) {
         const item = findItem(el, `.o_menu_item > a`, itemFinder);
         return item.classList.contains('selected');
     }
@@ -55,7 +55,7 @@
      * @param {(number|string)} optionFinder
      * @returns {boolean}
      */
-    function isOptionSelected(el, itemFinder, optionFinder) {
+    export function isOptionSelected(el, itemFinder, optionFinder) {
         const item = findItem(el, `.o_menu_item > a`, itemFinder);
         const option = findItem(item.parentNode, '.o_item_option > a', optionFinder);
         return option.classList.contains('selected');
@@ -65,7 +65,7 @@
      * @param {EventTarget} el
      * @returns {string[]}
      */
-    function getMenuItemTexts(el) {
+    export function getMenuItemTexts(el) {
         return [...getNode(el).querySelectorAll(`.dropdown ul .o_menu_item`)].map(
             e => e.innerText.trim()
         );
@@ -75,7 +75,7 @@
      * @param {EventTarget} el
      * @returns {HTMLButtonElement[]}
      */
-    function getButtons(el) {
+    export function getButtons(el) {
         return [...getNode(el).querySelector((`div.o_cp_bottom div.o_cp_buttons`)).children];
     }
 
@@ -83,7 +83,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleFilterMenu(el) {
+    export async function toggleFilterMenu(el) {
         await click(getNode(el).querySelector(`.o_filter_menu button`));
     }
 
@@ -91,7 +91,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleAddCustomFilter(el) {
+    export async function toggleAddCustomFilter(el) {
         await click(getNode(el).querySelector(`button.o_add_custom_filter`));
     }
 
@@ -99,7 +99,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function applyFilter(el) {
+    export async function applyFilter(el) {
         await click(getNode(el).querySelector(`div.o_add_filter_menu > button.o_apply_filter`));
     }
 
@@ -107,7 +107,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function addCondition(el) {
+    export async function addCondition(el) {
         await click(getNode(el).querySelector(`div.o_add_filter_menu > button.o_add_condition`));
     }
 
@@ -115,7 +115,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleGroupByMenu(el) {
+    export async function toggleGroupByMenu(el) {
         await click(getNode(el).querySelector(`.o_group_by_menu button`));
     }
 
@@ -123,7 +123,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleAddCustomGroup(el) {
+    export async function toggleAddCustomGroup(el) {
         await click(getNode(el).querySelector(`span.o_add_custom_group_by`));
     }
 
@@ -132,7 +132,7 @@
      * @param {string} fieldName
      * @returns {Promise}
      */
-    async function selectGroup(el, fieldName) {
+    export async function selectGroup(el, fieldName) {
         await editSelect(
             getNode(el).querySelector(`select.o_group_by_selector`),
             fieldName
@@ -143,7 +143,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function applyGroup(el) {
+    export async function applyGroup(el) {
         await click(getNode(el).querySelector(`div.o_add_group_by_menu > button.o_apply_group_by`));
     }
 
@@ -151,7 +151,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleFavoriteMenu(el) {
+    export async function toggleFavoriteMenu(el) {
         await click(getNode(el).querySelector(`.o_favorite_menu button`));
     }
 
@@ -159,7 +159,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleSaveFavorite(el) {
+    export async function toggleSaveFavorite(el) {
         await click(getNode(el).querySelector(`.o_favorite_menu .o_add_favorite .dropdown-item`));
     }
 
@@ -168,7 +168,7 @@
      * @param {string} name
      * @returns {Promise}
      */
-    async function editFavoriteName(el, name) {
+    export async function editFavoriteName(el, name) {
         await editInput(getNode(el).querySelector(`.o_favorite_menu .o_add_favorite input[type="text"]`), name);
     }
 
@@ -176,7 +176,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function saveFavorite(el) {
+    export async function saveFavorite(el) {
         await click(getNode(el).querySelector(`.o_favorite_menu .o_add_favorite button.o_save_favorite`));
     }
 
@@ -185,7 +185,7 @@
      * @param {(string|number)} favoriteFinder
      * @returns {Promise}
      */
-    async function deleteFavorite(el, favoriteFinder) {
+    export async function deleteFavorite(el, favoriteFinder) {
         const favorite = findItem(el, `.o_favorite_menu .o_menu_item`, favoriteFinder);
         await click(favorite.querySelector('i.fa-trash'));
     }
@@ -194,7 +194,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function toggleComparisonMenu(el) {
+    export async function toggleComparisonMenu(el) {
         await click(getNode(el).querySelector(`div.o_comparison_menu > button`));
     }
 
@@ -202,7 +202,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    function getFacetTexts(el) {
+    export function getFacetTexts(el) {
         return [...getNode(el).querySelectorAll(`.o_searchview .o_searchview_facet`)].map(
             facet => facet.innerText.trim()
         );
@@ -213,7 +213,7 @@
      * @param {(string|number)} facetFinder
      * @returns {Promise}
      */
-    async function removeFacet(el, facetFinder = 0) {
+    export async function removeFacet(el, facetFinder = 0) {
         const facet = findItem(el, `.o_searchview .o_searchview_facet`, facetFinder);
         await click(facet.querySelector('.o_facet_remove'));
     }
@@ -223,7 +223,7 @@
      * @param {string} value
      * @returns {Promise}
      */
-    async function editSearch(el, value) {
+    export async function editSearch(el, value) {
         await editInput(getNode(el).querySelector(`.o_searchview_input`), value);
     }
 
@@ -231,7 +231,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function validateSearch(el) {
+    export async function validateSearch(el) {
         await triggerEvent(
             getNode(el).querySelector(`.o_searchview_input`),
             'keydown', { key: 'Enter' }
@@ -243,7 +243,7 @@
      * @param {string} [menuFinder="Action"]
      * @returns {Promise}
      */
-    async function toggleActionMenu(el, menuFinder = "Action") {
+    export async function toggleActionMenu(el, menuFinder = "Action") {
         const dropdown = findItem(el, `.o_cp_action_menus button`, menuFinder);
         await click(dropdown);
     }
@@ -252,7 +252,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function pagerPrevious(el) {
+    export async function pagerPrevious(el) {
         await click(getNode(el).querySelector(`.o_pager button.o_pager_previous`));
     }
 
@@ -260,7 +260,7 @@
      * @param {EventTarget} el
      * @returns {Promise}
      */
-    async function pagerNext(el) {
+    export async function pagerNext(el) {
         await click(getNode(el).querySelector(`.o_pager button.o_pager_next`));
     }
 
@@ -268,7 +268,7 @@
      * @param {EventTarget} el
      * @returns {string}
      */
-    function getPagerValue(el) {
+    export function getPagerValue(el) {
         const pagerValue = getNode(el).querySelector(`.o_pager_counter .o_pager_value`);
         switch (pagerValue.tagName) {
             case 'INPUT':
@@ -282,7 +282,7 @@
      * @param {EventTarget} el
      * @returns {string}
      */
-    function getPagerSize(el) {
+    export function getPagerSize(el) {
         return getNode(el).querySelector(`.o_pager_counter span.o_pager_limit`).innerText.trim();
     }
 
@@ -291,7 +291,7 @@
      * @param {string} value
      * @returns {Promise}
      */
-    async function setPagerValue(el, value) {
+    export async function setPagerValue(el, value) {
         let pagerValue = getNode(el).querySelector(`.o_pager_counter .o_pager_value`);
         if (pagerValue.tagName === 'SPAN') {
             await click(pagerValue);
@@ -308,51 +308,6 @@
      * @param {string} viewType
      * @returns {Promise}
      */
-    async function switchView(el, viewType) {
+    export async function switchView(el, viewType) {
         await click(getNode(el).querySelector(`button.o_switch_view.o_${viewType}`));
     }
-
-    export default {
-        // Generic interactions
-        toggleMenu,
-        toggleMenuItem,
-        toggleMenuItemOption,
-        isItemSelected,
-        isOptionSelected,
-        getMenuItemTexts,
-        // Button interactions
-        getButtons,
-        // FilterMenu interactions
-        toggleFilterMenu,
-        toggleAddCustomFilter,
-        applyFilter,
-        addCondition,
-        // GroupByMenu interactions
-        toggleGroupByMenu,
-        toggleAddCustomGroup,
-        selectGroup,
-        applyGroup,
-        // FavoriteMenu interactions
-        toggleFavoriteMenu,
-        toggleSaveFavorite,
-        editFavoriteName,
-        saveFavorite,
-        deleteFavorite,
-        // ComparisonMenu interactions
-        toggleComparisonMenu,
-        // SearchBar interactions
-        getFacetTexts,
-        removeFacet,
-        editSearch,
-        validateSearch,
-        // Action menus interactions
-        toggleActionMenu,
-        // Pager interactions
-        pagerPrevious,
-        pagerNext,
-        getPagerValue,
-        getPagerSize,
-        setPagerValue,
-        // View switcher
-        switchView,
-    };

--- a/addons/web/static/tests/legacy/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_dom.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_dom **/
+/** @odoo-module **/
     
     import concurrency from "web.concurrency";
     import Widget from "web.Widget";
@@ -131,7 +131,7 @@
      * @param {boolean} [options.last=false] if true, clicks on the last element
      * @returns {Promise}
      */
-    async function click(el, options = {}) {
+    export async function click(el, options = {}) {
         let matches, target;
         let selectorMsg = "";
         if (typeof el === 'string') {
@@ -188,7 +188,7 @@
      *   element event if it is invisible
      * @returns {Promise}
      */
-    async function clickFirst(el, options) {
+    export async function clickFirst(el, options) {
         return click(el, Object.assign({}, options, { first: true }));
     }
 
@@ -203,7 +203,7 @@
      *   element event if it is invisible
      * @returns {Promise}
      */
-    async function clickLast(el, options) {
+    export async function clickLast(el, options) {
         return click(el, Object.assign({}, options, { last: true }));
     }
 
@@ -237,7 +237,7 @@
      * @param {jQuery|EventTarget} [options.ctrlKey=undefined] if the ctrl key should be considered pressed at the time of mouseup
      * @returns {Promise}
      */
-    async function dragAndDrop($el, $to, options) {
+    export async function dragAndDrop($el, $to, options) {
         let el = null;
         if (_isEventTarget($el)) {
             el = $el;
@@ -323,7 +323,7 @@
      * @param {number | string} [elFinder=0]
      * @returns {Element | null}
      */
-    function findItem(el, selector, elFinder = 0) {
+    export function findItem(el, selector, elFinder = 0) {
         const elements = [...getNode(el).querySelectorAll(selector)];
         if (!elements.length) {
             throw new Error(`No element found with selector "${selector}".`);
@@ -367,7 +367,7 @@
      * @param {(Component|Widget|jQuery|HTMLCollection|HTMLElement|string)} target
      * @returns {EventTarget}
      */
-    function getNode(target) {
+    export function getNode(target) {
         let nodes;
         if (target instanceof Component || target instanceof Widget) {
             nodes = [target.el];
@@ -398,7 +398,7 @@
      *
      * @param {jQuery} $datepickerEl element to which a datepicker is attached
      */
-    async function openDatepicker($datepickerEl) {
+    export async function openDatepicker($datepickerEl) {
         return click($datepickerEl.find('.o_datepicker_input'));
     }
 
@@ -410,7 +410,7 @@
      *
      * @returns {Promise}
      */
-    async function returnAfterNextAnimationFrame() {
+    export async function returnAfterNextAnimationFrame() {
         await concurrency.delay(0);
         await new Promise(resolve => {
             window.requestAnimationFrame(resolve);
@@ -430,7 +430,7 @@
      * @param {Boolean} [fast=false] true if the trigger event have to wait for a single tick instead of waiting for the next animation frame
      * @returns {Promise}
      */
-    async function triggerEvent(el, eventType, eventAttrs = {}, fast = false) {
+    export async function triggerEvent(el, eventType, eventAttrs = {}, fast = false) {
         let matches;
         let selectorMsg = "";
         if (_isEventTarget(el)) {
@@ -469,7 +469,7 @@
      * @param {string[]} events the events you want to trigger
      * @returns {Promise}
      */
-    async function triggerEvents(el, events) {
+    export async function triggerEvents(el, events) {
         if (el instanceof jQuery) {
             if (el.length !== 1) {
                 throw new Error(`target has length ${el.length} instead of 1`);
@@ -490,7 +490,7 @@
      * @param {string} char the character, or 'ENTER'
      * @returns {Promise}
      */
-    async function triggerKeypressEvent(char) {
+    export async function triggerKeypressEvent(char) {
         let keycode;
         if (char === 'Enter') {
             keycode = $.ui.keyCode.ENTER;
@@ -515,7 +515,7 @@
      * @param {string} type a mouse event type, such as 'mousedown' or 'mousemove'
      * @returns {Promise}
      */
-    async function triggerMouseEvent($el, type) {
+    export async function triggerMouseEvent($el, type) {
         const el = $el instanceof jQuery ? $el[0] : $el;
         if (!el) {
             throw new Error(`no target found to trigger MouseEvent`);
@@ -538,7 +538,7 @@
      * @param {string} type a mouse event type, such as 'mousedown' or 'mousemove'
      * @returns {HTMLElement}
      */
-    async function triggerPositionalMouseEvent(x, y, type) {
+    export async function triggerPositionalMouseEvent(x, y, type) {
         const ev = document.createEvent("MouseEvent");
         const el = document.elementFromPoint(x, y);
         ev.initMouseEvent(
@@ -561,7 +561,7 @@
      * @param {number} y
      * @returns {HTMLElement}
      */
-    async function triggerPositionalTapEvents(x, y) {
+    export async function triggerPositionalTapEvents(x, y) {
         const element = document.elementFromPoint(x, y);
         const touch = new Touch({
             identifier: 0,
@@ -586,20 +586,3 @@
         });
         return element;
     }
-
-    export default {
-        click,
-        clickFirst,
-        clickLast,
-        dragAndDrop,
-        findItem,
-        getNode,
-        openDatepicker,
-        returnAfterNextAnimationFrame,
-        triggerEvent,
-        triggerEvents,
-        triggerKeypressEvent,
-        triggerMouseEvent,
-        triggerPositionalMouseEvent,
-        triggerPositionalTapEvents,
-    };

--- a/addons/web/static/tests/legacy/helpers/test_utils_fields.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_fields.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_fields **/
+/** @odoo-module **/
     
     /**
      * Field Test Utils
@@ -9,7 +9,7 @@
      * testUtils file.
      */
 
-    import testUtilsDom from "web.test_utils_dom";
+    import { click, triggerEvent, triggerEvents } from "./test_utils_dom";
 
     const ARROW_KEYS_MAPPING = {
         down: 'ArrowDown',
@@ -29,7 +29,7 @@
      * @param {string} text Used as default value for the record name
      * @see clickM2OItem
      */
-    async function clickM2OCreateAndEdit(fieldName, text = "ABC") {
+    export async function clickM2OCreateAndEdit(fieldName, text = "ABC") {
         await clickOpenM2ODropdown(fieldName);
         const match = document.querySelector(`.o_field_many2one[name=${fieldName}] input`);
         await editInput(match, text);
@@ -44,11 +44,11 @@
      *    input
      * @returns {Promise}
      */
-    async function clickM2OHighlightedItem(fieldName, selector) {
+    export async function clickM2OHighlightedItem(fieldName, selector) {
         const m2oSelector = `${selector || ''} .o_field_many2one[name=${fieldName}] input`;
         const $dropdown = $(m2oSelector).autocomplete('widget');
         // clicking on an li (no matter which one), will select the focussed one
-        return testUtilsDom.click($dropdown[0].querySelector('li'));
+        return click($dropdown[0].querySelector('li'));
     }
 
     /**
@@ -63,7 +63,7 @@
      * @param {string} searchText
      * @returns {Promise}
      */
-    async function clickM2OItem(fieldName, searchText) {
+    export async function clickM2OItem(fieldName, searchText) {
         const m2oSelector = `.o_field_many2one[name=${fieldName}] input`;
         const $dropdown = $(m2oSelector).autocomplete('widget');
         const $target = $dropdown.find(`li:contains(${searchText})`).first();
@@ -71,7 +71,7 @@
             throw new Error('Menu item should be visible');
         }
         $target.mouseenter(); // This is NOT a mouseenter event. See jquery.js:5516 for more headaches.
-        return testUtilsDom.click($target);
+        return click($target);
     }
 
     /**
@@ -82,14 +82,14 @@
      *    input
      * @returns {Promise<HTMLInputElement>} the main many2one input
      */
-    async function clickOpenM2ODropdown(fieldName, selector) {
+    export async function clickOpenM2ODropdown(fieldName, selector) {
         const m2oSelector = `${selector || ''} .o_field_many2one[name=${fieldName}] input`;
         const matches = document.querySelectorAll(m2oSelector);
         if (matches.length !== 1) {
             throw new Error(`cannot open m2o: selector ${selector} has been found ${matches.length} instead of 1`);
         }
 
-        await testUtilsDom.click(matches[0]);
+        await click(matches[0]);
         return matches[0];
     }
 
@@ -105,7 +105,7 @@
      * @param {string[]} events
      * @returns {Promise}
      */
-    async function editAndTrigger(el, value, events) {
+    export async function editAndTrigger(el, value, events) {
         if (el instanceof jQuery) {
             if (el.length !== 1) {
                 throw new Error(`target ${el.selector} has length ${el.length} instead of 1`);
@@ -114,7 +114,7 @@
         } else {
             el.value = value;
         }
-        return testUtilsDom.triggerEvents(el, events);
+        return triggerEvents(el, events);
     }
 
     /**
@@ -129,7 +129,7 @@
      * @param {string|number} value
      * @returns {Promise}
      */
-    async function editInput(el, value) {
+    export async function editInput(el, value) {
         return editAndTrigger(el, value, ['input']);
     }
 
@@ -145,7 +145,7 @@
      * @param {string|number} value
      * @returns {Promise}
      */
-    function editSelect(el, value) {
+    export function editSelect(el, value) {
         return editAndTrigger(el, value, ['change']);
     }
 
@@ -166,7 +166,7 @@
      * @param {[string]} [options.item]
      * @returns {Promise}
      */
-    async function searchAndClickM2OItem(fieldName, options = {}) {
+    export async function searchAndClickM2OItem(fieldName, options = {}) {
         const input = await clickOpenM2ODropdown(fieldName, options.selector);
         if (options.search) {
             await editInput(input, options.search);
@@ -188,7 +188,7 @@
      *   char to get a letter key- and convert it into a keyCode.
      * @returns {Promise}
      */
-    function triggerKey(type, $el, keyCode) {
+    export function triggerKey(type, $el, keyCode) {
         type = 'key' + type;
         const params = {};
         if (typeof keyCode === 'string') {
@@ -208,7 +208,7 @@
         }
         params.keyCode = keyCode;
         params.which = keyCode;
-        return testUtilsDom.triggerEvent($el, type, params);
+        return triggerEvent($el, type, params);
     }
 
     /**
@@ -218,7 +218,7 @@
      * @param {number|string} keyCode @see triggerKey
      * @returns {Promise}
      */
-    function triggerKeydown($el, keyCode) {
+    export function triggerKeydown($el, keyCode) {
         return triggerKey('down', $el, keyCode);
     }
 
@@ -229,20 +229,6 @@
      * @param {number|string} keyCode @see triggerKey
      * @returns {Promise}
      */
-    function triggerKeyup($el, keyCode) {
+    export function triggerKeyup($el, keyCode) {
         return triggerKey('up', $el, keyCode);
     }
-
-    export default {
-        clickM2OCreateAndEdit,
-        clickM2OHighlightedItem,
-        clickM2OItem,
-        clickOpenM2ODropdown,
-        editAndTrigger,
-        editInput,
-        editSelect,
-        searchAndClickM2OItem,
-        triggerKey,
-        triggerKeydown,
-        triggerKeyup,
-    };

--- a/addons/web/static/tests/legacy/helpers/test_utils_file.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_file.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_file **/
+/** @odoo-module **/
 
 /**
  * FILE Test Utils
@@ -48,7 +48,7 @@ function _createFakeDataTransfer(files) {
  * @param {string} data.contentType
  * @returns {Promise<Object>} resolved with file created
  */
-function createFile(data) {
+export function createFile(data) {
     // Note: this is only supported by Chrome, and does not work in Incognito mode
     return new Promise(function (resolve, reject) {
         var requestFileSystem = window.requestFileSystem || window.webkitRequestFileSystem;
@@ -78,7 +78,7 @@ function createFile(data) {
  * @param {$.Element} $el
  * @param {Object} file must have been created beforehand (@see createFile)
  */
-function dragoverFile($el, file) {
+export function dragoverFile($el, file) {
     var ev = new Event('dragover', { bubbles: true });
     Object.defineProperty(ev, 'dataTransfer', {
         value: _createFakeDataTransfer(file),
@@ -92,7 +92,7 @@ function dragoverFile($el, file) {
  * @param {$.Element} $el
  * @param {Object} file must have been created beforehand (@see createFile)
  */
-function dropFile($el, file) {
+export function dropFile($el, file) {
     var ev = new Event('drop', { bubbles: true, });
     Object.defineProperty(ev, 'dataTransfer', {
         value: _createFakeDataTransfer([file]),
@@ -106,7 +106,7 @@ function dropFile($el, file) {
  * @param {$.Element} $el
  * @param {Object[]} files must have been created beforehand (@see createFile)
  */
-function dropFiles($el, files) {
+export function dropFiles($el, files) {
     var ev = new Event('drop', { bubbles: true, });
     Object.defineProperty(ev, 'dataTransfer', {
         value: _createFakeDataTransfer(files),
@@ -121,7 +121,7 @@ function dropFiles($el, files) {
  * @param {Object[]} files must have been created beforehand
  *   @see testUtils.file.createFile
  */
-function inputFiles(el, files) {
+export function inputFiles(el, files) {
     // could not use _createFakeDataTransfer as el.files assignation will only
     // work with a real FileList object.
     const dataTransfer = new window.DataTransfer();
@@ -141,15 +141,3 @@ function inputFiles(el, files) {
         el.dispatchEvent(new Event('change'));
     }
 }
-
-//------------------------------------------------------------------------------
-// Exposed API
-//------------------------------------------------------------------------------
-
-export default {
-    createFile: createFile,
-    dragoverFile: dragoverFile,
-    dropFile: dropFile,
-    dropFiles,
-    inputFiles,
-};

--- a/addons/web/static/tests/legacy/helpers/test_utils_form.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_form.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_form **/
+/** @odoo-module **/
 
 /**
  * Form Test Utils
@@ -9,7 +9,7 @@
  * testUtils file.
  */
 
-import testUtilsDom from "web.test_utils_dom";
+import { click } from "./test_utils_dom";
 
 /**
  * Clicks on the Edit button in a form view, to set it to edit mode. Note that
@@ -18,8 +18,8 @@ import testUtilsDom from "web.test_utils_dom";
  *
  * @param {FormController} form
  */
-function clickEdit(form) {
-    return testUtilsDom.click(form.$buttons.find('.o_form_button_edit'));
+export function clickEdit(form) {
+    return click(form.$buttons.find('.o_form_button_edit'));
 }
 
 /**
@@ -28,8 +28,8 @@ function clickEdit(form) {
  *
  * @param {FormController} form
  */
-function clickSave(form) {
-    return testUtilsDom.click(form.$buttons.find('.o_form_button_save'));
+export function clickSave(form) {
+    return click(form.$buttons.find('.o_form_button_save'));
 }
 
 /**
@@ -38,8 +38,8 @@ function clickSave(form) {
  *
  * @param {FormController} form
  */
-function clickCreate(form) {
-    return testUtilsDom.click(form.$buttons.find('.o_form_button_create'));
+export function clickCreate(form) {
+    return click(form.$buttons.find('.o_form_button_create'));
 }
 
 /**
@@ -48,8 +48,8 @@ function clickCreate(form) {
  *
  * @param {FormController} form
  */
-function clickDiscard(form) {
-    return testUtilsDom.click(form.$buttons.find('.o_form_button_cancel'));
+export function clickDiscard(form) {
+    return click(form.$buttons.find('.o_form_button_cancel'));
 }
 
 /**
@@ -58,14 +58,6 @@ function clickDiscard(form) {
  * @param {FormController} form
  * @param {[Object]} params given to the controller reload method
  */
-function reload(form, params) {
+export function reload(form, params) {
     return form.reload(params);
 }
-
-export default {
-    clickEdit: clickEdit,
-    clickSave: clickSave,
-    clickCreate: clickCreate,
-    clickDiscard: clickDiscard,
-    reload: reload,
-};

--- a/addons/web/static/tests/legacy/helpers/test_utils_graph.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_graph.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_graph **/
+/** @odoo-module **/
 
 /**
  * Graph Test Utils
@@ -16,10 +16,6 @@
  * @param {GraphController} graph
  * @param {[Object]} params given to the controller reload method
  */
-function reload(graph, params) {
+export function reload(graph, params) {
     return graph.reload(params);
 }
-
-export default {
-    reload: reload,
-};

--- a/addons/web/static/tests/legacy/helpers/test_utils_kanban.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_kanban.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_kanban **/
+/** @odoo-module **/
 
 /**
  * Kanban Test Utils
@@ -9,8 +9,8 @@
  * testUtils file.
  */
 
-import testUtilsDom from "web.test_utils_dom";
-import testUtilsFields from "web.test_utils_fields";
+import { click } from "./test_utils_dom";
+import { editAndTrigger } from "./test_utils_fields";
 
 /**
  * Clicks on the Create button in a kanban view. Note that this method checks that
@@ -19,8 +19,8 @@ import testUtilsFields from "web.test_utils_fields";
  * @param {KanbanController} kanban
  * @returns {Promise}
  */
-function clickCreate(kanban) {
-    return testUtilsDom.click(kanban.$buttons.find('.o-kanban-button-new'));
+export function clickCreate(kanban) {
+    return click(kanban.$buttons.find('.o-kanban-button-new'));
 }
 
 /**
@@ -29,12 +29,12 @@ function clickCreate(kanban) {
  * @param {jQuery} $column
  * @returns {Promise}
  */
-function toggleGroupSettings($column) {
+export function toggleGroupSettings($column) {
     var $dropdownToggler = $column.find('.o_kanban_config > a.dropdown-toggle');
     if (!$dropdownToggler.is(':visible')) {
         $dropdownToggler.css('display', 'block');
     }
-    return testUtilsDom.click($dropdownToggler);
+    return click($dropdownToggler);
 }
 
 /**
@@ -46,7 +46,7 @@ function toggleGroupSettings($column) {
  * @param {[string]} fieldName
  * @returns {Promise}
  */
-function quickCreate(kanban, value, fieldName) {
+export function quickCreate(kanban, value, fieldName) {
     var additionalSelector = fieldName ? ('[name=' + fieldName + ']'): '';
     var enterEvent = $.Event(
         'keydown',
@@ -55,7 +55,7 @@ function quickCreate(kanban, value, fieldName) {
             keyCode: $.ui.keyCode.ENTER,
         }
     );
-    return testUtilsFields.editAndTrigger(
+    return editAndTrigger(
         kanban.$('.o_kanban_quick_create input' + additionalSelector),
         value,
         ['input', enterEvent]
@@ -69,7 +69,7 @@ function quickCreate(kanban, value, fieldName) {
  * @param {[Object]} params given to the controller reload method
  * @returns {Promise}
  */
-function reload(kanban, params) {
+export function reload(kanban, params) {
     return kanban.reload(params);
 }
 
@@ -81,19 +81,10 @@ function reload(kanban, params) {
  * @param {jQuery} $record
  * @returns {Promise}
  */
-function toggleRecordDropdown($record) {
+export function toggleRecordDropdown($record) {
     var $dropdownToggler = $record.find('.o_dropdown_kanban > a.dropdown-toggle');
     if (!$dropdownToggler.is(':visible')) {
         $dropdownToggler.css('display', 'block');
     }
-    return testUtilsDom.click($dropdownToggler);
+    return click($dropdownToggler);
 }
-
-
-export default {
-    clickCreate: clickCreate,
-    quickCreate: quickCreate,
-    reload: reload,
-    toggleGroupSettings: toggleGroupSettings,
-    toggleRecordDropdown: toggleRecordDropdown,
-};

--- a/addons/web/static/tests/legacy/helpers/test_utils_mock.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_mock.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_mock **/
+/** @odoo-module **/
 
 /**
  * Mock Test Utils
@@ -16,8 +16,8 @@ import Bus from "web.Bus";
 import config from "web.config";
 import core from "web.core";
 import dom from "web.dom";
-import makeTestEnvironment from "web.test_env";
-import MockServer from "web.MockServer";
+import { makeTestEnvironment } from "./test_env";
+import { MockServer } from "./mock_server";
 import RamStorage from "web.RamStorage";
 import session from "web.session";
 import { patchWithCleanup, patchDate } from "@web/../tests/helpers/utils";
@@ -256,7 +256,7 @@ function _observe(widget) {
  * @param {string} params.model
  * @returns {Object} an object with 3 keys: arch, fields and viewFields
  */
-function getView(server, params) {
+export function getView(server, params) {
     var view = server.getView(params);
     const fields = server.fieldsGet(params.model);
     // mock the structure produced by the DataManager
@@ -289,7 +289,7 @@ function getView(server, params) {
  * @param {function} fn callback executed when the even is intercepted
  * @param {boolean} [propagate=false]
  */
-function intercept(widget, eventName, fn, propagate) {
+export function intercept(widget, eventName, fn, propagate) {
     var _trigger_up = widget._trigger_up.bind(widget);
     widget._trigger_up = function (event) {
         if (event.name === eventName) {
@@ -326,7 +326,7 @@ function intercept(widget, eventName, fn, propagate) {
  * @param {MockServer} [mockServer]
  * @returns {Promise<function>} the cleanup function
  */
-async function addMockEnvironmentOwl(Component, params, mockServer) {
+export async function addMockEnvironmentOwl(Component, params, mockServer) {
     params = params || {};
 
     // instantiate a mockServer if not provided
@@ -508,7 +508,7 @@ async function addMockEnvironmentOwl(Component, params, mockServer) {
  *   function. It is necessary for createView so that method can call some
  *   other methods on it.
  */
-async function addMockEnvironment(widget, params) {
+export async function addMockEnvironment(widget, params) {
     // log events triggered up if debug flag is true
     if (params.debug) {
         _observe(widget);
@@ -615,6 +615,7 @@ function legacyPatchDate(year, month, day, hours, minutes, seconds) {
     patchDate(year, month, day, hours, minutes, seconds);
     return function () {}; // all calls to that function are now useless
 }
+export { legacyPatchDate as patchDate };
 
 var patches = {};
 /**
@@ -623,7 +624,7 @@ var patches = {};
  * @param {Class|Object} target
  * @param {Object} props
  */
-function patch(target, props) {
+export function patch(target, props) {
     var patchID = _.uniqueId('patch_');
     target.__patchID = patchID;
     patches[patchID] = {
@@ -679,7 +680,7 @@ function patch(target, props) {
  *
  * @param {Class|Object} target
  */
-function unpatch(target) {
+export function unpatch(target) {
     var patchID = target.__patchID;
     var patch = patches[patchID];
     if (target.prototype) {
@@ -702,7 +703,7 @@ function unpatch(target) {
 }
 
 window.originalSetTimeout = window.setTimeout;
-function patchSetTimeout() {
+export function patchSetTimeout() {
     var original = window.setTimeout;
     var self = this;
     window.setTimeout = function (handler, delay) {
@@ -719,14 +720,3 @@ function patchSetTimeout() {
         window.setTimeout = original;
     };
 }
-
-export default {
-    addMockEnvironment: addMockEnvironment,
-    getView: getView,
-    addMockEnvironmentOwl: addMockEnvironmentOwl,
-    intercept: intercept,
-    patchDate: legacyPatchDate,
-    patch: patch,
-    unpatch: unpatch,
-    patchSetTimeout: patchSetTimeout,
-};

--- a/addons/web/static/tests/legacy/helpers/test_utils_modal.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_modal.js
@@ -1,4 +1,4 @@
-/** @odoo-module alias=web.test_utils_modal **/
+/** @odoo-module **/
     
     /**
      * Modal Test Utils
@@ -10,15 +10,13 @@
      */
 
     import { _t } from "web.core";
-    import testUtilsDom from "web.test_utils_dom";
+    import { click } from "./test_utils_dom";
 
     /**
      * Click on a button in the footer of a modal (which contains a given string).
      *
      * @param {string} text (in english: this method will perform the translation)
      */
-    function clickButton(text) {
-        return testUtilsDom.click($(`.modal-footer button:contains(${_t(text)})`));
+    export function clickButton(text) {
+        return click($(`.modal-footer button:contains(${_t(text)})`));
     }
-
-    export default { clickButton };

--- a/addons/web/static/tests/legacy/helpers/test_utils_pivot.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_pivot.js
@@ -1,6 +1,6 @@
-/** @odoo-module alias=web.test_utils_pivot **/
+/** @odoo-module **/
 
-import testUtilsDom from "web.test_utils_dom";
+import { click } from "./test_utils_dom";
 
 /**
  * Pivot Test Utils
@@ -22,8 +22,8 @@ import testUtilsDom from "web.test_utils_dom";
  * @param {PivotController} pivot
  * @param {string} measure
  */
-function clickMeasure(pivot, measure) {
-    return testUtilsDom.click(pivot.$buttons.find(`.dropdown-item[data-field=${measure}]`));
+export function clickMeasure(pivot, measure) {
+    return click(pivot.$buttons.find(`.dropdown-item[data-field=${measure}]`));
 }
 
 /**
@@ -33,8 +33,8 @@ function clickMeasure(pivot, measure) {
  *
  * @param {PivotController} pivot
  */
-function toggleMeasuresDropdown(pivot) {
-    return testUtilsDom.click(pivot.$buttons.filter('.btn-group:first').find('> button'));
+export function toggleMeasuresDropdown(pivot) {
+    return click(pivot.$buttons.filter('.btn-group:first').find('> button'));
 }
 
 /**
@@ -43,12 +43,6 @@ function toggleMeasuresDropdown(pivot) {
  * @param {PivotController} pivot
  * @param {[Object]} params given to the controller reload method
  */
-function reload(pivot, params) {
+export function reload(pivot, params) {
     return pivot.reload(params);
 }
-
-export default {
-    clickMeasure: clickMeasure,
-    reload: reload,
-    toggleMeasuresDropdown: toggleMeasuresDropdown,
-};

--- a/addons/web/static/tests/legacy/mock_relational_fields_tests.js
+++ b/addons/web/static/tests/legacy/mock_relational_fields_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import MockServer from 'web.MockServer';
+import { MockServer } from "@web/../tests/legacy/helpers/mock_server";
 
 QUnit.module('web', {}, function () {
 QUnit.module('legacy', {}, function () {

--- a/addons/web/static/tests/legacy/mockserver_tests.js
+++ b/addons/web/static/tests/legacy/mockserver_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import MockServer from "web.MockServer";
+import { MockServer } from "@web/../tests/legacy/helpers/mock_server";
 
 QUnit.module("Legacy MockServer", {
     beforeEach() {

--- a/addons/web/static/tests/legacy/owl_compatibility_tests.js
+++ b/addons/web/static/tests/legacy/owl_compatibility_tests.js
@@ -11,7 +11,7 @@
     import { LegacyComponent } from "@web/legacy/legacy_component";
     import { mapLegacyEnvToWowlEnv, useWowlService } from "@web/legacy/utils";
 
-    import makeTestEnvironment from "web.test_env";
+    import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
     import { makeTestEnv } from "@web/../tests/helpers/mock_env";
     import { getFixture, mount, useLogLifeCycle, destroy } from "@web/../tests/helpers/utils";
 

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -23,7 +23,7 @@ import { addLegacyMockEnvironment } from "../webclient/helpers";
 import { Component, useSubEnv, xml } from "@odoo/owl";
 
 import { mapLegacyEnvToWowlEnv } from "@web/legacy/utils";
-import makeTestEnvironment from "web.test_env";
+import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
 
 const serviceRegistry = registry.category("services");
 

--- a/addons/web/static/tests/webclient/helpers.js
+++ b/addons/web/static/tests/webclient/helpers.js
@@ -28,7 +28,7 @@ import ActionMenus from "web.ActionMenus";
 import basicFields from "web.basic_fields";
 import Registry from "web.Registry";
 import core from "web.core";
-import makeTestEnvironment from "web.test_env";
+import { makeTestEnvironment } from "@web/../tests/legacy/helpers/test_env";
 import { registerCleanup } from "../helpers/cleanup";
 import { makeTestEnv } from "../helpers/mock_env";
 import {
@@ -47,7 +47,7 @@ import {
     patchWithCleanup,
 } from "../helpers/utils";
 import session from "web.session";
-import LegacyMockServer from "web.MockServer";
+import { MockServer as LegacyMockServer } from "@web/../tests/legacy/helpers/mock_server";
 import Widget from "web.Widget";
 import { uiService } from "@web/core/ui/ui_service";
 import { ClientActionAdapter } from "@web/legacy/action_adapters";

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -1,7 +1,7 @@
 /** @odoo-module alias=web_editor.test_utils **/
 
 import ajax from "web.ajax";
-import MockServer from "web.MockServer";
+import { MockServer } from "@web/../tests/legacy/helpers/mock_server";
 import testUtils from "web.test_utils";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
 import Widget from "web.Widget";


### PR DESCRIPTION
This commit removes the alias of the module in web/tests/legacy in favor of the file path like @web/../tests/legacy/test_env. `export default`s that were used in these modules are converted to simple `export` and their associated `import` are also adapted.

task id: 3162300