### PR TITLE
[WIP][FIX] web: display correct remaining days for different timezones

### DIFF
--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.js
@@ -22,7 +22,7 @@ export class RemainingDaysField extends Component {
         if (!this.props.value) {
             return null;
         }
-        const today = luxon.DateTime.local().startOf("day");
+        const today = luxon.DateTime.local().toUTC().startOf("day");
         return Math.floor(this.props.value.startOf("day").diff(today, "days").days);
     }
 


### PR DESCRIPTION
Steps to reproduce:
-Go to purchase app for exemple with (demo data loaded) -Change computer timezone setting
(to gmt+12 if it's the afternoon else gmt-12)
-Refresh the page
-The remaining days (Order deadline) are changed

Bug:
dates are stored in the DB as UTC and are compared to the date in the user timezone

Fix:
restore behaviour of previous version (compare values in the same TZ)

opw-3110122
