### PR TITLE
[FIX] pos_coupon: post push order call

### DIFF
--- a/addons/pos_coupon/static/src/js/PaymentScreen.js
+++ b/addons/pos_coupon/static/src/js/PaymentScreen.js
@@ -8,6 +8,9 @@ odoo.define('pos_coupon.PaymentScreen', function (require) {
     const PosCouponPaymentScreen = (PaymentScreen) =>
         class extends PaymentScreen {
             async _postPushOrderResolve(order, server_ids) {
+                if(this.env.pos.coupon_programs.length === 0) {
+                    return super._postPushOrderResolve(order, server_ids);
+                }
                 const bookedCouponIds = new Set(
                     Object.values(order.bookedCouponCodes)
                         .map((couponCode) => couponCode.coupon_id)


### PR DESCRIPTION
Before, when pos coupon was installed, some code was running even if the module was not enabled in the config.
Now we check if we're using coupons before executing the function.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
