### PR TITLE
[FIX] account: Correct chart installation error due to missing country field

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3747,6 +3747,15 @@ msgid "Control-Access"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/res_config_settings.py:0
+#, python-format
+msgid ""
+"Contry field is missing in company \n"
+"Please go to Company setting."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__product_uom_category_id
 msgid ""
 "Conversion between Units of Measure can only occur if they belong to the "


### PR DESCRIPTION
When we create a new company and the country of the company is left empty save the record Now switch to new company open `invoicing`, then configuration, and open setting. now select any `package` in Fiscal Localization drop-down and click on save.
Traceback will be generated.

Step to Produce:-
- Install Invoicing
- Create new company and left country field empty and save the record
- Now switch to new created company
- Open Invoicing
- the configuration and open setting
- Select and package from the dropdown located in fiscal Localization.
- Click on save
- Traceback is generated `key error: res.partner.phone_sanitized `

See:-
![image](https://user-images.githubusercontent.com/91726130/230618687-c64325ce-a22c-488a-bdb4-c6c0450d45f1.png)

Fix:-
I fixed the issue by checking if the country is set on the company. If not, a RedirectWarning is raised, prompting the user to set the country in Company settings and redirect them to the company form view.

sentry-4055181639