### PR TITLE
[IMP] website_event: filters on multi website

### DIFF
--- a/addons/event/views/event_tag_views.xml
+++ b/addons/event/views/event_tag_views.xml
@@ -58,7 +58,7 @@
                 <tree string="Event Tags Categories">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
-                    <field name="category_id"/>
+                    <field name="category_id" options="{'no_quick_create':True}"/>
                     <field name="color" widget="color_picker"/>
                 </tree>
             </field>
@@ -72,7 +72,7 @@
                     <sheet>
                         <group>
                             <field name="name"/>
-                            <field name="category_id" widget="many2one"/>
+                            <field name="category_id" options="{'no_quick_create':True}" widget="many2one"/>
                             <field name="color" widget="color_picker"/>
                         </group>
                     </sheet>

--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -31,6 +31,7 @@
         'views/event_question_views.xml',
         'views/event_registration_answer_views.xml',
         'views/event_tag_category_views.xml',
+        'views/event_tag_views.xml',
         'views/event_type_views.xml',
         'views/website_event_menu_views.xml',
         'views/website_visitor_views.xml',

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -117,7 +117,9 @@ class WebsiteEventController(http.Controller):
             'current_type': current_type,
             'event_ids': events,  # event_ids used in website_event_track so we keep name as it is
             'dates': dates,
-            'categories': request.env['event.tag.category'].search([('is_published', '=', True)]),
+            'categories': request.env['event.tag.category'].search([
+                ('is_published', '=', True), '|', ('website_id', '=', website.id), ('website_id', '=', False)
+            ]),
             'countries': countries,
             'pager': pager,
             'searches': searches,
@@ -125,6 +127,7 @@ class WebsiteEventController(http.Controller):
             'keep': keep,
             'search_count': event_count,
             'original_search': fuzzy_search_term and search,
+            'website': website
         }
 
         if searches['date'] == 'old':

--- a/addons/website_event/models/__init__.py
+++ b/addons/website_event/models/__init__.py
@@ -7,6 +7,7 @@ from . import event_question_answer
 from . import event_registration
 from . import event_registration_answer
 from . import event_tag_category
+from . import event_tag
 from . import event_type
 from . import website
 from . import website_event_menu

--- a/addons/website_event/models/event_tag.py
+++ b/addons/website_event/models/event_tag.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class EventTag(models.Model):
+    _name = 'event.tag'
+    _inherit = ['event.tag', 'website.published.multi.mixin']
+
+    def default_get(self, fields_list):
+        result = super().default_get(fields_list)
+        if self.env.context.get('default_website_id'):
+            result['website_id'] = self.env.context.get('default_website_id')
+        return result

--- a/addons/website_event/models/event_tag_category.py
+++ b/addons/website_event/models/event_tag_category.py
@@ -6,7 +6,7 @@ from odoo import models
 
 class EventTagCategory(models.Model):
     _name = 'event.tag.category'
-    _inherit = ['event.tag.category', 'website.published.mixin']
+    _inherit = ['event.tag.category', 'website.published.multi.mixin']
 
     def _default_is_published(self):
         return True

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -8,7 +8,12 @@
         <field name="inherit_id" ref="event.view_event_form"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='right_event_details']/field[@name='company_id']" position="after">
+                <field name="website_id" invisible="1"/>
                 <field name="website_id" options="{'no_create': True}" domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]" groups="website.group_multi_website"/>
+            </xpath>
+            <xpath expr="//field[@name='tag_ids']" position="attributes">
+                <attribute name="context">{'default_website_id': website_id}</attribute>
+                <attribute name="groups">website.group_multi_website</attribute>
             </xpath>
             <div name="button_box" position="inside">
                 <field name="website_url" invisible="1"/>
@@ -74,6 +79,16 @@
                     </field>
                 </page>
             </page>
+              
+            <field name="tag_ids" position="attributes">
+                <attribute name="domain">['|', ('category_id.website_id', '=', website_id), ('category_id.website_id', '=', False)]</attribute>
+                <attribute name="attrs">{'invisible': [('website_id', '=', False)]}</attribute>
+            </field>
+
+            <field name="tag_ids" position="after">
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}" attrs="{'invisible': [('website_id', '!=', False)]}"></field>
+            </field>
+            
         </field>
     </record>
 

--- a/addons/website_event/views/event_tag_category_views.xml
+++ b/addons/website_event/views/event_tag_category_views.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <field name="tag_ids" position="before">
                 <field name="is_published" string="Show on Website" widget="boolean_toggle"/>
+                <field name="website_id" groups="website.group_multi_website" string="Website" attrs="{'invisible': [('is_published', '=', False)]}"/>
             </field>
         </field>
     </record>

--- a/addons/website_event/views/event_tag_views.xml
+++ b/addons/website_event/views/event_tag_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="event_tag_view_form_inherit" model="ir.ui.view">
+        <field name="name">event.tag.view.form.inherit</field>
+        <field name="model">event.tag</field>
+        <field name="inherit_id" ref="event.event_tag_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='category_id']" position="before">
+                <field name="website_id" invisible="1"/>
+            </xpath>
+
+            <xpath expr="//field[@name='category_id']" position="attributes">
+                <attribute name="domain">['|', ('website_id', '=', website_id), ('website_id', '=', False)]</attribute>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -211,7 +211,7 @@
                             <!-- Location -->
                             <div class="o_not_editable" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
                             <div class="mt8">
-                                <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.is_published)" t-as="tag">
+                                <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)" t-as="tag">
                                     <span t-if="tag.color"
                                           t-attf-class="badge mr4 #{'bg-primary' if tag in search_tags else ''} #{'o_tag_color_%s' % tag.color if tag.color else ''}">
                                         <span t-out="tag.name"/>


### PR DESCRIPTION
When having a multiple website filters appear on both website. event_tag_category determines what the filter should be. The problem is if I assign one event_tag_category one website it also appears as filter on other website.
[task-3254058](https://www.odoo.com/web#id=3254058&cids=1&menu_id=3940&action=5050&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
