### PR TITLE
[FIX] account:  default repartition_line_ids creation in taxes

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -40,6 +40,7 @@
                     <field name="sequence" widget="handle"/>
                     <field name="factor_percent" attrs="{'invisible': [('repartition_type', '=', 'base')]}"/>
                     <field name="repartition_type"/>
+                    <field name="document_type" invisible="1"/>
                     <field name="account_id" attrs="{'invisible': [('repartition_type', '=', 'base')]}" options="{'no_create': True}"/>
                     <field name="tag_ids"
                            widget="many2many_tags"
@@ -157,10 +158,13 @@
                             <div attrs="{'invisible': [('amount_type', '=', 'group')]}">
                                 <field name="country_code" invisible="1"/>
                                 <group string="Distribution for Invoices">
-                                    <field name="invoice_repartition_line_ids" nolabel="1" colspan="2"/>
+                                    <field name="invoice_repartition_line_ids" nolabel="1" colspan="2" context="{'default_document_type': 'invoice'}"/>
                                 </group>
                                 <group string="Distribution for Refunds">
-                                    <field name="refund_repartition_line_ids" nolabel="1" colspan="2"/>
+                                    <field name="refund_repartition_line_ids" nolabel="1" colspan="2" context="{'default_document_type': 'refund'}"/>
+                                </group>
+                                <group invisible="1">
+                                    <field name="repartition_line_ids"/>
                                 </group>
                             </div>
                             <field name="children_tax_ids" attrs="{'invisible':['|', ('amount_type','!=','group'), ('type_tax_use','=','none')]}" domain="[('type_tax_use','in',('none',type_tax_use)), ('amount_type','!=','group')]">

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -547,6 +547,13 @@ class TestUi(TestPointOfSaleHttpCommon):
                     'account_id': tax_received_account.id,
                 }),
             ],
+            'refund_repartition_line_ids': [
+                (0, 0, {'repartition_type': 'base'}),
+                (0, 0, {
+                    'repartition_type': 'tax',
+                    'account_id': tax_received_account.id,
+                }),
+            ],
         })
         zero_amount_product = self.env['product.product'].create({
             'name': 'Zero Amount Product',

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -519,6 +519,17 @@ class TestPoSProductsWithTax(TestPoSCommon):
                     'tag_ids': [(6, 0, self.tax_tag_invoice_tax.ids)],
                 }),
             ],
+            'refund_repartition_line_ids': [
+                (0, 0, {
+                    'repartition_type': 'base',
+                    'tag_ids': [(6, 0, self.tax_tag_refund_base.ids)],
+                }),
+                (0, 0, {
+                    'repartition_type': 'tax',
+                    'account_id': self.tax_received_account.id,
+                    'tag_ids': [(6, 0, self.tax_tag_refund_tax.ids)],
+                }),
+            ],
         })
 
         zero_amount_product = self.env['product.product'].create({


### PR DESCRIPTION
When we create a tax in 'Accounting' through 'Configuration/Accounting/Taxes' it does not add 'repartition_line_ids' by default. As a result when we open a session in 'point_of_sale' we will face the 'KeyError'.

Steps to reproduce:
1) Go to 'point_of_sale'.
2) Under 'Configuration/Taxes' create a tax(Do not add data in Distribution For Invoices and Distribution For Refunds).
3) Now open a session in point_of_sale under 'Dashboard'. By following above steps you can reproduce the error.

See: https://bit.ly/3ZRjsRr

This commit adds the functionalities to add 'repartion_line_ids' by default during the time of saving if the user has not manually entered it.

sentry - 4051481625