### PR TITLE
[FIX] account, payment, point_of_sale : prevent deletion of journals

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13703,6 +13703,12 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/account_journal.py:0
+#, python-format
+msgid "You cannot delete %s journals because it is link with another model."
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid "You cannot delete an entry which has been posted once."

--- a/addons/payment/models/account_journal.py
+++ b/addons/payment/models/account_journal.py
@@ -12,3 +12,9 @@ class AccountJournal(models.Model):
         acquirer_incompatible_journals = self.filtered(lambda j: j.type not in ('bank', 'cash'))
         if acquirer_incompatible_journals and self.env['payment.acquirer'].search_count([('journal_id', 'in', acquirer_incompatible_journals.ids)]):
             raise ValidationError(_("An acquirer is using this journal. Only bank and cash types are allowed."))
+
+    def _get_unlink_journals(self):
+        journals = super()._get_unlink_journals()
+        acquirer_journals = self.env['payment.acquirer'].search([('journal_id', 'in', self.ids)])
+        journals |= acquirer_journals.mapped('journal_id')
+        return journals

--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -8,3 +8,9 @@ class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     pos_payment_method_ids = fields.One2many('pos.payment.method', 'cash_journal_id', string='Point of Sale Payment Methods')
+
+    def _get_unlink_journals(self):
+        journals = super()._get_unlink_journals()
+        config_journals = self.env['pos.config'].search([('journal_id', 'in', self.ids)])
+        journals |= config_journals.mapped('journal_id')
+        return journals


### PR DESCRIPTION
When user is trying to delete the journal we will get a validation error:- The operation cannot be completed: another model requires the record being deleted. If possible, archive it instead.

Rather than giving technical errors, we can give proper errors so that users can easily understand.

Related Enterprise PR - https://github.com/odoo/enterprise/pull/39561

See:- 
![account_journal_delete](https://user-images.githubusercontent.com/53555057/231167833-b84d1de7-173f-455c-9cac-c9149aa325e9.png)


Applying these changes will resolve this issue.

sentry - 4057930920

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
