### PR TITLE
[IMP] mail: debounce mention suggestion

### DIFF
--- a/addons/im_livechat/static/tests/composer_patch_tests.js
+++ b/addons/im_livechat/static/tests/composer_patch_tests.js
@@ -7,6 +7,7 @@ import {
     click,
     dragenterFiles,
     start,
+    waitUntil,
 } from "@mail/../tests/helpers/test_utils";
 import { editInput, nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
 
@@ -136,6 +137,7 @@ QUnit.test("use a canned response", async (assert) => {
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
     assert.strictEqual($(".o-mail-Composer-input").val(), "");
     await insertText(".o-mail-Composer-input", ":");
+    await waitUntil(".o-mail-Composer-suggestion");
     assert.containsOnce($, ".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
@@ -167,7 +169,7 @@ QUnit.test("use a canned response some text", async (assert) => {
     await insertText(".o-mail-Composer-input", "bluhbluh ");
     assert.strictEqual($(".o-mail-Composer-input").val(), "bluhbluh ");
     await insertText(".o-mail-Composer-input", ":");
-    assert.containsOnce($, ".o-mail-Composer-suggestion");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
         $(".o-mail-Composer-input").val().replace(/\s/, " "),
@@ -196,7 +198,7 @@ QUnit.test("add an emoji after a canned response", async (assert) => {
     assert.containsNone($, ".o-mail-Composer-suggestion");
     assert.strictEqual($(".o-mail-Composer-input").val(), "");
     await insertText(".o-mail-Composer-input", ":");
-    assert.containsOnce($, ".o-mail-Composer-suggestion");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
         $(".o-mail-Composer-input").val().replace(/\s/, " "),

--- a/addons/mail/static/src/composer/composer.js
+++ b/addons/mail/static/src/composer/composer.js
@@ -232,6 +232,7 @@ export class Composer extends Component {
                 markEventHandled(ev, "composer.selectSuggestion");
             },
             options: [],
+            isLoadingRpc: this.suggestion.fetch.inProcess,
         };
         if (!this.hasSuggestions) {
             return props;

--- a/addons/mail/static/src/composer/navigable_list.js
+++ b/addons/mail/static/src/composer/navigable_list.js
@@ -8,6 +8,18 @@ import { Component, useEffect, useExternalListener, useRef, useState } from "@od
 import { markEventHandled, isEventHandled } from "../utils/misc";
 import { onExternalClick } from "@mail/utils/hooks";
 
+/**
+ * @typedef {Object} Props
+ * @property {{ el: HTMLElement}} anchorRef
+ * @property {string} [class]
+ * @property {Function} onSelect
+ * @property {array|Promise} options
+ * @property {string} [optionTemplate]
+ * @property {string} [placeholder]
+ * @property {import("@web/core/position_hook").Direction | import("@web/core/position_hook").Position} [position] default: "bottom"
+ * @property {boolean} [isLoadingRpc] display a loading indicator if true. Default: false
+ * @extends {Component<Props, Env>}
+ */
 export class NavigableList extends Component {
     static components = { ImStatus };
     static template = "mail.NavigableList";
@@ -19,8 +31,9 @@ export class NavigableList extends Component {
         optionTemplate: { type: String, optional: true },
         placeholder: { type: String, optional: true },
         position: { type: String, optional: true },
+        isLoadingRpc: { type: Boolean, optional: true },
     };
-    static defaultProps = { position: "bottom" };
+    static defaultProps = { position: "bottom", isLoadingRpc: false };
 
     setup() {
         this.rootRef = useRef("root");

--- a/addons/mail/static/src/composer/navigable_list.xml
+++ b/addons/mail/static/src/composer/navigable_list.xml
@@ -4,6 +4,9 @@
     <t t-name="mail.NavigableList" owl="1">
         <div class="o-mail-NavigableList bg-white m-0 p-0" t-ref="root" t-att-class="props.class">
             <div t-if="show" class="o-open border" t-on-mousedown.prevent="">
+                <div t-if="props.isLoadingRpc" class="position-absolute top-0 end-0 me-2 mt-2">
+                    <i class="fs-5 fa fa-spin fa-circle-o-notch"/>
+                </div>
                 <div t-if="state.isLoading" class="o-mail-NavigableList-item">
                     <a href="#" class="d-flex align-items-center w-100 py-2 px-4">
                         <i class="fa fa-spin fa-circle-o-notch"/>

--- a/addons/mail/static/src/utils/format.js
+++ b/addons/mail/static/src/utils/format.js
@@ -225,6 +225,6 @@ export function convertBrToLineBreak(str) {
     ).body.textContent;
 }
 
-export function cleanTerm(term) {
+export function cleanTerm(term = "") {
     return unaccent(term.toLowerCase());
 }

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -374,6 +374,7 @@ QUnit.test(
         });
         await openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "/");
+        await waitUntil(".o-mail-Composer-suggestion");
         await click(".o-mail-Composer-suggestion");
         await insertText(".o-mail-Composer-input", " is user?");
         assert.verifySteps([], "No rpc done");
@@ -391,6 +392,7 @@ QUnit.test("add an emoji after a command", async (assert) => {
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
     assert.strictEqual($(".o-mail-Composer-input").val(), "");
     await insertText(".o-mail-Composer-input", "/");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
         $(".o-mail-Composer-input").val().replace(/\s/, " "),
@@ -423,6 +425,7 @@ QUnit.test("add an emoji after a partner mention", async (assert) => {
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "T");
     await insertText(".o-mail-Composer-input", "e");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual($(".o-mail-Composer-input").val().replace(/\s/, " "), "@TestPartner ");
 
@@ -448,7 +451,7 @@ QUnit.test("mention a channel after some text", async (assert) => {
         "text content of composer should have content"
     );
     await insertText(".o-mail-Composer-input", "#");
-    assert.containsOnce($, ".o-mail-Composer-suggestion");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
         $(".o-mail-Composer-input").val().replace(/\s/, " "),
@@ -468,7 +471,7 @@ QUnit.test("add an emoji after a channel mention", async (assert) => {
     assert.containsNone($, ".o-mail-Composer-suggestion");
     assert.strictEqual($(".o-mail-Composer-input").val(), "");
     await insertText(".o-mail-Composer-input", "#");
-    assert.containsOnce($, ".o-mail-Composer-suggestion");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
         $(".o-mail-Composer-input").val().replace(/\s/, " "),
@@ -488,6 +491,7 @@ QUnit.test("pending mentions are kept when toggling composer", async (assert) =>
     await openFormView("res.partner", pyEnv.currentPartnerId);
     await click("button:contains(Send message)");
     await insertText(".o-mail-Composer-input", "@");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion:contains(Mitchell Admin)");
     await click("button:contains(Send message)");
     await click("button:contains(Send message)");
@@ -665,7 +669,8 @@ QUnit.test("Select composer suggestion via Enter does not send the message", asy
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "Shrek");
-    await afterNextRender(() => triggerHotkey("Enter"));
+    await waitUntil(".o-mail-Composer-suggestion");
+    triggerHotkey("Enter");
     assert.equal($(".o-mail-Composer-input").val().trim(), "@Shrek");
     assert.verifySteps([]);
 });

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -7,6 +7,7 @@ import {
     insertText,
     afterNextRender,
     nextAnimationFrame,
+    waitUntil,
 } from "@mail/../tests/helpers/test_utils";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 const { DateTime } = luxon;
@@ -1202,6 +1203,7 @@ QUnit.test("Chat with partner should be opened after clicking on their mention",
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "T");
     await insertText(".o-mail-Composer-input", "e");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion:contains(Test Partner)");
     await click(".o-mail-Composer-send");
     await click(".o_mail_redirect");
@@ -1248,6 +1250,7 @@ QUnit.test("Channel should be opened after clicking on its mention", async (asse
     await openFormView("res.partner", partnerId);
     await click("button:contains(Send message)");
     await insertText(".o-mail-Composer-input", "#");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion:contains(my-channel)");
     await click(".o-mail-Composer-send");
     await click(".o_channel_redirect");

--- a/addons/mail/static/tests/suggestion/suggestion_tests.js
+++ b/addons/mail/static/tests/suggestion/suggestion_tests.js
@@ -1,7 +1,13 @@
 /** @odoo-module **/
 
 import { Composer } from "@mail/composer/composer";
-import { click, insertText, start, startServer } from "@mail/../tests/helpers/test_utils";
+import {
+    click,
+    insertText,
+    start,
+    startServer,
+    waitUntil,
+} from "@mail/../tests/helpers/test_utils";
 import {
     makeDeferred,
     nextTick,
@@ -42,9 +48,8 @@ QUnit.test('display partner mention suggestions on typing "@"', async (assert) =
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     assert.containsNone($, ".o-mail-Composer-suggestion");
-
     await insertText(".o-mail-Composer-input", "@");
-    assert.containsN($, ".o-mail-Composer-suggestion", 3);
+    await waitUntil(".o-mail-Composer-suggestion", 3);
 });
 
 QUnit.test(
@@ -76,7 +81,7 @@ QUnit.test(
         await nextTick();
 
         await insertText(".o-mail-Composer-input", "@");
-        assert.containsN($, ".o-mail-Composer-suggestion", 3);
+        await waitUntil(".o-mail-Composer-suggestion", 3);
     }
 );
 
@@ -87,6 +92,7 @@ QUnit.test('display partner mention suggestions on typing "@" in chatter', async
     await click("button:contains(Send message)");
     assert.containsNone($, ".o-mail-Composer-suggestion");
     await insertText(".o-mail-Composer-input", "@");
+    await waitUntil(".o-mail-Composer-suggestion");
     assert.containsOnce($, ".o-mail-Composer-suggestion:contains(Mitchell Admin)");
 });
 
@@ -106,6 +112,7 @@ QUnit.test("show other channel member in @ mention", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
+    await waitUntil(".o-mail-Composer-suggestion:contains(TestPartner)");
     assert.containsOnce($, ".o-mail-Composer-suggestion:contains(TestPartner)");
 });
 
@@ -125,6 +132,7 @@ QUnit.test("select @ mention insert mention text in composer", async (assert) =>
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
+    await waitUntil(".o-mail-Composer-suggestion:contains(TestPartner)");
     await click(".o-mail-Composer-suggestion:contains(TestPartner)");
     assert.strictEqual($(".o-mail-Composer-input").val().trim(), "@TestPartner");
 });
@@ -150,6 +158,7 @@ QUnit.test("use a command for a specific channel type", async (assert) => {
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
     assert.strictEqual($(".o-mail-Composer-input").val(), "");
     await insertText(".o-mail-Composer-input", "/");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(
         $(".o-mail-Composer-input").val().replace(/\s/, " "),
@@ -201,6 +210,7 @@ QUnit.test("mention a channel", async (assert) => {
     assert.containsNone($, ".o-mail-Composer-suggestionList .o-open");
     assert.strictEqual($(".o-mail-Composer-input").val(), "");
     await insertText(".o-mail-Composer-input", "#");
+    await waitUntil(".o-mail-Composer-suggestion");
     assert.containsOnce($, ".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     assert.strictEqual(

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -210,6 +210,7 @@ QUnit.test("mention a channel with space in the name", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
@@ -222,6 +223,7 @@ QUnit.test('mention a channel with "&" in the name', async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
@@ -546,6 +548,7 @@ QUnit.test("Mention a partner with special character (e.g. apostrophe ')", async
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "Pyn");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce(
@@ -578,9 +581,11 @@ QUnit.test("mention 2 different partners that have the same name", async (assert
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "Te");
+    await waitUntil(".o-mail-Composer-suggestion:eq(0)");
     await click(".o-mail-Composer-suggestion:eq(0)");
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "Te");
+    await waitUntil(".o-mail-Composer-suggestion:eq(1)");
     await click(".o-mail-Composer-suggestion:eq(1)");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, ".o-mail-Message-body");
@@ -601,6 +606,7 @@ QUnit.test("mention a channel on a second line when the first line contains #", 
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#blabla\n");
     await insertText(".o-mail-Composer-input", "#");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-send");
     assert.containsOnce($(".o-mail-Message-body"), ".o_channel_redirect");
@@ -615,6 +621,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "#");
+        await waitUntil(".o-mail-Composer-suggestion");
         await click(".o-mail-Composer-suggestion");
         const text = $(".o-mail-Composer-input").val();
         $(".o-mail-Composer-input").val(text.slice(0, -1));
@@ -642,9 +649,11 @@ QUnit.test("mention 2 different channels that have the same name", async (assert
     await openDiscuss(channelId_1);
     await insertText(".o-mail-Composer-input", "#");
     await insertText(".o-mail-Composer-input", "m");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion:eq(0)");
     await insertText(".o-mail-Composer-input", "#");
     await insertText(".o-mail-Composer-input", "m");
+    await waitUntil(".o-mail-Composer-suggestion");
     await click(".o-mail-Composer-suggestion:eq(1)");
     await click(".o-mail-Composer-send");
     assert.containsOnce($, ".o-mail-Message-body");
@@ -678,6 +687,7 @@ QUnit.test(
         await insertText(".o-mail-Composer-input", "email@odoo.com\n");
         await insertText(".o-mail-Composer-input", "@");
         await insertText(".o-mail-Composer-input", "Te");
+        await waitUntil(".o-mail-Composer-suggestion");
         await click(".o-mail-Composer-suggestion");
         await click(".o-mail-Composer-send");
         assert.containsOnce(


### PR DESCRIPTION
Before this commit, when mentionning a user, `get_mention_suggestion` would be
called for each keypress after the "@". This PR add a debounce of 250ms before
calling `get_mention_suggestion`.
