### PR TITLE
[FIX] WIP: focus() called too soon on link label

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2013,6 +2013,7 @@ export class OdooEditor extends EventTarget {
                 this.historyStep(true);
                 this._historyStepsStates.set(peek(this._historySteps).id, 'consumed');
                 setTimeout(() => {
+                    // Line below may steal focus (without timeout)
                     this.editable.focus();
                     getDeepRange(this.editable, { select: true });
                 });

--- a/addons/web_editor/static/src/js/wysiwyg/dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/dialog.js
@@ -36,7 +36,14 @@ var WysiwygDialog = Dialog.extend({
 
         var self = this;
         this.opened(function () {
-            self.$('input:visible:first').focus();
+            // Issue seems to be, at least in part, calling .focus() too early
+
+            // self.$('input:visible:first')[0].addEventListener('load', function () { 
+            //     self.$('input:visible:first').focus();
+            // }, false);
+            // Solution above (and similar attempts with .on()) does not trigger (too late ?)
+            setTimeout(function () { self.$('input:visible:first').focus(); }, 20);
+            // Timeout works but is hackish, may fail if loading of input is very slow (very unlikely)
             self.$el.closest('.modal').addClass('o_web_editor_dialog');
             self.$el.closest('.modal').on('hidden.bs.modal', self.options.onClose);
         });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
