### PR TITLE
[IMP] spreadsheet: include ongoing day in period filters

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -71,49 +71,49 @@ export function checkFilterFieldMatching(fieldMatchings) {
  * @returns {Domain|undefined}
  */
 export function getRelativeDateDomain(now, offset, rangeType, fieldName, fieldType) {
-    let endDate = now.minus({ day: 1 }).endOf("day");
+    const startOfNextDay = now.plus({ days: 1 }).startOf("day");
+    let endDate = now.endOf("day");
     let startDate = endDate;
     switch (rangeType) {
         case "last_week": {
-            const offsetParam = { day: 7 * offset };
+            const offsetParam = { days: 7 * offset };
             endDate = endDate.plus(offsetParam);
-            startDate = now.minus({ day: 7 }).plus(offsetParam);
+            startDate = startOfNextDay.minus({ days: 7 }).plus(offsetParam);
             break;
         }
         case "last_month": {
-            const offsetParam = { day: 30 * offset };
+            const offsetParam = { days: 30 * offset };
             endDate = endDate.plus(offsetParam);
-            startDate = now.minus({ day: 30 }).plus(offsetParam);
+            startDate = startOfNextDay.minus({ days: 30 }).plus(offsetParam);
             break;
         }
         case "last_three_months": {
-            const offsetParam = { day: 90 * offset };
+            const offsetParam = { days: 90 * offset };
             endDate = endDate.plus(offsetParam);
-            startDate = now.minus({ day: 90 }).plus(offsetParam);
+            startDate = startOfNextDay.minus({ days: 90 }).plus(offsetParam);
             break;
         }
         case "last_six_months": {
-            const offsetParam = { day: 180 * offset };
+            const offsetParam = { days: 180 * offset };
             endDate = endDate.plus(offsetParam);
-            startDate = now.minus({ day: 180 }).plus(offsetParam);
+            startDate = startOfNextDay.minus({ days: 180 }).plus(offsetParam);
             break;
         }
         case "last_year": {
-            const offsetParam = { day: 365 * offset };
+            const offsetParam = { days: 365 * offset };
             endDate = endDate.plus(offsetParam);
-            startDate = now.minus({ day: 365 }).plus(offsetParam);
+            startDate = startOfNextDay.minus({ days: 365 }).plus(offsetParam);
             break;
         }
         case "last_three_years": {
-            const offsetParam = { day: 3 * 365 * offset };
+            const offsetParam = { days: 3 * 365 * offset };
             endDate = endDate.plus(offsetParam);
-            startDate = now.minus({ day: 3 * 365 }).plus(offsetParam);
+            startDate = startOfNextDay.minus({ days: 3 * 365 }).plus(offsetParam);
             break;
         }
         default:
             return undefined;
     }
-    startDate = startDate.startOf("day");
 
     let leftBound, rightBound;
     if (fieldType === "date") {

--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper_test.js
@@ -12,35 +12,35 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, 0, "last_week", "field", "date");
         assert.equal(getDateDomainDurationInDays(domain), 7);
-        assertDateDomainEqual(assert, "field", "2022-05-09", "2022-05-15", domain);
+        assertDateDomainEqual(assert, "field", "2022-05-10", "2022-05-16", domain);
     });
 
     QUnit.test("getRelativeDateDomain > last_month (last 30 days)", async function (assert) {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, 0, "last_month", "field", "date");
         assert.equal(getDateDomainDurationInDays(domain), 30);
-        assertDateDomainEqual(assert, "field", "2022-04-16", "2022-05-15", domain);
+        assertDateDomainEqual(assert, "field", "2022-04-17", "2022-05-16", domain);
     });
 
     QUnit.test("getRelativeDateDomain > last_three_months (last 90 days)", async function (assert) {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, 0, "last_three_months", "field", "date");
         assert.equal(getDateDomainDurationInDays(domain), 90);
-        assertDateDomainEqual(assert, "field", "2022-02-15", "2022-05-15", domain);
+        assertDateDomainEqual(assert, "field", "2022-02-16", "2022-05-16", domain);
     });
 
     QUnit.test("getRelativeDateDomain > last_six_months (last 180 days)", async function (assert) {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, 0, "last_six_months", "field", "date");
         assert.equal(getDateDomainDurationInDays(domain), 180);
-        assertDateDomainEqual(assert, "field", "2021-11-17", "2022-05-15", domain);
+        assertDateDomainEqual(assert, "field", "2021-11-18", "2022-05-16", domain);
     });
 
     QUnit.test("getRelativeDateDomain > last_year (last 365 days)", async function (assert) {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, 0, "last_year", "field", "date");
         assert.equal(getDateDomainDurationInDays(domain), 365);
-        assertDateDomainEqual(assert, "field", "2021-05-16", "2022-05-15", domain);
+        assertDateDomainEqual(assert, "field", "2021-05-17", "2022-05-16", domain);
     });
 
     QUnit.test(
@@ -49,7 +49,7 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
             const now = DateTime.fromISO("2022-05-16");
             const domain = getRelativeDateDomain(now, 0, "last_three_years", "field", "date");
             assert.equal(getDateDomainDurationInDays(domain), 3 * 365);
-            assertDateDomainEqual(assert, "field", "2019-05-17", "2022-05-15", domain);
+            assertDateDomainEqual(assert, "field", "2019-05-18", "2022-05-16", domain);
         }
     );
 
@@ -60,8 +60,8 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         assertDateDomainEqual(
             assert,
             "field",
-            "2022-05-09 00:00:00",
-            "2022-05-15 23:59:59",
+            "2022-05-10 00:00:00",
+            "2022-05-16 23:59:59",
             domain
         );
     });
@@ -73,8 +73,8 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         assertDateDomainEqual(
             assert,
             "field",
-            "2022-05-09 00:00:00",
-            "2022-05-15 23:59:59",
+            "2022-05-10 00:00:00",
+            "2022-05-16 23:59:59",
             domain
         );
     });
@@ -86,8 +86,8 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         assertDateDomainEqual(
             assert,
             "field",
-            "2022-05-08 22:00:00",
-            "2022-05-15 21:59:59",
+            "2022-05-09 22:00:00",
+            "2022-05-16 21:59:59",
             domain
         );
     });
@@ -101,8 +101,8 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
             assertDateDomainEqual(
                 assert,
                 "field",
-                "2022-05-08 22:00:00",
-                "2022-05-15 21:59:59",
+                "2022-05-09 22:00:00",
+                "2022-05-16 21:59:59",
                 domain
             );
         }
@@ -114,7 +114,7 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
             const now = DateTime.fromISO("2022-05-16");
             const domain = getRelativeDateDomain(now, -1, "last_week", "field", "date");
             assert.equal(getDateDomainDurationInDays(domain), 7);
-            assertDateDomainEqual(assert, "field", "2022-05-02", "2022-05-08", domain);
+            assertDateDomainEqual(assert, "field", "2022-05-03", "2022-05-09", domain);
         }
     );
 
@@ -122,7 +122,7 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         const now = DateTime.fromISO("2022-05-16");
         const domain = getRelativeDateDomain(now, -2, "last_month", "field", "date");
         assert.equal(getDateDomainDurationInDays(domain), 30);
-        assertDateDomainEqual(assert, "field", "2022-02-15", "2022-03-16", domain);
+        assertDateDomainEqual(assert, "field", "2022-02-16", "2022-03-17", domain);
     });
 
     QUnit.test(
@@ -131,7 +131,7 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
             const now = DateTime.fromISO("2022-05-16");
             const domain = getRelativeDateDomain(now, 1, "last_year", "field", "date");
             assert.equal(getDateDomainDurationInDays(domain), 365);
-            assertDateDomainEqual(assert, "field", "2022-05-16", "2023-05-15", domain);
+            assertDateDomainEqual(assert, "field", "2022-05-17", "2023-05-16", domain);
         }
     );
 
@@ -141,7 +141,7 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
             const now = DateTime.fromISO("2022-05-16");
             const domain = getRelativeDateDomain(now, -1, "last_three_years", "field", "date");
             assert.equal(getDateDomainDurationInDays(domain), 3 * 365);
-            assertDateDomainEqual(assert, "field", "2016-05-17", "2019-05-16", domain);
+            assertDateDomainEqual(assert, "field", "2016-05-18", "2019-05-17", domain);
         }
     );
 
@@ -152,8 +152,8 @@ QUnit.module("spreadsheet > Global filters helpers", {}, () => {
         assertDateDomainEqual(
             assert,
             "field",
-            "2022-05-02 00:00:00",
-            "2022-05-08 23:59:59",
+            "2022-05-03 00:00:00",
+            "2022-05-09 23:59:59",
             domain
         );
     });

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -1285,32 +1285,32 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
         await addGlobalFilter(model, { filter }, { pivot: { 1: { chain: "date", type: "date" } } });
         let computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 7);
-        assertDateDomainEqual(assert, "date", "2022-05-09", "2022-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2022-05-10", "2022-05-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_month" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 30);
-        assertDateDomainEqual(assert, "date", "2022-04-16", "2022-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2022-04-17", "2022-05-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_three_months" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 90);
-        assertDateDomainEqual(assert, "date", "2022-02-15", "2022-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2022-02-16", "2022-05-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_six_months" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 180);
-        assertDateDomainEqual(assert, "date", "2021-11-17", "2022-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2021-11-18", "2022-05-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_year" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 365);
-        assertDateDomainEqual(assert, "date", "2021-05-16", "2022-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2021-05-17", "2022-05-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_three_years" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 3 * 365);
-        assertDateDomainEqual(assert, "date", "2019-05-17", "2022-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2019-05-18", "2022-05-16", computedDomain);
     });
 
     QUnit.test("Relative date filter with offset domain value", async function (assert) {
@@ -1332,32 +1332,32 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
         );
         let computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 7);
-        assertDateDomainEqual(assert, "date", "2022-05-02", "2022-05-08", computedDomain);
+        assertDateDomainEqual(assert, "date", "2022-05-03", "2022-05-09", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_month" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 30);
-        assertDateDomainEqual(assert, "date", "2022-03-17", "2022-04-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2022-03-18", "2022-04-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_three_months" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 90);
-        assertDateDomainEqual(assert, "date", "2021-11-17", "2022-02-14", computedDomain);
+        assertDateDomainEqual(assert, "date", "2021-11-18", "2022-02-15", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_six_months" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 180);
-        assertDateDomainEqual(assert, "date", "2021-05-21", "2021-11-16", computedDomain);
+        assertDateDomainEqual(assert, "date", "2021-05-22", "2021-11-17", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_year" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 365);
-        assertDateDomainEqual(assert, "date", "2020-05-16", "2021-05-15", computedDomain);
+        assertDateDomainEqual(assert, "date", "2020-05-17", "2021-05-16", computedDomain);
 
         await setGlobalFilterValue(model, { id: "42", value: "last_three_years" });
         computedDomain = model.getters.getPivotComputedDomain("1");
         assert.equal(getDateDomainDurationInDays(computedDomain), 3 * 365);
-        assertDateDomainEqual(assert, "date", "2016-05-17", "2019-05-16", computedDomain);
+        assertDateDomainEqual(assert, "date", "2016-05-18", "2019-05-17", computedDomain);
     });
 
     QUnit.test(


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This PR includes the ongoing day in the current period filters.

### Current behavior before PR:

The periods in dashboard period filters don't include the ongoing day (today). 

For example, today is May 16th. "Last 7 Days" means May 9th 00:00 - May 15th 23:59. 

### Desired behavior after PR is merged:

"Last 7 Days" of May 16th refers to May 10th 00:00 - May 16th 23:59. 

task [3267525](https://www.odoo.com/web#id=3267525&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
