### PR TITLE
[FIX] core:  fix infinite recursion on unlinking records with computed fields

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -325,7 +325,7 @@ class StockMove(models.Model):
             quantity += move_line.product_uom_id._compute_quantity(move_line.qty_done, self.product_uom, round=False)
         return quantity
 
-    @api.depends('move_line_ids.qty_done', 'move_line_ids.product_uom_id', 'move_line_nosuggest_ids.qty_done')
+    @api.depends('move_line_ids.qty_done', 'move_line_nosuggest_ids.qty_done')
     def _quantity_done_compute(self):
         """ This field represents the sum of the move lines `qty_done`. It allows the user to know
         if there is still work to do.

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -108,7 +108,7 @@ class StockMoveLine(models.Model):
             if line.picking_id:
                 line.picking_type_id = line.picking_id.picking_type_id
 
-    @api.depends('move_id', 'move_id.location_id', 'move_id.location_dest_id')
+    @api.depends('move_id.location_id', 'move_id.location_dest_id')
     def _compute_location_id(self):
         for line in self:
             if not line.location_id:


### PR DESCRIPTION
Before this commit
==================
When unlinking more than 1000 records with computed fields, traceback occurs of maximum recursion depth reached. This is because the fields that depend on self to compute are marked to recompute when unlinking the records. As a result,  recompute keeps getting called and traceback occurs.

After this commit
==================
When unlinking more than 1000 records with computed fields, traceback doesn't occur. After we mark the fields that depend on self to compute, we remove the fields present in self. Due to this, there is no infinite loop when trying to recompute a field and no traceback occurs.

Task - 3271461