### PR TITLE
[FIX] website_blog: set create date as post date when it is not provided by user

### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -216,7 +216,7 @@ class BlogPost(models.Model):
         for blog_post in self:
             blog_post.published_date = blog_post.post_date
             if not blog_post.published_date:
-                blog_post._write(dict(post_date=blog_post.create_date)) # dont trigger inverse function
+                blog_post.update(dict(post_date=blog_post.create_date)) # dont trigger inverse function
 
     def _check_for_publication(self, vals):
         if vals.get('is_published'):


### PR DESCRIPTION
TypeError `cannot unpack non-iterable bool object` trace back that occurs in `website_blog/website_blog: _set_post_date`. while the user access the 'blog_post' model and removes the value of the `post_date` field and saves it so it will pass a false value then we face this issue. This is because from 16.0 `_write` method does not set create date value to the post date if it is not provided by the user.

see - https://tinyurl.com/2f8gpom4

In this commit we use `update()` instead of `_write()` it updates the value of the post date with its create_date.

sentry - 4056471738

