### PR TITLE
[FIX] website_slides: allows deletion of contents with correct completion time

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -415,7 +415,7 @@ class Slide(models.Model):
         # We don't use read_group() function, otherwise we will have issue with flushing the
         # data as completion_time is recursive and when it'll try to flush data before it is calculated
         for category in self.filtered(lambda slide: slide.is_category):
-            filtered_slides = category.slide_ids.filtered(lambda slide: slide.is_published)
+            filtered_slides = category.channel_id.slide_ids.filtered(lambda l: l.category_id == category and l.is_published)
             category.completion_time = sum(filtered_slides.mapped("completion_time"))
 
     @api.depends('slide_category', 'source_type', 'video_source_type')

--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -115,3 +115,37 @@ class TestVideoFromURL(slides_common.SlidesCase):
                     })
                     self.assertEqual('vimeo', slide.video_source_type)
                     self.assertEqual(vimeo_id, slide.vimeo_id)
+
+    def test_compute_category_completion_time(self):
+        self.category2 = self.env['slide.slide'].with_user(self.user_officer).create({
+            'name': 'Cooking Tips For Dieting',
+            'channel_id': self.channel.id,
+            'is_category': True,
+            'is_published': True,
+            'sequence': 5,
+        })
+        self.slide_4 = self.env['slide.slide'].with_user(self.user_officer).create({
+            'name': 'Vegan Diet',
+            'channel_id': self.channel.id,
+            'slide_category': 'document',
+            'is_published': True,
+            'completion_time': 5.0,
+            'sequence': 6,
+        })
+        self.slide_5 = self.env['slide.slide'].with_user(self.user_officer).create({
+            'name': 'Normal Diet',
+            'channel_id': self.channel.id,
+            'slide_category': 'document',
+            'is_published': True,
+            'completion_time': 1.5,
+            'sequence': 7,
+        })
+
+        before_unlink = self.category2.completion_time
+
+        self.channel.slide_ids[6].sudo().unlink()
+        self.category2._compute_category_completion_time()
+
+        after_unlink = self.category2.completion_time
+
+        self.assertNotEqual(before_unlink, after_unlink)


### PR DESCRIPTION
When the user try to delete the contents from the course which have more than one sections in it, it throws an AssertionError which is because it is trying to delete the content before calculating the duration of course.

steps to produce:-
- Install 'website_slides'
- Go to any course with more than one sections in it
- Click on 'Add Content'
- Create a new content with proper duration
- Now go to Contents from the content menu
- Search for the content you have just created
- Now delete it
- Traceback is generated

See:-
![image](https://user-images.githubusercontent.com/121805245/231758079-c25c9e61-399e-4241-8bc1-f5084315a573.png)

Fix:-
We have fixed this issue by fixing the compute method by update the code with the channel and calculating the completion time with respect to its sections. This will filters all the contents in the same course that belong to the same section and are published.

sentry-4057245274