### PR TITLE
[FIX] event_sale: fix NotNullViolation error for sale

### DIFF
--- a/addons/event_sale/i18n/event_sale.pot
+++ b/addons/event_sale/i18n/event_sale.pot
@@ -204,6 +204,12 @@ msgid "Event Tickets"
 msgstr ""
 
 #. module: event_sale
+#: code:addons/event_sale/models/sale_order.py:0
+#, python-format
+msgid "Event and Event Ticket are required!"
+msgstr ""
+
+#. module: event_sale
 #: model_terms:ir.ui.view,arch_db:event_sale.event_ticket_id_change_exception
 msgid "Exception:"
 msgstr ""

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
@@ -68,6 +69,12 @@ class SaleOrderLine(models.Model):
         'event.event.ticket', string='Event Ticket',
         help="Choose an event ticket and it will automatically create a registration for this event ticket.")
     event_ok = fields.Boolean(compute='_compute_event_ok')
+
+    @api.constrains('event_id', 'event_ticket_id')
+    def _check_event_id_and_event_type_id(self):
+        order_lines = self.filtered(lambda l: l.product_id.detailed_type == 'event' and not (l.event_id and l.event_ticket_id))
+        if order_lines:
+            raise UserError(_("Event and Event Ticket are required!"))
 
     @api.depends('product_id.detailed_type')
     def _compute_event_ok(self):


### PR DESCRIPTION
If applied, this commit will solve the NotNullViolation error when the fields
event and event ticket are not set in the quotation.

To reproduce this issue, follow the steps.
- Create a sale order for a registration.
- Set the 'event' field empty for that sale order line.
- Confirm the order.

see- https://tinyurl.com/48jssb2d

sentry - 4065656594, https://tinyurl.com/2nkwalsc

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
