### PR TITLE
[FIX] survey: send email toggle

### DIFF
--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -66,7 +66,7 @@ class SurveyInvite(models.TransientModel):
     survey_users_can_signup = fields.Boolean(related='survey_id.users_can_signup')
     deadline = fields.Datetime(string="Answer deadline")
     send_email = fields.Boolean(compute="_compute_send_email",
-                                inverse="_inverse_send_email")
+                                inverse="_inverse_send_email", company_dependent=True)
 
     @api.depends('survey_access_mode')
     def _compute_send_email(self):


### PR DESCRIPTION
To reproduce
============
try to share survey, on the dialog the toggle **Send By Email** is switched off, when trying to switch it on, it keeps going off

Problem
=======
when we set the value it's not stored so when the auto-save is triggered we will call the compute method that sets the toggles value to `False`

Solution
========
this field should be `store=True` which we can't apply on stable, so we will use the trick `company_dependent=True` and fix it correctly on master

opw-3246552