### PR TITLE
[FIX] web: Add missing pyUtils context function to basic_view.js 

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_view.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_view.js
@@ -248,7 +248,7 @@ var BasicView = AbstractView.extend({
         });
 
         if (!_.isObject(attrs.options)) { // parent arch could have already been processed (TODO this should not happen)
-            attrs.options = attrs.options ? pyUtils.py_eval(attrs.options) : {};
+            attrs.options = attrs.options ? pyUtils.py_eval(attrs.options, pyUtils.context()) : {};
         }
 
         if (attrs.on_change && attrs.on_change !== "0" && !field.onChange) {


### PR DESCRIPTION
This prevented the use of py.extras functionality within the options attribute.

For example, using context_today() to dynamically get the date of today for use in daterangepicker.

This PR fixes issue #116409 in combination with PR #118521