### PR TITLE
[FIX] board: Add to Dashboard domain not copied correctly

### DIFF
--- a/addons/board/static/src/legacy/js/add_to_board_menu.js
+++ b/addons/board/static/src/legacy/js/add_to_board_menu.js
@@ -66,8 +66,7 @@ odoo.define('board.AddToBoardMenu', function (require) {
             delete controllerQueryParams.context;
             context.add(Object.assign(controllerQueryParams, queryContext));
 
-            const domainArray = new Domain(this.env.action.domain || []);
-            const domain = Domain.prototype.normalizeArray(domainArray.toArray().concat(searchQuery.domain));
+            const domain = Domain.prototype.normalizeArray(searchQuery.domain);
 
             const evalutatedContext = context.eval();
             for (const key in evalutatedContext) {

--- a/addons/board/static/tests/dashboard_tests.js
+++ b/addons/board/static/tests/dashboard_tests.js
@@ -1012,8 +1012,8 @@ odoo.define("board.dashboard_tests", function (require) {
         var view_domain = ["display_name", "ilike", "a"];
         var filter_domain = ["display_name", "ilike", "b"];
 
-        // The filter domain already contains the view domain, but is always added by dashboard..,
-        var expected_domain = ["&", view_domain, "&", view_domain, filter_domain];
+        // The filter should not contain anything more
+        var expected_domain = ["&", view_domain, filter_domain];
 
         serverData.views = {
             "partner,false,list": '<list><field name="foo"/></list>',

--- a/doc/cla/corporate/asphericon.md
+++ b/doc/cla/corporate/asphericon.md
@@ -1,0 +1,15 @@
+Germany, 2023-04-14
+
+asphericon GmbH agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Frantisek Kavan <f.kavan@asphericon.cz> https://github.com/fkavan-asphericon
+
+List of contributors:
+
+Frantisek Kavan <f.kavan@asphericon.cz> https://github.com/fkavan-asphericon


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Domain is messed up after adding to dashboard action. It creates action with bad domain.
This messed up domain is then hard-coded to the XML action of Dashboard and it does not show all the desired records from Approvals.

**Current behavior before PR:**
From perfectly working domain it creates copy but with AND's and it disturbs the domain behavior.
We have perfectly fine domain like this: 
`["|","|","|",["request_owner_id","=",6],["category_id","=",14],["approver_ids.user_id","=",6],["message_is_follower","=",1]]`
https://github.com/odoo/odoo/blob/6bc4d7e3a27c94a0e3414cc661e52bf6e5907446/addons/board/static/src/legacy/js/add_to_board_menu.js#L69-L70
First line 69 creates domain, but strips all the OR's, then `domainArray.toArray()` creates `["|",["request_owner_id","=",6],["category_id","=",14],["approver_ids.user_id","=",6],["message_is_follower","=",1]]`. This domain is then concatenated with the original domain from `searchQuery.domain` and creates mess like this

`["&","&","&","|",["request_owner_id","=",6],["category_id","=",14],["approver_ids.user_id","=",6],["message_is_follower","=",1],"|","|","|",["request_owner_id","=",6],["category_id","=",14],["approver_ids.user_id","=",6],["message_is_follower","=",1]]`

**Desired behavior after PR is merged:**
The domain is just a copy from `searchQuery.domain` as it is done in non-legacy version.

**Impacted versions:** 15.0

**Video/Screenshot link:**
![image](https://user-images.githubusercontent.com/127088866/231955785-6ca9664c-2f31-4792-8c82-12c330d02b54.png)

**Support ticket:**
opw-3274713

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
