### PR TITLE
[FIX] l10n_fr_pos_cert: correctly display "Old price" when needed

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -11,7 +11,7 @@
 
     <t t-name="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
         <xpath expr="//t[@t-foreach='receipt.orderlines']" position="inside">
-            <t t-if="receipt.l10n_fr_hash !== false and line.price !== line.fixed_lst_price">
+            <t t-if="receipt.l10n_fr_hash !== false and line.price !== line.taxed_lst_unit_price">
                 <div class="pos-receipt-right-padding">
                     Old unit price:
                     <span class="oldPrice">

--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1937,7 +1937,7 @@ class Orderline extends PosModel {
         if (this.pos.config.iface_tax_included === 'total') {
             var product =  this.get_product();
             var taxes_ids = product.taxes_id;
-            var product_taxes = this.pos.get_taxes_after_fp(taxes_ids);
+            var product_taxes = this.pos.get_taxes_after_fp(taxes_ids, this.order.fiscal_position);
             return this.compute_all(product_taxes, lst_price, 1, this.pos.currency.rounding).total_included;
         }
         return lst_price;


### PR DESCRIPTION
Before this commit: when a product contains a tax it will show the "Old price" in the receipt. But the actual price and the Old price were the same. Also, if we have a fiscal position, it wouldn't consider it for calculating the `taxed_lst_unit_price`.

Steps to reproduce:
- Install the l10n_fr_pos_cert module
- Add a tax to a product
- Open a PoS session
- Add the product to the order and validate the order
- The order line in the receipt shows an "Old price" when it shouldn't.

opw-3236517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
