### PR TITLE
[IMP] website_forum: redirect to forum main page

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -307,7 +307,7 @@ class WebsiteForum(WebsiteProfile):
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/delete', type='http', auth="user", methods=['POST'], website=True)
     def question_delete(self, forum, question, **kwarg):
         question.active = False
-        return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
+        return request.redirect("/forum/%s" % slug(forum))
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/undelete', type='http', auth="user", methods=['POST'], website=True)
     def question_undelete(self, forum, question, **kwarg):


### PR DESCRIPTION
before this commit, on deleting a question from
forum is redirecting to the same question
page with deleted tag.

after this commit, user will be redirected to
forum home page after deleting a question


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
