### PR TITLE
[FIX] web: group (tag) size adaptation

### DIFF
--- a/addons/web/static/src/js/views/form/form_renderer.js
+++ b/addons/web/static/src/js/views/form/form_renderer.js
@@ -627,33 +627,36 @@ var FormRenderer = BasicRenderer.extend({
                     colspan = 1;
                 }
             }
-            var finalColspan = colspan - (isLabeledField ? 1 : 0);
-            currentColspan += colspan;
 
-            if (currentColspan > col) {
-                rows.push($currentRow);
-                $currentRow = $('<tr/>');
-                currentColspan = colspan;
-            }
+            if(!child.attrs.invisible){
+                var finalColspan = colspan - (isLabeledField ? 1 : 0);
+                currentColspan += colspan;
 
-            var $tds;
-            if (child.tag === 'field') {
-                $tds = self._renderInnerGroupField(child);
-            } else if (child.tag === 'label') {
-                $tds = self._renderInnerGroupLabel(child);
-            } else {
-                var $td = $('<td/>');
-                var $child = self._renderNode(child);
-                if ($child.hasClass('o_td_label')) { // transfer classname to outer td for css reasons
-                    $td.addClass('o_td_label');
-                    $child.removeClass('o_td_label');
+                if (currentColspan > col) {
+                    rows.push($currentRow);
+                    $currentRow = $('<tr/>');
+                    currentColspan = colspan;
                 }
-                $tds = $td.append($child);
+
+                var $tds;
+                if (child.tag === 'field') {
+                    $tds = self._renderInnerGroupField(child);
+                } else if (child.tag === 'label') {
+                    $tds = self._renderInnerGroupLabel(child);
+                } else {
+                    var $td = $('<td/>');
+                    var $child = self._renderNode(child);
+                    if ($child.hasClass('o_td_label')) { // transfer classname to outer td for css reasons
+                        $td.addClass('o_td_label');
+                        $child.removeClass('o_td_label');
+                    }
+                    $tds = $td.append($child);
+                }
+                if (finalColspan > 1) {
+                    $tds.last().attr('colspan', finalColspan);
+                }
+                $currentRow.append($tds);
             }
-            if (finalColspan > 1) {
-                $tds.last().attr('colspan', finalColspan);
-            }
-            $currentRow.append($tds);
         });
         rows.push($currentRow);
 

--- a/addons/web/static/tests/views/form_tests.js
+++ b/addons/web/static/tests/views/form_tests.js
@@ -592,6 +592,27 @@ QUnit.module('Views', {
         form.destroy();
     });
 
+    QUnit.test('invisible fields in group tag don`t take space in ui', async function (assert) {
+        assert.expect(1);
+
+        var form = await createView({
+            View: FormView,
+            model: 'partner',
+            data: this.data,
+            arch: '<form string="Partners">' +
+                    '<sheet>' +
+                        '<group>' +
+                            '<field name="foo" invisible="1"/>' +
+                            '<field name="bar"/>' +
+                         '</group>' +
+                    '</sheet>' +
+                '</form>',
+            res_id: 1,
+        });
+        assert.strictEqual(form.$('tr').length, 1)
+        form.destroy();
+    });
+
     QUnit.test('invisible elements are properly hidden', async function (assert) {
         assert.expect(3);
 


### PR DESCRIPTION
**Before this PR:**

Suppose there are 2 fields in a group tag and in that tag one field is invisible so the group tag will make the tr for both fields due to this the view is broken.

**After this PR:**

Now the group tag will not make tr for the invisible field.

Task-3179173

