### PR TITLE
[15.0][IMP] stock_account: add hook to decide when to create journal entries upon layer creation

### DIFF
--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -42,7 +42,7 @@ class StockValuationLayer(models.Model):
         for svl in self:
             if not svl.with_company(svl.company_id).product_id.valuation == 'real_time':
                 continue
-            if svl.currency_id.is_zero(svl.value):
+            if not svl._should_create_account_entry_move():
                 continue
             am_vals += svl.stock_move_id.with_company(svl.company_id)._account_entry_move(svl.quantity, svl.description, svl.id, svl.value)
         if am_vals:
@@ -126,3 +126,6 @@ class StockValuationLayer(models.Model):
             new_valuation = unit_cost * new_valued_qty
 
         return new_valued_qty, new_valuation
+
+    def _should_create_account_entry_move(self):
+        return not self.currency_id.is_zero(self.value)


### PR DESCRIPTION
Steps to reproduce the issue:

1. Create a product at zero cost and automated valuation
2. Create an inventory adjustment for that product adding 1 unit to WH/Stock
3. Check valuation report for that product
4. Check the total quantity in the journal items in the stock valuation account for that product

Result:
The total quantity in the layers is 1
The total quantity in the Stock valuation account for that product is zero.

Expected result:
The total quantity in the Stock valuation account for that product is 1.

You can tell me, ok, that is the users fault because they did not put a price. But that is not a valid statement IMHO. Data consistency should be more important. So something must be done:

- Either users cannot validate the transfer at zero cost (UserError)
- Or the journals at zero cost with some qty should be added

The changes proposed is just a hook so other module can change the criteria. I know the chance to get this merge in 15.0 is very low, just let me know if this has a minimum chance to be considered in master.

