### PR TITLE
[FIX] pos_loyalty : fix value when selling multiple gift cards

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -847,11 +847,13 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                                 || line.ignoreLoyaltyPoints({ program })) {
                                 continue;
                             }
-                            let price_to_use = line.get_price_with_tax();
+
+                            let pointsPerUnit = 0;
                             if (program.program_type === 'gift_card') {
-                                price_to_use = line.price;
+                                pointsPerUnit = line.price;
+                            } else {
+                                pointsPerUnit = round_precision(rule.reward_point_amount * line.get_price_with_tax() / line.get_quantity(), 0.01);
                             }
-                            const pointsPerUnit = round_precision(rule.reward_point_amount * price_to_use / line.get_quantity(), 0.01);
                             if (pointsPerUnit > 0) {
                                 splitPoints.push(...Array.apply(null, Array(line.get_quantity())).map(() => {
                                     if (line.giftBarcode && line.get_quantity() == 1) {

--- a/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
@@ -55,8 +55,9 @@ startSteps();
 ProductScreen.do.confirmOpeningPopup();
 ProductScreen.do.clickHomeCategory();
 ProductScreen.do.clickDisplayedProduct('Gift Card');
-ProductScreen.do.pressNumpad('Disc 5 0');
-PosLoyalty.check.orderTotalIs('25.00');
-PosLoyalty.exec.finalizeOrder('Cash', '25');
+ProductScreen.do.pressNumpad('Disc 5');
+ProductScreen.do.pressNumpad('Qty 5');
+PosLoyalty.check.orderTotalIs('1,250.00');
+PosLoyalty.exec.finalizeOrder('Cash', '1250');
 Tour.register('GiftCardWithDiscountTour', { test: true, url: '/pos/web' }, getSteps());
 //#endregion

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -812,5 +812,5 @@ class TestUi(TestPointOfSaleHttpCommon):
             login="accountman",
         )
         # Check the created gift cards.
-        self.assertEqual(len(programs['gift_card_1'].coupon_ids), 1)
-        self.assertEqual(programs['gift_card_1'].coupon_ids.points, 50)
+        self.assertEqual(len(programs['gift_card_1'].coupon_ids), 50)
+        self.assertEqual(len(programs['gift_card_1'].coupon_ids.filtered(lambda c: c.points == 50)), 50)


### PR DESCRIPTION
Current behavior:
In the PoS if you added multiple gift cards on the same order line, the value of these gift cards was not correct.

Steps to reproduce:
- Activate gift card in the PoS
- Open a PoS session
- Add a gift card to the order
- Change the quantity of gift card on the order line
- Validate the order
- Check the gift card value on the pdf downloaded

opw-3264945
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
