### PR TITLE
[FIX] base: use html method from lxml, fix template parsing when reset

### DIFF
--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -223,6 +223,24 @@ class TestEvalXML(common.TransactionCase):
     def test_xml(self):
         pass
 
-    @unittest.skip("not tested")
     def test_html(self):
-        pass
+        self.assertEqual(
+            self.eval_xml(Field(ET.fromstring(
+            """<parent>
+                <t t-if="True">
+                    <t t-out="'text'"/>
+                </t>
+                <t t-else="">
+                    <t t-out="'text2'"></t>
+                </t>
+            </parent>"""), type="html")),
+            """<parent>
+                <t t-if="True">
+                    <t t-out="'text'"></t>
+                </t>
+                <t t-else="">
+                    <t t-out="'text2'"></t>
+                </t>
+            </parent>""",
+            "Evaluating an HTML field should give empty nodes instead of self-closing tags"
+        )

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -142,7 +142,7 @@ def _eval_xml(self, node, env):
             return '<?xml version="1.0"?>\n'\
                 +_process("".join(etree.tostring(n, encoding='unicode') for n in node))
         if t == 'html':
-            return _process("".join(etree.tostring(n, encoding='unicode') for n in node))
+            return _process("".join(etree.tostring(n, method='html', encoding='unicode') for n in node))
 
         data = node.text
         if node.get('file'):


### PR DESCRIPTION
Reproduction:

1.Enable debug mode to access the Settings/Technical/Email Template view
2.Open the Shipping: Send by email template
3.Notice that there is a t-out with line[0] or ''
4.Click on the Reset Template button on the form view
5.The t-out is ". ." now

Reason: the template is not correctly parsed by DOM parser from string

Fix: This is a backward port of commit: https://github.com/odoo/odoo/pull/114632/commits/774fa99c89ba43a654a91c7a98c1e2b04aef34de To address the issue that when we reset an email template, the template is not correctly parsed, which breaks the template's structure and results a wrong resetting.

task-3210605

Related PR (fix in 16.2):
https://github.com/odoo/odoo/pull/114632

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
