### PR TITLE
[FIX] account: move hash and cash rounding

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1894,9 +1894,13 @@ class AccountMove(models.Model):
                 })
 
             # Create or update the cash rounding line.
-            if cash_rounding_line:
+            will_change = any(
+                self._field_will_change(cash_rounding_line, rounding_line_vals, field_name)
+                for field_name in rounding_line_vals
+            )
+            if cash_rounding_line and will_change:
                 cash_rounding_line.write(rounding_line_vals)
-            else:
+            elif not cash_rounding_line:
                 cash_rounding_line = self.env['account.move.line'].create(rounding_line_vals)
 
         existing_cash_rounding_line = self.line_ids.filtered(lambda line: line.display_type == 'rounding')


### PR DESCRIPTION
### Bug

When cash rounding is applied to an invoice whose journal has "Lock Posted Entries with Hash" enabled, the posting fails with an error stating that the move is already hashed.

### Steps to reproduce

1. activate cash rounding and create a cash rounding `C`
2. have a sales journal with "Lock Posted Entries with Hash" enabled
3. create an invoice with an amount that requires cash rounding
4. set the invoice's cash rounding to `C`
5. try to post the invoice.

=> you should see that posting fails with an error message stating that the move is already hashed.

opw-3243293