### PR TITLE
[FIX] account_sequence: PO bill wrong name

### DIFF
--- a/addons/account_sequence/models/sequence_mixin.py
+++ b/addons/account_sequence/models/sequence_mixin.py
@@ -35,6 +35,7 @@ class SequenceMixin(models.AbstractModel):
                 with self.env.cr.savepoint(flush=False), mute_logger('odoo.sql_db'):
                     self[self._sequence_field] = sequence
                     self.flush_recordset([self._sequence_field])
+                    self.modified([self._sequence_field])
                     break
             except DatabaseError as e:
                 # 23P01 ExclusionViolation


### PR DESCRIPTION
Current behaviour:
--
When resetting to draft a PO's bill, then creating a new bill from the same PO, the bill has a wrong
name in account_accountant.
ie: / instead of BILL/2023/04/0002

Steps to reproduce:
--
1. Install these modules: account_3way_match, sale_timesheet_enterprise, account_accountant
2. Create a Purchase Order and confirm
3. Set Received to 1
4. Create Bill
5. Input a Bill date (any) and confirm
6. In Accounting > Journal Items > Journal Entry, Bill has a normal name (ie: BILL/2023/04/0002)
7. Go back to the PO's Bill, and reset to draft, click cancel
8. In Accounting > Journal Items > Journal Entry, Bill has disappeared
9. Back to the PO, Create Bill
10. Input a Bill date (any) and confirm
11. In Accounting > Journal Items > Journal Entry, Bill name is : /

Cause of the issue:
--
When neither account_3way_match nor sale_timesheet_enterprise are installed, 
account.invoice.line().move_name (name in Journal Entry) is recomputed when 
recomputing qty_invoiced being triggered by account.move().action_post.

When account_3way_match AND sale_timesheet_enterprise are installed, 
recompute of account.invoice.line().move_name doesn't happen.

Fix:
--
To force recomputing of account.invoice.line().move_name, 
a modified has been added so that it's done without the recompute of qty_invoiced.

opw-3254165

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
