### PR TITLE
[FIX] web_editor: reset background color on text

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1696,6 +1696,9 @@ const Wysiwyg = Widget.extend({
                         }
                         // Unstash the mutations now that the color is picked.
                         this.odooEditor.historyUnstash();
+                        if(ev.data.target.classList.contains('o_colorpicker_reset')){
+                            ev.data.color = '';
+                        }
                         this._processAndApplyColor(eventName, ev.data.color);
                         // Deselect tables so the applied color can be seen
                         // without using `!important` (otherwise the selection


### PR DESCRIPTION
Before this commit:

When we select a text with no background color and press the reset button, the back ground color is change to black or white color in light and dark mode
 respectively.

After this commit:

When we select a text with no background color and press the reset button, the back ground color remains the same what it was earlier.

Taskid - 3237693
