### PR TITLE
[FIX] website: canonical URL

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1320,7 +1320,7 @@ class Website(models.Model):
         # Compare URL at the first routing iteration because it's the one with
         # the language in the path. It is important to also test the domain of
         # the current URL.
-        current_url = request.httprequest.url_root[:-1] + request.httprequest.environ['REQUEST_URI']
+        current_url = request.httprequest.url_root[:-1] + request.httprequest.environ.get('REQUEST_URI', '')
         canonical_url = self._get_canonical_url_localized(lang=request.lang, canonical_params=None)
         # A request path with quotable characters (such as ",") is never
         # canonical because request.httprequest.base_url is always unquoted,


### PR DESCRIPTION
Steps to reproduce:
open any odoo URL (Internal server error 500)

Bug:
"REQUEST_URI" is not present as a key

Fix:
add default empty value


