### PR TITLE
[IMP] mass_mailing: add multi-website support

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -282,17 +282,33 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
         """ Find a sent email with a given list of recipients. Email should match
         exactly the recipients.
 
-        :param email-to: a list of emails that will be compared to email_to
+        :param email_to: an email that will be compared to email_to of sent emails
+          (as a list of emails);
+
+        :return email: an email which is a dictionary mapping values given to
+          ``build_email``;
+        """
+        return self._find_sent_mail_wemails([email_to])
+
+    def _find_sent_mail_wemails(self, emails_to):
+        """ Find a sent email with a given list of recipients. Emails should match
+        exactly the email_to of outgoing email formatted as a list.
+
+        :param emails_to: a list of emails that will be compared to email_to
           of sent emails (also a list of emails);
 
         :return email: an email which is a dictionary mapping values given to
           ``build_email``;
         """
         for sent_email in self._mails:
-            if set(sent_email['email_to']) == set([email_to]):
+            if set(sent_email['email_to']) == set(emails_to):
                 break
         else:
-            raise AssertionError('sent mail not found for email_to %s' % (email_to))
+            debug_info = '\n'.join(
+                f"From: {sent_email['email_from']} - To {sent_email['email_to']}"
+                for sent_email in self._mails
+            )
+            raise AssertionError(f'sent mail not found for email_to {emails_to}\n{debug_info}')
         return sent_email
 
     def _filter_mail(self, status=None, mail_message=None, author=None, email_from=None):

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -70,7 +70,7 @@ class MailMail(models.Model):
         if not self.res_id or not self.mailing_id:
             return email_list
 
-        base_url = self.mailing_id.get_base_url()
+        base_url = self.get_base_url()
         for email_values in email_list:
             if not email_values['email_to']:
                 continue
@@ -81,17 +81,18 @@ class MailMail(models.Model):
             view_url = self.mailing_id._get_view_url(email_to, self.res_id)
 
             # replace links in body
-            if not tools.is_html_empty(email_values['body']):
-                if f'{base_url}/unsubscribe_from_list' in email_values['body']:
-                    email_values['body'] = email_values['body'].replace(
-                        f'{base_url}/unsubscribe_from_list',
-                        unsubscribe_url,
-                    )
-                if f'{base_url}/view' in email_values['body']:
-                    email_values['body'] = email_values['body'].replace(
-                        f'{base_url}/view',
-                        view_url,
-                    )
+            for body in ['body', 'body_alternative']:
+                if not tools.is_html_empty(email_values[body]):
+                    if f'{base_url}/unsubscribe_from_list' in email_values[body]:
+                        email_values[body] = email_values[body].replace(
+                            f'{base_url}/unsubscribe_from_list',
+                            unsubscribe_url,
+                        )
+                    if f'{base_url}/view' in email_values[body]:
+                        email_values[body] = email_values[body].replace(
+                            f'{base_url}/view',
+                            view_url,
+                        )
 
             # add headers
             email_values['headers'].update({

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -14,6 +14,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
     'data': [
         'data/ir_model_data.xml',
         'views/snippets/s_popup.xml',
+        'views/mailing_mailing_views.xml',
         'views/snippets_templates.xml',
     ],
     'auto_install': ['website', 'mass_mailing'],

--- a/addons/website_mass_mailing/models/__init__.py
+++ b/addons/website_mass_mailing/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import link_tracker
+from . import mailing_mailing
 from . import res_company

--- a/addons/website_mass_mailing/models/link_tracker.py
+++ b/addons/website_mass_mailing/models/link_tracker.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from werkzeug.urls import url_join
+
+from odoo import api, models
+
+
+class LinkTracker(models.Model):
+    _inherit = ['link.tracker']
+
+    @api.depends('mass_mailing_id.website_id')
+    def _compute_short_url_host(self):
+        tracker_with_website_mass_mailing = self.filtered(lambda t: t.mass_mailing_id.website_id)
+        super(LinkTracker, self - tracker_with_website_mass_mailing)._compute_short_url_host()
+        for tracker in tracker_with_website_mass_mailing:
+            tracker.short_url_host = url_join(tracker.mass_mailing_id.website_id.get_base_url(), '/r/')

--- a/addons/website_mass_mailing/models/mailing_mailing.py
+++ b/addons/website_mass_mailing/models/mailing_mailing.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class MassMailing(models.Model):
+    _name = 'mailing.mailing'
+    _inherit = ['mailing.mailing', 'website.multi.mixin']

--- a/addons/website_mass_mailing/tests/__init__.py
+++ b/addons/website_mass_mailing/tests/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_snippets
+from . import test_mailing_website

--- a/addons/website_mass_mailing/tests/test_mailing_website.py
+++ b/addons/website_mass_mailing/tests/test_mailing_website.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
+
+from odoo.tests.common import users
+
+from odoo.addons.mass_mailing.tests.common import MassMailCommon
+
+
+class TestMassMailingWebsite(MassMailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMassMailingWebsite, cls).setUpClass()
+        website_1 = cls.env['website'].create({
+            'name': 'Website 1',
+            'domain': 'www.website1.com',
+        })
+        website_2 = cls.env['website'].create({
+            'name': 'Website 2',
+            'domain': 'www.website2.com',
+        })
+        body_html = """
+            Test body
+            <a role="button" href="/unsubscribe_from_list" class="btn btn-link ">Unsubscribe</a>
+            <a href="/view" class="o_default_snippet_text">View Online</a>
+            <a role="button" href="/contactus" class="btn btn-link">Contact</a>
+        """
+        mailing_list = cls._create_mailing_list_of_x_contacts(1)
+        cls.mailing_1 = cls.env['mailing.mailing'].create({
+            'name': 'Test Mailing 1',
+            'subject': 'Test Subject 1',
+            'body_html': body_html,
+            'mailing_model_id': cls.env.ref('mass_mailing.model_mailing_list').id,
+            'mailing_type': 'mail',
+            'contact_list_ids': [mailing_list.id],
+            'website_id': website_1.id,
+        })
+        cls.mailing_2 = cls.env['mailing.mailing'].create({
+            'name': 'Test Mailing 2',
+            'subject': 'Test Subject 2',
+            'body_html': body_html,
+            'mailing_model_id': cls.env.ref('mass_mailing.model_mailing_list').id,
+            'mailing_type': 'mail',
+            'contact_list_ids': [mailing_list.id],
+            'website_id': website_2.id,
+        })
+
+    @users('user_marketing')
+    def test_mass_mailing_website(self):
+
+        def _assert_find_link(regex, mail):
+            self.assertEqual(len(re.findall(regex, mail['body'])), 1)
+            self.assertEqual(len(re.findall(regex, mail['body_alternative'])), 1)
+
+        with self.mock_mail_gateway():
+            (self.mailing_1 | self.mailing_2).action_send_mail()
+
+        mail_1 = self._mails[0]
+        unsubscribe_regex_1 = r'\bhttps?://(?:www\.)?website1\.com/.*?/unsubscribe\S*'
+        view_regex_1 = r'\bhttps?://(?:www\.)?website1\.com/.*?/view\S*'
+        contact_regex_1 = r'\bhttps?://(?:www\.)?website1\.com/r/\S*'
+
+        mail_2 = self._mails[1]
+        unsubscribe_regex_2 = r'\bhttps?://(?:www\.)?website2\.com/.*?/unsubscribe\S*'
+        view_regex_2 = r'\bhttps?://(?:www\.)?website2\.com/.*?/view\S*'
+        contact_regex_2 = r'\bhttps?://(?:www\.)?website2\.com/r/\S*'
+
+        tracker_mailing_1 = self.env['link.tracker'].search([('mass_mailing_id', '=', self.mailing_1.id)])
+        self.assertTrue('contactus' in tracker_mailing_1.url)
+        self.assertTrue('website1' in tracker_mailing_1.short_url_host)
+        tracker_mailing_2 = self.env['link.tracker'].search([('mass_mailing_id', '=', self.mailing_2.id)])
+        self.assertTrue('contactus' in tracker_mailing_2.url)
+        self.assertTrue('website2' in tracker_mailing_2.short_url_host)
+
+        _assert_find_link(unsubscribe_regex_1, mail_1)
+        _assert_find_link(view_regex_1, mail_1)
+        _assert_find_link(contact_regex_1, mail_1)
+
+        _assert_find_link(unsubscribe_regex_2, mail_2)
+        _assert_find_link(view_regex_2, mail_2)
+        _assert_find_link(contact_regex_2, mail_2)

--- a/addons/website_mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/website_mass_mailing/views/mailing_mailing_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_mail_mass_mailing_form" model="ir.ui.view">
+        <field name="name">mailing.mailing.form.inherit.website</field>
+        <field name="model">mailing.mailing</field>
+        <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_mail_mass_mailing_tree" model="ir.ui.view">
+        <field name="name">mailing.mailing.tree.inherit.website</field>
+        <field name="model">mailing.mailing</field>
+        <field name="inherit_id" ref="mass_mailing.view_mail_mass_mailing_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="website_id" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this commit, users could not choose what website to use when adding links
to a mass mailing.

This commits adds a `website_id` field to `mailing.mailing` so that all links in
the template will point to the relevant website. This concerns /view and
/unsubscribe_from_list urls as well as relative urls (that are shortened by the
`link.tracker` model).

Behavior without adding a specific website to the mailing stays the same.

Task-3240736




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
