### PR TITLE
[FIX] web: fix undefined checkDefinitionWriteAccess

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -31,7 +31,7 @@
                             <PropertyValue
                                 id="domId"
                                 canChangeDefinition="state.canChangeDefinition"
-                                checkDefinitionWriteAccess.bind="checkDefinitionWriteAccess"
+                                checkDefinitionWriteAccess="checkDefinitionWriteAccess"
                                 comodel="propertyConfiguration.comodel || ''"
                                 context="context"
                                 domain="propertyConfiguration.domain || '[]'"

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -102,7 +102,7 @@
                             tags="state.propertyDefinition.tags || []"
                             readonly="props.readonly"
                             canChangeTags="props.canChangeDefinition"
-                            checkDefinitionWriteAccess.bind="props.checkDefinitionWriteAccess"
+                            checkDefinitionWriteAccess="props.checkDefinitionWriteAccess"
                             deleteAction="'tags'"
                             onTagsChange.bind="onTagsChange"/>
                     </td>

--- a/addons/web/static/src/views/fields/properties/property_value.xml
+++ b/addons/web/static/src/views/fields/properties/property_value.xml
@@ -66,7 +66,7 @@
                     deleteAction="'value'"
                     readonly="props.readonly"
                     canChangeTags="props.canChangeDefinition"
-                    checkDefinitionWriteAccess.bind="props.checkDefinitionWriteAccess"
+                    checkDefinitionWriteAccess="props.checkDefinitionWriteAccess"
                     onValueChange.bind="onValueChange"
                     onTagsChange.bind="props.onTagsChange"/>
             </t>


### PR DESCRIPTION
The function `checkDefinitionWriteAccess​` from the property field component is passed from component to component via the props. When passing that function, each intermediate component binds the context of the function (i.e: `this​`) to their own context using the `.bind​` suffix.

When a component calls that function, `this​` will refer to the context of the parent component. As this props is optional, the function `checkDefinitionWriteAccess​` can be `undefined​` and calling the `bind`​ method on `undefined​` raises an exception. The fix consists of removing the `.bind​` suffix when passing the function from component to component. When a component calls that function, `this​` will now refer to the context of the property field component.

Steps to reproduce:
1. Create an article
2. Insert a kanban view with /kanban​
3. Click on the "create" button of the embedded view you inserted in step 2
4. Add a new property field of type "Tags​"
5. From the popover of the property field: Click on the "View In Kanban​"
6. Go back to the parent article

=> The embedded view shows the error message placeholder.

Reference: https://github.com/odoo/odoo/pull/108800

task-3280847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
