### PR TITLE
[FIX] base_import: Don't convert properly formatted date format

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -98,7 +98,7 @@ export class BaseImportModel {
             name_create_enabled_fields: {},
         };
         for (const [name, option] of Object.entries(this.importOptionsValues)) {
-            tempImportOptions[name] = ['date_format', 'datetime_format'].includes(name)
+            tempImportOptions[name] = ['date_format', 'datetime_format'].includes(name) && !option.value.includes('%')
                 ? moment_to_strftime_format(option.value)
                 : option.value;
         }


### PR DESCRIPTION
When importing documents that have a `date` or a  `datetime` field, a conversion is done on the format string in case it was still in the old moment format (e.g. YYYYMMDD).

The problem is that this conversion was done regardless if the format string was valid or not. This was producing botched format strings that would prevent any import having a date or datetime field with a proper format string.


