### PR TITLE
[IMP] l10n_it_edi: DatiFattureCollegate uses reconciled moves

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -144,9 +144,9 @@
             <DatiConvenzione t-if="origin_document_type == 'agreement'">
                 <t t-call="l10n_it_edi.account_invoice_FatturaPA_origin_document"/>
             </DatiConvenzione>
-            <DatiFattureCollegate t-if="record.reversed_entry_id">
-                <IdDocumento t-out="format_alphanumeric(record.reversed_entry_id.name[-20:])"/>
-                <Data t-out="format_date(record.reversed_entry_id.invoice_date)"/>
+            <DatiFattureCollegate t-foreach="record._get_reconciled_invoices()" t-as="credit_note">
+                <IdDocumento t-out="format_alphanumeric(credit_note.name[-20:])"/>
+                <Data t-out="format_date(credit_note.invoice_date)"/>
             </DatiFattureCollegate>
             <DatiFattureCollegate t-foreach="downpayment_moves" t-as="downpayment_move">
                 <IdDocumento t-out="format_alphanumeric(downpayment_move.name[-20:])"/>

--- a/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
+++ b/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
@@ -169,9 +169,6 @@ class TestItEdiReverseCharge(TestItEdi):
             ),
         }
         cls.reverse_charge_bill_2 = cls.env['account.move'].with_company(cls.company).create(bill_data_2)
-        cls.reverse_charge_refund = cls.reverse_charge_bill.with_company(cls.company)._reverse_moves([{
-            'invoice_date': fields.Date.from_string('2022-03-24'),
-        }])
 
         # Import bill San Marino
         bill_data_san_marino = {
@@ -193,7 +190,6 @@ class TestItEdiReverseCharge(TestItEdi):
         cls.reverse_charge_bill._post()
         cls.reverse_charge_bill_2._post()
         cls.reverse_charge_bill_san_marino._post()
-        cls.reverse_charge_refund._post()
 
     def test_reverse_charge_invoice(self):
         self._test_invoice_with_sample_file(self.reverse_charge_invoice, "reverse_charge_invoice.xml")
@@ -253,6 +249,10 @@ class TestItEdiReverseCharge(TestItEdi):
         )
 
     def test_reverse_charge_refund(self):
+        self.reverse_charge_refund = self.reverse_charge_bill.with_company(self.company)._reverse_moves([{
+            'invoice_date': fields.Date.from_string('2022-03-24'),
+        }], cancel=True)
+
         self._test_invoice_with_sample_file(
             self.reverse_charge_refund,
             "reverse_charge_bill.xml",


### PR DESCRIPTION
The `move.reversed_move_id` field only represents the credit note that the user has manually created to revert a move, entirely or partially, but it doesn't take into consideration all moves reconciled through other means.

We now use the method `move._get_reconciled_invoices()` which goes through all the partials to retrieve them instead.

This enables also the reconciliation with the outstanding credits case to be covered.

Task link: https://www.odoo.com/web#id=3281816&model=project.task
task-3281816