### PR TITLE
[FIX] base: enable clean MailDeliveryError in front-end

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -27,7 +27,7 @@ _test_logger = logging.getLogger('odoo.tests')
 SMTP_TIMEOUT = 60
 
 
-class MailDeliveryException(Exception):
+class MailDeliveryException(UserError):
     """Specific exception subclass for mail delivery errors"""
 
 

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -25,11 +25,11 @@ class UserError(Exception):
     state of a record. Semantically comparable to the generic 400 HTTP status codes.
     """
 
-    def __init__(self, message):
+    def __init__(self, message, *args, **kwargs):
         """
         :param message: exception message and frontend modal content
         """
-        super().__init__(message)
+        super().__init__(message, *args, **kwargs)
 
     @property
     def name(self):


### PR DESCRIPTION
MailDeliveryError is handled in the front-end
but safe_eval wraps it in a UserError.

As safe_eval is used for routing we don't ever
see MailDeliveryError when it reaches the front-end.

Fix is to add the type to the list of accepted
exceptions in safe_eval.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
