### PR TITLE
[FIX] stock: apply only quant with inventory quantity set

### DIFF
--- a/addons/stock/wizard/stock_inventory_adjustment_name.py
+++ b/addons/stock/wizard/stock_inventory_adjustment_name.py
@@ -23,5 +23,5 @@ class StockInventoryAdjustmentName(models.TransientModel):
     show_info = fields.Boolean('Show warning')
 
     def action_apply(self):
-        return self.quant_ids.with_context(
-            inventory_name=self.inventory_adjustment_name).action_apply_inventory()
+        quants = self.quant_ids.filtered('inventory_quantity_set')
+        return quants.with_context(inventory_name=self.inventory_adjustment_name).action_apply_inventory()


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”
- Create a purchase order with 10 unit of “P1”
- Confirm the PO and receive the delivery
- Go to inventory > operation > Inventory Adjustments
- Select the “quant” of “P1”: - quantity = 10 - inventory_quantity = 0
- Click on “Apply”
- Apply the wizard

Problem:
The quantity is updated to 0

When the `_apply_inventory` function is called, a move is created and validated to ensure that the quantity matches its corresponding `inventory_quantity`:
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_quant.py#L606-L611

`inventory_diff_quantity` is equal to -3 in this case, since it's the result of computing `inventory_quantity` - `quantity`, which is (0 - 3). Since we add a minus sign to `inventory_diff_quantity`, the final result becomes `3`.

Afterward, we call the `_update_available_quantity` function with a minus sign as well, so the value becomes -3:
https://github.com/odoo/odoo/blob/e1cea2640fc064a56b0dba4f79e6b8a91a48b4fc/addons/stock/models/stock_move_line.py#L307

As a result, when we add `quant.quantity`, which is 3, the final result becomes 0 (3 - 3):
https://github.com/odoo/odoo/blob/9d34c72b2c7bc187c5aac771e9e8cbddd7ead5f2/addons/stock/models/stock_quant.py#L635

Solution:
If no inventory_quantity set, ignore the apply of inventory for this quant.

opw-3268542
