### PR TITLE
[IMP] web_editor, website: add an "on hover" option for animations

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -174,6 +174,12 @@ export class MediaDialog extends Component {
                         if (this.props.media.dataset.shapeColors) {
                             element.dataset.shapeColors = this.props.media.dataset.shapeColors;
                         }
+                        if (this.props.media.dataset.shapeFlip) {
+                            element.dataset.shapeFlip = this.props.media.dataset.shapeFlip;
+                        }
+                        if (this.props.media.dataset.shapeRotate) {
+                            element.dataset.shapeRotate = this.props.media.dataset.shapeRotate;
+                        }
                     }
                 }
                 for (const otherTab of Object.keys(TABS).filter(key => key !== this.state.activeTab)) {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -180,6 +180,18 @@ export class MediaDialog extends Component {
                         if (this.props.media.dataset.shapeRotate) {
                             element.dataset.shapeRotate = this.props.media.dataset.shapeRotate;
                         }
+                        if (this.props.media.dataset.hoverEffect) {
+                            element.dataset.hoverEffect = this.props.media.dataset.hoverEffect;
+                        }
+                        if (this.props.media.dataset.hoverEffectColor) {
+                            element.dataset.hoverEffectColor = this.props.media.dataset.hoverEffectColor;
+                        }
+                        if (this.props.media.dataset.hoverEffectStrokeWidth) {
+                            element.dataset.hoverEffectStrokeWidth = this.props.media.dataset.hoverEffectStrokeWidth;
+                        }
+                        if (this.props.media.dataset.hoverEffectIntensity) {
+                            element.dataset.hoverEffectIntensity = this.props.media.dataset.hoverEffectIntensity;
+                        }
                     }
                 }
                 for (const otherTab of Object.keys(TABS).filter(key => key !== this.state.activeTab)) {

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -480,17 +480,6 @@
         </we-button-group>
     </div>
 
-    <div data-selector="img" data-exclude="[data-oe-type='image'] > img, [data-oe-xpath]">
-        <we-input string="Description" class="o_we_large"
-            data-select-attribute="" data-attribute-name="alt"
-            placeholder="Alt tag"
-            title="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...)."/>
-        <we-input string="Tooltip" class="o_we_large"
-            data-select-attribute="" data-attribute-name="title"
-            placeholder="Title tag"
-            title="'Title tag' is shown as a tooltip when you hover the picture."/>
-    </div>
-
     <t t-set="no_animations" t-value="False"/>
     <div data-js="ImageTools"
          data-selector="img">
@@ -518,7 +507,7 @@
                         <div class="o_scroll_shapes_basic">
                             <we-title class="">Geometrics</we-title>
                             <we-select-page string="Geometrics">
-                                <we-button data-set-img-shape="web_editor/geometric/geo_square" data-select-label="Square" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_square" data-no-transform="true" data-name="shape_img_square_opt"/> <!-- hidden and only used for hover effects -->
                                 <we-button data-set-img-shape="web_editor/geometric/geo_shuriken" data-select-label="Shuriken" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_diamond" data-select-label="Diamond" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_triangle" data-select-label="Triangle"/>
@@ -710,7 +699,8 @@
                         </div>
                     </div>
                 </we-select-pager>
-                <we-button data-set-img-shape="" data-no-preview="true" data-label="None" data-dependencies="shape_img_opt" class="o_we_image_shape_remove o_we_bg_danger fa fa-fw fa-times"/>
+                <we-button data-set-img-shape="" data-no-preview="true" data-label="None" data-dependencies="shape_img_opt"
+                    class="o_we_image_shape_remove o_we_bg_danger fa fa-fw fa-times" data-name="remove_img_shape_opt"/>
             </we-row>
             <we-row string="Colors" class="o_we_sublevel_1">
                 <we-colorpicker data-set-img-shape-color="true" data-dependencies="shape_img_opt" data-name="img-shape-color-0" data-color-id="0"/>
@@ -730,7 +720,14 @@
                     data-no-preview="true" data-dependencies="shape_img_opt" title="Rotate right"/>
             </we-row>
         </div>
-
+        <we-input string="Description" class="o_we_large"
+            data-select-attribute="" data-attribute-name="alt"
+            placeholder="Alt tag"
+            title="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...)."/>
+        <we-input string="Tooltip" class="o_we_large"
+            data-select-attribute="" data-attribute-name="title"
+            placeholder="Title tag"
+            title="'Title tag' is shown as a tooltip when you hover the picture."/>
         <we-row string="Transform">
             <we-button class="fa fa-fw fa-crop" data-crop="true" data-no-preview="true" title="Crop Image"/>
             <we-button class="o_we_bg_danger ms-0 border-start-0" data-reset-crop="" data-no-preview="true" title="Reset crop">
@@ -744,7 +741,7 @@
 
         <t t-call="web_editor.snippet_options_image_optimization_widgets"/>
 
-        <we-button-group string="Width" data-css-property="width">
+        <we-button-group string="Size" data-css-property="width">
             <we-button data-select-style="" title="Resize Default">Default</we-button>
             <we-button data-select-style="25%" title="Resize Quarter">25%</we-button>
             <we-button data-select-style="50%" title="Resize Half">50%</we-button>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -518,17 +518,17 @@
                         <div class="o_scroll_shapes_basic">
                             <we-title class="">Geometrics</we-title>
                             <we-select-page string="Geometrics">
-                                <we-button data-set-img-shape="web_editor/geometric/geo_square" data-select-label="Square"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_shuriken" data-select-label="Shuriken"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_diamond" data-select-label="Diamond"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_square" data-select-label="Square" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_shuriken" data-select-label="Shuriken" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_diamond" data-select-label="Diamond" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_triangle" data-select-label="Triangle"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_cornered_triangle" data-select-label="Corner Triangle"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_pentagon" data-select-label="Pentagon"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_hexagon" data-select-label="Hexagon"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_heptagon" data-select-label="Heptagon"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_star" data-select-label="Star 1"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_star_8pin" data-select-label="Star 2"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_star_16pin" data-select-label="Star 3"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_star_8pin" data-select-label="Star 2" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_star_16pin" data-select-label="Star 3" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_slanted" data-select-label="Slanted"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_emerald" data-select-label="Emerald"/>
                                 <we-button data-set-img-shape="web_editor/geometric/geo_tetris" data-select-label="Tetris"/>
@@ -549,18 +549,18 @@
 
                             <we-title>Geometrics Rounded</we-title>
                             <we-select-page string="Geometrics Rounded">
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_circle" data-select-label="Circle"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square" data-select-label="Square (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_diamond" data-select-label="Diamond (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_shuriken" data-select-label="Shuriken (R)"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_circle" data-select-label="Circle" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square" data-select-label="Square (R)" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_diamond" data-select-label="Diamond (R)" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_shuriken" data-select-label="Shuriken (R)" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_triangle" data-select-label="Triangle (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_pentagon" data-select-label="Pentagon (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_hexagon" data-select-label="Hexagon (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_heptagon" data-select-label="Heptagon (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star" data-select-label="Star 1 (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_7pin" data-select-label="Star 2 (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_8pin" data-select-label="Star 3 (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_16pin" data-select-label="Star 4 (R)"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_8pin" data-select-label="Star 3 (R)" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_16pin" data-select-label="Star 4 (R)" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_emerald" data-select-label="Emerald (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_lemon" data-select-label="Lemon (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_tear" data-select-label="Tear (R)"/>
@@ -569,8 +569,8 @@
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_cornered" data-select-label="Cornered"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_door" data-select-label="Door (R)"/>
                                 <we-button data-set-img-shape="web_editor/geometric_round/geo_round_sonar" data-select-label="Sonar (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_clover" data-select-label="Clover (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_bread" data-select-label="Bread (R)"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_clover" data-select-label="Clover (R)" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_bread" data-select-label="Bread (R)" data-no-transform="true"/>
                                 <t t-if="not no_animations">
                                     <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square_1" data-select-label="Square 1 (R)" data-animated="true"/>
                                     <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square_2" data-select-label="Square 2 (R)" data-animated="true"/>
@@ -588,7 +588,7 @@
                                 <we-button data-set-img-shape="web_editor/panel/panel_duo_step_pill" data-select-label="Duo Step Pill"/>
                                 <we-button data-set-img-shape="web_editor/panel/panel_trio_in_r" data-select-label="Trio In (R)"/>
                                 <we-button data-set-img-shape="web_editor/panel/panel_trio_out_r" data-select-label="Trio Out (R)"/>
-                                <we-button data-set-img-shape="web_editor/panel/panel_window" data-select-label="Window"/>
+                                <we-button data-set-img-shape="web_editor/panel/panel_window" data-select-label="Window" data-no-transform="true"/>
                             </we-select-page>
 
                             <we-title>Composites</we-title>
@@ -611,67 +611,67 @@
 
                             <we-title>Composition</we-title>
                             <we-select-page string="Composition">
-                                <we-button data-set-img-shape="web_editor/composition/composition_organic_line" data-select-label="Organic Line"/>
-                                <we-button data-set-img-shape="web_editor/composition/composition_oval_line" data-select-label="Oval Line"/>
+                                <we-button data-set-img-shape="web_editor/composition/composition_organic_line" data-select-label="Organic Line" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/composition/composition_oval_line" data-select-label="Oval Line" data-no-transform="true"/>
                                 <t t-if="not no_animations">
-                                    <we-button data-set-img-shape="web_editor/composition/composition_triangle_line" data-select-label="Triangle Line" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_line_1" data-select-label="Line 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_line_3" data-select-label="Line 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_line_2" data-select-label="Line 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_mixed_1" data-select-label="Mixed 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_mixed_2" data-select-label="Mixed 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_planet_1" data-select-label="Planet 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_planet_2" data-select-label="Planet 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_square_1" data-select-label="Square Dot 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_square_2" data-select-label="Square Dot 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_square_3" data-select-label="Square Dot 3" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_square_4" data-select-label="Square Dot 4" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/composition/composition_square_line" data-select-label="Square Line" data-animated="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_triangle_line" data-select-label="Triangle Line" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_line_1" data-select-label="Line 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_line_3" data-select-label="Line 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_line_2" data-select-label="Line 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_mixed_1" data-select-label="Mixed 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_mixed_2" data-select-label="Mixed 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_planet_1" data-select-label="Planet 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_planet_2" data-select-label="Planet 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_square_1" data-select-label="Square Dot 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_square_2" data-select-label="Square Dot 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_square_3" data-select-label="Square Dot 3" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_square_4" data-select-label="Square Dot 4" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/composition/composition_square_line" data-select-label="Square Line" data-animated="true" data-no-transform="true"/>
                                 </t>
                             </we-select-page>
 
                             <we-title>Patterns</we-title>
                             <we-select-page string="Patterns">
-                                <we-button data-set-img-shape="web_editor/pattern/pattern_organic_cross" data-select-label="Organic Cross"/>
-                                <we-button data-set-img-shape="web_editor/pattern/pattern_organic_caps" data-select-label="Organic Caps"/>
-                                <we-button data-set-img-shape="web_editor/pattern/pattern_oval_zebra" data-select-label="Oval Zebra"/>
+                                <we-button data-set-img-shape="web_editor/pattern/pattern_organic_cross" data-select-label="Organic Cross" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/pattern/pattern_organic_caps" data-select-label="Organic Caps" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/pattern/pattern_oval_zebra" data-select-label="Oval Zebra" data-no-transform="true"/>
                                 <t t-if="not no_animations">
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_1" data-select-label="Wave 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_line_star" data-select-label="Star" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_line_sun" data-select-label="Sun" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_2" data-select-label="Wave 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_3" data-select-label="Wave 3" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_point" data-select-label="Point" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_organic_dot" data-select-label="Organic Dot" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_labyrinth" data-select-label="Labyrinth" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_circuit" data-select-label="Circuit" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_4" data-select-label="Wave 4" data-animated="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_1" data-select-label="Wave 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_line_star" data-select-label="Star" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_line_sun" data-select-label="Sun" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_2" data-select-label="Wave 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_3" data-select-label="Wave 3" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_point" data-select-label="Point" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_organic_dot" data-select-label="Organic Dot" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_labyrinth" data-select-label="Labyrinth" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_circuit" data-select-label="Circuit" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/pattern/pattern_wave_4" data-select-label="Wave 4" data-animated="true" data-no-transform="true"/>
                                 </t>
                             </we-select-page>
 
                             <we-title>Solids</we-title>
                             <we-select-page string="Solids">
-                                <we-button data-set-img-shape="web_editor/solid/solid_blob_1" data-select-label="Blob 1"/>
-                                <we-button data-set-img-shape="web_editor/solid/solid_blob_2" data-select-label="Blob 2"/>
-                                <we-button data-set-img-shape="web_editor/solid/solid_blob_3" data-select-label="Blob 3"/>
-                                <we-button data-set-img-shape="web_editor/solid/solid_blob_4" data-select-label="Blob 4"/>
+                                <we-button data-set-img-shape="web_editor/solid/solid_blob_1" data-select-label="Blob 1" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/solid/solid_blob_2" data-select-label="Blob 2" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/solid/solid_blob_3" data-select-label="Blob 3" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/solid/solid_blob_4" data-select-label="Blob 4" data-no-transform="true"/>
                                 <t t-if="not no_animations">
-                                    <we-button data-set-img-shape="web_editor/solid/solid_blob_5" data-select-label="Blob 5" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/solid/solid_blob_shadow_1" data-select-label="Blob Shadow 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/solid/solid_blob_shadow_2" data-select-label="Blob Shadow 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/solid/solid_square_1" data-select-label="Square Shadow 1" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/solid/solid_square_2" data-select-label="Square Shadow 2" data-animated="true"/>
-                                    <we-button data-set-img-shape="web_editor/solid/solid_square_3" data-select-label="Square Shadow 3" data-animated="true"/>
+                                    <we-button data-set-img-shape="web_editor/solid/solid_blob_5" data-select-label="Blob 5" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/solid/solid_blob_shadow_1" data-select-label="Blob Shadow 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/solid/solid_blob_shadow_2" data-select-label="Blob Shadow 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/solid/solid_square_1" data-select-label="Square Shadow 1" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/solid/solid_square_2" data-select-label="Square Shadow 2" data-animated="true" data-no-transform="true"/>
+                                    <we-button data-set-img-shape="web_editor/solid/solid_square_3" data-select-label="Square Shadow 3" data-animated="true" data-no-transform="true"/>
                                 </t>
                             </we-select-page>
 
                             <we-title>Specials</we-title>
                             <we-select-page string="Specials" t-if="not no_animations">
-                                <we-button data-set-img-shape="web_editor/special/special_speed" data-select-label="Speed" data-animated="true"/>
-                                <we-button data-set-img-shape="web_editor/special/special_rain" data-select-label="Rain" data-animated="true"/>
-                                <we-button data-set-img-shape="web_editor/special/special_snow" data-select-label="Snow" data-animated="true"/>
-                                <we-button data-set-img-shape="web_editor/special/special_layered" data-select-label="Layered" data-animated="true"/>
-                                <we-button data-set-img-shape="web_editor/special/special_filter" data-select-label="Filter" data-animated="true"/>
+                                <we-button data-set-img-shape="web_editor/special/special_speed" data-select-label="Speed" data-animated="true" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/special/special_rain" data-select-label="Rain" data-animated="true" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/special/special_snow" data-select-label="Snow" data-animated="true" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/special/special_layered" data-select-label="Layered" data-animated="true" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/special/special_filter" data-select-label="Filter" data-animated="true" data-no-transform="true"/>
                                 <we-button data-set-img-shape="web_editor/special/special_flag" data-select-label="Flag" data-animated="true"/>
                                 <we-button data-set-img-shape="web_editor/special/special_organic" data-select-label="Organic" data-animated="true"/>
                             </we-select-page>
@@ -718,6 +718,16 @@
                 <we-colorpicker data-set-img-shape-color="true" data-dependencies="shape_img_opt" data-name="img-shape-color-2" data-color-id="2"/>
                 <we-colorpicker data-set-img-shape-color="true" data-dependencies="shape_img_opt" data-name="img-shape-color-3" data-color-id="3"/>
                 <we-colorpicker data-set-img-shape-color="true" data-dependencies="shape_img_opt" data-name="img-shape-color-4" data-color-id="4"/>
+            </we-row>
+            <we-row string="Transform" class="o_we_sublevel_1">
+                <we-button class="oi oi-fw oi-arrows-h" data-name="img_shape_transform_flip_x_opt" data-set-img-shape-flip-x="true"
+                    data-no-preview="true" data-dependencies="shape_img_opt" title="Horizontal mirror"/>
+                <we-button class="oi oi-fw oi-arrows-v" data-name="img_shape_transform_flip_y_opt" data-set-img-shape-flip-y="true"
+                    data-no-preview="true" data-dependencies="shape_img_opt" title="Vertical mirror"/>
+                <we-button class="fa fa-fw fa-rotate-left" data-name="img_shape_transform_rotate_x_opt" data-set-img-shape-rotate-left="true"
+                    data-no-preview="true" data-dependencies="shape_img_opt" title="Rotate left"/>
+                <we-button class="fa fa-fw fa-rotate-right" data-name="img_shape_transform_rotate_y_opt" data-set-img-shape-rotate-right="true"
+                    data-no-preview="true" data-dependencies="shape_img_opt" title="Rotate right"/>
             </we-row>
         </div>
 

--- a/addons/website/static/src/svg/hover_effects.svg
+++ b/addons/website/static/src/svg/hover_effects.svg
@@ -1,0 +1,201 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <!-- Image Zoom In -->
+    <g id="image_zoom_in">
+        <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+            <use id="shapeOverlay" xlink:href="#filterPath" fill="hover_effect_color" fill-opacity="0"/>
+        </svg>
+        <g id="hoverEffects">
+            <animateTransform
+                xlink:href="#shapeImage"
+                attributeName="transform"
+                attributeType="XML"
+                type="scale"
+                values="1;hover_effect_zoom"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+            <animate
+                xlink:href="#shapeOverlay"
+                attributeName="fill-opacity"
+                values="0;hover_effect_opacity"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+        </g>
+    </g>
+
+    <!-- Image Zoom Out -->
+    <g id="image_zoom_out">
+        <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+            <use id="shapeOverlay" xlink:href="#filterPath" fill="hover_effect_color" fill-opacity="0"/>
+        </svg>
+        <g id="hoverEffects">
+            <animateTransform
+                xlink:href="#shapeImage"
+                attributeName="transform"
+                attributeType="XML"
+                type="scale"
+                values="hover_effect_zoom;1"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+            <animate
+                xlink:href="#shapeOverlay"
+                attributeName="fill-opacity"
+                values="0;hover_effect_opacity"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+        </g>
+        <style>
+            <!-- only if not already animated -->
+            svg:not([class^="o_shape_anim_random_"]) #shapeImage {
+                scale: hover_effect_zoom;
+            }
+        </style>
+    </g>
+
+    <!-- Dolly Zoom -->
+    <g id="dolly_zoom">
+        <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+            <use id="shapeOverlay" xlink:href="#filterPath" fill="hover_effect_color" fill-opacity="0" style="transform-origin: center;"/>
+        </svg>
+        <g id="hoverEffects">
+            <animateTransform
+                xlink:href="#shapeImage"
+                attributeName="transform"
+                attributeType="XML"
+                type="scale"
+                calcMode="spline"
+                values="1;hover_effect_zoom"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3s"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+            <animateTransform
+                xlink:href="#clip-path"
+                attributeName="transform"
+                attributeType="XML"
+                type="scale"
+                calcMode="spline"
+                values="1;hover_effect_zoom"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3s"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+            <animate
+                xlink:href="#shapeOverlay"
+                attributeName="fill-opacity"
+                values="0;hover_effect_opacity"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+            <animateTransform
+                xlink:href="#shapeOverlay"
+                attributeName="transform"
+                attributeType="XML"
+                type="scale"
+                calcMode="spline"
+                values="1;hover_effect_zoom"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3s"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+        </g>
+    </g>
+
+    <!-- Outline -->
+    <g id="outline">
+        <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+            <defs>
+                <clipPath id="shapeBorderClipPath">
+                    <!-- Needed because the border is "centered" on the path -->
+                    <use xlink:href="#filterPath"/>
+                </clipPath>
+            </defs>
+            <use id="shapeBorder" xlink:href="#filterPath" fill="none" stroke="hover_effect_color"
+                stroke-width="0" stroke-opacity="hover_effect_opacity" clip-path="url(#shapeBorderClipPath)"/>
+        </svg>
+        <g id="hoverEffects">
+            <animate
+                xlink:href="#shapeBorder"
+                attributeName="stroke-width"
+                values="1;hover_effect_stroke_width"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+        </g>
+        <style>
+            #filterPath {
+                vector-effect: non-scaling-stroke;
+            }
+        </style>
+    </g>
+
+    <!-- Overlay -->
+    <g id="overlay">
+        <svg viewBox="0 0 1 1" preserveAspectRatio="none">
+            <use id="shapeOverlay" xlink:href="#filterPath" fill="hover_effect_color" fill-opacity="0"/>
+        </svg>
+        <g id="hoverEffects">
+            <animate
+                xlink:href="#shapeOverlay"
+                attributeName="fill-opacity"
+                values="0;hover_effect_opacity"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+        </g>
+    </g>
+
+    <!-- Image Mirror Blur -->
+    <g id="image_mirror_blur">
+        <g id="hoverEffects">
+            <animateTransform
+                xlink:href="#shapeImage"
+                attributeName="transform"
+                attributeType="XML"
+                type="scale"
+                values="1;hover_effect_zoom"
+                keyTimes="0;1"
+                keySplines="0.5 0 0.5 1"
+                dur="0.3"
+                fill="freeze"
+                repeatCount="1"
+                begin="indefinite"/>
+
+            <filter xmlns="http://www.w3.org/2000/svg" id="blurFilter">
+                <feGaussianBlur stdDeviation="3"/>
+            </filter>
+      </g>
+    </g>
+
+</svg>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -347,6 +347,30 @@
         <attribute name="data-dependencies">no_animation_opt</attribute>
     </xpath>
 
+    <!-- Hover effects options -->
+    <xpath expr="//div[@data-js='ImageTools']" position="inside">
+        <div id="o_hover_effects_options">
+            <we-select string="Effect" class="o_we_sublevel_1" data-attribute-name="hoverEffect"
+                data-set-img-shape-hover-effect="true" data-no-preview="true">
+                <we-button data-select-data-attribute="" data-name="hover_effect_none_opt">None</we-button>
+                <we-button data-select-data-attribute="overlay" data-name="hover_effect_overlay_opt">Overlay</we-button>
+                <we-button data-select-data-attribute="image_zoom_in" data-name="hover_effect_zoom_in_opt">Zoom In</we-button>
+                <we-button data-select-data-attribute="image_zoom_out" data-name="hover_effect_zoom_out_opt">Zoom Out</we-button>
+                <we-button data-select-data-attribute="dolly_zoom" data-name="hover_effect_dolly_zoom_opt">Dolly Zoom</we-button>
+                <we-button data-select-data-attribute="outline" data-name="hover_effect_outline_opt">Outline</we-button>
+                <we-button data-select-data-attribute="image_mirror_blur" data-name="hover_effect_mirror_blur_opt">Mirror Blur</we-button>
+            </we-select>
+            <we-range string="Intensity" class="o_we_sublevel_2" data-select-data-attribute="" data-attribute-name="hoverEffectIntensity"
+                data-dependencies="hover_effect_zoom_in_opt, hover_effect_zoom_out_opt, hover_effect_mirror_blur_opt, hover_effect_dolly_zoom_opt"
+                data-min="1" data-max="100" data-step="1" data-display-range-value="true" data-no-preview="true"/>
+            <we-colorpicker string="Color" class="o_we_sublevel_2" data-set-hover-effect-color="true" data-excluded="theme, common"
+                data-dependencies="hover_effect_dolly_zoom_opt, hover_effect_overlay_opt, hover_effect_zoom_in_opt, hover_effect_zoom_out_opt, hover_effect_outline_opt"
+                data-no-preview="true" data-name="hover_effect_color_opt"/>
+            <we-input string="Stroke Width" class="o_we_sublevel_2" data-select-data-attribute="" data-attribute-name="hoverEffectStrokeWidth"
+                data-step="1" data-min="1" data-unit="px" data-dependencies="hover_effect_outline_opt" data-no-preview="true"/>
+        </div>
+    </xpath>
+
     <!-- =================================================================== -->
     <!-- Adding website specific snippet options                             -->
     <!-- =================================================================== -->
@@ -1391,6 +1415,9 @@
                            data-select-class="o_animate o_animate_on_scroll"
                            data-force-animation="true"
                            data-name="animation_on_scroll_opt">On Scroll</we-button>
+                <we-button data-animation-mode="onHover"
+                           data-select-class="o_animate_on_hover"
+                           data-name="animation_on_hover_opt">On Hover</we-button>
             </we-select>
             <we-button-group data-dependencies="animation_on_scroll_opt"
                              data-no-preview="true" data-force-animation="true">
@@ -1399,8 +1426,7 @@
             </we-button-group>
         </we-row>
         <!-- Effect -->
-        <we-select string="Effect" class="o_we_sublevel_1" data-dependencies="!no_animation_opt"
-                   data-name="animation_effect_opt">
+        <we-select string="Effect" class="o_we_sublevel_1" data-name="animation_effect_opt">
             <we-button data-select-class=""
                        data-name="o_anim_no_effect_opt"
                        data-dependencies="no_animation_opt">None</we-button>
@@ -1438,8 +1464,7 @@
                        data-trigger="animation_direction_in_place_opt">Flip-In-Y</we-button>
         </we-select>
         <!-- Direction -->
-        <we-select string="Direction" class="o_we_sublevel_1"
-                   data-dependencies="!no_animation_opt" data-name="animation_direction_opt"
+        <we-select string="Direction" class="o_we_sublevel_1" data-name="animation_direction_opt"
                    data-force-animation="true">
             <we-button data-select-class=""
                        data-name="animation_direction_in_place_opt"
@@ -1469,8 +1494,7 @@
             <we-button data-select-class="o_animate_both_scroll">Every Time</we-button>
         </we-select>
         <!-- Intensity -->
-        <we-range string="Intensity" class="o_we_sublevel_1"
-                  data-name="animation_intensity_opt" data-dependencies="!no_animation_opt"
+        <we-range string="Intensity" class="o_we_sublevel_1" data-name="animation_intensity_opt"
                   data-animation-intensity="" data-min="1" data-max="100" data-step="1"
                   data-display-range-value="true" data-no-preview="true"/>
         <!-- Scroll Zone -->


### PR DESCRIPTION
**[IMP] web_editor: allow to flip/rotate image shapes**

This commit adds the possibility to horizontally/vertically mirror and
rotate the shape of an image. We've introduced a new sub-option for
image shapes called "Transform".

This new option is not available for certain shapes:
- If the transform will have no effect (a vertically and horizontally
symmetrical shape).
- With some animations, if the animation is too complex for the system
to work.
- For "devices" shapes because they are too specific for the option to
work. And anyway "devices" shapes are already available horizontally
flipped in the list.

task-3094258

________________________________________________________

**[IMP] web_editor, website: add an "on hover" option for animations**

This commit adds an "on hover" option for animations. We've added the
"on hover" option to the animation selector. This feature is only
available for images. It allows you to pick an animation that triggers
when you hover your mouse over an image. There are six different
animations to choose from. This new animation option doesn't work with
animated shapes and devices shapes.

task-3094258