### PR TITLE
[FIX] web,account: avoid ordering by many2one._order in Dashboard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -80,6 +80,7 @@ class account_journal(models.Model):
                 domain=[('journal_id', 'in', self.ids)],
                 fields=['journal_id'],
                 groupby=['journal_id'],
+                orderby='id',
             )
         }
         for journal in self:
@@ -289,12 +290,12 @@ class account_journal(models.Model):
             (number_waiting, sum_waiting) = self._count_results_and_sum_amounts(query_results_to_pay, currency, curr_cache=curr_cache)
             (number_draft, sum_draft) = self._count_results_and_sum_amounts(query_results_drafts, currency, curr_cache=curr_cache)
             (number_late, sum_late) = self._count_results_and_sum_amounts(late_query_results, currency, curr_cache=curr_cache)
-            read = self.env['account.move'].read_group([('journal_id', '=', self.id), ('to_check', '=', True)], ['amount_total_signed'], 'journal_id', lazy=False)
+            read = self.env['account.move'].read_group([('journal_id', '=', self.id), ('to_check', '=', True)], ['amount_total_signed'], 'journal_id', lazy=False, orderby='id')
             if read:
                 number_to_check = read[0]['__count']
                 to_check_balance = read[0]['amount_total_signed']
         elif self.type == 'general':
-            read = self.env['account.move'].read_group([('journal_id', '=', self.id), ('to_check', '=', True)], ['amount_total_signed'], 'journal_id', lazy=False)
+            read = self.env['account.move'].read_group([('journal_id', '=', self.id), ('to_check', '=', True)], ['amount_total_signed'], 'journal_id', lazy=False, orderby='id')
             if read:
                 number_to_check = read[0]['__count']
                 to_check_balance = read[0]['amount_total_signed']

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -107,7 +107,7 @@ class Base(models.AbstractModel):
             length = limit
             chunk_size = 100000
             while True:
-                more = len(self.read_group(domain, ['display_name'], groupby, offset=length, limit=chunk_size, lazy=True))
+                more = len(self.read_group(domain, ['display_name'], groupby, orderby='id', offset=length, limit=chunk_size, lazy=True))
                 length += more
                 if more < chunk_size:
                     break


### PR DESCRIPTION
Calling read_group without orderby can produce suboptimal queries because _read_group_prepare will use comodel._order if the groupby field is a many2one. This adds LEFT JOINs to the resulting queries. This can be avoided by adding an explicit orderby='id' for backend read_group calls, i.e. calls for whom the order of the read_group's results does not matter.

#### speedup

In a database with 3.5M account_moves, this speeds up the initial search_read of the Accounting App Dashboard by a factor two. Same goes for the computation of grouped ListViews' upperbound in web/web_read_group (1.9s -> ~850ms).

Should be up-to 16.2 as in master backend calls to read_group have been changed to new `_read_group` in https://github.com/odoo/odoo/pull/110737.

(Could use 4ef0c00b4b in 16.0 but not sure if it's really worth).

opw-3229092

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
