### PR TITLE
[FIX] sale_timesheet: days spent showing hours

### DIFF
--- a/addons/sale_timesheet/controllers/__init__.py
+++ b/addons/sale_timesheet/controllers/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import portal
+from . import pivot

--- a/addons/sale_timesheet/controllers/pivot.py
+++ b/addons/sale_timesheet/controllers/pivot.py
@@ -1,0 +1,44 @@
+import json
+
+from odoo import http, _
+from odoo.http import request
+from odoo.tools import float_round
+from odoo.addons.web.controllers.pivot import TableExporter
+
+
+class PivotExporter(TableExporter):
+
+    @http.route('/web/pivot/export_xlsx', type='http', auth="user")
+    def export_xlsx(self, data, **kw):
+        jdata = self.convert_columns(data)
+        return super().export_xlsx(json.dumps(jdata), **kw)
+
+    def convert_columns(self, data):
+        """
+        Backend data are all in hours. Widget converts the uom (hours > day) only for the frontend pivot view
+        The function is to handle it error-proof for downloading xlsx feature
+        """
+
+        dict_data = json.loads(data)
+        indexes = []
+        index = 0
+        if dict_data['model'] == 'timesheets.analysis.report':
+
+            hours_uom = request.env.ref('uom.product_uom_hour', raise_if_not_found=False)
+            if not hours_uom:
+                return dict_data
+
+            for col in dict_data['measure_headers']:
+                if _('Days Spent').lower() in col['title'].lower():
+                    indexes.append(index)
+                index += 1
+
+            for index in indexes:
+                for row in dict_data['rows']:
+                    col = row['values'][index]
+                    if col['value']:  # skip null
+                        try:
+                            col['value'] = str(float_round(float(col['value']) / hours_uom.factor, precision_digits=2, rounding_method='UP'))
+                        except Exception:
+                            continue
+        return dict_data

--- a/addons/sale_timesheet/i18n/sale_timesheet.pot
+++ b/addons/sale_timesheet/i18n/sale_timesheet.pot
@@ -402,6 +402,13 @@ msgid "Days Remaining)"
 msgstr ""
 
 #. module: sale_timesheet
+#. odoo-python
+#: code:addons/sale_timesheet/controllers/pivot.py:0
+#, python-format
+msgid "Days Spent"
+msgstr ""
+
+#. module: sale_timesheet
 #: model_terms:ir.ui.view,arch_db:sale_timesheet.project_project_view_form
 msgid "Default Service"
 msgstr ""


### PR DESCRIPTION
1. Install [Timesheet], [Sales]
2. Settings > Time Encoding > Encoding Method > Days/Half-days
- Make sure the company has more than 1 employee on Employee app
3. On Products, edit Service product type to have:
- invoicing policy: based on timesheets
- create on order: project
- uom: Days
4. On Sales app, create a SO and add a service with a price
- automatically a project will be created
5. On Timesheet app, create a project linked to the SOL
6. Create a task and set timesheet 1 day
7. Go to [Timesheet] > [Reporting] > [By Employee]
8. Group by SOL and dipslay the MEASURE 'Timesheet Revenues'
9. click on Download xlsx

Issue: Days Spent column shows hours

Impacted version: 16-master
opw-3283045