### PR TITLE
[IMP] survey: allow user to navigate freely

### DIFF
--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -1,0 +1,74 @@
+/** @odoo-module **/
+
+import { registry } from '@web/core/registry';
+
+registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions', {
+    test: true,
+    url: '/survey/start/853ebb30-40f2-43bf-a95a-bbf0e367a365',
+    steps: () => [{
+        content: 'Click on Start',
+        trigger: 'button.btn:contains("Start")',
+    }, {
+        content: 'Skip question Q1',
+        trigger: 'button.btn:contains("Continue")',
+    }, {
+        content: 'Skip question Q2',
+        extra_trigger: 'div.js_question-wrapper:contains("Q2")',
+        trigger: 'button.btn:contains("Continue")',
+    }, {
+        content: 'Check if Q3 button is Submit',
+        trigger: 'button.btn:contains("Submit")',
+        isCheck: true,
+    }, {
+        content: 'Go back to Q2',
+        trigger: 'button.btn[value="previous"]',
+    }, {
+        content: 'Check if the alert box is present',
+        trigger: 'div.o_survey_question_error span',
+        isCheck: true,
+    }, {
+        content: 'Skip question Q2 again',
+        trigger: 'button.btn:contains("Continue")',
+    }, {
+        content: 'Answer Q3',
+        trigger: 'div.js_question-wrapper:contains("Q3") label:contains("Answer 1")',
+    }, {
+        content: 'Click on Submit',
+        trigger: 'button.btn:contains("Submit")',
+    }, {
+        content: 'Check if question is Q1',
+        trigger: 'div.js_question-wrapper:contains("Q1")',
+        isCheck: true,
+    }, {
+        content: 'Click on "Next Skipped" button',
+        trigger: 'button.btn:contains("Next Skipped")',
+    }, {
+        content: 'Check if question is Q2',
+        trigger: 'div.js_question-wrapper:contains("Q2")',
+        isCheck: true,
+    }, {
+        content: 'Click on "Next Skipped" button',
+        trigger: 'button.btn:contains("Next Skipped")',
+    }, {
+        content: 'Check if question is Q1 again (should loop on skipped questions)',
+        trigger: 'div.js_question-wrapper:contains("Q1")',
+        isCheck: true,
+    }, {
+        content: 'Answer Q1',
+        trigger: 'div.js_question-wrapper:contains("Q1") label:contains("Answer 2")',
+    }, {
+        content: 'Check if the visible question is the skipped question Q2',
+        trigger: 'div.js_question-wrapper:contains("Q2")',
+        isCheck: true,
+    }, {
+        content: 'Answer Q2',
+        trigger: 'div.js_question-wrapper:contains("Q2") label:contains("Answer 3")',
+    }, {
+        content: 'Click on Submit',
+        trigger: 'button.btn:contains("Submit")',
+    }, {
+        content: 'Check if the survey is done',
+        trigger: 'div.o_survey_finished h1:contains("Thank you!")',
+        isCheck: true,
+    }],
+});

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -292,3 +292,48 @@ class TestUiFeedback(HttpCaseWithUserDemo):
     def test_06_survey_prefill(self):
         access_token = self.survey_feedback.access_token
         self.start_tour("/survey/start/%s" % access_token, 'test_survey_prefill')
+
+    def test_07_survey_roaming_mandatory_questions(self):
+        survey_with_mandatory_questions = self.env['survey.survey'].create({
+            'title': 'Survey With Mandatory questions',
+            'access_token': '853ebb30-40f2-43bf-a95a-bbf0e367a365',
+            'access_mode': 'public',
+            'users_can_go_back': True,
+            'questions_layout': 'page_per_question',
+            'description': "<p>Test survey with roaming freely option and mandatory questions</p>",
+            'question_and_page_ids': [
+                Command.create({
+                    'title': 'Q1',
+                    'sequence': 1,
+                    'question_type': 'simple_choice',
+                    'constr_mandatory': True,
+                    'suggested_answer_ids': [
+                        Command.create({'value': 'Answer 1'}),
+                        Command.create({'value': 'Answer 2'}),
+                        Command.create({'value': 'Answer 3'}),
+                    ],
+                }), Command.create({
+                    'title': 'Q2',
+                    'sequence': 2,
+                    'question_type': 'simple_choice',
+                    'constr_mandatory': True,
+                    'suggested_answer_ids': [
+                        Command.create({'value': 'Answer 1'}),
+                        Command.create({'value': 'Answer 2'}),
+                        Command.create({'value': 'Answer 3'}),
+                    ],
+                }), Command.create({
+                    'title': 'Q3',
+                    'sequence': 3,
+                    'question_type': 'simple_choice',
+                    'constr_mandatory': True,
+                    'suggested_answer_ids': [
+                        Command.create({'value': 'Answer 1'}),
+                        Command.create({'value': 'Answer 2'}),
+                    ],
+                }),
+            ]
+        })
+
+        access_token = survey_with_mandatory_questions.access_token
+        self.start_tour("/survey/start/%s" % access_token, 'test_survey_roaming_mandatory_questions')

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -97,7 +97,7 @@
                                            invisible="questions_layout == 'one_page' or survey_type == 'live_session'"/>
                                     <field name="questions_selection" widget="radio"
                                            invisible="survey_type == 'live_session'"/>
-                                    <field name="users_can_go_back" string="Back Button"
+                                    <field name="users_can_go_back" string="Allow Roaming"
                                            invisible="questions_layout == 'one_page' or survey_type == 'live_session'"/>
                                 </group>
                                 <group string="Participants" name="participants">

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -191,7 +191,7 @@
             </t>
 
             <div class="text-center mt16 mb256">
-                <button type="submit" value="finish" class="btn btn-primary disabled">Submit</button>
+                <button type="submit" value="finish" class="btn btn-secondary disabled">Submit</button>
                     <span class="fw-bold text-muted ms-2 d-none d-md-inline">
                         <span id="enter-tooltip">or press Enter</span>
                     </span>
@@ -209,9 +209,12 @@
 
             <div class="row">
                 <div class="col-12 text-center mt16">
-                    <button type="submit" t-att-value="'next' if not survey_last else 'finish'" class="btn btn-primary disabled">
-                        <t t-if="not survey_last">Continue</t>
-                        <t t-else="">Submit</t>
+                    <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else 'next_skipped'
+                        if answer.survey_first_submitted and skipped_questions.page_id and page in skipped_questions.page_id else 'next'"/>
+                    <button type="submit" t-att-value="submit_value" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} disabled">
+                        <t t-if="submit_value == 'finish'">Submit</t>
+                        <t t-elif="submit_value == 'next_skipped'">Next Skipped</t>
+                        <t t-else="">Continue</t>
                     </button>
                     <span class="fw-bold text-muted ms-2 d-none d-md-inline" id="enter-tooltip"> or press Enter</span>
                 </div>
@@ -247,8 +250,11 @@
 
                 <div class="row">
                     <div class="col-12 text-center mt16">
-                        <button type="submit" t-att-value="'next' if not survey_last else 'finish'" class="btn btn-primary disabled">
-                            <t t-if="answer.is_session_answer or survey_last">Submit</t>
+                        <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else
+                            'next_skipped' if answer.survey_first_submitted and skipped_questions and question in skipped_questions else 'next'"/>
+                        <button type="submit" t-att-value="submit_value" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} disabled">
+                            <t t-if="submit_value == 'finish'">Submit</t>
+                            <t t-elif="submit_value == 'next_skipped'">Next Skipped</t>
                             <t t-else="">Continue</t>
                         </button>
                         <span class="fw-bold text-muted ms-2 d-none d-md-inline">
@@ -318,10 +324,12 @@
         <t t-set="default_constr_error_msg">This question requires an answer.</t>
         <t t-set="default_validation_error_msg">The answer you entered is not valid.</t>
         <t t-set="default_comments_message">If other, please specify:</t>
+        <t t-set="is_skipped_question" t-value="skipped_questions and question in skipped_questions"/>
         <div t-att-class="'js_question-wrapper pb-4 %s %s' % ('d-none' if not display_question else '', 'me-2' if extra_right_margin else '')"
-             t-att-id="question.id" t-att-data-required="question.constr_mandatory"
-             t-att-data-constr-error-msg="question.constr_error_msg or default_constr_error_msg"
-             t-att-data-validation-error-msg="question.validation_error_msg or default_validation_error_msg">
+             t-att-id="question.id"
+             t-att-data-required="bool(question.constr_mandatory and (not survey.users_can_go_back or survey.questions_layout == 'one_page')) or None"
+             t-att-data-constr-error-msg="question.constr_error_msg or default_constr_error_msg if question.constr_mandatory else None"
+             t-att-data-validation-error-msg="question.validation_error_msg or default_validation_error_msg if question.validation_required else None">
             <div class="mb-4">
                 <h3 t-if="not hide_question_title">
                     <span t-field='question.title' class="text-break" />
@@ -337,7 +345,10 @@
             <t t-if="question.question_type == 'simple_choice'"><t t-call="survey.question_simple_choice"/></t>
             <t t-if="question.question_type == 'multiple_choice'"><t t-call="survey.question_multiple_choice"/></t>
             <t t-if="question.question_type == 'matrix'"><t t-call="survey.question_matrix"/></t>
-            <div class="o_survey_question_error overflow-hidden border-0 py-0 px-3 alert alert-danger" role="alert"></div>
+            <div t-attf-class="o_survey_question_error d-flex align-items-center justify-content-between overflow-hidden
+                 border-0 py-0 px-3 alert alert-danger #{'slide_in' if is_skipped_question else ''}" role="alert">
+                <span t-if="is_skipped_question" t-out="question.constr_error_msg or default_constr_error_msg"/>
+            </div>
         </div>
     </template>
 
@@ -414,6 +425,7 @@
         <t t-set="comment_line" t-value="answer_lines.filtered(lambda line: line.value_char_box)"/>
         <div class="row o_survey_form_choice"
              t-att-data-name="question.id"
+             t-att-data-is-skipped-question="is_skipped_question or None"
              data-question-type="simple_choice_radio">
             <t t-set="item_idx" t-value="0"/>
             <div t-attf-class="col-lg-12 d-flex flex-wrap">


### PR DESCRIPTION
This commit allows the user to navigate freely through a
survey with mandatory questions. He will be able to skip
questions and come back to them later. If he still hasn't
answered them at the final submit they will automatically
be displayed with an error message to invite the user to
answer them. The user can navigate through the skipped
questions with a button within the error box.

Task-2605657

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
