### PR TITLE
[FIX] mass_mailing : stricter perm for mailing.trace

### DIFF
--- a/addons/mass_mailing/security/ir.model.access.csv
+++ b/addons/mass_mailing/security/ir.model.access.csv
@@ -7,7 +7,7 @@ access_mailing_list_mm_user,access.mailing.list.mm.user,model_mailing_list,mass_
 access_utm_stage,utm.stage,utm.model_utm_stage,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_mailing_mm_user,access.mailing.mailing.mm.user,model_mailing_mailing,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_mailing_system,access.mailing.mailing.system,model_mailing_mailing,base.group_system,1,1,1,1
-access_mailing_trace_user,mailing.trace.user,model_mailing_trace,base.group_user,1,1,1,1
+access_mailing_trace_user,mailing.trace.user,model_mailing_trace,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_trace_mm_user,access.mailing.trace.mm.user,model_mailing_trace,mass_mailing.group_mass_mailing_user,1,1,1,1
 access_mailing_trace_report_mm_user,access.mailing.trace.report.mm.user,model_mailing_trace_report,mass_mailing.group_mass_mailing_user,1,0,0,0
 access_utm_campaign_mass_mailing_user,utm.campaign,utm.model_utm_campaign,mass_mailing.group_mass_mailing_user,1,1,1,1


### PR DESCRIPTION
Restrict permissions of access to mail.trace to group_mass_mailing_user.
