### PR TITLE
[FIX] l10n_es(_edi_sii): remove this tax that does not make any sense

### DIFF
--- a/addons/l10n_es/data/account_tax_data.xml
+++ b/addons/l10n_es/data/account_tax_data.xml
@@ -363,38 +363,6 @@
             }),
         ]"/>
     </record>
-    <record id="account_tax_template_s_iva21isp" model="account.tax.template">
-        <field name="description"/>
-        <!-- for resetting the value on existing DBs -->
-        <field name="type_tax_use">sale</field>
-        <field name="name">IVA 21% (ISP)</field>
-        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
-        <field name="amount" eval="21"/>
-        <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_iva_21"/>
-        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_07')],
-            }),
-            (0,0, {
-                'repartition_type': 'tax',
-                'account_id': ref('l10n_es.account_common_477'),
-                'tag_ids': [ref('mod_303_09')],
-            }),
-         ]"/>
-        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
-            (0,0, {
-                'repartition_type': 'base',
-                'tag_ids': [ref('mod_303_14_sale')],
-            }),
-            (0,0, {
-                'repartition_type': 'tax',
-                'account_id': ref('l10n_es.account_common_477'),
-                'tag_ids': [ref('mod_303_15')],
-            }),
-        ]"/>
-    </record>
     <record id="account_tax_template_p_iva21_bc" model="account.tax.template">
         <field name="sequence" eval="0"/>
         <!-- Para que sea el impuesto por defecto de compras -->

--- a/addons/l10n_es_edi_sii/data/account_tax_data.xml
+++ b/addons/l10n_es_edi_sii/data/account_tax_data.xml
@@ -8,9 +8,6 @@
         <field name="l10n_es_type">sujeto</field>
         <field name="tax_scope">service</field>
     </record>
-    <record id="l10n_es.account_tax_template_s_iva21isp" model="account.tax.template">
-        <field name="l10n_es_type">sujeto_isp</field>
-    </record>
     <record id="l10n_es.account_tax_template_p_iva21_bc" model="account.tax.template">
         <field name="name">21% IVA soportado (bienes corrientes)</field>
         <field name="l10n_es_type">sujeto</field>


### PR DESCRIPTION
In https://circulantis.com/blog/factura-inversion-sujeto-pasivo/ it clearly explains that sale ISP is always with 0% and as such to have a sale tax with 21% IVA does not make any sense.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
