### PR TITLE
[IMP] gamification: update users goals more precisely

### DIFF
--- a/addons/gamification/models/__init__.py
+++ b/addons/gamification/models/__init__.py
@@ -9,4 +9,5 @@ from . import gamification_goal
 from . import gamification_goal_definition
 from . import gamification_karma_rank
 from . import gamification_karma_tracking
+from . import ir_http
 from . import res_users

--- a/addons/gamification/models/ir_http.py
+++ b/addons/gamification/models/ir_http.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import time
+
+from odoo import models
+from odoo.http import request
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @classmethod
+    def _dispatch(cls, endpoint):
+        result = super()._dispatch(endpoint)
+        cls._tag_session_for_interactions_log()
+        return result
+
+    @classmethod
+    def _authenticate(cls, endpoint):
+        result = super()._authenticate(endpoint)
+        cls._tag_session_for_interactions_log(skip_log_record_update=True)
+        return result
+
+    @classmethod
+    def _tag_session_for_interactions_log(cls, skip_log_record_update=False):
+        """Add a timestamp to the session to throttle the interactions logging.
+
+        For gamification goals purposes, it is sufficient to know whether users
+        interacted with the application at least once between cron runs.
+        This method avoids fetching user data from the db (as it is lazy-loaded)
+        (and updating records) when it is not necessary. The timestamp value
+        stored on the session is the moment after which it will be necessary to
+        log user interaction again.
+
+        This method will update the `no_interactions_log_until_timestamp`
+        key to the session if necessary (not for public users or if the
+        current time is before the existing value on the session).
+
+        :param skip_log_record_update: Set `True` to also skip updating the
+         user's `last_interaction_date`. It can for example be used
+         when authenticating as the res.users.log record was just created
+         with the correct value, we just need to tag the session.
+        """
+        if (
+            not request.session.uid
+            or time.time() < request.session.get("no_interactions_log_until_timestamp", 0)
+            or not (user := request.env.user)
+        ):
+            return
+        if not skip_log_record_update:
+            user._update_last_interacted()
+        if not user.last_interacted_date:
+            return
+        cron_interval_seconds = request.env['gamification.challenge']._get_cron_update_interval_or_default()
+        request.session.no_interactions_log_until_timestamp = int(
+            user.last_interacted_date.timestamp() + cron_interval_seconds / 3
+        )

--- a/addons/gamification/tests/__init__.py
+++ b/addons/gamification/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_challenge
 from . import test_karma_tracking
+from . import test_performance

--- a/addons/gamification/tests/__init__.py
+++ b/addons/gamification/tests/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_challenge
+from . import test_cron
 from . import test_karma_tracking
 from . import test_performance

--- a/addons/gamification/tests/test_challenge.py
+++ b/addons/gamification/tests/test_challenge.py
@@ -65,10 +65,10 @@ class test_challenge(TestGamificationCommon):
     def test_20_update_all_goals_filter(self):
         # Enroll two internal and two portal users in the challenge
         (
-            portal_login_before_update,
-            portal_login_after_update,
-            internal_login_before_update,
-            internal_login_after_update,
+            portal_last_active_old,
+            portal_last_active_recent,
+            internal_last_active_old,
+            internal_last_active_recent,
         ) = all_test_users = self.env['res.users'].create([
             {
                 'name': f'{kind} {age} login',
@@ -92,19 +92,25 @@ class test_challenge(TestGamificationCommon):
 
         # Setup user access logs
         self.env['res.users.log'].search([('create_uid', 'in', challenge.user_ids.ids)]).unlink()
-        now = datetime.datetime.now()
+        now = self.env.cr.now()
 
         # Create "old" log in records
+        twenty_minutes_ago = now - datetime.timedelta(minutes=20)
         self.env['res.users.log'].create([
-            {"create_uid": internal_login_before_update.id, 'create_date': now - datetime.timedelta(minutes=3)},
-            {"create_uid": portal_login_before_update.id, 'create_date': now - datetime.timedelta(minutes=3)},
+            {'create_uid': user.id, 'create_date': twenty_minutes_ago, 'last_interacted_date': twenty_minutes_ago}
+            for user in (
+                portal_last_active_old,
+                portal_last_active_recent,
+                internal_last_active_old,
+                internal_last_active_recent,
+            )
         ])
 
         # Reset goal objective values
         all_test_users.partner_id.tz = False
 
         # Regenerate all goals
-        self.env["gamification.goal"].search([]).unlink()
+        self.env['gamification.goal'].search([]).unlink()
         self.assertFalse(self.env['gamification.goal'].search([]))
 
         challenge.action_check()
@@ -114,27 +120,29 @@ class test_challenge(TestGamificationCommon):
         self.assertEqual(len(goal_ids), 4)
         self.assertEqual(set(goal_ids.mapped('state')), {'inprogress'})
 
-        # Create more recent log in records
-        self.env['res.users.log'].create([
-            {"create_uid": internal_login_after_update.id, 'create_date': now + datetime.timedelta(minutes=3)},
-            {"create_uid": portal_login_after_update.id, 'create_date': now + datetime.timedelta(minutes=3)},
-        ])
+        # Update active status
+        users_recent = internal_last_active_recent | portal_last_active_recent
+        for recent_user in users_recent:
+            recent_user._update_last_interacted()
+        self.assertTrue(all(user.last_interacted_date != twenty_minutes_ago for user in users_recent))
+        users_recent.log_ids.flush_recordset()
 
         # Update goal objective checked by goal definition
         all_test_users.partner_id.write({'tz': 'Europe/Paris'})
+        all_test_users.flush_recordset()
 
         # Update goals as done by _cron_update
         challenge._update_all()
-        unchanged_goal_id = self.env['gamification.goal'].search([
+        unchanged_goal_ids = self.env['gamification.goal'].search([
             ('challenge_id', '=', challenge.id),
             ('state', '=', 'inprogress'),  # others were updated to "reached"
             ('user_id', 'in', challenge.user_ids.ids),
         ])
-        # Check that even though login record for internal user is older than goal update, their goal was reached.
+
+        # Check that goals of users not recently active were not updated
         self.assertEqual(
-            portal_login_before_update,
-            unchanged_goal_id.user_id,
-            "Only portal user last logged in before last challenge update should not have been updated.",
+            portal_last_active_old | internal_last_active_old,
+            unchanged_goal_ids.user_id,
         )
 
 

--- a/addons/gamification/tests/test_cron.py
+++ b/addons/gamification/tests/test_cron.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.base.tests.common import TransactionCase
+from odoo.tools import mute_logger
+
+
+class TestGamificationCron(TransactionCase):
+    def test_get_cron_update_interval_or_default_interval(self):
+        # Check that we get the lower frequency set on the cron.
+        self.env.ref("gamification.ir_cron_check_challenge").write({
+            "interval_type": "hours",
+            "interval_number": 12,
+        })
+        self.assertEqual(12*60*60, self.env["gamification.challenge"]._get_cron_update_interval_or_default())
+
+    @mute_logger('odoo.models.unlink')
+    def test_get_cron_update_interval_or_default_default(self):
+        """Test that the method returns 24h if the record isn't found."""
+        cron = self.env.ref("gamification.ir_cron_check_challenge")
+        cron.unlink()
+        self.assertEqual(24*60*60, self.env["gamification.challenge"]._get_cron_update_interval_or_default())

--- a/addons/gamification/tests/test_performance.py
+++ b/addons/gamification/tests/test_performance.py
@@ -5,7 +5,7 @@ from odoo.tests import tagged
 @tagged("post_install", "-at_install")
 class TestPerformance(TestWebLogin):
     def test_web_login(self):
-        with self.assertQueryCount(174):  # com: 151 ; ent: 174 ; local gamification only: 126
+        with self.assertQueryCount(184):  # com: 161 ; ent: 184 ; local gamification only: 134
             try:
                 super().test_web_login()
             except AssertionError:
@@ -13,7 +13,7 @@ class TestPerformance(TestWebLogin):
                 pass
 
     def test_web_login_external(self):
-        with self.assertQueryCount(262):  # com: 250 ; ent: 262 ; local gamification only: 110
+        with self.assertQueryCount(271):  # com: 260 ; ent: 271 ; local gamification only: 117
             try:
                 super().test_web_login_external()
             except AssertionError:

--- a/addons/gamification/tests/test_performance.py
+++ b/addons/gamification/tests/test_performance.py
@@ -1,0 +1,26 @@
+from odoo.addons.web.tests.test_login import TestWebLogin
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPerformance(TestWebLogin):
+    def test_web_login(self):
+        with self.assertQueryCount(174):  # com: 151 ; ent: 174 ; local gamification only: 126
+            try:
+                super().test_web_login()
+            except AssertionError:
+                # See `test_web_login_external`
+                pass
+
+    def test_web_login_external(self):
+        with self.assertQueryCount(262):  # com: 250 ; ent: 262 ; local gamification only: 110
+            try:
+                super().test_web_login_external()
+            except AssertionError:
+                # Running this test in post_install is best practice for performance evaluation.
+                # In a full installation of Odoo, other modules may alter the flow of loging in
+                # (see portal's version of the test).
+                # As gamification is only dependent on `base` and `mail`, we have to re-run the
+                # base version of the test, with stale assertions. It doesn't matter because we
+                # only care to track the number of queries necessary to reach the end.
+                pass

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1671,6 +1671,7 @@ class HttpCase(TransactionCase):
             session.login = user
             session.session_token = uid and security.compute_session_token(session, env)
             session.context = dict(env['res.users'].context_get())
+            session.no_interactions_log_until_timestamp = int(datetime.now().timestamp()) + 28_800  # 8 hours
 
         odoo.http.root.session_store.save(session)
         # Reset the opener: turns out when we set cookies['foo'] we're really


### PR DESCRIPTION
In the cron updating challenges, we were historically filtering out
records of users that didn't log in since the last update. This doesn't
work because sessions can last a long time.

We temporarily fixed this by updating all goals for internal users, but
this can lead to unnecessary computations too.

We here introduce a `last_interacted_date` field on res.users.log.
In order to limit the performance impact for supporting our needs, we
 * store a timestamp in the session (because the env user is lazy
 loaded as many request do not need the user's data)
 * throttle writes to the database

Storing the timestamp in the session is chosen over a form of cache
because it is not linked to a process/worker.

The login tests used (available with gamification alone but modified
by other modules on runbot) likely covers the worst case scenario as we
change sessions. Other existing performance tests are generally done
with authenticated users such that the cache is filled and no extra
query is performed during all the subsequent operations of the tests.

Task-3148858