### PR TITLE
[FIX] point_of_sale: accept GS1 barcodes in PoS

### DIFF
--- a/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
@@ -46,7 +46,10 @@ BarcodeParser.include({
         const result = {
             rule: Object.assign({}, rule),
             ai: match[1],
-            string_value: match[2]
+            string_value: match[2],
+            code: match[2],
+            base_code: match[2],
+            type: rule.type
         };
         if (rule.gs1_content_type === 'measure'){
             let decimalPosition = 0; // Decimal position begin at the end, 0 means no decimal

--- a/addons/point_of_sale/static/src/js/barcode_reader.js
+++ b/addons/point_of_sale/static/src/js/barcode_reader.js
@@ -110,11 +110,10 @@ var BarcodeReader = core.Class.extend({
         const callbacks = Object.keys(this.exclusive_callbacks).length
             ? this.exclusive_callbacks
             : this.action_callbacks;
-        let parsed_results = this.barcode_parser.parse_barcode(code);
-        if (! Array.isArray(parsed_results)) {
-            parsed_results = [parsed_results];
-        }
-        for (const parsed_result of parsed_results) {
+        let parsed_result = this.barcode_parser.parse_barcode(code);
+        if (Array.isArray(parsed_result)) {
+            [...callbacks.multiple].map(cb => cb(parsed_result));
+        } else {
             if (callbacks[parsed_result.type]) {
                 for (const cb of callbacks[parsed_result.type]) {
                     await cb(parsed_result);


### PR DESCRIPTION
This update enables PoS to handle GS1 barcodes, which was previously not possible even though the GS1 nomenclature could be selected. GS1 barcodes can now be used to extract product identifiers, lot numbers, and serial numbers from the code.

opw-3204299

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
