### PR TITLE
[IMP] web_editor: fontawesome subnodes should make a node non-empty

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1713,7 +1713,7 @@ export function isEmptyBlock(blockEl) {
     for (const node of nodes) {
         // There is no text and no double BR, the only thing that could make
         // this visible is a "visible empty" node like an image.
-        if (node.nodeName != 'BR' && isSelfClosingElement(node)) {
+        if (node.nodeName != 'BR' && (isSelfClosingElement(node) || isFontAwesome(node))) {
             return false;
         }
     }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -110,6 +110,15 @@ describe('insert HTML', () => {
                 contentAfter: '<p>content</p><div>abc</div><p>def[]</p>',
             });
         });
+        it('should keep an "empty" block which contains fontawesome nodes when inserting multiple nodes', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>content</p>[]',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<div><i class="fa fa-circle-o-notch"></i></div><p>after</p>'));
+                },
+                contentAfter: '<p>content</p><div><i class="fa fa-circle-o-notch"></i></div><p>after[]</p>',
+            });
+        });
     });
     describe('not collapsed selection', () => {
         it('should delete selection and insert html in its place', async () => {


### PR DESCRIPTION
For each node that the `insert` command inserts, the previous node is evaluated
and tested to be a `shrunk` block. If it is, it is considered "invisible" and
removed.

Prior to this commit, an element containing sub-elements with a fontawesome icon
was considered to be `isEmptyBlock==='true'` even though it is supposedly
visible as it contains that icon.

In Knowledge, when an embedded view is not fully loaded, it is intended for it
to be a simple `div` element with a `i` subchild with a loading icon. It should
not be removed as an "empty" block since it will get its content when it
finishes loading.

Task-3284580