### PR TITLE
[FIX] core: dict_items is only reversible since Python3.8

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2535,7 +2535,7 @@ class BaseModel(metaclass=MetaModel):
             new_terms = []
             for order_term in orderby.split(','):
                 order_term = order_term.strip()
-                for key_name, annoted in itertools.chain(reversed(annoted_groupby.items()), annoted_aggregates.items()):
+                for key_name, annoted in itertools.chain(reversed(list(annoted_groupby.items())), annoted_aggregates.items()):
                     key_name = key_name.split(':')[0]
                     if order_term.startswith(f'{key_name} ') or key_name == order_term:
                         order_term = order_term.replace(key_name, annoted)


### PR DESCRIPTION
Our minimal Python version is still Python3.7
`reversed(annoted_groupby.items())` doesn't work in Python3.7 because `dict_items` are not reversible in this version (only available in Python3.8 :
https://docs.python.org/3/whatsnew/3.8.html#other-language-changes).

Convert into list before `reversed` to be compatible in Python3.7

