### PR TITLE
[FIX] web_editor: show background image options after save

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3600,6 +3600,11 @@ registry.BackgroundOptimize = ImageHandlerOption.extend({
     async cleanForSave() {
         const img = this._getImg();
         if (img.matches('.o_modified_image_to_save')) {
+            // First delete everything in the dataset because a data attribute
+            // could have been be removed (ex : glFilter).
+            Object.entries(this.$target[0].dataset).forEach(([key]) => {
+                delete this.$target[0].dataset[key];
+            });
             this.$target.addClass('o_modified_image_to_save');
             Object.entries(img.dataset).forEach(([key, value]) => {
                 this.$target[0].dataset[key] = value;
@@ -3631,15 +3636,20 @@ registry.BackgroundOptimize = ImageHandlerOption.extend({
      */
     async _loadImageInfo() {
         this.img = new Image();
-        Object.entries(this.$target[0].dataset).filter(([key]) =>
+        const targetEl = this.$target[0].classList.contains("oe_img_bg")
+            ? this.$target[0] : this.$target[0].querySelector(".oe_img_bg");
+        if (targetEl) {
+            Object.entries(targetEl.dataset).filter(([key]) =>
             // Avoid copying dynamic editor attributes
-            !['oeId','oeModel', 'oeField', 'oeXpath', 'noteId'].includes(key)
-        ).forEach(([key, value]) => {
-            this.img.dataset[key] = value;
-        });
-        const src = getBgImageURL(this.$target[0]);
-        // Don't set the src if not relative (ie, not local image: cannot be modified)
-        this.img.src = src.startsWith('/') ? src : '';
+            !["oeId", "oeModel", "oeField", "oeXpath", "noteId"].includes(key)
+            ).forEach(([key, value]) => {
+                this.img.dataset[key] = value;
+            });
+            const src = getBgImageURL(targetEl);
+            // Don't set the src if not relative (ie, not local image: cannot
+            // be modified)
+            this.img.src = src.startsWith("/") ? src : "";
+        }
         return await this._super(...arguments);
     },
     /**


### PR DESCRIPTION
Steps to reproduce the bug:
- Add a cover snippet on the website.
- Change the background image with one of your own.
- Save and Edit again. => Options such as "Filter", "Width" and "Quality" do not appear anymore.

The problem is that the `src` attribute of the background image is not correctly updated when initializing the image. This is because the target used to recover the URL of the background image is the snippet and not the image itself. This problem is resolved by ensuring that the argument of the function `getBgImageURL` is the background image. Now that the `src` attribute is correctly updated, the `computeVisibility` function of the the `BackgroudOptimize` option works properly and the options "Filter" "Width" and "Quality" are displayed as wanted.

With this in hand, another problem appears:
- Add a cover snippet on the website.
- Change the background image with one of your own.
- Put the "Blur" filter on it.
- Save & Edit again.
- Remove the filter.
- Save and edit again. => "Blur" is displayed for the filter but "None" should be displayed.

This problem exists because at the save request, the dataset of `this._getImg()` is copied into the dataset of the target. However, it could happen that an option has been removed from the dataset (for example `data-gl-filter`). In order to work properly, the target dataset should first be deleted and then filled with the content of the dataset of `this._getImg()`.

task-3288643
