### PR TITLE
[FIX] website: fix navbar alignment option label of the slogan header

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2192,7 +2192,7 @@ options.registry.HeaderNavbar = options.Class.extend({
         // For all header templates except those in the following array, change
         // the label of the option to "Mobile Alignment" (instead of
         // "Alignment") because it only impacts the mobile view.
-        if (!["'default'", "'hamburger'", "'sidebar'"].includes(weUtils.getCSSVariableValue('header-template'))) {
+        if (!["'default'", "'hamburger'", "'sidebar'", "'slogan'"].includes(weUtils.getCSSVariableValue('header-template'))) {
             const alignmentOptionTitleEl = this.el.querySelector('[data-name="header_alignment_opt"] we-title');
             alignmentOptionTitleEl.textContent = _t("Mobile Alignment");
         }


### PR DESCRIPTION
This commit changes the label of the alignment option for the slogan header from "Mobile Alignment" to "Alignment" because the alignment also affects desktops, as of the changes made in commit [1].

[1]: https://github.com/odoo/odoo/commit/7e8ba9bc2fe3b917d4e00ccee845e2715572b3da

task-3254619