### PR TITLE
[FIX] base_setup: prevent the traceback while configure template in settings

### DIFF
--- a/addons/base_setup/models/res_config_settings.py
+++ b/addons/base_setup/models/res_config_settings.py
@@ -40,7 +40,7 @@ class ResConfigSettings(models.TransientModel):
             implied_group='base.group_multi_currency',
             help="Allows to work in a multi currency environment")
     paperformat_id = fields.Many2one(related="company_id.paperformat_id", string='Paper format', readonly=False)
-    external_report_layout_id = fields.Many2one(related="company_id.external_report_layout_id", readonly=False)
+    external_report_layout_id = fields.Many2one(related="company_id.external_report_layout_id")
     show_effect = fields.Boolean(string="Show Effect", config_parameter='base_setup.show_effect')
     company_count = fields.Integer('Number of Companies', compute="_compute_company_count")
     active_user_count = fields.Integer('Number of Active Users', compute="_compute_active_user_count")

--- a/addons/base_setup/views/res_config_settings_views.xml
+++ b/addons/base_setup/views/res_config_settings_views.xml
@@ -118,10 +118,6 @@
                                             Choose the layout of your documents
                                         </div>
                                         <div class="content-group">
-                                            <div class="mt16" groups="base.group_no_one">
-                                                <label for="external_report_layout_id" string="Layout" class="col-3 col-lg-3 o_light_label"/>
-                                                <field name="external_report_layout_id" domain="[('type','=', 'qweb')]" class="oe_inline"/>
-                                            </div>
                                             <div class="mt8">
                                                 <button name="%(web.action_base_document_layout_configurator)d" string="Configure Document Layout" type="action" class="oe_link" icon="fa-arrow-right"/>
                                                 <button name="edit_external_header" string="Edit Layout" type="object" class="oe_link" groups="base.group_no_one"/>


### PR DESCRIPTION
when the user selects the template from the options (except: external_layout_background,external_layout_boxed,external_layout_clean, external_layout_standard) available in the Layout field in a general setting. then it leads to static changes in all the available reports.

## Steps to reproduce:

[Particular for this traceback]

1). Install the module like "Invoicing".
2). Then Go to the setting module.
3). Search for the layout.
4). Then select the template like "report_invoice_document" from the options
    available in the Layout field.
5). Save the changes.
6). Then Clicking on "Preview Document" will raise the traceback. 
7). And when you print the invoice report it will also give the error.

## see the traceback:

AttributeError: 'res.company' object has no attribute 'fiscal_position_id'
  File "<684>", line 2103, in template_684
  File "<684>", line 2085, in template_684_content
  File "<684>", line 361, in template_684_t_call_0
QWebException: Error while render the template
AttributeError: 'res.company' object has no attribute 'fiscal_position_id'
Template: account.report_invoice_document
Path: /t/t/div[1]/t[1]
Node: <t t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)"/>
  File "addons/web/controllers/report.py", line 113, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "odoo/http.py", line 708, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "addons/account/models/ir_actions_report.py", line 57, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "odoo/addons/base/models/ir_actions_report.py", line 801, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "odoo/addons/base/models/ir_actions_report.py", line 702, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
  File "odoo/addons/base/models/ir_actions_report.py", line 878, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "odoo/addons/base/models/ir_actions_report.py", line 617, in _render_template
    return view_obj._render_template(template, values).encode()
  File "odoo/addons/base/models/ir_ui_view.py", line 2164, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 580, in _render
    result = ''.join(rendering)
  File "<207>", line 57, in template_207
  File "<207>", line 39, in template_207_content
  File "<207>", line 25, in template_207_t_call_0
  File "<203>", line 97, in template_203
  File "<203>", line 72, in template_203_content
  File "<684>", line 2109, in template_684


Applying these changes will resolve this issue.

sentry - 4077769045
