### PR TITLE
[FIX] stock: Serial number synchro between SM and SMLs

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -652,7 +652,8 @@ class StockMove(models.Model):
                 show_source_location=self.picking_type_id.code != 'incoming',
                 show_destination_location=self.picking_type_id.code != 'outgoing',
                 show_package=not self.location_id.usage == 'supplier',
-                show_reserved_quantity=self.state != 'done' and not self.picking_id.immediate_transfer and self.picking_type_id.code != 'incoming'
+                show_reserved_quantity=self.state != 'done' and not self.picking_id.immediate_transfer and self.picking_type_id.code != 'incoming',
+                must_create_lot_id=True
             ),
         }
 
@@ -958,6 +959,9 @@ class StockMove(models.Model):
                         'warning': {'title': _('Warning'), 'message': _('Existing Serial Numbers (%s). Please correct the serial numbers encoded.') % ','.join(existing_lots.mapped('display_name'))}
                     }
                 break
+        if self.env.context.get('must_create_lot_id'):
+            new_move_lines = self.move_line_ids if self.picking_type_id.show_reserved else self.move_line_nosuggest_ids
+            new_move_lines._create_lot_id_from_lot_name()
 
     @api.onchange('product_uom')
     def onchange_product_uom(self):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -4693,3 +4693,29 @@ class StockMove(SavepointCase):
         self.assertEqual(move.reserved_availability, 2)
         # check forecast_availability expressed in product base uom
         self.assertEqual(move.forecast_availability, 24)
+
+    def test_create_lot_id_from_lot_name(self):
+        """
+        Check that the lot_id is correctly created when the lot_name and the corresponding context key is set.
+        """
+        move = self.env['stock.move'].create({
+            'name': self.product_serial.name,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product_serial.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+        })
+        move._action_confirm()
+        ml = self.env['stock.move.line'].create({
+            'lot_name': 'test_SN_001',
+            'tracking': 'serial',
+            'product_id': self.product_serial.id,
+            'product_uom_id': move.product_uom.id,
+            'company_id': self.env.company.id,
+            'location_id': move.location_id.id,
+            'location_dest_id': move.location_dest_id.id,
+            'move_id': move.id,
+        })
+        ml.with_context({'must_create_lot_id': True})._create_lot_id_from_lot_name()
+        self.assertTrue(ml.lot_id)


### PR DESCRIPTION
When adding SNs on the stock move, you can see them in the SMLs but the opposite is not true.

This issue is happening because when adding a serial number in the stock move line (through details view), it is created a stock_move_live with respective lot_name but lot_id is NULL. In the Stock move view, the SN are displayed by lot_ids, this way all the SN added through SML are not displayed

To fix the issue there was implemented a method responsible for creating lot_id if lot_name was created through details view

How to reproduce:
1. create a planned receipt for 5 units of a tracked product and mark it as to do
2. show the Serial number column in the stock moves
3. create 2 serials in the stock moves
4. open stock move lines
5. create an additional serial in the move lines and confirm
6. the new serial is not visible in the stock moves

OPW: 3252808