### PR TITLE
[FIX] hr_timesheet : remove round from effective hours computation

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -268,12 +268,12 @@ class Task(models.Model):
     def _compute_effective_hours(self):
         if not any(self._ids):
             for task in self:
-                task.effective_hours = round(sum(task.timesheet_ids.mapped('unit_amount')), 2)
+                task.effective_hours = sum(task.timesheet_ids.mapped('unit_amount'))
             return
         timesheet_read_group = self.env['account.analytic.line'].read_group([('task_id', 'in', self.ids)], ['unit_amount', 'task_id'], ['task_id'])
         timesheets_per_task = {res['task_id'][0]: res['unit_amount'] for res in timesheet_read_group}
         for task in self:
-            task.effective_hours = round(timesheets_per_task.get(task.id, 0.0), 2)
+            task.effective_hours = timesheets_per_task.get(task.id, 0.0)
 
     @api.depends('effective_hours', 'subtask_effective_hours', 'planned_hours')
     def _compute_progress_hours(self):


### PR DESCRIPTION
Steps to reproduce the issue:

1. Add a project and create a task with a timesheet in it
2. set the allocated hours to 00:03
3. add a line in the timesheet with hours spent 00:03

Current Behaviour:
The percentage calculated would be 96%, even though the time allocated and time spent are equal.

Desired Behaviour:
The percentage should be 100 as both values i.e. time spent and time allocated are equal.

This is happening because effective_hours value is being rounded off to 2 decimal places and planned_hours is not, which is creating a small difference in both values.

OPW-3270858

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
