### PR TITLE
[FIX] point_of_sale: stock_move not accessible in test

### DIFF
--- a/addons/point_of_sale/tests/test_pos_stock_account.py
+++ b/addons/point_of_sale/tests/test_pos_stock_account.py
@@ -209,6 +209,9 @@ class TestPoSStock(TestPoSCommon):
 
         group_owner = self.env.ref('stock.group_tracking_owner')
         self.env.user.write({'groups_id': [(4, group_owner.id)]})
+        group_stock_user = self.env.ref('stock.group_stock_user')
+        self.env.user.write({'groups_id': [(4, group_stock_user.id)]})
+
         self.product4 = self.create_product('Product 3', self.categ_basic, 30.0, 15.0)
         inventory = self.env['stock.inventory'].create({
             'name': 'Inventory adjustment'


### PR DESCRIPTION
The test test_03_order_product_w_owner was crashing in an indeterministic way. The logs linked to these crashes were showing that the stock_move coming from the test were not accessible by the user. In this fix, we add a group to the user so that he can access those stock_moves.

runbot-error-id: 20517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
