### PR TITLE
[FIX] web: Adjust header image positioning to prevent QR code overlap…

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/layout_assets/layout_boxed.scss
+++ b/addons/web/static/src/webclient/actions/reports/layout_assets/layout_boxed.scss
@@ -5,7 +5,8 @@
 .o_boxed_header {
     border-bottom: 1px solid map-get($grays, '200');
     img {
-        max-height: 100px;
+        max-height: 96px;
+        max-width: 200px;
     }
     h4 {
         color: #999999;

--- a/addons/web/static/src/webclient/actions/reports/layout_assets/layout_clean.scss
+++ b/addons/web/static/src/webclient/actions/reports/layout_assets/layout_clean.scss
@@ -2,8 +2,8 @@
     color: #000;
 }
 .o_clean_header img {
-    max-height: 90px;
-    max-width: 300px;
+    max-height: 96px;
+    max-width: 200px;
 }
 .o_clean_footer {
     margin: 0 3px;

--- a/addons/web/static/src/webclient/actions/reports/layout_assets/layout_standard.scss
+++ b/addons/web/static/src/webclient/actions/reports/layout_assets/layout_standard.scss
@@ -27,3 +27,9 @@
         margin-bottom: 0;
     }
 }
+
+.o_standard_header img {
+    max-height: 45px;
+    max-width: 200px;
+    margin-bottom: 16px;
+}

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -408,7 +408,7 @@
 
     <template id="external_layout_standard">
         <div t-attf-class="header o_company_#{company.id}_layout" t-att-style="report_header_style">
-            <div class="row">
+            <div class="row o_standard_header clearfix">
                 <div class="col-3 mb4">
                     <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" style="max-height: 45px;" alt="Logo"/>
                 </div>


### PR DESCRIPTION
Fixing bug where adding a big image to a layout's header ruins the layout, causing the QR code to be split across two pages, which does not follow the Swiss QR standards.

Steps to reproduce the bug:
1 - Install accounting and l10n_ch modules.
2 - Switch company to CH Company.
3 - Set up a bank account with a QR-IBAN in the Accounting app.
4 - Go to Settings and add a large image to the invoice layout (company slogan) and some text.
5 - Create an invoice for a customer in Switzerland and print it out as a PDF.

Before the bug fix, the large header image would push down the page, causing problems with the QR code being split into two pages, which does not comply with the Swiss QR standards.

Task-id: 3260001

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
