### PR TITLE
[IMP] mail, mass_mailing{_sms}, sms, various: don't display canceled message

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -9,6 +9,7 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import partial
+from itertools import repeat
 from lxml import html
 from unittest.mock import patch
 
@@ -345,7 +346,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 for mail in filtered
             )
             raise AssertionError(
-                f'mail.mail not found for message {mail_message} / status {status} / record {record.model}, {record.id} / author {author}\n{debug_info}'
+                f'mail.mail not found for message {mail_message} / status {status} / record {record._name}, {record.id} / author {author}\n{debug_info}'
             )
         return mail
 
@@ -525,6 +526,24 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                     f'Message: expected {fvalue} for {fname}, got {message[fname]}',
                 )
 
+    def assertMessageRecordsCount(self, records, expected_counts, base_counts=None):
+        """ Assert the number of mail.message per records.
+
+        :param recordset records: records for which the number of message are asserted
+        :param list expected_counts: expected count of message in record order
+        :param list base_counts: optional list of initial count that will be deducted from
+            the count before comparing it to the expected count
+        """
+        self.assertEqual(len(records), len(expected_counts), 'Number of records and expected_counts must be equals')
+        if base_counts:
+            self.assertEqual(len(records), len(base_counts), 'Number of records and base_counts must be equals')
+        for idx, (count, base_count, expected_count) in enumerate(zip(
+                self.get_message_count_per_record(records),
+                base_counts if base_counts else repeat(0),
+                expected_counts)):
+            self.assertEqual(count - base_count, expected_count,
+                             f'Invalid message count for record #{idx} (count: {count}, base count: {base_count})')
+
     def assertNoMail(self, recipients, mail_message=None, author=None):
         """ Check no mail.mail and email was generated during gateway mock. """
         try:
@@ -535,6 +554,16 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
             raise AssertionError('mail.mail exists for message %s / recipients %s but should not exist' % (mail_message, recipients.ids))
         finally:
             self.assertNotSentEmail(recipients)
+
+    def assertNoMailWRecord(self, record, mail_message=None, author=None):
+        """ Check no mail.mail matching the parameter was generated during gateway mock. """
+        try:
+            self._find_mail_mail_wrecord(record, mail_message=mail_message, author=author)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(
+                'mail.mail exists for message %s / record %s but should not exist' % (mail_message, record.id))
 
     def assertNotSentEmail(self, recipients=None):
         """Check no email was generated during gateway mock.
@@ -655,6 +684,19 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                 )
 
         return sent_mail
+
+    # ------------------------------------------------------------
+    # TOOLS
+    # ------------------------------------------------------------
+
+    def get_message_count_per_record(self, recordset):
+        if not recordset:
+            return []
+        count_by_res_id = dict(self.env['mail.message']._read_group(
+            [('model', '=', recordset[0]._name), ('res_id', 'in', recordset.ids)],
+            groupby=['res_id'], aggregates=['id:count'])
+        )
+        return [count_by_res_id.get(record.id, 0) for record in recordset]
 
 
 class MailCase(MockEmail):

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -220,6 +220,7 @@ class TestMailComposerRendering(TestMailComposer):
 
     @users('employee')
     def test_mail_mass_mode_template_with_mso(self):
+        self.mail_template.use_default_to = True
         mail_compose_message = self.env['mail.compose.message'].create({
             'composition_mode': 'mass_mail',
             'model': 'res.partner',

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -39,6 +39,7 @@ class TestMailTemplate(MailCommon):
 
     @users('employee')
     def test_mail_compose_message_content_from_template_mass_mode(self):
+        self.mail_template.use_default_to = True
         mail_compose_message = self.env['mail.compose.message'].create({
             'composition_mode': 'mass_mail',
             'model': 'res.partner',

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -733,7 +733,7 @@ class MailComposer(models.TransientModel):
     # RENDERING / VALUES GENERATION
     # ------------------------------------------------------------
 
-    def _prepare_mail_values(self, res_ids):
+    def _prepare_mail_values(self, res_ids, mass_include_canceled=False):
         """Generate the values that will be used by send_mail to create either
          mail_messages or mail_mails depending on composition mode.
 
@@ -772,6 +772,8 @@ class MailComposer(models.TransientModel):
             STA - 'subtype_id',
 
         :param list res_ids: list of record IDs on which composer runs;
+        :param bool mass_include_canceled: whether to include canceled message
+            in mass_mail mode or not
 
         :return dict: for each res_id, values to create the mail.mail or to
           give to message_post, depending on composition mode;
@@ -801,7 +803,9 @@ class MailComposer(models.TransientModel):
 
         if email_mode:
             mail_values_all = self._process_mail_values_state(mail_values_all)
-        return mail_values_all
+        if not email_mode or mass_include_canceled:
+            return mail_values_all
+        return {res_id: values for res_id, values in mail_values_all.items() if values.get('state') != 'cancel'}
 
     def _prepare_mail_values_static(self):
         """Prepare values always valid, not rendered or dynamic whatever the

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -61,12 +61,13 @@ class MassMailCase(MailCase, MockLinkTracker):
         :param records: records given to mailing that generated traces. It is
           used notably to find traces using their IDs;
         :param check_mail: if True, also check mail.mail records that should be
-          linked to traces;
+          linked to traces unless not sent (trace_status == 'cancel');
         :param sent_unlink: it True, sent mail.mail are deleted and we check gateway
           output result instead of actual mail.mail records;
         :param mail_links_info: if given, should follow order of ``recipients_info``
           and give details about links. See ``assertLinkShortenedHtml`` helper for
-          more details about content to give;
+          more details about content to give.
+          Not tested for mail with trace status == 'cancel';
         :param author: author of sent mail.mail;
         """
         # map trace state to email state
@@ -118,14 +119,16 @@ class MassMailCase(MailCase, MockLinkTracker):
                     email, partner, status, record,
                     len(recipient_trace), debug_info)
             )
-            self.assertTrue(bool(recipient_trace.mail_mail_id_int))
+            # In mass_mail mode, messages that would be canceled are not created, only the trace is created.
+            mail_not_created = recipient_trace.trace_status == 'cancel'
+            self.assertTrue(mail_not_created or bool(recipient_trace.mail_mail_id_int))
             if 'failure_type' in recipient_info or status in ('error', 'cancel', 'bounce'):
                 self.assertEqual(recipient_trace.failure_type, recipient_info['failure_type'])
 
             if 'failure_reason' in recipient_info:
                 self.assertEqual(recipient_trace.failure_reason, recipient_info['failure_reason'])
 
-            if check_mail:
+            if check_mail and not mail_not_created:
                 if author is None:
                     author = self.env.user.partner_id
 
@@ -164,7 +167,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                         fields_values=fields_values,
                     )
 
-            if link_info:
+            if link_info and not mail_not_created:
                 trace_mail = self._find_mail_mail_wrecord(record)
                 for (anchor_id, url, is_shortened, add_link_params) in link_info:
                     link_params = {'utm_medium': 'Email', 'utm_source': mailing.name}

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -25,21 +25,32 @@ class MailComposeMessage(models.TransientModel):
             self.mass_mailing_id = mass_mailing.id
         return super()._action_send_mail(auto_commit=auto_commit)
 
-    def _prepare_mail_values(self, res_ids):
-        """ When being in mass mailing mode, add 'mailing.trace' values directly
-        in the o2m field of mail.mail. """
-        mail_values_all = super()._prepare_mail_values(res_ids)
+    def _prepare_mail_values(self, res_ids, mass_include_canceled=False):
+        """ If it is a mass mailing:
 
+        - Add 'mailing.trace' values directly in the o2m field for mail not canceled.
+        - If not mass_include_canceled, create mailing traces for the canceled mail
+        (created in sudo).
+        """
         # use only for allowed models in mass mailing
-        if (self.composition_mode != 'mass_mail' or
-            not self.mass_mailing_id or
-            not self.model_is_thread):
+        is_mass_mailing = self.composition_mode == 'mass_mail' and self.mass_mailing_id and self.model_is_thread
+        mail_values_all = super()._prepare_mail_values(res_ids,
+                                                       mass_include_canceled=mass_include_canceled or is_mass_mailing)
+
+        if not is_mass_mailing:
             return mail_values_all
 
+        canceled_message_traces_values = []
+        results = {}
         trace_values_all = self._prepare_mail_values_mailing_traces(mail_values_all)
         with file_open("mass_mailing/static/src/scss/mass_mailing_mail.scss", "r") as fd:
             styles = fd.read()
         for res_id, mail_values in mail_values_all.items():
+            if not mass_include_canceled and mail_values.get('state') == 'cancel':
+                if res_id in trace_values_all:
+                    canceled_message_traces_values.append(trace_values_all[res_id])
+                continue
+            results[res_id] = mail_values
             if mail_values.get('body_html'):
                 body = self.env['ir.qweb']._render(
                     'mass_mailing.mass_mailing_mail_layout',
@@ -54,7 +65,9 @@ class MailComposeMessage(models.TransientModel):
                 'mailing_id': self.mass_mailing_id.id,
                 'mailing_trace_ids': [(0, 0, trace_values_all[res_id])] if res_id in trace_values_all else False,
             })
-        return mail_values_all
+        self.env['mailing.trace'].sudo().create(canceled_message_traces_values)
+
+        return results
 
     def _get_done_emails(self, mail_values_dict):
         seen_list = super()._get_done_emails(mail_values_dict)

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -119,6 +119,15 @@ class SMSCase(MockSMS):
         """ Check no sms went through gateway during mock. """
         self.assertTrue(len(self._new_sms) == 0)
 
+    def assertNoSMSMatching(self, partner, number, status=None):
+        """ Check no mail.mail matching the parameter was generated during gateway mock. """
+        try:
+            self._find_sms_sms(partner, number, status)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError('sms.sms exists for partner %s / number %s but should not exist' % (partner, number))
+
     def assertSMSIapSent(self, numbers, content=None):
         """ Check sent SMS. Order is not checked. Each number should have received
         the same content. Useful to check batch sending.

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -241,18 +241,21 @@ class TestMassMailing(TestMassMailCommon):
         self.env['mail.blacklist'].flush_model(['active'])
 
         mailing.write({'mailing_domain': [('id', 'in', recipients.ids)]})
+        init_message_counts = self.get_message_count_per_record(recipients)
         with self.mock_mail_gateway(mail_unlink_sent=False):
             mailing.action_send_mail()
 
-        self.assertMailTraces(
-            [{'email': 'test.record.00@test.example.com'},
+        expected_traces = [{'email': 'test.record.00@test.example.com'},
              {'email': 'test.record.01@test.example.com'},
              {'email': 'test.record.02@test.example.com'},
              {'email': 'test.record.03@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_bl'},
-             {'email': 'test.record.04@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_bl'}],
-            mailing, recipients, check_mail=True
-        )
+             {'email': 'test.record.04@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_bl'}]
+        self.assertMailTraces(expected_traces, mailing, recipients, check_mail=True)
         self.assertEqual(mailing.canceled, 2)
+        self.assertEqual(len(self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])), 3,
+                         "Only the 3 sent mails have been created, the canceled ones have not been created")
+        expected_message_count = [0 if t.get('trace_status') == 'cancel' else 1 for t in expected_traces]
+        self.assertMessageRecordsCount(recipients, expected_message_count, init_message_counts)
 
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -269,12 +272,20 @@ class TestMassMailing(TestMassMailCommon):
             'active': True,
         }])
 
+        init_message_counts = self.get_message_count_per_record(test_records)
         with self.mock_mail_gateway(mail_unlink_sent=False):
             self.mailing_bl.action_send_mail()
-        self.assertMailTraces([
+        expected_traces = [
             {'email': email_normalize(test_records[0].email_from), 'trace_status': 'cancel', 'failure_type': 'mail_bl'},
             {'email': email_normalize(test_records[1].email_from), 'trace_status': 'sent'},
-        ], self.mailing_bl, test_records, check_mail=False)
+        ]
+        self.assertMailTraces(expected_traces, self.mailing_bl, test_records, check_mail=False)
+
+        self.assertEqual(self.mailing_bl.canceled, 1)
+        self.assertEqual(len(self.env['mail.mail'].sudo().search([('mailing_id', '=', self.mailing_bl.id)])), 1,
+                         "Only the sent mail has been created, the canceled one has not been created")
+        expected_message_count = [0 if t.get('trace_status') == 'cancel' else 1 for t in expected_traces]
+        self.assertMessageRecordsCount(test_records, expected_message_count, init_message_counts)
 
     @users('user_marketing')
     @mute_logger('odoo.addons.mail.models.mail_mail')
@@ -291,18 +302,22 @@ class TestMassMailing(TestMassMailCommon):
             'mailing_model_id': self.env['ir.model']._get('mailing.test.optout'),
             'mailing_domain': [('id', 'in', recipients.ids)]
         })
+        init_message_counts = self.get_message_count_per_record(recipients)
         with self.mock_mail_gateway(mail_unlink_sent=False):
             mailing.action_send_mail()
 
-        self.assertMailTraces(
-            [{'email': 'test.record.00@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_optout'},
-             {'email': 'test.record.01@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_optout'},
-             {'email': 'test.record.02@test.example.com'},
-             {'email': 'test.record.03@test.example.com'},
-             {'email': 'test.record.04@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_bl'}],
-            mailing, recipients, check_mail=True
-        )
+        expected_traces = [
+            {'email': 'test.record.00@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_optout'},
+            {'email': 'test.record.01@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_optout'},
+            {'email': 'test.record.02@test.example.com'},
+            {'email': 'test.record.03@test.example.com'},
+            {'email': 'test.record.04@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_bl'}]
+        self.assertMailTraces(expected_traces, mailing, recipients, check_mail=True)
         self.assertEqual(mailing.canceled, 3)
+        self.assertEqual(len(self.env['mail.mail'].sudo().search([('mailing_id', '=', self.mailing_bl.id)])), 2,
+                         "Only the 2 sent mails have been created, the canceled ones have not been created")
+        expected_message_count = [0 if t.get('trace_status') == 'cancel' else 1 for t in expected_traces]
+        self.assertMessageRecordsCount(recipients, expected_message_count, init_message_counts)
 
     @users('user_marketing')
     def test_mailing_w_seenlist_unstored_partner(self):
@@ -353,6 +368,7 @@ class TestMassMailing(TestMassMailCommon):
         mailing_contact_3 = self.env['mailing.contact'].create({'name': 'test 3', 'email': 'test3@test.example.com'})
         mailing_contact_4 = self.env['mailing.contact'].create({'name': 'test 4', 'email': 'test4@test.example.com'})
         mailing_contact_5 = self.env['mailing.contact'].create({'name': 'test 5', 'email': 'test5@test.example.com'})
+        records = mailing_contact_1 + mailing_contact_2 + mailing_contact_3 + mailing_contact_4 + mailing_contact_5
 
         # create mailing list record
         mailing_list_1 = self.env['mailing.list'].create({
@@ -390,17 +406,16 @@ class TestMassMailing(TestMassMailCommon):
             'mailing_model_id': self.env['ir.model']._get('mailing.list').id,
             'contact_list_ids': [(4, ml.id) for ml in mailing_list_1 | mailing_list_2],
         })
+        init_message_counts = self.get_message_count_per_record(records)
         with self.mock_mail_gateway(mail_unlink_sent=False):
             mailing.action_send_mail()
 
-        self.assertMailTraces(
-            [{'email': 'test@test.example.com', 'trace_status': 'sent'},
+        expected_traces = [{'email': 'test@test.example.com', 'trace_status': 'sent'},
              {'email': 'test@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_dup'},
              {'email': 'test3@test.example.com'},
              {'email': 'test4@test.example.com'},
-             {'email': 'test5@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_optout'}],
-            mailing,
-            mailing_contact_1 + mailing_contact_2 + mailing_contact_3 + mailing_contact_4 + mailing_contact_5,
-            check_mail=True
-        )
+             {'email': 'test5@test.example.com', 'trace_status': 'cancel', 'failure_type': 'mail_optout'}]
+        self.assertMailTraces(expected_traces, mailing, records, check_mail=True)
         self.assertEqual(mailing.canceled, 2)
+        expected_message_count = [0 if t.get('trace_status') == 'cancel' else 1 for t in expected_traces]
+        self.assertMessageRecordsCount(records, expected_message_count, init_message_counts)

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -91,6 +91,7 @@ class TestMassSMSInternals(TestMassSMSCommon):
             'customer_id': False,
             'phone_nbr': '0456110011',
         })
+        records = self.records + new_record_1 + void_record + falsy_record_1 + falsy_record_2 + bl_record_1
         self.env['phone.blacklist'].sudo().create({'number': '0456110011'})
         # new customer, number already on record -> should be ignored
         country_be_id = self.env.ref('base.be').id
@@ -107,7 +108,11 @@ class TestMassSMSInternals(TestMassSMSCommon):
         records_numbers = self.records_numbers + ['+32456999999']
 
         mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids)
-        mailing.write({'sms_force_send': False})  # force outgoing sms, not sent
+        mailing.write({
+            'sms_force_send': False,  # force outgoing sms, not sent
+            'keep_archives': True,  # keep a note on document (mass_keep_log)
+        })
+        init_message_counts = self.get_message_count_per_record(records)
         with self.with_user('user_marketing'):
             with self.mockSMSGateway():
                 mailing.action_send_sms()
@@ -147,12 +152,19 @@ class TestMassSMSInternals(TestMassSMSCommon):
              for record in falsy_record_1 + falsy_record_2],
             mailing, falsy_record_1 + falsy_record_2,
         )
+        # check note posted on records
+        expected_message_counts = [1] * 10 + [1, 0, 0, 0, 0]
+        self.assertMessageRecordsCount(records, expected_message_counts, init_message_counts)
 
     @users('user_marketing')
     def test_mass_sms_internals_done_ids(self):
         mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids)
-        mailing.write({'sms_force_send': False})  # check with outgoing traces, not already sent
+        mailing.write({
+            'sms_force_send': False,  # check with outgoing traces, not already sent
+            'keep_archives': True,  # keep a note on document (mass_keep_log)
+        })
 
+        init_message_counts = self.get_message_count_per_record(self.records[:5])
         with self.with_user('user_marketing'):
             with self.mockSMSGateway():
                 mailing.action_send_sms(res_ids=self.records[:5].ids)
@@ -166,7 +178,11 @@ class TestMassSMSInternals(TestMassSMSCommon):
              for i, record in enumerate(self.records[:5])],
             mailing, self.records[:5],
         )
+        # check note posted on records
+        expected_message_counts = [1] * 5
+        self.assertMessageRecordsCount(self.records[:5], expected_message_counts, init_message_counts)
 
+        init_message_counts = self.get_message_count_per_record(self.records)
         with self.with_user('user_marketing'):
             with self.mockSMSGateway():
                 mailing.action_send_sms(res_ids=self.records.ids)
@@ -188,6 +204,9 @@ class TestMassSMSInternals(TestMassSMSCommon):
              for i, record in enumerate(self.records[5:])],
             mailing, self.records[5:],
         )
+        # check note posted on records
+        expected_message_counts = [0] * 5 + [1] * 5
+        self.assertMessageRecordsCount(self.records, expected_message_counts, init_message_counts)
 
     @mute_logger('odoo.addons.mail.models.mail_render_mixin')
     def test_mass_sms_test_button(self):
@@ -345,17 +364,20 @@ class TestMassSMS(TestMassSMSCommon):
         mailing.write({
             'mailing_model_id': self.env['ir.model']._get('mail.test.sms.bl.optout'),
             'mailing_domain': [('id', 'in', recipients.ids)],
+            'keep_archives': True,  # keep a note on document (mass_keep_log)
         })
 
+        init_message_counts = self.get_message_count_per_record(recipients)
         with self.mockSMSGateway():
             mailing.action_send_sms()
 
-        self.assertSMSTraces(
-            [{'number': '+32456000000', 'trace_status': 'cancel', 'failure_type': 'sms_optout'},
+        expected_traces = [{'number': '+32456000000', 'trace_status': 'cancel', 'failure_type': 'sms_optout'},
              {'number': '+32456000101', 'trace_status': 'cancel', 'failure_type': 'sms_optout'},
              {'number': '+32456000202', 'trace_status': 'sent'},
              {'number': '+32456000303', 'trace_status': 'sent'},
-             {'number': '+32456000404', 'trace_status': 'cancel', 'failure_type': 'sms_blacklist'}],
-            mailing, recipients
-        )
+             {'number': '+32456000404', 'trace_status': 'cancel', 'failure_type': 'sms_blacklist'}]
+        self.assertSMSTraces(expected_traces, mailing, recipients)
         self.assertEqual(mailing.canceled, 3)
+
+        expected_message_counts = [0 if t['trace_status'] == 'cancel' else 1 for t in expected_traces]
+        self.assertMessageRecordsCount(recipients, expected_message_counts, init_message_counts)

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -95,6 +95,8 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
 
         self.assertEqual(mailing.sent, 50)
         self.assertEqual(mailing.delivered, 50)
+        self.assertEqual(mailing.canceled, 12)
 
-        cancelled_mail_count = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)])
-        self.assertEqual(len(cancelled_mail_count), 12, 'Should not have auto deleted the blacklisted emails')
+        mail_mail_count = len(self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)]))
+        self.assertEqual(mail_mail_count, 0,
+                         "Mail_mail for blacklisted emails mustn't have been created and others must have been deleted")


### PR DESCRIPTION
# mail/mass_mailing

In order to not display most message not sent to the recipient in the chatter,
while preparing message to be sent by email in mass_mail composition mode, we
only create not canceled message (mail_mail.state != 'cancel').
However, for mailing only, we still save the mailing trace allowing
investigation in case of doubt even for canceled message.
Note that an error can happen while sending the message (invalid smtp
server, ...) that would prevent the message to be received by the recipient
(mail_mail.state == 'exception'). In that case, the message will still be
displayed in the chatter and there will be no indication that the mail has
not been sent if it is not a notification (no red envelop aside the message).

Rather than adding new tests, we have slightly modified the existing ones to
add checks about message creation.

Technical note: Alternative solutions have been investigated but discarded
because there is no need to store something we don't need. Alternatives
discarded:
- filter out the message in error when displaying them in the chatter (add 1
query each time the messages are fetched for the chatter)
- generalize the mechanism created for notification to all messages to display
an indication that a message has not been sent to some recipient


# sms/mass_mailing_sms

In order to not display most message not sent to the recipient in the chatter,
while preparing message to be sent by sms in mass composition mode, we only
create not canceled message (sms_sms.state != 'canceled').
However, for mailing only, we still save the mailing trace allowing
investigation in case of doubt even for canceled message.
Note that an error can happen while sending the message that would prevent the
message to be received by the recipient. In that case, the message will still
be displayed in the chatter and there will be no indication that the mail has
not been sent if it is not a notification (no red envelop aside the message).

Rather than adding new tests, we have slightly modified the existing ones to
add checks about message creation.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
