### PR TITLE
[FIX] stock_account: _should_be_valued doesn't return bool

### DIFF
--- a/addons/stock_account/models/stock_location.py
+++ b/addons/stock_account/models/stock_location.py
@@ -27,4 +27,4 @@ class StockLocation(models.Model):
         be considered when valuating the stock of a company.
         """
         self.ensure_one()
-        return self.usage == 'internal' or (self.usage == 'transit' and self.company_id)
+        return self.usage == 'internal' or bool(self.usage == 'transit' and self.company_id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
_should_be_valued should always return a bool.

Current behavior before PR:
Currently, when it's False, it returns False. However, when it's True, it returns self.company_id.

Desired behavior after PR is merged:
 After this fix, it returns True instead of self.company_id.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
