### PR TITLE
[FIX] delivery: use `float_repr` for rounding unit value

### DIFF
--- a/addons/delivery/models/delivery_carrier.py
+++ b/addons/delivery/models/delivery_carrier.py
@@ -5,7 +5,7 @@ import psycopg2
 import re
 
 from odoo import api, fields, models, registry, SUPERUSER_ID, _
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_round, float_repr
 from odoo.tools.misc import groupby
 from odoo.exceptions import UserError
 
@@ -406,7 +406,7 @@ class DeliveryCarrier(models.Model):
                 for line in lines)
             rounded_qty = max(1, float_round(unit_quantity, precision_digits=0))
             country_of_origin = product.country_of_origin.code or lines[0].picking_id.picking_type_id.warehouse_id.partner_id.country_id.code
-            unit_price = float_round(sum(line.sale_price for line in lines) / rounded_qty, precision_digits=price_unit_prec)
+            unit_price = float_repr(sum(line.sale_price for line in lines) / rounded_qty, precision_digits=price_unit_prec)
             commodities.append(DeliveryCommodity(product, amount=rounded_qty, monetary_value=unit_price, country_of_origin=country_of_origin))
 
         return commodities


### PR DESCRIPTION
Steps to reproduce:
1. Make a sale order with a product priced at 24.99
2. Add UPS international shipping
3. Confirm the sale order, and attempt to validate the sale order

Gets an error from UPS:
`Invalid or missing product unit value for product number 1. Valid length is 1 to 19 numeric and it can hold up to 6 decimal places`

The reason for this is that `float_round` adds a rounding error. Basically:
`float_round(24.99, precision_digits=2)` => `24.990000000000002`

(See discussion at https://github.com/odoo/odoo/issues/7024)

opw-3289042


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
