### PR TITLE
[FIX] website: handle missing homepage view when the view is deleted.

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -474,7 +474,16 @@ class Website(models.Model):
 
         def configure_page(page_code, snippet_list, pages_views, cta_data):
             if page_code == 'homepage':
-                page_view_id = self.with_context(website_id=website.id).viewref('website.homepage')
+                try:
+                    page_view_id = self.with_context(website_id=website.id).viewref('website.homepage')
+                except ValueError as e:
+                    homepage_url = website.homepage_url or '/'
+                    homepage_page = self.env['website.page'].search([('url', '=', homepage_url)], limit=1)
+                    if homepage_page:
+                        page_view_id = self.with_context(website_id=website.id).viewref(homepage_page.key)
+                    else:
+                        logger.warning('Homepage view not found for website URL: %s', homepage_url)
+                        return
             else:
                 page_view_id = self.env['ir.ui.view'].browse(pages_views[page_code])
             rendered_snippets = []


### PR DESCRIPTION
This issue occurs when the user deletes the 'home' view and tries to configure the website manually.

Steps to produce the error :
1. Install the website module.
2. Go to the Settings menu and select the "Technical" option.
3. From the drop-down, select "Views".
4. Look for the "Home" view and delete it.
5. Now, configure the website manually and thus, the error occurs.

```
ValueError: No record found for unique ID website.homepage. It may have been deleted.
  File "odoo/http.py", line 2119, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1702, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1729, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1926, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 719, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "addons/website/models/website.py", line 629, in configurator_apply
    configure_page(page_code, snippet_lists.get(page_code, []), pages_views, cta_data)
  File "addons/website/models/website.py", line 463, in configure_page
    page_view_id = self.with_context(website_id=website.id).viewref('website.homepage')
  File "addons/website/models/website.py", line 1045, in viewref
    raise ValueError('No record found for unique ID %s. It may have been deleted.' % (view_id))
```

This commit will solve the issue by adding a condition that if the view is not found, it gets the view reference using homepage_url configured from the website

sentry-4037847923




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
