### PR TITLE
[FIX] web_editor: When removing link the first letter becomes the default link

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
@@ -56,7 +56,8 @@ Text.prototype.oDeleteBackward = function (offset, alreadyMoved = false) {
     if (
         isZWS ||
         isSpace &&
-        getState(parentNode, firstSplitOffset, DIRECTIONS.LEFT).cType !== CTYPES.CONTENT
+        getState(parentNode, firstSplitOffset, DIRECTIONS.LEFT).cType !== CTYPES.CONTENT ||
+        parentNode.tagName === 'A' && !isVisible(parentNode) && !parentNode.classList.contains('btn')
     ) {
         parentNode.oDeleteBackward(firstSplitOffset, alreadyMoved);
         if (isZWS) {
@@ -143,7 +144,9 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false, 
                     return;
                 }
             }
-            parentEl.oDeleteBackward(parentOffset, alreadyMoved);
+            if(!(this.tagName === 'A' && !this.classList.contains('btn') && !isVisible(this))) {
+                parentEl.oDeleteBackward(parentOffset, alreadyMoved);
+            }
             return;
         }
 

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -555,36 +555,15 @@ describe('Link', () => {
                 }
             });
         });
-        it('should keep isolated link after a delete', async () => {
+        it('should remove isolated link after a keyboard delete', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a<a href="#/">b[]</a>c</p>',
                 stepFunction: async editor => {
                     const a = await clickOnLink(editor);
                     console.log(a.closest('.odoo-editor-editable').outerHTML);
                     await deleteBackward(editor);
-                    console.log(a.closest('.odoo-editor-editable').outerHTML);
-                    window.chai.expect(a.parentElement.isContentEditable).to.be.equal(false);
                 },
-                contentAfterEdit: '<p>a<a href="#/" contenteditable="true" oe-zws-empty-inline="">[]\u200B</a>c</p>',
                 contentAfter: '<p>a[]c</p>',
-            });
-        });
-        it('should keep isolated link after a delete and typing', async () => {
-            await testEditor(BasicEditor, {
-                contentBefore: '<p>a<a href="#/">b[]</a>c</p>',
-                stepFunction: async editor => {
-                    const a = await clickOnLink(editor);
-                    window.chai.expect(a.parentElement.isContentEditable).to.be.equal(false);
-                    await deleteBackward(editor);
-                    window.chai.expect(a.parentElement.isContentEditable).to.be.equal(false);
-                    await insertText(editor, '1');
-                    window.chai.expect(a.parentElement.isContentEditable).to.be.equal(false);
-                    await insertText(editor, '2');
-                    window.chai.expect(a.parentElement.isContentEditable).to.be.equal(false);
-                    await insertText(editor, '3');
-                    window.chai.expect(a.parentElement.isContentEditable).to.be.equal(false);
-                },
-                contentAfter: '<p>a<a href="#/">123[]</a>c</p>',
             });
         });
     });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_popover_widget.js
@@ -140,6 +140,19 @@ const LinkPopoverWidget = Widget.extend({
         if (document !== this.options.wysiwyg.odooEditor.document) {
             $(this.options.wysiwyg.odooEditor.document).on('mouseup.link_popover', onClickDocument);
         }
+        const onKeyDownDocument = (e) => {
+            if(popoverShown && !e.target.isConnected){
+                this.popover.hide();
+                this.options.wysiwyg.odooEditor._activateContenteditable();
+                const sel = this.options.wysiwyg.odooEditor.document.getSelection();
+                const range  = new Range();
+                range.setStart(sel.anchorNode,sel.anchorOffset);
+                range.collapse(true);
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
+        }
+        $(document).on('keydown.link_popover', onKeyDownDocument);
 
         return this._super(...arguments);
     },


### PR DESCRIPTION
Current behaviour before commit:

When removing link, the first letter becomes the default link.

Desired behaviour after commit:

Now hitting backspace removes link completely.

Task id- 2889606



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
