### PR TITLE
[IMP] project: improve the list view by adding personal stage

### DIFF
--- a/addons/hr_timesheet/static/src/views/timesheet_graph/timesheet_graph_model.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_graph/timesheet_graph_model.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { GraphModel } from "@web/views/graph/graph_model";
+import { ProjectTaskGraphModel } from "@project/views/project_task_graph/project_task_graph_model";
 
 const FIELDS = [
     'unit_amount', 'effective_hours', 'planned_hours', 'remaining_hours', 'total_hours_spent', 'subtask_effective_hours',
     'overtime', 'number_hours', 'difference', 'timesheet_unit_amount'
 ];
 
-export class hrTimesheetGraphModel extends GraphModel {
+export class hrTimesheetGraphModel extends ProjectTaskGraphModel {
     /**
      * @override
      */
@@ -36,4 +36,4 @@ export class hrTimesheetGraphModel extends GraphModel {
         return super._getProcessedDataPoints(...arguments);
     }
 }
-hrTimesheetGraphModel.services = [...GraphModel.services, "company"];
+hrTimesheetGraphModel.services = [...ProjectTaskGraphModel.services, "company"];

--- a/addons/hr_timesheet/static/src/views/timesheet_graph/timesheet_graph_view.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_graph/timesheet_graph_view.js
@@ -1,13 +1,13 @@
 /** @odoo-module **/
 
-import { projectGraphView } from "@project/views/project_task_graph/project_graph_view";
+import { projectTaskGraphView } from "@project/views/project_task_graph/project_task_graph_view";
 import { hrTimesheetGraphModel } from "./timesheet_graph_model";
 import { registry } from "@web/core/registry";
 
 const viewRegistry = registry.category("views");
 
 export const hrTimesheetGraphView = {
-  ...projectGraphView,
+  ...projectTaskGraphView,
   Model: hrTimesheetGraphModel,
 };
 

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -243,7 +243,7 @@
             <field name="model">project.task</field>
             <field name="inherit_id" ref="project.view_project_task_pivot"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='stage_id']" position='after'>
+                <xpath expr="//field[@name='planned_hours']" position='after'>
                     <field name="planned_hours" widget="timesheet_uom"/>
                     <field name="remaining_hours" widget="timesheet_uom"/>
                     <field name="effective_hours" widget="timesheet_uom"/>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -167,17 +167,17 @@ class Task(models.Model):
     # See project_task_stage_personal.py for the model defininition
     personal_stage_type_ids = fields.Many2many('project.task.type', 'project_task_user_rel', column1='task_id', column2='stage_id',
         ondelete='restrict', group_expand='_read_group_personal_stage_type_ids', copy=False,
-        domain="[('user_id', '=', user.id)]", depends=['user_ids'], string='Personal Stage')
+        domain="[('user_id', '=', user.id)]", depends=['user_ids'], string='Personal Stages')
     # Personal Stage computed from the user
     personal_stage_id = fields.Many2one('project.task.stage.personal', string='Personal Stage State', compute_sudo=False,
         compute='_compute_personal_stage_id', help="The current user's personal stage.")
     # This field is actually a related field on personal_stage_id.stage_id
     # However due to the fact that personal_stage_id is computed, the orm throws out errors
     # saying the field cannot be searched.
-    personal_stage_type_id = fields.Many2one('project.task.type', string='Personal User Stage',
+    personal_stage_type_id = fields.Many2one('project.task.type', string='Personal Stage',
         compute='_compute_personal_stage_type_id', inverse='_inverse_personal_stage_type_id', store=False,
         search='_search_personal_stage_type_id', default=_default_personal_stage_type_id,
-        help="The current user's personal task stage.")
+        help="The current user's personal task stage.", domain="[('user_id', '=', uid)]")
     partner_id = fields.Many2one('res.partner',
         string='Customer', recursive=True, tracking=True, compute='_compute_partner_id', store=True, readonly=False,
         domain="['|', ('company_id', '=?', company_id), ('company_id', '=', False)]", )

--- a/addons/project/static/src/views/project_task_graph/project_task_graph_model.js
+++ b/addons/project/static/src/views/project_task_graph/project_task_graph_model.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+
+import { GraphModel } from "@web/views/graph/graph_model";
+
+export class ProjectTaskGraphModel extends GraphModel {
+    _getDefaultFilterLabel(field) {
+        if (field.fieldName === "project_id") {
+            return this.env._t("🔒 Private");
+        }
+        return super._getDefaultFilterLabel(field);
+    }
+}

--- a/addons/project/static/src/views/project_task_graph/project_task_graph_view.js
+++ b/addons/project/static/src/views/project_task_graph/project_task_graph_view.js
@@ -3,9 +3,14 @@
 import { ProjectControlPanel } from "@project/components/project_control_panel/project_control_panel";
 import { registry } from "@web/core/registry";
 import { graphView } from "@web/views/graph/graph_view";
+import { ProjectTaskGraphModel } from "./project_task_graph_model";
 
 const viewRegistry = registry.category("views");
 
-export const projectGraphView = {...graphView, ControlPanel: ProjectControlPanel};
+export const projectTaskGraphView = {
+    ...graphView,
+    ControlPanel: ProjectControlPanel,
+    Model: ProjectTaskGraphModel,
+};
 
-viewRegistry.add("project_graph", projectGraphView);
+viewRegistry.add("project_task_graph", projectTaskGraphView);

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -119,7 +119,6 @@
             <field name="arch" type="xml">
                 <pivot string="Tasks" sample="1" js_class="project_pivot">
                     <field name="project_id" type="row"/>
-                    <field name="stage_id" type="col"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
                     <field name="planned_hours" widget="float_time"/>
@@ -137,6 +136,12 @@
             <field name="arch" type="xml">
                 <xpath expr="/pivot" position="inside">
                     <field name="user_ids" type="row"/>
+                </xpath>
+                <xpath expr="//field[@name='project_id']" position="after">
+                    <field name="stage_id" type="col"/>
+                </xpath>
+                <xpath expr="//field[@name='project_id']" position="attributes">
+                    <attribute name="invisible">True</attribute>
                 </xpath>
             </field>
         </record>
@@ -683,6 +688,9 @@
                 <xpath expr="//field[@name='partner_id']" position="after">
                     <field name="parent_id" optional="hide" context="{'search_view_ref': 'project.view_task_search_form', 'search_default_project_id': project_id}" groups="base.group_no_one"/>
                 </xpath>
+                <xpath expr="//field[@name='stage_id']" position="after">
+                    <field name="personal_stage_type_id" string="Personal Stage" optional="hide"/>
+                </xpath>
             </field>
         </record>
 
@@ -746,7 +754,7 @@
             <field name="name">project.task.graph</field>
             <field name="model">project.task</field>
             <field name="arch" type="xml">
-                <graph string="Tasks" sample="1" js_class="project_graph">
+                <graph string="Tasks" sample="1" js_class="project_task_graph">
                     <field name="project_id" invisible="context.get('default_project_id', False)"/>
                     <field name="stage_id"/>
                     <field name="color" invisible="1"/>

--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -374,6 +374,14 @@ export class GraphModel extends Model {
     }
 
     /**
+     * @protected
+     * @returns {string}
+     */
+    _getDefaultFilterLabel(field) {
+        return this.env._t("Undefined");
+    }
+
+    /**
      * Eventually filters and sort data points.
      * @protected
      * @returns {Object[]}
@@ -383,7 +391,7 @@ export class GraphModel extends Model {
         let processedDataPoints = [];
         if (mode === "line") {
             processedDataPoints = this.dataPoints.filter(
-                (dataPoint) => dataPoint.labels[0] !== this.env._t("Undefined")
+                (dataPoint) => dataPoint.labels[0] !== this._getDefaultFilterLabel(groupBy[0]),
             );
         } else if (mode === "pie") {
             processedDataPoints = this.dataPoints.filter(
@@ -505,7 +513,7 @@ export class GraphModel extends Model {
                     if (type === "boolean") {
                         label = `${val}`; // toUpperCase?
                     } else if (val === false) {
-                        label = this.env._t("Undefined");
+                        label = this._getDefaultFilterLabel(gb);
                     } else if (["many2many", "many2one"].includes(type)) {
                         const [id, name] = val;
                         const key = JSON.stringify([fieldName, name]);


### PR DESCRIPTION
This will improve the following generic UX

-  rename 'personal user stage' into 'personal stage' for private task
- added the 'personal stage' field to the right of the stage optional=hide
- earlier gantt view open with the user now it will open with groupby  project
- removed groupby stage in pivot view
- rename 'undefined' into 'private' for graph view of private task

task-3251648
