### PR TITLE
[FIX] web_editor: fix image option width selector

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5774,8 +5774,8 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             1920: '1920px',
         };
         widths[img.naturalWidth] = sprintf(_t("%spx"), img.naturalWidth);
-        widths[optimizedWidth] = sprintf(_t("%dpx (Suggested)"), optimizedWidth);
-        widths[maxWidth] = sprintf(_t("%dpx (Original)"), maxWidth);
+        widths[optimizedWidth] = sprintf(_t("%spx (Suggested)"), optimizedWidth);
+        widths[maxWidth] = sprintf(_t("%spx (Original)"), maxWidth);
         return Object.entries(widths)
             .filter(([width]) => width <= maxWidth)
             .sort(([v1], [v2]) => v1 - v2);


### PR DESCRIPTION
Since commit [1], underscore functions have been replaced with native JavaScript functions. However, this replacement caused a display issue with the 'sprintf' function that is used to display several "width" values in the image option width selector. In order to properly display the "width" values, the 'sprintf' function should handle both string (%s) and numeric (%d) placeholders, as it was done with underscore. However, the function only handled string placeholders (%s), resulting in non-string "width" values being improperly displayed. To fix this issue, this commit updates the image option width selector to use only string values (%s) in the 'sprintf' function.

Steps to reproduce the bug:

- Open the home page in Website edit mode.
- Drag and drop a "Text-image" snippet onto the page.
- Click on the image to show its options in the editor panel.
- Open the "width" selector in the image option section.
- Bug: the "%d" placeholders have not been replaced by the correct numeric values.

[1]: https://github.com/odoo/odoo/commit/614de869892fd2623311ac1fae5c76ee06a356c7

task-3289218