### PR TITLE
[FIX] pos_loyalty: correctly compute loyalty point with rewards applied

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -912,6 +912,15 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                         points += rule.reward_point_amount * totalProductQty;
                     }
                 }
+
+                //If the reward point mode is money, we need to take the reward discount into account for the point calculation
+                const rewardLines = orderLines.filter((line) => line.reward_id && this.pos.reward_by_id[line.reward_id].program_id.id === program.id 
+                                                        && !rule.valid_product_ids.has(line.product.id) && program.program_type !== 'gift_card');
+                if (rule.reward_point_mode === 'money' && !rule.any_product) {
+                    for (const rewardLine of rewardLines) {
+                        points += round_precision(rule.reward_point_amount * rewardLine.get_price_with_tax(), 0.01);
+                    }
+                }
             }
             const res = points ? [{points}] : [];
             if (splitPoints.length) {

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -206,3 +206,15 @@ PosLoyalty.do.clickConfirmButton();
 ProductScreen.check.totalAmountIs('92.00');
 
 Tour.register('PosLoyaltyTour5', { test: true, url: '/pos/web' }, getSteps());
+
+startSteps();
+
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('AAA Partner');
+ProductScreen.exec.addOrderline('Test Product A', '1.00', '100');
+PosLoyalty.do.clickRewardButton();
+ProductScreen.check.totalAmountIs('90.00');
+PosLoyalty.exec.finalizeOrder('Cash', '90');
+
+Tour.register('PosLoyaltyTour6', { test: true, url: '/pos/web' }, getSteps());


### PR DESCRIPTION
Current behavior:
When creating a loyalty program that only applies on specific products, the computation doesn't take into account the discounted value of the order

Steps to reproduce:
- Create product A with a price of 100$
- Create a loyalty program:
   - The rules should apply only on product A and grand 10 point per $ spent 
   - The rewards should give a discount of 10$ per order for 30 points
- Open a pos session
- Add product A to the order, and apply the reward
- The total should be 90$, but the UI show that the customer will get 100 points

opw-3258039
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
