### PR TITLE
[FIX] web: prevent trackback while unsupported data type

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -236,6 +236,8 @@ class ExportXlsxWriter:
             cell_style = self.date_style
         elif isinstance(cell_value, float):
             cell_style.set_num_format(self.float_format)
+        elif isinstance(cell_value, list):
+            cell_value = str(cell_value)
         self.write(row, column, cell_value, cell_style)
 
 


### PR DESCRIPTION
This issue is generated when the customer wants to create new Property ('task_properties') in project.task model on Project Module and set the type
 of fields. customer data, that will be passed in the list data type however
datatype is different, and try to export it, the error would be generated.

Stack Trace:-

  TypeError: float() argument must be a string or a real number, not 'list'
    File "xlsxwriter/worksheet.py", line 512, in _write
      f = float(token)
  TypeError: Unsupported type <class 'list'> in write()
    File "addons/web/controllers/export.py", line 558, in web_export_xlsx
      return self.base(data)
    File "addons/web/controllers/export.py", line 494, in base
      response_data = self.from_group_data(fields, tree)
    File "addons/web/controllers/export.py", line 580, in from_group_data
      x, y = xlsx_writer.write_group(x, y, group_name, group)
    File "addons/web/controllers/export.py", line 259, in write_group
      row, column = self._write_row(row, column, record)
    File "addons/web/controllers/export.py", line 264, in _write_row
      self.write_cell(row, column, value)
    File "addons/web/controllers/export.py", line 239, in write_cell
      self.write(row, column, cell_value, cell_style)
    File "addons/web/controllers/export.py", line 213, in write
      self.worksheet.write(row, column, cell_value, style)
    File "xlsxwriter/worksheet.py", line 85, in cell_wrapper
      return method(self, *args, **kwargs)
    File "xlsxwriter/worksheet.py", line 445, in write
      return self._write(row, col, *args)
    File "xlsxwriter/worksheet.py", line 517, in _write
      raise TypeError("Unsupported type %s in write()" % type(token))


Step to Produce:-
 -install Project Module.
 -click on Menu > My task(project.task).
 -open any one task.
 -create the one property('task_properties')> select any data type(such as text)
 -then, export that task('task_properties' this fields must be included
                          while exporting).
 -error would be generated.

Applying these changes will resolve this issue.

sentry:- 4050303285
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
