### PR TITLE
[FIX] web_editor: crop buttons out of the screen

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
@@ -38,6 +38,7 @@ const ImageCropWidget = Widget.extend({
         this.aspectRatio = data.aspectRatio || "0/0";
         const mimetype = data.mimetype || src.endsWith('.png') ? 'image/png' : 'image/jpeg';
         this.mimetype = options.mimetype || mimetype;
+        this.clickopt = this._onCropOptionClick;
     },
     /**
      * @override
@@ -182,7 +183,8 @@ const ImageCropWidget = Widget.extend({
      * @param {MouseEvent} ev
      */
     _onCropOptionClick(ev) {
-        const {action, value, scaleDirection} = ev.currentTarget.dataset;
+        let {action, value, scaleDirection} = {};
+        ev.currentTarget ? {action, value, scaleDirection} = ev.currentTarget.dataset : {action, value, scaleDirection} = ev;
         switch (action) {
             case 'ratio':
                 this.$cropperImage.cropper('reset');
@@ -191,6 +193,7 @@ const ImageCropWidget = Widget.extend({
                 break;
             case 'zoom':
             case 'reset':
+                this.$cropperImage.cropper('setAspectRatio',0);
                 this.$cropperImage.cropper(action, value);
                 break;
             case 'rotate':

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -596,6 +596,8 @@ img.o_we_selected_image {
     background-color: rgba(128, 128, 128, 0.5);
     @include o-position-absolute(0, 0, 0, 0);
     z-index: 1024;
+    height: 100%;
+    overflow: auto;
 
     .o_we_cropper_wrapper {
         position: absolute;
@@ -605,7 +607,6 @@ img.o_we_selected_image {
         margin-top: 0.5rem;
         display: flex;
         flex-wrap: wrap;
-        bottom: 1rem;
 
         input[type=radio] {
             display: none;

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -345,8 +345,8 @@
     <div t-name="wysiwyg.widgets.crop" class="o_we_crop_widget" contenteditable="false">
         <div class="o_we_cropper_wrapper">
             <img class="o_we_cropper_img"/>
-            <div class="o_we_crop_buttons text-center mt16 position-fixed o_we_no_overlay" contenteditable="false">
-                <div class="btn-group btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
+            <div class="o_we_crop_buttons text-center mt16 position-absolute o_we_no_overlay" contenteditable="false">
+                <div class="btn-group croptool btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
                     <t t-foreach="widget.aspectRatios" t-as="ratio">
                         <t t-set="is_active" t-value="ratio === widget.aspectRatio"/>
                         <label t-attf-class="btn #{is_active and 'active' or ''}" data-action="ratio" t-att-data-value="ratio">
@@ -354,22 +354,22 @@
                         </label>
                     </t>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group croptool" role="group">
                     <button type="button" title="Zoom In" data-action="zoom" data-value="0.1"><i class="fa fa-fw fa-search-plus"/></button>
                     <button type="button" title="Zoom Out" data-action="zoom" data-value="-0.1"><i class="fa fa-fw fa-search-minus"/></button>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group croptool" role="group">
                     <button type="button" title="Rotate Left" data-action="rotate" data-value="-90"><i class="fa fa-fw fa-rotate-left"/></button>
                     <button type="button" title="Rotate Right" data-action="rotate" data-value="90"><i class="fa fa-fw fa-rotate-right"/></button>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group croptool" role="group">
                     <button type="button" title="Flip Horizontal" data-action="flip" data-scale-direction="scaleX"><i class="fa fa-fw fa-arrows-h"/></button>
                     <button type="button" title="Flip Vertical" data-action="flip" data-scale-direction="scaleY"><i class="fa fa-fw fa-arrows-v"/></button>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group croptool" role="group">
                     <button type="button" title="Reset Image" data-action="reset"><i class="fa fa-refresh"/> Reset Image</button>
                 </div>
-                <div class="btn-group" role="group">
+                <div class="btn-group croptool" role="group">
                     <button type="button" title="Apply" data-action="apply" class="btn btn-primary"><i class="fa fa-check"/> Apply</button>
                     <button type="button" title="Discard" data-action="discard" class="btn btn-danger"><i class="fa fa-times"/> Discard</button>
                 </div>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -585,6 +585,48 @@
                 Reset
             </we-button>
         </we-row>
+        <div id="cropTools" class="cropBtns">
+            <div class="cropTool">
+                <we-row class="cropBtns" string="└ Aspect Ratio">
+                        <we-button data-action="ratio" data-image-transform="" data-no-preview="true" data-value="0/0">Flexible</we-button>
+                </we-row>
+                <we-row class="cropBtns" string=" ">
+                        <we-button data-action="ratio" data-image-transform="" data-no-preview="true" data-value="16/9">16:9</we-button>
+                        <we-button data-action="ratio" data-image-transform="" data-no-preview="true" data-value="4/3" >4:3</we-button>
+                        <we-button data-action="ratio" data-image-transform="" data-no-preview="true" data-value="1/1" >1:1</we-button>
+                        <we-button data-action="ratio" data-image-transform="" data-no-preview="true" data-value="2/3" >2:3</we-button>
+                </we-row>
+            </div>
+            <div class="cropTool">
+                <we-row class="cropBtns" string="└ Zoom">
+                    <we-button class="fa fa-fw fa-search-plus" data-action="zoom" data-image-transform="" data-no-preview="true" data-value="0.1" title="Zoom In"/>
+                    <we-button class="fa fa-fw fa-search-minus" data-action="zoom"  data-image-transform="" data-no-preview="true" data-value="-0.1" title="Zoom Out"/>
+                </we-row>
+            </div>
+            <div class="cropTool">
+                <we-row class="cropBtns" string="└ Rotate">
+                    <we-button class="fa fa-fw fa-rotate-left" data-action="rotate" data-image-transform="" data-no-preview="true" data-value="-90" title="Rotate Left"/>
+                    <we-button class="fa fa-fw fa-rotate-right" data-action="rotate" data-image-transform="" data-no-preview="true" data-value="90" title="Rotate Right"/>
+                </we-row>
+            </div>
+            <div class="cropTool">
+                <we-row class="cropBtns" string="└ Flip">
+                    <we-button class="fa fa-fw fa-arrows-h" data-action="flip" data-image-transform="" data-no-preview="true" data-scale-direction="scaleX" title="Flip-Horizontal"/>
+                    <we-button class="fa fa-fw fa-arrows-v" data-action="flip" data-image-transform="" data-no-preview="true" data-scale-direction="scaleY" title="Flip-Vertical"/>
+                </we-row>
+            </div>
+            <div class="cropTool">
+                <we-row class="cropBtns" string="└ Reset">
+                    <we-button data-action="reset" data-image-transform="" data-no-preview="true" title="Reset Image">Reset</we-button>
+                </we-row>
+            </div>
+            <div class="cropTool">
+                <we-row class="cropBtns" string=" ">
+                    <we-button class="btn o_we_bg_brand_primary" data-action="apply" data-image-transform="" data-no-preview="true"  title="Apply">Apply</we-button>
+                    <we-button class="btn o_we_bg_danger" data-action="discard" data-image-transform="" data-no-preview="true" title="Discard">Discard</we-button>
+                </we-row>
+            </div>
+        </div>
 
         <we-button-group string="Width" data-css-property="width">
             <we-button data-select-style="" title="Resize Default">Default</we-button>


### PR DESCRIPTION
**Before this commit:**

The crop buttons were attached to the bottom of the screen.

**After this commit:**

The crop buttons will be added to the sidebar in mass-mailing, website making the buttons more accessible.

task-3258587