### PR TITLE
[FIX] account: prevent change of currency line for unsaved records

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1533,6 +1533,7 @@ class AccountMove(models.Model):
         for invoice in self:
             if invoice.journal_id.currency_id and invoice.journal_id.currency_id != invoice.currency_id:
                 self.env.add_to_compute(self._fields['journal_id'], invoice)
+            self.env.add_to_compute(invoice.invoice_line_ids._fields['currency_id'], invoice.invoice_line_ids)
 
     def _inverse_payment_reference(self):
         self.line_ids._conditional_add_to_compute('name', lambda line: (


### PR DESCRIPTION
Steps to reproduce:
- Create a new invoice
- add a customer and a product
- change the currency
- SAVE

Issue:
- The invoice lines won't have the currency_id set with the right one

Cause:
- Since the record is not yet saved, the compute who's depends on 'move.currency_id' won't be triggered
https://github.com/odoo/odoo/blob/5f2412ac0ebb7e5868fc6c60789914de2c213d3f/addons/account/models/account_move_line.py#L449-L450

Solution:
prevent the change of currency if the record is not saved

opw-3288226