### PR TITLE
[FIX] loyalty,pos_*: fixed ir.config.parameter calls

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -129,7 +129,7 @@ class LoyaltyReward(models.Model):
 
     @api.depends('discount_product_domain')
     def _compute_reward_product_domain(self):
-        compute_all_discount_product = self.env['ir.config_parameter'].get_param('loyalty.compute_all_discount_product_ids', 'enabled')
+        compute_all_discount_product = self.env['ir.config_parameter'].sudo().get_param('loyalty.compute_all_discount_product_ids', 'enabled')
         for reward in self:
             if compute_all_discount_product == 'enabled':
                 reward.reward_product_domain = "null"
@@ -138,7 +138,7 @@ class LoyaltyReward(models.Model):
 
     @api.depends('discount_product_ids', 'discount_product_category_id', 'discount_product_tag_id', 'discount_product_domain')
     def _compute_all_discount_product_ids(self):
-        compute_all_discount_product = self.env['ir.config_parameter'].get_param('loyalty.compute_all_discount_product_ids', 'enabled')
+        compute_all_discount_product = self.env['ir.config_parameter'].sudo().get_param('loyalty.compute_all_discount_product_ids', 'enabled')
         for reward in self:
             if compute_all_discount_product == 'enabled':
                 reward.all_discount_product_ids = self.env['product.product'].search(reward._get_discount_product_domain())

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -200,7 +200,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
 
     def test_program_numbers_one_discount_line_per_tax(self):
         order = self.empty_order
-        self.env['ir.config_parameter'].set_param('loyalty.compute_all_discount_product_ids', 'enabled')
+        self.env['ir.config_parameter'].sudo().set_param('loyalty.compute_all_discount_product_ids', 'enabled')
         # Create taxes
         self.tax_15pc_excl = self.env['account.tax'].create({
             'name': "15% Tax excl",


### PR DESCRIPTION
Before this commit
==================
ir.config.parameter calls were made without the use of .sudo()

After this commit
==================
ir.config.parameter calls use .sudo()


Changes the calls introduced in :
https://github.com/odoo/odoo/commit/f9cb34ae2f1ce35afd109d3f681e7eb4e67bc338
