### PR TITLE
[FIX] hr_expense: speed up installation process

### DIFF
--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -2,10 +2,24 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.tools.sql import column_exists, create_column
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+
+    def _auto_init(self):
+        if not column_exists(self.env.cr, "product_template", "can_be_expensed"):
+            # In case of a big database with a lot of product tempaltes, the RAM gets exhausted
+            # To prevent a process from being killed, we create the column 'can_be_expensed' manually
+            # Then we do the computation in a query by setting can_be_expensed to false for consumables and services
+            create_column(self.env.cr, "product_template", "can_be_expensed", "boolean")
+            self.env.cr.execute("""
+                UPDATE product_template product
+                SET can_be_expensed = false
+                WHERE product.type not in ('consu', 'service')
+                """)
+        return super()._auto_init()
 
     can_be_expensed = fields.Boolean(string="Can be Expensed", compute='_compute_can_be_expensed',
         store=True, readonly=False, help="Specify whether the product can be selected in an expense.")


### PR DESCRIPTION
## Before this commit
The process is being killed upon installing the expense module due to the computed field `can_be_expensed` on product.template.

## After this commit:
The column `can_be_expensed` is added to the DB schema and computed manually using SQL, which is faster and requires less RAM.

opw-3277568