### PR TITLE
[IMP] speedup routing map

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -79,6 +79,42 @@ class SignedIntConverter(NumberConverter):
     num_convert = int
 
 
+class LazyCompiledBuilder:
+    def __init__(self, rule, _compile_builder, append_unknown):
+        self.rule = rule
+        self._callable = None
+        self._compile_builder = _compile_builder
+        self._append_unknown = append_unknown
+
+    def __get__(self, *args):
+        # Rule.compile will actually call
+        #
+        #   self._build = self._compile_builder(False).__get__(self, None)
+        #   self._build_unknown = self._compile_builder(True).__get__(self, None)
+        #
+        # meaning the _build and _build unkown will contain _compile_builder().__get__(self, None).
+        # This is why this override of __get__ is needed.
+        return self
+
+    def __call__(self, *args, **kwargs):
+        if self._callable is None:
+            self._callable = self._compile_builder(self._append_unknown).__get__(self.rule, None)
+            del self.rule
+            del self._compile_builder
+            del self._append_unknown
+        return self._callable(*args, **kwargs)
+
+
+class FasterRule(werkzeug.routing.Rule):
+    """
+    _compile_builder is a major part of the routing map generation and rules
+    are actually not build so often.
+    This classe makes calls to _compile_builder lazy
+    """
+    def _compile_builder(self, append_unknown=True):
+        return LazyCompiledBuilder(self, super()._compile_builder, append_unknown)
+
+
 class IrHttp(models.AbstractModel):
     _name = 'ir.http'
     _description = "HTTP Routing"
@@ -202,7 +238,7 @@ class IrHttp(models.AbstractModel):
                 routing = submap(endpoint.routing, ROUTING_KEYS)
                 if routing['methods'] is not None and 'OPTIONS' not in routing['methods']:
                     routing['methods'] = routing['methods'] + ['OPTIONS']
-                rule = werkzeug.routing.Rule(url, endpoint=endpoint, **routing)
+                rule = FasterRule(url, endpoint=endpoint, **routing)
                 rule.merge_slashes = False
                 routing_map.add(rule)
             cls._routing_map[key] = routing_map

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -20,6 +20,7 @@ from . import test_ir_actions
 from . import test_ir_attachment
 from . import test_ir_cron
 from . import test_ir_filters
+from . import test_ir_http
 from . import test_ir_mail_server
 from . import test_ir_model
 from . import test_ir_sequence

--- a/odoo/addons/base/tests/test_ir_http.py
+++ b/odoo/addons/base/tests/test_ir_http.py
@@ -1,0 +1,30 @@
+import logging
+import re
+import time
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged('-at_install', 'post_install')
+class TestIrHttpPerformances(TransactionCase):
+
+    def test_routing_map_performance(self):
+        self.env['ir.http']._clear_routing_map()
+        # if the routing map was already generated it is possible that some compiled regex are in cache.
+        # we want to mesure the cold state, when the worker just spawned, we need to empty the re cache
+        re._cache.clear()
+
+        self.env['ir.http']._clear_routing_map()
+        start = time.time()
+        self.env['ir.http'].routing_map()
+        duration = time.time() - start
+        _logger.info('Routing map web generated in %.3fs', duration)
+
+        # generate the routing map of another website, to check if we can benefit from anything computed by the previous routing map
+        start = time.time()
+        self.env['ir.http'].routing_map(key=1)
+        duration = time.time() - start
+        _logger.info('Routing map website1 generated in %.3fs', duration)

--- a/odoo/cli/server.py
+++ b/odoo/cli/server.py
@@ -15,11 +15,8 @@ import atexit
 import csv # pylint: disable=deprecated-module
 import logging
 import os
-import signal
+import re
 import sys
-import threading
-import traceback
-import time
 
 from psycopg2 import ProgrammingError, errorcodes
 
@@ -32,6 +29,8 @@ __version__ = odoo.release.version
 
 # Also use the `odoo` logger for the main script.
 _logger = logging.getLogger('odoo')
+
+re._MAXCACHE = 4096  # default is 512, a little too small for odoo
 
 def check_root_user():
     """Warn if the process's user is 'root' (on POSIX system)."""


### PR DESCRIPTION
The current target, 16.0 is a little arbitrary, to discuss.

The routing map is an important part of the cold loading of a page. This can be improved multiple way.

## Possible improvements:
### Improve the totally cold routing map
Most of the time spent is in the `werkzeug.routing.Rule.add` method representing 70~80% of the total routing map generation time.
This will need some low level thinking and optimisations
Another part is the `odoo.http._generate_routing_rules`, not so massive but still visible, mainly the `getmembers`, `is_method_a_route`, `build_controllers`, ... Hard to say what is possible to do but a possible improvement would be to generate a registry of routes inside the route decorator.

### Improve muti webiste routing map
Between website, the main difference is the rewrites rules:
`rewrites = dict([(x.url_from, x) for x in request.env['website.rewrite'].sudo().search(domain)])`

A simple assumption is that, if this list is empty, we could use the `None` routing map. 
Even if this list is not empty, we could alter the `None` routing map to remove some rules, add some redirect
A ModelConverter is also added if website is installed.

### Improve multidb routing map
The mro dynamic composition would make this difficult but investigating a per module routing map and combining them
based on the installed module could be an important improvement for the saas infrastructure. 

## What is actually done in this pr
Even if there are more possible improvements, werkzeug 2.2 will change how the routing map is managed, going from regexes to a decision tree. The change proposed in this pr change should remain compatible in theory or at least not to difficult to adapt.

### Lazy _compile_builder: 
~600 ms -> ~200ms. 
Instead of generating the build method for ~1100 routes, will only create the method when accessing this page and matching the rule, or when accessing the sitemap or searching a page (only a small amount of routes are actually build in this scenario)

### Increase re _MAX_SIZE
One important part of the routing map is compiling the regex for routes. They actually are the same for all databases, all website, .... and it take around 100~150 ms. Last test increasing the _MAX_SIZE from 512 to 2200 allowed to speedup the 
second routing map from ~200 to ~70 ms. This improvement is also cross db, but 2200 is maybe to low to benefit from that
since the re._MAX_SIZE is used by all regexes. The proposed size here is 4096.
This imp should be visible either for a db with mutiple website, or for a worker serving multiple db, or even if the routing map was invalidated and regenared.

Note that this cache could be conceptually dedicated to routes and populated exclusively from the @route decorator, avoiding to add database specific rules to this cache, but this is a little hard to combine. 





