### PR TITLE
[FIX] pos_sale: default value on order life fields function

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -121,7 +121,7 @@ class PosOrderLine(models.Model):
         result['sale_order_origin_id'] = bool(orderline.sale_order_origin_id) and orderline.sale_order_origin_id.read(fields=['name'])[0]
         return result
 
-    def _order_line_fields(self, line, session_id):
+    def _order_line_fields(self, line, session_id=None):
         result = super()._order_line_fields(line, session_id)
         vals = result[2]
         if vals.get('sale_order_origin_id', False):


### PR DESCRIPTION
In the point of sale, the function order_line_fields have default value for session but not in pos sale. There are some calls made without this argument this it make it crash.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
