### PR TITLE
[IMP] hr_timesheet,project: refactor 'planned_hours' field

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -7,7 +7,7 @@ from odoo import fields, models, api
 class ReportProjectTaskUser(models.Model):
     _inherit = "report.project.task.user"
 
-    planned_hours = fields.Float('Allocated Time', readonly=True)
+    allocated_hours = fields.Float('Allocated Time', readonly=True)
     effective_hours = fields.Float('Hours Spent', readonly=True)
     remaining_hours = fields.Float('Remaining Hours', readonly=True)
     remaining_hours_percentage = fields.Float('Remaining Hours Percentage', readonly=True)
@@ -17,11 +17,11 @@ class ReportProjectTaskUser(models.Model):
 
     def _select(self):
         return super()._select() +  """,
-                CASE WHEN COALESCE(t.planned_hours, 0) = 0 THEN 0.0 ELSE LEAST((t.effective_hours * 100) / t.planned_hours, 100) END as progress,
+                CASE WHEN COALESCE(t.allocated_hours, 0) = 0 THEN 0.0 ELSE LEAST((t.effective_hours * 100) / t.allocated_hours, 100) END as progress,
                 t.effective_hours,
-                t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
-                CASE WHEN t.planned_hours > 0 THEN t.remaining_hours / t.planned_hours ELSE 0 END as remaining_hours_percentage,
-                t.planned_hours,
+                t.allocated_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
+                CASE WHEN t.allocated_hours > 0 THEN t.remaining_hours / t.allocated_hours ELSE 0 END as remaining_hours_percentage,
+                t.allocated_hours,
                 t.overtime,
                 t.total_hours_spent
         """
@@ -30,7 +30,7 @@ class ReportProjectTaskUser(models.Model):
         return super()._group_by() + """,
                 t.effective_hours,
                 t.subtask_effective_hours,
-                t.planned_hours,
+                t.allocated_hours,
                 t.overtime,
                 t.total_hours_spent
         """

--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -10,8 +10,7 @@
                     <attribute name="js_class">hr_timesheet_graphview</attribute>
                 </xpath>
                 <xpath expr="//field[@name='project_id']" position='after'>
-                    <field name="remaining_hours_percentage" invisible="1"/>
-                    <field name="planned_hours" widget="timesheet_uom" type="measure"/>
+                    <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                 </xpath>
@@ -24,8 +23,7 @@
             <field name="inherit_id" ref="project.view_task_project_user_pivot"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='project_id']" position='after'>
-                    <field name="remaining_hours_percentage" invisible="1"/>
-                    <field name="planned_hours" widget="timesheet_uom" type="measure"/>
+                    <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                     <field name="total_hours_spent" widget="timesheet_uom" type="measure"/>

--- a/addons/hr_timesheet/static/src/views/timesheet_graph/timesheet_graph_model.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_graph/timesheet_graph_model.js
@@ -3,7 +3,7 @@
 import { ProjectTaskGraphModel } from "@project/views/project_task_graph/project_task_graph_model";
 
 const FIELDS = [
-    'unit_amount', 'effective_hours', 'planned_hours', 'remaining_hours', 'total_hours_spent', 'subtask_effective_hours',
+    'unit_amount', 'effective_hours', 'allocated_hours', 'remaining_hours', 'total_hours_spent', 'subtask_effective_hours',
     'overtime', 'number_hours', 'difference', 'timesheet_unit_amount'
 ];
 

--- a/addons/hr_timesheet/tests/test_project_task_quick_create.py
+++ b/addons/hr_timesheet/tests/test_project_task_quick_create.py
@@ -22,7 +22,7 @@ class TestProjectTaskQuickCreate(TestCommonTimesheet):
             task_form = Form(self.env['project.task'].with_context({'tracking_disable': True, 'default_project_id': self.project_customer.id}), view="project.quick_create_task_form")
             task_form.display_name = expression
             task = task_form.save()
-            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.planned_hours)
+            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.allocated_hours)
             self.assertEqual(results, values)
 
     def test_create_task_with_invalid_expressions(self):
@@ -35,5 +35,5 @@ class TestProjectTaskQuickCreate(TestCommonTimesheet):
             task_form = Form(self.env['project.task'].with_context({'tracking_disable': True, 'default_project_id': self.project_customer.id}), view="project.quick_create_task_form")
             task_form.display_name = expression
             task = task_form.save()
-            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.planned_hours)
+            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.allocated_hours)
             self.assertEqual(results, (expression, 0, 0, '0', 0))

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -661,9 +661,9 @@ class TestTimesheet(TestCommonTimesheet):
         with self.assertRaises(UserError):
             self.task1.write({'project_id': False, 'parent_id': False})
 
-    def test_percentage_of_planned_hours(self):
-        """ Test the percentage of planned hours on a task. """
-        self.task1.planned_hours = 11/60
+    def test_percentage_of_allocated_hours(self):
+        """ Test the percentage of allocated hours on a task. """
+        self.task1.allocated_hours = 11/60
         self.assertEqual(self.task1.effective_hours, 0, 'No timesheet should be created yet.')
         self.assertEqual(self.task1.progress, 0, 'No timesheet should be created yet.')
         self.env['account.analytic.line'].create([
@@ -687,4 +687,4 @@ class TestTimesheet(TestCommonTimesheet):
                 'employee_id': self.empl_employee.id,
             },
         ])
-        self.assertEqual(self.task1.progress, 100, 'The percentage of planned hours should be 100%.')
+        self.assertEqual(self.task1.progress, 100, 'The percentage of allocated hours should be 100%.')

--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -165,10 +165,10 @@
                             <div t-if="is_uom_day">Days recorded on sub-tasks: <span t-esc="timesheets._convert_hours_to_days(timesheets_by_subtask_amount)" t-options='{"widget": "timesheet_uom"}'/></div>
                             <div t-else="">Hours recorded on sub-tasks: <span t-esc="timesheets_by_subtask_amount" t-options='{"widget": "float_time"}'/></div>
                         </div>
-                        <t t-set="planned_time" t-value="task.planned_hours"></t>
-                        <div t-if="planned_time > 0" name="planned_time" t-attf-class="{{task.remaining_hours &lt; 0 and 'text-danger' or ''}}">
-                            <div t-if="is_uom_day">Remaining Days: <span t-esc="timesheets._convert_hours_to_days(planned_time - timesheets_amount - timesheets_by_subtask_amount)" t-options='{"widget": "timesheet_uom"}'/></div>
-                            <div t-else="">Remaining Hours: <span t-esc="planned_time - timesheets_amount - timesheets_by_subtask_amount" t-options='{"widget": "float_time"}'/></div>
+                        <t t-set="allocated_time" t-value="task.allocated_hours"></t>
+                        <div t-if="allocated_time > 0" name="allocated_time" t-attf-class="{{task.remaining_hours &lt; 0 and 'text-danger' or ''}}">
+                            <div t-if="is_uom_day">Remaining Days: <span t-esc="timesheets._convert_hours_to_days(allocated_time - timesheets_amount - timesheets_by_subtask_amount)" t-options='{"widget": "timesheet_uom"}'/></div>
+                            <div t-else="">Remaining Hours: <span t-esc="allocated_time - timesheets_amount - timesheets_by_subtask_amount" t-options='{"widget": "float_time"}'/></div>
                         </div>
                     </th>
                 </tr>

--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -24,19 +24,19 @@
                 <t t-call="hr_timesheet.portal_timesheet_table"/>
             </div>
         </xpath>
-        <xpath expr="//div[@name='portal_my_task_planned_hours']" position="after">
-            <div t-if="task.planned_hours > 0"><strong>Progress:</strong> <span t-field="task.progress"/>%</div>
+        <xpath expr="//div[@name='portal_my_task_allocated_hours']" position="after">
+            <div t-if="task.allocated_hours > 0"><strong>Progress:</strong> <span t-field="task.progress"/>%</div>
         </xpath>
-        <xpath expr="//div[@name='portal_my_task_planned_hours']/t" position="replace">
-            <t t-call="hr_timesheet.portal_my_task_planned_hours_template"></t>
+        <xpath expr="//div[@name='portal_my_task_allocated_hours']/t" position="replace">
+            <t t-call="hr_timesheet.portal_my_task_allocated_hours_template"></t>
         </xpath>
     </template>
 
-    <template id="portal_my_task_planned_hours_template">
-        <t t-if="is_uom_day and timesheets._convert_hours_to_days(task.planned_hours) > 0">
-            <span t-out="timesheets._convert_hours_to_days(task.planned_hours)" t-options='{"widget": "timesheet_uom"}'/>
+    <template id="portal_my_task_allocated_hours_template">
+        <t t-if="is_uom_day and timesheets._convert_hours_to_days(task.allocated_hours) > 0">
+            <span t-out="timesheets._convert_hours_to_days(task.allocated_hours)" t-options='{"widget": "timesheet_uom"}'/>
         </t>
-        <t t-if="not is_uom_day and task.planned_hours > 0" t-call="project.portal_my_task_planned_hours_template"></t>
+        <t t-if="not is_uom_day and task.allocated_hours > 0" t-call="project.portal_my_task_allocated_hours_template"></t>
     </template>
 
     <template id="portal_tasks_list_inherit" inherit_id="project.portal_tasks_list" name="Portal: My Tasks with Timesheets">
@@ -55,13 +55,13 @@
             <td class="text-end">
                 <t t-if="is_uom_day">
                     <t t-out="timesheet_ids._convert_hours_to_days(task.effective_hours)"/>
-                    <span t-if="task.planned_hours > 0"> / <t t-out="timesheet_ids._convert_hours_to_days(task.planned_hours)"/></span>
+                    <span t-if="task.allocated_hours > 0"> / <t t-out="timesheet_ids._convert_hours_to_days(task.allocated_hours)"/></span>
                 </t>
                 <t t-else="">
                     <span t-field="task.effective_hours" t-options='{"widget": "float_time"}'/>
-                    <t t-if="task.planned_hours > 0">
+                    <t t-if="task.allocated_hours > 0">
                         /
-                        <span t-field="task.planned_hours" t-options='{"widget": "float_time"}'/>
+                        <span t-field="task.allocated_hours" t-options='{"widget": "float_time"}'/>
                     </t>
                 </t>
             </td>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="project.project_sharing_project_task_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='child_ids']/tree/field[@name='portal_user_names']" position="after">
-                <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Initially Planned Hours" optional="hide"/>
+                <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide"/>
                 <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
                 <field name="subtask_effective_hours" string="Sub-tasks Hours Spent" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide"/>
                 <field name="total_hours_spent" string="Total Hours" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
@@ -17,11 +17,11 @@
             <xpath expr="//field[@name='date_deadline']" position="before">
                 <field name="encode_uom_in_days" invisible="1"/>
                 <field name="subtask_count" invisible="1"/>
-                <label for="planned_hours" invisible="not allow_timesheets"/>
+                <label for="allocated_hours" invisible="not allow_timesheets"/>
                 <div class="text-nowrap" invisible="not allow_timesheets">
-                    <field name="planned_hours" class="oe_inline" widget="float_time"/>
+                    <field name="allocated_hours" class="oe_inline" widget="float_time"/>
                     <span invisible="subtask_count == 0">
-                        (incl. <field name="subtask_planned_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
+                        (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                         <span class="fw-bold text-dark"> Sub-tasks</span>)
                     </span>
                     <span>(<field name="progress" class="oe_inline" nolabel="1" widget="integer"/> %)</span>
@@ -95,16 +95,16 @@
                                   invisible="subtask_effective_hours == 0.0" />
                             <span class="o_td_label float-start">
                                 <label class="fw-bold" for="remaining_hours" string="Remaining Hours"
-                                       invisible="planned_hours == 0.0 or encode_uom_in_days or remaining_hours &lt; 0"/>
+                                       invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &lt; 0"/>
                                 <label class="fw-bold" for="remaining_hours" string="Remaining Days"
-                                       invisible="planned_hours == 0.0 or not encode_uom_in_days or remaining_hours &lt; 0"/>
+                                       invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &lt; 0"/>
                                 <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Hours"
-                                       invisible="planned_hours == 0.0 or encode_uom_in_days or remaining_hours &gt;= 0"/>
+                                       invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &gt;= 0"/>
                                 <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Days"
-                                       invisible="planned_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
+                                       invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
                             </span>
                             <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
-                                  invisible="planned_hours == 0.0" nolabel="1"/>
+                                  invisible="allocated_hours == 0.0" nolabel="1"/>
                         </group>
                     </group>
                 </page>
@@ -120,12 +120,12 @@
             <templates position="before">
                 <field name="progress" />
                 <field name="remaining_hours" />
-                <field name="planned_hours" />
+                <field name="allocated_hours" />
                 <field name="allow_timesheets"/>
                 <field name="encode_uom_in_days" invisible="1"/>
             </templates>
             <div class="oe_kanban_bottom_left" position="inside">
-                <t name="planned_hours" t-if="record.planned_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value">
+                <t name="allocated_hours" t-if="record.allocated_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value">
                     <t t-set="badge" t-value="'border border-success'"/>
                     <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 80 and record.progress.raw_value &lt;= 100"/>
                     <t t-set="badge" t-value="'border border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="project.view_task_form2" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='child_ids']/tree/field[@name='company_id']" position="after">
-                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="effective_hours" widget="timesheet_uom" sum="Hours Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="total_hours_spent" widget="timesheet_uom" sum="Total Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
@@ -17,11 +17,11 @@
                 <xpath expr="//label[@for='date_deadline']" position="before" groups="hr_timesheet.group_hr_timesheet_user">
                     <field name="encode_uom_in_days" invisible="1"/>
                     <field name="subtask_count" invisible="1"/>
-                    <label for="planned_hours" invisible="not allow_timesheets"/>
+                    <label for="allocated_hours" invisible="not allow_timesheets"/>
                     <div class="text-nowrap" invisible="not allow_timesheets">
-                        <field name="planned_hours" class="oe_inline o_field_float_time" widget="timesheet_uom_no_toggle"/>
+                        <field name="allocated_hours" class="oe_inline o_field_float_time" widget="timesheet_uom_no_toggle"/>
                         <span invisible="subtask_count == 0">
-                            (incl. <field name="subtask_planned_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
+                            (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                             <span class="fw-bold text-dark"> Sub-tasks</span>)
                         </span>
                         <span invisible="not project_id">(<field name="progress" class="oe_inline" nolabel="1" widget="integer"/> %)</span>
@@ -138,23 +138,23 @@
                                    invisible="subtask_effective_hours == 0.0" />
                             <span class="o_td_label float-start my-1">
                                 <label class="fw-bold" for="remaining_hours" string="Remaining Hours"
-                                       invisible="planned_hours == 0.0 or encode_uom_in_days or remaining_hours &lt; 0"/>
+                                       invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &lt; 0"/>
                                 <label class="fw-bold" for="remaining_hours" string="Remaining Days"
-                                       invisible="planned_hours == 0.0 or not encode_uom_in_days or remaining_hours &lt; 0"/>
+                                       invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &lt; 0"/>
                                 <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Hours"
-                                       invisible="planned_hours == 0.0 or encode_uom_in_days or remaining_hours &gt;= 0"/>
+                                       invisible="allocated_hours == 0.0 or encode_uom_in_days or remaining_hours &gt;= 0"/>
                                 <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Days"
-                                       invisible="planned_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
+                                       invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
                             </span>
                             <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
-                                   invisible="planned_hours == 0.0" nolabel="1" decoration-danger="remaining_hours &lt; 0"/>
+                                   invisible="allocated_hours == 0.0" nolabel="1" decoration-danger="remaining_hours &lt; 0"/>
                         </group>
                     </group>
                 </page>
                 </xpath>
                 <xpath expr="//field[@name='depend_on_ids']/tree//field[@name='company_id']" position="after">
                     <field name="progress" column_invisible="True" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="subtask_effective_hours" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="total_hours_spent" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
@@ -172,12 +172,12 @@
                 <field name="date_deadline" position="before">
                     <field name="progress" column_invisible="True"/>
                     <field name="effective_hours" column_invisible="True"/>
-                    <field name="planned_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="planned_hours == 0" optional="hide"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide"/>
                     <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0"/>
                     <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-Tasks Total Effective Hours" optional="hide"/>
                     <field name="total_hours_spent" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Total Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" invisible="planned_hours == 0"/>
-                    <field name="progress" widget="progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="planned_hours == 0" options="{'overflow_class': 'bg-danger'}" />
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Total Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" invisible="allocated_hours == 0"/>
+                    <field name="progress" widget="progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" />
                 </field>
             </field>
         </record>
@@ -190,12 +190,12 @@
                 <templates position="before">
                     <field name="progress" />
                     <field name="remaining_hours" />
-                    <field name="planned_hours" />
+                    <field name="allocated_hours" />
                     <field name="allow_timesheets"/>
                     <field name="encode_uom_in_days" invisible="1"/>
                 </templates>
                 <div class="oe_kanban_bottom_left" position="inside">
-                   <t name="planned_hours" t-if="record.planned_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value">
+                   <t name="allocated_hours" t-if="record.allocated_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value">
                         <t t-set="badge" t-value=""/>
                         <t t-set="badge" t-value="'bg-warning'" t-if="record.progress.raw_value &gt;= 80 and record.progress.raw_value &lt;= 100"/>
                         <t t-set="badge" t-value="'bg-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
@@ -232,7 +232,7 @@
                     <attribute name="js_class">hr_timesheet_graphview</attribute>
                 </xpath>
                 <xpath expr="//field[@name='stage_id']" position='after'>
-                    <field name="planned_hours" widget="timesheet_uom"/>
+                    <field name="allocated_hours" widget="timesheet_uom"/>
                     <field name="remaining_hours" widget="timesheet_uom"/>
                     <field name="effective_hours" widget="timesheet_uom"/>
                     <field name="total_hours_spent" widget="timesheet_uom"/>
@@ -247,8 +247,10 @@
             <field name="model">project.task</field>
             <field name="inherit_id" ref="project.view_project_task_pivot"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='planned_hours']" position='after'>
-                    <field name="planned_hours" widget="timesheet_uom"/>
+                <xpath expr="//field[@name='allocated_hours']" position='attributes'>
+                    <attribute name="widget">timesheet_uom</attribute>
+                </xpath>
+                <xpath expr="//field[@name='allocated_hours']" position='after'>
                     <field name="remaining_hours" widget="timesheet_uom"/>
                     <field name="effective_hours" widget="timesheet_uom"/>
                     <field name="total_hours_spent" widget="timesheet_uom"/>

--- a/addons/project/data/project_demo.xml
+++ b/addons/project/data/project_demo.xml
@@ -266,7 +266,7 @@
         <!-- Project 1 Tasks -->
         <record id="project_1_task_1" model="project.task">
             <field name="sequence">20</field>
-            <field name="planned_hours">20.0</field>
+            <field name="allocated_hours">20.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Office planning</field>
@@ -277,7 +277,7 @@
         </record>
 
         <record id="project_1_task_2" model="project.task">
-            <field name="planned_hours" eval="32.0"/>
+            <field name="allocated_hours" eval="32.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -324,7 +324,7 @@
         </record>
 
         <record id="project_1_task_3" model="project.task">
-            <field name="planned_hours" eval="10.0"/>
+            <field name="allocated_hours" eval="10.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -375,7 +375,7 @@
 
         <record id="project_1_task_4" model="project.task">
             <field name="sequence">17</field>
-            <field name="planned_hours">8.0</field>
+            <field name="allocated_hours">8.0</field>
             <field name="stage_id" ref="project_stage_2"/>
             <field name="user_ids" eval="False"/>
             <field name="priority">1</field>
@@ -424,7 +424,7 @@
         </record>
 
         <record id="project_1_task_5" model="project.task">
-            <field name="planned_hours" eval="15.0"/>
+            <field name="allocated_hours" eval="15.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -465,7 +465,7 @@
         </record>
 
         <record id="project_1_task_6" model="project.task">
-            <field name="planned_hours" eval="76.0"/>
+            <field name="allocated_hours" eval="76.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -508,7 +508,7 @@
         </record>
 
         <record id="project_1_task_7" model="project.task">
-            <field name="planned_hours" eval="24.0"/>
+            <field name="allocated_hours" eval="24.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -539,7 +539,7 @@
         </record>
 
         <record id="project_1_task_8" model="project.task">
-            <field name="planned_hours" eval="60.0"/>
+            <field name="allocated_hours" eval="60.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -592,7 +592,7 @@
         </record>
 
         <record id="project_1_task_9" model="project.task">
-            <field name="planned_hours" eval="40.0"/>
+            <field name="allocated_hours" eval="40.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_1"/>
@@ -648,7 +648,7 @@
         </record>
         <record id="project_1_task_10" model="project.task">
             <field name="sequence">20</field>
-            <field name="planned_hours">20.0</field>
+            <field name="allocated_hours">20.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Customer review</field>
@@ -660,7 +660,7 @@
         </record>
         <record id="project_1_task_11" model="project.task">
             <field name="sequence">20</field>
-            <field name="planned_hours">0.25</field>
+            <field name="allocated_hours">0.25</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Daily stand-up meeting - Send minutes</field>
@@ -671,7 +671,7 @@
         </record>
         <record id="project_1_task_12" model="project.task">
             <field name="sequence">20</field>
-            <field name="planned_hours">8.0</field>
+            <field name="allocated_hours">8.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project.project_1_task_10"/>
@@ -680,7 +680,7 @@
         </record>
         <record id="project_1_task_13" model="project.task">
             <field name="sequence">10</field>
-            <field name="planned_hours">2.0</field>
+            <field name="allocated_hours">2.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project.project_1_task_12"/>
@@ -689,7 +689,7 @@
         </record>
         <record id="project_1_task_14" model="project.task">
             <field name="sequence">20</field>
-            <field name="planned_hours">2.0</field>
+            <field name="allocated_hours">2.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project.project_1_task_12"/>
@@ -698,7 +698,7 @@
         </record>
         <record id="project_1_task_15" model="project.task">
             <field name="sequence">30</field>
-            <field name="planned_hours">2.0</field>
+            <field name="allocated_hours">2.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project.project_1_task_12"/>
@@ -706,7 +706,7 @@
             <field name="stage_id" ref="project_stage_1"/>
         </record>
         <record id="project_1_task_16" model="project.task">
-            <field name="planned_hours" eval="24.0"/>
+            <field name="allocated_hours" eval="24.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="name">Chair Cabinet</field>
@@ -719,7 +719,7 @@
         <record id="project_1_task_17" model="project.task">
             <field name="name">Plywood requirement</field>
             <field name="sequence">40</field>
-            <field name="planned_hours">2.0</field>
+            <field name="allocated_hours">2.0</field>
             <field name="project_id" ref="project.project_project_1"/>
             <field name="parent_id" ref="project.project_1_task_16"/>
             <field name="stage_id" ref="project_stage_2"/>
@@ -727,7 +727,7 @@
 
         <!-- Project 2 Tasks-->
         <record id="project_2_task_1" model="project.task">
-            <field name="planned_hours">12.0</field>
+            <field name="allocated_hours">12.0</field>
             <field name="stage_id" ref="project_stage_2"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="priority">0</field>
@@ -775,7 +775,7 @@
         </record>
 
         <record id="project_2_task_2" model="project.task">
-            <field name="planned_hours">24.0</field>
+            <field name="allocated_hours">24.0</field>
             <field name="stage_id" ref="project_stage_2"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="project_id" ref="project.project_project_2"/>
@@ -823,7 +823,7 @@
         </record>
 
         <record id="project_2_task_3" model="project.task">
-            <field name="planned_hours" eval="40.0"/>
+            <field name="allocated_hours" eval="40.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_2"/>
@@ -885,7 +885,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_4" model="project.task">
-            <field name="planned_hours" eval="16.0"/>
+            <field name="allocated_hours" eval="16.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_2"/>
@@ -920,7 +920,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_5" model="project.task">
-            <field name="planned_hours" eval="38.0"/>
+            <field name="allocated_hours" eval="38.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_2"/>
@@ -952,7 +952,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_6" model="project.task">
-            <field name="planned_hours">42.0</field>
+            <field name="allocated_hours">42.0</field>
             <field name="user_ids" eval="False"/>
             <field name="stage_id" ref="project_stage_1"/>
             <field name="project_id" ref="project.project_project_2"/>
@@ -982,7 +982,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_7" model="project.task">
-            <field name="planned_hours" eval="22.0"/>
+            <field name="allocated_hours" eval="22.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_2"/>
@@ -1032,7 +1032,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_8" model="project.task">
-            <field name="planned_hours">14.0</field>
+            <field name="allocated_hours">14.0</field>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="stage_id" ref="project_stage_0"/>
             <field name="project_id" ref="project.project_project_2"/>
@@ -1064,7 +1064,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_9" model="project.task">
-            <field name="planned_hours" eval="18.0"/>
+            <field name="allocated_hours" eval="18.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin')), Command.link(ref('base.user_demo'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_2"/>
@@ -1079,7 +1079,7 @@ Send it ASAP, its urgent.</field>
 
         <record id="project_2_task_10" model="project.task">
             <field name="sequence">20</field>
-            <field name="planned_hours">35.0</field>
+            <field name="allocated_hours">35.0</field>
             <field name="user_ids" eval="False"/>
             <field name="project_id" ref="project.project_project_2"/>
             <field name="name">Unit Testing</field>
@@ -1092,7 +1092,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_2_task_11" model="project.task">
-            <field name="planned_hours" eval="20.0"/>
+            <field name="allocated_hours" eval="20.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="stage_id" ref="project_stage_3"/>
             <field name="priority">0</field>
@@ -1104,7 +1104,7 @@ Send it ASAP, its urgent.</field>
 
         <!-- Project 3 Tasks -->
         <record id="project_3_task_1" model="project.task">
-            <field name="planned_hours" eval="40.0"/>
+            <field name="allocated_hours" eval="40.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_3"/>
@@ -1114,7 +1114,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_3_task_2" model="project.task">
-            <field name="planned_hours" eval="10.0"/>
+            <field name="allocated_hours" eval="10.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">0</field>
             <field name="project_id" ref="project.project_project_3"/>
@@ -1152,7 +1152,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_3_task_3" model="project.task">
-            <field name="planned_hours" eval="24.0"/>
+            <field name="allocated_hours" eval="24.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_3"/>
@@ -1167,7 +1167,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_3_task_4" model="project.task">
-            <field name="planned_hours" eval="76.0"/>
+            <field name="allocated_hours" eval="76.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_3"/>
@@ -1176,7 +1176,7 @@ Send it ASAP, its urgent.</field>
         </record>
 
         <record id="project_3_task_5" model="project.task">
-            <field name="planned_hours" eval="40.0"/>
+            <field name="allocated_hours" eval="40.0"/>
             <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
             <field name="priority">1</field>
             <field name="project_id" ref="project.project_project_3"/>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -156,8 +156,8 @@ class Task(models.Model):
     project_id = fields.Many2one('project.project', string='Project', domain="['|', ('company_id', '=', False), ('company_id', '=?',  company_id)]", index=True, tracking=True, change_default=True)
     display_in_project = fields.Boolean(default=True, readonly=True)
     task_properties = fields.Properties('Properties', definition='project_id.task_properties_definition', copy=True)
-    planned_hours = fields.Float("Allocated Time", tracking=True)
-    subtask_planned_hours = fields.Float("Sub-tasks Planned Hours", compute='_compute_subtask_planned_hours',
+    allocated_hours = fields.Float("Allocated Time", tracking=True)
+    subtask_allocated_hours = fields.Float("Sub-tasks Allocated Time", compute='_compute_subtask_allocated_hours',
         help="Sum of the hours allocated for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the allocated hours of this task.")
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id', string='Assignees', context={'active_test': False}, tracking=True)
@@ -499,10 +499,10 @@ class Task(models.Model):
             task.access_warning = _(
                 "The task cannot be shared with the recipient(s) because the privacy of the project is too restricted. Set the privacy of the project to 'Visible by following customers' in order to make it accessible by the recipient(s).")
 
-    @api.depends('child_ids.planned_hours')
-    def _compute_subtask_planned_hours(self):
+    @api.depends('child_ids.allocated_hours')
+    def _compute_subtask_allocated_hours(self):
         for task in self:
-            task.subtask_planned_hours = sum(child_task.planned_hours + child_task.subtask_planned_hours for child_task in task.child_ids)
+            task.subtask_allocated_hours = sum(child_task.allocated_hours + child_task.subtask_allocated_hours for child_task in task.child_ids)
 
     @api.depends('child_ids')
     def _compute_subtask_count(self):
@@ -1360,7 +1360,7 @@ class Task(models.Model):
 
         defaults = {
             'name': msg.get('subject') or _("No Subject"),
-            'planned_hours': 0.0,
+            'allocated_hours': 0.0,
             'partner_id': msg.get('author_id'),
         }
         defaults.update(custom_values)

--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -48,7 +48,7 @@ class ProjectTaskRecurrence(models.Model):
             'name',
             'parent_id',
             'partner_id',
-            'planned_hours',
+            'allocated_hours',
             'project_id',
             'project_privacy_visibility',
             'recurrence_id',

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -12,7 +12,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
     _auto = False
     _order = 'date'
 
-    planned_hours = fields.Float(string='Allocated Hours', readonly=True)
+    allocated_hours = fields.Float(string='Allocated Time', readonly=True)
     date = fields.Datetime('Date', readonly=True)
     date_assign = fields.Datetime(string='Assignment Date', readonly=True)
     date_deadline = fields.Date(string='Deadline', readonly=True)
@@ -94,7 +94,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
               ),
               all_stage_task_moves AS (
                  SELECT count(*) as __count,
-                        sum(planned_hours) as planned_hours,
+                        sum(allocated_hours) as allocated_hours,
                         project_id,
                         %(date_begin)s as date_begin,
                         %(date_end)s as date_end,
@@ -106,14 +106,14 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                             -- * The stage at creation for those for which we do not have any mail message and a
                             --   mail tracking value on project.task stage_id.
                             SELECT DISTINCT task_id,
-                                   planned_hours,
+                                   allocated_hours,
                                    project_id,
                                    %(date_begin)s as date_begin,
                                    %(date_end)s as date_end,
                                    first_value(stage_id) OVER task_date_begin_window AS stage_id
                               FROM (
                                      SELECT pt.id as task_id,
-                                            pt.planned_hours,
+                                            pt.allocated_hours,
                                             pt.project_id,
                                             COALESCE(LAG(mm.date) OVER (PARTITION BY mm.res_id ORDER BY mm.id), pt.create_date) as date_begin,
                                             CASE WHEN mtv.id IS NOT NULL THEN mm.date
@@ -134,7 +134,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                                       WHERE pt.active=true AND pt.id IN (SELECT id from task_ids)
                                    ) task_stage_id_history
                           GROUP BY task_id,
-                                   planned_hours,
+                                   allocated_hours,
                                    project_id,
                                    %(date_begin)s,
                                    %(date_end)s,
@@ -145,7 +145,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                             -- once (=those for which we have at least a mail message and a mail tracking value
                             -- on project.task stage_id).
                             SELECT pt.id as task_id,
-                                   pt.planned_hours,
+                                   pt.allocated_hours,
                                    pt.project_id,
                                    last_stage_id_change_mail_message.date as date_begin,
                                    (now() at time zone 'utc')::date + INTERVAL '%(interval)s' as date_end,
@@ -165,14 +165,14 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                                    ) AS last_stage_id_change_mail_message ON TRUE
                              WHERE pt.active=true AND pt.id IN (SELECT id from task_ids)
                         ) AS project_task_burndown_chart
-               GROUP BY planned_hours,
+               GROUP BY allocated_hours,
                         project_id,
                         %(date_begin)s,
                         %(date_end)s,
                         stage_id
               )
               SELECT (project_id*10^13 + stage_id*10^7 + to_char(date, 'YYMMDD')::integer)::bigint as id,
-                     planned_hours,
+                     allocated_hours,
                      project_id,
                      stage_id,
                      date,

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -165,7 +165,7 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
             'user_ids': self.user_projectuser,
             'project_id': self.project_pigs.id,
             'partner_id': self.partner_2.id,
-            'planned_hours': 12,
+            'allocated_hours': 12,
         })
 
         another_parent_task = Task.create({
@@ -173,7 +173,7 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
             'user_ids': self.user_projectuser,
             'project_id': self.project_pigs.id,
             'partner_id': self.partner_3.id,
-            'planned_hours': 0,
+            'allocated_hours': 0,
         })
 
         # remove the partner_id of the 'goats' project
@@ -186,7 +186,7 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
         # the child task 1 is linked to a project without partner_id (goats project)
         child_task_1 = Task.with_context(default_project_id=self.project_goats.id, default_parent_id=parent_task.id).create({
             'name': 'Task Child with project',
-            'planned_hours': 3,
+            'allocated_hours': 3,
         })
 
         # the child task 2 is linked to a project with a partner_id (pigs project)
@@ -194,7 +194,7 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
             'name': 'Task Child without project',
             'parent_id': parent_task.id,
             'project_id': self.project_pigs.id,
-            'planned_hours': 5,
+            'allocated_hours': 5,
         })
 
         self.assertEqual(
@@ -210,7 +210,7 @@ class TestProjectFlow(TestProjectCommon, MailCommon):
             "Parent task should have 2 children")
 
         self.assertEqual(
-            parent_task.subtask_planned_hours, 8,
+            parent_task.subtask_allocated_hours, 8,
             "Planned hours of subtask should impact parent task")
 
         # change the parent of a subtask without a project partner_id

--- a/addons/project/tests/test_project_task_quick_create.py
+++ b/addons/project/tests/test_project_task_quick_create.py
@@ -41,7 +41,7 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
             task_form = Form(self.env['project.task'].with_context({'tracking_disable': True, 'default_project_id': self.project_pigs.id}), view="project.quick_create_task_form")
             task_form.display_name = expression
             task = task_form.save()
-            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.planned_hours)
+            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.allocated_hours)
             self.assertEqual(results, values)
 
     def test_create_task_with_invalid_expressions(self):
@@ -56,5 +56,5 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
             task_form = Form(self.env['project.task'].with_context({'tracking_disable': True, 'default_project_id': self.project_pigs.id}), view="project.quick_create_task_form")
             task_form.display_name = expression
             task = task_form.save()
-            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.planned_hours)
+            results = (task.name, len(task.tag_ids), len(task.user_ids), task.priority, task.allocated_hours)
             self.assertEqual(results, (expression, 0, 0, '0', 0))

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -221,9 +221,9 @@
                                     <div t-else=""><strong>Project:</strong> <a t-field="task.project_id"/></div>
                                     <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "date"}'/></div>
                                     <div t-if="task.milestone_id and task.allow_milestones"><strong>Milestone:</strong> <span t-field="task.milestone_id"/></div>
-                                    <div name="portal_my_task_planned_hours">
-                                    <strong t-if="task.planned_hours > 0">Allocated Time:</strong>
-                                    <t t-call="project.portal_my_task_planned_hours_template"/>
+                                    <div name="portal_my_task_allocated_hours">
+                                    <strong t-if="task.allocated_hours > 0">Allocated Time:</strong>
+                                    <t t-call="project.portal_my_task_allocated_hours_template"/>
                                     </div>
                                 </div>
                                 <div class="col-12 col-md-6" name="portal_my_task_second_column"></div>
@@ -266,7 +266,7 @@
         </xpath>
     </template>
 
-    <template id="portal_my_task_planned_hours_template">
-        <span t-out="task.planned_hours" t-options='{"widget": "float_time"}'/>
+    <template id="portal_my_task_allocated_hours_template">
+        <span t-out="task.allocated_hours" t-options='{"widget": "float_time"}'/>
     </template>
 </odoo>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -121,7 +121,7 @@
                     <field name="project_id" type="row"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
-                    <field name="planned_hours" widget="float_time"/>
+                    <field name="allocated_hours" widget="float_time"/>
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="working_hours_open" widget="float_time"/>
                 </pivot>

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -250,16 +250,16 @@ class SaleOrderLine(models.Model):
 
     def _convert_qty_company_hours(self, dest_company):
         company_time_uom_id = dest_company.project_time_mode_id
-        planned_hours = 0.0
+        allocated_hours = 0.0
         product_uom = self.product_uom
         if product_uom == self.env.ref('uom.product_uom_unit'):
             product_uom = self.env.ref('uom.product_uom_hour')
         if product_uom.category_id == company_time_uom_id.category_id:
             if product_uom != company_time_uom_id:
-                planned_hours = product_uom._compute_quantity(self.product_uom_qty, company_time_uom_id)
+                allocated_hours = product_uom._compute_quantity(self.product_uom_qty, company_time_uom_id)
             else:
-                planned_hours = self.product_uom_qty
-        return planned_hours
+                allocated_hours = self.product_uom_qty
+        return allocated_hours
 
     def _timesheet_create_project(self):
         project = super()._timesheet_create_project()

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -165,7 +165,7 @@ class TestProject(TestCommonSaleTimesheet):
         self.env['project.task'].create({
             'name': 'task A',
             'project_id': self.project_global.id,
-            'planned_hours': 10,
+            'allocated_hours': 10,
             'timesheet_ids': [
                 Command.create({
                     'name': '/',

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -102,7 +102,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         task = Task.with_context(default_project_id=self.project_non_billable.id).create({
             'name': 'first task',
             'partner_id': self.project_non_billable.partner_id.id,
-            'planned_hours': 10,
+            'allocated_hours': 10,
         })
         timesheet1 = Timesheet.create({
             'name': 'Test Line',
@@ -160,7 +160,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         task = Task.with_context(default_project_id=self.project_non_billable.id).create({
             'name': 'first task',
             'partner_id': self.project_non_billable.partner_id.id,
-            'planned_hours': 10,
+            'allocated_hours': 10,
         })
         timesheet1 = Timesheet.create({
             'name': 'Test Line',

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -223,10 +223,10 @@ class TestSaleService(TestCommonSaleTimesheet):
         self.assertEqual(self.sale_order.tasks_count, 1, "The SO should have only one task")
         self.assertEqual(so_line1.task_id.sale_line_id, so_line1, "The created task is also linked to its origin sale line, for invoicing purpose.")
         self.assertFalse(so_line1.task_id.user_ids, "The created task should be unassigned")
-        self.assertEqual(so_line1.product_uom_qty, so_line1.task_id.planned_hours, "The planned hours should be the same as the ordered quantity of the native SO line")
+        self.assertEqual(so_line1.product_uom_qty, so_line1.task_id.allocated_hours, "The planned hours should be the same as the ordered quantity of the native SO line")
 
         so_line1.write({'product_uom_qty': 20})
-        self.assertEqual(so_line1.product_uom_qty, so_line1.task_id.planned_hours, "The planned hours should have changed when updating the ordered quantity of the native SO line")
+        self.assertEqual(so_line1.product_uom_qty, so_line1.task_id.allocated_hours, "The planned hours should have changed when updating the ordered quantity of the native SO line")
 
         # cancel SO
         self.sale_order._action_cancel()
@@ -237,7 +237,7 @@ class TestSaleService(TestCommonSaleTimesheet):
         self.assertEqual(so_line1.task_id.sale_line_id, so_line1, "The created task is also linked to its origin sale line, for invoicing purpose.")
 
         so_line1.write({'product_uom_qty': 30})
-        self.assertEqual(so_line1.product_uom_qty, so_line1.task_id.planned_hours, "The planned hours should have changed when updating the ordered quantity, even after SO cancellation")
+        self.assertEqual(so_line1.product_uom_qty, so_line1.task_id.allocated_hours, "The planned hours should have changed when updating the ordered quantity, even after SO cancellation")
 
         # reconfirm SO
         self.sale_order.action_draft()
@@ -503,14 +503,14 @@ class TestSaleService(TestCommonSaleTimesheet):
         })
 
         self.sale_order.action_confirm()
-        self.assertEqual(sale_order_line.product_uom_qty, sale_order_line.task_id.planned_hours, "The planned hours should be the same as the ordered quantity of the native SO line")
+        self.assertEqual(sale_order_line.product_uom_qty, sale_order_line.task_id.allocated_hours, "The planned hours should be the same as the ordered quantity of the native SO line")
 
         sale_order_line.write({'product_uom_qty': 20})
-        self.assertEqual(sale_order_line.product_uom_qty, sale_order_line.task_id.planned_hours, "The planned hours should have changed when updating the ordered quantity of the native SO line")
+        self.assertEqual(sale_order_line.product_uom_qty, sale_order_line.task_id.allocated_hours, "The planned hours should have changed when updating the ordered quantity of the native SO line")
 
         self.sale_order._action_cancel()
         sale_order_line.write({'product_uom_qty': 30})
-        self.assertEqual(sale_order_line.product_uom_qty, sale_order_line.task_id.planned_hours, "The planned hours should have changed when updating the ordered quantity, even after SO cancellation")
+        self.assertEqual(sale_order_line.product_uom_qty, sale_order_line.task_id.allocated_hours, "The planned hours should have changed when updating the ordered quantity, even after SO cancellation")
 
         self.sale_order.action_lock()
         with self.assertRaises(UserError):
@@ -596,7 +596,7 @@ class TestSaleService(TestCommonSaleTimesheet):
         self.assertEqual(prepaid_service_sol.remaining_hours, 2, "The remaining hours should not change.")
 
     def test_several_uom_sol_to_planned_hours(self):
-        planned_hours_for_uom = {
+        allocated_hours_for_uom = {
             'day': 8.0,
             'hour': 1.0,
             'unit': 1.0,
@@ -619,7 +619,7 @@ class TestSaleService(TestCommonSaleTimesheet):
             'order_id': self.sale_order.id,
         }
 
-        for uom_name in planned_hours_for_uom:
+        for uom_name in allocated_hours_for_uom:
             uom_id = self.env.ref('uom.product_uom_%s' % uom_name)
 
             product_vals.update({
@@ -640,7 +640,7 @@ class TestSaleService(TestCommonSaleTimesheet):
 
         tasks = project.task_ids
         for task in tasks:
-            self.assertEqual(task.planned_hours, planned_hours_for_uom[task.sale_line_id.name])
+            self.assertEqual(task.allocated_hours, allocated_hours_for_uom[task.sale_line_id.name])
 
     def test_add_product_analytic_account(self):
         """ When we have a project with an analytic account and we add a product to the task,

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -501,7 +501,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         task = Task.with_context(default_project_id=self.project_template.id).create({
             'name': 'first task',
             'partner_id': self.partner_b.id,
-            'planned_hours': 10,
+            'allocated_hours': 10,
             'sale_line_id': self.so.order_line[0].id
         })
 

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -133,7 +133,7 @@
     </template>
 
     <template id="portal_timesheet_table_inherit" inherit_id="hr_timesheet.portal_timesheet_table">
-        <xpath expr="//div[@name='planned_time']" position="after">
+        <xpath expr="//div[@name='allocated_time']" position="after">
             <span t-if="task.allow_billable and task.sale_line_id and task.sale_line_id.remaining_hours_available" t-attf-class="{{task.remaining_hours_so &lt; 0 and 'text-danger' or ''}}">
                 <div t-if="is_uom_day">Remaining Days on SO: <span t-esc="timesheets._convert_hours_to_days(task.remaining_hours_so)" t-options='{"widget": "timesheet_uom"}'/></div>
                 <div t-else="">Remaining Hours on SO: <span t-esc="task.remaining_hours_so" t-options='{"widget": "float_time"}'/></div>

--- a/addons/sale_timesheet/wizard/project_create_sale_order.py
+++ b/addons/sale_timesheet/wizard/project_create_sale_order.py
@@ -166,7 +166,7 @@ class ProjectCreateSalesOrder(models.TransientModel):
             self.env['account.analytic.line'].search(search_domain).write({
                 'so_line': sale_order_line.id
             })
-            sale_order_line.with_context({'no_update_planned_hours': True}).write({
+            sale_order_line.with_context({'no_update_allocated_hours': True}).write({
                 'product_uom_qty': sale_order_line.qty_delivered
             })
             # Avoid recomputing price_unit
@@ -241,7 +241,7 @@ class ProjectCreateSalesOrder(models.TransientModel):
             self.env['account.analytic.line'].search(search_domain).write({
                 'so_line': map_entry.sale_line_id.id
             })
-            map_entry.sale_line_id.with_context({'no_update_planned_hours': True}).write({
+            map_entry.sale_line_id.with_context({'no_update_allocated_hours': True}).write({
                 'product_uom_qty': map_entry.sale_line_id.qty_delivered,
             })
             # Avoid recomputing price_unit


### PR DESCRIPTION
Before this commit 'project.task' model 'planned_hours' field is inconsistent to the 'allocated_hours' field.

After this commit rename the 'planned_hours' to 'allocated_hours' and related string change to 'Allocated Time'.

task-3231680
