### PR TITLE
[FIX] website_forum: redirect to correct page

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -254,7 +254,7 @@ class Forum(models.Model):
 
     def go_to_website(self):
         self.ensure_one()
-        website_url = self._compute_website_url
+        website_url = self._compute_website_url()
         if not website_url:
             return False
         return self.env['website'].get_client_action(website_url)


### PR DESCRIPTION
**Before this PR:**

While clicking on the Go To Website button of the view it redirects to 404 error page because the function is getting the object instead of URL.

**After this PR:**

Now the function will get the URL.

Task-3293598
