### PR TITLE
[FIX] l10n_fr_pos_cert: do not allow order removing

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/TicketScreen.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/TicketScreen.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+
+import { TicketScreen } from "@point_of_sale/js/Screens/TicketScreen/TicketScreen";
+import { patch } from "@web/core/utils/patch";
+import { ErrorPopup } from "@point_of_sale/js/Popups/ErrorPopup";
+
+patch(TicketScreen.prototype, "l10n_fr_pos_cert.TicketScreen", {
+    // @Override
+    async _onBeforeDeleteOrder(order) {
+        if (this.pos.globalState.is_french_country()) {
+            this.popup.add(ErrorPopup, {
+                title: this.env._t("Forbidden to remove order"),
+                body: this.env._t("It is not allowed to remove an order.")
+            });
+            return false;
+        }
+        return this._super(...arguments);
+    },
+    shouldHideDeleteButton(order) {
+        return this.pos.globalState.is_french_country() ? true : this._super(...arguments);;
+    }
+});

--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -46,23 +46,6 @@ patch(Order.prototype, "l10n_fr_pos_cert.Order", {
         result = Boolean(result || this.pos.is_french_country());
         return result;
     },
-    destroy(option) {
-        // SUGGESTION: It's probably more appropriate to apply this restriction
-        // in the TicketScreen.
-        if (
-            option &&
-            option.reason == "abandon" &&
-            this.pos.is_french_country() &&
-            this.get_orderlines().length
-        ) {
-            this.env.services.popup.add(ErrorPopup, {
-                title: _t("Fiscal Data Module error"),
-                body: _t("Deleting of orders is not allowed."),
-            });
-        } else {
-            this._super(...arguments);
-        }
-    },
 });
 
 patch(Orderline.prototype, "l10n_fr_pos_cert.Orderline", {

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -147,10 +147,18 @@ export class TicketScreen extends IndependentToOrderScreen {
                 this._selectNextOrder(order);
             }
             this.env.pos.removeOrder(order);
+
+            if (!this.env.pos.get_order_list().length && this.shouldAddDefaultOrder()) {
+                // Make sure that there is at least one order when we leave the ticket screen
+                this.env.pos.add_new_order();
+            }
         }
         if (this.env.pos.isOpenOrderShareable()) {
             this.env.pos._removeOrdersFromServer();
         }
+    }
+    shouldAddDefaultOrder() {
+        return !this.env.pos.config.module_pos_restaurant;
     }
     async onNextPage() {
         if (this._state.syncedOrders.currentPage < this._getLastPage()) {

--- a/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TicketScreen.js
@@ -88,6 +88,9 @@ patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
         }
         await _super(...arguments);
     },
+    shouldAddDefaultOrder() {
+        return (this._super() || (this.env.pos.config.module_pos_restaurant && !this.env.pos.config.is_table_management));
+    },
     async setTip(order, serverId, amount) {
         try {
             const paymentline = order.get_paymentlines()[0];


### PR DESCRIPTION
In the context of french localisation, it's forbidden to remove an order. This commit move the code to the ticket screen.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
