### PR TITLE
[FIX] pos_restaurant: stop removing order after idle in BillScreen

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/ReceiptScreen/ReceiptScreen.js
@@ -13,7 +13,7 @@ const PosResReceiptScreen = (ReceiptScreen) =>
             this.pos = usePos();
             onWillUnmount(() => {
                 // When leaving the receipt screen to the floor screen the order is paid and can be removed
-                if (this.pos.mainScreen.name === "FloorScreen") {
+                if (this.pos.mainScreen.name === "FloorScreen" && this.constructor.name !== "BillScreen") {
                     this.env.pos.removeOrder(this.currentOrder);
                 }
             });


### PR DESCRIPTION
Current behavior:
If you stay idle for too long on the bill screen you will be redirected to the table screen and the order will be removed. This happens because the bill screen inherits from the receipt screen that remove orders if you are idle for too long.

Steps to reproduce:
- Go on a table
- Add some products
- Go to the bill screen
- Wait for the idle time to be reached
- You will be redirected to the table screen and the order will be removed

opw-3264151
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
