### PR TITLE
[IMP] l10n_it_edi: Changing EDI mode between demo/test/prod

### DIFF
--- a/addons/account_edi_proxy_client/views/account_edi_proxy_user_views.xml
+++ b/addons/account_edi_proxy_client/views/account_edi_proxy_user_views.xml
@@ -11,6 +11,7 @@
                             <group>
                                 <field name="company_id" groups="base.group_multi_company" invisible="1"/>
                                 <field name="proxy_type" readonly="1" options="{'no_open': True}"/>
+                                <field name="edi_mode" readonly="1"/>
                                 <field name="id_client" readonly="1"/>
                                 <field name="edi_identification" readonly="1"/>
                                 <field name="private_key_filename" invisible="1"/>
@@ -30,6 +31,8 @@
             <field name="arch" type="xml">
                 <tree create="false" delete="false" edit="false">
                     <field name="company_id" groups="base.group_multi_company" invisible="1"/>
+                    <field name="proxy_type" readonly="1" options="{'no_open': True}"/>
+                    <field name="edi_mode" readonly="1"/>
                     <field name="id_client" readonly="1"/>
                     <field name="edi_identification" readonly="1"/>
                     <field name="private_key_filename" invisible="1"/>

--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -1,98 +1,45 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields, _
-from odoo.exceptions import UserError
+from odoo import _, api, models, fields
+from odoo.exceptions import ValidationError
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
-    l10n_it_edi_proxy_current_state = fields.Char(compute='_compute_l10n_it_edi_proxy_current_state')
-    l10n_it_edi_sdicoop_register = fields.Boolean(compute='_compute_l10n_it_edi_sdicoop_register', inverse='_set_l10n_it_edi_sdicoop_register_demo_mode')
-    l10n_it_edi_sdicoop_demo_mode = fields.Selection(
-        [('demo', 'Demo'),
-         ('test', 'Test (experimental)'),
-         ('prod', 'Official')],
-        compute='_compute_l10n_it_edi_sdicoop_demo_mode',
-        inverse='_set_l10n_it_edi_sdicoop_register_demo_mode',
+    l10n_it_edi_register = fields.Boolean(
+        compute='_compute_l10n_it_edi_register',
+        inverse='_set_l10n_it_edi_mode',
         readonly=False)
-
-    def _create_proxy_user(self, company_id, edi_mode):
-        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
-        edi_identification = fattura_pa._get_proxy_identification(company_id)
-        self.env['account_edi_proxy_client.user']._register_proxy_user(company_id, 'l10n_it_edi', edi_mode, edi_identification)
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_sdicoop_demo_mode(self):
-        for config in self:
-            edi_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-            config.l10n_it_edi_sdicoop_demo_mode = edi_user.edi_mode
-
-    def _set_l10n_it_edi_sdicoop_demo_mode(self):
-        for config in self:
-            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', config.l10n_it_edi_sdicoop_demo_mode)
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_is_edi_proxy_active(self):
-        for config in self:
-            config.is_edi_proxy_active = config.company_id.account_edi_proxy_client_ids
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_proxy_current_state(self):
-        for config in self:
-            proxy_user = config.company_id.account_edi_proxy_client_ids.search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-
-            config.l10n_it_edi_proxy_current_state = 'inactive' if not proxy_user else 'demo' if proxy_user.id_client[:4] == 'demo' else 'active'
+    l10n_it_edi_mode = fields.Selection(
+        selection=[('demo', 'Demo'), ('test', 'Test (experimental)'), ('prod', 'Official')],
+        compute="_compute_l10n_it_edi_mode", inverse="_set_l10n_it_edi_mode", readonly=False)
+    l10n_it_edi_mode_old = fields.Selection(related="company_id.l10n_it_edi_mode")
 
     @api.depends('company_id')
-    def _compute_l10n_it_edi_sdicoop_register(self):
-        """Needed because it expects a compute"""
-        self.l10n_it_edi_sdicoop_register = False
+    def _compute_l10n_it_edi_register(self):
+        for config in self:
+            config.l10n_it_edi_register = bool(config.l10n_it_edi_mode_old)
+
+    @api.depends('company_id')
+    def _compute_l10n_it_edi_mode(self):
+        for config in self:
+            config.l10n_it_edi_mode = config.l10n_it_edi_mode_old
+
+    @api.depends('company_id', 'l10n_it_edi_register')
+    def _set_l10n_it_edi_mode(self):
+        for config in self:
+            # This is just for access tests, as it shouldn't be possible to set False back
+            if not config.l10n_it_edi_mode:
+                continue
+            if not config.l10n_it_edi_register:
+                raise ValidationError(_("Please explicitly allow Odoo to process your E-invoices."))
+            config.button_create_proxy_user()
 
     def button_create_proxy_user(self):
-        fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
-        edi_identification = fattura_pa._get_proxy_identification(self.company_id)
-        if not edi_identification:
-            return
-
-        self.env['account_edi_proxy_client.user']._register_proxy_user(self.company_id, 'l10n_it_edi', self.l10n_it_edi_sdicoop_demo_mode, edi_identification)
-
-    def _set_l10n_it_edi_sdicoop_register_demo_mode(self):
-        for config in self:
-
-            proxy_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-
-            real_proxy_users = self.env['account_edi_proxy_client.user'].sudo().search([
-                ('id_client', 'not like', 'demo'),
-            ])
-
-            # Update the config as per the selected radio button
-            previous_demo_state = proxy_user.edi_mode
-            edi_mode = config.l10n_it_edi_sdicoop_demo_mode
-            self.env['ir.config_parameter'].set_param('account_edi_proxy_client.demo', edi_mode)
-            # If the user is trying to change from a state in which they have a registered official or testing proxy client
-            # to another state, we should stop them
-            if real_proxy_users and previous_demo_state != edi_mode:
-                raise UserError(_("The company has already registered with the service as 'Test' or 'Official', it cannot change."))
-
-            if config.l10n_it_edi_sdicoop_register:
-                # There should only be one user at a time, if there are no users, register one
-                if not proxy_user:
-                    self._create_proxy_user(config.company_id, edi_mode)
-                    return
-
-                # If there is a demo user, and we are transitioning from demo to test or production, we should
-                # delete all demo users and then create the new user.
-                elif proxy_user.id_client[:4] == 'demo' and edi_mode != 'demo':
-                    self.env['account_edi_proxy_client.user'].search([('id_client', '=like', 'demo%')]).sudo().unlink()
-                    self._create_proxy_user(config.company_id, edi_mode)
+        old_proxy_user = self.company_id.l10n_it_active_proxy_user_id
+        if not old_proxy_user or old_proxy_user.edi_mode != self.l10n_it_edi_mode:
+            fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
+            edi_identification = fattura_pa._get_proxy_identification(self.company_id)
+            if edi_identification:
+                self.company_id.register_proxy_user(self.l10n_it_edi_mode)

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -10,7 +10,6 @@
                 <block title="Electronic Document Invoicing" attrs="{'invisible':[('country_code', '!=', 'IT')]}" id='account_edi'>
                     <setting>
                         <div class="group-content">
-                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
                             <span class="o_form_label">
                                 Fattura Elettronica mode
                             </span>
@@ -21,25 +20,17 @@
                                 Saving this change will direct all companies on this database to this use this configuration.
                                 Once registered for testing or official, the mode cannot be changed.
                             </div>
-                            <field name="l10n_it_edi_sdicoop_demo_mode"
-                                    widget="radio"
-                                    options="{'horizontal': true}"/>
+                            <field name="l10n_it_edi_mode" widget="radio" options="{'horizontal': true}"/>
                         </div>
-                        <div class="mt8 content-group" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','=','active'), '&amp;', ('l10n_it_edi_proxy_current_state','=','demo'), ('l10n_it_edi_sdicoop_demo_mode','=','demo')]}">
+                        <field name="l10n_it_edi_mode_old" invisible="1"/>
+                        <div class="mt8 content-group">
                             <span class="o_form_label">Allow Odoo to process invoices</span>
                             <div class="text-muted">
                                 By checking this box, I accept that Odoo may process my invoices.
                             </div>
-                            <div class="content-group">
-                                <field name="l10n_it_edi_sdicoop_register"/>
+                            <div class="content-group" attrs="{'readonly': [('l10n_it_edi_mode_old', '!=', False)]}">
+                                <field name="l10n_it_edi_register"/>
                             </div>
-
-                        </div>
-                        <div class="text-success mt8" attrs="{'invisible': [('l10n_it_edi_proxy_current_state','in', ['inactive', 'demo'])]}">
-                            An Official or Test service has been registered.
-                        </div>
-                        <div class="text-success mt8" attrs="{'invisible': ['|',('l10n_it_edi_proxy_current_state','!=', 'demo'), ('l10n_it_edi_sdicoop_demo_mode', '!=', 'demo')]}">
-                            A Demo service is in use.
                         </div>
                     </setting>
                 </block>


### PR DESCRIPTION
Clients complain the lack of flexibility, being unable to change between demo mode, test service and production service. A message is added to sent invoices, with the kind of service that was used to post the invoice.

1.  using a different account_edi_proxy_client.user
2.  (removing all account_edi_documents and attachments)  --> ?
3.  (resetting invoice/bills sent status) --> ?

Task link: https://www.odoo.com/web#id=3175400&model=project.task
task-3175400