### PR TITLE
[IMP] hr_recruitment: sanitize applicant's phone/mobile and normalize email

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -62,6 +62,9 @@
             <field name="emp_id" invisible="1"/>
             <field name="meeting_ids" invisible="1"/>
             <field name="refuse_reason_id" invisible="1"/>
+            <field name="email_normalized" invisible="1"/>
+            <field name="partner_phone_sanitized" invisible="1"/>
+            <field name="partner_mobile_sanitized" invisible="1"/>
             <header>
                 <button string="Create Employee" name="create_employee_from_applicant" type="object" data-hotkey="q" groups="hr_recruitment.group_hr_recruitment_user"
                         class="o_create_employee" invisible="emp_id or not active or not date_closed"/>


### PR DESCRIPTION
In order to have faster and more reliable search for similar applicants, 1 - we add normalized email and sanitized phone and mobile fields on hr.applicant. 2 - we use those fields for a search of similar applicants.

task - 3282883

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
