### PR TITLE
[IMP] pos_sale: show processed order

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1550,7 +1550,7 @@ export class PosStore extends Reactive {
      * Make the products corresponding to the given ids to be available_in_pos and
      * fetch them to be added on the loaded products.
      */
-    async _addProducts(ids, setAvailable = true) {
+    async _addProducts(ids, setAvailable = false) {
         if (setAvailable) {
             await this.orm.write("product.product", ids, { available_in_pos: true });
         }

--- a/addons/pos_sale/static/src/css/pos_sale.css
+++ b/addons/pos_sale/static/src/css/pos_sale.css
@@ -92,3 +92,12 @@
 .order-management-screen .text-gray {
     color: #808080;
 }
+.order-management-screen .isProcessed {
+    background: #01939a;
+    border-radius: 1rem;
+    color: #fff;
+    font-size: small;
+    min-width: 20px;
+    padding: 6px;
+    text-align: center;
+}

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -175,17 +175,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                     .filter((line) => !this.pos.db.get_product_by_id(line.product_id[0]))
                     .map((line) => line.product_id[0]);
                 if (product_to_add_in_pos.length) {
-                    const { confirmed } = await this.popup.add(ConfirmPopup, {
-                        title: this.env._t("Products not available in POS"),
-                        body: this.env._t(
-                            "Some of the products in your Sale Order are not available in POS, do you want to import them?"
-                        ),
-                        confirmText: this.env._t("Yes"),
-                        cancelText: this.env._t("No"),
-                    });
-                    if (confirmed) {
-                        await this.pos._addProducts(product_to_add_in_pos);
-                    }
+                    await this.pos._addProducts(product_to_add_in_pos);
                 }
 
                 /**

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderRow.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderRow.js
@@ -64,4 +64,14 @@ export class SaleOrderRow extends Component {
         const salesman = this.order.user_id;
         return salesman ? salesman[1] : null;
     }
+    get isProcessed() {
+        for (let order of this.env.services.pos.get_order_list()) {
+            for (let lines of order.get_orderlines()) {
+                if(this.order.id === lines.sale_order_origin_id.id) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderRow.xml
+++ b/addons/pos_sale/static/src/xml/OrderManagementScreen/SaleOrderRow.xml
@@ -7,7 +7,9 @@
         t-on-click="() => this.props.onClickSaleOrder(props.order)">
             <div class="col name">
                 <div t-if="ui.isSmall">Order</div>
+                <div t-if="isProcessed and ui.isSmall" class="isProcessed">Being processed</div>
                 <div><t t-esc="name"/></div>
+                <div t-if="isProcessed and !ui.isSmall" class="isProcessed">Being processed</div>
             </div>
             <div class="col date">
                 <div t-if="ui.isSmall">Date</div>


### PR DESCRIPTION
It is possible to process multiple sale orders in the point of sale within the same pos order. Before this commit, it was not possible to see on the sale order management screen if the order was already processed or not.

With this commit, we display this information in the sale order management screen.

This commit also remove the unnecessary popup that ask the user if he wishes to import products not available in POS. We import them automatically.

task-id: 3298078

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
