### PR TITLE
[FIX] hr_holidays: only show holidays from company in My Time Off

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -654,7 +654,7 @@
         <field name="search_view_id" ref="hr_leave_view_search_my"/>
         <field name="view_ids" eval="[(5, 0, 0),
                 (0, 0, {'view_mode': 'kanban', 'view_id': ref('hr_leave_view_kanban')})]"/>
-        <field name="domain">[('user_id', '=', uid)]</field>
+        <field name="domain">[('user_id', '=', uid), ('employee_id.company_id', 'in', allowed_company_ids)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Keep track of your PTOs.


### PR DESCRIPTION
Users with employees in multiple companies would get an error when trying to access "My Time Off" as it was trying to read their employee records in other companies.
