### PR TITLE
[FIX] sale_coupon_{delivery},sale_mrp: correct value in commercial invoices

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -201,3 +201,7 @@ class SaleOrderLine(models.Model):
 
         undeletable_lines = super()._check_line_unlink()
         return undeletable_lines.filtered(lambda line: not line.is_delivery)
+
+    def get_discount_amount(self):
+        # TO BE OVERRIDE
+        return 0

--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -50,7 +50,8 @@ class StockMoveLine(models.Model):
     def _compute_sale_price(self):
         for move_line in self:
             if move_line.move_id.sale_line_id:
-                unit_price = move_line.move_id.sale_line_id.price_reduce_taxinc
+                discount = move_line.move_id.sale_line_id.get_discount_amount()
+                unit_price = (move_line.move_id.sale_line_id.price_total - discount) / move_line.move_id.sale_line_id.product_uom_qty
                 qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.move_id.sale_line_id.product_uom)
             else:
                 unit_price = move_line.product_id.list_price

--- a/addons/sale_coupon_delivery/models/sale_order.py
+++ b/addons/sale_coupon_delivery/models/sale_order.py
@@ -80,5 +80,5 @@ class SalesOrderLine(models.Model):
                     discount_amount = sum(self.order_id.order_line.filtered(lambda l: l.product_id == coupon_program.discount_line_product_id).mapped('price_total'))
                     discount += (self.price_total / sum(lines.mapped('price_total'))) * discount_amount
             elif coupon_program.reward_type == "product" and self.product_id == coupon_program.reward_id.reward_product_id:
-                discount += self.price_total
+                discount += sum(self.order_id.order_line.filtered(lambda l: l.product_id == coupon_program.discount_line_product_id).mapped('price_total'))
         return discount * -1

--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -9,9 +9,22 @@ class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
     def _compute_sale_price(self):
-        kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom')
+        def get_bom_component_price_ratio(bom_id):
+            price_ratio_vals = dict()
+            product_id = bom_id.product_id or bom_id.product_tmpl_id.product_variant_id
+            total_bom_price = product_id._compute_bom_price(bom_id)
+            for bom_line in bom_id.bom_line_ids:
+                price_ratio_vals.update({
+                    bom_line.product_id.id: bom_line.product_id.standard_price / total_bom_price
+                })
+            return price_ratio_vals
+
+        kit_lines = self.filtered(lambda move_line: move_line.move_id.sale_line_id and move_line.move_id.bom_line_id.bom_id.type == 'phantom')
+        price_ratio_vals = get_bom_component_price_ratio(kit_lines.move_id.bom_line_id.bom_id) if kit_lines else {}
         for move_line in kit_lines:
-            unit_price = move_line.product_id.list_price
+            discount = move_line.move_id.sale_line_id.get_discount_amount()
+            sale_unit_price = (move_line.move_id.sale_line_id.price_total - discount) / move_line.move_id.sale_line_id.product_uom_qty
+            unit_price = sale_unit_price * price_ratio_vals.get(move_line.product_id.id, 0)
             qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)
             move_line.sale_price = unit_price * qty
         super(StockMoveLine, self - kit_lines)._compute_sale_price()


### PR DESCRIPTION
Before this commit
==================
Shipping methods like FedEx generates commercial invoice - It ignores global
discounts and the total amount of commercial invoice doesn't harmonize with
the amount total of all the product line in the SO after deducting the global
discounts.

With this commit, the total amount of commercial invoice synchronizes with
the amount total of all the product line in the SO after deducting the global
discount.

TaskID - 3083693