### PR TITLE
[FIX] website: redirect properly to anchor when submitting a form

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -339,7 +339,14 @@ odoo.define('website.s_website_form', function (require) {
                     }
                     switch (successMode) {
                         case 'redirect': {
-                            successPage = successPage.startsWith("/#") ? successPage.slice(1) : successPage;
+                            if (successPage.includes('#')) {
+                                // Consider only the anchor if the link stays on
+                                // the current page, to simply scroll to it.
+                                const currentPage = window.location.pathname;
+                                const anchorIndex = successPage.indexOf('#');
+                                successPage = successPage.slice(0, anchorIndex) === currentPage ?
+                                    successPage.slice(anchorIndex) : successPage;
+                            }
                             if (successPage.charAt(0) === "#") {
                                 await dom.scrollTo($(successPage)[0], {
                                     duration: 500,


### PR DESCRIPTION
Before this commit, when setting the Form "On Success" option to "Redirect" and setting the URL to an anchor on the same page, if we are not on the Home page (i.e. "/"), the form and the loading effect of the "Submit" button were not reset after the form submission. It gives the impression that the form was not correctly sent, even though it is the case.

This commit allows a form to be properly reset when redirecting to an anchor for every pages, and not only for the Home page (as only this case was taken into account).

Steps to reproduce:
- On the "Contact Us" page, go in edit mode.
- Set the Form "On Success" option to "Redirect" and set the URL to the "/contactus#bottom" anchor.
- Save and then fill and submit the form. 
=> The page scrolls to the "#bottom" anchor, but the form is not reset and the submit button is still loading.

task-3290913