### PR TITLE
[IMP] web_editor: allow to create links with enter

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3383,24 +3383,37 @@ X[]
         });
     });
 
-    describe('automatic link creation when typing a space after an url', () => {
+    describe('automatic link creation when pressing Space, Enter or Shift+Enter after an url', () => {
         it('should transform url after space', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a http://test.com b http://test.com[] c http://test.com d</p>',
                 stepFunction: async (editor) => {
                     editor.testMode = false;
-                    const selection = document.getSelection();
-                    const anchorOffset = selection.anchorOffset;
-                    const p = editor.editable.querySelector('p');
-                    const textNode = p.childNodes[0];
-                    triggerEvent(editor.editable, 'keydown', {key: ' ', code: 'Space'});
-                    textNode.textContent = "a http://test.com b http://test.com\u00a0 c http://test.com d";
-                    selection.extend(textNode, anchorOffset + 1);
-                    selection.collapseToEnd();
-                    triggerEvent(editor.editable, 'input', {data: ' ', inputType: 'insertText' });
-                    triggerEvent(editor.editable, 'keyup', {key: ' ', code: 'Space'});
+                    await insertText(editor, ' ');
                 },
-                contentAfter: '<p>a http://test.com b <a href="http://test.com">http://test.com</a>&nbsp;[] c http://test.com d</p>',
+                contentAfter: '<p>a http://test.com b <a href="http://test.com">http://test.com</a>[] c http://test.com d</p>',
+                //in reality: '<p>a http://test.com b <a href="http://test.com">http://test.com</a>&nbsp;[] c http://test.com d</p>'
+            });
+        });
+        it('should transform url after enter', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a http://test.com b http://test.com[] c http://test.com d</p>',
+                stepFunction: async (editor) => {
+                    triggerEvent(editor.editable, 'keydown', {key: 'Enter'});
+                    triggerEvent(editor.editable, 'input', {data: ' ', inputType: 'insertParagraph' });
+                    triggerEvent(editor.editable, 'keyup', {key: 'Enter'});
+                },
+                contentAfter: '<p>a http://test.com b <a href="http://test.com">http://test.com</a></p><p>[]&nbsp;c http://test.com d</p>',
+            });
+        });
+        it('should transform url after shift+enter', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a http://test.com b http://test.com[] c http://test.com d</p>',
+                stepFunction: async (editor) => {
+                    triggerEvent(editor.editable, 'keydown', {key: 'Enter', shiftKey: true});
+                    triggerEvent(editor.editable, 'keyup', {key: 'Enter', shiftKey: true});
+                },
+                contentAfter: '<p>a http://test.com b <a href="http://test.com">http://test.com</a><br>[]&nbsp;c http://test.com d</p>',
             });
         });
         it('should not transform url after two space', async () => {
@@ -3412,10 +3425,10 @@ X[]
                     const anchorOffset = selection.anchorOffset;
                     const p = editor.editable.querySelector('p');
                     const textNode = p.childNodes[0];
-                    triggerEvent(editor.editable, 'keydown', {key: ' ', code: 'Space'});
                     textNode.textContent = "a http://test.com b http://test.com \u00a0 c http://test.com d";
                     selection.extend(textNode, anchorOffset + 1);
                     selection.collapseToEnd();
+                    triggerEvent(editor.editable, 'keydown', {key: ' ', code: 'Space'});
                     triggerEvent(editor.editable, 'input', {data: ' ', inputType: 'insertText' });
                     triggerEvent(editor.editable, 'keyup', {key: ' ', code: 'Space'});
                 },


### PR DESCRIPTION
Typing a valid URL and pressing space creates a clickable link with that URL. Users expect the same to happen when pressing enter instead (with or without pressing Shift), but that was not the case previously.

This commit enables link creation with both Enter and Shift+Enter.

While this behavior is part of the `keydown` event for space and Shift+Enter, it is part of the later `input` event for Enter (without Shift). This is due to a necessary call to historyRollback() that would undo the just-created link, forcing its creation to be delayed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
