### PR TITLE
[FIX] l10n_it_edi: Fix Discount line addition

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -722,11 +722,13 @@ class AccountEdiFormat(models.Model):
                     general_discount = discounted_amount - taxable_amount
                     sequence = len(elements) + 1
 
-                    with invoice_form.invoice_line_ids.new() as invoice_line_global_discount:
-                        invoice_line_global_discount.tax_ids.clear()
-                        invoice_line_global_discount.sequence = sequence
-                        invoice_line_global_discount.name = 'SCONTO' if general_discount < 0 else 'MAGGIORAZIONE'
-                        invoice_line_global_discount.price_unit = general_discount
+                    invoice_form.invoice_line_ids.create({
+                        'move_id': invoice_form.id,
+                        'tax_ids': [fields.Command.clear()],
+                        'name':'SCONTO' if general_discount < 0 else 'MAGGIORAZIONE',
+                        'sequence': sequence,
+                        'price_unit': general_discount
+                    })
 
             new_invoice = invoice_form
 

--- a/addons/l10n_it_edi/tests/expected_xmls/IT00470550013_simpl_discount.xml
+++ b/addons/l10n_it_edi/tests/expected_xmls/IT00470550013_simpl_discount.xml
@@ -1,0 +1,46 @@
+<p:FatturaElettronicaSemplificata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.0/Schema_del_file_xml_FatturaPA_versione_1.0.xsd" versione="FSM10">
+<FatturaElettronicaHeader>
+    <DatiTrasmissione>
+      <IdTrasmittente>
+        <IdPaese>IT</IdPaese>
+        <IdCodice>01234560157</IdCodice>
+      </IdTrasmittente>
+      <ProgressivoInvio>___ignore___</ProgressivoInvio>
+      <FormatoTrasmissione>FSM10</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+    </DatiTrasmissione>
+    <CedentePrestatore>
+      <IdFiscaleIVA>
+        <IdPaese>IT</IdPaese>
+        <IdCodice>01234560157</IdCodice>
+      </IdFiscaleIVA>
+      <CodiceFiscale>01234560157</CodiceFiscale>
+      <Denominazione>company_2_data</Denominazione>
+      <Sede>
+        <Indirizzo>1234 Test Street </Indirizzo>
+        <CAP>12345</CAP>
+        <Comune>Prova</Comune>
+        <Nazione>IT</Nazione>
+      </Sede>
+      <RegimeFiscale>RF01</RegimeFiscale>
+    </CedentePrestatore>
+    <CessionarioCommittente>
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody>
+    <DatiGenerali>
+      <DatiGeneraliDocumento>
+        <TipoDocumento>TD07</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2022-03-24</Data>
+        <Numero>___ignore___</Numero>
+        <ScontoMaggiorazione>
+          <Tipo>SC</Tipo>
+          <Importo>9.01</Importo>
+        </ScontoMaggiorazione>
+      </DatiGeneraliDocumento>
+    </DatiGenerali>
+    <DatiBeniServizi>
+    </DatiBeniServizi>
+  </FatturaElettronicaBody>
+</p:FatturaElettronicaSemplificata>

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -52,8 +52,10 @@ class TestItEdiImport(TestItEdi):
         cls.invoice_filename1 = 'IT01234567890_FPR01.xml'
         cls.invoice_filename2 = 'IT01234567890_FPR02.xml'
         cls.signed_invoice_filename = 'IT01234567890_FPR01.xml.p7m'
+        cls.invoice_discount_file = 'IT00470550013_simpl_discount.xml'
         cls.invoice_content = cls._get_test_file_content(cls.invoice_filename1)
         cls.signed_invoice_content = cls._get_test_file_content(cls.signed_invoice_filename)
+        cls.invoice_discount_content = cls._get_test_file_content(cls.invoice_discount_file)
         cls.invoice = cls.env['account.move'].create({
             'move_type': 'in_invoice',
             'ref': '01234567890'
@@ -129,3 +131,11 @@ class TestItEdiImport(TestItEdi):
         self.assertEqual(len(attachments), 1)
         invoices = self.env['account.move'].search([('payment_reference', '=', 'TWICE_TEST')])
         self.assertEqual(len(invoices), 1)
+
+    def test_discount_line(self):
+        """Test discount line addition after bill import"""
+
+        content = etree.fromstring(self.invoice_discount_content)
+        invoices = self.edi_format._create_invoice_from_xml_tree(self.invoice_discount_file, content)
+
+        self.assertEqual(invoices.line_ids.name, 'SCONTO')


### PR DESCRIPTION
In the current implementation, a new invoice line is created in the cache using the new() as a form, which is then used to populate the invoice line. However, the new() method does not have an `__enter__` attribute since it is not wrapped with `contextmanager`, hence the `with` statement fails.

Solution is to simplify the create using Command and attaching it to the O2M field.

opw-3248135
opw-3278824
