### PR TITLE
[IMP] modules: cache modules paths

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -176,6 +176,7 @@ class IrModule(models.Model):
                 import odoo.modules.module as module
                 try:
                     odoo.addons.__path__.append(module_dir)
+                    module.reset_modules()
                     z.extractall(module_dir)
                     dirs = [d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))]
                     for mod_name in dirs:
@@ -190,6 +191,7 @@ class IrModule(models.Model):
                             errors[mod_name] = exception_to_unicode(e)
                 finally:
                     odoo.addons.__path__.remove(module_dir)
+                    module.reset_modules()
         r = ["Successfully imported module '%s'" % mod for mod in success]
         for mod, error in errors.items():
             r.append("Error while importing module '%s'.\n\n %s \n Make sure those modules are installed and try again." % (mod, error))

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -6,7 +6,7 @@ from os.path import join as opj
 from unittest.mock import patch
 
 import odoo.addons
-from odoo.modules.module import load_manifest
+from odoo.modules.module import load_manifest, reset_modules
 from odoo.release import major_version
 from odoo.tests.common import BaseCase
 
@@ -19,11 +19,14 @@ class TestModuleManifest(BaseCase):
         cls.addons_path = cls._tmp_dir.name
 
         patcher = patch.object(odoo.addons, '__path__', [cls.addons_path])
+        cls.addClassCleanup(reset_modules)
         cls.startClassPatcher(patcher)
+        reset_modules()
 
     def setUp(self):
         self.module_root = tempfile.mkdtemp(prefix='odoo-test-module-', dir=self.addons_path)
         self.module_name = os.path.basename(self.module_root)
+        self.addCleanup(reset_modules)
 
     def test_default_manifest(self):
         with open(opj(self.module_root, '__manifest__.py'), 'w') as file:

--- a/odoo/addons/base/wizard/base_module_update_views.xml
+++ b/odoo/addons/base/wizard/base_module_update_views.xml
@@ -10,7 +10,7 @@
                     <field name="state" invisible="1"/>
                     <separator string="Module Update Result" states="done"/>
                     <group states="init">
-                        <span class="o_form_label" colspan="2">Click on Update below to start the process...</span>
+                        <span class="o_form_label" colspan="2">Update app list from sources. Only applies to modules available since last restart. Click on Update below to start the process...</span>
                     </group>
                     <group states="done" >
                         <field name="updated"/>

--- a/odoo/addons/test_lint/tests/lint_case.py
+++ b/odoo/addons/test_lint/tests/lint_case.py
@@ -15,7 +15,7 @@ class LintCase(BaseCase):
         """ Yields the paths of all the module files matching the provided globs
         (AND-ed)
         """
-        for modroot in map(get_module_path, get_modules()):
+        for modroot in get_modules().values():
             for root, _, fnames in os.walk(modroot):
                 fnames = [j(root, n) for n in fnames]
                 for glob in globs:

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -35,9 +35,6 @@ def initialize(cr):
         cr.execute(base_sql_file.read())  # pylint: disable=sql-injection
 
     for i in odoo.modules.get_modules():
-        mod_path = odoo.modules.get_module_path(i)
-        if not mod_path:
-            continue
 
         # This will raise an exception if no/unreadable descriptor file.
         info = odoo.modules.get_manifest(i)


### PR DESCRIPTION
The manipulation around module paths are quite slow. To define the path of a module, we will iterate on all manifest name and all addons path and check for eventual .zip extension, for each modules.

On the other hand, we have this information when discovering the list of modules using get_modules.

The proposal is to store this list once, and keep the path of each addon in it using a frozendict.

This will speedup the first discovery of an addon_manifest as well as get_module_path, get_resource_path, ....

As an example, during the generation of the `session_info`, the method `_get_code_translations` will make many calls to get_resource_path leading to a lot of time spent in `os.path.exists` (~9ms). With this change, this part of the session_info is ~9 times faster and only takes 10ms, because we only need to check if the i18n elements exists.

