### PR TITLE
[FIX] hr_expense: prevent deletion of hr_expense product

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1992,6 +1992,15 @@ msgid "You cannot approve your own expenses"
 msgstr ""
 
 #. module: hr_expense
+#: code:addons/hr_expense/models/product_product.py:0
+#: code:addons/hr_expense/models/product_template.py:0
+#, python-format
+msgid ""
+"You cannot delete %(name)s as it is used in 'Sales Expense'.Please archive "
+"it instead."
+msgstr ""
+
+#. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:0
 #, python-format
 msgid "You cannot delete a posted or approved expense."

--- a/addons/hr_expense/models/__init__.py
+++ b/addons/hr_expense/models/__init__.py
@@ -6,5 +6,6 @@ from . import account_move_line
 from . import hr_department
 from . import hr_expense
 from . import product_template
+from . import product_product
 from . import res_config_settings
 from . import account_journal_dashboard

--- a/addons/hr_expense/models/product_product.py
+++ b/addons/hr_expense/models/product_product.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_sale_expense_products(self):
+        product_data = [
+            self.env.ref('hr_expense.food_expense_product', False),
+            self.env.ref('hr_expense.mileage_expense_product', False),
+            self.env.ref('hr_expense.accomodation_expense_product', False),
+            self.env.ref('hr_expense.allowance_expense_product', False)
+        ]
+        for product in self.filtered(lambda p: p in product_data):
+            raise UserError(_(
+                "You cannot delete %(name)s as it is used in 'Sales Expense'."
+                "Please archive it instead.",
+                name=product.name
+            ))

--- a/addons/hr_expense/models/product_template.py
+++ b/addons/hr_expense/models/product_template.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class ProductTemplate(models.Model):
@@ -20,3 +21,18 @@ class ProductTemplate(models.Model):
     @api.depends('type')
     def _compute_can_be_expensed(self):
         self.filtered(lambda p: p.type not in ['consu', 'service']).update({'can_be_expensed': False})
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_sale_expense_products(self):
+        product_data = [
+            self.env.ref('hr_expense.food_expense_product', False),
+            self.env.ref('hr_expense.mileage_expense_product', False),
+            self.env.ref('hr_expense.accomodation_expense_product', False),
+            self.env.ref('hr_expense.allowance_expense_product', False)
+        ]
+        for product in self.filtered(lambda p: p.product_variant_ids in product_data):
+            raise UserError(_(
+                "You cannot delete %(name)s as it is used in 'Sales Expense'."
+                "Please archive it instead.",
+                name=product.name
+            ))


### PR DESCRIPTION
When user delete product in 'hr_expense' module that is present in the demo data of 'sale_expense'. While installing 'sale_expense' module the user is getting error as the product that is referenced from 'hr_expense' has been deleted.

Steps to produce:
- Install hr_expense module.
- Delete all expenses.
- Go to configuration and then Expense Categories.
- Delete any category between 'Car Travel Expense', 'Air Flight' and 'Expenses'.
- Install 'sale_expense' module.

Traceback will be generated.

```
File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 677, in _tag_root
    f(rec)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 530, in _tag_record
    raise Exception("Cannot update missing record %r" % xid)
Exception: Cannot update missing record 'hr_expense.product_product_fixed_cost'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/odoo/odoo/odoo/modules/loading.py", line 86, in load_demo
    load_data(cr, idref, mode, kind='demo', package=package)
  File "/home/odoo/odoo/odoo/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 733, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 799, in convert_xml_import
    obj.parse(doc.getroot())
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 719, in parse
    self._tag_root(de)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 677, in _tag_root
    f(rec)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 681, in _tag_root
    raise ParseError('while parsing %s:%s, near\n%s' % (
odoo.tools.convert.ParseError: while parsing /home/odoo/odoo/odoo/addons/sale_expense/data/sale_expense_demo.xml:5, near
<record id="hr_expense.product_product_fixed_cost" model="product.product">
            <field name="invoice_policy">delivery</field>
            <field name="expense_policy">cost</field>
        </record>
```

This commit will raise an UserError while deleting the hr_expense products.

sentry - 4113713209

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
