### PR TITLE
[FIX] pos_restaurant: display Order button

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/ProductScreen/ActionpadWidget.js
+++ b/addons/pos_restaurant/static/src/js/Screens/ProductScreen/ActionpadWidget.js
@@ -8,7 +8,7 @@ import { ActionpadWidget } from "@point_of_sale/js/Screens/ProductScreen/Actionp
 patch(ActionpadWidget.prototype, "point_of_sale.ActionpadWidget", {
     get swapButton() {
         return (
-            this.props.actionName === "Payment" &&
+            String.prototype.valueOf.call(this.props.actionName) === "Payment" &&
             this.pos.globalState.config.module_pos_restaurant &&
             this.pos.globalState.printers_category_ids_set.size
         );


### PR DESCRIPTION
Before this commit, the Order button wasn't displayed due to an incorrect comparison with a `LazyTranslatedString` object (`this.props.actionName`). This commit resolves the issue by ensuring proper comparison of `this.props.actionName` with the string "Payment".

opw-3300533

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
