### PR TITLE
[FIX] web: x2many field optional ViewMode

### DIFF
--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -44,7 +44,9 @@ export class X2ManyField extends Component {
         );
 
         this.archInfo = this.props.views?.[this.props.viewMode] || {};
-        this.className = computeViewClassName(this.props.viewMode, this.archInfo.xmlDoc);
+        if (this.props.viewMode) {
+            this.className = computeViewClassName(this.props.viewMode, this.archInfo.xmlDoc);
+        }
 
         const { activeActions, creates } = this.archInfo;
         if (this.props.viewMode === "kanban") {


### PR DESCRIPTION
Before this commit, when having a x2many field invisible in a view, and displaying it anyway in studio, there was a crash because some variable was undefined.

This originated from commit f22961ad07e4b04efe4b504ee5a276f20802ed1f, which did not account for the fact that viewMode is an optional props.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
