### PR TITLE
[FIX] stock: change product's company

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -6628,6 +6628,14 @@ msgstr ""
 #: code:addons/stock/models/product.py:0
 #, python-format
 msgid ""
+"This product's company cannot be changed as long as there are stock move "
+"line of it belonging to another company."
+msgstr ""
+
+#. module: stock
+#: code:addons/stock/models/product.py:0
+#, python-format
+msgid ""
 "This product's company cannot be changed as long as there are quantities of it"
 " belonging to another company."
 msgstr ""

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -765,14 +765,12 @@ class ProductTemplate(models.Model):
         if 'company_id' in vals and vals['company_id']:
             products_changing_company = self.filtered(lambda product: product.company_id.id != vals['company_id'])
             if products_changing_company:
-                # Forbid changing a product's company when quant(s) exist in another company.
-                quant = self.env['stock.quant'].sudo().search([
+                move_lines = self.env['stock.move.line'].search([
                     ('product_id', 'in', products_changing_company.product_variant_ids.ids),
                     ('company_id', 'not in', [vals['company_id'], False]),
-                    ('quantity', '!=', 0),
                 ], order=None, limit=1)
-                if quant:
-                    raise UserError(_("This product's company cannot be changed as long as there are quantities of it belonging to another company."))
+                if move_lines:
+                    raise UserError(_("This product's company cannot be changed as long as there are stock move line of it belonging to another company."))
 
         if 'uom_id' in vals:
             new_uom = self.env['uom.uom'].browse(vals['uom_id'])


### PR DESCRIPTION
[FIX] stock: change product's company

Steps to reproduce the bug:
- Connect with the company A
- Create a consumable product “P1”
- Create a receipt transfer with this product
- confirm the transfer
- Come back to the product form
- limiter le produit que a la “Company B”

Problem:
no user error triggered
Go to inventory > operation > transfer: a Traceback is triggered

Before this commit, there is no verification while changing a product's company for consumable. That can lead to an issue where some operations cannot be done because of access errors. To avoid that, this commit prevents to change the product's company if some move lines for this product exist in another company.

Opw-3300559
