### PR TITLE
[FIX] Update de.po in purchase

### DIFF
--- a/addons/purchase/i18n/de.po
+++ b/addons/purchase/i18n/de.po
@@ -31,7 +31,7 @@ msgid ""
 "                'Purchase Order - %s' % (object.name))"
 msgstr ""
 "\n"
-"                (object.state in ('draft', 'sent') und 'Angebotsanfrage - %s' % (object.name) oder\n"
+"                (object.state in ('draft', 'sent') and 'Angebotsanfrage - %s' % (object.name) or\n"
 "                'Kaufauftrag - %s' % (object.name))"
 
 #. module: purchase


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wrong Translation in de.po

Current behavior before PR:
Not possible to print Purchase Order PDF
Desired behavior after PR is merged:
Possible to print purchase report without invvalid syntax error





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
