### PR TITLE
[FIX] account: recompute cash rounding for draft invoices only

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1978,7 +1978,7 @@ class AccountMove(models.Model):
     @contextmanager
     def _sync_rounding_lines(self, container):
         yield
-        for invoice in container['records']:
+        for invoice in container['records'].search([('state', '=', 'draft')]):
             invoice._recompute_cash_rounding_lines()
 
     @contextmanager


### PR DESCRIPTION
If you have a posted invoice with a cash rounding line, then change the cash rounding method from for example, Up to Down, an error will be raised if you edit that invoice (for example editing the Payment Reference field).

This is caused because `recompute_cash_rounding_lines()` is called when editing an invoice, but here it will give different results as the rounding method has changed, so it will try to edit the lines of a posted entry, which is forbidden.

The fix is to call the recompute only for invoices that are in draft.

opw-3235296
