### PR TITLE
[REF] point_of_sale,pos_*: merge of price_manually_set & price_automatically_set

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/OrderReceipt.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/OrderReceipt.js
@@ -1,0 +1,18 @@
+/** @odoo-module */
+
+import { OrderReceipt } from "@point_of_sale/js/Screens/ReceiptScreen/OrderReceipt";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderReceipt.prototype, "l10n_fr_pos_cert.OrderReceipt", {
+    showOldPrice(receipt, orderline) {
+        const oldPrice = orderline.price_lst;
+        const currentPrice = orderline.price_with_tax;
+        return (
+            !orderline.down_payment_details &&
+            orderline.price_changed &&
+            orderline.price_with_tax > 0 && // we don't want to display old_price for refunds.
+            receipt.l10n_fr_hash &&
+            oldPrice !== currentPrice
+        );
+    },
+});

--- a/addons/l10n_fr_pos_cert/static/src/js/Orderline.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/Orderline.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+
+import { Orderline } from "@point_of_sale/js/Screens/ProductScreen/Orderline";
+import { patch } from "@web/core/utils/patch";
+
+patch(Orderline.prototype, "l10n_fr_pos_cert.Orderline", {
+    get showOldPrice() {
+        const orderline = this.props.line;
+        const oldPrice = orderline.get_taxed_lst_unit_price();
+        const currentPrice = orderline.get_display_price();
+        return (
+            !orderline.down_payment_details &&
+            !orderline.refunded_orderline_id &&
+            orderline.price_changed &&
+            this.pos.globalState.is_french_country() &&
+            oldPrice !== currentPrice
+        );
+    },
+});

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -11,7 +11,8 @@
 
     <t t-name="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
         <xpath expr="//t[@t-foreach='receipt.orderlines']" position="inside">
-            <t t-if="receipt.l10n_fr_hash !== false and line.price_manually_set">
+            <!-- moda - manually -->
+            <t t-if="this.showOldPrice(receipt, line)">
                 <div class="pos-receipt-right-padding">
                     Old unit price:
                     <span class="oldPrice">

--- a/addons/l10n_fr_pos_cert/static/src/xml/Orderline.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/Orderline.xml
@@ -3,7 +3,8 @@
 
     <t t-name="Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension" owl="1">
         <xpath expr="//ul[hasclass('info-list')]" position="inside">
-            <t t-if="env.pos.is_french_country() !== false and props.line.price_manually_set">
+            <!-- moda - manually -->
+            <t t-if="this.showOldPrice">
                 <li class="info">
                     Old unit price:
                     <span class="oldPrice">

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -127,7 +127,8 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
                 this.currentOrder.get_selected_orderline().set_discount(val);
             } else if (this.env.pos.numpadMode === "price") {
                 var selected_orderline = this.currentOrder.get_selected_orderline();
-                selected_orderline.price_manually_set = true;
+                // moda - manually
+                selected_orderline.price_changed = true;
                 selected_orderline.set_unit_price(val);
             }
         }
@@ -160,7 +161,8 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
             Object.assign(options, {
                 price: code.value,
                 extras: {
-                    price_manually_set: true,
+                    // moda - manually
+                    price_changed: true,
                 },
             });
         } else if (code.type === "weight") {

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/TicketScreen.js
@@ -545,7 +545,7 @@ export class TicketScreen extends IndependentToOrderScreen {
         return {
             quantity: -qty,
             price: orderline.price,
-            extras: { price_automatically_set: true },
+            extras: { price_changed: true },
             merge: false,
             refunded_orderline_id: orderline.id,
             tax_ids: orderline.tax_ids,

--- a/addons/pos_discount/static/src/js/DiscountButton.js
+++ b/addons/pos_discount/static/src/js/DiscountButton.js
@@ -77,7 +77,7 @@ export class DiscountButton extends Component {
                               )
                             : this.env._t("No tax")),
                     extras: {
-                        price_automatically_set: true,
+                        price_changed: true,
                     },
                 });
             }

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -510,7 +510,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
             line.coupon_id = options.coupon_id;
             line.reward_identifier_code = options.reward_identifier_code;
             line.points_cost = options.points_cost;
-            line.price_automatically_set = true;
+            line.price_changed = true;
         }
         line.giftBarcode = options.giftBarcode;
         line.giftCardId = options.giftCardId;

--- a/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
+++ b/addons/pos_sale/static/src/js/OrderManagementScreen/SaleOrderManagementScreen.js
@@ -206,7 +206,8 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(IndependentTo
                             description: line.name,
                             price: line.price_unit,
                             tax_ids: orderFiscalPos ? undefined : line.tax_id,
-                            price_manually_set: true,
+                            // moda - manually
+                            price_changed: true,
                             sale_order_origin_id: clickedOrder,
                             sale_order_line_id: line,
                             customer_note: line.customer_note,
@@ -318,7 +319,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(IndependentTo
                             order: this.env.pos.get_order(),
                             product: down_payment_product,
                             price: down_payment,
-                            price_automatically_set: true,
+                            price_changed: true,
                             sale_order_origin_id: clickedOrder,
                             down_payment_details: tab,
                         }


### PR DESCRIPTION
*:l10n_fr_pos_cert,pos_discount,pos_loyalty,pos_sale

Previously, two fields were required to indicate that the price of a command line had been modified by the user.
- `price_manually_set`: this field was used to indicate a price change of an orderline via the numpad. 
- `price_automatically_set`: this field was used to indicate that the price was automatically calculated by the application when the orderline came from a sale order or an old order that was being refunded.

These two fields have a common use except for the French certification where it is necessary to display the old price on the order line when it is modified.

Now, these two fields are called `price_changed`, the behavior is the same as before except that for the french certification some additional conditions have been added. We will display the old price when :
- We are in a down payment.
- The field `price_changed` is set to true.
- When the total of the orderline is positive to avoid displaying the old price in case of refund.
- When we are in a French company.
- When the old price is different from the new price.