### PR TITLE
[IMP] *: optimize multi-company rule

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -93,97 +93,97 @@
         <field name="name">Account Entry</field>
         <field name="model_id" ref="model_account_move"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="account_move_line_comp_rule" model="ir.rule">
         <field name="name">Entry lines</field>
         <field name="model_id" ref="model_account_move_line"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="journal_group_comp_rule" model="ir.rule">
         <field name="name">Journal Group multi-company</field>
         <field name="model_id" ref="model_account_journal_group"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="journal_comp_rule" model="ir.rule">
         <field name="name">Journal multi-company</field>
         <field name="model_id" ref="model_account_journal"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="account_comp_rule" model="ir.rule">
         <field name="name">Account multi-company</field>
         <field name="model_id" ref="model_account_account"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="account_root_comp_rule" model="ir.rule">
         <field name="name">Account Root multi-company</field>
         <field name="model_id" ref="model_account_root"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="tax_comp_rule" model="ir.rule">
         <field name="name">Tax multi-company</field>
         <field name="model_id" ref="model_account_tax"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="invoice_analysis_comp_rule" model="ir.rule">
         <field name="name">Invoice Analysis multi-company</field>
         <field name="model_id" ref="model_account_invoice_report"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="account_fiscal_position_comp_rule" model="ir.rule">
         <field name="name">Account fiscal Mapping company rule</field>
         <field name="model_id" ref="model_account_fiscal_position"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="account_bank_statement_comp_rule">
         <field name="name">Account bank statement company rule</field>
         <field name="model_id" ref="model_account_bank_statement"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="account_bank_statement_line_comp_rule">
         <field name="name">Account bank statement line company rule</field>
         <field name="model_id" ref="model_account_bank_statement_line"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="account_reconcile_model_template_comp_rule">
         <field name="name">Account reconcile model template company rule</field>
         <field name="model_id" ref="model_account_reconcile_model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="account_payment_comp_rule">
         <field name="name">Account payment company rule</field>
         <field name="model_id" ref="model_account_payment"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="account_payment_term_comp_rule">
         <field name="name">Account payment term company rule</field>
         <field name="model_id" ref="model_account_payment_term"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <!-- Billing record rules for account.move -->

--- a/addons/account_analytic_default/security/account_analytic_default_security.xml
+++ b/addons/account_analytic_default/security/account_analytic_default_security.xml
@@ -6,8 +6,8 @@
         <field name="name">Analytic Default multi company rule</field>
         <field name="model_id" ref="model_account_analytic_default"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
-     
+
     </data>
 </odoo>

--- a/addons/analytic/security/analytic_security.xml
+++ b/addons/analytic/security/analytic_security.xml
@@ -6,28 +6,28 @@
         <field name="name">Analytic multi company rule</field>
         <field name="model_id" ref="model_account_analytic_account"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
-     
+
     <record id="analytic_line_comp_rule" model="ir.rule">
         <field name="name">Analytic line multi company rule</field>
         <field name="model_id" ref="model_account_analytic_line"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="analytic_group_comp_rule" model="ir.rule">
         <field name="name">Analytic line multi company rule</field>
         <field name="model_id" ref="model_account_analytic_group"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="analytic_tag_comp_rule" model="ir.rule">
         <field name="name">Analytic line multi company rule</field>
         <field name="model_id" ref="model_account_analytic_tag"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 </data>
 <data noupdate="0">

--- a/addons/crm/security/crm_security.xml
+++ b/addons/crm/security/crm_security.xml
@@ -35,7 +35,7 @@
     <record id="crm_lead_company_rule" model="ir.rule">
         <field name="name">CRM Lead Multi-Company</field>
         <field name="model_id" ref="model_crm_lead"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="crm_rule_all_lead" model="ir.rule">
@@ -63,7 +63,7 @@
         <field name="name">CRM Lead Multi-Company</field>
         <field name="model_id" ref="model_crm_activity_report"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
 </data>

--- a/addons/delivery/security/delivery_carrier_security.xml
+++ b/addons/delivery/security/delivery_carrier_security.xml
@@ -5,7 +5,7 @@
       <field name="name">Delivery Carrier multi-company</field>
       <field name="model_id" ref="model_delivery_carrier"/>
       <field name="global" eval="True"/>
-      <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+      <field name="domain_force"> [('company_id', 'in', company_ids + [False])]</field>
     </record>
   </data>
 </odoo>

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -114,37 +114,37 @@
             <field name="name">Fleet vehicle: Multi Company</field>
             <field name="model_id" ref="model_fleet_vehicle"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
         <record id="ir_rule_fleet_log_fuel" model="ir.rule">
             <field name="name">Fleet log fuel: Multi Company</field>
             <field name="model_id" ref="model_fleet_vehicle_log_fuel"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
         <record id="ir_rule_fleet_log_services" model="ir.rule">
             <field name="name">Fleet log services: Multi Company</field>
             <field name="model_id" ref="model_fleet_vehicle_log_services"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
         <record id="ir_rule_fleet_cost" model="ir.rule">
             <field name="name">Fleet cost: Multi Company</field>
             <field name="model_id" ref="model_fleet_vehicle_cost"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
         <record id="ir_rule_fleet_log_contract" model="ir.rule">
             <field name="name">Fleet log contract: Multi Company</field>
             <field name="model_id" ref="model_fleet_vehicle_log_contract"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
         <record id="ir_rule_fleet_odometer" model="ir.rule">
             <field name="name">Fleet odometer: Multi Company</field>
             <field name="model_id" ref="model_fleet_vehicle_odometer"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('vehicle_id.company_id', '=', False), ('vehicle_id.company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('vehicle_id.company_id', 'in', company_ids + [False])]</field>
         </record>
     </data>
 </odoo>

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -30,28 +30,28 @@
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="hr_dept_comp_rule" model="ir.rule">
         <field name="name">Department multi company rule</field>
         <field name="model_id" ref="model_hr_department"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="hr_employee_public_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee_public"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="hr_job_comp_rule" model="ir.rule">
         <field name="name">Job multi company rule</field>
         <field name="model_id" ref="model_hr_job"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
 </data>

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -21,7 +21,7 @@
             <field name="name">HR Contract: Multi Company</field>
             <field name="model_id" ref="model_hr_contract"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
         </record>
 
     </data>

--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -55,13 +55,13 @@
             <field name="name">Expense multi company rule</field>
             <field name="model_id" ref="model_hr_expense"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">['|',('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
         </record>
         <record id="hr_expense_report_comp_rule" model="ir.rule">
             <field name="name">Expense Report multi company rule</field>
             <field name="model_id" ref="model_hr_expense_sheet"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">['|',('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
         </record>
 
     </data>

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -133,13 +133,13 @@
         <field name="name">Time Off: multi company global rule</field>
         <field name="model_id" ref="model_hr_leave"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('holiday_status_id.company_id', '=', False), ('holiday_status_id.company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('holiday_status_id.company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="hr_leave_allocation_rule_multicompany" model="ir.rule">
         <field name="name">Leave Allocations: multi company global rule</field>
         <field name="model_id" ref="model_hr_leave_allocation"/>
-        <field name="domain_force">['|', ('holiday_status_id.company_id', '=', False), ('holiday_status_id.company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('holiday_status_id.company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="hr_leave_allocation_rule_employee" model="ir.rule">
@@ -221,6 +221,6 @@
         <field name="name">Time Off multi company rule</field>
         <field name="model_id" ref="model_hr_leave_type"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 </odoo>

--- a/addons/hr_holidays_calendar/security/hr_holidays_calendar_security.xml
+++ b/addons/hr_holidays_calendar/security/hr_holidays_calendar_security.xml
@@ -3,6 +3,6 @@
         <field name="name">Time Off Report Calendar: multi company global rule</field>
         <field name="model_id" ref="model_hr_leave_report_calendar"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 </odoo>

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -10,7 +10,7 @@
         <field name="name">Applicant multi company rule</field>
         <field name="model_id" ref="model_hr_applicant"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="group_hr_recruitment_user" model="res.groups">

--- a/addons/lunch/security/lunch_security.xml
+++ b/addons/lunch/security/lunch_security.xml
@@ -69,28 +69,28 @@
             <field name="name">Lunch supplier: Multi Company</field>
             <field name="model_id" ref="model_lunch_supplier"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <record id="ir_rule_lunch_product_multi_company" model="ir.rule">
             <field name="name">Lunch product: Multi Company</field>
             <field name="model_id" ref="model_lunch_product"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <record id="ir_rule_lunch_location_multi_company" model="ir.rule">
             <field name="name">Lunch location: Multi Company</field>
             <field name="model_id" ref="model_lunch_location"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <record id="ir_rule_lunch_product_report_multi_company" model="ir.rule">
             <field name="name">Lunch product report: Multi Company</field>
             <field name="model_id" ref="model_lunch_product_report"/>
             <field name="global" eval="True"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
     </data>
 </odoo>

--- a/addons/maintenance/security/maintenance.xml
+++ b/addons/maintenance/security/maintenance.xml
@@ -41,28 +41,28 @@
         <field name="name">Maintenance Request Multi-company rule</field>
         <field name="model_id" ref="model_maintenance_request"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="maintenance_equipment_comp_rule" model="ir.rule">
         <field name="name">Maintenance Equipment Multi-company rule</field>
         <field name="model_id" ref="model_maintenance_equipment"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="maintenance_team_comp_rule" model="ir.rule">
         <field name="name">Maintenance Team Multi-company rule</field>
         <field name="model_id" ref="model_maintenance_team"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="maintenance_equipment_category_comp_rule" model="ir.rule">
         <field name="name">Maintenance Equipment Category Multi-company rule</field>
         <field name="model_id" ref="model_maintenance_equipment_category"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="base.user_admin" model="res.users">

--- a/addons/mrp/security/mrp_security.xml
+++ b/addons/mrp/security/mrp_security.xml
@@ -54,7 +54,7 @@
         <field name="name">mrp_workcenter multi-company</field>
         <field name="model_id" search="[('model','=','mrp.workcenter')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="mrp_workorder_rule">
@@ -68,35 +68,35 @@
         <field name="name">mrp_bom multi-company</field>
         <field name="model_id" search="[('model','=','mrp.bom')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="mrp_bom_line_rule">
         <field name="name">mrp_bom_line multi-company</field>
         <field name="model_id" search="[('model','=','mrp.bom.line')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="mrp_bom_byproduct_rule">
         <field name="name">mrp_bom_byproduct multi-company</field>
         <field name="model_id" search="[('model','=','mrp.bom.byproduct')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="mrp_routing_rule">
         <field name="name">mrp_routing multi-company</field>
         <field name="model_id" search="[('model','=','mrp.routing')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="mrp_routing_workcenter_rule">
         <field name="name">mrp_routing_workcenter multi-company</field>
         <field name="model_id" search="[('model','=','mrp.routing.workcenter')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="mrp_workcenter_productivity">

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -69,7 +69,7 @@
         <field name="name">Point Of Sale Order Analysis multi-company</field>
         <field name="model_id" ref="model_report_pos_order"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
     <record id="rule_pos_payment_method_multi_company" model="ir.rule">
         <field name="name">PoS Payment Method</field>

--- a/addons/product/security/product_security.xml
+++ b/addons/product/security/product_security.xml
@@ -35,35 +35,35 @@
         <field name="name" >Product multi-company</field>
         <field name="model_id" ref="model_product_template"/>
         <field name="global" eval="True"/>
-        <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+        <field name="domain_force"> [('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="product_pricelist_comp_rule">
         <field name="name">product pricelist company rule</field>
         <field name="model_id" ref="model_product_pricelist"/>
         <field name="global" eval="True"/>
-        <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+        <field name="domain_force"> [('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="product_pricelist_item_comp_rule">
         <field name="name">product pricelist item company rule</field>
         <field name="model_id" ref="model_product_pricelist_item"/>
         <field name="global" eval="True"/>
-        <field name="domain_force"> ['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+        <field name="domain_force"> [('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="product_supplierinfo_comp_rule">
         <field name="name">product supplierinfo company rule</field>
         <field name="model_id" ref="model_product_supplierinfo"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="product_packaging_comp_rule">
         <field name="name">product packaging company rule</field>
         <field name="model_id" ref="model_product_packaging"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
 </data>

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -35,14 +35,14 @@
         <field name="name">Purchase Order multi-company</field>
         <field name="model_id" ref="model_purchase_order"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="purchase_order_line_comp_rule">
         <field name="name">Purchase Order Line multi-company</field>
         <field name="model_id" ref="model_purchase_order_line"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record id="portal_purchase_order_user_rule" model="ir.rule">
@@ -78,14 +78,14 @@
         <field name="name">Purchases &amp; Bills Union multi-company</field>
         <field name="model_id" ref="model_purchase_bill_union"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record id="purchase_order_report_comp_rule" model="ir.rule">
         <field name="name">Purchase Order Report multi-company</field>
         <field name="model_id" ref="model_purchase_report"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
 </data>

--- a/addons/purchase_requisition/security/purchase_requisition_security.xml
+++ b/addons/purchase_requisition/security/purchase_requisition_security.xml
@@ -6,14 +6,14 @@
         <field name="name">Purchase Requisition multi-company</field>
         <field name="model_id" ref="model_purchase_requisition"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="purchase_requisition_line_comp_rule">
         <field name="name">Purchase requisition Line multi-company</field>
         <field name="model_id" ref="model_purchase_requisition_line"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
 </data>

--- a/addons/repair/security/repair_security.xml
+++ b/addons/repair/security/repair_security.xml
@@ -7,7 +7,7 @@
         <field name="name">repair multi-company</field>
         <field name="model_id" search="[('model','=','repair.order')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     </data>

--- a/addons/sale/security/sale_security.xml
+++ b/addons/sale/security/sale_security.xml
@@ -51,14 +51,14 @@
         <field name="name">Sales Order Line multi-company</field>
         <field name="model_id" ref="model_sale_order_line"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <record model="ir.rule" id="sale_order_report_comp_rule">
         <field name="name">Sales Order Analysis multi-company</field>
         <field name="model_id" ref="model_sale_report"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
     <!-- Payments -->

--- a/addons/sale_management/security/sale_management_security.xml
+++ b/addons/sale_management/security/sale_management_security.xml
@@ -10,7 +10,7 @@
         <field name="name">Quotation Template multi-company</field>
         <field name="model_id" ref="model_sale_order_template"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
 </odoo>

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -37,7 +37,7 @@
         <record model="ir.rule" id="sale_team_comp_rule">
             <field name="name">Sales Team multi-company</field>
             <field name="model_id" ref="model_crm_team"/>
-            <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <record model="ir.ui.menu" id="sales_team.menu_sale_config">

--- a/addons/stock/security/stock_security.xml
+++ b/addons/stock/security/stock_security.xml
@@ -104,7 +104,7 @@
         <field name="name">Location multi-company</field>
         <field name="model_id" ref="model_stock_location"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
      <record model="ir.rule" id="stock_move_rule">
@@ -118,14 +118,14 @@
         <field name="name">stock_move_line multi-company</field>
         <field name="model_id" search="[('model','=','stock.move.line')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|','|',('company_id','=',False),('company_id', 'in', company_ids),'&amp;',('location_dest_id.company_id', '=', False), ('location_dest_id.usage', '=', 'transit')]</field>
+        <field name="domain_force">['|',('company_id', 'in', company_ids),'&amp;',('location_dest_id.company_id', '=', False), ('location_dest_id.usage', '=', 'transit')]</field>
      </record>
 
     <record model="ir.rule" id="stock_quant_rule">
         <field name="name">stock_quant multi-company</field>
         <field name="model_id" ref="model_stock_quant"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="stock_inventory_line_comp_rule">
@@ -153,21 +153,21 @@
         <field name="name">product_pulled_flow multi-company</field>
         <field name="model_id" ref="model_stock_rule"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="stock_location_route_comp_rule">
         <field name="name">stock_location_route multi-company</field>
         <field name="model_id" ref="model_stock_location_route"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="stock_quant_package_comp_rule">
         <field name="name">stock_quant_package multi-company</field>
         <field name="model_id" ref="model_stock_quant_package"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
     <record model="ir.rule" id="stock_scrap_company_rule">
@@ -181,7 +181,7 @@
         <field name="name">report_stock_quantity_flow multi-company</field>
         <field name="model_id" ref="model_report_stock_quantity"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
 </data>

--- a/addons/stock_landed_costs/security/stock_landed_cost_security.xml
+++ b/addons/stock_landed_costs/security/stock_landed_cost_security.xml
@@ -6,7 +6,7 @@
         <field name="name">stock_landed_cost multi-company</field>
         <field name="model_id" search="[('model','=','stock.landed.cost')]" model="ir.model"/>
         <field name="global" eval="True"/>
-        <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 
 </data>

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -6,7 +6,7 @@
             <field name="name">Mail Test Multi Company</field>
             <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
     </data>

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -19,7 +19,7 @@
             the multi-company rule because it might interfere with the user's company rule
             and make some users unselectable in relational fields. This means that partners
             of internal users are always visible, not matter the company setting. -->
-            <field name="domain_force">['|', '|', ('partner_share', '=', False), ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+            <field name="domain_force">['|', ('partner_share', '=', False), ('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <record model="ir.rule" id="res_partner_portal_public_rule">
@@ -59,13 +59,13 @@
             <field name="name">Partner bank company rule</field>
             <field name="model_id" ref="model_res_partner_bank"/>
             <field name="global" eval="True"/>
-                <field name="domain_force">['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+                <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <record id="res_currency_rate_rule" model="ir.rule">
             <field name="name">multi-company currency rate rule</field>
             <field name="model_id" ref="model_res_currency_rate"/>
-            <field name="domain_force">['|',('company_id','=',False),('company_id', 'in', company_ids)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
         <!-- Security restriction for private addresses -->

--- a/odoo/addons/base/views/ir_rule_views.xml
+++ b/odoo/addons/base/views/ir_rule_views.xml
@@ -98,7 +98,7 @@
             <field name="name">Property multi-company</field>
             <field name="model_id" ref="model_ir_property"/>
             <field eval="True" name="global"/>
-            <field name="domain_force">['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
 
 


### PR DESCRIPTION
When we use the `|` (or) version of this rule the ORM generates two sub-queries when checking the company. This causes sub-optimal and in some cases really bad planning for the queries and thus PG takes hours to complete them.

Example (formatted):
```sql
    SELECT "mrp_routing_workcenter".id
      FROM "mrp_routing_workcenter"
 LEFT JOIN "mrp_bom" AS "mrp_routing_workcenter__bom_id"
        ON "mrp_routing_workcenter"."bom_id" = "mrp_routing_workcenter__bom_id"."id"
     WHERE "mrp_routing_workcenter"."workcenter_id" in (1)
       AND (  ("mrp_routing_workcenter"."bom_id" in (
                    SELECT "mrp_bom".id
                      FROM "mrp_bom"
                     WHERE ("mrp_bom"."company_id" in (1))
                   )
              )
           OR ("mrp_routing_workcenter"."bom_id" in (
                    SELECT "mrp_bom".id
                      FROM "mrp_bom"
                     WHERE "mrp_bom"."company_id" IS NULL
                   )
              )
           )
  ORDER BY "mrp_routing_workcenter__bom_id"."sequence",
           "mrp_routing_workcenter__bom_id"."id",
           "mrp_routing_workcenter"."sequence",
           "mrp_routing_workcenter"."id"
```

If we use the single term version the generated query has only one sub-query:
```sql
    SELECT "mrp_routing_workcenter".id
      FROM "mrp_routing_workcenter"
 LEFT JOIN "mrp_bom" AS "mrp_routing_workcenter__bom_id"
        ON "mrp_routing_workcenter"."bom_id" = "mrp_routing_workcenter__bom_id"."id"
     WHERE "mrp_routing_workcenter"."workcenter_id" in (1)
       AND (  ("mrp_routing_workcenter"."bom_id" in (
                    SELECT "mrp_bom".id
                      FROM "mrp_bom"
                     WHERE (("mrp_bom"."company_id" in (1))
                        OR  ("mrp_bom"."company_id" IS NULL))
                   )
              )
           )
  ORDER BY "mrp_routing_workcenter__bom_id"."sequence",
           "mrp_routing_workcenter__bom_id"."id",
           "mrp_routing_workcenter"."sequence",
           "mrp_routing_workcenter"."id"
```
In this version PG is able to produce a better query plan resulting in better execution times.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
