### PR TITLE
[FIX] auth_signup: avoid res_users_login_key error in logs

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -10,6 +10,7 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
+from odoo.tools import mute_logger
 from odoo.tools.misc import ustr
 
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
@@ -142,10 +143,11 @@ class ResUsers(models.Model):
         # create a copy of the template user (attached to a specific partner_id if given)
         values['active'] = True
         try:
-            with self.env.cr.savepoint():
+            with self.env.cr.savepoint(), mute_logger('odoo.sql_db'):
                 return template_user.with_context(no_reset_password=True).copy(values)
         except Exception as e:
             # copy may failed if asked login is not available.
+            _logger.warning("Signup error: %s", ustr(e), exc_info=True)
             raise SignupError(ustr(e))
 
     def reset_password(self, login):


### PR DESCRIPTION
This commit prevents printing following expected error in the logs:

```
ERROR: duplicate key value violates unique constraint "res_users_login_key"
DETAIL:  Key (login)=(admin) already exists.
```

STEPS:
* go to signup page ('/web/signup').
* give 'admin' as email and fill out other details.
* click on the signup button.

https://online.sentry.io/issues/3933777844/

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
