### PR TITLE
[FIX] iot: pip install geoip2

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -106,7 +106,8 @@ PIP_TO_INSTALL="
     pyusb \
     v4l2 \
     pysmb==1.2.9.1 \
-    cryptocode==0.1"
+    cryptocode==0.1 \
+    geoip2==2.9.0"
 
 pip3 install ${PIP_TO_INSTALL}
 


### PR DESCRIPTION
Before this commit:
The odoo service on the IoT box will crash on start if it's synchronised with an Odoo server version 16.1 (or higher).

Trying to manually start Odoo, we have the following traceback:
```
Traceback (most recent call last):
  File "/home/pi/odoo/odoo-bin", line 5, in <module>
    import odoo
  ...
    from odoo.http import request
  File "/home/pi/odoo/odoo/http.py", line 140, in <module>
    import geoip2.database
ModuleNotFoundError: No module named 'geoip2'
```

Since: https://github.com/odoo/odoo/pull/91337 `geoip2` python library is an Odoo requirement, which is not installed on the IoT box.

After this commit:
Odoo service start without crashing

opw-3278925

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
