### PR TITLE
[FIX] hr_timesheet: name_search on task in multi-company setting

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -256,3 +256,13 @@ class Task(models.Model):
         uom_hour = self.env.ref('uom.product_uom_hour')
         uom_day = self.env.ref('uom.product_uom_day')
         return round(uom_hour._compute_quantity(time, uom_day, raise_if_failure=False), 2)
+
+    @api.model
+    def _name_search(self, name='', args=None, operator='ilike', limit=100, name_get_uid=None):
+        allowed_company_ids = self.env.context['allowed_company_ids']
+        if len(allowed_company_ids) > 1:  # multi-company setting
+            # implicit assertion that there is only 1 company_id condition in the domain
+            company_cond_idx = next((index for index, item in enumerate(args) if item[0] == 'company_id'), None)
+            if company_cond_idx is not None:
+                args[company_cond_idx] = ('company_id', 'in', allowed_company_ids)
+        return super(Task, self)._name_search(name, args, operator, limit, name_get_uid)


### PR DESCRIPTION
## Current behaviour
If we have 2 companies (A,B), while being logged in company A, but having selected both company A and B, when we try to add a timesheet for a project and a task created in company B, the `name_search` on the task doesn't show results for the task created in company B, even though we have selected both companies.

## Expected behaviour
Task created in an another company should show up, if those companies have been selected.

## Steps to reproduce
- Install Timesheets.
- Settings > Create another company (ex: "Another Company")
- In "Another Company" (make sure to switch companies, don't reassign manually companies by hand), create a new Project and a Task in it
- Switch back to "YourCompany".
- Select both companies "YourCompany" & "Another Company".
- In Timesheets, try to create a new line with the project + task from "Another Company", the project shows up in the name_search, but not the task.

## Reason for the problem
The domain passed to the `name_search` of the task has a condition of the form `('company_id', '=', company_id)`. This domain comes from: https://github.com/odoo/odoo/blob/4424e9015c76a15d02a1cd0e9d6cb296aa093abe/addons/hr_timesheet/models/hr_timesheet.py#L47-L49 The right hand side `company_id` defaults to `self.env.company`. The project's `name_search` doesn't have this problem, as there is no condition on the company for it.

## Fix
Override the `_name_search` for tasks, and relax the condition on the company by adding the ids of the `allowed_company_ids`, to search for tasks that are also in the "selected" companies. `allowed_company_ids` also contains the id of the currently checked-out company by default.
Alternative solution would be to remove the `('company_id', '=', company_id)` from the field domain, but it's untested, and it is too risky for stable as it can have a wide impact.

## Affected versions
- 14.0  <-- issue present in grid + kanban view
- 15.0
- saas-15.2
- 16.0  <-- issue present in all views, list view doesn't work, unless you save the line with the project on it first.
- saas-16.1
- saas-16.2
- master
---
opw-3290969

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
