### PR TITLE
[FIX] product: fix field & tooltip visibility issue

### DIFF
--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -7,11 +7,14 @@
         <field name="inherit_id" ref="sale.product_template_form_view_invoice_policy"/>
         <field name="arch" type="xml">
             <field name="invoice_policy" position="after">
-                <field name="service_tracking" required="1" attrs="{'invisible': [('type', '!=', 'service')]}"/>
+                <field name="service_tracking" required="1" attrs="{'invisible': [('detailed_type', '!=', 'service')]}"/>
             </field>
             <field name="product_tooltip" position="after">
-                <field name="project_id" context="{'default_allow_billable': True}" attrs="{'invisible':[('service_tracking','!=','task_global_project')], 'required':[('service_tracking','==','task_global_project')]}"/>
-                <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" attrs="{'invisible':[('service_tracking','not in',['task_in_project', 'project_only'])]}"/>
+                <field name="project_id" context="{'default_allow_billable': True}" attrs="{'invisible':['|', ('service_tracking','!=','task_global_project'), ('detailed_type', '!=', 'service')], 'required':[('service_tracking','==','task_global_project')]}"/>
+                <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" attrs="{'invisible':['|', ('service_tracking','not in',['task_in_project', 'project_only']), ('detailed_type', '!=', 'service')]}"/>
+            </field>
+            <field name="product_tooltip" position="attributes">
+                <attribute name="attrs">{'invisible': [('detailed_type', '=', 'gift')]}</attribute>
             </field>
         </field>
     </record>

--- a/addons/sale_timesheet/views/product_views.xml
+++ b/addons/sale_timesheet/views/product_views.xml
@@ -13,8 +13,8 @@
                 <field name="service_policy" string="Invoicing Policy" attrs="{'invisible': [('type', '!=', 'service')], 'required': [('type', '=', 'service')]}"/>
             </xpath>
             <field name="product_tooltip" position="after">
-                <label for="product_tooltip" string="" attrs="{'invisible': ['|', ('type', '!=', 'service'), ('service_policy', '!=', 'ordered_timesheet')]}"/>
-                <div attrs="{'invisible': ['|', ('type', '!=', 'service'), ('service_policy', '!=', 'ordered_timesheet')]}" class="font-italic text-muted">
+                <label for="product_tooltip" string="" attrs="{'invisible': ['|', ('detailed_type', '!=', 'service'), ('service_policy', '!=', 'ordered_timesheet')]}"/>
+                <div attrs="{'invisible': ['|', ('detailed_type', '!=', 'service'), ('service_policy', '!=', 'ordered_timesheet')]}" class="font-italic text-muted">
                     Warn the salesperson for an upsell when work done exceeds
                     <field name="service_upsell_threshold" widget="percentage" class="oe_inline"/>
                     of hours sold. (<field name="service_upsell_threshold_ratio" class="oe_inline"/>)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
In product form view, create on order field and tooltip is only visible when user select service in product type otherwise this field is not visible.

Current behavior before PR:
create on order field and tooltip is visible on all product type.

Desired behavior after PR is merged:
create on order field and tooltip is visible on only service product type.

Fix:
add invisible attribute on field and tooltips for hiding that field.

task-3277977
