### PR TITLE
[IMP] point_of_sale,pos_restaurant: websocket integration

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -102,6 +102,11 @@
             'web/static/src/webclient/barcode/barcode_scanner.js',
             'web/static/src/webclient/barcode/ZXingBarcodeDetector.js',
             'web/static/src/webclient/barcode/crop_overlay.js',
+            # bus service
+            'bus/static/src/services/bus_service.js',
+            'bus/static/src/bus_parameters_service.js',
+            'bus/static/src/multi_tab_service.js',
+            'bus/static/src/workers/*',
             # report download utils
             'web/static/src/webclient/actions/reports/utils.js',
             # libs

--- a/addons/point_of_sale/static/src/app/pos_store.js
+++ b/addons/point_of_sale/static/src/app/pos_store.js
@@ -34,7 +34,6 @@ export class PosStore extends Reactive {
         this.popup = popup;
         this.numberBuffer = number_buffer;
         this.barcodeReader = barcode_reader;
-        this.bus = bus_service;
         this.globalState = new PosGlobalState({ orm, env, hardwareProxy: hardware_proxy });
         this.hardwareProxy = hardware_proxy;
         // FIXME POSREF: the hardwareProxy needs the pos and the pos needs the hardwareProxy. Maybe
@@ -49,8 +48,8 @@ export class PosStore extends Reactive {
         this.showScreen("ProductScreen");
 
         // initialize bus_service and listen on pos_config-`id` channel
-        this.bus.addChannel(`pos_config-${this.globalState.config.id}`);
-        this.bus.addEventListener("notification", async (message) =>
+        bus_service.addChannel(`pos_config-${this.globalState.config.id}`);
+        bus_service.addEventListener("notification", async (message) =>
             message.detail.map((detail) => {
                 this.handleBusMessages(detail);
             })

--- a/addons/point_of_sale/static/tests/unit/pos_app_tests.js
+++ b/addons/point_of_sale/static/tests/unit/pos_app_tests.js
@@ -21,6 +21,11 @@ QUnit.module("Chrome", {
                 start() {
                     return { bus: new EventBus() };
                 },
+            })
+            .add("bus_service", {
+                start() {
+                    return { addChannel: () => {}, addEventListener: () => {} };
+                },
             });
 
         for (const service of [

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -53,24 +53,25 @@ class PosOrder(models.Model):
         "returns: list -- list of tuples that represents a domain.
         """
         return [('state', '=', 'draft'), ('table_id', 'in', table_ids)]
+
     @api.model
     def remove_from_ui(self, server_ids):
         table_id = self.env['pos.order'].search([('id', 'in', server_ids)]).table_id
         order_ids = super().remove_from_ui(server_ids)
-        self.sendTableCountNotification(table_id)
+        self.send_table_count_notification(table_id)
         return order_ids
 
     @api.model
     def create_from_ui(self, orders, draft=False):
         orders = super().create_from_ui(orders, draft)
         order_ids = self.env['pos.order'].search([('id', 'in', [order['id'] for order in orders])])
-        self.sendTableCountNotification(order_ids.table_id)
+        self.send_table_count_notification(order_ids.table_id)
         return orders
 
-    def sendTableCountNotification(self, table_ids):
+    def send_table_count_notification(self, table_ids):
         for config_id in self.env['pos.config'].search([('floor_ids', 'in', table_ids.floor_id.ids)]):
             order_count = config_id.get_tables_order_count()
-            self.env['bus.bus']._sendone(f'pos_config-{config_id.id}', 'table_order_count', order_count)
+            self.env['bus.bus']._sendone(f'pos_config-{config_id.id}', 'TABLE_ORDER_COUNT', order_count)
 
     @api.model
     def get_table_draft_orders(self, table_ids):

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -71,7 +71,7 @@ class RestaurantFloor(models.Model):
         self.active = False
 
         for config_id in self.pos_config_ids:
-            self.env['bus.bus']._sendone(f'pos_config-{config_id.id}', 'disable_floor', {
+            self.env['bus.bus']._sendone(f'pos_config-{config_id.id}', 'DISABLE_FLOOR', {
                 'id': self.id,
                 'table_ids': self.table_ids.ids,
             })
@@ -99,14 +99,14 @@ class RestaurantTable(models.Model):
         draft_orders = self.env['pos.order'].search([('table_id', 'in', self.ids), ('state', '=', 'draft')])
         return len(draft_orders) > 0
 
-    def multi_write(self, table_list):
+    def multi_write(self, table_vals):
         for table in self:
-            table.write(table_list[str(table.id)])
+            table.write(table_vals[str(table.id)])
             table.sendBusMessage(table)
 
     @api.model_create_multi
-    def create(self, table_list):
-        records = super().create(table_list)
+    def create(self, table_vals):
+        records = super().create(table_vals)
         for table in records:
             self.sendBusMessage(table)
         return records
@@ -128,7 +128,7 @@ class RestaurantTable(models.Model):
         }
 
         for config_id in pos_config_ids:
-            self.env['bus.bus']._sendone(f'pos_config-{config_id.id}', 'table_changed', {
+            self.env['bus.bus']._sendone(f'pos_config-{config_id.id}', 'TABLE_CHANGED', {
                 'changes': values
             })
 

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -3,20 +3,14 @@
 
     <t t-name="pos_restaurant.FloorScreen" owl="1">
         <div class="floor-screen screen">
-            <EditBar t-if="pos.globalState.isEditMode" selectedTables="selectedTables" nbrFloors="nbrFloors" 
-                        floorMapScrollTop="state.floorMapScrollTop" isColorPicker="state.isColorPicker" toggleColorPicker.bind="toggleColorPicker"
-                        createTable.bind="createTable" duplicateTableOrFloor.bind="duplicateTableOrFloor" renameTable.bind="renameTable"
-                        changeSeatsNum.bind="changeSeatsNum" changeToCircle.bind="changeToCircle" changeToSquare.bind="changeToSquare" 
-                        setTableColor.bind="setTableColor" setFloorColor.bind="setFloorColor" deleteFloorOrTable.bind="deleteFloorOrTable"
-                        toggleEditMode.bind="toggleEditMode"
-            />
+            <t t-if="pos.globalState.isEditMode" t-call="pos_restaurant.EditBar" />
             <div class="floor-selector">
                 <t t-foreach="pos.globalState.floors" t-as="floor" t-key="floor.id">
                     <span class="button button-floor" t-att-class="{ active: floor.id === state.selectedFloorId }" t-on-click="() => this.selectFloor(floor)">
                         <t t-esc="floor.name" />
                     </span>
                 </t>
-                <span class="button button-add" t-ref="add-floor-ref" t-on-click="addFloor">
+                <span class="button button-add" t-on-click="addFloor" t-if="this.pos.globalState.isEditMode">
                     ADD FLOOR
                 </span>
             </div>
@@ -27,6 +21,7 @@
                 t-on-touchmove="_onPinchMove"
                 t-on-touchend="_onPinchEnd"
                 class="floor-map"
+                t-attf-style="background-color:{{state.floorBackground}}"
                 t-ref="floor-map-ref"
             >
                 <t t-if="pos.globalState.floors.length > 0">
@@ -36,7 +31,7 @@
                     <div t-else="" t-ref="map">
                         <t t-foreach="activeTables" t-as="table" t-key="table.id">
                             <Table t-if="!state.selectedTableIds.includes(table.id)" onClick.bind="onSelectTable" table="table" />
-                            <EditableTable t-else="" table="table" selectedTables="selectedTables" onSaveTable.bind="onSaveTable" limit="floorMapRef" />
+                            <EditableTable t-else="" table="table" selectedTables="selectedTables" updateTables.bind="updateTables" limit="floorMapRef" />
                         </t>
                     </div>
                 </t>
@@ -46,6 +41,58 @@
                     </div>
                 </t>
             </div>
+        </div>
+    </t>
+
+    <t t-name="pos_restaurant.EditBar" owl="1">
+        <div class="edit-bar-top">
+            <span class="edit-button first-button" t-if="!env.isMobile"></span>
+            <span class="edit-button" t-on-click.stop="createTable">
+                <i class="fa fa-plus icon-button" role="img" aria-label="Add" title="Add"></i>
+                <span class="text-button">ADD</span>
+            </span>
+            <span class="edit-button" t-att-class="{ disabled: selectedTables.length == 0 }" t-on-click.stop="changeSeatsNum">
+                <i class="fa fa-user icon-button" role="img" aria-label="Seats" title="Seats"></i>
+                <span class="text-button">SEATS</span>
+            </span>
+            <span class="edit-button" t-att-class="{ disabled: selectedTables.length == 0 }" t-on-click.stop="changeShape">
+                <span class="button-option round">
+                    <i class="fa icon-button" t-att-class="{ 'fa-circle-o round': selectedTables[0]?.shape == 'square', 'fa-square-o square': selectedTables[0]?.shape != 'square' }" role="img" aria-label="Shape" title="Shape"></i>
+                </span>
+                <span class="text-button">SHAPE</span>
+            </span>
+            <span class="edit-button" t-att-class="{ 'is-active': state.isColorPicker }" t-on-click.stop="() => { this.state.isColorPicker = !this.state.isColorPicker }">
+                <i class="fa fa-paint-brush icon-button" role="img" aria-label="Tint" title="Tint"></i>
+                <span class="text-button">FILL</span>
+            </span>
+            <span class="edit-button" t-att-class="{ disabled: selectedTables.length > 1 }" t-on-click.stop="selectedTables.length > 0 ? renameTable : renameFloor">
+                <i class="fa fa-pencil-square-o icon-button" role="img" aria-label="Rename" title="Rename"></i>
+                <span class="text-button">RENAME</span>
+            </span>
+            <span class="edit-button" t-on-click.stop="duplicateTableOrFloor">
+                <i class="fa fa-clone icon-button" role="img" aria-label="Copy" title="Copy"></i>
+                <span class="text-button">COPY</span>
+            </span>
+            <span class="edit-button trash" t-on-click.stop="selectedTables.length > 0 ? deleteTable : deleteFloor">
+                <i class="fa fa-trash icon-button" role="img" aria-label="Delete" title="Delete"></i>
+                <span class="text-button">DELETE</span>
+            </span>
+            <span class="edit-button" t-on-click.stop="() => { this.pos.globalState.isEditMode = false; this.state.selectedTableIds = []}">
+                <div class="close-edit-button">
+                    <i class="fa fa-times icon-button" role="img" aria-label="Close" title="Close"></i>
+                    <span class="text-button">CLOSE</span>
+                </div>
+            </span>
+        </div>
+        <div t-if="state.isColorPicker and selectedTables.length > 0" class="color-picker">
+            <t t-foreach="constructor.colors" t-as="color" t-key="color.tableColor">
+                <span class="color"  t-attf-style="background-color:{{color.tableColor}}" role="img" t-att-aria-label="color.label" t-att-title="color.label" t-on-click.stop="() => this.setTableColor(color.tableColor)" />
+            </t>
+        </div>
+        <div t-if="state.isColorPicker and selectedTables.length == 0" class="color-picker">
+            <t t-foreach="constructor.colors" t-as="color" t-key="color.floorColor">
+                <span class="color"  t-attf-style="background-color:{{color.floorColor}}" role="img" t-att-aria-label="color.label" t-att-title="color.label" t-on-click.stop="() => this.setFloorColor(color.floorColor)" />
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/floor_screen/table.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/table.js
@@ -70,14 +70,14 @@ export class Table extends Component {
     }
     get orderCount() {
         const table = this.props.table;
-        const orderOnTable = this.pos.globalState
+        const numOrdersOnTable = this.pos.globalState
             .getTableOrders(table.id)
             .filter(
                 (o) => !o.finalized && (o.orderlines.length > 0 || o.paymentlines.length > 0)
             ).length;
-        return table.order_count && table.order_count > orderOnTable
+        return table.order_count && table.order_count > numOrdersOnTable
             ? table.order_count
-            : orderOnTable;
+            : numOrdersOnTable;
     }
     get orderCountClass() {
         const countClass = { "order-count": true };

--- a/addons/pos_restaurant/static/src/app/floor_screen/table.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/table.js
@@ -41,13 +41,6 @@ export class Table extends Component {
                 widthTable * Math.floor(index / nbrHorizontal) +
                 5 +
                 Math.floor(index / nbrHorizontal) * 10;
-            const widthTable = (window.innerWidth - nbrHorizontal * 10) / nbrHorizontal;
-            const position_h =
-                widthTable * (index % nbrHorizontal) + 5 + (index % nbrHorizontal) * 10;
-            const position_v =
-                widthTable * Math.floor(index / nbrHorizontal) +
-                5 +
-                Math.floor(index / nbrHorizontal) * 10;
             return `
                 width: ${widthTable}px;
                 height: ${widthTable}px;
@@ -77,14 +70,14 @@ export class Table extends Component {
     }
     get orderCount() {
         const table = this.props.table;
-        const orderOnTable = this.env.pos
+        const orderOnTable = this.pos.globalState
             .getTableOrders(table.id)
-            .filter((o) => o.orderlines.length > 0 || o.paymentlines.length > 0).length;
+            .filter(
+                (o) => !o.finalized && (o.orderlines.length > 0 || o.paymentlines.length > 0)
+            ).length;
         return table.order_count && table.order_count > orderOnTable
             ? table.order_count
-            : this.pos.globalState
-                  .getTableOrders(table.id)
-                  .filter((o) => o.orderlines.length !== 0 || o.paymentlines.length !== 0).length;
+            : orderOnTable;
     }
     get orderCountClass() {
         const countClass = { "order-count": true };

--- a/addons/pos_restaurant/static/src/app/floor_screen/table.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/table.js
@@ -41,6 +41,13 @@ export class Table extends Component {
                 widthTable * Math.floor(index / nbrHorizontal) +
                 5 +
                 Math.floor(index / nbrHorizontal) * 10;
+            const widthTable = (window.innerWidth - nbrHorizontal * 10) / nbrHorizontal;
+            const position_h =
+                widthTable * (index % nbrHorizontal) + 5 + (index % nbrHorizontal) * 10;
+            const position_v =
+                widthTable * Math.floor(index / nbrHorizontal) +
+                5 +
+                Math.floor(index / nbrHorizontal) * 10;
             return `
                 width: ${widthTable}px;
                 height: ${widthTable}px;
@@ -70,7 +77,10 @@ export class Table extends Component {
     }
     get orderCount() {
         const table = this.props.table;
-        return table.order_count !== undefined
+        const orderOnTable = this.env.pos
+            .getTableOrders(table.id)
+            .filter((o) => o.orderlines.length > 0 || o.paymentlines.length > 0).length;
+        return table.order_count && table.order_count > orderOnTable
             ? table.order_count
             : this.pos.globalState
                   .getTableOrders(table.id)

--- a/addons/pos_restaurant/static/src/app/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/pos_store.js
@@ -41,7 +41,6 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
     // the websocket and dispatch them to the different utility functions.
     handleBusMessages(detail) {
         this._super(...arguments);
-        console.debug("socketMessage", detail);
         if (detail.type === "TABLE_ORDER_COUNT") {
             this.ws_syncTableCount(detail.payload);
         } else if (detail.type === "TABLE_CHANGED") {
@@ -97,9 +96,6 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
             // Is a table update
             for (const key in table) {
                 if (table[key] !== newTable[key]) {
-                    console.debug(
-                        `table ${table.id} changed ${key} from ${table[key]} to ${newTable[key]}`
-                    );
                     table[key] = newTable[key];
                 }
             }

--- a/addons/pos_restaurant/static/src/app/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/pos_store.js
@@ -42,16 +42,16 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
     handleBusMessages(detail) {
         this._super(...arguments);
         console.debug("socketMessage", detail);
-        if (detail.type === "table_order_count") {
+        if (detail.type === "TABLE_ORDER_COUNT") {
             this.ws_syncTableCount(detail.payload);
-        } else if (detail.type === "table_changed") {
+        } else if (detail.type === "TABLE_CHANGED") {
             this.ws_syncTableChanges(detail.payload);
-        } else if (detail.type === "disable_floor") {
+        } else if (detail.type === "DISABLE_FLOOR") {
             this.ws_disableFloor(detail.payload);
         }
     },
 
-    // Handles server bus messages of type `disable_floor`,
+    // Handles server bus messages of type `DISABLE_FLOOR`,
     // it will delete the floor and its tables.
     ws_disableFloor(data) {
         const floorId = data.id;

--- a/addons/pos_restaurant/static/src/js/models.js
+++ b/addons/pos_restaurant/static/src/js/models.js
@@ -137,10 +137,7 @@ patch(PosGlobalState.prototype, "pos_restaurant.PosGlobalState", {
         }
     },
     getTableById(tableId) {
-        return this.floors
-            .map((floor) => floor.tables)
-            .flat()
-            .find((table) => table.id === tableId);
+        return this.getTables().find((table) => table.id === tableId);
     },
     getTables() {
         return this.floors.map((floor) => floor.tables).flat();


### PR DESCRIPTION
### Commit 1:
Before a longpolling every 5 seconds was set up to sync the number of orders per table in the pos_restaurant, which was not very userfriendly / efficient.

Now, the longpolling has been replaced by a bus (websocket). As soon as an order is sent to the server by another PoS, the server dispatches the information to all other PoS using the corresponding floor plan.

The floorplan edition has also been improved and now goes through the websocket to synchronize all PoS (The rest is in the commit 2).

### Commit 2:

The bus_service was initialized in the `pos_store` of the `point_of_sale`, but is now used only in the `pos_restaurant` via override. This was done for obvious future use.

Modification of the components `floor_screen.js` and `edit_bar.js`, to use the classic ORM functions, create, write.

The code of `edit_bar.js` has been merged in `floor_screen.js` because we were passing to `edit_bar` a big amount of property coming from `floor_screen`, so it's easier to gather the code in order to avoid an intensive property passing.

The functions in `floor_screen.js` have been modified because before some of them were doing update, delete and create records to the server. The functions have been split in order to keep the logic clearer and better match the CRUD.

The function `updateTables` is now the only one that takes care of updating table objects and sending them to the server.