### PR TITLE
[FIX] odoo: Keep mimetype of a file

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -303,7 +303,7 @@ class IrAttachment(models.Model):
             elif values.get('datas'):
                 raw = base64.b64decode(values['datas'])
             if raw:
-                mimetype = guess_mimetype(raw)
+                mimetype = guess_mimetype(raw, default=self.mimetype) if self.mimetype else guess_mimetype(raw)
         return mimetype or 'application/octet-stream'
 
     def _postprocess_contents(self, values):


### PR DESCRIPTION
Steps to reproduce the issue:

Let's consider a scheduled actioni SA on Model M with the following Python Code:

att = env["ir.attachment"].create({"name": "test.txt", "raw": b"content"}) if att.mimetype != "text/plain":
  raise Warning('Error 1')
att.write({'raw': b"new_content"})
if att.mimetype != "text/plain":
  raise Warning('Error 2')

Running manually SA raised Error 2 because the mimetype of the attachment was updated into 'application/octet-stream' instead of keeping the mimetype 'text/plain'

opw:3277070