### PR TITLE
[IMP] project: sub-tasks/task convertion action

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -291,7 +291,20 @@
                         </button>
                         <button name="%(project_task_action_sub_task)d" type="action" class="oe_stat_button" icon="fa-tasks"
                             invisible="not id or subtask_count == 0" context="{'default_user_ids': user_ids, 'default_project_id': project_id, 'default_milestone_id': milestone_id}">
-                            <field name="subtask_count" widget="statinfo" string="Sub-tasks"/>
+                            <div class="o_field_widget o_stat_info">
+                                <div class="d-flex align-items-baseline gap-1">
+                                    <span class="o_stat_value order-1">
+                                        <field name="subtask_count" widget="statinfo" nolabel="1"/>
+                                    </span>
+                                    <span class="o_stat_text order-2">Sub-tasks</span>
+                                </div>
+                                <div class="d-flex align-items-baseline gap-1">
+                                    <span class="o_stat_value">
+                                        <field name="closed_subtask_count" widget="statinfo" nolabel="1"/>
+                                    </span>
+                                    <span class="o_stat_text order-2">Closed</span>
+                                </div>
+                            </div>
                         </button>
                         <button name="action_dependent_tasks" type="object" invisible="dependent_tasks_count == 0" class="oe_stat_button" icon="fa-tasks" groups="project.group_project_task_dependencies">
                             <field name="dependent_tasks_count" widget="statinfo" string="Blocking Tasks" />
@@ -502,6 +515,27 @@
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>
                         <field name="description" invisible="1"/>
                     </group>
+                </form>
+            </field>
+        </record>
+
+        <record id="project_task_convert_to_subtask_view_form" model="ir.ui.view">
+            <field name="name">project.task.convert.to.subtask.form</field>
+            <field name="model">project.task</field>
+            <field name="arch" type="xml">
+                <form>
+                    <div class="text-muted o_row mb-3">
+                        To transform a task into a sub-task, select a parent task. Alternatively, leave the parent task field blank to convert a sub-task into a standalone task.
+                    </div>
+                    <group>
+                        <field name="project_id" invisible="1" />
+                        <field name="company_id" invisible="1" />
+                        <field name="parent_id" domain="[('id', '!=', id)]" context="{'search_default_project_id': project_id, 'search_default_open_tasks': 1}" /> 
+                    </group>
+                    <footer>
+                        <button string="Convert Task" class="btn-primary" special="save" data-hotkey="q"/>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z" />
+                    </footer>
                 </form>
             </field>
         </record>
@@ -977,6 +1011,17 @@
             <field name="state">code</field>
             <field name="code">
                 model._ensure_personal_stages(); action = env["ir.actions.actions"]._for_xml_id("project.action_view_my_task")
+            </field>
+        </record>
+
+        <record id="action_server_convert_to_subtask" model="ir.actions.server">
+            <field name="name">Convert to Task/Sub-Task</field>
+            <field name="model_id" ref="project.model_project_task"/>
+            <field name="binding_model_id" ref="project.model_project_task"/>
+            <field name="binding_view_types">form</field>
+            <field name="state">code</field>
+            <field name="code">
+                action = record.action_convert_to_subtask()
             </field>
         </record>
 


### PR DESCRIPTION
Before this commit, the conversion from a subtask to a standalone task
or the opposite was possible in debug mode. In order to provide for
users a way to convert task to subtask or the opposite without polluting
the interface, a action is added. Also, when the user clicks on search
more on a many2one field pointing on `project.task`, if the active_model
and the active_id are defined then if we will try to load the last
update status by using `active_id` even if `active_model` is not the
`project.project` model.

This commit adds a action that opens a form dialog. The user
can choose to put a parent task or not. If not, the task becomes a
standalone task. Otherwise, the selected parent task becomes the parent.
This commit adds also an additional check before loading and displaying
the last update status of the project active to be sure the `active_id`
is the id of a project, that is, `active_model` has to be equal to
`project.project` to be able to load the last project update status.

Moreover, a UI change in the stat button showing the number of subtask
is modified in order to display also the number of closed sub tasks.

task-3251617
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
