### PR TITLE
[IMP] project: merge date_deadline and planned_date_end

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -14,7 +14,7 @@
                 <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100"/>
                 <field name="progress" widget="progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}"/>
             </xpath>
-            <xpath expr="//field[@name='date_deadline']" position="before">
+            <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="encode_uom_in_days" invisible="1"/>
                 <field name="subtask_count" invisible="1"/>
                 <label for="allocated_hours" invisible="not allow_timesheets"/>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -145,7 +145,7 @@ class Task(models.Model):
     date_end = fields.Datetime(string='Ending Date', index=True, copy=False)
     date_assign = fields.Datetime(string='Assigning Date', copy=False, readonly=True,
         help="Date on which this task was last assigned (or unassigned). Based on this, you can get statistics on the time it usually takes to assign tasks.")
-    date_deadline = fields.Date(string='Deadline', index=True, copy=False, tracking=True)
+    date_deadline = fields.Datetime(string='Deadline', index=True, copy=False, tracking=True)
 
     date_last_stage_update = fields.Datetime(string='Last Stage Update',
         index=True,

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -17,7 +17,7 @@ class ReportProjectTaskUser(models.Model):
     create_date = fields.Datetime("Create Date", readonly=True)
     date_assign = fields.Datetime(string='Assignment Date', readonly=True)
     date_end = fields.Datetime(string='Ending Date', readonly=True)
-    date_deadline = fields.Date(string='Deadline', readonly=True)
+    date_deadline = fields.Datetime(string='Deadline', readonly=True)
     date_last_stage_update = fields.Datetime(string='Last Stage Update', readonly=True)
     project_id = fields.Many2one('project.project', string='Project', readonly=True)
     working_days_close = fields.Float(string='Working Days to Close',

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -223,7 +223,7 @@
                                 <div class="col-12 col-md-6">
                                     <div t-if="project_accessible"><strong>Project:</strong> <a t-attf-href="/my/projects/#{task.project_id.id}" t-field="task.project_id"/></div>
                                     <div t-else=""><strong>Project:</strong> <a t-field="task.project_id"/></div>
-                                    <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "date"}'/></div>
+                                    <div t-if="task.date_deadline"><strong>Deadline:</strong> <span t-field="task.date_deadline" t-options='{"widget": "datetime"}'/></div>
                                     <div t-if="task.milestone_id and task.allow_milestones"><strong>Milestone:</strong> <span t-field="task.milestone_id"/></div>
                                     <div name="portal_my_task_allocated_hours">
                                     <strong t-if="task.allocated_hours > 0">Allocated Time:</strong>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -173,7 +173,7 @@
                             <field name="company_id" invisible="1" />
                             <field name="state" invisible="1" />
                             <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" invisible="not project_id"/>
-                            <field name="date_deadline" invisible="state in ['1_done', '1_canceled']"/>
+                            <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" decoration-danger="date_deadline &lt; current_date"/>
                         </group>
                     </group>
                     <notebook>
@@ -199,7 +199,7 @@
                                     <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide" invisible="not project_id"/>
                                     <field name="user_ids" column_invisible="True" />
                                     <field name="portal_user_names" string="Assignees" optional="show"/>
-                                    <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="show"/>
+                                    <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" decoration-danger="date_deadline &lt; current_date" optional="show"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                                     <field name="stage_id" optional="show"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link float-end"

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -351,7 +351,7 @@
                             <field name="partner_id" nolabel="0" widget="res_partner_many2one" class="o_task_customer_field" invisible="not project_id"/>
                             <label for="date_deadline"/>
                             <div id="date_deadline_and_recurring_task" class="d-inline-flex w-100">
-                                <field name="date_deadline" nolabel="1"/>
+                                <field name="date_deadline" nolabel="1" decoration-danger="date_deadline &lt; current_date and state not in ['1_done', '1_canceled']"/>
                                 <field name="recurring_task" nolabel="1" class="ms-0" style="width: fit-content;"
                                        widget="boolean_icon" options="{'icon': 'fa-repeat'}"
                                        invisible="not active or parent_id"

--- a/addons/project_todo/tests/test_mail_activity_todo_create.py
+++ b/addons/project_todo/tests/test_mail_activity_todo_create.py
@@ -26,4 +26,4 @@ class TestMailActivityTodo(TransactionCase):
         self.assertTrue(activity_1.exists(), 'An Activity should have been created')
         self.assertEqual(activity_1.summary, todo_1.name, 'The Todo and The Activity should have the same name/summary')
         self.assertEqual(activity_1.user_id, todo_1.user_ids, 'The Todo and The Activity should have the same user')
-        self.assertEqual(activity_1.date_deadline, todo_1.date_deadline, 'The Todo and The Activity should have the same date deadline')
+        self.assertEqual(activity_1.date_deadline, todo_1.date_deadline.date(), 'The Todo and The Activity should have the same date deadline')


### PR DESCRIPTION
**[IMP] project: merge date_deadline and planned_date_end**
**Before this commit:**
- The existing of two dates behaving as and end date for project_task
(date_deadline and planned_date_end) is confusing.

**In this commit:**
- The main goal is to simplify the interface by having one field/widget
that acts as both the deadline and the end date, instead of having two separate fields.
So we removed planned_date_end (changes can be seen in the enterprise related pr (link at
the end) and changed the date_deadline type from date to datetime in project_task and
report_project_task_user

Related PRs:
Enterprise: https://github.com/odoo/enterprise/pull/40866

task-3084978