### PR TITLE
[IMP] core: move json_default from tools/date_utils to tools/json

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -12,8 +12,8 @@ from psycopg2 import InterfaceError
 import odoo
 from odoo import api, fields, models
 from odoo.service.server import CommonServer
+from odoo.tools.json import json_default
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
-from odoo.tools import date_utils
 
 _logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ TIMEOUT = 50
 # Bus
 #----------------------------------------------------------
 def json_dump(v):
-    return json.dumps(v, separators=(',', ':'), default=date_utils.json_default)
+    return json.dumps(v, separators=(',', ':'), default=json_default)
 
 def hashable(key):
     if isinstance(key, list):

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -7,7 +7,7 @@ import logging
 
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
 from odoo.tests.common import TransactionCase, users, warmup, tagged
-from odoo.tools import mute_logger, json_default, sql
+from odoo.tools import mute_logger, sql
 from odoo import Command
 
 _logger = logging.getLogger(__name__)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -177,9 +177,10 @@ from .exceptions import UserError, AccessError, AccessDenied
 from .modules.module import get_manifest
 from .modules.registry import Registry
 from .service import security, model as service_model
-from .tools import (config, consteq, date_utils, file_path, parse_version,
+from .tools import (config, consteq, file_path, parse_version,
                     profiler, submap, unique, ustr,)
 from .tools.func import filter_kwargs, lazy_property
+from .tools.json import json_default
 from .tools.mimetypes import guess_mimetype
 from .tools.misc import pickle
 from .tools._vendor import sessions
@@ -1551,7 +1552,7 @@ class Request:
         :param collections.abc.Mapping cookies: cookies to set on the client
         :rtype: :class:`~odoo.http.Response`
         """
-        data = json.dumps(data, ensure_ascii=False, default=date_utils.json_default)
+        data = json.dumps(data, ensure_ascii=False, default=json_default)
 
         headers = werkzeug.datastructures.Headers(headers)
         headers['Content-Length'] = len(data)

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -5,8 +5,6 @@ from datetime import date, datetime, time
 import pytz
 from dateutil.relativedelta import relativedelta
 
-from .func import lazy
-from odoo.loglevels import ustr
 
 def get_month(date):
     ''' Compute the month dates range on which the 'date' parameter belongs to.
@@ -198,19 +196,6 @@ def subtract(value, *args, **kwargs):
     :return: the resulting date/datetime.
     """
     return value - relativedelta(*args, **kwargs)
-
-def json_default(obj):
-    """
-    Properly serializes date and datetime objects.
-    """
-    from odoo import fields
-    if isinstance(obj, datetime):
-        return fields.Datetime.to_string(obj)
-    if isinstance(obj, date):
-        return fields.Date.to_string(obj)
-    if isinstance(obj, lazy):
-        return obj._value
-    return ustr(obj)
 
 
 def date_range(start, end, step=relativedelta(months=1)):

--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -4,6 +4,13 @@ import re
 
 import markupsafe
 
+from datetime import date, datetime
+
+from odoo import fields
+from odoo.loglevels import ustr
+
+from .func import lazy
+
 JSON_SCRIPTSAFE_MAPPER = {
     '&': r'\u0026',
     '<': r'\u003c',
@@ -53,3 +60,15 @@ class JSON:
         """
         return _ScriptSafe(json_.dumps(*args, **kwargs))
 scriptsafe = JSON()
+
+def json_default(obj):
+    """
+    Properly serializes some odoo tools objects.
+    """
+    if isinstance(obj, datetime):
+        return fields.Datetime.to_string(obj)
+    if isinstance(obj, date):
+        return fields.Date.to_string(obj)
+    if isinstance(obj, lazy):
+        return obj._value
+    return ustr(obj)


### PR DESCRIPTION
Since odoo/odoo@1ecb0641efead9966faafb853c1e03138a49f111 `json_default` is no longer entirely related to dates anymore.

Besides, if you want to a new object to implement the JSON serialization for, which has nothing to do with dates, it's weird to have to add it in tools/date_utils.

I therefore suggest to move this in tools/json rather than tools/date_utils