### PR TITLE
[IMP] LLM content generation for website configurator

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -592,28 +592,27 @@ class Website(models.Model):
                 try:
                     IrQweb = self.env['ir.qweb'].with_context(website_id=website.id, lang=website.default_lang_id.code)
                     render = IrQweb._render('website.' + snippet, cta_data)
-                    if render:
-                        el = html.fromstring(render)
+                    el = html.fromstring(render)
 
-                        # Add the data-snippet attribute to identify the snippet
-                        # for compatibility code
-                        el.attrib['data-snippet'] = snippet
+                    # Add the data-snippet attribute to identify the snippet
+                    # for compatibility code
+                    el.attrib['data-snippet'] = snippet
 
-                        # Tweak the shape of the first snippet to connect it
-                        # properly with the header color in some themes
-                        if i == 1:
-                            shape_el = el.xpath("//*[hasclass('o_we_shape')]")
-                            if shape_el:
-                                shape_el[0].attrib['class'] += ' o_header_extra_shape_mapping'
+                    # Tweak the shape of the first snippet to connect it
+                    # properly with the header color in some themes
+                    if i == 1:
+                        shape_el = el.xpath("//*[hasclass('o_we_shape')]")
+                        if shape_el:
+                            shape_el[0].attrib['class'] += ' o_header_extra_shape_mapping'
 
-                        # Tweak the shape of the last snippet to connect it
-                        # properly with the footer color in some themes
-                        if i == nb_snippets:
-                            shape_el = el.xpath("//*[hasclass('o_we_shape')]")
-                            if shape_el:
-                                shape_el[0].attrib['class'] += ' o_footer_extra_shape_mapping'
-                        rendered_snippet = pycompat.to_text(etree.tostring(el))
-                        rendered_snippets.append(rendered_snippet)
+                    # Tweak the shape of the last snippet to connect it
+                    # properly with the footer color in some themes
+                    if i == nb_snippets:
+                        shape_el = el.xpath("//*[hasclass('o_we_shape')]")
+                        if shape_el:
+                            shape_el[0].attrib['class'] += ' o_footer_extra_shape_mapping'
+                    rendered_snippet = pycompat.to_text(etree.tostring(el))
+                    rendered_snippets.append(rendered_snippet)
                 except ValueError as e:
                     logger.warning(e)
             page_view_id.save(value=''.join(rendered_snippets), xpath="(//div[hasclass('oe_structure')])[last()]")

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -362,6 +362,7 @@ class ApplyConfiguratorScreen extends Component {
             const data = {
                 'selected_features': selectedFeatures,
                 'industry_id': this.state.selectedIndustry.id,
+                'industry_name': this.state.selectedIndustry.label,
                 'selected_palette': selectedPalette,
                 'theme_name': themeName,
                 'website_purpose': WEBSITE_PURPOSES[

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -39,6 +39,8 @@ class TestConfiguratorCommon(odoo.tests.HttpCase):
                 return []
             elif '/api/website/2/configurator/custom_resources/' in endpoint:
                 return {'images': {}}
+            elif '/api/olg/1/generate_placeholder' in endpoint:
+                return {"a non existing placeholder": "😠", 'Catchy Headline': 'Welcome to XXXX - Your Super test'}
 
         iap_patch = patch('odoo.addons.iap.tools.iap_tools.iap_jsonrpc', iap_jsonrpc_mocked_configurator)
         self.startPatcher(iap_patch)


### PR DESCRIPTION
When building a website with the website configurator, you get pages
with nice layout.
However, the text inside is not adapted to your company, industry or
even language.

Using a LLM, we could easily get text much more relevant to customer
need.

The scope of this task should be static page generated with website
configurator (homepage, about us, pricing, ...).
Later, in other tasks, we want also user to be able to generate text
inside the website builder (similar to Wix AI text wizard)

This commit implement the bare minimum to generate and replace website
content by AI generated sentences based of the information provided by
the user in the configurator
Please find the PR of the IAP part here :
https://github.com/odoo/iap-apps/pull/656

task-3248852