### PR TITLE
[FIX] tools,hr_attendance,product,stock: prevent illegal barcode in code128 type

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -5,7 +5,7 @@ import pytz
 from dateutil.relativedelta import relativedelta
 
 from odoo import models, fields, api, exceptions, _
-from odoo.tools import float_round
+from odoo.tools import float_round, check_barcode_is_code128
 
 
 class HrEmployee(models.Model):
@@ -38,6 +38,14 @@ class HrEmployee(models.Model):
     total_overtime = fields.Float(
         compute='_compute_total_overtime', compute_sudo=True,
         groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance,hr.group_hr_user")
+
+    @api.constrains('barcode')
+    def _check_barcode_value(self):
+        for record in self:
+            unsupported_chars = check_barcode_is_code128(record.barcode)
+            if unsupported_chars:
+                raise exceptions.ValidationError(_("Invalid Barcode Format, following characters are not supported: %s",
+                    " ".join(unsupported_chars)))
 
     @api.depends('overtime_ids.duration', 'attendance_ids')
     def _compute_total_overtime(self):

--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -6,7 +6,7 @@ from odoo.exceptions import ValidationError
 from odoo.osv import expression
 
 
-from odoo.tools import float_compare, float_round
+from odoo.tools import float_compare, float_round, check_barcode_is_code128
 
 
 class ProductPackaging(models.Model):
@@ -27,6 +27,14 @@ class ProductPackaging(models.Model):
         ('positive_qty', 'CHECK(qty > 0)', 'Contained Quantity should be positive.'),
         ('barcode_uniq', 'unique(barcode)', 'A barcode can only be assigned to one packaging.'),
     ]
+
+    @api.constrains('barcode')
+    def _check_barcode_value(self):
+        for record in self:
+            unsupported_chars = check_barcode_is_code128(record.barcode)
+            if unsupported_chars:
+                raise ValidationError(_("Invalid Barcode Format, following characters are not supported: %s",
+                    " ".join(unsupported_chars)))
 
     @api.constrains('barcode')
     def _check_barcode_uniqueness(self):

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
-from odoo.tools import float_compare
+from odoo.tools import float_compare, check_barcode_is_code128
 from odoo.tools.misc import unique
 
 
@@ -88,6 +88,14 @@ class ProductProduct(models.Model):
     image_128 = fields.Image("Image 128", compute='_compute_image_128')
     can_image_1024_be_zoomed = fields.Boolean("Can Image 1024 be zoomed", compute='_compute_can_image_1024_be_zoomed')
     write_date = fields.Datetime(compute='_compute_write_date', store=True)
+
+    @api.constrains('barcode')
+    def _check_barcode_value(self):
+        for record in self:
+            unsupported_chars = check_barcode_is_code128(record.barcode)
+            if unsupported_chars:
+                raise ValidationError(_("Invalid Barcode Format, following characters are not supported: %s",
+                    " ".join(unsupported_chars)))
 
     @api.depends('image_variant_1920', 'image_variant_1024')
     def _compute_can_image_variant_1024_be_zoomed(self):

--- a/odoo/tools/barcode.py
+++ b/odoo/tools/barcode.py
@@ -52,3 +52,8 @@ def check_barcode_encoding(barcode, encoding):
            and len(barcode) == barcode_size \
            and re.match(r"^\d+$", barcode) \
            and get_barcode_check_digit(barcode) == int(barcode[-1])
+
+def check_barcode_is_code128(barcode):
+    if barcode:
+        unsupported_chars = re.findall("[^\x00-\x7F\xF1-\xF4]", barcode)
+        return unsupported_chars


### PR DESCRIPTION
When user enters an illegal barcode(for example: 'Rangée A') in 'stock.location' and tries to print the 'Location Barcode' report the error occurs.

see this traceback:
```
ValueError: Illegal barcode with value 'Rangée A' in code 'Code128'
  File "odoo/addons/base/models/ir_actions_report.py", line 565, in barcode
    barcode = createBarcodeDrawing(barcode_type, value=value, format='png', **kwargs)
  File "reportlab/graphics/barcode/__init__.py", line 116, in createBarcodeDrawing
    raise ValueError("Illegal barcode with value '%s' in code '%s'" % (options.get('value',None), codeName))
ValueError: Cannot convert into barcode.
  File "<1489>", line 231, in template_1489
  File "<1489>", line 213, in template_1489_content
  File "<1489>", line 170, in template_1489_t_call_0
  File "odoo/addons/base/models/ir_qweb.py", line 2376, in _get_field
    content = converter.record_to_html(record, field_name, field_options)
  File "odoo/addons/base/models/ir_qweb_fields.py", line 129, in record_to_html
    return False if value is False else self.value_to_html(value, options=options)
  File "odoo/addons/base/models/ir_qweb_fields.py", line 712, in value_to_html
    barcode = self.env['ir.actions.report'].barcode(
  File "odoo/addons/base/models/ir_actions_report.py", line 578, in barcode
    raise ValueError("Cannot convert into barcode.")
QWebException: Error while render the template
ValueError: Cannot convert into barcode.
Template: stock.report_generic_barcode
Path: /t/t/div/table/t/tr/t/td/div[2]
Node: <div t-if="o.barcode" t-field="o.barcode" t-options="{\'widget\': \'barcode\', \'humanreadable\': 1, \'width\': 400, \'height\': 100}"/>
  File "addons/web/controllers/report.py", line 113, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "addons/account/models/ir_actions_report.py", line 57, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "odoo/addons/base/models/ir_actions_report.py", line 801, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "odoo/addons/base/models/ir_actions_report.py", line 702, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
  File "odoo/addons/base/models/ir_actions_report.py", line 878, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "odoo/addons/base/models/ir_actions_report.py", line 617, in _render_template
    return view_obj._render_template(template, values).encode()
  File "odoo/addons/base/models/ir_ui_view.py", line 2164, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 580, in _render
    result = ''.join(rendering)
  File "<1490>", line 54, in template_1490
  File "<1490>", line 43, in template_1490_content
  File "<1489>", line 237, in template_1489
```

steps to reproduce:
    1. Turn on the developer's mode.
    2. Install Barcode module if not installed.
    3. Open Inventory module and click on products menu.
    4. Open a product and go to Inventory page in its form view.
    5. Click on 'Virtual Locations/Production' and a form view will appear.
    6. Edit the barcode field and set barcode as 'Rangée A'.
    7. Then print 'Location Barcode' report error will occur.

code128 type consists of characters with ASCII values in the range of 0 to 127 or in the range of 241 to 244 (which are specific characters used in Code 128 barcodes). 'é' does not comes under code128 type due to which error occurs.

Applying this commit will fix this issue. The same issue is occurring from different models which will be fixed in this PR.

sentry-4156923870
sentry-4285569180

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
