### PR TITLE
[FIX] web, web_editor: preset border colors are black after clicking

### DIFF
--- a/addons/web/static/src/scss/bs_mixins_overrides.scss
+++ b/addons/web/static/src/scss/bs_mixins_overrides.scss
@@ -44,6 +44,12 @@ $o-color-extras-nesting-selector: '&' !default;
     }
 }
 
+@mixin o-border-color($color, $important: true) {
+    @if ($color) {
+        border-color: $color#{if($important, ' !important', '')};
+    }
+}
+
 // Override background utilities so that they come with a default contrasted
 // color (especially useful in the frontend editor for example). Also modifies
 // the way .text-muted elements are rendered in those environments.
@@ -56,6 +62,11 @@ $o-color-extras-nesting-selector: '&' !default;
         &:hover, &:focus {
             @include o-bg-color(darken($color, 10%), $text-color, false);
         }
+    }
+}
+@mixin border-variant($parent, $color) {
+    #{$parent} {
+        @include o-border-color($color);
     }
 }
 @mixin bg-gradient-variant($parent, $color, $text-color: null) {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -645,6 +645,7 @@ blockquote {
     $-color-name: 'o-color-#{$index}';
     $-color: map-get($colors, $-color-name);
     @include bg-variant(".bg-#{$-color-name}", $-color);
+    @include border-variant(".border-#{$-color-name}", $-color);
     @include text-emphasis-variant(".text-#{$-color-name}", $-color);
 }
 


### PR DESCRIPTION
Reproduction:
1. Go to Email Marketing, create a new empty email template
2. Drag a block with pictures, click the picture and set the border to 10 px
3. Click the picture again, it’s possible to change the color of the borders
4. Set the color as one of the first five preset colors, it always turns to black

Reason: the class border-o-color doesn’t exist so it is always set as black

Fix: add scss code to generate the class with prefix border

task-3223449


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
