### PR TITLE
[IMP] core: refactor loading.py

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_expression
 from . import test_float
 from . import test_format_address_mixin
 from . import test_func
+from . import test_graph
 from . import test_http_case
 from . import test_image
 from . import test_avatar_mixin

--- a/odoo/addons/base/tests/graph_legacy.py
+++ b/odoo/addons/base/tests/graph_legacy.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+""" Modules dependency graph. """
+
+import itertools
+# import logging
+
+import odoo
+import odoo.tools as tools
+
+# _logger = logging.getLogger(__name__)
+
+class Graph(dict):
+    """ Modules dependency graph.
+
+    The graph is a mapping from module name to Nodes.
+
+    """
+
+    def add_node(self, name, info):
+        max_depth, father = 0, None
+        for d in info['depends']:
+            n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
+            if n.depth >= max_depth:
+                father = n
+                max_depth = n.depth
+        if father:
+            return father.add_child(name, info)
+        else:
+            return Node(name, self, info)
+
+    def update_from_db(self, cr):
+        if not len(self):
+            return
+        # update the graph with values from the database (if exist)
+        ## First, we set the default values for each package in graph
+        additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in
+                           self.keys()}
+        ## Then we get the values from the database
+        cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
+                   '  FROM ir_module_module'
+                   ' WHERE name IN %s', (tuple(additional_data),)
+                   )
+
+        ## and we update the default values with values from the database
+        additional_data.update((x['name'], x) for x in cr.dictfetchall())
+
+        for package in self.values():
+            for k, v in additional_data[package.name].items():
+                setattr(package, k, v)
+
+    def add_module(self, cr, module, force=None):
+        self.add_modules(cr, [module], force)
+
+    def add_modules(self, cr, module_list, force=None):
+        if force is None:
+            force = []
+        packages = []
+        len_graph = len(self)
+        for module in module_list:
+            info = odoo.modules.module.get_manifest(module)
+            if info and info['installable']:
+                packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
+            # elif module != 'studio_customization':
+            #     _logger.warning('module %s: not installable, skipped', module)
+
+        dependencies = dict([(p, info['depends']) for p, info in packages])
+        current, later = set([p for p, info in packages]), set()
+
+        while packages and current > later:
+            package, info = packages[0]
+            deps = info['depends']
+
+            # if all dependencies of 'package' are already in the graph, add 'package' in the graph
+            if all(dep in self for dep in deps):
+                if not package in current:
+                    packages.pop(0)
+                    continue
+                later.clear()
+                current.remove(package)
+                node = self.add_node(package, info)
+                # for kind in ('init', 'demo', 'update'):
+                #     if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
+                #         setattr(node, kind, True)
+            else:
+                later.add(package)
+                packages.append((package, info))
+            packages.pop(0)
+
+        self.update_from_db(cr)
+
+        for package in later:
+            unmet_deps = [p for p in dependencies[package] if p not in self]
+            # _logger.info('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
+
+        return len(self) - len_graph
+
+
+    def __iter__(self):
+        level = 0
+        done = set(self.keys())
+        while done:
+            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
+            for name, module in level_modules:
+                done.remove(name)
+                yield module
+            level += 1
+
+    def __str__(self):
+        return '\n'.join(str(n) for n in self if n.depth == 0)
+
+class Node(object):
+    """ One module in the modules dependency graph.
+
+    Node acts as a per-module singleton. A node is constructed via
+    Graph.add_module() or Graph.add_modules(). Some of its fields are from
+    ir_module_module (set by Graph.update_from_db()).
+
+    """
+    def __new__(cls, name, graph, info):
+        if name in graph:
+            inst = graph[name]
+        else:
+            inst = object.__new__(cls)
+            graph[name] = inst
+        return inst
+
+    def __init__(self, name, graph, info):
+        self.name = name
+        self.graph = graph
+        self.info = info or getattr(self, 'info', {})
+        if not hasattr(self, 'children'):
+            self.children = []
+        if not hasattr(self, 'depth'):
+            self.depth = 0
+
+    @property
+    def data(self):
+        return self.info
+
+    def add_child(self, name, info):
+        node = Node(name, self.graph, info)
+        node.depth = self.depth + 1
+        if node not in self.children:
+            self.children.append(node)
+        for attr in ('init', 'update', 'demo'):
+            if hasattr(self, attr):
+                setattr(node, attr, True)
+        self.children.sort(key=lambda x: x.name)
+        return node
+
+    def __setattr__(self, name, value):
+        super(Node, self).__setattr__(name, value)
+        if name in ('init', 'update', 'demo'):
+            tools.config[name][self.name] = 1
+            for child in self.children:
+                setattr(child, name, value)
+        if name == 'depth':
+            for child in self.children:
+                setattr(child, name, value + 1)
+
+    def __iter__(self):
+        return itertools.chain(
+            self.children,
+            itertools.chain.from_iterable(self.children)
+        )
+
+    def __str__(self):
+        return self._pprint()
+
+    def _pprint(self, depth=0):
+        s = '%s\n' % self.name
+        for c in self.children:
+            s += '%s`-> %s' % ('   ' * depth, c._pprint(depth+1))
+        return s
+
+    def should_have_demo(self):
+        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
+
+    @property
+    def parents(self):
+        if self.depth == 0:
+            return []
+
+        return (
+            node for node in self.graph.values()
+            if node.depth < self.depth
+            if self in node.children
+        )

--- a/odoo/addons/base/tests/test_graph.py
+++ b/odoo/addons/base/tests/test_graph.py
@@ -8,8 +8,10 @@ from typing import Iterable, List, Dict
 
 from odoo.tests.common import BaseCase, TransactionCase
 from odoo.modules.graph import PackageGraph
-from odoo.modules.module import _DEFAULT_MANIFEST
+from odoo.modules.module import _DEFAULT_MANIFEST, get_manifest
 from odoo.tools import mute_logger
+
+from .graph_legacy import Graph as GraphLegacy
 
 _logger = logging.getLogger(__name__)
 
@@ -36,6 +38,7 @@ class TestGraph(BaseCase):
             for name, depends in dependency.items()
         }
         with patch('odoo.modules.graph.PackageGraph._update_from_database'), \
+                patch(__package__ + '.graph_legacy.Graph.update_from_db'), \
                 patch('odoo.modules.module.get_manifest', lambda name: manifests.get(name, {})):
             graph = PackageGraph(None)
             graph_legacy = GraphLegacy()
@@ -118,223 +121,30 @@ class TestGraph(BaseCase):
         )
 
 
-# test doesn't work because the order depends on the state which should not be 'uninstalled'
-# class TestGraphAll(TransactionCase):
-#     @mute_logger('odoo.modules.graph')
-#     def test_graph_order_all(self):
-#         self.env['ir.module.module'].update_list()
-#         modules = self.env['ir.module.module'].search([]).mapped('name')
-#         for module in modules:  # cache manifest for fair performance comparison
-#             odoo.modules.module.get_manifest(module)
-#
-#         graph = PackageGraph(self.cr)
-#         graph_legacy = GraphLegacy()
-#
-#         time0 = time.time()
-#         graph.add(modules)
-#         names = list(p.name for p in graph)
-#         time1 = time.time()
-#
-#         time0_legacy = time.time()
-#         graph_legacy.add_modules(self.cr, modules)
-#         names_legacy = list(g.name for g in graph_legacy)
-#         time1_legacy = time.time()
-#
-#         self.assertListEqual(names, names_legacy)
-#         _logger.info('\nCurrent Graph order time: %s\nLegacy Graph order time: %s', time1 - time0, time1_legacy - time0_legacy)
+class TestGraphAll(TransactionCase):
+    @mute_logger('odoo.modules.graph')
+    def test_graph_order_all(self):
+        self.env['ir.module.module'].update_list()
+        modules = self.env['ir.module.module'].search([])
+        module_names = modules.mapped('name')
+        for module_name in module_names:  # cache manifest for fair performance comparison
+            get_manifest(module_name)
 
+        modules.filtered(lambda m: m.state != 'uninstallable').state = 'installed'
+        modules.flush_model()
 
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+        graph = PackageGraph(self.cr)
+        graph_legacy = GraphLegacy()
 
-""" Modules dependency graph. """
+        time0 = time.time()
+        graph.add(module_names)
+        names = list(p.name for p in graph)
+        time1 = time.time()
 
-import itertools
-# import logging
+        time0_legacy = time.time()
+        graph_legacy.add_modules(self.cr, module_names)
+        names_legacy = list(g.name for g in graph_legacy)
+        time1_legacy = time.time()
 
-import odoo
-import odoo.tools as tools
-
-# _logger = logging.getLogger(__name__)
-
-class GraphLegacy(dict):
-    """ Modules dependency graph.
-
-    The graph is a mapping from module name to Nodes.
-
-    """
-
-    def add_node(self, name, info):
-        max_depth, father = 0, None
-        for d in info['depends']:
-            n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
-            if n.depth >= max_depth:
-                father = n
-                max_depth = n.depth
-        if father:
-            return father.add_child(name, info)
-        else:
-            return Node(name, self, info)
-
-    def update_from_db(self, cr):
-        return
-        # if not len(self):
-        #     return
-        # # update the graph with values from the database (if exist)
-        # ## First, we set the default values for each package in graph
-        # additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in
-        #                    self.keys()}
-        # ## Then we get the values from the database
-        # cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
-        #            '  FROM ir_module_module'
-        #            ' WHERE name IN %s', (tuple(additional_data),)
-        #            )
-        #
-        # ## and we update the default values with values from the database
-        # additional_data.update((x['name'], x) for x in cr.dictfetchall())
-        #
-        # for package in self.values():
-        #     for k, v in additional_data[package.name].items():
-        #         setattr(package, k, v)
-
-    def add_module(self, cr, module, force=None):
-        self.add_modules(cr, [module], force)
-
-    def add_modules(self, cr, module_list, force=None):
-        if force is None:
-            force = []
-        packages = []
-        len_graph = len(self)
-        for module in module_list:
-            info = odoo.modules.module.get_manifest(module)
-            if info and info['installable']:
-                packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
-            # elif module != 'studio_customization':
-            #     _logger.warning('module %s: not installable, skipped', module)
-
-        dependencies = dict([(p, info['depends']) for p, info in packages])
-        current, later = set([p for p, info in packages]), set()
-
-        while packages and current > later:
-            package, info = packages[0]
-            deps = info['depends']
-
-            # if all dependencies of 'package' are already in the graph, add 'package' in the graph
-            if all(dep in self for dep in deps):
-                if not package in current:
-                    packages.pop(0)
-                    continue
-                later.clear()
-                current.remove(package)
-                node = self.add_node(package, info)
-                # for kind in ('init', 'demo', 'update'):
-                #     if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
-                #         setattr(node, kind, True)
-            else:
-                later.add(package)
-                packages.append((package, info))
-            packages.pop(0)
-
-        self.update_from_db(cr)
-
-        for package in later:
-            unmet_deps = [p for p in dependencies[package] if p not in self]
-            # _logger.info('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
-
-        return len(self) - len_graph
-
-
-    def __iter__(self):
-        level = 0
-        done = set(self.keys())
-        while done:
-            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
-            for name, module in level_modules:
-                done.remove(name)
-                yield module
-            level += 1
-
-    def __str__(self):
-        return '\n'.join(str(n) for n in self if n.depth == 0)
-
-class Node(object):
-    """ One module in the modules dependency graph.
-
-    Node acts as a per-module singleton. A node is constructed via
-    Graph.add_module() or Graph.add_modules(). Some of its fields are from
-    ir_module_module (set by Graph.update_from_db()).
-
-    """
-    def __new__(cls, name, graph, info):
-        if name in graph:
-            inst = graph[name]
-        else:
-            inst = object.__new__(cls)
-            graph[name] = inst
-        return inst
-
-    def __init__(self, name, graph, info):
-        self.name = name
-        self.graph = graph
-        self.info = info or getattr(self, 'info', {})
-        if not hasattr(self, 'children'):
-            self.children = []
-        if not hasattr(self, 'depth'):
-            self.depth = 0
-
-    @property
-    def data(self):
-        return self.info
-
-    def add_child(self, name, info):
-        node = Node(name, self.graph, info)
-        node.depth = self.depth + 1
-        if node not in self.children:
-            self.children.append(node)
-        for attr in ('init', 'update', 'demo'):
-            if hasattr(self, attr):
-                setattr(node, attr, True)
-        self.children.sort(key=lambda x: x.name)
-        return node
-
-    def __setattr__(self, name, value):
-        super(Node, self).__setattr__(name, value)
-        if name in ('init', 'update', 'demo'):
-            tools.config[name][self.name] = 1
-            for child in self.children:
-                setattr(child, name, value)
-        if name == 'depth':
-            for child in self.children:
-                setattr(child, name, value + 1)
-
-    def __iter__(self):
-        return itertools.chain(
-            self.children,
-            itertools.chain.from_iterable(self.children)
-        )
-
-    def __str__(self):
-        return self._pprint()
-
-    def _pprint(self, depth=0):
-        s = '%s\n' % self.name
-        for c in self.children:
-            s += '%s`-> %s' % ('   ' * depth, c._pprint(depth+1))
-        return s
-
-    def should_have_demo(self):
-        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
-
-    @property
-    def parents(self):
-        if self.depth == 0:
-            return []
-
-        return (
-            node for node in self.graph.values()
-            if node.depth < self.depth
-            if self in node.children
-        )
-
-
-
+        self.assertListEqual(names, names_legacy)
+        _logger.info('\nCurrent Graph order time: %s\nLegacy Graph order time: %s', time1 - time0, time1_legacy - time0_legacy)

--- a/odoo/addons/base/tests/test_graph.py
+++ b/odoo/addons/base/tests/test_graph.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import time
+import logging
+from unittest.mock import patch
+from typing import Iterable, List, Dict
+
+from odoo.tests.common import BaseCase, TransactionCase
+from odoo.modules.graph import PackageGraph
+from odoo.modules.module import _DEFAULT_MANIFEST
+from odoo.tools import mute_logger
+
+_logger = logging.getLogger(__name__)
+
+class TestGraph(BaseCase):
+    @mute_logger('odoo.modules.graph')
+    def _test_graph_order(
+            self,
+            dependency: Dict[str, List[str]],
+            modules_list: Iterable[Iterable[str]],
+            expected: List[str]
+    ) -> None:
+        """
+        Test the order of the modules that need to be loaded
+
+        :param dependency: A dictionary of module dependency: {module_a: [module_b, module_c]}
+        :param modules_list: [['module_a', 'module_b'], ['module_c'], ...]
+            module_a and module_b will be added in the first round
+            module_c will be added in the second round
+            ...
+        :param expected: expected graph order
+        """
+        manifests = {
+            name: {**_DEFAULT_MANIFEST.copy(), **{'depends': depends}}
+            for name, depends in dependency.items()
+        }
+        with patch('odoo.modules.graph.PackageGraph._update_from_database'), \
+                patch('odoo.modules.module.get_manifest', lambda name: manifests.get(name, {})):
+            graph = PackageGraph(None)
+            graph_legacy = GraphLegacy()
+
+            for modules in modules_list:
+                graph.add(modules)
+                graph_legacy.add_modules(None, modules)
+
+            names = list(p.name for p in graph)
+            names_legacy = list(p.name for p in graph_legacy)
+
+            self.assertListEqual(names, expected)
+            self.assertListEqual(names_legacy, expected)
+
+    def test_graph_order_1(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'module2': ['module1'],
+            'module3': ['module1'],
+            'module4': ['module2', 'module3'],
+            'module5': ['module2', 'module4'],
+        }
+        # modules are in random order
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+        # module 5's depends is missing
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module1', 'module2', 'module3', 'module5']],
+            ['base', 'module1', 'module2', 'module3']
+        )
+        # module 6's manifest is missing
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module1', 'module2', 'module3', 'module4', 'module5', 'module6']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+        # three adding rounds
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module1', 'module2', 'module3'], ['module4', 'module5']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+
+    def test_graph_order_2(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'module2': ['module1'],
+            'module3': ['module1'],
+            'module4': ['module3'],
+            'module5': ['module2'],
+        }
+        # module4 and module5 have the same depth but don't have shared depends
+        # they should be ordered by name
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
+            ['base', 'module1', 'module2', 'module3', 'module4', 'module5']
+        )
+
+    def test_graph_order_3(self):
+        dependency = {
+            'base': [],
+            'module1': ['base'],
+            'module2': ['module1'],
+            # depends loop
+            'module3': ['module1', 'module5'],
+            'module4': ['module2', 'module3'],
+            'module5': ['module2', 'module4'],
+        }
+        self._test_graph_order(
+            dependency,
+            [['base'], ['module3', 'module4', 'module1', 'module5', 'module2']],
+            ['base', 'module1', 'module2']
+        )
+
+
+# test doesn't work because the order depends on the state which should not be 'uninstalled'
+# class TestGraphAll(TransactionCase):
+#     @mute_logger('odoo.modules.graph')
+#     def test_graph_order_all(self):
+#         self.env['ir.module.module'].update_list()
+#         modules = self.env['ir.module.module'].search([]).mapped('name')
+#         for module in modules:  # cache manifest for fair performance comparison
+#             odoo.modules.module.get_manifest(module)
+#
+#         graph = PackageGraph(self.cr)
+#         graph_legacy = GraphLegacy()
+#
+#         time0 = time.time()
+#         graph.add(modules)
+#         names = list(p.name for p in graph)
+#         time1 = time.time()
+#
+#         time0_legacy = time.time()
+#         graph_legacy.add_modules(self.cr, modules)
+#         names_legacy = list(g.name for g in graph_legacy)
+#         time1_legacy = time.time()
+#
+#         self.assertListEqual(names, names_legacy)
+#         _logger.info('\nCurrent Graph order time: %s\nLegacy Graph order time: %s', time1 - time0, time1_legacy - time0_legacy)
+
+
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+""" Modules dependency graph. """
+
+import itertools
+# import logging
+
+import odoo
+import odoo.tools as tools
+
+# _logger = logging.getLogger(__name__)
+
+class GraphLegacy(dict):
+    """ Modules dependency graph.
+
+    The graph is a mapping from module name to Nodes.
+
+    """
+
+    def add_node(self, name, info):
+        max_depth, father = 0, None
+        for d in info['depends']:
+            n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
+            if n.depth >= max_depth:
+                father = n
+                max_depth = n.depth
+        if father:
+            return father.add_child(name, info)
+        else:
+            return Node(name, self, info)
+
+    def update_from_db(self, cr):
+        return
+        # if not len(self):
+        #     return
+        # # update the graph with values from the database (if exist)
+        # ## First, we set the default values for each package in graph
+        # additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in
+        #                    self.keys()}
+        # ## Then we get the values from the database
+        # cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
+        #            '  FROM ir_module_module'
+        #            ' WHERE name IN %s', (tuple(additional_data),)
+        #            )
+        #
+        # ## and we update the default values with values from the database
+        # additional_data.update((x['name'], x) for x in cr.dictfetchall())
+        #
+        # for package in self.values():
+        #     for k, v in additional_data[package.name].items():
+        #         setattr(package, k, v)
+
+    def add_module(self, cr, module, force=None):
+        self.add_modules(cr, [module], force)
+
+    def add_modules(self, cr, module_list, force=None):
+        if force is None:
+            force = []
+        packages = []
+        len_graph = len(self)
+        for module in module_list:
+            info = odoo.modules.module.get_manifest(module)
+            if info and info['installable']:
+                packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
+            # elif module != 'studio_customization':
+            #     _logger.warning('module %s: not installable, skipped', module)
+
+        dependencies = dict([(p, info['depends']) for p, info in packages])
+        current, later = set([p for p, info in packages]), set()
+
+        while packages and current > later:
+            package, info = packages[0]
+            deps = info['depends']
+
+            # if all dependencies of 'package' are already in the graph, add 'package' in the graph
+            if all(dep in self for dep in deps):
+                if not package in current:
+                    packages.pop(0)
+                    continue
+                later.clear()
+                current.remove(package)
+                node = self.add_node(package, info)
+                # for kind in ('init', 'demo', 'update'):
+                #     if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
+                #         setattr(node, kind, True)
+            else:
+                later.add(package)
+                packages.append((package, info))
+            packages.pop(0)
+
+        self.update_from_db(cr)
+
+        for package in later:
+            unmet_deps = [p for p in dependencies[package] if p not in self]
+            # _logger.info('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
+
+        return len(self) - len_graph
+
+
+    def __iter__(self):
+        level = 0
+        done = set(self.keys())
+        while done:
+            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
+            for name, module in level_modules:
+                done.remove(name)
+                yield module
+            level += 1
+
+    def __str__(self):
+        return '\n'.join(str(n) for n in self if n.depth == 0)
+
+class Node(object):
+    """ One module in the modules dependency graph.
+
+    Node acts as a per-module singleton. A node is constructed via
+    Graph.add_module() or Graph.add_modules(). Some of its fields are from
+    ir_module_module (set by Graph.update_from_db()).
+
+    """
+    def __new__(cls, name, graph, info):
+        if name in graph:
+            inst = graph[name]
+        else:
+            inst = object.__new__(cls)
+            graph[name] = inst
+        return inst
+
+    def __init__(self, name, graph, info):
+        self.name = name
+        self.graph = graph
+        self.info = info or getattr(self, 'info', {})
+        if not hasattr(self, 'children'):
+            self.children = []
+        if not hasattr(self, 'depth'):
+            self.depth = 0
+
+    @property
+    def data(self):
+        return self.info
+
+    def add_child(self, name, info):
+        node = Node(name, self.graph, info)
+        node.depth = self.depth + 1
+        if node not in self.children:
+            self.children.append(node)
+        for attr in ('init', 'update', 'demo'):
+            if hasattr(self, attr):
+                setattr(node, attr, True)
+        self.children.sort(key=lambda x: x.name)
+        return node
+
+    def __setattr__(self, name, value):
+        super(Node, self).__setattr__(name, value)
+        if name in ('init', 'update', 'demo'):
+            tools.config[name][self.name] = 1
+            for child in self.children:
+                setattr(child, name, value)
+        if name == 'depth':
+            for child in self.children:
+                setattr(child, name, value + 1)
+
+    def __iter__(self):
+        return itertools.chain(
+            self.children,
+            itertools.chain.from_iterable(self.children)
+        )
+
+    def __str__(self):
+        return self._pprint()
+
+    def _pprint(self, depth=0):
+        s = '%s\n' % self.name
+        for c in self.children:
+            s += '%s`-> %s' % ('   ' * depth, c._pprint(depth+1))
+        return s
+
+    def should_have_demo(self):
+        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
+
+    @property
+    def parents(self):
+        if self.depth == 0:
+            return []
+
+        return (
+            node for node in self.graph.values()
+            if node.depth < self.depth
+            if self in node.children
+        )
+
+
+

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -45,7 +45,7 @@ class TestModuleManifest(BaseCase):
             'data': [],
             'demo': [],
             'demo_xml': [],
-            'depends': [],
+            'depends': ['base'],
             'description': '',
             'external_dependencies': {},
             'icon': '/base/static/description/icon.png',

--- a/odoo/addons/test_loading/__init__.py
+++ b/odoo/addons/test_loading/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+

--- a/odoo/addons/test_loading/__manifest__.py
+++ b/odoo/addons/test_loading/__manifest__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'test-loading-1',
+    'version': '0.1',
+    'category': 'Hidden/Tests',
+    'description': """A module to test the registry loading/upgrading/installing feature.""",
+    'depends': ['base'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_loading/tests/__init__.py
+++ b/odoo/addons/test_loading/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_loading_standalone

--- a/odoo/addons/test_loading/tests/test_loading_standalone.py
+++ b/odoo/addons/test_loading/tests/test_loading_standalone.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.modules.registry import Registry
+from odoo.modules import get_manifest
+from odoo.tools import make_index_name, table_exists
+from odoo.tests import standalone
+
+# +----------------+
+# |      base      |
+# +----------------+
+#   ^
+#   |
+#   |
+# +----------------+
+# |  test_loading  |
+# +----------------+
+#   ^
+#   |
+#   |
+# +----------------+
+# | test_loading_1 | <-----+
+# +----------------+       |
+#   ^                      |
+#   |                      |
+#   |                      |
+# +----------------+     +----------------+
+# | test_loading_2 |     | test_loading_3 |
+# +----------------+     +----------------+
+#
+
+def _check_database_registry_consistency(env, model_name):
+    """ check the consistency between the database and the registry """
+    # check model
+    Model = env[model_name]
+    Model.invalidate_model()
+    model_record = env['ir.model'].search([('model', '=', model_name)], limit=1)
+    assert model_record.name == Model._description
+
+    # check fields
+    Fields = env['ir.model.fields']
+    Fields.invalidate_model()
+    fields = Model._fields
+    field_records = Fields.search([('model', '=', model_name)])
+    for field_record in field_records:
+        assert field_record.name in fields
+        field = fields[field_record.name]
+        assert field_record.field_description == field.string
+        assert field_record.translate == bool(field.translate)
+        assert field_record.required == field.required
+
+    # check not null
+    env.cr.execute("""
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = %s
+          AND is_nullable = 'NO'
+          AND column_name != 'id'
+    """, (Model._table,))
+    not_null_columns = {r[0] for r in env.cr.fetchall()}
+    assert set(field_records.filtered('required').mapped('name')) == not_null_columns
+
+    # check index
+    # since field indexes are not removed automatically, and their definitions are not updated automatically
+    # we only check indexes marked in registry exist in database
+    env.cr.execute("""
+        SELECT indexname
+        FROM pg_indexes
+        WHERE tablename = %s;
+    """, (Model._table,))
+    index_names = {r[0] for r in env.cr.fetchall()}
+    assert set(field_records.filtered('index').mapped(lambda f: make_index_name(Model._table, f.name))) < index_names
+
+    # check sql constraints
+    env.cr.execute("""
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = %s::regclass
+        AND contype != 'p'
+    """, (Model._table,))
+    constraint_names = {r[0] for r in env.cr.fetchall()}
+    Constraints = env['ir.model.constraint']
+    Constraints.invalidate_model()
+    constraint_records = Constraints.search([('model', '=', model_name)])
+    assert set(constraint_records.mapped('name')) == constraint_names
+    # since overriden ir_model_constraint recordsets are kept in database, we only compare the final one
+    _sql_constraints = tuple((f'{Model._table}_{c[0]}', c[1].replace(' ', '').lower(), c[2]) for c in Model._sql_constraints)
+    constraint_definition = {
+        c.name: c.definition
+        for c in constraint_records.filtered('definition')
+        if (c.name, c.definition, c.message) in _sql_constraints
+    }
+    assert len(constraint_definition) == len(Model._sql_constraints)
+    env.cr.execute("""
+        SELECT conname, pg_get_constraintdef(oid)
+        FROM pg_constraint
+        WHERE conname IN %s
+    """, (tuple(constraint_definition.keys()),))
+    for name, definition in env.cr.fetchall():
+        assert constraint_definition[name].replace(" ", "").lower() == definition.replace(" ", "").lower()
+
+@standalone('loading_standalone')
+def test_00_cleanup(env):
+    env['ir.module.module'].search([('name', 'ilike', 'test_loading_'), ('state', '!=', 'uninstalled')]).button_immediate_uninstall()
+    env.reset()  # clear the set of environments
+    env = env()  # get an environment that refers to the new registry
+    assert 'test_loading_1.model' not in env
+    assert not table_exists(env.cr, 'test_loading_1_model')
+
+@standalone('loading_standalone')
+def test_01_install_test_loading_3(env):
+    env.ref('base.module_test_loading_1').button_immediate_install()
+    # test_loading_1 has been installed, check if the env of pre_init_hook for test_loading_3 is ready while installing
+    env.ref('base.module_test_loading_3').button_immediate_install()
+
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reload the registry to check that the database is still consistent
+    Registry.new(env.registry.db_name)
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+@standalone('loading_standalone')
+def test_02_install_test_loading_2(env):
+    env.ref('base.module_test_loading_2').button_immediate_install()
+
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reload the registry to check that the database is still consistent
+    Registry.new(env.registry.db_name)
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+@standalone('loading_standalone')
+def test_02_upgrade_test_loading_1(env):
+    env['res.lang']._activate_lang('fr_FR')
+    record_1 = env.ref('test_loading_1.test_loading_1_record_1')
+
+    record_1.with_context(lang='fr_FR').name_y = 'ValueY 1 FR'
+
+    env.ref('base.module_test_loading_1').button_immediate_upgrade()
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reload the registry to check that the database is still consistent
+    Registry.new(env.registry.db_name)
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # translations shouldn't be lost after upgrade
+    assert record_1.with_context(lang='fr_FR').name_y == 'ValueY 1 FR'
+    assert record_1.with_context(lang='en_US').name_y == 'ValueY 1'
+
+@standalone('loading_standalone')
+def test_03_uninstall_test_loading_3(env):
+    env.ref('base.module_test_loading_3').button_immediate_uninstall()
+
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 2'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reload the registry to check that the database is still consistent
+    Registry.new(env.registry.db_name)
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 2'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+@standalone('loading_standalone')
+def test_04_auto_install(env):
+    test_00_cleanup(env)
+    env.reset()
+    env = env()
+    manifest_test_loading_2 = get_manifest('test_loading_2')
+    # hack the lru_cache value to simulate the auto_install
+    manifest_test_loading_2['auto_install'] = set(manifest_test_loading_2['depends'])
+
+    # populate the auto_install from the manifest to the database
+    env['ir.module.module'].update_list()
+    env.ref('base.module_test_loading_3').button_immediate_install()
+
+    env.reset()
+    env = env()
+    assert env.ref('base.module_test_loading_2').state == 'installed'
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reload the registry to check that the database is still consistent
+    Registry.new(env.registry.db_name)
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reset the lru_cache to revert the hack
+    get_manifest.cache_clear()
+    env['ir.module.module'].update_list()
+
+@standalone('loading_standalone')
+def test_05_install_hook(env):
+    test_00_cleanup(env)
+    env.reset()
+    env = env()
+    get_manifest.cache_clear()
+    manifest_test_loading_3 = get_manifest('test_loading_3')
+    manifest_test_loading_3['post_init_hook'] = 'post_init_hook'
+
+    env.ref('base.module_test_loading_3').button_immediate_install()
+
+    env.reset()
+    env = env()
+    assert env.ref('base.module_test_loading_2').state == 'installed'
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    # reload the registry to check that the database is still consistent
+    Registry.new(env.registry.db_name)
+    env.reset()
+    env = env()
+    assert env['test_loading_1.model']._description == 'Testing Loading Model 3'
+    _check_database_registry_consistency(env, 'test_loading_1.model')
+
+    get_manifest.cache_clear()

--- a/odoo/addons/test_loading_1/__init__.py
+++ b/odoo/addons/test_loading_1/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/odoo/addons/test_loading_1/__manifest__.py
+++ b/odoo/addons/test_loading_1/__manifest__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'test-loading-1',
+    'version': '0.1',
+    'category': 'Hidden/Tests',
+    'description': """A module to test the registry loading/upgrading/installing feature.""",
+    'depends': ['test_loading'],
+    'data': ['ir.model.access.csv', 'data/test_loading_1_data.xml'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_loading_1/data/test_loading_1_data.xml
+++ b/odoo/addons/test_loading_1/data/test_loading_1_data.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data>
+        <record id="test_loading_1_record_1" model="test_loading_1.model">
+            <field name="name_x">ValueX 1</field>
+            <field name="name_y">ValueY 1</field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/test_loading_1/ir.model.access.csv
+++ b/odoo/addons/test_loading_1/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_test_loading_1_model,access_test_loading_1_model,model_test_loading_1_model,,1,1,1,1

--- a/odoo/addons/test_loading_1/models.py
+++ b/odoo/addons/test_loading_1/models.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+class test_loading_1_model(models.Model):
+    """
+    This model uses different types of columns to make it possible to test
+    the registry loading/upgrading/installing feature.
+    """
+    _name = 'test_loading_1.model'
+    _description = 'Testing Loading Model 1'
+
+    name_x = fields.Char('NameX 1')
+    name_y = fields.Char('NameY 1')
+
+    _sql_constraints = [
+        ('name_uniq', 'unique (name_x)', 'Each name_x must be unique.'),
+    ]

--- a/odoo/addons/test_loading_2/__init__.py
+++ b/odoo/addons/test_loading_2/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/odoo/addons/test_loading_2/__manifest__.py
+++ b/odoo/addons/test_loading_2/__manifest__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'test-loading-2',
+    'version': '0.1',
+    'category': 'Hidden/Tests',
+    'description': """A module to test the registry loading/upgrading/installing feature.""",
+    'depends': ['test_loading_1'],
+    'data': ['data/test_loading_2_data.xml'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_loading_2/data/test_loading_2_data.xml
+++ b/odoo/addons/test_loading_2/data/test_loading_2_data.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <data>
+        <record id="test_loading_1_record_2" model="test_loading_1.model">
+            <field name="name_x">ValueX 2</field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/test_loading_2/models.py
+++ b/odoo/addons/test_loading_2/models.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+class test_loading_1_model(models.Model):
+    """
+    This model uses different types of columns to make it possible to test
+    the registry loading/upgrading/installing feature.
+    """
+    _inherit = 'test_loading_1.model'
+    _description = 'Testing Loading Model 2'
+
+    name_x = fields.Char('NameX 2')
+    name_y = fields.Char('NameY 2')
+
+    _sql_constraints = [
+        ('name_uniq', 'UNIQUE (name_x, name_y)', 'Each (name, name_y) must be unique.'),
+    ]

--- a/odoo/addons/test_loading_3/__init__.py
+++ b/odoo/addons/test_loading_3/__init__.py
@@ -12,3 +12,6 @@ def post_init_hook(env):
     module = env.ref('base.module_test_loading_2')
     if module:
         module.sudo().button_install()
+
+def post_init_hook_error(env):
+    raise Exception("Some error happen while installing test_loading_3")

--- a/odoo/addons/test_loading_3/__init__.py
+++ b/odoo/addons/test_loading_3/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models
+
+def pre_init_hook(env):
+    # check env is ready to use
+    env['test_loading_1.model'].search([], limit=1)
+
+def post_init_hook(env):
+    # this function won't be called by default since it is not declared in the __manifest__.py
+    module = env.ref('base.module_test_loading_2')
+    if module:
+        module.sudo().button_install()

--- a/odoo/addons/test_loading_3/__manifest__.py
+++ b/odoo/addons/test_loading_3/__manifest__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'test-loading-3',
+    'version': '0.1',
+    'category': 'Hidden/Tests',
+    'description': """A module to test the registry loading/upgrading/installing feature.""",
+    'depends': ['test_loading_1'],
+    'data': ['data/test_loading_3_data.xml'],
+    'installable': True,
+    'pre_init_hook': 'pre_init_hook',
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_loading_3/data/test_loading_3_data.xml
+++ b/odoo/addons/test_loading_3/data/test_loading_3_data.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data>
+        <record id="test_loading_1_record_3" model="test_loading_1.model">
+            <field name="name_x">ValueX 3</field>
+            <field name="name_z">ValueZ 3</field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/test_loading_3/models.py
+++ b/odoo/addons/test_loading_3/models.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+class test_loading_1_model(models.Model):
+    """
+    This model uses different types of columns to make it possible to test
+    the registry loading/upgrading/installing feature.
+    """
+    _inherit = 'test_loading_1.model'
+    _description = 'Testing Loading Model 3'
+
+    name_y = fields.Char('Translated NameY 3', translate=True, index='trigram')
+    name_z = fields.Char('Required NameZ 3', default='ValueZ 3 default', required=True)
+
+    _sql_constraints = [
+        ('name_uniq', 'unique (name_x, name_z)', 'Each (name, name_z) must be unique.'),
+    ]

--- a/odoo/addons/test_loading_4/__init__.py
+++ b/odoo/addons/test_loading_4/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/odoo/addons/test_loading_4/__manifest__.py
+++ b/odoo/addons/test_loading_4/__manifest__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'test-loading-4',
+    'version': '0.1',
+    'category': 'Hidden/Tests',
+    'description': """A module to test the registry loading/upgrading/installing feature.""",
+    'depends': ['test_loading_1'],
+    'data': ['data/test_loading_4_data.xml'],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_loading_4/data/test_loading_4_data.xml
+++ b/odoo/addons/test_loading_4/data/test_loading_4_data.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <data>
+        <record id="test_loading_1_record_4" model="test_loading_1.model">
+            <field name="name_x">ValueX 4</field>
+        </record>
+    </data>
+</odoo>

--- a/odoo/addons/test_loading_4/models.py
+++ b/odoo/addons/test_loading_4/models.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+class test_loading_1_model(models.Model):
+    """
+    This model uses different types of columns to make it possible to test
+    the registry loading/upgrading/installing feature.
+    """
+    _inherit = 'test_loading_1.model'
+    _description = 'Testing Loading Model 4'
+
+    name_x = fields.Char('NameX 4')

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2943,7 +2943,7 @@ class BaseModel(metaclass=MetaModel):
                 for field in klass._field_definitions:
                     definitions[field.name].append(field)
         for name, fields_ in definitions.items():
-            if f'{cls._name}.{name}' in cls.pool._database_translated_fields:
+            if cls.pool._database_translated_fields and f'{cls._name}.{name}' in cls.pool._database_translated_fields:
                 # the field is currently translated in the database; ensure the
                 # field is translated to avoid converting its column to varchar
                 # and losing data

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -3,187 +3,280 @@
 
 """ Modules dependency graph. """
 
-import itertools
 import logging
+from typing import Set, Dict, Tuple, Iterable, Iterator
 
 import odoo
 import odoo.tools as tools
 
 _logger = logging.getLogger(__name__)
 
-class Graph(dict):
-    """ Modules dependency graph.
+# THE LOADING ORDER
+#
+# Dependency Graph:
+#      +---------+
+#      |  base   |
+#      +---------+
+#        ^
+#        |
+#        |
+#      +---------+
+#      | module1 | <-----+
+#      +---------+       |
+#        ^               |
+#        |               |
+#        |               |
+#      +---------+     +---------+
+#   +> | module2 |     | module3 |
+#   |  +---------+     +---------+
+#   |    ^               ^     ^
+#   |    |               |     |
+#   |    |               |     |
+#   |  +---------+       |     |  +---------+
+#   |  | module4 | ------+     +- | module5 |
+#   |  +---------+                +---------+
+#   |    ^
+#   |    |
+#   |    |
+#   |  +---------+
+#   +- | module6 |
+#      +---------+
+#
+#
+# We always load module base in the zeroth phase, because
+# 1. base should always be the single drain of the dependency graph
+# 2. we need to use models in the base to upgrade other modules
+#
+# If there is no module to update(init/upgrade)
+# the loading order of modules in the same phase are sorted by the (depth, name)
+# where depth is the longest distance from the module to the base module along the dependency graph.
+# For example: the depth of module6 is 4 (path: module6 -> module4 -> module2 -> module1 -> base)
+# As a result, the loading order is
+# phase 0: base
+# phase 1: module1 -> module2 -> module3 -> module4 -> module5 -> module6
+#
+# If there are some modules need update(init/upgrade)
+# Since the Odoo update module by module(not perfect but successful solution), we sacrifice some determinacy of
+# overriding order while installing modules to avoid raising errors.
+# For example,
+# 'installed' : base, module1, module2, module3, module4, module6
+# 'to install': module5
+# module6 extends modelA with an extra field1 = fields.Char(required=True, default='value')
+# If the loading order is base -> module1 -> module2 -> module3 -> module4 -> module5 -> module6
+# While loading and installing module5, module6 hasn't been loaded. If module5 imports a new record for modelA as data
+# while installing, field1 won't be populated to the database and violates the not-null constraint
+# So we load those non-'to install' modules at first if possible and then those 'to install' modules in the next phase
+# As a result, the updating order is
+# phase 0: base
+# phase 1: module1 -> module2 -> module3 -> module4 -> module6
+# phase 2: module5
+#
+# In summary:
+# phase 0: base
+# phase odd: (modules: 1. don't need init; 2. all depends modules have been loaded or going to be loaded in this phase)
+# phase even: (models: 1. need init; 2. all depends modules have been loaded or going to be loaded in this phase)
+#
+#
+# Corner case
+# Sometimes the dependency may be changed for sake of upgrade
+# For example
+#      BEFORE UPGRADE                                       UPGRADING
+#
+#      +---------+                                          +---------+
+#      |  base   |                                          |  base   |
+#      +---------+                                          +---------+
+#        ^   installed                                        ^    to upgrade
+#        |                                                    |
+#        |                                                    |
+#      +---------+                                          +---------+
+#      | module1 |                                          | module1 | <-----+
+#      +---------+                                          +---------+       |
+#        ^   installed                                        ^    to upgrade |
+#        |                         ==>                        |               |
+#        |                                                    |               |
+#      +---------+                                          +---------+     +---------+
+#      | module2 |                                          | module2 |     | module3 |
+#      +---------+                                          +---------+     +---------+
+#        ^   installed                                        ^    to upgrade ^    to install
+#        |                                                    |               |
+#        |                                                    |               |
+#      +---------+                                          +---------+       |
+#      | module4 |                                          | module4 | ------+
+#      +---------+                                          +---------+
+#            installed                                             to upgrade
+#
+# Because of the new dependency module4 -> module3
+# The module3 will be marked 'to install' while upgrading, and module4 should be loaded after module3
+# As a result, the updating order is
+# phase 0: base
+# phase 1: module1 -> module2
+# phase 2: module3
+# phase 3: module4
 
-    The graph is a mapping from module name to Nodes.
 
+class lazy_recursive_property(tools.lazy_property):
+    """
+    a non-thread-safe lazy recursive property
     """
 
-    def add_node(self, name, info):
-        max_depth, father = 0, None
-        for d in info['depends']:
-            n = self.get(d) or Node(d, self, None)  # lazy creation, do not use default value for get()
-            if n.depth >= max_depth:
-                father = n
-                max_depth = n.depth
-        if father:
-            return father.add_child(name, info)
-        else:
-            return Node(name, self, info)
-
-    def update_from_db(self, cr):
-        if not len(self):
-            return
-        # update the graph with values from the database (if exist)
-        ## First, we set the default values for each package in graph
-        additional_data = {key: {'id': 0, 'state': 'uninstalled', 'dbdemo': False, 'installed_version': None} for key in self.keys()}
-        ## Then we get the values from the database
-        cr.execute('SELECT name, id, state, demo AS dbdemo, latest_version AS installed_version'
-                   '  FROM ir_module_module'
-                   ' WHERE name IN %s',(tuple(additional_data),)
-                   )
-
-        ## and we update the default values with values from the database
-        additional_data.update((x['name'], x) for x in cr.dictfetchall())
-
-        for package in self.values():
-            for k, v in additional_data[package.name].items():
-                setattr(package, k, v)
-
-    def add_module(self, cr, module, force=None):
-        self.add_modules(cr, [module], force)
-
-    def add_modules(self, cr, module_list, force=None):
-        if force is None:
-            force = []
-        packages = []
-        len_graph = len(self)
-        for module in module_list:
-            info = odoo.modules.module.get_manifest(module)
-            if info and info['installable']:
-                packages.append((module, info)) # TODO directly a dict, like in get_modules_with_version
-            elif module != 'studio_customization':
-                _logger.warning('module %s: not installable, skipped', module)
-
-        dependencies = dict([(p, info['depends']) for p, info in packages])
-        current, later = set([p for p, info in packages]), set()
-
-        while packages and current > later:
-            package, info = packages[0]
-            deps = info['depends']
-
-            # if all dependencies of 'package' are already in the graph, add 'package' in the graph
-            if all(dep in self for dep in deps):
-                if not package in current:
-                    packages.pop(0)
-                    continue
-                later.clear()
-                current.remove(package)
-                node = self.add_node(package, info)
-                for kind in ('init', 'demo', 'update'):
-                    if package in tools.config[kind] or 'all' in tools.config[kind] or kind in force:
-                        setattr(node, kind, True)
-            else:
-                later.add(package)
-                packages.append((package, info))
-            packages.pop(0)
-
-        self.update_from_db(cr)
-
-        for package in later:
-            unmet_deps = [p for p in dependencies[package] if p not in self]
-            _logger.info('module %s: Unmet dependencies: %s', package, ', '.join(unmet_deps))
-
-        return len(self) - len_graph
+    def __get__(self, obj, cls):
+        if obj is None:
+            return self
+        _visited = f'_{self.fget.__name__}_visited'
+        if getattr(obj, _visited, False):
+            raise RecursionError
+        setattr(obj, _visited, True)
+        value = self.fget(obj)
+        delattr(obj, _visited)
+        setattr(obj, self.fget.__name__, value)
+        return value
 
 
-    def __iter__(self):
-        level = 0
-        done = set(self.keys())
-        while done:
-            level_modules = sorted((name, module) for name, module in self.items() if module.depth==level)
-            for name, module in level_modules:
-                done.remove(name)
-                yield module
-            level += 1
-
-    def __str__(self):
-        return '\n'.join(str(n) for n in self if n.depth == 0)
-
-class Node(object):
-    """ One module in the modules dependency graph.
-
-    Node acts as a per-module singleton. A node is constructed via
-    Graph.add_module() or Graph.add_modules(). Some of its fields are from
-    ir_module_module (set by Graph.update_from_db()).
-
+class Package:
     """
-    def __new__(cls, name, graph, info):
-        if name in graph:
-            inst = graph[name]
-        else:
-            inst = object.__new__(cls)
-            graph[name] = inst
-        return inst
-
-    def __init__(self, name, graph, info):
+    Python package for the Odoo module with the same name
+    """
+    def __init__(self, name: str, package_graph: 'PackageGraph') -> None:
+        # manifest data
         self.name = name
-        self.graph = graph
-        self.info = info or getattr(self, 'info', {})
-        if not hasattr(self, 'children'):
-            self.children = []
-        if not hasattr(self, 'depth'):
-            self.depth = 0
+        self.manifest = odoo.modules.module.get_manifest(name) or {}
+
+        # ir_module_module data             # column_name
+        self.id = None                      # id
+        self.state = 'uninstalled'          # state
+        self.dbdemo = False                 # demo
+        self.installed_version = None       # latest_version
+
+        # info for upgrade
+        self.load_state = None               # the state when loaded to packages
+        self.load_version = None             # the version when loaded to packages
+
+        # dependency
+        self.depends: Set[Package] = set()
+        self.package_graph = package_graph
+
+    @lazy_recursive_property
+    def depth(self) -> int:
+        """ Return the longest distance from self to module 'base' along dependencies. """
+        return max(package.depth for package in self.depends) + 1 if self.depends else 0
+
+    @lazy_recursive_property
+    def phase(self) -> int:
+        if not self.package_graph._update_module:
+            return 1 if self.depends else 0
+        return max(
+            package.phase + 1 if (package.state == 'to install') ^ (self.state == 'to install') or package.name == 'base'
+            else package.phase for package in self.depends
+        ) if self.depends else 0
 
     @property
-    def data(self):
-        return self.info
-
-    def add_child(self, name, info):
-        node = Node(name, self.graph, info)
-        node.depth = self.depth + 1
-        if node not in self.children:
-            self.children.append(node)
-        for attr in ('init', 'update', 'demo'):
-            if hasattr(self, attr):
-                setattr(node, attr, True)
-        self.children.sort(key=lambda x: x.name)
-        return node
-
-    def __setattr__(self, name, value):
-        super(Node, self).__setattr__(name, value)
-        if name in ('init', 'update', 'demo'):
-            tools.config[name][self.name] = 1
-            for child in self.children:
-                setattr(child, name, value)
-        if name == 'depth':
-            for child in self.children:
-                setattr(child, name, value + 1)
-
-    def __iter__(self):
-        return itertools.chain(
-            self.children,
-            itertools.chain.from_iterable(self.children)
-        )
-
-    def __str__(self):
-        return self._pprint()
-
-    def _pprint(self, depth=0):
-        s = '%s\n' % self.name
-        for c in self.children:
-            s += '%s`-> %s' % ('   ' * depth, c._pprint(depth+1))
-        return s
-
-    def should_have_demo(self):
-        return (hasattr(self, 'demo') or (self.dbdemo and self.state != 'installed')) and all(p.dbdemo for p in self.parents)
+    def loading_order(self) -> Tuple[int, str]:
+        return self.depth, self.name
 
     @property
-    def parents(self):
-        if self.depth == 0:
-            return []
+    def updating_order(self) -> Tuple[int, int, str]:
+        return self.phase, self.depth, self.name
 
-        return (
-            node for node in self.graph.values()
-            if node.depth < self.depth
-            if self in node.children
-        )
+    def demo_installable(self) -> bool:
+        return all(p.dbdemo for p in self.depends)
+
+
+class PackageGraph:
+    """
+    Sorted Python packages for Odoo modules with the same names ordered by (package.phase, package.depth, package.name)
+    """
+
+    def __init__(self, cr, update_module=False) -> None:
+        self._packages: Dict[str, Package] = {}
+        self._cr = cr
+        self._update_module = update_module
+        self._sort_key = (lambda package: package.updating_order) \
+            if update_module else (lambda package: package.loading_order)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._packages
+
+    def __getitem__(self, name: str) -> Package:
+        return self._packages[name]
+
+    def __iter__(self) -> Iterator[Package]:
+        return iter(sorted(self._packages.values(), key=self._sort_key))
+
+    def __reversed__(self) -> Iterator[Package]:
+        return iter(sorted(self._packages.values(), key=self._sort_key, reverse=True))
+
+    def __len__(self) -> int:
+        return len(self._packages)
+
+    @property
+    def is_loading_order_sorted(self) -> bool:
+        return max(p.phase for p in self._packages.values()) <= 1 if self._update_module else True
+
+    def add(self, names: Iterable[str]) -> None:
+        for name in names:
+            package = self._packages[name] = Package(name, self)
+            if not package.manifest.get('installable'):
+                message = None if name == 'studio_customization' else 'not_installable'
+                self._remove(name, message)
+
+        self._update_depends(names)
+        self._check_depth(names)
+        self._update_from_database(names)
+
+    def _update_depends(self, names: Iterable[str]) -> None:
+        for name in names:
+            package = self._packages.get(name)
+            if package is not None:
+                try:
+                    package.depends = set(self._packages[dep] for dep in package.manifest['depends'])
+                except KeyError:
+                    self._remove(name, 'missing_depends')
+
+    def _check_depth(self, names: Iterable[str]) -> None:
+        for name in names:
+            package = self._packages.get(name)
+            try:
+                package and package.depth
+            except RecursionError:
+                self._remove(name, 'depends_loop')
+
+    def _update_from_database(self, names: Iterable[str]) -> None:
+        names = tuple(name for name in names if name in self._packages)
+        if not names:
+            return
+        # update packages with values from the database (if exist)
+        query = '''
+            SELECT name, id, state, demo, latest_version AS installed_version
+            FROM ir_module_module
+            WHERE name IN %s
+        '''
+        self._cr.execute(query, [names])
+        for name, id_, state, demo, installed_version in self._cr.fetchall():
+            if state == 'uninstallable':
+                self._remove(name, 'not_installable')
+            if not self._update_module and state == ['to install', 'uninstalled']:
+                self._remove(name, 'not_installed')
+            package = self._packages[name]
+            package.id = id_
+            package.state = state
+            package.dbdemo = demo
+            package.installed_version = installed_version
+            package.load_version = installed_version
+            package.load_state = state
+
+    def _remove(self, name: str, reason: str = None) -> None:
+        package = self._packages.pop(name, None)
+        if package is not None:
+            if reason:
+                logger, message = self._REMOVE_MESSAGES.get(reason, (_logger.debug, reason))
+                logger('module %s: %s', name, message)
+            for other, other_package in list(self._packages.items()):
+                if package in other_package.depends:
+                    self._remove(other, reason)
+
+    _REMOVE_MESSAGES = {
+        'depends_loop': (_logger.warning, 'in a dependency loop, skipped'),
+        'not_installable': (_logger.warning, 'not installable, skipped'),
+        'not_installed': (_logger.info, 'not installed or some depends are not installed, skipped'),
+        'missing_depends': (_logger.info, 'some depends are not loaded, skipped'),
+    }

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -254,8 +254,13 @@ class PackageGraph:
         for name, id_, state, demo, installed_version in self._cr.fetchall():
             if state == 'uninstallable':
                 self._remove(name, 'not_installable')
-            if not self._update_module and state == ['to install', 'uninstalled']:
+                continue
+            if not self._update_module and state in ['to install', 'uninstalled']:
                 self._remove(name, 'not_installed')
+                continue
+            if name not in self._packages:
+                # has been recursively removed for sake of not_installable or not_installed
+                continue
             package = self._packages[name]
             package.id = id_
             package.state = state

--- a/odoo/modules/graph.py
+++ b/odoo/modules/graph.py
@@ -192,6 +192,7 @@ class PackageGraph:
         self._update_module = update_module
         self._sort_key = (lambda package: package.updating_sort_key) \
             if update_module else (lambda package: package.loading_sort_key)
+        self._sort_key = lambda package: package.loading_sort_key
 
     def __contains__(self, name: str) -> bool:
         return name in self._packages

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -4,20 +4,23 @@
 """ Modules (also called addons) management.
 
 """
-
+import collections
 import itertools
 import logging
 import sys
 import threading
 import time
 
+from typing import Dict
+
 import odoo
 import odoo.modules.db
-import odoo.modules.graph
 import odoo.modules.migration
 import odoo.modules.registry
 from .. import SUPERUSER_ID, api, tools
+from ..tools import OrderedSet
 from .module import adapt_version, initialize_sys_path, load_openerp_module
+from odoo.modules.graph import PackageGraph
 
 _logger = logging.getLogger(__name__)
 _test_logger = logging.getLogger('odoo.tests')
@@ -44,7 +47,7 @@ def load_data(env, idref, mode, kind, package):
             keys = [kind]
         files = []
         for k in keys:
-            for f in package.data[k]:
+            for f in package.manifest[k]:
                 if f in files:
                     _logger.warning("File %s is imported twice in module %s %s", f, package.name, kind)
                 files.append(f)
@@ -79,69 +82,277 @@ def load_demo(env, package, idref, mode):
     """
     Loads demo data for the specified package.
     """
-    if not package.should_have_demo():
-        return False
+    loaded = False
+    if package.demo_installable():
+        try:
+            if package.manifest.get('demo') or package.manifest.get('demo_xml'):
+                _logger.info("Module %s: loading demo", package.name)
+                with env.cr.savepoint(flush=False):
+                    load_data(env, idref, mode, kind='demo', package=package)
+            loaded = True
+        except Exception as e:
+            # If we could not install demo data for this module
+            _logger.warning(
+                "Module %s demo data failed to install, installed without demo data",
+                package.name, exc_info=True)
 
-    try:
-        if package.data.get('demo') or package.data.get('demo_xml'):
-            _logger.info("Module %s: loading demo", package.name)
-            with env.cr.savepoint(flush=False):
-                load_data(env, idref, mode, kind='demo', package=package)
-        return True
-    except Exception as e:
-        # If we could not install demo data for this module
-        _logger.warning(
-            "Module %s demo data failed to install, installed without demo data",
-            package.name, exc_info=True)
+            todo = env.ref('base.demo_failure_todo', raise_if_not_found=False)
+            Failure = env.get('ir.demo_failure')
+            if todo and Failure is not None:
+                todo.state = 'open'
+                Failure.create({'module_id': package.id, 'error': str(e)})
 
-        todo = env.ref('base.demo_failure_todo', raise_if_not_found=False)
-        Failure = env.get('ir.demo_failure')
-        if todo and Failure is not None:
-            todo.state = 'open'
-            Failure.create({'module_id': package.id, 'error': str(e)})
-        return False
+    if loaded != package.dbdemo:
+        package.dbdemo = loaded
+        env['ir.module.module'].invalidate_model(['demo'])
+        env.cr.execute('UPDATE ir_module_module SET demo = %s WHERE id = %s', (loaded, package.id))
 
 
 def force_demo(env):
     """
     Forces the `demo` flag on all modules, and installs demo data for all installed modules.
     """
-    graph = odoo.modules.graph.Graph()
+    graph = PackageGraph(env.cr)
     env.cr.execute('UPDATE ir_module_module SET demo=True')
     env.cr.execute(
         "SELECT name FROM ir_module_module WHERE state IN ('installed', 'to upgrade', 'to remove')"
     )
     module_list = [name for (name,) in env.cr.fetchall()]
-    graph.add_modules(env.cr, module_list, ['demo'])
+    graph.add(module_list)
 
     for package in graph:
         load_demo(env, package, {}, 'init')
 
-    env['ir.module.module'].invalidate_model(['demo'])
     env['res.groups']._update_user_groups_view()
 
 
-def load_module_graph(env, graph, status=None, perform_checks=True,
-                      skip_modules=None, report=None, models_to_check=None):
-    """Migrates+Updates or Installs all module nodes from ``graph``
-
-       :param env:
-       :param graph: graph of module nodes to load
-       :param status: deprecated parameter, unused, left to avoid changing signature in 8.0
-       :param perform_checks: whether module descriptors should be checked for validity (prints warnings
-                              for same cases)
-       :param skip_modules: optional list of module names (packages) which have previously been loaded and can be skipped
-       :param report:
-       :param set models_to_check:
-       :return: list of modules that were installed or updated
-    """
-    if models_to_check is None:
-        models_to_check = set()
-
-    processed_modules = []
-    loaded_modules = []
+def _load_module(env, package) -> OrderedSet:
     registry = env.registry
-    migrations = odoo.modules.migration.MigrationManager(env.cr, graph)
+    module_name = package.name
+
+    load_openerp_module(package.name)
+    model_names = registry.load(env.cr, package)
+
+    if package.name is not None:
+        registry._init_modules.add(package.name)
+
+    return model_names
+
+def _install_module(env, package) -> OrderedSet:
+    registry = env.registry
+    module_name = package.name
+    module_id = package.id
+
+    if package.name != 'base':
+        env.flush_all()
+
+    load_openerp_module(package.name)
+
+    py_module = sys.modules['odoo.addons.%s' % (module_name,)]
+    pre_init = package.manifest.get('pre_init_hook')
+    if pre_init:
+        registry.setup_models(env.cr)
+        getattr(py_module, pre_init)(env)
+
+    model_names = registry.load(env.cr, package)
+    registry.setup_models(env.cr)
+    registry.init_models(env.cr, model_names, {'module': package.name}, install=True)
+
+    module = env['ir.module.module'].browse(module_id)
+
+    module._check()
+
+    idref = {}
+    load_data(env, idref, 'init', kind='data', package=package)
+    if not tools.config['without_demo'] or package.dbdemo:
+        load_demo(env, package, idref, 'init')
+
+    # Update translations for all installed languages
+    overwrite = odoo.tools.config["overwrite_existing_translations"]
+    module._update_translations(overwrite=overwrite)
+
+    if package.name is not None:
+        registry._init_modules.add(package.name)
+
+    post_init = package.manifest.get('post_init_hook')
+    if post_init:
+        getattr(py_module, post_init)(env)
+
+    env.flush_all()
+    _check_access_rules(env, module_name, model_names)
+
+    module = env['ir.module.module'].browse(module_id)
+    package.installed_version = adapt_version(package.manifest['version'])
+    package.state = 'installed'
+    # Set new modules and dependencies
+    module.write({'state': 'installed', 'latest_version': package.installed_version})
+    env.flush_all()
+    return model_names
+
+def _upgrade_module(env, package, migrations) -> OrderedSet:
+    registry = env.registry
+    module_name = package.name
+    module_id = package.id
+
+    if package.name != 'base':
+        registry.setup_models(env.cr)
+    migrations.migrate_module(package, 'pre')
+    if package.name != 'base':
+        env.flush_all()
+
+    load_openerp_module(package.name)
+
+    model_names = registry.load(env.cr, package)
+    registry.setup_models(env.cr)
+    registry.init_models(env.cr, model_names, {'module': package.name}, install=False)
+
+    module = env['ir.module.module'].browse(module_id)
+
+    module._check()
+
+    # upgrading the module information
+    module.write(module.get_values_from_terp(package.manifest))
+
+    idref = {}
+    load_data(env, idref, 'update', kind='data', package=package)
+    if package.dbdemo:
+        load_demo(env, package, idref, 'update')
+
+    migrations.migrate_module(package, 'post')
+
+    # Update translations for all installed languages
+    overwrite = odoo.tools.config["overwrite_existing_translations"]
+    module._update_translations(overwrite=overwrite)
+
+    if package.name is not None:
+        registry._init_modules.add(package.name)
+
+    env.flush_all()
+    # validate the views that have not been checked yet
+    env['ir.ui.view']._validate_module_views(module_name)
+
+    _check_access_rules(env, module_name, model_names)
+
+    module = env['ir.module.module'].browse(module_id)
+    package.installed_version = adapt_version(package.manifest['version'])
+    package.state = 'installed'
+    # Set new modules and dependencies
+    module.write({'state': 'installed', 'latest_version': package.installed_version})
+    env.flush_all()
+    return model_names
+
+def _check_access_rules(env, module_name, model_names):
+    registry = env.registry
+    concrete_models = [model for model in model_names if not registry[model]._abstract]
+    if concrete_models:
+        env.cr.execute("""
+                        SELECT model FROM ir_model 
+                        WHERE id NOT IN (SELECT DISTINCT model_id FROM ir_model_access) AND model IN %s
+                    """, [tuple(concrete_models)])
+        models = [model for [model] in env.cr.fetchall()]
+        if models:
+            lines = [
+                f"The models {models} have no access rules in module {module_name}, consider adding some, like:",
+                "id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink"
+            ]
+            for model in models:
+                xmlid = model.replace('.', '_')
+                lines.append(
+                    f"{module_name}.access_{xmlid},access_{xmlid},{module_name}.model_{xmlid},base.group_user,1,0,0,0")
+            _logger.warning('\n'.join(lines))
+
+def _test_module(env, module_name, setup_models = True):
+    test_queries = test_time = 0
+    test_results = None
+    loader = odoo.tests.loader
+    suite = loader.make_suite([module_name], 'at_install')
+    if suite.countTestCases():
+        if setup_models:
+            env.registry.setup_models(env.cr)
+        # need to commit any modification the module's installation or
+        # update made to the schema or data so the tests can run
+        # (separately in their own transaction)
+        env.flush_all()
+        env.cr.commit()
+        # Python tests
+        env['ir.http']._clear_routing_map()  # force routing map to be rebuilt
+
+        tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
+        test_results = loader.run_suite(suite, module_name)
+        test_time = time.time() - tests_t0
+        test_queries = odoo.sql_db.sql_counter - tests_q0
+
+        if not test_results.wasSuccessful():
+            _logger.error(
+                "Module %s: %d failures, %d errors of %d tests",
+                module_name, test_results.failures_count, test_results.errors_count,
+                test_results.testsRun
+            )
+
+    return test_results, test_queries, test_time
+
+
+def load_module_graph(env, graph: PackageGraph, force_test: bool = False) -> OrderedSet:
+    """Load, upgrade and install all module nodes from ``graph`` for the registry ``env.registry``
+
+           :param env: Odoo environment with the registry to be loaded
+           :param graph: ordered packages to be loaded/upgraded/installed
+           :param force_test: if True, all modules will be tested
+
+           :return: OrderedSet of module names that were installed or upgraded during this call
+        """
+
+    update_module = graph._update_module
+    registry = env.registry
+
+    # models_to_check
+    # a model is marked models_to_check and re-inited to promise the ** eventual consistency **
+    # between the registry and the database if
+    #
+    # Scenario 1. it is updated and loaded but not updated again
+    #    because while loading an 'installed' module, its models are be inited
+    #
+    #    Note: Strictly speaking, it should be re-inited before the next 'to install'/'to update' module, since update
+    #          hooks may use the model's ORM. But we sacrifice some correctness while updating for performance, since it
+    #          rarely cause problems
+    #
+    #          the corner case may only cause problems when you upgrade some(but not all) modules
+    #          For example:
+    # 	            there are some modules with loading order
+    # 	            module_A -> module_B -> module_C -> module_D
+    #
+    # 	            module_B depends on module_A
+    # 	            module_C depends on module_A
+    # 	            module_D depends on module_C
+    #
+    # 	            field_X is defined in module_A, module_B, module_C, module_D with
+    # 		            not specified `required` for module_A
+    # 		            `required=True` for module_B
+    # 		            `required=False` for module_C
+    # 		            not specified `required` for module_D
+    #
+    # 	        for sake of the loading order, the field_X should be `required=False` specified by module_C
+    # 	        when module_B and module_D are 'to upgrade',
+    # 	        after module_B is upgraded, the column for field_X has not-null constraint
+    # 	        ** if we don't re-init the model for field_X after loading module_C **,
+    # 	        while upgrading module_D, module_D may import some data which has empty field_X and cause error
+    #
+    # Scenario 2. it is updated and a module which has larger loading order has been updated/loaded before this module
+    #    because the updating order when update_module is True may be different from the loading order when the
+    #    update_module is False
+    #
+    # Scenario 3. its module is `to remove`
+    #    caused by the trick that removing a module means load all other modules again without the module
+    #
+    updated_models = OrderedSet()  # models whose modules are installed/upgraded
+    updated_loaded_models = OrderedSet()  # models which are updated and then loaded but not updated again
+    loaded_models: Dict[(int, str), OrderedSet] = {}  # {loading_order: models}
+    largest_loading_order = (-1, '')
+
+    updated_modules = OrderedSet()
+
+    if update_module:
+        migrations = odoo.modules.migration.MigrationManager(env.cr, graph)
     module_count = len(graph)
     _logger.info('loading %d modules...', module_count)
 
@@ -150,180 +361,72 @@ def load_module_graph(env, graph, status=None, perform_checks=True,
     loading_extra_query_count = odoo.sql_db.sql_counter
     loading_cursor_query_count = env.cr.sql_log_count
 
-    models_updated = set()
 
     for index, package in enumerate(graph, 1):
         module_name = package.name
-        module_id = package.id
 
-        if skip_modules and module_name in skip_modules:
+        if module_name in env.registry._init_modules:
             continue
 
         module_t0 = time.time()
         module_cursor_query_count = env.cr.sql_log_count
         module_extra_query_count = odoo.sql_db.sql_counter
 
-        needs_update = (
-            hasattr(package, "init")
-            or hasattr(package, "update")
-            or package.state in ("to install", "to upgrade")
-        )
-        module_log_level = logging.DEBUG
-        if needs_update:
-            module_log_level = logging.INFO
+        need_update = update_module and package.state in ("to install", "to upgrade")
+        need_test = tools.config.options['test_enable'] and (need_update or force_test)
+
+        module_log_level = logging.INFO if need_update else logging.DEBUG
         _logger.log(module_log_level, 'Loading module %s (%d/%d)', module_name, index, module_count)
 
-        new_install = package.state == 'to install'
-        if needs_update:
-            if not new_install:
-                if package.name != 'base':
-                    registry.setup_models(env.cr)
-                migrations.migrate_module(package, 'pre')
-            if package.name != 'base':
-                env.flush_all()
-
-        load_openerp_module(package.name)
-
-        if new_install:
-            py_module = sys.modules['odoo.addons.%s' % (module_name,)]
-            pre_init = package.info.get('pre_init_hook')
-            if pre_init:
-                registry.setup_models(env.cr)
-                getattr(py_module, pre_init)(env)
-
-        model_names = registry.load(env.cr, package)
-
-        mode = 'update'
-        if hasattr(package, 'init') or package.state == 'to install':
-            mode = 'init'
-
-        loaded_modules.append(package.name)
-        if needs_update:
-            models_updated |= set(model_names)
-            models_to_check -= set(model_names)
-            registry.setup_models(env.cr)
-            registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
-        elif package.state != 'to remove':
-            # The current module has simply been loaded. The models extended by this module
-            # and for which we updated the schema, must have their schema checked again.
-            # This is because the extension may have changed the model,
-            # e.g. adding required=True to an existing field, but the schema has not been
-            # updated by this module because it's not marked as 'to upgrade/to install'.
-            models_to_check |= set(model_names) & models_updated
-
-        idref = {}
-
-        if needs_update:
-            # Can't put this line out of the loop: ir.module.module will be
-            # registered by init_models() above.
-            module = env['ir.module.module'].browse(module_id)
-
-            if perform_checks:
-                module._check()
-
-            if package.state == 'to upgrade':
-                # upgrading the module information
-                module.write(module.get_values_from_terp(package.data))
-            load_data(env, idref, mode, kind='data', package=package)
-            demo_loaded = package.dbdemo = load_demo(env, package, idref, mode)
-            env.cr.execute('update ir_module_module set demo=%s where id=%s', (demo_loaded, module_id))
-            module.invalidate_model(['demo'])
-
-            migrations.migrate_module(package, 'post')
-
-            # Update translations for all installed languages
-            overwrite = odoo.tools.config["overwrite_existing_translations"]
-            module._update_translations(overwrite=overwrite)
-
-        if package.name is not None:
-            registry._init_modules.add(package.name)
-
-        if needs_update:
-            if new_install:
-                post_init = package.info.get('post_init_hook')
-                if post_init:
-                    getattr(py_module, post_init)(env)
-
-            if mode == 'update':
-                # validate the views that have not been checked yet
-                env['ir.ui.view']._validate_module_views(module_name)
-
-            # need to commit any modification the module's installation or
-            # update made to the schema or data so the tests can run
-            # (separately in their own transaction)
+        if need_update:
+            if package.state == 'to install':
+                model_names = _install_module(env, package)
+            else:  # 'to upgrade'
+                model_names = _upgrade_module(env, package, migrations)
+            updated_models |= model_names
+            updated_loaded_models -= model_names
+            updated_modules.add(package.name)
+            # update/install different modules in different transactions
+            env.flush_all()
             env.cr.commit()
-            concrete_models = [model for model in model_names if not registry[model]._abstract]
-            if concrete_models:
-                env.cr.execute("""
-                    SELECT model FROM ir_model 
-                    WHERE id NOT IN (SELECT DISTINCT model_id FROM ir_model_access) AND model IN %s
-                """, [tuple(concrete_models)])
-                models = [model for [model] in env.cr.fetchall()]
-                if models:
-                    lines = [
-                        f"The models {models} have no access rules in module {module_name}, consider adding some, like:",
-                        "id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink"
-                    ]
-                    for model in models:
-                        xmlid = model.replace('.', '_')
-                        lines.append(f"{module_name}.access_{xmlid},access_{xmlid},{module_name}.model_{xmlid},base.group_user,1,0,0,0")
-                    _logger.warning('\n'.join(lines))
+            if largest_loading_order > package.loading_order:  # shortcut to avoid the set operation below
+                # scenario 2 for models_to_check
+                registry.models_to_check |= model_names & OrderedSet.union(
+                    *(_model_names for order, _model_names in loaded_models.items() if order > package.loading_order),
+                )
+        else:
+            model_names = _load_module(env, package)  # returns an OrderedSet
+            updated_loaded_models |= updated_models & model_names
+            if update_module and package.state == 'to remove':
+                # scenario 3 for models_to_check
+                registry.models_to_check |= model_names
 
-        updating = tools.config.options['init'] or tools.config.options['update']
-        test_time = test_queries = 0
-        test_results = None
-        if tools.config.options['test_enable'] and (needs_update or not updating):
-            loader = odoo.tests.loader
-            suite = loader.make_suite([module_name], 'at_install')
-            if suite.countTestCases():
-                if not needs_update:
-                    registry.setup_models(env.cr)
-                # Python tests
-                env['ir.http']._clear_routing_map()     # force routing map to be rebuilt
+        if update_module:
+            loaded_models[(package.depth, package.name)] = model_names
+            largest_loading_order = max(largest_loading_order, package.loading_order)
 
-                tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, module_name)
-                report.update(test_results)
-                test_time = time.time() - tests_t0
-                test_queries = odoo.sql_db.sql_counter - tests_q0
-
-                # tests may have reset the environment
-                module = env['ir.module.module'].browse(module_id)
-
-        if needs_update:
-            processed_modules.append(package.name)
-
-            ver = adapt_version(package.data['version'])
-            # Set new modules and dependencies
-            module.write({'state': 'installed', 'latest_version': ver})
-
-            package.load_state = package.state
-            package.load_version = package.installed_version
-            package.state = 'installed'
-            for kind in ('init', 'demo', 'update'):
-                if hasattr(package, kind):
-                    delattr(package, kind)
-            module.env.flush_all()
-
-        extra_queries = odoo.sql_db.sql_counter - module_extra_query_count - test_queries
         extras = []
-        if test_queries:
-            extras.append(f'+{test_queries} test')
-        if extra_queries:
-            extras.append(f'+{extra_queries} other')
+        test_time = 0
+        if need_test:
+            test_results, test_query_count, test_time = _test_module(env, module_name, setup_models=not need_update)
+            module_extra_query_count += test_query_count
+            if test_results:
+                registry._assertion_report.update(test_results)
+            if test_query_count:
+                extras.append(f'+{test_query_count} test')
+        other_query_count = odoo.sql_db.sql_counter - module_extra_query_count
+        if other_query_count:
+            extras.append(f'+{other_query_count} other')
+
         _logger.log(
             module_log_level, "Module %s loaded in %.2fs%s, %s queries%s",
             module_name, time.time() - module_t0,
             f' (incl. {test_time:.2f}s test)' if test_time else '',
-            env.cr.sql_log_count - module_cursor_query_count,
+                         env.cr.sql_log_count - module_cursor_query_count,
             f' ({", ".join(extras)})' if extras else ''
         )
-        if test_results and not test_results.wasSuccessful():
-            _logger.error(
-                "Module %s: %d failures, %d errors of %d tests",
-                module_name, test_results.failures_count, test_results.errors_count,
-                test_results.testsRun
-            )
+
+    registry.models_to_check |= updated_loaded_models  # scenario 1 for models_to_check
 
     _logger.runbot("%s modules loaded in %.2fs, %s queries (+%s extra)",
                    len(graph),
@@ -331,60 +434,123 @@ def load_module_graph(env, graph, status=None, perform_checks=True,
                    env.cr.sql_log_count - loading_cursor_query_count,
                    odoo.sql_db.sql_counter - loading_extra_query_count)  # extra queries: testes, notify, any other closed cursor
 
-    return loaded_modules, processed_modules
+    return updated_modules
 
-def _check_module_names(cr, module_names):
-    mod_names = set(module_names)
-    if 'base' in mod_names:
-        # ignore dummy 'all' module
-        if 'all' in mod_names:
-            mod_names.remove('all')
-    if mod_names:
-        cr.execute("SELECT count(id) AS count FROM ir_module_module WHERE name in %s", (tuple(mod_names),))
-        if cr.dictfetchone()['count'] != len(mod_names):
-            # find out what module name(s) are incorrect:
-            cr.execute("SELECT name FROM ir_module_module")
-            incorrect_names = mod_names.difference([x['name'] for x in cr.dictfetchall()])
-            _logger.warning('invalid module names, ignored: %s', ", ".join(incorrect_names))
 
-def load_marked_modules(env, graph, states, force, progressdict, report,
-                        loaded_modules, perform_checks, models_to_check=None):
-    """Loads modules marked with ``states``, adding them to ``graph`` and
-       ``loaded_modules`` and returns a list of installed/upgraded modules."""
+def _update_ir_module_module(env, upgrade_module_names, install_module_names):
+    """ update modules' dependency, state"""
+    Module = env['ir.module.module']
 
-    if models_to_check is None:
-        models_to_check = set()
+    if upgrade_module_names:
+        modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', upgrade_module_names)])
+        if modules:
+            modules.button_upgrade()
+        ignored_module_names = set(upgrade_module_names) - set(modules.mapped('name')) - {'all'}
+        if ignored_module_names:
+            _logger.warning(
+                'modules: %s are ignored for upgrading, because they were not installed, they are going to be removed or their names are invalid',
+                ", ".join(ignored_module_names))
 
-    processed_modules = []
-    while True:
-        env.cr.execute("SELECT name from ir_module_module WHERE state IN %s", (tuple(states),))
-        module_list = [name for (name,) in env.cr.fetchall() if name not in graph]
-        if not module_list:
-            break
-        graph.add_modules(env.cr, module_list, force)
-        _logger.debug('Updating graph with %d more modules', len(module_list))
-        loaded, processed = load_module_graph(
-            env, graph, progressdict, report=report, skip_modules=loaded_modules,
-            perform_checks=perform_checks, models_to_check=models_to_check
-        )
-        processed_modules.extend(processed)
-        loaded_modules.extend(loaded)
-        if not processed:
-            break
-    return processed_modules
+    if install_module_names:
+        modules = Module.search([('state', 'in', ('uninstalled', 'to install')), ('name', 'in', install_module_names)])
+        if modules:
+            modules.button_install()
+        ignored_module_names = set(install_module_names) - set(modules.mapped('name'))
+        if ignored_module_names:
+            _logger.warning(
+                'modules: %s are ignored for installing, because they have been installed or their names are invalid',
+                ", ".join(ignored_module_names))
 
-def load_modules(registry, force_demo=False, status=None, update_module=False):
+    env.flush_all()
+
+def _check_fields_to_untranslate(env):
+    registry = env.registry
+    # set up the registry without the patch for translated fields
+    database_translated_fields = registry._database_translated_fields
+    registry._database_translated_fields = None
+    registry.setup_models(env.cr)
+    # determine which translated fields should no longer be translated,
+    # and make their model fix the database schema
+    models_to_untranslate = OrderedSet()
+    for full_name in database_translated_fields:
+        model_name, field_name = full_name.rsplit('.', 1)
+        if model_name in registry:
+            field = registry[model_name]._fields.get(field_name)
+            if field and not field.translate:
+                _logger.debug("Making field %s non-translated", field)
+                models_to_untranslate.add(model_name)
+    registry.models_to_check |= models_to_untranslate
+
+def _check_models(env):
+    registry = env.registry
+    if not registry.models_to_check:
+        return
+    registry.init_models(
+        env.cr,
+        [model_name for model_name in registry.models_to_check if model_name in env],
+        {'models_to_check': True}
+    )
+    registry.models_to_check = OrderedSet()
+
+def _check_modules(env):
+    Module = env['ir.module.module']
+
+    # check that all installed modules have been loaded by the registry
+    modules = Module.search(Module._get_modules_to_load_domain(), order='name')
+    missing = [name for name in modules.mapped('name') if name not in env.registry._init_modules]
+    if missing:
+        _logger.error("Some modules are not loaded, some dependencies or manifest may be missing: %s", missing)
+
+    # check that new module dependencies have been properly installed after a migration/upgrade
+    modules = Module.search([('name', 'in', ('to install', 'to upgrade', 'to remove'))], order='name')
+    if modules:
+        _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", modules.mapped('name'))
+
+def _cleanup(env):
+    env.cr.execute("SELECT model from ir_model")
+    for (model,) in env.cr.fetchall():
+        if model in env.registry:
+            env[model]._check_removed_columns(log=True)
+        elif _logger.isEnabledFor(logging.INFO):  # more an info that a warning...
+            _logger.runbot(
+                "Model %s is declared but cannot be loaded! (Perhaps a module was partially removed or renamed)", model)
+
+    # Cleanup orphan records
+    env['ir.model.data']._process_end(env.registry.updated_modules)
+
+def _check_views(env):
+    registry = env.registry
+    # STEP 6: verify custom views on every model
+    env['res.groups']._update_user_groups_view()
+    View = env['ir.ui.view']
+    for model in registry:
+        try:
+            View._validate_custom_views(model)
+        except Exception as e:
+            _logger.warning('invalid custom view(s) for model %s: %s', model, tools.ustr(e))
+
+def load_modules(
+        dbname: str,
+        update_module: bool = False,
+        force_test: bool = False,
+        _force_demo: bool = False
+) -> None:
     """ Load the modules for a registry object that has just been created.  This
         function is part of Registry.new() and should not be used anywhere else.
+
+        Args:
+            dbname (str): the name of database
+            update_module (bool, optional): If True, init, upgrade and remove modules while loading
+            force_test (bool, optional): force_test at_install tests
+            _force_demo (bool, optional): If True, forcely load demo for all updated modules
+                deprecated: it will mark the demo field of all modules to True, which will install/update demo data for
+                all modules when they are updated in the future
     """
     initialize_sys_path()
 
-    force = []
-    if force_demo:
-        force.append('demo')
-
-    models_to_check = set()
-
+    registry = odoo.modules.registry.Registry.registries[dbname]
+    updated_modules = OrderedSet()
+    assert registry.loaded is False
     with registry.cursor() as cr:
         # prevent endless wait for locks on schema changes (during online
         # installs) if a concurrent transaction has accessed the table;
@@ -394,38 +560,32 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
         if not odoo.modules.db.is_initialized(cr):
             if not update_module:
                 _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
+                registry.ready = True
                 return
             _logger.info("init db")
             odoo.modules.db.initialize(cr)
-            update_module = True # process auto-installed modules
-            tools.config["init"]["all"] = 1
-            if not tools.config['without_demo']:
-                tools.config["demo"]['all'] = 1
-
-        if 'base' in tools.config['update'] or 'all' in tools.config['update']:
-            cr.execute("update ir_module_module set state=%s where name=%s and state=%s", ('to upgrade', 'base', 'installed'))
-
-        # STEP 1: LOAD BASE (must be done before module dependencies can be computed for later steps)
-        graph = odoo.modules.graph.Graph()
-        graph.add_module(cr, 'base', force)
-        if not graph:
-            _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
-            raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
-
-        if update_module and odoo.tools.table_exists(cr, 'ir_model_fields'):
+            update_module = True  # process auto-installed modules
+        elif update_module and registry._database_translated_fields is None:
             # determine the fields which are currently translated in the database
             cr.execute("SELECT model || '.' || name FROM ir_model_fields WHERE translate IS TRUE")
             registry._database_translated_fields = {row[0] for row in cr.fetchall()}
 
-        # processed_modules: for cleanup step after install
-        # loaded_modules: to avoid double loading
-        report = registry._assertion_report
-        env = api.Environment(cr, SUPERUSER_ID, {})
-        loaded_modules, processed_modules = load_module_graph(
-            env, graph, status, perform_checks=update_module,
-            report=report, models_to_check=models_to_check)
+        # STEP 1: LOAD BASE (must be done before module dependencies can be computed for later steps)
+        if any(m in tools.config['update'] for m in ('base', 'all')):
+            cr.execute("UPDATE ir_module_module SET state = %s WHERE name = %s AND state = %s", ('to upgrade', 'base', 'installed'))
+        if _force_demo:
+            cr.execute("UPDATE ir_module_module SET demo = %s WHERE name = %s", (True, 'base'))
+        graph = PackageGraph(cr, update_module=update_module)
+        graph.add(['base'])
+        if not graph:
+            _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
+            raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
 
-        load_lang = tools.config.pop('load_language')
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        updated_modules |= load_module_graph(env, graph, force_test=force_test)
+
+        load_lang = tools.config['load_language']
+        tools.config['load_language'] = None
         if load_lang or update_module:
             # some base models are used below, so make sure they are set up
             registry.setup_models(cr)
@@ -436,168 +596,78 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
 
         # STEP 2: Mark other modules to be loaded/updated
         if update_module:
-            Module = env['ir.module.module']
-            _logger.info('updating modules list')
-            Module.update_list()
+            upgrade_module_names = [k for k, v in tools.config['update'].items() if v and k != 'base']
+            install_module_names = [k for k, v in tools.config['init'].items() if v and k != 'base']
+            if not upgrade_module_names and install_module_names:
+                env['ir.module.module'].update_list()
+            _update_ir_module_module(env, upgrade_module_names, install_module_names)
+            if _force_demo:
+                force_demo(env)
 
-            _check_module_names(cr, itertools.chain(tools.config['init'], tools.config['update']))
+        states = ('installed', 'to upgrade', 'to remove', 'to install') if update_module else ('installed', 'to upgrade', 'to remove')
+        env.cr.execute("SELECT name from ir_module_module WHERE state IN %s", (states,))
+        module_list = [name for (name,) in env.cr.fetchall() if name not in graph]
+        graph.add(module_list)
+        _logger.debug('Updating graph with %d more modules', len(module_list))
 
-            module_names = [k for k, v in tools.config['init'].items() if v]
-            if module_names:
-                modules = Module.search([('state', '=', 'uninstalled'), ('name', 'in', module_names)])
-                if modules:
-                    modules.button_install()
-
-            module_names = [k for k, v in tools.config['update'].items() if v]
-            if module_names:
-                modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', module_names)])
-                if modules:
-                    modules.button_upgrade()
-
-            env.flush_all()
-            cr.execute("update ir_module_module set state=%s where name=%s", ('installed', 'base'))
-            Module.invalidate_model(['state'])
-
-        # STEP 3: Load marked modules (skipping base which was done in STEP 1)
-        # IMPORTANT: this is done in two parts, first loading all installed or
-        #            partially installed modules (i.e. installed/to upgrade), to
-        #            offer a consistent system to the second part: installing
-        #            newly selected modules.
-        #            We include the modules 'to remove' in the first step, because
-        #            they are part of the "currently installed" modules. They will
-        #            be dropped in STEP 6 later, before restarting the loading
-        #            process.
-        # IMPORTANT 2: We have to loop here until all relevant modules have been
-        #              processed, because in some rare cases the dependencies have
-        #              changed, and modules that depend on an uninstalled module
-        #              will not be processed on the first pass.
-        #              It's especially useful for migrations.
-        previously_processed = -1
-        while previously_processed < len(processed_modules):
-            previously_processed = len(processed_modules)
-            processed_modules += load_marked_modules(env, graph,
-                ['installed', 'to upgrade', 'to remove'],
-                force, status, report, loaded_modules, update_module, models_to_check)
-            if update_module:
-                processed_modules += load_marked_modules(env, graph,
-                    ['to install'], force, status, report,
-                    loaded_modules, update_module, models_to_check)
-
-        if update_module:
-            # set up the registry without the patch for translated fields
-            database_translated_fields = registry._database_translated_fields
-            registry._database_translated_fields = ()
-            registry.setup_models(cr)
-            # determine which translated fields should no longer be translated,
-            # and make their model fix the database schema
-            models_to_untranslate = set()
-            for full_name in database_translated_fields:
-                model_name, field_name = full_name.rsplit('.', 1)
-                if model_name in registry:
-                    field = registry[model_name]._fields.get(field_name)
-                    if field and not field.translate:
-                        _logger.debug("Making field %s non-translated", field)
-                        models_to_untranslate.add(model_name)
-            registry.init_models(cr, list(models_to_untranslate), {'models_to_check': True})
+        updated_modules |= load_module_graph(env, graph, force_test=force_test)
+        registry.updated_modules |= updated_modules
 
         registry.loaded = True
         registry.setup_models(cr)
 
-        # check that all installed modules have been loaded by the registry
-        Module = env['ir.module.module']
-        modules = Module.search(Module._get_modules_to_load_domain(), order='name')
-        missing = [name for name in modules.mapped('name') if name not in graph]
-        if missing:
-            _logger.error("Some modules are not loaded, some dependencies or manifest may be missing: %s", missing)
+        tools.config['init'], tools.config['update'] = {}, {}
 
-        # STEP 3.5: execute migration end-scripts
-        migrations = odoo.modules.migration.MigrationManager(cr, graph)
-        for package in graph:
-            migrations.migrate_module(package, 'end')
+        if updated_modules:
 
-        # check that new module dependencies have been properly installed after a migration/upgrade
-        cr.execute("SELECT name from ir_module_module WHERE state IN ('to install', 'to upgrade')")
-        module_list = [name for (name,) in cr.fetchall()]
-        if module_list:
-            _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
+            # STEP 3.5: execute migration end-scripts
+            migrations = odoo.modules.migration.MigrationManager(cr, graph)
+            for package in graph:
+                migrations.migrate_module(package, 'end')
 
-        # STEP 3.6: apply remaining constraints in case of an upgrade
-        registry.finalize_constraints()
+            # STEP 3.6: apply remaining constraints in case of an upgrade
+            registry.finalize_constraints()
 
-        # STEP 4: Finish and cleanup installations
-        if processed_modules:
+            # load modules recursively in case any module is marked 'to install'/'to upgrade' during loading
+            registry.has_modules_to_update = bool(env['ir.module.module'].search([
+                ('state', 'in', ('to upgrade', 'to install')),
+                ('name', 'not in', tuple(registry._init_modules))
+            ]))
 
-            cr.execute("SELECT model from ir_model")
-            for (model,) in cr.fetchall():
-                if model in registry:
-                    env[model]._check_removed_columns(log=True)
-                elif _logger.isEnabledFor(logging.INFO):    # more an info that a warning...
-                    _logger.runbot("Model %s is declared but cannot be loaded! (Perhaps a module was partially removed or renamed)", model)
+            if registry.has_modules_to_update or not graph.is_loading_order_sorted:
+                cr.commit()
+                return
 
-            # Cleanup orphan records
-            env['ir.model.data']._process_end(processed_modules)
-            env.flush_all()
-
-        for kind in ('init', 'demo', 'update'):
-            tools.config[kind] = {}
-
-        # STEP 5: Uninstall modules to remove
         if update_module:
+            # STEP 5: Uninstall modules to remove
             # Remove records referenced from ir_model_data for modules to be
             # removed (and removed the references from ir_model_data).
-            cr.execute("SELECT name, id FROM ir_module_module WHERE state=%s", ('to remove',))
-            modules_to_remove = dict(cr.fetchall())
-            if modules_to_remove:
-                pkgs = reversed([p for p in graph if p.name in modules_to_remove])
-                for pkg in pkgs:
-                    uninstall_hook = pkg.info.get('uninstall_hook')
+            packages_to_remove = [p for p in reversed(graph) if p.state == 'to remove']
+            if packages_to_remove:
+                registry.has_modules_removed = True
+                for package in packages_to_remove:
+                    uninstall_hook = package.manifest.get('uninstall_hook')
                     if uninstall_hook:
-                        py_module = sys.modules['odoo.addons.%s' % (pkg.name,)]
+                        py_module = sys.modules['odoo.addons.%s' % (package.name,)]
                         getattr(py_module, uninstall_hook)(env)
                         env.flush_all()
 
                 Module = env['ir.module.module']
-                Module.browse(modules_to_remove.values()).module_uninstall()
-                # Recursive reload, should only happen once, because there should be no
-                # modules to remove next time
-                cr.commit()
+                Module.browse([package.id for package in packages_to_remove]).module_uninstall()
                 _logger.info('Reloading registry once more after uninstalling modules')
-                registry = odoo.modules.registry.Registry.new(
-                    cr.dbname, force_demo, status, update_module
-                )
-                cr.reset()
-                registry.check_tables_exist(cr)
                 cr.commit()
-                return registry
+                cr.reset()
+                return
 
-        # STEP 5.5: Verify extended fields on every model
-        # This will fix the schema of all models in a situation such as:
-        #   - module A is loaded and defines model M;
-        #   - module B is installed/upgraded and extends model M;
-        #   - module C is loaded and extends model M;
-        #   - module B and C depend on A but not on each other;
-        # The changes introduced by module C are not taken into account by the upgrade of B.
-        if models_to_check:
-            registry.init_models(cr, list(models_to_check), {'models_to_check': True})
-
-        # STEP 6: verify custom views on every model
-        if update_module:
-            env['res.groups']._update_user_groups_view()
-            View = env['ir.ui.view']
-            for model in registry:
-                try:
-                    View._validate_custom_views(model)
-                except Exception as e:
-                    _logger.warning('invalid custom view(s) for model %s: %s', model, tools.ustr(e))
-
-        if report.wasSuccessful():
-            _logger.info('Modules loaded.')
-        else:
-            _logger.error('At least one test failed when loading the modules.')
-
-
-        # STEP 8: save installed/updated modules for post-install tests and _register_hook
-        registry.updated_modules += processed_modules
+        if registry._database_translated_fields is not None:
+            _check_fields_to_untranslate(env)
+        _check_models(env)
+        _check_modules(env)
+        if registry.has_modules_removed:
+            registry.check_tables_exist(cr)
+        if registry.updated_modules:
+            _cleanup(env)
+            _check_views(env)
 
         # STEP 9: call _register_hook on every model
         # This is done *exactly once* when the registry is being loaded. See the
@@ -607,6 +677,16 @@ def load_modules(registry, force_demo=False, status=None, update_module=False):
         for model in env.values():
             model._register_hook()
         env.flush_all()
+
+        registry.ready = True
+        cr.commit()
+
+        # check report
+        if registry._assertion_report.wasSuccessful():
+            _logger.info('Modules loaded.')
+        else:
+            _logger.error('At least one test failed when loading the modules.')
+        return
 
 
 def reset_modules_state(db_name):

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -34,7 +34,7 @@ _DEFAULT_MANIFEST = {
     'data': [],
     'demo': [],
     'demo_xml': [],
-    'depends': [],
+    'depends': ['base'],
     'description': '',
     'external_dependencies': {},
     #icon: f'/{module}/static/description/icon.png',  # automatic
@@ -322,6 +322,12 @@ def load_manifest(module, mod_path=None):
     if not manifest.get('license'):
         manifest['license'] = 'LGPL-3'
         _logger.warning("Missing `license` key in manifest for %r, defaulting to LGPL-3", module)
+
+    if module == 'base':
+        manifest['depends'] = []
+    elif not manifest['depends']:
+        # prevent the hack `'depends': []` except 'base' module
+        manifest['depends'] = _DEFAULT_MANIFEST['depends'].copy()
 
     # auto_install is either `False` (by default) in which case the module
     # is opt-in, either a list of dependencies in which case the module is

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -144,6 +144,7 @@ class Registry(Mapping):
         # 3. are removed in while uninstalling
         # 4. has fields to untranslate
         self.models_to_fixup = OrderedSet()
+        self.all_models_set_up = True
         self.has_modules_removed = False
         self.has_modules_to_update = False
         self.loaded_xmlids = set()

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -55,13 +55,7 @@ def check_super(passwd):
 # This should be moved to odoo.modules.db, along side initialize().
 def _initialize_db(id, db_name, demo, lang, user_password, login='admin', country_code=None, phone=None):
     try:
-        db = odoo.sql_db.db_connect(db_name)
-        with closing(db.cursor()) as cr:
-            # TODO this should be removed as it is done by Registry.new().
-            odoo.modules.db.initialize(cr)
-            odoo.tools.config['load_language'] = lang
-            cr.commit()
-
+        odoo.tools.config['load_language'] = lang
         registry = odoo.modules.registry.Registry.new(db_name, demo, update_module=True)
 
         with closing(registry.cursor()) as cr:

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -62,7 +62,7 @@ def _initialize_db(id, db_name, demo, lang, user_password, login='admin', countr
             odoo.tools.config['load_language'] = lang
             cr.commit()
 
-        registry = odoo.modules.registry.Registry.new(db_name, demo, None, update_module=True)
+        registry = odoo.modules.registry.Registry.new(db_name, demo, update_module=True)
 
         with closing(registry.cursor()) as cr:
             env = odoo.api.Environment(cr, SUPERUSER_ID, {})

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1298,7 +1298,7 @@ def preload_registries(dbnames):
     rc = 0
     for dbname in dbnames:
         try:
-            update_module = config['init'] or config['update']
+            update_module = bool(config['init'] or config['update'])
             registry = Registry.new(dbname, update_module=update_module)
 
             # run test_file if provided
@@ -1316,8 +1316,7 @@ def preload_registries(dbnames):
             if config['test_enable']:
                 t0 = time.time()
                 t0_sql = odoo.sql_db.sql_counter
-                module_names = (registry.updated_modules if update_module else
-                                sorted(registry._init_modules))
+                module_names = sorted(registry.updated_modules if update_module else registry._init_modules)
                 _logger.info("Starting post tests")
                 tests_before = registry._assertion_report.testsRun
                 post_install_suite = loader.make_suite(module_names, 'post_install')

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -524,8 +524,6 @@ class configmanager(object):
         )
 
         self.options['init'] = opt.init and dict.fromkeys(opt.init.split(','), 1) or {}
-        self.options['demo'] = (dict(self.options['init'])
-                                if not self.options['without_demo'] else {})
         self.options['update'] = opt.update and dict.fromkeys(opt.update.split(','), 1) or {}
         self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1138,12 +1138,8 @@ class OrderedSet(MutableSet):
     def update(self, elems):
         self._map.update(zip(elems, itertools.repeat(None)))
 
-    def union(self, *sets):
-        return OrderedSet(
-            itertools.chain.from_iterable(
-                itertools.chain([self], sets)
-            )
-        )
+    def union(*elems):
+        return OrderedSet(itertools.chain.from_iterable(elems))
 
     def difference_update(self, elems):
         for elem in elems:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1138,6 +1138,13 @@ class OrderedSet(MutableSet):
     def update(self, elems):
         self._map.update(zip(elems, itertools.repeat(None)))
 
+    def union(self, *sets):
+        return OrderedSet(
+            itertools.chain.from_iterable(
+                itertools.chain([self], sets)
+            )
+        )
+
     def difference_update(self, elems):
         for elem in elems:
             self.discard(elem)


### PR DESCRIPTION
[IMP] core: refactor loading registry

## The object of this commit is
1. decouple the graph.py and loading.py.
   loading.py defines the loading/updating processes
   graph.py defines the loading/updating order
2. simplify graph.py to improve the readability and time complexity
3. promise the eventual consistency between the registry and the database

## Changes in details:
### config:
the tools.config['demo'] is removed, because
1. it didn't work as it described to install demo at the granularity of modules
2. only 2 modes for demo installation are needed
    a. `bool(tools.config['without_demo']) is True` : don't install demo
    b. `bool(tools.config['without_demo']) is False`: install demo when the demo
       for the module is installable

### each package/pkg/node of the graph:
before:
1. manifest dict can be got from `package.data` and `package.info`
2. `package.init`, `package.update` contains the config for install/upgrade
3. `package.demo` contains the config for demo when upgrade/install
4. `package.load_state` and `package.load_version` are only available when a
   module is updated when loading
5. `package.should_have_demo()` returns if the loading.py should install demo
   for the package

after:
1. manifest dict can only be got from `package.manifest`
2. `package.init`, `package.update` are removed since they only have part of
   install/upgrade info comparing with the `package.state`
3. `package.demo` is removed since we directly get the demo config from
   `tool.config['without_demo']` but not `tools.config['demo']`
4. `package.load_state` and `package.load_version` are always available
5. `package.demo_installable()` returns if the package's demo can be installed

### manifest:
before:
If `depends: []` or undefined `depends` in a manifest, the module installed
before all module with `depends: ['base']` but after the 'base' module

after:
the hack `depends: []` or undefined `depends` will be changed to
`depends: ['base']` in manifest

### install an installed module from CLI
calling button_install for an installed module from UI or code does nothing
before:
the specified modules for `-i` from CLI will actually be upgraded if they have
already been installed, and the special process will be populated along one of 
the modules' longest dependency path
for example
if all modules are installed
<img width="267" alt="image" src="https://github.com/odoo/odoo/assets/25711015/dc42996c-975e-4deb-946f-925a2c28f862">
The longest dependency path for module4 is
`base -> module2 -> module3 -> module4` where the distance from module4 to base is 3
instead of `base -> module1 -> module4` where the distance from module4 to base is 2
If module1 is in `-i`, module4 will not be upgraded
If module2 is in `-i`, module4 will be upgraded

after:
The feature is dropped, the specified modules for `-i` from CLI will do nothing
if these modules have already been installed