### PR TITLE
[FIX] account: fix PO-bill link total_amount match

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2896,9 +2896,10 @@ class AccountMove(models.Model):
 
             try:
                 if decoder and not success:
-                    with self.env.cr.savepoint(), self._get_edi_creation() as invoice:
-                        # pylint: disable=not-callable
-                        success = decoder(invoice, file_data, new)
+                    with self.env.cr.savepoint():
+                        with self._get_edi_creation() as invoice:
+                            # pylint: disable=not-callable
+                            success = decoder(invoice, file_data, new)
                         if success:
                             invoice._link_bill_origin_to_purchase_orders(timeout=4)
 


### PR DESCRIPTION
The total amount is not computed until `with _get_edi_creation():` goes off, so the function that does the link by the `amount_total` must be excluded from that part of the `with` clause.

Task link: https://www.odoo.com/web#id=3278824&model=project.task
opw-3278824