### PR TITLE
[FIX] mail: use logger warning instead of exception

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -621,7 +621,7 @@ class MailMail(models.Model):
                 raise
             except Exception as e:
                 failure_reason = tools.ustr(e)
-                _logger.exception('failed sending mail (id: %s) due to %s', mail.id, failure_reason)
+                _logger.warning('failed sending mail (id: %s) due to %s', mail.id, failure_reason, exc_info=True)
                 mail.write({'state': 'exception', 'failure_reason': failure_reason})
                 mail._postprocess_sent_message(success_pids=success_pids, failure_reason=failure_reason, failure_type='unknown')
                 if raise_exception:


### PR DESCRIPTION
When a user sets the wrong mail in the `email_from` field in `mail.mail` and sends the mail it will generate an exception in the log.

Steps to reproduce :
1. Install the mail module.
2. Create one SMTP outgoing mail server.
3. Open Setting > Technical > Emails.
4. Create one email and set the wrong value in the `email_from` field (like "Mitchell Admin" <@yourcompany.example.com>) and fill the value in `email_to` field.
5. Save it and click on the `send now` button.
6. Exception is generated in the log.

Traceback on sentry : 
```
AssertionError: Malformed 'Return-Path' or 'From' address: "zwjdwyoklazppiacwm" <@zbugnevas> - It should contain one valid plain ASCII email
  File "addons/mail/models/mail_mail.py", line 578, in _send
    res = IrMailServer.send_email(
  File "home/odoo/src/custom/trial/saas_trial/models/mail.py", line 68, in send_email
    res = super(IrMailServer, self).send_email(message, **kwargs)
  File "odoo/addons/base/models/ir_mail_server.py", line 683, in send_email
    smtp_from, smtp_to_list, message = self._prepare_email_message(message, smtp)
  File "odoo/addons/base/models/ir_mail_server.py", line 633, in _prepare_email_message
    assert smtp_from_rfc2822, (
```

In this commit, generate a logger warning instead of a logger exception.

sentry - 4027010025





