### PR TITLE
[FIX] crm: properly assign leads in edge cases

### DIFF
--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -158,7 +158,10 @@ class Team(models.Model):
         commit_bundle_size = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.commit.bundle', 100))
         while population:
             counter += 1
-            member_id = random.choices(population, weights=weights, k=1)[0]
+            if any(weights):
+                member_id = random.choices(population, weights=weights, k=1)[0]
+            else:
+                member_id = random.choices(population)
             member_index = population.index(member_id)
             member_data = members_data[member_id]
 


### PR DESCRIPTION
CRM module uses smart way to assign leads to sales team members: it uses random
function with weights for each members. The weights computation is a bit tricky
to explain, but important part is that all weights might be zero.
It leads to the following error in Python v3.12+ [1]

`Total of weights must be greater than zero`.

Fix it by using plain random function in such cases

[1]: https://github.com/python/cpython/commit/041d8b48a2e59fa642b2c5124d78086baf74e339

https://online.sentry.io/issues/4156882948