### PR TITLE
[IMP] core: handle filestore error as warning

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2003,7 +2003,7 @@ class Application:
                 pass
             elif isinstance(exc, SessionExpiredException):
                 _logger.info(exc)
-            elif isinstance(exc, (UserError, AccessError, NotFound)):
+            elif isinstance(exc, (UserError, AccessError, NotFound, FileNotFoundError)):
                 _logger.warning(exc)
             else:
                 _logger.error("Exception during request handling.", exc_info=True)


### PR DESCRIPTION
When the filestore is not available, for instance on a test db or when debuging an issue we get flooded by error messages and long tracebacks which makes debugging complex. This commit changes the error to a warning similar to how other NotFound errors are handled.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
