### PR TITLE
[FIX] web: fix missing kanbanView titles on mobile 

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -8,7 +8,7 @@
                     <t t-esc="groupName"></t>
                     <span class="badge text-bg-500 rounded-pill lh-1 ms-2" t-esc="group.count"></span>
                 </div>
-                <span t-if="!env.isSmall and !group.isFolded"
+                <span t-if="!group.isFolded"
                     t-esc="groupName"
                     class="o_column_title flex-grow-1 d-inline-block mw-100 text-truncate fs-4 fw-bold align-top text-900"
                     />


### PR DESCRIPTION
After introducing a fix for the kanban headers in the Social Module in this commit f8a4624001492d7b69b6f1ae75c0834f77725f26, we noticed that the header titles weren't displaying in mobile. 
This commit fixes that issue by readapting the conditional code. 

test-3326563
part of task-3326263


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
