### PR TITLE
[IMP] mail: remove sidebar grey background

### DIFF
--- a/addons/mail/static/src/web/discuss_app/sidebar.xml
+++ b/addons/mail/static/src/web/discuss_app/sidebar.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.DiscussSidebar" owl="1">
-    <div class="o-mail-DiscussSidebar d-flex flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end bg-light">
+    <div class="o-mail-DiscussSidebar d-flex flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end bg-100">
         <div class="d-flex justify-content-center">
             <button t-on-click="onClickStartMeeting" class="btn btn-primary rounded" title="Start a meeting">
                 Start a meeting
@@ -34,7 +34,6 @@
 <t t-name="mail.Mailbox" owl="1">
     <button class="btn d-flex align-items-center py-1 px-0 border-0 rounded-0 fw-normal text-dark"
         t-att-class="{
-            'bg-100': mailbox.localId !== store.discuss.threadLocalId,
             'o-active bg-200': mailbox.localId === store.discuss.threadLocalId,
         }"
         t-on-click="(ev) => this.openThread(ev, mailbox)"
@@ -84,7 +83,6 @@
     <t t-set="counter" t-value="threadService.getCounter(thread)"/>
     <button class="o-mail-DiscussCategoryItem btn d-flex align-items-center w-100 px-0 py-2 border-0 text-reset"
         t-att-class="{
-            'bg-100': threadLocalId !== store.discuss.threadLocalId,
             'o-active bg-200': threadLocalId === store.discuss.threadLocalId,
             'o-unread': thread.message_unread_counter > 0,
         }"


### PR DESCRIPTION
== ISSUE ==

When opening the Discuss module, there is a weird grey background on the sidebar.

== After this commit ==

This commit removes that style on the element, to keep only a background on the active one.

task-3326309
part of task-3326263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
