### PR TITLE
[FIX] product:  preventing product category deletion

### DIFF
--- a/addons/product/models/product.py
+++ b/addons/product/models/product.py
@@ -70,9 +70,11 @@ class ProductCategory(models.Model):
         main_category = self.env.ref('product.product_category_all')
         if main_category in self:
             raise UserError(_("You cannot delete this product category, it is the default generic category."))
-        expense_category = self.env.ref('product.cat_expense', raise_if_not_found=False)
-        if expense_category and expense_category in self:
-            raise UserError(_("You cannot delete the %s product category.", expense_category.name))
+        external_ids = self.get_external_id()
+        for category in self:
+            external_id = external_ids[category.id]
+            if external_id and not external_id.startswith('export'):
+                raise UserError(_("You cannot delete the %s product category.", category.display_name))
 
 
 class ProductProduct(models.Model):


### PR DESCRIPTION
When we delete a product category 'All/Deliveries' and then install 'delivery_mondialrelay' after uninstalling it once then we face this issue.
ParseError' :
'while parsing /home/odoo/src/odoo/saas-16.2/addons/delivery_mondialrelay'.

Steps to reproduce:
1) Install 'delivery_mondialrelay'.
2) In 'stock' under 'Products' change the product category from 'All/Deliveries'
 to some other category of products having category 'All/Deliveries'.
3)Go to product categories in 'stock' under 'Configuration/Products'. 
4) Delete category named 'All/Deliveries'.
5) Uninstall the module 'delivery_mondialrelay'.
6)Now again install module 'delivery_mondialrelay'. 
By following the above steps you will be able to reproduce the error.

Note: The database shoud be loaded without demo data for ease of error production.

Applying these changes will resolve this issue.

Sentry - 4149235213