### PR TITLE
[IMP] tools: prioritize es_MX over es

### DIFF
--- a/addons/mail/models/template_reset_mixin.py
+++ b/addons/mail/models/template_reset_mixin.py
@@ -74,6 +74,12 @@ class TemplateResetMixin(models.AbstractModel):
                 if base_trans_file:
                     translation_importer.load_file(base_trans_file, code, xmlids=xml_ids)
 
+                # Step 1.5: in case of latin america Spanish variation, load es_MX too
+                if base_lang_code == "es" and lang_code != "es_MX":
+                    mx_trans_file = get_module_resource(module_name, 'i18n', 'es_MX.po')
+                    if mx_trans_file:
+                        translation_importer.load_file(mx_trans_file, code, xmlids=xml_ids)
+
             # Step 2: reset translation file with main language file (can possibly override the
             # terms coming from the base language)
             trans_file = get_module_resource(module_name, 'i18n', lang_code + '.po')

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -942,6 +942,12 @@ class Module(models.Model):
                         _logger.info('module %s: loading base translation file %s for language %s', module_name, base_lang_code, lang)
                         translation_importer.load_file(base_trans_file, lang)
 
+                    if base_lang_code == "es" and lang != "es_MX":
+                        mx_trans_file = get_module_resource(module_name, 'i18n', 'es_MX.po')
+                        if mx_trans_file:
+                            _logger.info('module %s: loading translation file %s for language %s', module_name, "es_MX", lang)
+                            translation_importer.load_file(mx_trans_file, lang)
+
                     # i18n_extra folder is for additional translations handle manually (eg: for l10n_be)
                     base_trans_extra_file = get_module_resource(module_name, 'i18n_extra', base_lang_code + '.po')
                     if base_trans_extra_file:

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1479,6 +1479,12 @@ class CodeTranslations:
                     get_resource_path(mod, 'i18n', lang + '.po'),
                     get_resource_path(mod, 'i18n_extra', lang_base + '.po'),
                     get_resource_path(mod, 'i18n_extra', lang + '.po')]
+        if lang_base == "es" and lang != "es_MX":
+            # force es_MX as fallback language for the different spanish
+            # es_MX is more actively translated and closer to many languages
+            po_paths = [po_paths[0]] + [get_resource_path(mod, 'i18n', 'es_MX.po')] + \
+                po_paths[1:3] + [get_resource_path(mod, 'i18n_extra', 'es_MX.po')] + \
+                [po_paths[3]]
         return [path for path in po_paths if path]
 
     @staticmethod


### PR DESCRIPTION
The translations on `Spanish (Mexico)` are more active than on `Spanish`
(16.0 and saas-16.2 below)
![transifex-spanish](https://github.com/odoo/odoo/assets/564822/c145d62c-6b93-4226-890d-5dcb277b1173)
![spanish2](https://github.com/odoo/odoo/assets/564822/da246dd7-ae06-4856-ac15-084fb9633f8a)

Moreover, most other countries speaking a variant of Spanish are located in Latin America and are closer to `es_MX` than `es`.

To solve this, fallback on `es_MX` instead of `es` for any Spanish language that is not `es_MX` (note that `es` fallbacks on `es_MX` now).