### PR TITLE
[FIX] mail: consistent size of input in discuss header

### DIFF
--- a/addons/mail/static/src/discuss_app/autoresize_input.xml
+++ b/addons/mail/static/src/discuss_app/autoresize_input.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.AutoresizeInput" owl="1">
     <input
-        class="o-mail-AutoresizeInput text-truncate px-2 py-1 border-1 bg-transparent border-transparent"
+        class="o-mail-AutoresizeInput text-truncate px-2 border-1 bg-transparent border-transparent"
         t-attf-class="{{ props.className }}"
         t-attf-placeholder="{{ props.placeholder }}"
         t-att-disabled="props.disabled"

--- a/addons/mail/static/src/discuss_app/discuss.xml
+++ b/addons/mail/static/src/discuss_app/discuss.xml
@@ -9,7 +9,7 @@
                 <ThreadIcon className="'me-2 align-self-center'" thread="thread"/>
                 <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                     <AutoresizeInput
-                        className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 text-dark'"
+                        className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 text-dark py-0'"
                         disabled="!thread.isRenameable"
                         onValidate.bind="renameThread"
                         value="thread.displayName"
@@ -18,7 +18,7 @@
                         <div class="flex-shrink-0 mx-2 py-2 border-start"/>
                         <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
                         <AutoresizeInput
-                            className="'o-mail-Discuss-threadDescription flex-shrink-1'"
+                            className="'o-mail-Discuss-threadDescription flex-shrink-1 py-1'"
                             onValidate.bind="updateThreadDescription"
                             placeholder="autogrowDescriptionPlaceholder"
                             value="thread.description or ''"
@@ -40,6 +40,7 @@
                             <t t-if="store.user" t-esc="store.user.name"/>
                             <t t-else="">
                                 <AutoresizeInput
+                                    className="'py-1'"
                                     onValidate.bind="renameGuest"
                                     value="store.guest.name"
                                 />


### PR DESCRIPTION
Before this commit, input size of thread name was bigger than the description one. This happens because the input is sized according to the font size, and the thread name was bigger due to `lead` classname.

This commit fixes the issue by reducing the padding of input of thread name input, so that both input have the exact same height.

![discuss-header-input-size](https://github.com/odoo/odoo/assets/6569390/4f829fa5-9d85-40f1-a498-68d2f3129117)
