### PR TITLE
[FIX] website_sale: prevent invalid literal issue for category in url

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -209,12 +209,13 @@ class WebsiteSale(http.Controller):
     def shop(self, page=0, category=None, search='', ppg=False, **post):
         add_qty = int(post.get('add_qty', 1))
         Category = request.env['product.public.category']
-        if category:
-            category = Category.search([('id', '=', int(category))], limit=1)
+        if category and isinstance(category, str):
+            domain = [('id', '=', int(category))] if category.isnumeric() else [('name', 'ilike', category)]
+            category = Category.search(domain, limit=1)
             if not category or not category.can_access_from_current_website():
                 raise NotFound()
         else:
-            category = Category
+            category = category or Category
 
         if ppg:
             try:


### PR DESCRIPTION
If applied, this commit will solve the issue of the invalid literal for integer, when the user enters the URL like 'shop?category=string' instead of the 'shop?category=1'.

Steps to produce:
- Go to Website > Enable the 'ecommerce Category' from Website > Customize.
- Click on any category.
- Now change the URL with '/shop?category=any_string'

Fix this issue by handling the search of the category.
See Traceback
```
ValueError: invalid literal for int() with base 10: "1') ORDER BY 1-- RgKe"
  File "odoo/http.py", line 1987, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1583, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1610, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1723, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 696, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 324, in shop
    category = Category.search([('id', '=', int(category))], limit=1)
```

Sentry - 4180088992


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
