### PR TITLE
[FIX] stock: fix can not find generic route in stock

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -8683,6 +8683,12 @@ msgid "You cannot delete a scrap which is done."
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_location.py:0
+#, python-format
+msgid "You cannot delete route %s; archive it instead."
+msgstr ""
+
+#. module: stock
 #: code:addons/stock/models/stock_quant.py:0
 #, python-format
 msgid "You cannot modify inventory loss quantity"

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -431,6 +431,14 @@ class Route(models.Model):
         if not self.warehouse_selectable:
             self.warehouse_ids = [(5, 0, 0)]
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_stock_route_data(self):
+        external_ids = self.get_external_id()
+        for route in self:
+            external_id = external_ids.get(route.id)
+            if external_id and not external_id.startswith('__export__'):
+                raise UserError(_("You cannot delete route %s; archive it instead.", route.name))
+
     def toggle_active(self):
         for route in self:
             route.with_context(active_test=False).rule_ids.filtered(lambda ru: ru.active == route.active).toggle_active()

--- a/addons/stock/tests/test_stock_location_route.py
+++ b/addons/stock/tests/test_stock_location_route.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests import common
+from odoo.exceptions import UserError
+
+
+class TestStockLocationRoute(common.TransactionCase):
+    def test_unlink_prevent_route_group(self):
+        route_a = self.env["stock.location.route"].create(
+            {"name": "a_route"}
+        )
+        self.env['ir.model.data'].create({
+            'name': route_a.name,
+            'module': 'Stock',
+            'model': route_a._name,
+            'res_id': route_a.id,
+        })
+        with self.assertRaises(UserError, msg="You cannot delete route a_route; archive it instead."):
+            route_a.unlink()


### PR DESCRIPTION
when the user deletes the route of `stock` module that is present in the data file of`Purchase Stock`. while installing or upgrading the `MRP Subcontracting` module the user gets an error as the stock route referenced from the
`Purchase Stock` module has been deleted.

Steps to reproduce :
1. Install the Inventory module.
2. Install the purchase and MRP module.
3. Open the Inventory app.
4. Go to configuration > settings.
5. Enable Multi-steps routes and save them.
6. Open configuration > Routes.
7. Delete the `Buy` route.
8. Install the `MRP Subcontracting` module.
9. Traceback generated.

```
UserError: Can't find any generic route Buy.
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 279, in _tag_function
    _eval_xml(self, rec, env)
  File "odoo/tools/convert.py", line 204, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/mrp_subcontracting/models/stock_warehouse.py", line 37, in write
    res = super().write(vals)
  File "addons/mrp/models/stock_warehouse.py", line 282, in write
    return super(StockWarehouse, self).write(vals)
  File "addons/stock/models/stock_warehouse.py", line 197, in write
    warehouse.write(picking_type_vals)
  File "addons/mrp_subcontracting/models/stock_warehouse.py", line 37, in write
    res = super().write(vals)
  File "addons/mrp/models/stock_warehouse.py", line 282, in write
    return super(StockWarehouse, self).write(vals)
  File "addons/stock/models/stock_warehouse.py", line 206, in write
    global_rules = warehouse._get_global_route_rules_values()
  File "addons/mrp_subcontracting/models/stock_warehouse.py", line 90, in _get_global_route_rules_values
    rules = super(StockWarehouse, self)._get_global_route_rules_values()
  File "addons/purchase_stock/models/stock.py", line 35, in _get_global_route_rules_values
    'route_id': self._find_global_route('purchase_stock.route_warehouse0_buy', _('Buy')).id,
  File "addons/stock/models/stock_warehouse.py", line 379, in _find_global_route
    raise UserError(_('Can\'t find any generic route %s.') % (route_name))
ParseError: while parsing /home/odoo/src/odoo/saas-16.2/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml:10, somewhere inside
<function model="stock.warehouse" name="write">
            <value model="stock.warehouse" eval="obj().env['stock.warehouse'].search([]).ids"/>
            <value eval="{'subcontracting_to_resupply': True}"/>
        </function>
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 32, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/addons/base/models/res_config.py", line 614, in execute
    installation_status = self._install_modules(to_install)
  File "odoo/addons/base/models/res_config.py", line 32, in _install_modules
    result = to_install_modules.button_immediate_install()
  File "home/odoo/src/custom/trial/saas_trial/models/module.py", line 80, in button_immediate_install
    return super(IrModuleModule, self).button_immediate_install()
  File "<decorator-gen-73>", line 2, in button_immediate_install
  File "odoo/addons/base/models/ir_module.py", line 76, in check_and_log
    return method(self, *args, **kwargs)
  File "odoo/addons/base/models/ir_module.py", line 472, in button_immediate_install
    return self._button_immediate_function(type(self).button_install)
  File "home/odoo/src/custom/trial/saas_trial/models/module.py", line 52, in _button_immediate_function
    res = super(IrModuleModule, self)._button_immediate_function(function)
  File "odoo/addons/base/models/ir_module.py", line 596, in _button_immediate_function
    registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
  File "<decorator-gen-14>", line 2, in new
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 481, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 226, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

This commit will raise an UserError while deleting the route which is created from the data file.

sentry - 4128085959

