### PR TITLE
[FIX] product: prevent traceback when xml_id is not found

### DIFF
--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -67,8 +67,9 @@ class ProductLabelLayout(models.TransientModel):
     def process(self):
         self.ensure_one()
         xml_id, data = self._prepare_report_data()
-        if not xml_id:
+        try:
+            report_action = self.env.ref(xml_id).report_action(None, data=data)
+            report_action.update({'close_on_report_download': True})
+        except(ValueError):
             raise UserError(_('Unable to find report template for %s format', self.print_format))
-        report_action = self.env.ref(xml_id).report_action(None, data=data)
-        report_action.update({'close_on_report_download': True})
         return report_action


### PR DESCRIPTION
When the user deletes product.report_product_template_label_dymo from ir.model.data and then tries to print product label with dymo as paperformat the error occurs.

See this traceback:
```
KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7f49211c8280>, 'product.report_product_template_label_dymo')
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: External ID not found in the system: product.report_product_template_label_dymo
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 32, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/product/wizard/product_label_layout.py", line 72, in process
    report_action = self.env.ref(xml_id).report_action(None, data=data)
  File "odoo/api.py", line 566, in ref
    res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
  File "odoo/addons/base/models/ir_model.py", line 1984, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-40>", line 2, in _xmlid_lookup
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 1977, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
```

Steps to reproduce:
    1. Turn on developers mode.
    2. Open view 'ir.model.data.tree'.
    3. Search product.report_product_template_label_dymo and delete it.
    4. Click on inventory module and then click on product menu.
    5. Open a product and click on print label button.
    6. Select dymo as format and confirm it.
    7. The error will occur

Applying this commit will fix this issue.

sentry-4167053460

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
