### PR TITLE
[FIX] mail: send & print on one or multiple invoices changes template

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2583,6 +2583,8 @@ class MailThread(models.AbstractModel):
             # unless asked specifically, send emails after the transaction to
             # avoid side effects due to emails being sent while the transaction fails
             if not test_mode and send_after_commit:
+                if kwargs.get('composition_mode', False) and kwargs['composition_mode'] == "mass_mail":
+                    return emails
                 email_ids = emails.ids
                 dbname = self.env.cr.dbname
                 _context = self._context

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -233,7 +233,7 @@ class TestMailComposerRendering(TestMailComposer):
 
         self.assertIn(
             self.body_html,
-            values[self.partner_employee.id]['body_html'],
+            values[self.partner_employee.id]['body'],
             'We must preserve (mso) comments in email html'
         )
 
@@ -258,6 +258,6 @@ class TestMailComposerRendering(TestMailComposer):
 
         self.assertIn(
             self.body_html,
-            values[self.partner_employee.id]['body_html'],
+            values[self.partner_employee.id]['body'],
             'We must preserve (mso) comments in email html'
         )

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -49,7 +49,7 @@ class TestMailTemplate(MailCommon):
         values = mail_compose_message.get_mail_values(self.partner_employee.ids)
 
         self.assertEqual(values[self.partner_employee.id]['subject'], '6', 'We must trust mail template values')
-        self.assertIn('13', values[self.partner_employee.id]['body_html'], 'We must trust mail template values')
+        self.assertIn('13', values[self.partner_employee.id]['body'], 'We must trust mail template values')
 
     def test_mail_template_acl(self):
         # Sanity check


### PR DESCRIPTION
Before: when using the Send & Print button to send an email for an invoice, if only one invoice was selected we'd get a different email layout than if multiple invocies (mass_mail) were selected. This happens because the flow for one invoice includes the extra step of rendering the email layout correctly, while the flow for multiple invoices doesn't.

The flow is now changed so that:
- Getting the mail values returns the same keys for both single and multiple invoices.
- For every mail_value, regardless of mass_mail, we use an almost identical flow (the one that was used for a single invoice before).
- Almost identical flow because if in mass_mail, we return the mail.message object instead of sending the email directly. The mail.message objects returned are then used for batch mail sending.

Some tests were changed as they asserted the 'body_html' key which was only used for mass_mail. Since we use the same keys now, we assert 'body' instead.

task-3168606
