### PR TITLE
[FIX] survey: Get back to the previous question without answering the current

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -519,6 +519,9 @@ class Survey(http.Controller):
             if question in inactive_questions:  # if question is inactive, skip validation and save
                 continue
             answer, comment = self._extract_comment_from_answers(question, post.get(str(question.id)))
+            if 'previous_page_id' in post and len(answer) == 0:
+                # If the user just want get back and hasn't fill any input
+                continue
             errors.update(question.validate_question(answer, comment))
             if not errors.get(question.id):
                 answer_sudo.save_lines(question, answer, comment)

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -463,7 +463,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
             var $form = this.$('form');
             var formData = new FormData($form[0]);
 
-            if (!options.skipValidation) {
+            if (!options.skipValidation && !params.previous_page_id) {
                 // Validation pre submit
                 if (!this._validateForm($form, formData)) {
                     return;


### PR DESCRIPTION
Steps:
- Create a survey with 2 mandatory questions
- Enable the 'back button' in the survey's options
- Start the test, answer the first question then try to back without answering the next

Issue:
You are prevented to do that. The survey asks you to answer.

Cause:
Before sending answer to the server to evaluation, there is a pre validation on the JS side which doesn't consider if the we are just trying to go back, then on server side it's the same, there is a validation of answer without considering that.

opw-3293146