### PR TITLE
[FIX] base, web: error handling of invalid leaf

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4513,7 +4513,10 @@ class BaseModel(metaclass=MetaModel):
                 domain = [(self._active_name, '=', 1)] + domain
 
         if domain:
-            return expression.expression(domain, self).query
+            try:
+                return expression.expression(domain, self).query
+            except ValueError as e:
+                raise UserError(str(e))
         else:
             return Query(self.env.cr, self._table, self._table_query)
 


### PR DESCRIPTION
Currently, when an invalid domain causes an error it raises an Exception which will be caught by the sentry and generates unnecessary traffic.

So, we stop catching exceptions from invalid domains that are supposed to be generated by User's Mistakes.

Steps to reproduce:
    1. Turn on developer mode.
    2. Install mass_mailing module and open it.
    3. Click on the new button.
    4. Enter subject and set recipients as contact or mailing contact.
    5. In code editor pass the domain as [('', '=', 0)]
    6. error will occur - ValueError: Invalid leaf ('', '=', 0)

See this traceback: 
```
ValueError: Invalid leaf ('', '=', 1)
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 1485, in search_count
    query = self._search(domain, limit=limit)
  File "odoo/addons/base/models/res_partner.py", line 899, in _search
    return super()._search(domain, offset, limit, order, access_rights_uid)
  File "odoo/models.py", line 4759, in _search
    query = self._where_calc(domain)
  File "odoo/models.py", line 4506, in _where_calc
    return expression.expression(domain, self).query
  File "odoo/osv/expression.py", line 448, in __init__
    self.parse()
  File "odoo/osv/expression.py", line 613, in parse
    push(leaf, self.root_model, self.root_alias)
  File "odoo/osv/expression.py", line 600, in push
    check_leaf(leaf, internal)
  File "odoo/osv/expression.py", line 397, in check_leaf
    raise ValueError("Invalid leaf %s" % str(element))
```

Applying this commit will fix this issue.

sentry-3945982195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
