### PR TITLE
[FIX] mass_mailing: update iframe on theme select

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -356,6 +356,8 @@ export class MassMailingHtmlField extends HtmlField {
             this.wysiwyg.$iframeBody.closest('body').removeClass("o_force_mail_theme_choice");
 
             $themeSelectorNew.remove();
+            // resize once theme is selected
+            this.onIframeUpdated();
 
             this.wysiwyg.setSnippetsMenuFolded(device.isMobile || themeName === 'basic');
 


### PR DESCRIPTION
In 16.0, the iframe is updated in switchThemes before any of the theme selection indicator classes are removed.

This leads to the resize not actually fitting the selected theme.

We fix this by calling an update once the styles are updated.

task-3290103

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
