### PR TITLE
[FIX] l10n_eg_edi_eta: changes the computation of fields depending on…

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -31,7 +31,7 @@ class AccountMove(models.Model):
 
     @api.depends('l10n_eg_eta_json_doc_id.raw')
     def _compute_eta_long_id(self):
-        for rec in self:
+        for rec in self.with_context(bin_size=False):
             response_data = rec.l10n_eg_eta_json_doc_id and json.loads(rec.l10n_eg_eta_json_doc_id.raw).get('response')
             if response_data:
                 rec.l10n_eg_long_id = response_data.get('l10n_eg_long_id')


### PR DESCRIPTION
During the computation of a non-stored field, when accessing the raw field on the attachment, the ORM enters a lazy mode where it will return the size of the attachment instead of its content. This laziness does not happen if we are not in a compute function. To circumvent this, we removed the computation on some fields on the invoices to prevent a traceback when parsing the json content of the file

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
