### PR TITLE
[FIX] account_peppol: temporarily restrict installation

### DIFF
--- a/addons/account_peppol/__init__.py
+++ b/addons/account_peppol/__init__.py
@@ -3,3 +3,9 @@
 
 from . import models
 from . import wizard
+
+from odoo.exceptions import UserError
+
+def pre_init_hook(env):
+    if env['ir.config_parameter'].get_param('account_peppol.edi.mode', False) != 'test':
+        raise UserError("This module is not ready to be installed.")

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -23,5 +23,6 @@
         'views/res_config_settings_views.xml',
         'wizard/account_move_send_views.xml',
     ],
+    'pre_init_hook': 'pre_init_hook',
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
We do not want to make account_peppol easily installable at the moment.
This commit restricts installation to testing.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
