### PR TITLE
[FIX] hr_gamification: missing margin below badge button, adapt milk

### DIFF
--- a/addons/hr_gamification/views/hr_employee_views.xml
+++ b/addons/hr_gamification/views/hr_employee_views.xml
@@ -11,14 +11,16 @@
                 <page string="Received Badges" name="received_badges" attrs="{'invisible': [('user_id', '=', False)]}">
                     <field name="has_badges" invisible="1"/>
                     <button string="Grant a Badge" type="action" name="%(action_reward_wizard)d"/> to reward this employee for a good action
-                    <div class="o_field_nocontent" attrs="{'invisible': [('has_badges', '=', True)]}">
+                    <div class="o_field_nocontent mt-2" attrs="{'invisible': [('has_badges', '=', True)]}">
                         <p>
                             Grant this employee his first badge
                         </p><p class="oe_grey">
                             Badges are rewards of good work. Give them to people you believe deserve it.
                         </p>
                     </div>
-                    <field name="badge_ids" mode="kanban" />
+                    <div class="mt-2">
+                        <field name="badge_ids" mode="kanban" />
+                    </div>
                 </page>
             </xpath>
 


### PR DESCRIPTION
Before this commit, when viewing the received badges tab in an employee's profile, there was a lack of spacing below the "Grant a badge" button.

This commit resolves the issue by introducing proper spacing between the button and the displayed badges.

task-3329971
part of task-3326263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
