### PR TITLE
[FIX] payment: translate post-processing messages

### DIFF
--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 
 import psycopg2
 
-from odoo import fields, http
+from odoo import _, fields, http
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -58,11 +58,11 @@ class PaymentPostProcessing(http.Controller):
         for tx in monitored_txs:
             display_message = None
             if tx.state == 'pending':
-                display_message = tx.provider_id.pending_msg
+                display_message = _(tx.provider_id.pending_msg)
             elif tx.state == 'done':
-                display_message = tx.provider_id.done_msg
+                display_message = _(tx.provider_id.done_msg)
             elif tx.state == 'cancel':
-                display_message = tx.provider_id.cancel_msg
+                display_message = _(tx.provider_id.cancel_msg)
             display_values_list.append({
                 'display_message': display_message,
                 **tx._get_post_processing_values(),


### PR DESCRIPTION
Before this commit, the messages displayed on the payment processing page were not translated.

Now the messages about the transaction will be translated on the payment processing page.

task-3055122
