### PR TITLE
[FIX] pos_sale: Pick from reserved stock.move.line

### DIFF
--- a/addons/pos_sale/models/__init__.py
+++ b/addons/pos_sale/models/__init__.py
@@ -6,4 +6,5 @@ from . import pos_order
 from . import crm_team
 from . import pos_session
 from . import sale_order
+from . import stock_picking
 from . import res_config_settings

--- a/addons/pos_sale/models/stock_picking.py
+++ b/addons/pos_sale/models/stock_picking.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    def _create_move_from_pos_order_lines(self, lines):
+        lines_to_unreserve = self.env['pos.order.line']
+        for line in lines:
+            if line.order_id.to_ship:
+                continue
+            if any(wh != line.order_id.config_id.warehouse_id for wh in line.sale_order_line_id.move_ids.location_id.warehouse_id):
+                continue
+            lines_to_unreserve |= line
+        lines_to_unreserve.sale_order_line_id.move_ids.filtered(lambda ml: ml.state not in ['cancel', 'done'])._do_unreserve()
+        return super()._create_move_from_pos_order_lines(lines)


### PR DESCRIPTION
Usecase to reproduce:
- Set reservation method to closest location
- Set the POS as real time stock
- Put 1 unit in A and 1 unit in location B
- Create a SO for 1 unit
- Sell it in the POS

Expected behavior:
The unit has been taken from the reservation in location A

Current behavior:
The unit is taken from B

It happens because the SO is unreserved after the new picking and stock.move.line creation. Since the unit is reserved, he can't pick it and take a random ones.
The solution here is to unreserve the related stock.move to free the reserved unit, it will not always be the same than the SO but it will consider it in the removal strategy. It could also fix the case where only 1 unit remains in stock and he won't pick it.

opw-3271217

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
