### PR TITLE
[FIX] website_slides: fix attendee creation in list view

### DIFF
--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -25,6 +25,7 @@
                 <tree string="Attendees" editable="top">
                     <field name="channel_id" string="Course Name"/>
                     <field name="channel_user_id"/>
+                    <field name="partner_id" string="Contact"/>
                     <field name="partner_email" string="Email"/>
                     <field name="create_date" string="Enrolled On"/>
                     <field name="write_date" string="Last Action On"/>


### PR DESCRIPTION
`partner_id` was removed from the list view via #64152.
When creating an attendee from this list view, there is no way to set the partner and in effect the partner email, however, it exists in the kanban view.

Re-adding the `partner_id` field re-enables list view creation functionalities to how it was in v14.

opw-3328559