### PR TITLE
[FIX] account: prevent trace back while the customer has no address.

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -34,7 +34,7 @@ class AccountMoveSend(models.Model):
             code_to_label = dict(wizard.move_ids.partner_id._fields['ubl_cii_format'].selection)
             codes = wizard.move_ids.partner_id.mapped('ubl_cii_format')
             if any(codes):
-                wizard.checkbox_ubl_cii_label = ", ".join(code_to_label[c] for c in codes)
+                wizard.checkbox_ubl_cii_label = ", ".join(code_to_label[c] for c in codes if c)
             else:
                 wizard.checkbox_ubl_cii_label = False
 


### PR DESCRIPTION
[FIX] account: prevent trace back while the customer has no address.

"KeyError False" is generated If the user selects two or more invoices from the
Tree view and at least one of the invoices do not have a customer address,
and then click the "Send" button, and an error will occur. This is because the
code is trying to get the "False" key from a dictionary, but the dictionary does
not contain that key.'

Traceback on sentry:
```
KeyError: False
  File "odoo/http.py", line 2106, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1689, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1716, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1913, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 708, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6538, in onchange
    snapshot1 = Snapshot(record, nametree)
  File "odoo/models.py", line 6298, in __init__
    self.fetch(name)
  File "odoo/models.py", line 6308, in fetch
    self[name] = record[name]
  File "odoo/models.py", line 5923, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1188, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1347, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4291, in _compute_field_value
    getattr(self, field.compute)()
  File "addons/account_edi_ubl_cii/models/account_move_send.py", line 37, in _compute_checkbox_ubl_cii_label
    wizard.checkbox_ubl_cii_label = ", ".join(code_to_label[c] for c in codes)
  File "addons/account_edi_ubl_cii/models/account_move_send.py", line 37, in <genexpr>
    wizard.checkbox_ubl_cii_label = ", ".join(code_to_label[c] for c in codes)
```

Steps to Reproduce
- Install `account'  modules.
- Create a new customer without adding the address.
- Open an Invoices module, and Select two or more invoices, In which a minimum
 of one does not have a customer address.
- Click a 'send' in action. An Error will be generated.

Applying this commit will resolve this issue by adding a condition if
code has the key.

sentry-4054584178

