### PR TITLE
[FIX] website_twitter:  prevent valuerror at authentication failure

### DIFF
--- a/addons/website_twitter/models/website_twitter.py
+++ b/addons/website_twitter/models/website_twitter.py
@@ -34,6 +34,7 @@ class WebsiteTwitter(models.Model):
         except requests.HTTPError as e:
             _logger.debug("Twitter API request failed with code: %r, msg: %r, content: %r",
                           e.response.status_code, e.response.reason, e.response.content)
+            e.sentry_ignored = True
             raise
 
     @api.model


### PR DESCRIPTION
When the user using twitter's developer API has not completed user authentication settings properly or has not provided proper twitter screen name then they may face this issue when the cron 'Twitter: Fetch new favorites' is executed. User may also face similar error when the user wants some services through API which they may get only under paid subscription.

HTTPError: 403 Client Error: Forbidden for url: https://api.twitter.com/oauth2/token
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(362,)", line 1, in <module>
  File "addons/website_twitter/models/website_twitter.py", line 46, in _refresh_favorite_tweets
    website.fetch_favorite_tweets()
  File "addons/website_twitter/models/website_twitter.py", line 62, in fetch_favorite_tweets
    response = self._request(website, REQUEST_FAVORITE_LIST_URL, params=params)
  File "addons/website_twitter/models/website_twitter.py", line 29, in _request
    access_token = self._get_access_token(website)
  File "addons/website_twitter/models/website_twitter.py", line 86, in _get_access_token
    r.raise_for_status()
  File "requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
    
ValueError: <class 'requests.exceptions.HTTPError'>: "403 Client Error: Forbidden for url: https://api.twitter.com/oauth2/token" while evaluating
'model._refresh_favorite_tweets()'
  File "odoo/addons/base/models/ir_cron.py", line 368, in _callback
    self.env['ir.actions.server'].browse(server_action_id).run()
  File "odoo/addons/base/models/ir_actions.py", line 668, in run
    res = runner(run_self, eval_context=eval_context)
  File "addons/website/models/ir_actions_server.py", line 61, in _run_action_code_multi
    res = super(ServerAction, self)._run_action_code_multi(eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 538, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))

This commit would prevent the traceback on sentry by ignoring it's log .As these kind of issues may cause lot of noise on sentry.

Sentry - 4170447022

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
