### PR TITLE
[FIX] account: ignore exception error in sentry

### DIFF
--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -49,7 +49,7 @@ class IrAttachment(models.Model):
             pdf_reader = OdooPdfFileReader(buffer, strict=False)
         except Exception as e:
             # Malformed pdf
-            _logger.exception("Error when reading the pdf: %s", e)
+            _logger.warning("Error when reading the pdf: %s", e, exc_info=True)
             return []
 
         # Process embedded files.


### PR DESCRIPTION
When we upload the PDF file in the invoice and if it does not have xref table then error will be generated.

See Trace back:
```PdfReadError: Could not find xref table at specified location
  File "addons/account/models/ir_attachment.py", line 49, in _decode_edi_pdf
    pdf_reader = OdooPdfFileReader(buffer, strict=False)
  File "odoo/tools/pdf.py", line 189, in <lambda>
    old_init(self, stream=stream, strict=strict, warndest=None, overwriteWarnings=False)
  File "PyPDF2/pdf.py", line 1084, in __init__
    self.read(stream)
  File "PyPDF2/pdf.py", line 1901, in read
    raise utils.PdfReadError("Could not find xref table at specified location")
```

we stop catching exception in sentry.

sentry - 4114889780

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
