### PR TITLE
[FIX] mrp: prevent traceback while add new work order in manufacturing orders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1302,7 +1302,7 @@ class MrpProduction(models.Model):
                 previous_workorder = workorder
                 last_workorder_per_bom[workorder.operation_id.bom_id] = workorder
         for move in (self.move_raw_ids | self.move_finished_ids):
-            if move.operation_id:
+            if move.operation_id and move.operation_id in workorder_per_operation:
                 move.write({
                     'workorder_id': workorder_per_operation[move.operation_id].id
                 })


### PR DESCRIPTION
An error occurs because workorder_ids is not set in manufacturing orders.

steps to produce an error:
1) create a new BOM of storable product and in route set manufacture = True. 
2) add operations of that product also add the components in component lines add the operation_ids.
3) now go to that particular product, click on replenish, set the quantity, and confirm that.
4) now open the manufacture order of that product. 
5) remove all the work orders and add new work order try to save.

sentry traceback:
```
KeyError: mrp.routing.workcenter(25,)
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(931,)", line 1, in <module>
  File "addons/stock/models/stock_rule.py", line 574, in run_scheduler
    self._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
  File "addons/point_of_sale/models/pos_session.py", line 1999, in _run_scheduler_tasks
    super(ProcurementGroup, self)._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
  File "addons/stock/models/stock_rule.py", line 545, in _run_scheduler_tasks
    orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
  File "addons/stock/models/stock_orderpoint.py", line 542, in _procure_orderpoint_confirm
    orderpoints_batch._post_process_scheduler()
  File "addons/mrp/models/stock_orderpoint.py", line 148, in _post_process_scheduler
    ]).action_confirm()
  File "addons/mrp/models/mrp_production.py", line 1263, in action_confirm
    production.workorder_ids._action_confirm()
  File "home/odoo/src/enterprise/16.0/mrp_workorder/models/mrp_workorder.py", line 568, in _action_confirm
    res = super()._action_confirm()
  File "addons/mrp/models/mrp_workorder.py", line 499, in _action_confirm
    production._link_workorders_and_moves()
  File "addons/mrp/models/mrp_production.py", line 1296, in _link_workorders_and_moves
    'workorder_id': workorder_per_operation[move.operation_id].id
```

applying these changes will resolve this issue.

sentry-4171798131