### PR TITLE
[FIX] website_sale_loyalty: prevent traceback when user apply discount code

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -11,7 +11,7 @@ class WebsiteSale(main.WebsiteSale):
 
     @http.route()
     def pricelist(self, promo, **post):
-        order = request.website.sale_get_order()
+        order = request.website.sale_get_order(force_create=True)
         coupon_status = order._try_apply_code(promo)
         if 'error' not in coupon_status:
             if len(coupon_status) == 1:


### PR DESCRIPTION
If the user is not logged in website and try to checkout with the discount code without any product then this error will be generated.

Steps to reproduce:

- Install website_sale_loyalty module.
- Now, do logout from the website
- In Website > Shop, select any of the items.
- Add this item to the cart and go to the cart page.
- Now duplicate this page, In the current page delete all the items from the cart.
- Now on the duplicate page click on apply button of the discount code.
- Traceback will be generated.

Traceback:

```ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5189, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: sale.order()
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1838, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale_loyalty/controllers/main.py", line 15, in pricelist
    coupon_status = order._try_apply_code(promo)
  File "addons/sale_loyalty/models/sale_order.py", line 963, in _try_apply_code
    self.ensure_one()
  File "odoo/models.py", line 5192, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

Applying this commit will resolve the issue.

sentry:- 4116672397