### PR TITLE
[FIX] utm: prevent utm.mixin keyerror during module uninstallation

### DIFF
--- a/addons/utm/models/ir_http.py
+++ b/addons/utm/models/ir_http.py
@@ -22,5 +22,6 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _post_dispatch(cls, response):
-        cls._set_utm(response)
+        if 'utm.mixin' in request.env:
+            cls._set_utm(response)
         super()._post_dispatch(response)


### PR DESCRIPTION
This issue occurs when the _set_utm function in the ir_http.py file was attempting to access the 'utm.mixin' model after uninstalling the UTM module.

steps to produce :
1. Install the 'utm' module.
2. once installed, delete the module and thus, the traceback will be generated

```
KeyError: 'utm.mixin'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    ir_http._post_dispatch(response)
  File "addons/utm/models/ir_http.py", line 25, in _post_dispatch
    cls._set_utm(response)
  File "addons/utm/models/ir_http.py", line 19, in _set_utm
    for url_parameter, __, cookie_name in request.env['utm.mixin'].tracking_fields():
  File "odoo/api.py", line 521, in __getitem__
    return self.registry[model_name](self, (), ())
  File "odoo/modules/registry.py", line 190, in __getitem__
    return self.models[model_name]
```

This commit will solve the issue by adding a check to verify the presence of 'utm.mixin' in request.env before accessing the tracking fields.

sentry-3958588195





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
