### PR TITLE
[FIX] account: prevent keyerror when parsing csv data when module uni…

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -738,6 +738,10 @@ class AccountChartTemplate(models.AbstractModel):
         assert re.fullmatch(r"[a-z0-9_]+", module)
 
         res = {}
+        module_id = self.env['ir.module.module'].search([('name', '=', module)], limit=1)
+        if module_id and module_id.state == 'uninstalled':
+            _logger.debug("No file %s found for template '%s'", model, module)
+            return res
         for template in self._get_parent_template(template_code)[::-1] or ['']:
             try:
                 with file_open(f"{module}/data/template/{model}{f'-{template}' if template else ''}.csv", 'r') as csv_file:


### PR DESCRIPTION
This issue occurs when attempting to parse CSV files related to an uninstalled module 'l10n_ph'.

steps to produce :
1. Install the 'l10n_ph' module.
2. once installed, delete the module and try to install the 'stock' module. thus, traceback will be generated

```
KeyError: 'l10n_ph_atc'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 32, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/addons/base/models/res_config.py", line 600, in execute
    self.set_values()
  File "home/odoo/src/enterprise/saas-16.2/sale_timesheet_enterprise/models/res_config_settings.py", line 47, in set_values
    return super().set_values()
  File "addons/sale_project/models/res_config_settings.py", line 11, in set_values
    super().set_values()
  File "addons/sale_management/models/res_config_settings.py", line 31, in set_values
    super().set_values()
  File "addons/sale/wizard/res_config_settings.py", line 94, in set_values
    super().set_values()
  File "addons/hr_expense/models/res_config_settings.py", line 35, in set_values
    super().set_values()
  File "addons/project/models/res_config_settings.py", line 70, in set_values
    super().set_values()
  File "addons/account/models/res_config_settings.py", line 169, in set_values
    self.env['account.chart.template'].try_loading(self.chart_template, company=self.company_id)
  File "addons/account/models/chart_template.py", line 141, in try_loading
    return self._load(template_code, company, install_demo)
  File "addons/account/models/chart_template.py", line 178, in _load
    data = self._get_chart_template_data(template_code)
  File "addons/account/models/chart_template.py", line 511, in _get_chart_template_data
    data = func(self, template_code)
  File "addons/account/models/chart_template.py", line 49, in wrapper
    return func(*args, **kwargs)
  File "addons/account/models/chart_template.py", line 611, in _get_account_tax
    tax_data = self._parse_csv(template_code, 'account.tax')
  File "addons/account/models/chart_template.py", line 745, in _parse_csv
    res[row['id']] = {
  File "addons/account/models/chart_template.py", line 749, in <dictcomp>
    else (value and ast.literal_eval(value) or False) if model_fields[key].type in ('boolean', 'int', 'float')
```

This commit will solve the issue by adding a module check to the code, that if the module is found and its state is 'uninstalled', the method logs a debug message and returns an empty dictionary.

sentry-4184561125




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
