### PR TITLE
[FIX] web: Unblocking for self target

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -844,7 +844,7 @@ function makeActionManager(env) {
             env.services.ui.block();
             env.services.router.redirect(url);
             browser.removeEventListener("beforeunload", onUnload);
-            if (!willUnload) {
+            if (willUnload) {
                 env.services.ui.unblock();
             }
         } else {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The screen continues to load even after the report is downloaded as the unblock function is not called after redirection.
https://github.com/odoo/odoo/blob/saas-16.1/addons/l10n_fr_fec/wizard/account_fr_fec.py#L403-L408
https://github.com/odoo/odoo/pull/107830/files
[OPW-3268315](https://www.odoo.com/web#id=3268315&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

Current behavior before PR:
After the FEC report is downloaded, the screen continues to load.
The report is returned with the type 'ir.actions.act_url' and target 'self' where the unblock function wasn't called.

Desired behavior after PR is merged:
After the FEC report is downloaded, the screen doesn't keep loading and the wizard is editable again.
The report is returned with the type 'ir.actions.act_url' and target 'self' where the unblock function is called.

Co-authored by: @kbs-odoo 
 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
