### PR TITLE
[IMP] hr_holidays: do not refuse leave allocation if already used

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -701,6 +701,13 @@ class HolidaysAllocation(models.Model):
         if any(holiday.state not in ['confirm', 'validate', 'validate1'] for holiday in self):
             raise UserError(_('Allocation request must be confirmed or validated in order to refuse it.'))
 
+        days_per_allocation = self.holiday_status_id._get_employees_days_per_allocation(self.employee_id.ids)
+
+        for allocation in self:
+            days_taken = days_per_allocation[allocation.employee_id.id][allocation.holiday_status_id][allocation]['virtual_leaves_taken']
+            if days_taken > 0:
+                raise UserError(_('You cannot refuse this allocation request since the employee has already taken leaves for it. Please refuse or delete those leaves first.'))
+
         self.write({'state': 'refuse', 'approver_id': current_employee.id})
         # If a category that created several holidays, cancel all related
         linked_requests = self.mapped('linked_request_ids')


### PR DESCRIPTION
Before this commit it was possible to refuse a leave allocation even if the employee already took leaves using time from this allocation. If this allocation is then refused, you get a negative balance for the allocated days, which should not be possible.

With this commit, we raise a UserError when trying to refuse such an allocation, stating that the user should handle the problematic leaves first.

task-3330749

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
