### PR TITLE
[IMP] point_of_sale: Add demo data for product with variants

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_demo.xml
+++ b/addons/point_of_sale/data/point_of_sale_demo.xml
@@ -173,6 +173,23 @@
             <field name="value_ids" eval="[(6, 0, [ref('fabric_attribute_plastic'), ref('fabric_attribute_leather'), ref('fabric_attribute_custom')])]"/>
         </record>
 
+        <!--
+        Handle automatically created product.template.attribute.value.
+        This will allow setting fields like "price_extra" and "exclude_for"
+         -->
+        <function model="ir.model.data" name="_update_xmlids">
+            <value model="base"
+                eval="[{
+                'xml_id': 'point_of_sale.desk_organizer_attribute_fabric_value_leather',
+                'record': obj().env.ref('point_of_sale.desk_organizer_fabric').product_template_value_ids[1],
+            },]" />
+        </function>
+
+        <record id="point_of_sale.desk_organizer_attribute_fabric_value_leather"
+            model="product.template.attribute.value">
+            <field name="price_extra">23</field>
+        </record>
+        
         <record id="magnetic_board" model="product.product">
           <field name="available_in_pos">True</field>
           <field name="list_price">1.98</field>


### PR DESCRIPTION
[IMP] point_of_sale: Add demo data for product with variants 

There is already a product that has attributes of type `Variants Creation Mode: Never`. ( the `Desk Organizer` ). This PR adds a price extra to one of it's variants. This is very useful when testing, as previously no product with attributes of type `Variants Creation Mode: Never` had a price extra associated.

Closes: 3338210


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
