### PR TITLE
[FIX] web_editor: entering a hax color trigger traceback

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -805,11 +805,11 @@ const ColorPaletteWidget = Widget.extend({
      * @private
      * @param {Event} ev
      */
-    _onColorPickerPreview: function (ev) {
+    _onColorPickerPreview: async function (ev) {
         if (ev.target === this.gradientColorPicker) {
             this._updateGradientColor(ev, true);
         } else {
-            this.trigger_up('color_hover', Object.assign(this.getSelectedColors(), {
+            await this.trigger_up('color_hover', Object.assign(this.getSelectedColors(), {
                 color: ev.data.cssColor,
                 target: this.colorPicker.el,
             }));


### PR DESCRIPTION
**Current behavior before PR:**

In mass_mailing entering a hax color for text trigger traceback.

**Desired behavior after PR is merged:**

Now, the traceback will not be triggered and color will be applied to the text

Task-3271517
