### PR TITLE
[IMP] project : gantt view improvements

### DIFF
--- a/addons/resource/models/utils.py
+++ b/addons/resource/models/utils.py
@@ -84,8 +84,8 @@ def filter_domain_leaf(domain, field_check, field_name_mapping=None):
         next_elem = domain.pop() # Browsing the domain backward simplifies the filtering
         if is_leaf(next_elem):
             field_name, op, value = next_elem
-            field_name = field_name_mapping.get(field_name, field_name)
             if field_check(field_name):
+                field_name = field_name_mapping.get(field_name, field_name)
                 stack.append((field_name, op, value))
                 ignored_elems.append(False)
             else:

--- a/addons/resource/tests/test_utils.py
+++ b/addons/resource/tests/test_utils.py
@@ -50,10 +50,10 @@ class TestExpression(TransactionCase):
 
         # Testing field mapping 1
         self.assertEqual(
-            ['&', '!', ('field3', '=', False), ('field3', '!=', 'test')],
+            [('field4', '!=', 'test')],
             normalize_domain(utils.filter_domain_leaf(
                 ['|', ('field1', 'in', [1, 2]), '!', ('field2', '=', False), ('field3', '!=', 'test')],
                 lambda field: field == 'field3',
-                field_name_mapping={'field2': 'field3'},
+                field_name_mapping={'field3': 'field4'},
             ))
         )


### PR DESCRIPTION
Before this commit, the group by in the gantt view of project didn't allow the user to find records for which there were not scheduled tasks. For example, if a Sale Order didn't have a scheduled task, when grouping by Sale Order, the latter was not displayed. And searching for its name was not displaying it either.

After this commit, when a user is searching for a sale order, even if the latter does not have any scheduled task, it is displayed in order to facilitate the scheduling of new tasks.

In order to do so, a group expand on sale_order_id for the project.task model have been introduced.

TaskId: 3251630

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
