### PR TITLE
[IMP] website, *: allow web configurator to drop non-website snippets

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2985,13 +2985,13 @@ var SnippetsMenu = Widget.extend({
                 const isCustomSnippet = !!el.closest('#snippet_custom');
 
                 // Associate in-page snippets to their name
-                // TODO I am not sure this is useful anymore and it should at
-                // least be made more robust using data-snippet
                 let snippetClasses = $sbody.attr('class').match(/s_[^ ]+/g);
                 if (snippetClasses && snippetClasses.length) {
                     snippetClasses = '.' + snippetClasses.join('.');
                 }
-                const $els = self.$body.find(snippetClasses).not('[data-name]').add($(snippetClasses)).add($sbody);
+                const dataSnippetAttr = $sbody[0].dataset.snippet;
+                const selector = dataSnippetAttr ? `[data-snippet=${dataSnippetAttr}]` : snippetClasses;
+                const $els = self.$body.find(selector).not('[data-name]').add($(selector)).add($sbody);
                 $els.attr('data-name', name).data('name', name);
 
                 // Create the thumbnail


### PR DESCRIPTION
*: web_editor

When defining themes, we can specify the list of snippets that will be
dropped on the page after the configurator has completed. However, the
addition of snippets belonging to modules other than "website" is
currently not supported.

This commit adds the support for adding these external snippets. The
principle is the following: in `snippets_lists` in the themes manifest
files, in order to add
- a website snippet, we can either directly put the snippet name or
prefix it by `website.` (e.g. both `website.s_text_image` and 's_text_
image` will work).
- a non-website snippet, we must prefix the snippet name by its module
(e.g. `website_sale.s_dynamic_snippet_products`).

Since the external snippets cannot be customized in XML files like the
website snippets if their modules are not already installed, a new way
to still customize them has been added: in the theme manifest, after
`snippet_lists`, a new key `theme_customizations` is added. Its value is
a dictionary whose keys are the page codes (e.g. "homepage"), like in
`snippet_lists`. Their value is another dictionary whose keys are the
snippet names (without the module prefix) we want to customize.
For example:

```python
'snippet_lists': {...},
'theme_customizations': {
    'homepage': {
        's_dynamic_snippet_products': {...},  # = snippet dictionary
        's_online_appointment': {...},
    },
},
```

Their values depend on whether the snippet is a dynamic snippet (e.g.
Products, Blog Posts, Events) or an inner content (e.g. Online
Appointment) and if we want to customize the background or not.

1) Dynamic snippets:
These snippets need to be initialized when adding them, otherwise they
are not displayed as expected. If no customization is specified, default
values are used, displaying them as if they were just dropped.

In order to customize them, keys are added in the snippets dictionary:
- 'filter_name' -> the id of the dynamic filter record.
- 'template_key' -> the template key in the DOM, in the `data-template-
key` attribute.
- 'data-attributes' -> a dictionary containing the data-attributes we
want to modify (any of them can be specified but only the ones that can
be changed using the right panel should be added, for the user to have a
control on them). The data-attributes are the keys, without the 'data-'
prefix, and the values are written like in the DOM (in general, we just
need to copy it).
- 'hover_effect' (for Blog Posts) -> the class corresponding to the
hover effect we want to apply.

Examples:
```python
's_dynamic_snippet_products': {
    'filter_name': 'website_sale.dynamic_filter_latest_sold_products',
    'template_key': 'website_sale.dynamic_filter_template_product_product_card_group',
    'data_attributes': {'number-of-records': '12', 'product-category-id': '1', 'carousel-interval': '2000', 'number-of-elements': '2'},
},
's_events': {
    'template_key': 'website_event.dynamic_filter_template_event_event_card',
    'data_attributes': {'filter-by-tag-ids': '[{"id":5,"name":"Culture","display_name":"Culture","category_id":"2,Activity"}]'},
},
's_blog_posts': {
    'filter_name': 'website_blog.dynamic_filter_most_viewed_blog_posts',
    'hover_effect': 's_blog_posts_effect_chico',
    'data_attributes': {'number-of-records': '4', 'number-of-elements': '2'},
},
```

2) Inner contents:
Inner content snippets were just dropped on the page, below the other
"normal" snippets, while it should not be the case since they can only
be dropped inside an other snippet. This commit adds the support for
them. Note that if no customization is specified, it will behave the
same way as before.

In these snippets dictionary, we add the following keys:
- 'drop_in' -> the name of the snippet in which the inner content needs
to be dropped (without the module prefix).
- 'xpath' -> the xpath specifying the inner content location in the
snippet. Note that it will always be added as the last element of the
xpath.

Example:
```python
's_online_appointment': {
    'drop_in': 's_text_image',
    'xpath': '//div[hasclass("col-lg-4")]',
},
```

3) Background
For the external snippets having the Background option set on their
`<section>` tag, it is possible to customize them by adding the
'background' key in the snippets dictionary. It can contain the
following keys:
- 'color' -> an `o_ccx` color class.
- 'image' -> a string with the `background-image`, `background-
position`, ... inline style definitions.
- 'shape' -> a dictionary containing:
    - 'data-oe-shape-data' -> the shape data like in the DOM.
    - 'element' -> a string of the shape element (the shape `<div>`).

Example:
```python
's_dynamic_snippet_products': {
    ...
    'background': {
        'color': 'o_cc3',
        'image': 'background-image: url("/web/image/website.s_cover_default_image"); background-position: 50% 50%;',
        'shape': {
            'data-oe-shape-data': '{"shape":"web_editor/Wavy/07","flip":["x"]}',
            'element': """<div class="o_we_shape o_web_editor_Wavy_07" style="background-image: url('/web_editor/shape/web_editor/Wavy/07.svg?c3=o-color-1&amp;flip=x'); background-position: 50% 0%;"/>""",
        },
    },
},
```

This commit also improves the way the `data-name` attributes are set on
the snippets. Indeed, it was only based on a snippet classes match, so
changing the classes when customizing caused some matches to fail. Now,
it considers the `data-snippet` attribute first.

task-3252992