### PR TITLE
[FIX] stock: prevent traceback while change the Unit of Measure of product

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -189,7 +189,8 @@ class Product(models.Model):
                     0.0,
                 )
                 continue
-            rounding = product.uom_id.rounding
+            # use _origin to acess virtual recordset
+            rounding = product._origin.uom_id.rounding
             res[product_id] = {}
             if dates_in_the_past:
                 qty_available = quants_res.get(origin_product_id, [0.0])[0] - moves_in_res_past.get(origin_product_id, 0.0) + moves_out_res_past.get(origin_product_id, 0.0)


### PR DESCRIPTION
An error occurs because it receives the virtual recordset (eg: product.product(``<NewId origin=138>,``) ) instead of recordset.

steps to produce error:
1) install the ebay sales.
2) open one product and try to change UOM.

traceback on sentry:
```
KeyError: <NewId origin=138>
  File "odoo/api.py", line 958, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'product.product(<NewId origin=138>,).virtual_available'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 965, in get
    raise CacheMiss(record, field)
AssertionError: precision_rounding must be positive, got 0.0
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6494, in onchange
    snapshot0 = Snapshot(record, nametree, fetch=(not first_call))
  File "odoo/models.py", line 6307, in __init__
    self.fetch(name)
  File "odoo/models.py", line 6315, in fetch
    self[name] = [Snapshot(line, tree[name]) for line in record[name]]
  File "odoo/models.py", line 6315, in <listcomp>
    self[name] = [Snapshot(line, tree[name]) for line in record[name]]
  File "odoo/models.py", line 6307, in __init__
    self.fetch(name)
  File "odoo/models.py", line 6317, in fetch
    self[name] = record[name]
  File "odoo/models.py", line 5932, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1209, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1368, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4302, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "addons/stock/models/product.py", line 126, in _compute_quantities
    res = products._compute_quantities_dict(self._context.get('lot_id'), self._context.get('owner_id'), self._context.get('package_id'), self._context.get('from_date'), self._context.get('to_date'))
  File "addons/mrp/models/product.py", line 195, in _compute_quantities_dict
    super(ProductProduct, regular_products)._compute_quantities_dict(lot_id, owner_id, package_id, from_date=from_date, to_date=to_date)
  File "addons/stock/models/product.py", line 199, in _compute_quantities_dict
    res[product_id]['qty_available'] = float_round(qty_available, precision_rounding=rounding)
  File "odoo/tools/float_utils.py", line 54, in float_round
    rounding_factor = _float_check_precision(precision_digits=precision_digits,
  File "odoo/tools/float_utils.py", line 29, in _float_check_precision
    assert precision_rounding is None or precision_rounding > 0,\
```

applying these changes will resolve this issue.

sentry-4187635960