### PR TITLE
[FIX] website_blog: prevent unsupported operand issue in website_blog

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -75,6 +75,10 @@ class WebsiteBlog(http.Controller):
         BlogPost = request.env['blog.post']
         BlogTag = request.env['blog.tag']
 
+        try:
+            page = int(page)
+        except ValueError:
+            page = 1
         # prepare domain
         domain = request.website.website_domain()
 


### PR DESCRIPTION
The TypeError is caused by subtracting a string from an integer when a user enters the URL like '/blog?page=abc' instead of the '/blog?page=3'.

Steps to produce:
1. Install website_blog > Go to website > Click on any blog.
2. Now change the URL with '/blog?page=any_string'.

```
TypeError: unsupported operand type(s) for -: 'str' and 'int'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1838, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_blog/controllers/main.py", line 210, in blog
    values = self._prepare_blog_values(blogs=blogs, blog=blog, tags=tag, page=page, search=search, **opt)
  File "addons/website_blog/controllers/main.py", line 114, in _prepare_blog_values
    offset = (page - 1) * self._blog_post_per_page
```

This commit will solve the issue by adding a try-except block to convert the 'page' variable to an integer.

sentry-4196684325





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
