### PR TITLE
[FIX] auth_signup: prevent traceback while open send password reset instruction

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7582,6 +7582,12 @@ msgid ""
 msgstr ""
 
 #. module: mail
+#: code:addons/mail/models/mail_template.py:0
+#, python-format
+msgid "You cannot delete this %s template.Please archive it instead."
+msgstr ""
+
+#. module: mail
 #: code:addons/mail/models/mail_channel.py:0
 #, python-format
 msgid ""

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -85,6 +85,14 @@ class MailTemplate(models.Model):
         for template in self:
             template.can_write = template in writable_templates
 
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_reset_password_email(self):
+        mail_template = self.env.ref('auth_signup.reset_password_email', False)
+        if mail_template.id in self.ids:
+            raise UserError(_(
+                "You cannot delete this %s template."
+                "Please archive it instead.", mail_template.name))
+
     # ------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------


### PR DESCRIPTION
When the user delete the record of  'Auth Signup: Reset Password' in The setting and try to access that by the 'send password reset instruction' Template then an error will be generated.

Steps to reproduced error:

- Install the 'Signup' module.
- Configure SMTP server.
- In Settings > Technical > Email > open Email Template.
- Delete 'Auth Signup: Reset Password' Email Template.
- Now settings > User & Companies > Users > open mitchell admin user.
- In form view of res.users click on 'SEND PASSWORD RESET INSTRUCTION'.
- Traceback will be generated.

Traceback:
```KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7f947a63ab90>, 'auth_signup.reset_password_email')
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: External ID not found in the system: auth_signup.reset_password_email
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "addons/auth_signup/models/res_users.py", line 231, in web_create_users
    res = super(ResUsers, self).web_create_users(list(new_emails))
  File "addons/base_setup/models/res_users.py", line 23, in web_create_users
    user = self.with_context(signup_valid=True).create(default_values)
  File "<decorator-gen-232>", line 2, in create
  File "odoo/api.py", line 387, in _model_create_single
    return create(self, arg)
  File "home/odoo/src/custom/trial/saas_trial/models/res_users.py", line 100, in create
    res = super(ResUsers, self).create(values)
  File "<decorator-gen-116>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/auth_signup/models/res_users.py", line 244, in create
    users_with_email.with_context(create_user=True).action_reset_password()
  File "home/odoo/src/custom/trial/saas_trial/models/res_users.py", line 183, in action_reset_password
    super(ResUsers, internal_users).action_reset_password()
  File "addons/auth_signup/models/res_users.py", line 184, in action_reset_password
    template = self.env.ref('auth_signup.reset_password_email')
  File "odoo/api.py", line 566, in ref
    res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
  File "odoo/addons/base/models/ir_model.py", line 1984, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-40>", line 2, in _xmlid_lookup
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 1977, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
```

Applying this commit will resolve this issue.

Sentry:- 4180361733
