### PR TITLE
[FIX] payment_{adyen, sips}, tools: prevent traceback when incorrect website url

### DIFF
--- a/addons/payment_adyen/i18n/payment_adyen.pot
+++ b/addons/payment_adyen/i18n/payment_adyen.pot
@@ -86,6 +86,13 @@ msgid "Incorrect Payment Details"
 msgstr ""
 
 #. module: payment_adyen
+#. odoo-python
+#: code:addons/payment_adyen/models/payment_provider.py:0
+#, python-format
+msgid "Invalid URL %s"
+msgstr ""
+
+#. module: payment_adyen
 #: model_terms:ir.ui.view,arch_db:payment_adyen.payment_provider_form
 msgid "Learn More"
 msgstr ""

--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -9,6 +9,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 from odoo.addons.payment_adyen.const import API_ENDPOINT_VERSIONS
+from odoo.tools import single_wesite_re
 
 _logger = logging.getLogger(__name__)
 
@@ -37,6 +38,15 @@ class PaymentProvider(models.Model):
     adyen_recurring_api_url = fields.Char(
         string="Recurring API URL", help="The base URL for the Recurring API endpoints",
         required_if_provider='adyen')
+
+    @api.constrains('adyen_checkout_api_url', 'adyen_recurring_api_url')
+    def _check_adyen_url(self):
+        for payment in self:
+            checkout_api_url = single_wesite_re.match(str(payment.adyen_checkout_api_url))
+            recurring_api_url = single_wesite_re.match(str(payment.adyen_recurring_api_url))
+            if payment.adyen_checkout_api_url and not checkout_api_url or payment.adyen_recurring_api_url and not recurring_api_url:
+                raise ValidationError(
+                    _('Invalid URL %s') % (payment.adyen_checkout_api_url if not checkout_api_url else payment.adyen_recurring_api_url))
 
     #=== CRUD METHODS ===#
 

--- a/addons/payment_sips/i18n/payment_sips.pot
+++ b/addons/payment_sips/i18n/payment_sips.pot
@@ -21,6 +21,13 @@ msgid "Interface Version"
 msgstr ""
 
 #. module: payment_sips
+#. odoo-python
+#: code:addons/payment_sips/models/payment_provider.py:0
+#, python-format
+msgid "Invalid URL %s"
+msgstr ""
+
+#. module: payment_sips
 #: model:ir.model.fields,field_description:payment_sips.field_payment_acquirer__sips_merchant_id
 msgid "Merchant ID"
 msgstr ""

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -63,6 +63,9 @@ etree.set_default_parser(etree.XMLParser(resolve_entities=False))
 
 NON_BREAKING_SPACE = u'\N{NO-BREAK SPACE}'
 
+# matches a string containing only one website
+single_wesite_re = re.compile(r"""(http|https):\/\/([\w\-_]+(?:(?:\.[\w\-_]+)+))([\w\-\.,@?^=%&:/~\+#]*[\w\-\@?^=%&/~\+#])?""")
+
 #----------------------------------------------------------
 # Subprocesses
 #----------------------------------------------------------


### PR DESCRIPTION
When the user enters an incorrect website URL during the setup of 'Adyen or Sips' payment acquirer after that any portal user tries to pay via 'Adyen or Sips' through e-commerce, during that time traceback will be generated

Steps To Produce for Adyen:-

1) Install 'Payment Adyen' and 'website_sale' modules
2) Go to Website > Configuration > eCommerce > Payment Providers
3) Activate 'Adyen' and choose the state 'test mode' option
   Configure 'Adyen' payment provider with
  Checkout API URL  = 2006/V67/paymentMethods
4) Now open 'Incognito Window' without sign-in, and purchase any product
5) Choose Pay with the 'Adyen' option and click on 'Pay Now' button

Traceback will be generated.

This is because of an invalid URL.

regex reference : https://www.i2tutorials.com/match-urls-using-regular-expressions-in-python/

See Traceback:-

```
MissingSchema: Invalid URL '2006/V67/paymentMethods': No schema supplied. Perhaps you meant http://2006/V67/paymentMethods?
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/payment_adyen/controllers/main.py", line 75, in adyen_payment_methods
    response_content = provider_sudo._adyen_make_request(
  File "addons/payment_adyen/models/payment_provider.py", line 119, in _adyen_make_request
    response = requests.request(method, url, json=payload, headers=headers, timeout=60)
  File "requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "requests/sessions.py", line 528, in request
    prep = self.prepare_request(req)
  File "requests/sessions.py", line 456, in prepare_request
    p.prepare(
  File "requests/models.py", line 316, in prepare
    self.prepare_url(url, params)
  File "requests/models.py", line 390, in prepare_url
    raise MissingSchema(error)
```

Applying these changes will resolve this issue.

sentry - 4181981080

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
