### PR TITLE
[FIX] account: display table borders on invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -88,7 +88,9 @@
 
                         <t t-set="display_discount" t-value="any(l.discount for l in o.invoice_line_ids)"/>
 
-                        <table class="table table-sm o_main_table table-borderless" name="invoice_line_table">
+                        <t t-set="layout" t-value="o.company_id.external_report_layout_id.key or 'web.external_layout_standard'" />
+                        <table t-attf-class="table table-sm o_main_table-end {{ 'table-borderless' if layout != 'web.external_layout_boxed' else '' }}"
+                               name="invoice_line_table">
                             <thead>
                                 <tr>
                                     <th name="th_description" class="text-start"><span>Description</span></th>
@@ -165,7 +167,8 @@
                     <div class="clearfix mb-4">
                         <div id="total" class="row">
                             <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ms-auto">
-                                <table class="table table-sm table-borderless" style="page-break-inside: avoid;">
+                                <t t-set="layout" t-value="o.company_id.external_report_layout_id.key or 'web.external_layout_standard'" />
+                                <table t-attf-class="table table-sm {{ 'table-borderless' if layout != 'web.external_layout_boxed' else '' }}" style="page-break-inside: avoid;">
 
                                     <!--Tax totals-->
                                     <t t-set="tax_totals" t-value="o.tax_totals"/>


### PR DESCRIPTION
Steps to reproduce:
- In Settings, select the Boxed Invoice document configuration
- Create an invoice
- Print

Issue:
The product lines do not have borders

Cause:
We set "table-borderless" class in the invoice template, overriding the BS5 default behaviour

Solution
Conditionnaly set the "table-borderless"

opw-3251616