### PR TITLE
[FIX] base: prevent trackback while passing string value instead json

### DIFF
--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -173,3 +173,8 @@ class TestHttpEchoReplyJsonWithDB(TestHttpBase):
         self.assertEqual(res.text, '{"jsonrpc": "2.0", "id": 0, "result": '
             f'{{"lang": "en_US", "tz": false, "uid": {self.jackoneill.id}, "name": "Thor"}}'
             '}')
+
+    def test_echojson_wrong_payload(self):
+        res = self.db_url_open('/test_http/echo-json?race=Asgard', data='wrong payload', headers=CT_JSON)
+        self.assertEqual(res.json().get('error').get('code'), 200)
+        self.assertEqual(res.json().get('error').get('message'), 'Odoo Server Error')

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1952,7 +1952,7 @@ class JsonRPCDispatcher(Dispatcher):
         return self._response(error=error)
 
     def _response(self, result=None, error=None):
-        request_id = self.jsonrequest.get('id')
+        request_id = self.jsonrequest.get('id') if isinstance(self.jsonrequest, dict) else False
         response = {'jsonrpc': '2.0', 'id': request_id}
         if error is not None:
             response['error'] = error


### PR DESCRIPTION
This issue might occur when a string value passed instead of a JSON. To prevent this problem, By including a validated check
 to make sure that only valid JSON objects are passed

Trace-back on sentry:
```
AttributeError: 'str' object has no attribute 'get'
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1916, in dispatch
    self.request.params = dict(self.jsonrequest.get('params', {}), **args)
AttributeError: 'str' object has no attribute 'get'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1702, in _serve_db
    exc.error_response = self.registry['ir.http']._handle_error(exc)
  File "addons/http_routing/models/ir_http.py", line 626, in _handle_error
    response = super()._handle_error(exception)
  File "odoo/addons/base/models/ir_http.py", line 169, in _handle_error
    return request.dispatcher.handle_error(exception)
  File "odoo/http.py", line 1952, in handle_error
    return self._response(error=error)
  File "odoo/http.py", line 1955, in _response
    request_id = self.jsonrequest.get('id')
```

sentry:-  4197263038


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
