### PR TITLE
[IMP] web: debug function to view assets size

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu_items.js
+++ b/addons/web/static/src/core/debug/debug_menu_items.js
@@ -3,6 +3,8 @@
 import { browser } from "@web/core/browser/browser";
 import { routeToUrl } from "@web/core/browser/router_service";
 import { registry } from "@web/core/registry";
+import { Component, xml } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
 
 function activateAssetsDebugging({ env }) {
     return {
@@ -46,6 +48,83 @@ export function regenerateAssets({ env }) {
     };
 }
 
+// Dialog Declaration
+// it's used to display all the assets used in a page and their size
+class ViewAssetsDialog extends Component {}
+ViewAssetsDialog.template = xml`
+<Dialog title="this.constructor.title">
+    <p>
+    Found files :
+    </p>
+    <pre t-esc="props.output"/>
+</Dialog>`;
+ViewAssetsDialog.components = { Dialog };
+ViewAssetsDialog.props = {
+    output: { type: String },
+    close: { type: Function },
+};
+ViewAssetsDialog.title = "Assets size";
+
+async function getUsedBundles() {
+    const url = "./";
+    const regex = /(?<=\=\"\/web\/assets\/)(.*)(?=\" data-asset-bundle)/gm;
+
+    const page = await fetch(url)
+        .then( r => r.text() )
+        .then( t => {return(t);});
+
+    const matches = page.match(regex); // get all bundles declared in 'page'
+    let bundles = [];
+    matches.forEach((match) => {
+        let parts = match.split('/');
+        bundles.push({path : match, name : parts[parts.length - 1]});
+    });
+    return bundles;
+}
+
+function getStats(bundle) {
+    const regex = /\/\* | \*\//;
+    let parts = bundle.split(regex);
+    parts.splice(0,1);
+    let parts_info = [];
+    for (let i = 0; i < parts.length; i+=2){
+        let data = parts[i + 1];
+        parts_info.push({
+            'file': parts[i],
+            'data': data,
+            'length': data.length,
+        });
+    }
+    return parts_info.sort(function(a, b){return a.length - b.length;}).reverse();
+}
+
+export function viewAssetsSize({ env }) {
+    return {
+        type: "item",
+        description: env._t("View Assets Size"),
+        callback: async() => {
+            const bundles= await getUsedBundles();
+            let output="";
+            for (let bundle in bundles){
+                const url = "./web/assets/"+bundles[bundle].path;
+                const bundle_content = await fetch(url)
+                    .then( r => r.text() )
+                    .then( t => {return(t);});
+                const stats = getStats(bundle_content);
+
+                output+="Assets in " + bundles[bundle].name + " :\n";
+                for (let stat in stats ){
+                    output += stats[stat].file + " : " + stats[stat].length + " o\n";
+                }
+                output+='\n';
+            }
+
+            env.services.dialog.add(ViewAssetsDialog, { output } );
+        },
+        sequence: 450,
+    };
+}
+
 function becomeSuperuser({ env }) {
     const becomeSuperuserURL = browser.location.origin + "/web/become";
     return {
@@ -69,7 +148,7 @@ function leaveDebugMode({ env }) {
             route.search.debug = "";
             browser.location.href = browser.location.origin + routeToUrl(route);
         },
-        sequence: 450,
+        sequence: 460,
     };
 }
 
@@ -80,4 +159,5 @@ registry
     .add("regenerateAssets", regenerateAssets)
     .add("becomeSuperuser", becomeSuperuser)
     .add("leaveDebugMode", leaveDebugMode)
-    .add("activateTestsAssetsDebugging", activateTestsAssetsDebugging);
+    .add("activateTestsAssetsDebugging", activateTestsAssetsDebugging)
+    .add("viewAssetSize", viewAssetsSize);


### PR DESCRIPTION
The goal is to be able to tell the useless / problematic parts in an assets bundle and try to reduce their size with a script that checks the size of the CSS/JS produced by each file inside a specific assets bundle.

This commit add a new debug button that display every asset loaded.

task-3248659 - Step 2