### PR TITLE
[FIX] tools: prevent trace back while the customer post an encoded message

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -309,6 +309,8 @@ def is_html_empty(html_content):
     """
     if not html_content:
         return True
+    if isinstance(html_content, bytes):
+        html_content = html_content.decode('utf-8')
     tag_re = re.compile(r'\<\s*\/?(?:p|div|span|br|b|i|font)(?:(?=\s+\w*)[^/>]*|\s*)/?\s*\>')
     return not bool(re.sub(tag_re, '', html_content).strip())
 


### PR DESCRIPTION
'cannot use a string pattern on a bytes-like object' is generated if the user
 posts a message which can also be decoded or bytes.

See traceback : 

```
TypeError: cannot use a string pattern on a bytes-like object
  File "odoo/http.py", line 2117, in __call__
    response = request._serve_nodb()
  File "odoo/http.py", line 1667, in _serve_nodb
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1924, in dispatch
    result = endpoint(**self.request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/custom/default/saas_worker/controllers/main.py", line 2239, in smtp
    proxy.message_process(None, message)
  File "addons/mail/models/mail_thread.py", line 1246, in message_process
    thread_id = self._message_route_process(message, msg_dict, routes)
  File "addons/mail/models/mail_thread.py", line 1180, in _message_route_process
    new_msg = thread.message_post(**post_params)
  File "home/odoo/src/enterprise/saas-16.2/documents/models/document.py", line 280, in message_post
    return super(Document, self).message_post(message_type=message_type, **kwargs)
  File "addons/mail/models/mail_thread.py", line 2062, in message_post
    self._message_post_after_hook(new_message, msg_values)
  File "home/odoo/src/enterprise/saas-16.2/documents/models/document.py", line 305, in _message_post_after_hook
    document.message_post(body=msg_vals.get('body', ''), subject=self.name)
  File "home/odoo/src/enterprise/saas-16.2/documents/models/document.py", line 280, in message_post
    return super(Document, self).message_post(message_type=message_type, **kwargs)
  File "addons/mail/models/mail_thread.py", line 2038, in message_post
    self._process_attachments_for_post(attachments, attachment_ids, msg_values)
  File "addons/mail/models/mail_thread.py", line 2116, in _process_attachments_for_post
    body = message_values['body'] if not is_html_empty(message_values['body']) else ''
  File "odoo/tools/mail.py", line 313, in is_html_empty
    return not bool(re.sub(tag_re, '', html_content).strip())
  File "re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
```

Applying this commit will resolve this issue by converting the bytes to strings if the message is in encoded form.

sentry-4163534571

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
