### PR TITLE
[FIX] website_sale: handle assertion error

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -901,8 +901,8 @@ class WebsiteSale(http.Controller):
 
     @http.route('/shop/save_shop_layout_mode', type='json', auth='public', website=True)
     def save_shop_layout_mode(self, layout_mode):
-        assert layout_mode in ('grid', 'list'), "Invalid shop layout mode"
-        request.session['website_sale_shop_layout_mode'] = layout_mode
+        if layout_mode in ('grid', 'list'):
+            request.session['website_sale_shop_layout_mode'] = layout_mode
 
     @http.route(['/shop/cart/quantity'], type='json', auth="public", methods=['POST'], website=True, csrf=False)
     def cart_quantity(self):


### PR DESCRIPTION
Previously, the `save_shop_layout_mode` method raised an AssertionError when an invalid shop layout mode was received . So, we modifies the method to check if the layout_mode is valid ('grid' or 'list') using an if statement instead of an assert statement to prevent unnecessary noise in the Sentry.

Applying these changes will resolve this issue.

sentry-4197274318

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
