### PR TITLE
[FIX] web_editor: image format is not supported

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/media.js
@@ -148,7 +148,7 @@ var FileWidget = SearchableMediaWidget.extend({
     }),
     existingAttachmentsTemplate: undefined,
 
-    IMAGE_MIMETYPES: ['image/jpg', 'image/jpeg', 'image/jpe', 'image/png', 'image/svg+xml', 'image/gif'],
+    IMAGE_MIMETYPES: ['image/jpg', 'image/jpeg', 'image/jpe', 'image/png', 'image/svg+xml', 'image/gif', 'image/webp'],
     IMAGE_EXTENSIONS: ['.jpg', '.jpeg', '.jpe', '.png', '.svg', '.gif'],
     NUMBER_OF_ATTACHMENTS_TO_DISPLAY: 30,
     MAX_DB_ATTACHMENTS: 5,
@@ -678,15 +678,23 @@ var FileWidget = SearchableMediaWidget.extend({
     /**
      * @private
      */
-    _onURLInputChange: function () {
+    _onURLInputChange: async function () {
         const inputValue = this.$urlInput.val().split('?')[0];
         var emptyValue = (inputValue === '');
-
         var isURL = /^.+\..+$/.test(inputValue); // TODO improve
         var isImage = _.any(this.IMAGE_EXTENSIONS, function (format) {
             return inputValue.endsWith(format);
         });
 
+        if (isURL && !isImage) {
+            try {
+                const response = await fetch(inputValue);
+                const contentType = response.headers.get('Content-Type');
+                isImage = this.IMAGE_MIMETYPES.includes(contentType);
+            }  catch (error) {
+                this.$urlWarning.removeClass('d-none');
+            }
+        }
         this._updateAddUrlUi(emptyValue, isURL, isImage);
     },
     /**


### PR DESCRIPTION
**Current behavior before PR:**

- Image format is not supported though it's a JPG image.
- Even if the url is validated, and when we hit inert URL the image is not.
displayed.
- Url regex needed to be updated as it failed for the document url search.

**Desired behavior after PR is merged:**

- Image format is supported if valid.
- Image can be added from valid image URL.
- Url regex is updated.

task-3323862