### PR TITLE
[FIX] base: error handling of automated actions

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -574,7 +574,11 @@ class IrActionsServer(models.Model):
             for field, new_value in res.items():
                 record_cached[field] = new_value
         else:
-            self.env[self.model_id.model].browse(self._context.get('active_id')).write(res)
+            try:
+                self.env[self.model_id.model].browse(self._context.get('active_id')).write(res)
+            except Exception as e:
+                e.sentry_ignored = True
+                raise
 
     def _run_action_object_create(self, eval_context=None):
         """Create specified model object with specified values.


### PR DESCRIPTION
If Automation Actions's configuration is done wrong it will
cause Error at runtime which will be caught in sentry and
causes unnecessary traffic.

So, we stop catching exceptions from Automated Actions.

Trace-back on sentry:
```
ValueError: Wrong value for sale.order.state: 'records.action_confirm()'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/base_automation/models/base_automation.py", line 415, in write
    action._process(records, domain_post=domain_post)
  File "addons/base_automation/models/base_automation.py", line 340, in _process
    raise e
  File "addons/base_automation/models/base_automation.py", line 337, in _process
    action_server.sudo().with_context(**ctx).run()
  File "odoo/addons/base/models/ir_actions.py", line 706, in run
    res = runner(run_self, eval_context=eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 583, in _run_action_object_write
    self.env[self.model_id.model].browse(self._context.get('active_id')).write(res)
  File "addons/base_automation/models/base_automation.py", line 411, in write
    write.origin(self.with_env(actions.env), vals, **kw)
  File "addons/sale_project/models/sale_order.py", line 165, in write
    return super(SaleOrder, self).write(values)
  File "home/odoo/src/enterprise/saas-16.2/sale_subscription/models/sale_order.py", line 674, in write
    res = super().write(vals)
  File "addons/rating/models/rating_mixin.py", line 101, in write
    result = super(RatingMixin, self).write(values)
  File "addons/event_sale/models/sale_order.py", line 15, in write
    result = super(SaleOrder, self).write(vals)
  File "addons/mail/models/mail_thread.py", line 311, in write
    result = super(MailThread, self).write(values)
  File "addons/mail/models/mail_activity_mixin.py", line 241, in write
    return super(MailActivityMixin, self).write(vals)
  File "odoo/models.py", line 3825, in write
    field.write(self, value)
  File "odoo/fields.py", line 1124, in write
    cache_value = self.convert_to_cache(value, records)
  File "odoo/fields.py", line 2703, in convert_to_cache
    raise ValueError("Wrong value for %s: %r" % (self, value))
```

sentry-4199491664
