### PR TITLE
[FIX] base: ignore exception error in sentry while upload large image in chatter

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -345,6 +345,9 @@ class IrAttachment(models.Model):
                     # Catch error during test where we provide fake image
                     # raise UserError(_("This file could not be decoded as an image file. Please try with a different file."))
                     _logger.info('Post processing ignored : %s', e)
+                except (Image.DecompressionBombError, Image.DecompressionBombWarning) as e:
+                    e.sentry_ignored = True
+                    raise
         return values
 
     def _check_contents(self, values):


### PR DESCRIPTION
When user upload large image file in chatter then error will be generated, which
will be caught by sentry and causes unnecessary traffic.

Steps to reproduce this error (ex. in invoices):
- Install Account.
- Go to invoices -> Add attachment -> upload large image file
(ex. more than 178956970 pixels image file).

See Trace back:
```
DecompressionBombError: Image size (199810688 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
  File "addons/web/controllers/binary.py", line 188, in upload_attachment
    attachment = Model.create({
  File "<decorator-gen-427>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "home/odoo/src/enterprise/saas-16.2/documents_account/models/ir_attachment.py", line 8, in create
    attachments = super().create(vals_list)
  File "<decorator-gen-237>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "home/odoo/src/enterprise/saas-16.2/documents/models/ir_attachment.py", line 76, in create
    attachments = super().create(vals_list)
  File "<decorator-gen-57>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/ir_attachment.py", line 649, in create
    values = self._check_contents(values)
  File "odoo/addons/base/models/ir_attachment.py", line 364, in _check_contents
    values = self._postprocess_contents(values)
  File "odoo/addons/base/models/ir_attachment.py", line 332, in _postprocess_contents
    img = ImageProcess(base64.b64decode(values['datas']), verify_resolution=False)
  File "odoo/tools/image.py", line 81, in __init__
    self.image = Image.open(io.BytesIO(source))
  File "PIL/Image.py", line 2994, in open
    im = _open_core(fp, filename, prefix, formats)
  File "PIL/Image.py", line 2981, in _open_core
    _decompression_bomb_check(im.size)
  File "PIL/Image.py", line 2890, in _decompression_bomb_check
    raise DecompressionBombError(
```

sentry - 3964193649

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
