### PR TITLE
[IMP] base: allow to create a savepoint from an env

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2890,7 +2890,7 @@ class AccountMove(models.Model):
 
             try:
                 if decoder and not success:
-                    with self.env.cr.savepoint(), self._get_edi_creation() as invoice:
+                    with self.env.savepoint(), self._get_edi_creation() as invoice:
                         # pylint: disable=not-callable
                         success = decoder(invoice, file_data, new)
                         if success:

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -195,7 +195,7 @@ class AccountChartTemplate(models.AbstractModel):
         # Install the demo data when the first localization is instanciated on the company
         if install_demo and self.ref('base.module_account').demo and not reload_template:
             try:
-                with self.env.cr.savepoint():
+                with self.env.savepoint():
                     self._load_data(self._get_demo_data(company))
                     self._post_load_demo_data(company)
             except Exception:

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -28,7 +28,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
             ],
         })
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.company_data['default_account_revenue'].company_id = self.company_data_2['company']
 
     def test_toggle_reconcile(self):
@@ -128,16 +128,16 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         move.line_ids.filtered(lambda line: line.account_id == account).reconcile()
 
         # Try to set the account as a not-reconcile one.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             account.reconcile = False
 
     def test_toggle_reconcile_outstanding_account(self):
         ''' Test the feature when the user sets an account as not reconcilable when a journal
         is configured with this account as the payment credit or debit account.
         Since such an account should be reconcilable by nature, a ValidationError is raised.'''
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             self.company_data['default_journal_bank'].company_id.account_journal_payment_debit_account_id.reconcile = False
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             self.company_data['default_journal_bank'].company_id.account_journal_payment_credit_account_id.reconcile = False
 
     def test_remove_account_from_account_group(self):

--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -46,7 +46,7 @@ def test_all_l10n(env):
         env.user.company_id = company
         _logger.info('Testing COA: %s (company: %s)', template_code, company.name)
         try:
-            with env.cr.savepoint():
+            with env.savepoint():
                 env['account.chart.template'].try_loading(template_code, company, install_demo=True)
         except Exception:
             _logger.error("Error when creating COA %s", template_code, exc_info=True)

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -51,7 +51,7 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
         })
 
         # Set a different company on the analytic account.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.analytic_account_a.company_id = self.company_data_2['company']
 
         # Making the analytic account not company dependent is allowed.

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -355,7 +355,7 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
 
     def test_constraints(self):
         def assertStatementLineConstraint(statement_line_vals):
-            with self.assertRaises(Exception), self.cr.savepoint():
+            with self.assertRaises(Exception), self.env.savepoint():
                 self.env['account.bank.statement.line'].create(statement_line_vals)
 
         statement_line_vals = {
@@ -401,12 +401,12 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
                 'move_id': st_line.move_id.id,
             },
         ]
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             st_line.move_id.write({
                 'line_ids': [(0, 0, vals) for vals in addition_lines_to_create]
             })
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             st_line.line_ids.create(addition_lines_to_create)
 
     def test_statement_line_move_onchange_1(self):

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -18,7 +18,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         journal_bank.currency_id = self.currency_data['currency']
 
         # Try to set a different currency on the 'debit' account.
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             journal_bank.default_account_id.currency_id = self.company_data['currency']
 
     def test_changing_journal_company(self):
@@ -30,7 +30,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
             'journal_id': self.company_data['default_journal_sale'].id,
         })
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.company_data['default_journal_sale'].company_id = self.company_data_2['company']
 
     def test_account_control_create_journal_entry(self):
@@ -53,7 +53,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
 
         # Should fail because 'default_account_expense' is not allowed.
         self.company_data['default_journal_misc'].account_control_ids |= self.company_data['default_account_revenue']
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.env['account.move'].create(move_vals)
 
         # Should be allowed because both accounts are accepted.
@@ -79,7 +79,7 @@ class TestAccountJournal(AccountTestInvoicingCommon):
         })
 
         # There is already an other line using the 'default_account_expense' account.
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             self.company_data['default_journal_misc'].account_control_ids |= self.company_data['default_account_revenue']
 
         # Assigning both should be allowed

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -125,7 +125,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # It should raise an error.
         custom_account.currency_id = self.currency_data['currency']
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.line_ids[0].account_id = custom_account
 
         # The currency set on the account is the same as the one set on the company.
@@ -150,7 +150,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.test_move.ref = 'whatever'
 
         # Try to edit a line into a locked fiscal year.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
@@ -159,11 +159,11 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # Try to edit the account of a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.line_ids[0].write({'account_id': self.test_move.line_ids[0].account_id.copy().id})
 
         # Try to edit a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
@@ -172,7 +172,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # Try to add a new tax on a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[2].id, {'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)]}),
@@ -180,7 +180,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # Try to create a new line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
@@ -194,16 +194,16 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # You can't remove the journal entry from a locked period.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.date = fields.Date.from_string('2018-01-01')
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.name = "Othername"
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.unlink()
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.button_draft()
 
         # Try to add a new journal entry prior to the lock date.
@@ -223,7 +223,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         })
 
         # You can't lock the fiscal year if there is some unreconciled statement.
-        with self.assertRaises(RedirectWarning), self.cr.savepoint():
+        with self.assertRaises(RedirectWarning), self.env.savepoint():
             self.test_move.company_id.fiscalyear_lock_date = fields.Date.from_string('2017-01-01')
 
     def test_misc_tax_lock_date_1(self):
@@ -250,7 +250,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.test_move.line_ids[0].write({'account_id': self.test_move.line_ids[0].account_id.copy().id})
 
         # Try to edit a line having some taxes.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
@@ -259,7 +259,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # Try to add a new tax on a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[2].id, {'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)]}),
@@ -267,7 +267,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # Try to edit a tax line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
@@ -289,7 +289,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         })
 
         # Try to create a line affecting the taxes.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.write({
                 'line_ids': [
                     (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
@@ -304,16 +304,16 @@ class TestAccountMove(AccountTestInvoicingCommon):
             })
 
         # You can't remove the journal entry from a locked period.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.date = fields.Date.from_string('2018-01-01')
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.name = "Othername"
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.unlink()
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.test_move.button_draft()
 
         copy_move = self.test_move.copy({'date': self.test_move.date})
@@ -322,7 +322,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         copy_move.action_post()
 
         # You can't change the date to one being in a locked period.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             copy_move.date = fields.Date.from_string('2017-01-01')
 
     def test_misc_draft_reconciled_entries_1(self):
@@ -373,7 +373,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         (lines[0] + lines[2]).reconcile()
 
         # You can't write something impacting the reconciliation on an already reconciled line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             draft_moves[0].write({
                 'line_ids': [
                     (1, lines[1].id, {'credit': lines[1].credit + 100.0}),
@@ -390,7 +390,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         })
 
         # You can't unlink an already reconciled line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             draft_moves.unlink()
 
     def test_add_followers_on_post(self):
@@ -558,7 +558,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         # You cannot remove journal items if the related journal entry is posted.
         self.test_move.action_post()
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             unlink_posted_items()
 
         # You can remove journal items if the related journal entry is draft.
@@ -580,7 +580,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         move.currency_id.active = False
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             move.action_post()
 
         # Make sure that the invoice can still be posted when the currency is active
@@ -815,11 +815,11 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         self.test_move.action_post()
         with self.assertRaisesRegex(UserError, "You cannot modify the taxes related to a posted journal item"),\
-             self.cr.savepoint():
+             self.env.savepoint():
             edit_tax_on_posted_moves()
 
         with self.assertRaisesRegex(UserError, "You cannot modify the taxes related to a posted journal item"),\
-             self.cr.savepoint():
+             self.env.savepoint():
             self.test_move.line_ids.filtered(lambda l: l.tax_line_id).tax_line_id = False
 
         # You can remove journal items if the related journal entry is draft.
@@ -903,7 +903,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         exchange_diff = moves.line_ids.matched_debit_ids.exchange_move_id
         self.assertTrue(exchange_diff)
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             exchange_diff.button_draft()
 
     def test_always_exigible_caba_account(self):

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2149,11 +2149,11 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         not_receivable_lines = move.line_ids - receivable_lines
 
         # Write a receivable account on a not-receivable line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             not_receivable_lines.write({'account_id': receivable_lines[0].account_id.copy().id})
 
         # Write a not-receivable account on a receivable line.
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             receivable_lines.write({'account_id': not_receivable_lines[0].account_id.copy().id})
 
         # Write another receivable account on a receivable line.
@@ -3340,7 +3340,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             ],
         })
         self.product_a.property_account_income_id.deprecated = True
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             move.action_post()
 
     def test_change_currency_id(self):

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -2543,7 +2543,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
     def test_reconcile_plan(self):
         @contextmanager
         def rollback():
-            savepoint = self.cr.savepoint()
+            savepoint = self.env.savepoint()
             yield
             savepoint.rollback()
 

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -745,7 +745,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
     def test_register_payment_constraints(self):
         # Test to register a payment for a draft journal entry.
         self.out_invoice_1.button_draft()
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.env['account.payment.register']\
                 .with_context(active_model='account.move', active_ids=self.out_invoice_1.ids)\
                 .create({})
@@ -755,7 +755,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             .with_context(active_model='account.move', active_ids=self.out_invoice_2.ids)\
             .create({})\
             ._create_payments()
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.env['account.payment.register']\
                 .with_context(active_model='account.move', active_ids=self.out_invoice_2.ids)\
                 .create({})

--- a/addons/account/tests/test_account_tax.py
+++ b/addons/account/tests/test_account_tax.py
@@ -26,5 +26,5 @@ class TestAccountTax(AccountTestInvoicingCommon):
             ],
         })
 
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self.company_data['default_tax_sale'].company_id = self.company_data_2['company']

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -337,7 +337,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         self.assertEqual(copies[5].name, 'XMISC/2019/00004')
 
         # Can't have twice the same name
-        with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'), self.env.cr.savepoint():
+        with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'), self.env.savepoint():
             copies[0].name = 'XMISC/2019/00001'
 
         # Lets remove the order by date

--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -142,7 +142,7 @@ class ResUsers(models.Model):
         # create a copy of the template user (attached to a specific partner_id if given)
         values['active'] = True
         try:
-            with self.env.cr.savepoint():
+            with self.env.savepoint():
                 return template_user.with_context(no_reset_password=True).copy(values)
         except Exception as e:
             # copy may failed if asked login is not available.
@@ -198,7 +198,7 @@ class ResUsers(models.Model):
                 raise UserError(_("Cannot send email: user %s has no email address.", user.name))
             email_values['email_to'] = user.email
             # TDE FIXME: make this template technical (qweb)
-            with self.env.cr.savepoint():
+            with self.env.savepoint():
                 force_send = not(self.env.context.get('import_file', False))
                 template.send_mail(user.id, force_send=force_send, raise_exception=True, email_values=email_values)
             _logger.info("Password reset email sent for user <%s> to <%s>", user.login, user.email)

--- a/addons/auth_totp_mail_enforce/models/res_users.py
+++ b/addons/auth_totp_mail_enforce/models/res_users.py
@@ -107,7 +107,7 @@ class Users(models.Model):
             'partner_ids': [],
             'scheduled_date': False,
         }
-        with self.env.cr.savepoint():
+        with self.env.savepoint():
             template.with_context(**context).send_mail(
                 self.id, force_send=True, raise_exception=True, email_values=email_values, email_layout_xmlid='mail.mail_notification_light'
             )

--- a/addons/barcodes/tests/test_barcode_nomenclature.py
+++ b/addons/barcodes/tests/test_barcode_nomenclature.py
@@ -63,19 +63,19 @@ class TestBarcodeNomenclature(common.TransactionCase):
             'encoding': 'ean8',
         })
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             # Must fail because empty braces.
             barcode_rule.pattern = '......{}..'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             # Must fail because decimal can't be before integer.
             barcode_rule.pattern = '......{DN}'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             # Must fail because a pattern can't have multiple braces group.
             barcode_rule.pattern = '....{NN}{DD}'
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             # Must fail because '*' isn't accepted (should be '.*' instead).
             barcode_rule.pattern = '*'
 

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -50,7 +50,7 @@ class TestStructure(TransactionCase):
         # reactivate it and correct the vat number
         with patch('odoo.addons.base_vat.models.res_partner.check_vies', type(self)._vies_check_func):
             self.env.user.company_id.vat_check_vies = True
-            with self.assertRaises(ValidationError), self.env.cr.savepoint():
+            with self.assertRaises(ValidationError), self.env.savepoint():
                 company.vat = "BE0987654321"  # VIES refused, don't fallback on other check
             company.vat = "BE0477472701"
 

--- a/addons/crm_iap_enrich/models/crm_lead.py
+++ b/addons/crm_iap_enrich/models/crm_lead.py
@@ -53,7 +53,7 @@ class Lead(models.Model):
         batches = [self[index:index + 50] for index in range(0, len(self), 50)]
         for leads in batches:
             lead_emails = {}
-            with self._cr.savepoint():
+            with self.env.savepoint():
                 try:
                     self._cr.execute(
                         "SELECT 1 FROM {} WHERE id in %(lead_ids)s FOR UPDATE NOWAIT".format(self._table),

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -223,7 +223,7 @@ class Contract(models.Model):
             auto_commit = not getattr(threading.current_thread(), 'testing', False)
             for contract in self:
                 try:
-                    with self.env.cr.savepoint():
+                    with self.env.savepoint():
                         contract.write(vals)
                 except ValidationError as e:
                     _logger.warning(e)

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -487,7 +487,7 @@ class TestAccessRightsRead(TestHrHolidaysAccessRightsCommon):
             'date_to': datetime.now() + relativedelta(days=1),
             'number_of_days': 1,
         })
-        with self.assertRaises(AccessError), self.cr.savepoint():
+        with self.assertRaises(AccessError), self.env.savepoint():
             res = other_leave.with_user(self.user_employee_id).read(['number_of_days', 'state', 'name'])
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')
@@ -502,7 +502,7 @@ class TestAccessRightsRead(TestHrHolidaysAccessRightsCommon):
             'date_to': datetime.now() + relativedelta(days=1),
             'number_of_days': 1,
         })
-        with self.assertRaises(AccessError), self.cr.savepoint():
+        with self.assertRaises(AccessError), self.env.savepoint():
             other_leave.invalidate_model(['name'])
             name = other_leave.with_user(self.user_employee_id).name
 
@@ -753,7 +753,7 @@ class TestAccessRightsUnlink(TestHrHolidaysAccessRightsCommon):
             'state': 'confirm',
         }
         leave = self.request_leave(self.user_employee_id, datetime.now() + relativedelta(days=-4), 1, values)
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             leave.with_user(self.user_employee.id).unlink()
 
     def test_leave_unlink_validate_by_user(self):
@@ -765,7 +765,7 @@ class TestAccessRightsUnlink(TestHrHolidaysAccessRightsCommon):
         }
         leave = self.request_leave(self.user_employee_id, datetime.now() + relativedelta(days=5), 1, values)
         leave.with_user(self.user_hrmanager_id).write({'state': 'validate'})
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             leave.with_user(self.user_employee.id).unlink()
 
 class TestMultiCompany(TestHrHolidaysCommon):

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -267,7 +267,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
         }
         with mute_logger('odoo.sql_db'):
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     self.env['hr.leave'].create(leave_vals)
 
         leave_vals = {
@@ -281,7 +281,7 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
         leave = self.env['hr.leave'].create(leave_vals)
         with mute_logger('odoo.sql_db'):
             with self.assertRaises(IntegrityError):  # No ValidationError
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     leave.write({
                         'date_from': datetime.today().strftime('%Y-%m-11 19:00:00'),
                         'date_to': datetime.today().strftime('%Y-%m-10 10:00:00'),

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -70,7 +70,7 @@ class TestHolidaysOvertime(TransactionCase):
         with self.with_user('user'):
             self.assertEqual(self.user.total_overtime, 0, 'No overtime')
 
-            with self.assertRaises(ValidationError), self.cr.savepoint():
+            with self.assertRaises(ValidationError), self.env.savepoint():
                 self.env['hr.leave'].create({
                     'name': 'no overtime',
                     'employee_id': self.employee.id,
@@ -96,11 +96,11 @@ class TestHolidaysOvertime(TransactionCase):
             overtime = leave.sudo().overtime_id.with_user(self.user)
 
             # An employee cannot delete an overtime adjustment
-            with self.assertRaises(AccessError), self.cr.savepoint():
+            with self.assertRaises(AccessError), self.env.savepoint():
                 overtime.unlink()
 
             # ... nor change its duration
-            with self.assertRaises(AccessError), self.cr.savepoint():
+            with self.assertRaises(AccessError), self.env.savepoint():
                 overtime.duration = 8
 
     def test_leave_adjust_overtime(self):
@@ -151,7 +151,7 @@ class TestHolidaysOvertime(TransactionCase):
 
         leave.date_to = datetime(2021, 1, 6)
         self.assertEqual(self.employee.total_overtime, 0)
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             leave.date_to = datetime(2021, 1, 7)
 
         leave.date_to = datetime(2021, 1, 5)
@@ -160,7 +160,7 @@ class TestHolidaysOvertime(TransactionCase):
     def test_employee_create_allocation(self):
         with self.with_user('user'):
             self.assertEqual(self.employee.total_overtime, 0)
-            with self.assertRaises(ValidationError), self.cr.savepoint():
+            with self.assertRaises(ValidationError), self.env.savepoint():
                 self.env['hr.leave.allocation'].create({
                     'name': 'test allocation',
                     'holiday_status_id': self.leave_type_employee_allocation.id,
@@ -223,7 +223,7 @@ class TestHolidaysOvertime(TransactionCase):
         })
         self.assertEqual(self.employee.total_overtime, 8)
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             alloc.number_of_days = 3
 
         alloc.number_of_days = 2

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -204,5 +204,5 @@ class TestWorkEntry(TestWorkEntryBase):
 
         with mute_logger('odoo.sql_db'):
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     (work_entry_1 + work_entry_2).write({'state': 'validated'})

--- a/addons/l10n_latam_check/tests/test_third_party_checks.py
+++ b/addons/l10n_latam_check/tests/test_third_party_checks.py
@@ -65,7 +65,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         delivery.action_post()
         self.assertFalse(check.l10n_latam_check_current_journal_id, 'Current journal was not computed properly on delivery')
         # check dont delivery twice
-        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.env.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         # Check Return / Rejection
@@ -81,7 +81,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         supplier_return.action_post()
         self.assertEqual(check.l10n_latam_check_current_journal_id, self.rejected_check_journal, 'Current journal was not computed properly on return')
         # check dont return twice
-        with self.assertRaisesRegex(ValidationError, "it can't be received it again"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it can't be received it again"), self.env.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         # Check Claim/Return to customer
@@ -97,7 +97,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         customer_return.action_post()
         self.assertFalse(check.l10n_latam_check_current_journal_id, 'Current journal was not computed properly on customer return')
         # check dont claim twice
-        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.env.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         operations = self.env['account.payment'].search([('l10n_latam_check_id', '=', check.id), ('state', '=', 'posted')], order="date desc, id desc")
@@ -113,7 +113,7 @@ class TestThirdChecks(L10nLatamCheckTest):
             active_model='account.payment', active_ids=[check.id]).create({'destination_journal_id': bank_journal.id})._create_payments()
         self.assertEqual(check.l10n_latam_check_current_journal_id, bank_journal, 'Current journal was not computed properly on delivery')
         # check dont deposit twice
-        with self.assertRaisesRegex(UserError, "All selected checks must be on the same journal and on hand"), self.cr.savepoint():
+        with self.assertRaisesRegex(UserError, "All selected checks must be on the same journal and on hand"), self.env.savepoint():
             self.env['l10n_latam.payment.mass.transfer'].with_context(
                 active_model='account.payment', active_ids=[check.id]).create({'destination_journal_id': bank_journal.id})._create_payments()
 
@@ -131,7 +131,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         bank_rejection.action_post()
         self.assertEqual(check.l10n_latam_check_current_journal_id, self.rejected_check_journal, 'Current journal was not computed properly on return')
         # check dont reject twice
-        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.env.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         # Check Claim/Return to customer
@@ -147,7 +147,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         customer_return.action_post()
         self.assertFalse(check.l10n_latam_check_current_journal_id, 'Current journal was not computed properly on customer return')
         # check dont return twice
-        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.env.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         operations = self.env['account.payment'].search([('l10n_latam_check_id', '=', check.id), ('state', '=', 'posted')], order="date desc, id desc")

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -25,7 +25,7 @@ class TestLoyalty(TransactionCase):
         # Test that we can not unlink dicount line product id
         with mute_logger('odoo.sql_db'):
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     self.program.reward_ids.discount_line_product_id.unlink()
 
     def test_loyalty_mail(self):

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -55,7 +55,7 @@ class TestMailTemplate(MailCommon):
     def test_mail_template_abstract_model(self):
         """Check abstract models cannot be set on templates."""
         # create
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             self.env['mail.template'].create({
                 'name': 'Test abstract template',
                 'model_id': self.env['ir.model']._get('mail.thread').id, # abstract model
@@ -65,7 +65,7 @@ class TestMailTemplate(MailCommon):
             'name': 'Test abstract template',
             'model_id': self.env['ir.model']._get('res.partner').id,
         })
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             template.write({
                 'name': 'Test abstract template',
                 'model_id': self.env['ir.model']._get('mail.thread').id,

--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -36,7 +36,7 @@ def uninstall_hook(env):
     # Fail unlink means that the route is used somewhere (e.g. route_id on stock.rule). In this case
     # we don't try to do anything.
     try:
-        with env.cr.savepoint():
+        with env.savepoint():
             pbm_routes.unlink()
     except:
         pass

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1051,7 +1051,7 @@ class TestBoM(TestMrpCommon):
             line.product_id = finished
             line.product_uom_id = uom_unit
             line.product_qty = 5
-        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
+        with self.assertRaises(exceptions.ValidationError), self.env.savepoint():
             bom_finished = bom_finished.save()
 
     def test_validate_no_bom_line_with_same_product_variant(self):
@@ -1067,7 +1067,7 @@ class TestBoM(TestMrpCommon):
             line.product_id = self.product_7_3
             line.product_uom_id = uom_unit
             line.product_qty = 5
-        with self.assertRaises(exceptions.ValidationError), self.cr.savepoint():
+        with self.assertRaises(exceptions.ValidationError), self.env.savepoint():
             bom_finished = bom_finished.save()
         
     def test_validate_bom_line_with_different_product_variant(self):

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -372,17 +372,17 @@ class TestMrpByProduct(common.TransactionCase):
             })
 
         # Update byproduct has cost share > 100%
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             byproduct_1.cost_share = 120
             mo.write({'move_byproduct_ids': [(4, byproduct_1.id)]})
 
         # Update byproduct has cost share < 0%
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             byproduct_1.cost_share = -10
             mo.write({'move_byproduct_ids': [(4, byproduct_1.id)]})
 
         # Update byproducts have total cost share > 100%
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             byproduct_1.cost_share = 60
             byproduct_2.cost_share = 70
             mo.write({'move_byproduct_ids': [(6, 0, [byproduct_1.id, byproduct_2.id])]})

--- a/addons/mrp_subcontracting/__init__.py
+++ b/addons/mrp_subcontracting/__init__.py
@@ -19,7 +19,7 @@ def uninstall_hook(env):
     # Fail unlink means that the route is used somewhere (e.g. route_id on stock.rule). In this case
     # we don't try to do anything.
     try:
-        with env.cr.savepoint():
+        with env.savepoint():
             subcontracting_routes.unlink()
             operations_type_to_remove.unlink()
     except:

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -296,7 +296,7 @@ class PosSession(models.Model):
                 self._create_picking_at_end_of_session()
                 self.order_ids.filtered(lambda o: not o.is_total_cost_computed)._compute_total_cost_at_session_closing(self.picking_ids.move_ids)
             try:
-                with self.env.cr.savepoint():
+                with self.env.savepoint():
                     data = self.with_company(self.company_id).with_context(check_move_validity=False, skip_invoice_sync=True)._create_account_move(balancing_account, amount_to_balance, bank_payment_method_diffs)
             except AccessError as e:
                 if sudo:

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -45,7 +45,7 @@ class StockPicking(models.Model):
 
             positive_picking._create_move_from_pos_order_lines(positive_lines)
             try:
-                with self.env.cr.savepoint():
+                with self.env.savepoint():
                     positive_picking._action_done()
             except (UserError, ValidationError):
                 pass
@@ -64,7 +64,7 @@ class StockPicking(models.Model):
             )
             negative_picking._create_move_from_pos_order_lines(negative_lines)
             try:
-                with self.env.cr.savepoint():
+                with self.env.savepoint():
                     negative_picking._action_done()
             except (UserError, ValidationError):
                 pass

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -377,7 +377,7 @@ class ProductProduct(models.Model):
             self = to_unlink
 
         try:
-            with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):
+            with self.env.savepoint(), tools.mute_logger('odoo.sql_db'):
                 self.unlink()
         except Exception:
             # We catch all kind of exceptions to be sure that the operation

--- a/addons/product/models/product_template_attribute_line.py
+++ b/addons/product/models/product_template_attribute_line.py
@@ -168,7 +168,7 @@ class ProductTemplateAttributeLine(models.Model):
         ptal_to_archive = self.env['product.template.attribute.line']
         for ptal in self:
             try:
-                with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):
+                with self.env.savepoint(), tools.mute_logger('odoo.sql_db'):
                     super(ProductTemplateAttributeLine, ptal).unlink()
             except Exception:
                 # We catch all kind of exceptions to be sure that the operation

--- a/addons/product/models/product_template_attribute_value.py
+++ b/addons/product/models/product_template_attribute_value.py
@@ -138,7 +138,7 @@ class ProductTemplateAttributeValue(models.Model):
         ptav_to_archive = self.env['product.template.attribute.value']
         for ptav in self:
             try:
-                with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):
+                with self.env.savepoint(), tools.mute_logger('odoo.sql_db'):
                     super(ProductTemplateAttributeValue, ptav).unlink()
             except Exception:
                 # We catch all kind of exceptions to be sure that the operation

--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -445,7 +445,7 @@ class TestProductAttributeValueConfig(TestProductAttributeValueCommon):
         self.assertEqual(self.computer._get_first_possible_combination(), computer_ssd_512 + computer_ram_32 + computer_hdd_4)
 
         # Not possible to add an exclusion when only one variant is left -> it deletes the product template associated to it
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             self._add_exclude(computer_ram_32, computer_hdd_4)
 
         # If an exclusion rule deletes all variants at once it does not delete the template.

--- a/addons/project/tests/test_task_dependencies.py
+++ b/addons/project/tests/test_task_dependencies.py
@@ -80,14 +80,14 @@ class TestTaskDependencies(TestProjectCommon):
         self.assertEqual(len(self.task_2.depend_on_ids), 1, "The task 2 should have one dependency.")
 
         # 4) Add task1 as dependency in task3 and check a validation error is raised
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             self.task_3.write({
                 'depend_on_ids': [Command.link(self.task_1.id)],
             })
         self.assertEqual(len(self.task_3.depend_on_ids), 0, "The dependency should not be added in the task 3 because of a cyclic dependency.")
 
         # 5) Add task1 as dependency in task2 and check a validation error is raised
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             self.task_2.write({
                 'depend_on_ids': [Command.link(self.task_1.id)],
             })

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -276,7 +276,7 @@ class AccountMove(models.Model):
         :param purchase_orders: a list of purchase orders to be linked to this vendor bill
         :param force_write: whether to delete all existing invoice lines before adding the vendor bill lines
         """
-        with self.env.cr.savepoint():
+        with self.env.savepoint():
             with self._get_edi_creation() as invoice:
                 if force_write and invoice.line_ids:
                     invoice.invoice_line_ids = [Command.clear()]

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -527,7 +527,7 @@ class StockWarehouseOrderpoint(models.Model):
                                 orderpoint.company_id, values))
 
                     try:
-                        with self.env.cr.savepoint():
+                        with self.env.savepoint():
                             self.env['procurement.group'].with_context(from_orderpoint=True).run(procurements, raise_user_error=raise_user_error)
                     except ProcurementException as errors:
                         orderpoints_exceptions = []

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1018,7 +1018,7 @@ class StockQuant(models.Model):
                    DELETE FROM stock_quant WHERE id in (SELECT unnest(to_delete_quant_ids) from dupes)
         """
         try:
-            with self.env.cr.savepoint():
+            with self.env.savepoint():
                 self.env.cr.execute(query)
                 self.env.invalidate_all()
         except Error as e:

--- a/addons/stock/tests/test_robustness.py
+++ b/addons/stock/tests/test_robustness.py
@@ -55,7 +55,7 @@ class TestRobustness(TransactionCase):
 
         # change the factor
         with self.assertRaises(UserError):
-            with self.cr.savepoint():
+            with self.env.savepoint():
                 move1.product_uom.factor = 0.05
 
         # assert the reservation
@@ -108,7 +108,7 @@ class TestRobustness(TransactionCase):
 
         # change the stock usage
         with self.assertRaises(UserError):
-            with self.cr.savepoint():
+            with self.env.savepoint():
                 test_stock_location.scrap_location = False
 
         # unreserve

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -200,9 +200,9 @@ class TestMailAlias(MailCommon):
         bounce_alias = self.env['ir.config_parameter'].sudo().get_param('mail.bounce.alias')
 
         # test you cannot create aliases matching bounce / catchall
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError), self.env.savepoint():
             self.env['mail.alias'].create({'alias_model_id': alias_model_id, 'alias_name': catchall_alias})
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError), self.env.savepoint():
             self.env['mail.alias'].create({'alias_model_id': alias_model_id, 'alias_name': bounce_alias})
 
         new_mail_alias = self.env['mail.alias'].create({
@@ -211,11 +211,11 @@ class TestMailAlias(MailCommon):
         })
 
         # test that re-using catchall and bounce alias raises UserError
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError), self.env.savepoint():
             new_mail_alias.write({
                 'alias_name': catchall_alias
             })
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError), self.env.savepoint():
             new_mail_alias.write({
                 'alias_name': bounce_alias
             })
@@ -227,9 +227,9 @@ class TestMailAlias(MailCommon):
         self.assertFalse(copy_new_mail_alias.alias_name)
 
         # cannot set catchall / bounce to used alias
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError), self.env.savepoint():
             self.env['ir.config_parameter'].sudo().set_param('mail.catchall.alias', new_mail_alias.alias_name)
-        with self.assertRaises(exceptions.UserError), self.cr.savepoint():
+        with self.assertRaises(exceptions.UserError), self.env.savepoint():
             self.env['ir.config_parameter'].sudo().set_param('mail.bounce.alias', new_mail_alias.alias_name)
 
 

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -38,7 +38,7 @@ class WebsiteForm(http.Controller):
             # here be committed. It should not either roll back everything in
             # this controller method. Instead, we use a savepoint to roll back
             # what has been done inside the try clause.
-            with request.env.cr.savepoint():
+            with request.env.savepoint():
                 if request.env['ir.http']._verify_request_recaptcha_token('website_form'):
                     # request.params was modified, update kwargs to reflect the changes
                     kwargs = dict(request.params)

--- a/addons/website_forum/tests/test_forum_karma_access.py
+++ b/addons/website_forum/tests/test_forum_karma_access.py
@@ -94,14 +94,14 @@ class TestForumCRUD(TestForumCommon):
 
         with mute_logger('odoo.sql_db'):
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     # One should not be able to vote more than once on a same post
                     Vote.with_user(self.user_employee).create({
                         'post_id': self.admin_post.id,
                         'vote': '1',
                     })
             with self.assertRaises(IntegrityError):
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     # One should not be able to vote more than once on a same post
                     Vote.with_user(self.user_employee).create({
                         'post_id': self.admin_post.id,

--- a/addons/website_profile/models/res_users.py
+++ b/addons/website_profile/models/res_users.py
@@ -53,7 +53,7 @@ class Users(models.Model):
             }
             params.update(kwargs)
             token_url = self.get_base_url() + '/profile/validate_email?%s' % urls.url_encode(params)
-            with self._cr.savepoint():
+            with self.env.savepoint():
                 activation_template.sudo().with_context(token_url=token_url).send_mail(
                     self.id, force_send=True, raise_exception=True)
         return True

--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -14,7 +14,7 @@ class TestSlideInternals(slides_common.SlidesCase):
     @users('user_manager')
     def test_slide_create_vote_constraint(self):
         # test vote value must be 1, 0 and -1.
-        with self.assertRaises(psycopg2.errors.CheckViolation), self.cr.savepoint():
+        with self.assertRaises(psycopg2.errors.CheckViolation), self.env.savepoint():
             self.env['slide.slide.partner'].create({
                 'slide_id': self.slide.id,
                 'channel_id': self.channel.id,

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -426,7 +426,7 @@ class ir_cron(models.Model):
 
     def try_write(self, values):
         try:
-            with self._cr.savepoint():
+            with self.env.savepoint():
                 self._cr.execute(f"""
                     SELECT id
                     FROM "{self._table}"

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1476,7 +1476,7 @@ class IrModelSelection(models.Model):
             if not records:
                 return
             try:
-                with self.env.cr.savepoint():
+                with self.env.savepoint():
                     records.write({fname: value})
             except Exception:
                 # going through the ORM failed, probably because of an exception
@@ -2208,7 +2208,7 @@ class IrModelData(models.Model):
             # now delete the records
             _logger.info('Deleting %s', records)
             try:
-                with self._cr.savepoint():
+                with self.env.savepoint():
                     records.unlink()
             except Exception:
                 if len(records) <= 1:
@@ -2256,7 +2256,7 @@ class IrModelData(models.Model):
         for data in self.browse(undeletable_ids).exists():
             record = self.env[data.model].browse(data.res_id)
             try:
-                with self.env.cr.savepoint():
+                with self.env.savepoint():
                     if record.exists():
                         # record exists therefore the data is still undeletable,
                         # remove it from module_data

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -253,7 +253,7 @@ class TestIrModel(TransactionCase):
 
         INVALID_ORDERS = ['', 'x_wat', 'id esc', 'create_uid,', 'id, x_is_yellow']
         for order in INVALID_ORDERS:
-            with self.assertRaises(ValidationError), self.cr.savepoint():
+            with self.assertRaises(ValidationError), self.env.savepoint():
                 self.bananas_model.order = order
 
         # check that the constraint is checked at model creation

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -62,7 +62,7 @@ class TestPartner(TransactionCase):
         test_partner_company.write({'company_id': False})
         self.assertFalse(test_user.partner_id.company_id.id, "If the company_id is deleted from the partner company, it should be propagated to its children")
 
-        with self.assertRaises(UserError, msg="You should not be able to update the company_id of the partner company if the linked user of a child partner is not an allowed to be assigned to that company"), self.cr.savepoint():
+        with self.assertRaises(UserError, msg="You should not be able to update the company_id of the partner company if the linked user of a child partner is not an allowed to be assigned to that company"), self.env.savepoint():
             test_partner_company.write({'company_id': company_2.id})
 
     def test_commercial_field_sync(self):

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -47,7 +47,7 @@ class ViewCase(common.TransactionCase):
     def assertInvalid(self, arch, expected_message=None, name='invalid view', inherit_id=False):
         with mute_logger('odoo.addons.base.models.ir_ui_view'):
             with self.assertRaises(ValidationError) as catcher:
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     self.View.create({
                         'name': name,
                         'model': 'ir.ui.view',
@@ -277,18 +277,18 @@ class TestViewInheritance(ViewCase):
 
     def test_no_recursion(self):
         r1 = self.makeView('R1')
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             r1.write({'inherit_id': r1.id})
 
         r2 = self.makeView('R2', r1.id)
         r3 = self.makeView('R3', r2.id)
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             r2.write({'inherit_id': r3.id})
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             r1.write({'inherit_id': r3.id})
 
-        with self.assertRaises(ValidationError), self.cr.savepoint():
+        with self.assertRaises(ValidationError), self.env.savepoint():
             r1.write({
                 'inherit_id': r1.id,
                 'arch': self.arch_for('itself', parent=True),
@@ -3291,7 +3291,7 @@ class TestViews(ViewCase):
         # modifying a view extension should validate the other views
         with mute_logger('odoo.addons.base.models.ir_ui_view'):
             with self.assertRaises(ValidationError):
-                with self.cr.savepoint():
+                with self.env.savepoint():
                     view1.arch = """<form position="inside">
                         <field name="type"/>
                     </form>"""

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -151,7 +151,7 @@ class MergePartnerAutomatic(models.TransientModel):
                     self._cr.execute(query, (dst_partner.id, partner.id, dst_partner.id))
             else:
                 try:
-                    with mute_logger('odoo.sql_db'), self._cr.savepoint():
+                    with mute_logger('odoo.sql_db'), self.env.savepoint():
                         query = 'UPDATE "%(table)s" SET "%(column)s" = %%s WHERE "%(column)s" IN %%s' % query_dic
                         self._cr.execute(query, (dst_partner.id, tuple(src_partners.ids),))
 
@@ -190,7 +190,7 @@ class MergePartnerAutomatic(models.TransientModel):
                 return
             records = Model.sudo().search([(field_model, '=', 'res.partner'), (field_id, '=', src.id)])
             try:
-                with mute_logger('odoo.sql_db'), self._cr.savepoint():
+                with mute_logger('odoo.sql_db'), self.env.savepoint():
                     records.sudo().write({field_id: dst_partner.id})
                     records.env.flush_all()
             except psycopg2.Error:

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2503,7 +2503,7 @@ class TestFields(TransactionCaseWithUserDemo):
         self.assertEqual(image_data_uri(record.image_256)[:30], 'data:image/png;base64,iVBORw0K')
 
         # ensure invalid image raises
-        with self.assertRaises(UserError), self.cr.savepoint():
+        with self.assertRaises(UserError), self.env.savepoint():
             record.write({
                 'image': 'invalid image',
             })
@@ -2759,7 +2759,7 @@ class TestX2many(common.TransactionCase):
             'a_restricted_b_ids': [Command.set(record_b.ids)],
         })
         with self.assertRaises(psycopg2.IntegrityError):
-            with mute_logger('odoo.sql_db'), self.cr.savepoint():
+            with mute_logger('odoo.sql_db'), self.env.savepoint():
                 record_a.unlink()
         # Test B is still cascade.
         record_b.unlink()
@@ -2773,7 +2773,7 @@ class TestX2many(common.TransactionCase):
             'b_restricted_b_ids': [Command.set(record_b.ids)],
         })
         with self.assertRaises(psycopg2.IntegrityError):
-            with mute_logger('odoo.sql_db'), self.cr.savepoint():
+            with mute_logger('odoo.sql_db'), self.env.savepoint():
                 record_b.unlink()
         # Test A is still cascade.
         record_a.unlink()

--- a/odoo/addons/test_testing_utilities/tests/test_methods.py
+++ b/odoo/addons/test_testing_utilities/tests/test_methods.py
@@ -5,6 +5,7 @@ from unittest import mock, TestCase
 
 import psycopg2
 
+from odoo.api import Environment
 from odoo.exceptions import AccessError
 from odoo.sql_db import BaseCursor
 from odoo.tests import common
@@ -58,7 +59,7 @@ class TestBasic(common.TransactionCase):
         Raises an exception when `savepoint()` calls `flush()` during setup.
         """
         # ensure we catch the error with the "base" method to avoid any interference
-        with mock.patch.object(BaseCursor, 'flush', side_effect=CustomError), \
+        with mock.patch.object(Environment, 'flush_all', side_effect=CustomError), \
              TestCase.assertRaises(self, CustomError):
             with self.assertRaises(CustomError):
                 raise NotImplementedError

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -25,6 +25,7 @@ from weakref import WeakSet
 
 from decorator import decorate
 
+from .sql_db import _EnvironmentFlushingSavepoint, Savepoint
 from .exceptions import AccessError, CacheMiss
 from .tools import classproperty, frozendict, lazy_property, OrderedSet, Query, StackMap
 from .tools.translate import _
@@ -818,6 +819,8 @@ class Environment(Mapping):
             self._cache_key[field] = result
             return result
 
+    def savepoint(self) -> Savepoint:
+        return _EnvironmentFlushingSavepoint(self)
 
 class Transaction:
     """ A object holding ORM data structures for a transaction. """

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1175,7 +1175,7 @@ class BaseModel(metaclass=MetaModel):
 
             # try to create in batch
             try:
-                with cr.savepoint():
+                with self.env.savepoint():
                     recs = self._load_records(data_list, mode == 'update')
                     ids.extend(recs.ids)
                 return
@@ -1192,7 +1192,7 @@ class BaseModel(metaclass=MetaModel):
             # try again, this time record by record
             for i, rec_data in enumerate(data_list, 1):
                 try:
-                    with cr.savepoint():
+                    with self.env.savepoint():
                         rec = self._load_records([rec_data], mode == 'update')
                         ids.append(rec.id)
                 except psycopg2.Warning as e:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -14,6 +14,7 @@ import re
 import threading
 import time
 import uuid
+import warnings
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from inspect import currentframe
@@ -164,6 +165,11 @@ class BaseCursor:
         relevant hooks.
         """
         if flush:
+            warnings.warn(
+                "Starting odoo 16.4, you should use 'env.savepoint()' to create a savepoint that will flush the cache",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return _FlushingSavepoint(self)
         else:
             return Savepoint(self)

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -109,6 +109,22 @@ class _FlushingSavepoint(Savepoint):
             self._cr.flush()
         super()._close(rollback)
 
+class _EnvironmentFlushingSavepoint(Savepoint):
+    def __init__(self, env):
+        self.env = env
+        env.flush_all()
+        super().__init__(env.cr)
+
+    def rollback(self):
+        self.env.cr.clear()
+        super().rollback()
+
+    def _close(self, rollback):
+        if not rollback:
+            self.env.flush_all()
+            self.env.cr.flush()
+        super()._close(rollback)
+
 class BaseCursor:
     """ Base class for cursors that manage pre/post commit hooks. """
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -389,7 +389,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
         """ Context manager that clears the environment upon failure. """
         with ExitStack() as init:
             if hasattr(self, 'env'):
-                init.enter_context(self.env.cr.savepoint())
+                init.enter_context(self.env.savepoint())
                 if issubclass(exception, AccessError):
                     # The savepoint() above calls flush(), which leaves the
                     # record cache with lots of data.  This can prevent


### PR DESCRIPTION
When creating a savepoint, it is usually necessary to flush the environment, so the database has all the changes up-to the moment the savepoint is created.
From the cursor, it is not always obvious which environment to choose and this used to create a number of nondeterministic errors.

This commit introduces a way to create a savepoint from the environment. It will flush this specific environment.

We will leave the option to create a savepoint from the cursor.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
