### PR TITLE
[FIX] sale_project: Translate project title on sale order creation

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -213,8 +213,12 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         values = self._timesheet_create_project_prepare_values()
         if self.product_id.project_template_id:
-            values['name'] = "%s - %s" % (values['name'], self.product_id.project_template_id.name)
             project = self.product_id.project_template_id.copy(values)
+            languages = self.env['res.lang'].search([('active', '=', 'true')])
+            for lang in languages:
+                project.with_context(lang=lang.code).write({
+                    'name': "%s - %s" % (values['name'], self.product_id.project_template_id.with_context(lang=lang.code).name)
+                })
             project.tasks.write({
                 'sale_line_id': self.id,
                 'partner_id': self.order_id.partner_id.id,


### PR DESCRIPTION
Steps to reproduce:

  - Install `Sales - Project` and `Field Service` modules
  - Enable Spanish language
  - Create a new product:
    - Product Type: Service
    - Create on Order: Project & Task - Project Template: Field Service
  - Create a new quotation, add the above product and confirm the sale
  - Open the created project related to quotation
  - Check the project title translations

Issue:

  The project title is not translated correctly. E.g.:
  In 14.0+:
    - English: "SO0123 - Field Service"
    - Spanish: "Servicio externo"

  In 16.0+:
    - English: "SO0123 - Field Service"
    - Spanish: "SO0123 - Field Service"

Cause:

  In 14.0: The project title is translated based on the original title
  that is set on the project template. In this case, the project title
  is "Field Service".

  In 16.0: The project title is translated based on the title that is
  set on the project. In this case, the project title is "SO0123 -
  Field Service" and since there is no translation for this title, the
  same title is returned.

  The difference between both versions is that in 16.0, when copying and
  translating the fields values, if a field has been 'overwritten' by
  giving it to the `copy()` method, it will be considered as an
  exclude fields, and therefore will not be translated based on the
  original title, like in 14.0 .
  https://github.com/odoo/odoo/blob/ae643ab48b3447f372bfe08fbad7515f370b7cbe/odoo/models.py#L4757

  However, in both cases, the title will not be translated correctly
  since no translation is defined for the concatenation of the sale
  order name and the project template name.

Solution:

  After copying the project, update the title of the project with the
  translated concatenated title in all active languages.

opw-3298004

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
