### PR TITLE
[ADD] l10n_br_sale: localize customer-facing quotations for Brazil

### DIFF
--- a/addons/l10n_br_sale/__init__.py
+++ b/addons/l10n_br_sale/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_br_sale/__manifest__.py
+++ b/addons/l10n_br_sale/__manifest__.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Brazil - Sale',
+    'version': '1.0',
+    'description': 'Sale modifications for Brazil',
+    'category': 'Localization',
+    'depends': [
+        'l10n_br',
+        'sale_management',
+    ],
+    'data': [
+        'views/sale_portal_templates.xml',
+        'report/sale_order_templates.xml',
+        'report/report_invoice_templates.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_br_sale/report/report_invoice_templates.xml
+++ b/addons/l10n_br_sale/report/report_invoice_templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="document_tax_totals_template_brazil" inherit_id="account.document_tax_totals_template">
+        <!-- hide the tax summary above the total -->
+        <t t-as="subtotal" position="attributes">
+            <!-- doc for quotations, sale_order for online quote (o is used for invoices) -->
+            <attribute name="t-if">(doc or sale_order).company_id.country_id.code != 'BR' if (doc or sale_order) else True</attribute>
+        </t>
+    </template>
+</odoo>

--- a/addons/l10n_br_sale/report/sale_order_templates.xml
+++ b/addons/l10n_br_sale/report/sale_order_templates.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_saleorder_document_brazil" inherit_id="sale.report_saleorder_document">
+        <!-- hide the taxes th -->
+        <th name="th_taxes" position="attributes">
+            <attribute name="t-if">doc.company_id.country_id.code != 'BR'</attribute>
+        </th>
+        <!-- hide the taxes td -->
+        <td name="td_taxes" position="attributes">
+            <attribute name="t-if">doc.company_id.country_id.code != 'BR'</attribute>
+        </td>
+        <!-- hide the "Tax excl." th -->
+        <th name="th_subtotal" position="attributes">
+            <attribute name="t-if">doc.company_id.country_id.code != 'BR'</attribute>
+        </th>
+        <!-- hide the "Tax excl." td -->
+        <td name="td_subtotal" position="attributes">
+            <attribute name="t-if">doc.company_id.country_id.code != 'BR'</attribute>
+        </td>
+        <!-- rename the "Tax incl." th, avoid touching original <span> to keep existing translations working -->
+        <xpath expr="//th[@name='th_total']/span" position="attributes">
+            <attribute name="t-if">doc.company_id.country_id.code != 'BR'</attribute>
+        </xpath>
+        <xpath expr="//th[@name='th_total']/span" position="after">
+            <span t-else="">Total</span>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_br_sale/views/sale_portal_templates.xml
+++ b/addons/l10n_br_sale/views/sale_portal_templates.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="sale_order_portal_content_brazil" inherit_id="sale.sale_order_portal_content">
+        <!-- hide the taxes th -->
+        <th id="taxes_header" position="attributes">
+            <attribute name="t-if">sale_order.company_id.country_id.code != 'BR'</attribute>
+        </th>
+        <!-- hide the taxes td -->
+        <td id="taxes" position="attributes">
+            <attribute name="t-if">sale_order.company_id.country_id.code != 'BR'</attribute>
+        </td>
+        <!-- hide the "Tax excl." th -->
+        <th id="subtotal_header" position="attributes">
+            <attribute name="t-if">sale_order.company_id.country_id.code != 'BR'</attribute>
+        </th>
+        <!-- hide the "Tax excl." td -->
+        <td id='subtotal' position="attributes">
+            <attribute name="t-if">not line.is_downpayment and sale_order.company_id.country_id.code != 'BR'</attribute>
+        </td>
+        <!-- rename the "Tax incl." th, avoid touching original <span> to keep existing translations working -->
+        <xpath expr="//th[@id='total_header']/span" position="attributes">
+            <attribute name="t-if">sale_order.company_id.country_id.code != 'BR'</attribute>
+        </xpath>
+        <xpath expr="//th[@id='total_header']/span" position="after">
+            <span t-else="">Total</span>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -478,13 +478,13 @@
                                 <th t-if="display_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                     <span>Disc.%</span>
                                 </th>
-                                <th t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                <th t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes_header">
                                     <span>Taxes</span>
                                 </th>
-                                <th class="text-end">
+                                <th class="text-end" id="subtotal_header">
                                     <span>Tax excl.</span>
                                 </th>
-                                <th class="text-end" t-if="sale_order.tax_calculation_rounding_method == 'round_per_line'">
+                                <th class="text-end" t-if="sale_order.tax_calculation_rounding_method == 'round_per_line'" id="total_header">
                                     <span>Tax incl.</span>
                                 </th>
                             </tr>
@@ -526,10 +526,10 @@
                                                 <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
                                             </strong>
                                         </td>
-                                        <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                        <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
                                             <span t-out="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"/>
                                         </td>
-                                        <td t-if="not line.is_downpayment" class="text-end">
+                                        <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
                                         </td>
                                         <td class="text-end" t-if="sale_order.tax_calculation_rounding_method == 'round_per_line' and not line.is_downpayment" >


### PR DESCRIPTION
Brazilians don't expect to see tax-related info on quotations. This modifies the quotation PDF and online quotation views, taking care not to break existing translations.

task-3325740

PS: this doesn't include translations, the only translatable string is "Total" which is valid Portuguese.
