### PR TITLE
[FIX] core: avoid error when using env from api.Environment in pre_init_hook

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -191,6 +191,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True,
             py_module = sys.modules['odoo.addons.%s' % (module_name,)]
             pre_init = package.info.get('pre_init_hook')
             if pre_init:
+                registry.setup_models(cr)
                 getattr(py_module, pre_init)(cr)
 
         model_names = registry.load(cr, package)


### PR DESCRIPTION
When reinstalling a module, an error occurred if using env from api.Environment in pre_init_hook.

Example:
- Module A depends on module B, and model M that created from module A
- When reinstalling module B, an error occurred if using env['M'] in pre_init_hook




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
