### PR TITLE
[IMP] account: remove redundant warning message

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -174,16 +174,13 @@ class AccountMoveSend(models.Model):
             display_messages = []
             if wizard.enable_send_mail:
                 invoices_without_mail_data = wizard.move_ids.filtered(lambda x: not x.partner_id.email)
-                if invoices_without_mail_data:
-                    if wizard.mode == 'invoice_multi':
-                        display_messages.append(_(
-                            "The following invoice(s) will not be sent by email, because the customers don't have email "
-                            "address: "
-                        ))
-                        display_messages.append(", ".join(invoices_without_mail_data.mapped('name')))
-                        send_mail_readonly = True
-                    else:
-                        display_messages.append(_("Please add an email address for your partner"))
+                if invoices_without_mail_data and wizard.mode == 'invoice_multi':
+                    display_messages.append(_(
+                        "The following invoice(s) will not be sent by email, because the customers don't have email "
+                        "address: "
+                    ))
+                    display_messages.append(", ".join(invoices_without_mail_data.mapped('name')))
+                    send_mail_readonly = True
 
             wizard.send_mail_readonly = send_mail_readonly
             wizard.send_mail_warning_message = "".join(display_messages) if display_messages else None

--- a/addons/snailmail_account/wizard/account_move_send.py
+++ b/addons/snailmail_account/wizard/account_move_send.py
@@ -27,11 +27,11 @@ class AccountMoveSend(models.Model):
             wizard.checkbox_send_by_post = not wizard.send_by_post_warning_message \
                 and wizard.company_id.invoice_is_snailmail
 
-    @api.depends('mode')
+    @api.depends('mode', 'checkbox_send_mail')
     def _compute_send_by_post_warning_message(self):
         for wizard in self:
             display_messages = []
-            if wizard.enable_send_by_post:
+            if wizard.enable_send_by_post and wizard.checkbox_send_mail:
                 wrong_address_partners = wizard.move_ids.partner_id\
                     .filtered(lambda x: not self.env['snailmail.letter']._is_valid_address(x))
                 if wrong_address_partners:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Improve warning message that gets shown when sending an invoice
by removing the redundant "Please add an email..." message
And only show the "The following customer doesn't have a valid address..."
if the email checkbox is checked

Based on [this task](https://www.odoo.com/web#id=3336623&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

Current behavior before PR:

Both warning message shows up when the user doesn't have an email address

Desired behavior after PR is merged:

No more of the redundant "Please add an email..." message
And only show the "The following customer doesn't have a valid address..."
if the email checkbox is checked


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
