### PR TITLE
[FIX] account : correct analytic rule validation message

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -14167,7 +14167,7 @@ msgstr ""
 #. module: account
 #: code:addons/account/models/account_analytic_default.py:31
 #, python-format
-msgid "An analytic default requires an analytic account or an analytic tag used for analytic distribution."
+msgid "An analytic default requires an analytic account."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_analytic_default.py
+++ b/addons/account/models/account_analytic_default.py
@@ -28,7 +28,7 @@ class AccountAnalyticDefault(models.Model):
                and not any(tag.analytic_distribution_ids for tag in default.analytic_tag_ids)
                for default in self
                ):
-            raise ValidationError(_('An analytic default requires an analytic account or an analytic tag used for analytic distribution.'))
+            raise ValidationError(_('An analytic default requires an analytic account.'))
 
     @api.model
     def account_get(self, product_id=None, partner_id=None, account_id=None, user_id=None, date=None, company_id=None):


### PR DESCRIPTION
An analytic rule can be created without any tag so the error message is not correct.

Steps to Reproduce:
In v14 and v15, try adding an analytic defaults rule without an account and without any tag.

Current Behaviour:
The error message says that either an analytic tag or an account is required for the rule to be created.

Expected Behaviour:
We can clearly see that the rule can be created without a tag, but not without an account. So the account is the only required item here.

OPW-3274645


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
