### PR TITLE
[DRAFT][FIX] website_sale: prevent the invalid field from search order

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -173,7 +173,9 @@ class WebsiteSale(http.Controller):
     def _get_search_order(self, post):
         # OrderBy will be parsed in orm and so no direct sql injection
         # id is added to be sure that order is a unique sort key
-        order = post.get('order') or request.env['website'].get_current_website().shop_default_sort
+        order = post.get('order')
+        if order not in (product_map[0] for product_map in request.env['website']._get_product_sort_mapping()):
+            order = request.env['website'].get_current_website().shop_default_sort
         return 'is_published desc, %s, id desc' % order
 
     def _get_search_domain(self, search, category, attrib_values, search_in_description=True):


### PR DESCRIPTION
When the user change the order name which is not present in the Sort By in eCommerce and tries to access the invalid field, it gets an error.

Steps to produce:-
- Install 'website_sale'
- Inside 'website' click on 'shop'
- From the Sort By drop down list select any option
- In the URL change the order to 'undefined'
- Traceback is generated

see:-
```
ValueError: Invalid field 'undefined' on model 'product.template'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1838, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 387, in shop
    fuzzy_search_term, product_count, search_product = self._shop_lookup_products(attrib_set, options, post, search, website)
  File "addons/website_sale/controllers/main.py", line 244, in _shop_lookup_products
    product_count, details, fuzzy_search_term = website._search_with_fuzzy("products_only", search,
  File "addons/website/models/website.py", line 1564, in _search_with_fuzzy
    count, results = self._search_exact(search_details, search, limit, order)
  File "addons/website/models/website.py", line 1589, in _search_exact
    results, count = model._search_fetch(search_detail, search, limit, order)
  File "addons/website/models/mixins.py", line 353, in _search_fetch
    results = model.search(
  File "odoo/models.py", line 1507, in search
    return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
  File "odoo/models.py", line 1530, in search_fetch
    query = self._search(domain, offset=offset, limit=limit, order=order or self._order)
  File "odoo/models.py", line 4763, in _search
    query.order = self._generate_order_by(order, query).replace('ORDER BY ', '')
  File "odoo/models.py", line 4639, in _generate_order_by
    order_by_elements = self._generate_order_by_inner(self._table, order_spec, query)
  File "odoo/models.py", line 4603, in _generate_order_by_inner
    raise ValueError("Invalid field %r on model %r" % (order_field, self._name))
```

Applying this commit will fix this issue.

sentry-4197262409