### PR TITLE
[FIX] website: form with optional report to print doesn't fail

### DIFF
--- a/addons/website_form/controllers/main.py
+++ b/addons/website_form/controllers/main.py
@@ -205,7 +205,10 @@ class WebsiteForm(http.Controller):
         model_name = model.sudo().model
         if model_name == 'mail.mail':
             values.update({'reply_to': values.get('email_from')})
-        record = request.env[model_name].with_user(SUPERUSER_ID).with_context(mail_create_nosubscribe=True).create(values)
+        record = request.env[model_name].with_user(SUPERUSER_ID).with_context(
+            mail_create_nosubscribe=True,
+            commit_assetsbundle=False,
+        ).create(values)
 
         if custom or meta:
             _custom_label = "%s\n___________\n\n" % _("Other Information:")  # Title for custom fields

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -835,7 +835,7 @@ class IrActionsReport(models.Model):
         # assets are not in cache and must be generated. To workaround this issue, we manually
         # commit the writes in the `ir.attachment` table. It is done thanks to a key in the context.
         context = dict(self.env.context)
-        if not config['test_enable']:
+        if not config['test_enable'] and 'commit_assetsbundle' not in context:
             context['commit_assetsbundle'] = True
 
         # Disable the debug mode in the PDF rendering in order to not split the assets bundle


### PR DESCRIPTION
14.0 backport of https://github.com/odoo/odoo/pull/119612

Steps to reproduce:

- Install industry_fsm_report, website
- Create Project P, add column/stage PC. Edit stage,
Email Template = Task: Intervention Schduled. Edit the template >
Advanced Settings > Optional report to print and attach = Worksheet Report (PDF). Save everything.
- Go to website, "contact us" page > Edit the form, Action = Create a task, Project = P > Save

Issue:

When you first submit the form, it will fail, but the task will be created and visible in project P. By instinct, the user will submit the form again, so the task will be duplicated. The second form submit will return a success message.

When submitting a form, we first generate a savepoint (added in commit 5a499ec). Since this is the first interaction with the report system, during the handling of the form, the assetsbundle will be generated (see keyword 'commit_assetsbundle'), which will cause a commit. Finally, assuming no other error is raised, we try to delete the savepoint. However, since a commit was executed, then the savepoint will no longer exist, which will cause an error status to be returned.

Solution:

When submitting a form, pass `commit_assetsbundle=False` to the record creation, which prevents the commit from happening.

This solution has a downside; creating the record also sends an email and the report attached to that email will have broken styling. This is still an improvement to the current behaviour, which doesn't send the first email at all.

opw-3183912