### PR TITLE
[FIX] base: use html method from lxml for translated template

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1367,6 +1367,18 @@ class TranslationImporter:
             Model = env[model_name]
             model_table = Model._table
             for field_name, field_dictionary in model_dictionary.items():
+                # we do this to tell lxml that the xml nodes should be printed as HTML nodes
+                # otherwise browser assumes that 'self-closing' tags are opening tags, left unclosed
+                field = self.env[model_name]._fields.get(field_name)
+                if field.translate and field.type == 'html':
+                    for translations in field_dictionary.values():
+                        for lang, translation in translations.items():
+                            try:
+                                # this is a normalisation step for auto-closing t tags
+                                translations[lang] = etree.tostring(etree.HTML(translation).find('body')[0], method='html', encoding='unicode')
+                            except Exception:
+                                continue
+
                 for sub_field_dictionary in cr.split_for_in_conditions(field_dictionary.items()):
                     # [xmlid, translations, xmlid, translations, ...]
                     params = []


### PR DESCRIPTION
Reproduction:
1. Change the language to French 2.Enable debug mode to access the Settings/Technical/Email Template view 3.Open the Shipping: Send by email template
4.Notice that there is a t-out with line[0] or ''
5.Click on the Reset Template button on the form view 6.The t-out is ". ." now

Fix: This is a side fix of c6d1fcb9cc7d1244cc39c0477c6887a19ecdadc4 In the previous commit, we solved the same issue when we reset the template in English. However, the translation for the templates still has the same issue. This fix adds an extra step to parse the translation by xml if it’s possible to parse it, and then we tell lxml that the xml nodes should be printed as HTML nodes. The same thing we did in the previous commit

opw-3324158


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
