### PR TITLE
[IMP] project: add company specific stages 

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -55,6 +55,12 @@
         <field name="domain_force">['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
     </record>
 
+    <record model="ir.rule" id="project_project_stage_rule">
+        <field name="name">Project Stage: multi-company</field>
+        <field name="model_id" ref="model_project_project_stage"/>
+        <field name="domain_force">['|', ('company_id', 'in', company_ids), ('company_id', '=', False)]</field>
+    </record>
+
     <record model="ir.rule" id="project_project_manager_rule">
         <field name="name">Project: project manager: see all</field>
         <field name="model_id" ref="model_project_project"/>

--- a/addons/project/static/src/views/project_project_list/project_project_list_renderer.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_renderer.js
@@ -1,0 +1,18 @@
+/** @odoo-module */
+
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { getRawValue } from "@web/views/kanban/kanban_record";
+
+export class ProjectProjectListRenderer extends ListRenderer {
+    isCellReadonly(column, record) {
+        let readonly = super.isCellReadonly(column, record);
+        const { selection } = this.props.list;
+        if (column.name === "stage_id" && selection.length) {
+            const companyId = getRawValue(selection[0], "company_id");
+            readonly = selection.some(
+                (task) => getRawValue(task, "company_id") !== companyId
+            );
+        }
+        return readonly;
+    }
+}

--- a/addons/project/static/src/views/project_project_list/project_project_list_view.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_view.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { listView } from '@web/views/list/list_view';
+import { ProjectProjectListRenderer } from "./project_project_list_renderer";
+
+export const projectProjectListView = {
+    ...listView,
+    Renderer: ProjectProjectListRenderer,
+};
+
+registry.category("views").add("project_project_list", projectProjectListView);

--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -11,6 +11,7 @@ from . import test_project_recurrence
 from . import test_project_sharing
 from . import test_project_sharing_portal_access
 from . import test_project_sharing_ui
+from . import test_project_stage_multicompany
 from . import test_project_subtasks
 from . import test_project_task_type
 from . import test_project_ui

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -1,0 +1,87 @@
+from .test_multicompany import TestMultiCompanyProject
+
+from odoo.exceptions import UserError
+
+
+class TestProjectStagesMulticompany(TestMultiCompanyProject):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestProjectStagesMulticompany, cls).setUpClass()
+
+        Users = cls.env['res.users'].with_context({'no_reset_password': True})
+        cls.user_manager_companies = Users.create({
+            'name': 'Manager Companies',
+            'login': 'manager-all',
+            'email': 'manager@companies.com',
+            'company_id': cls.company_a.id,
+            'company_ids': [(4, cls.company_a.id), (4, cls.company_b.id)],
+            'groups_id':
+                [(6, 0, [
+                    cls.env.ref('base.group_user').id,
+                    cls.env.ref('project.group_project_stages').id,
+                    cls.env.ref('project.group_project_manager').id,
+                ])]
+        })
+        cls.stage_company_a, cls.stage_company_b, cls.stage_company_none = cls.env['project.project.stage'].create([{
+            'name': 'Stage Company A',
+            'company_id': cls.company_a.id,
+        }, {
+            'name': 'Stage Company B',
+            'company_id': cls.company_b.id,
+        }, {
+            'name': 'Stage Company None',
+        }])
+        cls.project_company_none = cls.env['project.project'].create({
+            'name': 'Project Company None'
+        })
+
+    def test_move_linked_project_stage_other_company(self):
+        """ This test will check that an error is raised if a project belonging to a stage
+        (both linked to company A) is moved to another stage (belonging to company B) """
+        self.project_company_a.stage_id = self.stage_company_a.id
+        with self.assertRaises(UserError):
+            self.project_company_a.stage_id = self.stage_company_b.id
+
+    def test_move_project_stage_other_company(self):
+        """ This test will check that an error is raised a project belonging to a stage (both
+        not linked to any company) is moved to another stage (belonging to company B) """
+        self.project_company_none.stage_id = self.stage_company_none.id
+        with self.assertRaises(UserError):
+            self.project_company_none.stage_id = self.stage_company_b.id,
+
+    def test_move_linked_project_stage_same_company(self):
+        """ This test will check that no error is raised if a project belonging to a stage (with
+        only the project belonging to company B and the stage not linked to any company) is moved
+        to another stage (belonging to company B) """
+        self.project_company_b.stage_id = self.stage_company_none.id
+        self.project_company_b.stage_id = self.stage_company_b.id
+
+    def test_move_project_stage_same_company(self):
+        """ This test will check that no error is raised if a project belonging to a stage (both
+        linked to company A) is moved to another stage (also belonging to company A) """
+        self.project_company_a.stage_id = self.stage_company_a.id
+        self.stage_company_none.company_id = self.company_a.id
+        self.project_company_a.stage_id = self.stage_company_none.id
+
+    def test_change_project_company(self):
+        """ This test will check that a project's stage is changed according to the
+        company it is linked to. When a project (belonging to a stage with both the
+        project and the stage linked to company A) changes company for company B,
+        the stage should change for the lowest stage in sequence that is linked to
+        company B. If there is no stage linked to company B, then the lowest stage
+        in sequence linked to no company will be chosen """
+        project = self.project_company_a.with_user(self.user_manager_companies)
+        project.stage_id = self.stage_company_a.id
+        project.company_id = self.company_b.id
+
+        # Check that project was moved to stage_company_b
+        self.assertEqual(self.project_company_a.stage_id, self.stage_company_b, "Project Company A should now be in Stage Company B")
+
+        # Here we remove the company from the stage; then changing the project's company to company A should
+        # move it to the first stage in sequence that is linked to no company, and not in stage company A
+        self.stage_company_a.company_id = False
+
+        project.company_id = self.company_a.id
+
+        self.assertNotEqual(self.project_company_a.stage_id, self.stage_company_a, "Project Company A should not be in Stage Company A")

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -8,6 +8,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="mail_template_id" optional="hide" context="{'default_model': 'project.project'}"/>
+                <field name="company_id" optional="hide" groups="base.group_multi_company"/>
                 <field name="fold" optional="show"/>
             </tree>
         </field>
@@ -43,6 +44,7 @@
                         </group>
                         <group>
                             <field name="fold"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                 </sheet>
@@ -62,7 +64,14 @@
                         <div class="o_kanban_record oe_kanban_global_click">
                             <strong><field name="name"/></strong>
                             <br/>
-                            <span class="text-muted"><field name="mail_template_id"/></span>
+                            <span class="text-muted" invisible="not mail_template_id">
+                                <field name="mail_template_id"/>
+                                <br/>
+                            </span>
+                            <span groups="base.group_multi_company" invisible="not company_id">
+                                <field name="company_id"/>
+                                <br/>
+                            </span>
                         </div>
                     </t>
                 </templates>
@@ -77,7 +86,11 @@
             <search>
                 <field name="name"/>
                 <field name="mail_template_id"/>
+                <field name="company_id" groups="base.group_multi_company"/>
                 <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
+                <group>
+                    <filter string="Company" name="company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
+                </group>
             </search>
         </field>
     </record>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -24,7 +24,7 @@
                         invisible="privacy_visibility != 'portal'" context="{'default_access_mode': 'read', 'dialog_size': 'medium'}" data-hotkey="r"/>
                         <button name="%(project.project_share_wizard_action)d" string="Share Editable" type="action" class="oe_highlight" groups="project.group_project_manager"
                         invisible="privacy_visibility != 'portal'" context="{'default_access_mode': 'edit', 'dialog_size': 'medium'}" data-hotkey="e"/>
-                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" groups="project.group_project_stages"/>
+                        <field name="stage_id" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" groups="project.group_project_stages" domain="[('company_id', 'in', (company_id, False))]"/>
                     </header>
                 <sheet string="Project">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
@@ -204,7 +204,7 @@
             <field name="name">project.project.tree</field>
             <field name="model">project.project</field>
             <field name="arch" type="xml">
-                <tree decoration-muted="active == False" string="Projects" multi_edit="1" sample="1" default_order="is_favorite desc, sequence, name, id">
+                <tree decoration-muted="active == False" string="Projects" multi_edit="1" sample="1" default_order="is_favorite desc, sequence, name, id" js_class="project_project_list">
                     <field name="sequence" column_invisible="True"/>
                     <field name="message_needaction" column_invisible="True"/>
                     <field name="active" column_invisible="True"/>
@@ -220,7 +220,7 @@
                     <field name="last_update_color" column_invisible="True"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" optional="show" widget="project_state_selection" options="{'hide_label': True}"/>
-                    <field name="stage_id" options="{'no_open': True}" optional="show"/>
+                    <field name="stage_id" options="{'no_open': True}" domain="[('company_id', 'in', (company_id, False))]" optional="show"/>
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
                 </tree>
             </field>


### PR DESCRIPTION
Adding a company_id field in project.project.stage will allow companies
to have their own individual stages, which was not possible before since
all the stages were shared between all companies.

task-3330285
