### PR TITLE
[IMP] mps: possibility to change period in view

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -15,11 +15,13 @@
 
     @include media-breakpoint-up(lg) {
         .o_control_panel_breadcrumbs, .o_control_panel_navigation {
-            flex: 1
+            flex: 1;
+            height: 100%;
         }
 
         .o_control_panel_actions {
             min-width: MIN(500px, 33%);
+            height: 100%;
         }
     }
 

--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -396,9 +396,13 @@ export class ExportDataDialog extends Component {
     }
 
     async setDefaultExportList() {
-        this.state.exportList = Object.values(this.knownFields).filter(
-            (e) => e.default_export || this.props.defaultExportList.find((i) => i.name === e.id)
-        );
+        if (this.props.context.default_template_id) {
+            this.loadExportList(this.props.context.default_template_id);
+        } else {
+            this.state.exportList = Object.values(this.knownFields).filter(
+                (e) => e.default_export || this.props.defaultExportList.find((i) => i.name === e.id)
+            );
+        }
     }
 
     setFormat(ev) {

--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -52,7 +52,10 @@ export const companyService = {
             const { data, error } = ev.detail;
             const { model, method } = data.params;
             if (!error && model === "res.company" && UPDATE_METHODS.includes(method)) {
-                if (!browser.localStorage.getItem("running_tour")) {
+                if (
+                    !browser.localStorage.getItem("running_tour") &&
+                    !data.params.kwargs?.context?.settings?.do_not_reload
+                ) {
                     action.doAction("reload_context");
                 }
             }


### PR DESCRIPTION
This pr adds the possibility to change directly the time range used in the MPS gantt planning and default export fields.

Previously, it was only possible to change the time range in the settings of MRP, which was not convenient.
The use can now change it directly in the view. It will not impact the settings and refreshing the page will reset the range chosen in the settings.
Added the "Year" range.
There is also the possibility to determinate the number of columns to display for each range in the MRP settings.

In addition, the export to xls/csv did not contain any fields by default. It was due to the view not inheriting from the ListController. The solution found is to create a template, to pass the id to the dialog thanks to the context, and then loading that template as the default one.

Task-3288653


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
