### PR TITLE
[FIX] auth_signup: ignore signup error in sentry when user signup with same mail

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -146,6 +146,7 @@ class ResUsers(models.Model):
                 return template_user.with_context(no_reset_password=True).copy(values)
         except Exception as e:
             # copy may failed if asked login is not available.
+            e.sentry_ignored = True
             raise SignupError(ustr(e))
 
     def reset_password(self, login):


### PR DESCRIPTION
when the user will do signup with the same mail id with a different name or the same name we are ignoring this 'SignUp' Error in sentry to reduce the noise of 'Signup Error'.

See Traceback:-

```
UniqueViolation: duplicate key value violates unique constraint "res_users_login_key"
DETAIL:  Key (login)=(ahmedgamal.fcih@gmail.com) already exists.

  File "addons/auth_signup/models/res_users.py", line 146, in _create_user_from_template
    return template_user.with_context(no_reset_password=True).copy(values)
  File "addons/auth_signup/models/res_users.py", line 256, in copy
    return sup.copy(default=default)
  File "odoo/addons/base/models/res_users.py", line 672, in copy
    return super(Users, self).copy(default)
  File "odoo/models.py", line 4913, in copy
    record_copy = self.create(vals)
  File "<decorator-gen-228>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/digest/models/res_users.py", line 12, in create
    users = super(ResUsers, self).create(vals_list)
  File "<decorator-gen-217>", line 2, in create
  File "odoo/api.py", line 390, in _model_create_single
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "odoo/api.py", line 390, in <genexpr>
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "home/odoo/src/custom/trial/saas_trial/models/res_users.py", line 100, in create
    res = super(ResUsers, self).create(values)
  File "<decorator-gen-186>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/hr/models/res_users.py", line 205, in create
    res = super().create(vals_list)
  File "<decorator-gen-117>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "addons/auth_signup/models/res_users.py", line 239, in create
    users = super(ResUsers, self).create(vals_list)
  File "<decorator-gen-141>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "addons/mail/models/res_users.py", line 91, in create
    users = super(Users, self).create(vals_list)
  File "<decorator-gen-113>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/res_users.py", line 1574, in create
    users = super(UsersView, self).create(new_vals_list)
  File "<decorator-gen-111>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/res_users.py", line 1282, in create
    return super(UsersImplied, self).create(vals_list)
  File "<decorator-gen-103>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/res_users.py", line 571, in create
    users = super(Users, self).create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4023, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4226, in _create
    cr.execute(
  File "odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
SignupError: duplicate key value violates unique constraint "res_users_login_key"
DETAIL:  Key (login)=(ahmedgamal.fcih@gmail.com) already exists.

  File "addons/auth_signup/controllers/main.py", line 83, in web_auth_reset_password
    self.do_signup(qcontext)
  File "addons/auth_signup/controllers/main.py", line 153, in do_signup
    self._signup_with_values(qcontext.get('token'), values)
  File "addons/auth_signup/controllers/main.py", line 157, in _signup_with_values
    login, password = request.env['res.users'].sudo().signup(values, token)
  File "addons/auth_signup/models/res_users.py", line 98, in signup
    partner_user = self._signup_create_user(values)
  File "addons/auth_signup/models/res_users.py", line 119, in _signup_create_user
    return self._create_user_from_template(values)
  File "addons/auth_signup/models/res_users.py", line 149, in _create_user_from_template
    raise SignupError(ustr(e))
```

sentry - 4199543548

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
