### PR TITLE
[FIX] web:  restrict export of compute_all_tax field

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -349,7 +349,7 @@ class AccountMoveLine(models.Model):
     # === Invoice sync fields === #
     term_key = fields.Binary(compute='_compute_term_key')
     tax_key = fields.Binary(compute='_compute_tax_key')
-    compute_all_tax = fields.Binary(compute='_compute_all_tax')
+    compute_all_tax = fields.Binary(compute='_compute_all_tax', exportable=False)
     compute_all_tax_dirty = fields.Boolean(compute='_compute_all_tax')
     epd_key = fields.Binary(compute='_compute_epd_key')
     epd_needed = fields.Binary(compute='_compute_epd_needed')


### PR DESCRIPTION
When a user tries to export the journal item, this issue is generated when a field has data of datatype `dict`.

Steps to produce:
1. Install Accounting > Go to accounting > Journal items.
2. Now select any item > Action > Export.
3. Include `compute_all_tax` in fields to import section and Click export. 
Note: Format for export must be xlsx.

```
TypeError: float() argument must be a string or a real number, not 'dict'
  File "xlsxwriter/worksheet.py", line 512, in _write
    f = float(token)
TypeError: Unsupported type <class 'dict'> in write()
  File "addons/web/controllers/export.py", line 558, in web_export_xlsx
    return self.base(data)
  File "addons/web/controllers/export.py", line 499, in base
    response_data = self.from_data(columns_headers, export_data)
  File "addons/web/controllers/export.py", line 590, in from_data
    xlsx_writer.write_cell(row_index + 1, cell_index, cell_value)
  File "addons/web/controllers/export.py", line 239, in write_cell
    self.write(row, column, cell_value, cell_style)
  File "addons/web/controllers/export.py", line 213, in write
    self.worksheet.write(row, column, cell_value, style)
  File "xlsxwriter/worksheet.py", line 85, in cell_wrapper
    return method(self, *args, **kwargs)
  File "xlsxwriter/worksheet.py", line 445, in write
    return self._write(row, col, *args)
  File "xlsxwriter/worksheet.py", line 517, in _write
    raise TypeError("Unsupported type %s in write()" % type(token))
```
So,this commit restricts the export of the compute_all_tax field by setting the 
exportable attribute to False, as it is only a technical field here : 
https://github.com/odoo/odoo/blob/c48a8d5877ef1ca74d83884d8302171e51562eeb/addons/account/models/account_move_line.py#L352

sentry-4207162678



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
