### PR TITLE
[IMP] base, web, l10n_in: add parameter to hide the cancel button in RedirectWarning

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -106,7 +106,7 @@ class AccountMove(models.Model):
                     "res_id" : move.company_id.id,
                     "views": [[self.env.ref("base.view_company_form").id, "form"]],
                 }
-                raise RedirectWarning(msg, action, _('Go to Company configuration'))
+                raise RedirectWarning(msg, action, _('Go to Company configuration'), hide_cancel_button=True)
             elif move.journal_id.type == 'purchase':
                 move.l10n_in_state_id = company_unit_partner.state_id
 

--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -127,12 +127,13 @@ export class RedirectWarningDialog extends Dialog {
         super.setup();
         this.actionService = useService("action");
         const { data, subType } = this.props;
-        const [message, actionId, buttonText, additional_context] = data.arguments;
+        const [message, actionId, buttonText, additional_context, hide_cancel_button] = data.arguments;
         this.title = capitalize(subType) || this.env._t("Odoo Warning");
         this.message = message;
         this.actionId = actionId;
         this.buttonText = buttonText;
         this.additionalContext = additional_context;
+        this.hide_cancel_button = hide_cancel_button;
     }
     async onClick() {
         const options = {};

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -15,7 +15,7 @@
 
     <t t-name="web.RedirectWarningDialogFooter" owl="1">
       <button  class="btn btn-primary" t-on-click="onClick"><t t-esc="env._t(buttonText)"/></button>
-      <button  class="btn btn-secondary" t-on-click="onCancel">Cancel</button>
+      <button  class="btn btn-secondary" t-if="!hide_cancel_button" t-on-click="onCancel">Cancel</button>
     </t>
 
     <t t-name="web.Error504DialogBody" owl="1">

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -49,9 +49,10 @@ class RedirectWarning(Exception):
         the redirection.
     :param dict additional_context: parameter passed to action_id.
            Can be used to limit a view to active_ids for example.
+    :param bool hide_cancel_button: if True will hide the Close button in the warning.
     """
-    def __init__(self, message, action, button_text, additional_context=None):
-        super().__init__(message, action, button_text, additional_context)
+    def __init__(self, message, action, button_text, additional_context=None, hide_cancel_button=False):
+        super().__init__(message, action, button_text, additional_context, hide_cancel_button)
 
     # using this RedirectWarning won't crash if used as an UserError
     @property


### PR DESCRIPTION
adds a parameter 'hide_cancel_button' that hides the Close button in the RedirectWarning dialog and uses the new parameter in l10n_in to hide the Close button when trying to create an invoice where company data is missing an address.

task-3339621
