### PR TITLE
[IMP] account: show journal in error message when account not allowed in journal

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13880,7 +13880,7 @@ msgstr ""
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid ""
-"You cannot use this account (%s) in this journal, check the field 'Allowed "
+"You cannot use this account (%s) in this journal (%s), check the field 'Allowed "
 "Journals' on the related account."
 msgstr ""
 
@@ -13888,7 +13888,7 @@ msgstr ""
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid ""
-"You cannot use this account (%s) in this journal, check the section "
+"You cannot use this account (%s) in this journal (%s), check the section "
 "'Control-Access' under tab 'Advanced Settings' on the related journal."
 msgstr ""
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4081,7 +4081,8 @@ class AccountMoveLine(models.Model):
                 raise UserError(_('The account selected on your journal entry forces to provide a secondary currency. You should remove the secondary currency on the account.'))
 
             if account.allowed_journal_ids and journal not in account.allowed_journal_ids:
-                raise UserError(_('You cannot use this account (%s) in this journal, check the field \'Allowed Journals\' on the related account.', account.display_name))
+                raise UserError(_('You cannot use this account (%s) in this journal (%s), check the field \'Allowed '
+                                  'Journals\' on the related account.', account.display_name, journal.name))
 
             if account in (journal.default_account_id, journal.suspense_account_id):
                 continue
@@ -4090,8 +4091,8 @@ class AccountMoveLine(models.Model):
             is_type_control_ok = not journal.type_control_ids or account.user_type_id in journal.type_control_ids
 
             if not is_account_control_ok or not is_type_control_ok:
-                raise UserError(_("You cannot use this account (%s) in this journal, check the section 'Control-Access' under "
-                                  "tab 'Advanced Settings' on the related journal.", account.display_name))
+                raise UserError(_("You cannot use this account (%s) in this journal (%s), check the section 'Control-Access' under "
+                                  "tab 'Advanced Settings' on the related journal.", account.display_name, journal.name))
 
     @api.constrains('account_id', 'tax_ids', 'tax_line_id', 'reconciled')
     def _check_off_balance(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
We had a client who could not add payments to import invoices for two months because the currency exchange journal did not allow a certain account. Since the error message only talked about the account not being allowed in the journal, and mentioned the account but not the journal, our functional staff assumed it was a bug because the journal of the invoice was correctly configured.
After downloading a copy of the database and debugging we found the currency exchange journal to be the culprit.

Current behavior before PR:
Before this commit the user could not see which journal was not allowing changes in an invoice like setting an account on a line or adding an existing payment to the invoice.
Normally the journal in question is the journal of the invoice, but there is at least one other case where the cause of the error is not so obvious: the currency exchange journal.

Desired behavior after PR is merged:
After this commit we will avoid this possible confusion which could leave users unable to add payments in other currencies to their invoices without knowing how to fix it.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
