### PR TITLE
[FIX] auth_signup: prevent traceback of 'no name or partner given for new user'

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -135,9 +135,9 @@ class ResUsers(models.Model):
             raise ValueError(_('Signup: invalid template user'))
 
         if not values.get('login'):
-            raise ValueError(_('Signup: no login given for new user'))
+            raise UserError(_('Signup: no login given for new user'))
         if not values.get('partner_id') and not values.get('name'):
-            raise ValueError(_('Signup: no name or partner given for new user'))
+            raise UserError(_('Signup: no name or partner given for new user'))
 
         # create a copy of the template user (attached to a specific partner_id if given)
         values['active'] = True


### PR DESCRIPTION
Currently,  when the user will do signup without giving a name.
'SignUp' Error of 'no name or partner given for new user'  is generated.

Steps To Produce:-

1) Install 'auth_signup' and 'sale' module
2) Do signup by using '127.0.0.1:8069/web/signup'
3) Now right-click on the input of 'Your Name' > click on inspect
4) remove required='required'
5) Without doing a refresh, fill in all the values ad click on signup.

Traceback will be generated.

So, instead of raising 'ValueError', we can raise 'UserError' so that user
can understand their mistake.

See Traceback:-

```
ValueError: Signup: no name or partner given for new user
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1838, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/auth_signup/controllers/main.py", line 44, in web_auth_signup
    self.do_signup(qcontext)
  File "addons/auth_signup/controllers/main.py", line 153, in do_signup
    self._signup_with_values(qcontext.get('token'), values)
  File "addons/auth_signup/controllers/main.py", line 157, in _signup_with_values
    login, password = request.env['res.users'].sudo().signup(values, token)
  File "addons/auth_signup/models/res_users.py", line 103, in signup
    self._signup_create_user(values)
  File "addons/auth_signup/models/res_users.py", line 119, in _signup_create_user
    return self._create_user_from_template(values)
  File "addons/auth_signup/models/res_users.py", line 140, in _create_user_from_template
    raise ValueError(_('Signup: no name or partner given for new user'))
```

For 'Portal User Template', you can check this PR:- https://github.com/odoo/odoo/pull/122228

Applying this commit will resolve this issue.

sentry-4193426091

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
