### PR TITLE
[FIX] project: preventing typeError when Changing Multiple task states

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2076,7 +2076,7 @@ class Task(models.Model):
                         task_ids_per_stage[task.stage_id].append(task.id)
                     for stage, task_ids in task_ids_per_stage.items():
                         tasks = self.browse(task_ids)
-                        tasks._track_set_log_message(_lt("Current Stage: %s", stage.name))
+                        tasks._track_set_log_message(_("Current Stage: %s", stage.name))
                 else:
                     self._track_set_log_message(_("Current Stage: %s", self.stage_id.name))
 


### PR DESCRIPTION
TypeError: expected string or bytes-like object
This error occurs when we try to change multiple task states. steps to reproduce:
1. install the 'project' and navigate to the 'project.task'
2. go to the list view and select multiple tasks.
3. attempt to change the state of the selected tasks. at this point, this error occurs.

see stack trace:
```
TypeError: expected string or bytes-like object
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 136, in retrying
    env.cr.flush()  # submit the changes to the database
  File "odoo/sql_db.py", line 129, in flush
    self.precommit.run()
  File "odoo/tools/misc.py", line 1184, in run
    func()
  File "addons/mail/models/mail_thread.py", line 533, in _track_finalize
    tracking = records.with_context(context)._message_track(fnames, initial_values)
  File "addons/mail/models/mail_thread.py", line 613, in _message_track
    record.message_post(
  File "addons/rating/models/mail_thread.py", line 178, in message_post
    message = super(MailThread, self).message_post(**kwargs)
  File "addons/mail/models/mail_thread.py", line 2038, in message_post
    self._process_attachments_for_post(attachments, attachment_ids, msg_values)
  File "addons/mail/models/mail_thread.py", line 2116, in _process_attachments_for_post
    body = message_values['body'] if not is_html_empty(message_values['body']) else ''
  File "odoo/tools/mail.py", line 313, in is_html_empty
    return not bool(re.sub(tag_re, '', html_content).strip())
  File "re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
```

After applying this commit will fix this issue.

sentry-4209561538

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
