### PR TITLE
[FIX] website_slides: allow attendee creation from list

### DIFF
--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -24,6 +24,7 @@
             <field name="arch" type="xml">
                 <tree string="Attendees" editable="top">
                     <field name="channel_id" string="Course Name"/>
+                    <field name="partner_id"/>
                     <field name="channel_user_id"/>
                     <field name="partner_email" string="Email"/>
                     <field name="create_date" string="Enrolled On"/>


### PR DESCRIPTION
before this commit, if user tries to create a new
attendee to the course from the attendee list
view, an exception will be shown to the end
user.

traceback: Model: Channel / Partners (Members) (slide.channel.partner), Field: Partner (partner_id)

traceback was shown because of a missing required
field in the view.

after this commit, attendee can be added to the
course without any exception.

issue:  https://github.com/odoo/odoo/issues/92939




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
