### PR TITLE
[FIX] hr_timesheet: add timesheets with "Group By"

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -22,7 +22,7 @@
             <field name="name">account.analytic.line.tree.hr_timesheet</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <tree editable="bottom" string="Timesheet Activities" sample="1">
+                <tree string="Timesheet Activities" sample="1">
                     <field name="date"/>
                     <field name="employee_id" invisible="1"/>
                     <field name="project_id" required="1" options="{'no_create_edit': True, 'no_open': 1}"/>


### PR DESCRIPTION
Issue:
In the timesheets list view, the "New" button
to create a new record does not appear.

Cause:
We assign the editable attribute to `bottom`.
This behaviour is incompatible with `Group By`.

opw-3304692