### PR TITLE
[IMP] hr: refine simple user form view

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -198,7 +198,7 @@
                                 <group>
                                     <group string='Status' name="active_group">
                                         <field name="employee_type"/>
-                                        <field name="user_id" string="Related User" domain="[('share', '=', False)]" context="{'allow_create_employee': False, 'default_create_employee': False}" widget="many2one_avatar_user"/>
+                                        <field name="user_id" string="Related User" domain="[('share', '=', False)]" context="{'default_create_employee_id': active_id}" widget="many2one_avatar_user"/>
                                     </group>
                                     <group string="Attendance/Point of Sale" name="identification_group">
                                         <field name="pin" string="PIN Code"/>
@@ -422,7 +422,7 @@
             <field name="groups_id" eval="[(4, ref('base.group_erp_manager'))]"/>
             <field name="state">code</field>
             <field name="code">
-                action = records.with_context(allow_create_employee=False).action_create_user()
+                action = records.action_create_user()
             </field>
         </record>
 

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -205,9 +205,21 @@
             <field name="model">res.users</field>
             <field name="inherit_id" ref="base.view_users_simple_form"/>
             <field name="arch" type="xml">
+                <xpath expr="//sheet" position="inside">
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_open_employees"
+                            class="oe_stat_button"
+                            icon="fa-users"
+                            invisible="employee_count == 0"
+                            context="{'active_test': False}"
+                            type="object">
+                            <field name="employee_count" widget="statinfo" string="Employee"/>
+                        </button>
+                    </div>
+                </xpath>
                 <xpath expr="//field[@name='mobile']" position="after">
                     <field name="create_employee_id" force_save="1" invisible="1"/>
-                    <field name="create_employee" force_save="1" string="Create Employee" invisible="not context.get('allow_create_employee', True) or create_employee_id &gt; 0" groups="hr.group_hr_user"/>
+                    <field name="create_employee" force_save="1" string="Create Employee" invisible="create_employee_id &gt; 0 or id &gt; 0" groups="hr.group_hr_user"/>
                 </xpath>
             </field>
         </record>

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -53,7 +53,7 @@
                     <notebook>
                         <page string="Members" name="members_users">
                             <field name="member_ids" mode="kanban"
-                                class="w-100" context="{'allow_create_employee': False}">
+                                class="w-100">
                                 <kanban>
                                     <field name="id"/>
                                     <field name="name"/>


### PR DESCRIPTION
When we go to the simple user view, no need to show "Create Employee" option unless we are inviting a new user. Also, to standardize the behavior, we remove the context that conditionally used to hide the option.

Moreover, we add smartbutton leading to the related employees' view to the simple user form view.

task - 3334739





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
