### PR TITLE
[15.0][IMP] purchase: Add context option fill_qty_to_invoice_zero_line

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -525,7 +525,7 @@ class PurchaseOrder(models.Model):
                 if line.display_type == 'line_section':
                     pending_section = line
                     continue
-                if not float_is_zero(line.qty_to_invoice, precision_digits=precision):
+                if not float_is_zero(line.qty_to_invoice, precision_digits=precision) or self.env.context.get('fill_qty_to_invoice_zero_line', False):
                     if pending_section:
                         line_vals = pending_section._prepare_account_move_line()
                         line_vals.update({'sequence': sequence})


### PR DESCRIPTION
When a supplier issues an invoice with the quantities delivered and a different one with the returns made, it is necessary that all the lines are reflected to zero in the first invoice so that the user can inform the quantity invoiced by the supplier in a simpler way and in the order the over-invoiced quantity is reflected to show that the supplier's credit note is pending, which will be created automatically when the order is invoiced.

Adding this simple context check offers infinite possibilities that would be very complex to realise given the implementation of the method (we would practically have to overwrite it).

The ultimate solution could be to add a wizard with options for the user to choose from, but this is not the goal of this PR.

@Tecnativa TT43449

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
