### PR TITLE
[IMP] website: Show "Edit in Website Builder" for terms and conditions

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -154,8 +154,15 @@
                                                     class="oe_account_terms mt-5 w-100"
                                                     placeholder="Insert your terms &amp; conditions here..."/>
                                         </div>
-                                        <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}">
+                                        <field name="module_website" invisible="1"/>
+                                        <div class="mt8" attrs="{'invisible': ['|', ('terms_type', '!=', 'html'), ('module_website', '==', True)]}">
                                             <button name="action_update_terms" icon="oi-arrow-right" type="object" string="Update Terms" class="btn-link"/>
+                                        </div>
+                                        <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html'), ('module_website', '==', False)]}">
+                                            <strong class="align-top">URL: </strong><field name="terms_url"/>
+                                            <div>
+                                                <button name='action_update_terms_website' icon="oi-arrow-right" type="object" string="Edit in Website Builder" class="btn-link"/>
+                                            </div>
                                         </div>
                                         <field name="preview_ready" invisible="1"/>
                                         <div class="mt4 ms-1" attrs="{'invisible': [('preview_ready', '=', False)]}">

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -29,7 +29,6 @@ class ResConfigSettings(models.TransientModel):
     cart_abandoned_delay = fields.Float(string="Send After", related='website_id.cart_abandoned_delay', readonly=False)
     send_abandoned_cart_email = fields.Boolean('Abandoned Email', related='website_id.send_abandoned_cart_email', readonly=False)
     add_to_cart_action = fields.Selection(related='website_id.add_to_cart_action', readonly=False)
-    terms_url = fields.Char(compute='_compute_terms_url', string="URL", help="A preview will be available at this URL.")
 
     module_delivery_mondialrelay = fields.Boolean("Mondial Relay Connector")
     group_product_pricelist = fields.Boolean(
@@ -55,11 +54,6 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         related='website_id.show_line_subtotals_tax_selection',
     )
-
-    @api.depends('website_id')
-    def _compute_terms_url(self):
-        for record in self:
-            record.terms_url = '%s/terms' % record.website_id.get_base_url()
 
     @api.model
     def get_values(self):
@@ -100,10 +94,6 @@ class ResConfigSettings(models.TransientModel):
                 record.website_id.auth_signup_uninvited = 'b2c'
             else:
                 record.website_id.auth_signup_uninvited = 'b2b'
-
-    def action_update_terms(self):
-        self.ensure_one()
-        return self.env["website"].get_client_action('/terms', True)
 
     def action_open_extra_info(self):
         self.ensure_one()

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="res_config_settings_view_form_web_terms" model="ir.ui.view">
-        <field name="name">res.config.settings.view.form.inherit.account.web.terms</field>
-        <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
-        <field name="arch" type="xml">
-            <button name="action_update_terms" position="replace">
-                <div class="mt8" attrs="{'invisible': [('terms_type', '!=', 'html')]}" groups="website.group_website_designer">
-                    <strong class="align-top">URL: </strong><field name="terms_url"/>
-                    <div>
-                        <button name='action_update_terms' icon="oi-arrow-right" type="object" string="Edit in Website Builder" class="btn-link"/>
-                    </div>
-                </div>
-            </button>
-        </field>
-    </record>
-
     <record id="res_config_settings_view_form_inherit_sale" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.sale</field>
         <field name="model">res.config.settings</field>


### PR DESCRIPTION
Prveiously the "Edit in Website Builder" button was not shown for terms and conditions if website is installed, it was shown only if the website_sale module was installed. This commit fixes that.

task-3342876



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
