### PR TITLE
[FIX] base_automation,lunch,mail: prevent modify architecture of email template

### DIFF
--- a/addons/base_automation/tests/test_mail_composer.py
+++ b/addons/base_automation/tests/test_mail_composer.py
@@ -10,8 +10,8 @@ class TestMailFullComposer(HttpCase):
     def test_full_composer_tour(self):
         self.env['mail.template'].create({
             'name': 'Test template',  # name hardcoded for test
-            'partner_to': '${object.id}',
-            'lang': '${object.lang}',
+            'partner_to': '{{ object.id }}',
+            'lang': '{{ object.lang }}',
             'auto_delete': True,
             'model_id': self.ref('base.model_res_partner'),
         })

--- a/addons/lunch/data/mail_template_data.xml
+++ b/addons/lunch/data/mail_template_data.xml
@@ -4,9 +4,9 @@
     <record id="lunch_order_mail_supplier" model="mail.template">
         <field name="name">Lunch: Supplier Order</field>
         <field name="model_id" ref="lunch.model_lunch_supplier"/>
-        <field name="email_from">{{ ctx['order']['email_from'] }}</field>
-        <field name="partner_to">{{ ctx['order']['supplier_id'] }}</field>
-        <field name="subject">Orders for {{ ctx['order']['company_name'] }}</field>
+        <field name="email_from">{{ ctx.get('order') and ctx['order']['email_from'] }}</field>
+        <field name="partner_to">{{ ctx.get('order') and  ctx['order']['supplier_id'] }}</field>
+        <field name="subject">Orders for {{ ctx.get('order') and  ctx['order']['company_name'] }}</field>
         <field name="lang">{{ ctx.get('default_lang') }}</field>
         <field name="description">Sent to vendor with the order of the day</field>
         <field name="body_html" type="html">
@@ -36,7 +36,7 @@
                     <td valign="top" style="font-size: 13px;">
     <div>
         <t t-set="lines" t-value="ctx.get('lines', [])"/>
-        <t t-set="order" t-value="ctx.get('order')"/>
+        <t t-set="order" t-value="ctx.get('order',{})"/>
         <t t-set="currency" t-value="user.env['res.currency'].browse(order.get('currency_id'))"/>
         <p>
         Dear <t t-out="order.get('supplier_name', '')">Laurie Poiret</t>,
@@ -86,7 +86,7 @@
                     <td></td>
                     <td></td>
                     <td style="width: 100%; font-size: 13px; border-top: 1px solid black;"><strong>Total</strong></td>
-                    <td style="width: 100%; font-size: 13px; border-top: 1px solid black;" align="right"><strong t-out="format_amount(order['amount_total'], currency) or ''">$ 10.00</strong></td>
+                    <td style="width: 100%; font-size: 13px; border-top: 1px solid black;" align="right"><strong t-out="order.get('amount_total') and format_amount(order['amount_total'], currency) or ''">$ 10.00</strong></td>
                 </tr>
             </tbody>
         </table>

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -9221,6 +9221,13 @@ msgid "The text-only beginning of the body used as email preview."
 msgstr ""
 
 #. module: mail
+#. odoo-python
+#: code:addons/mail/models/mail_template.py:0
+#, python-format
+msgid "There are issues in the Architecture of this template"
+msgstr ""
+
+#. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/components/message_list/message_list.xml:0
 #, python-format

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -153,7 +153,7 @@ class TestMailTemplate(MailCommon):
         with self.assertRaises(AccessError):
             employee_template.with_context(lang='fr_FR').subject = '{{ object.foo }}'
 
-        employee_template.with_context(lang='fr_FR').sudo().subject = '{{ object.foo }}'
+        employee_template.with_context(lang='fr_FR').sudo().subject = '{{ object.name }}'
 
     def test_server_archived_usage_protection(self):
         """ Test the protection against using archived server (servers used cannot be archived) """

--- a/addons/survey/tests/test_survey_invite.py
+++ b/addons/survey/tests/test_survey_invite.py
@@ -156,7 +156,7 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
         # Verifies whether changing the value of the "email_from" field reflects on the receiving end.
         action = self.survey.action_send_survey()
         action['context']['default_send_email'] = True
-        invite_form = Form(self.env[action['res_model']].with_context(action['context']))
+        invite_form = Form(self.env[action['res_model']].sudo().with_context(action['context']))
         invite_form.partner_ids.add(self.survey_user.partner_id)
         invite_form.template_id.write({'email_from':'{{ object.partner_id.email_formatted }}'})
         invite = invite_form.save()


### PR DESCRIPTION
This error occurs when the user tries to change the architecture in the Email
Template. The problem rises when a user tries to change the architecture in the
Email Template. let's take one example if the user attempts to change this kind
of data like {{ object.company_id.name }} to {{ object.comny_id.name }} this and
save that data. So, this faulty template will be saved, and when a user tries to
use this template for sending emails or generating reports it will raise
UserError.

Steps To Reproduce:-
Taking example of sale(sale_management) Module : -
- Open > Email Template> select Sale Email Template
- Change the Email Temaplte like {{ object.company_id.name }} to
{{ object.compay_id.name }} this> save it.
- Go to Sales > open order > click on Send by email
It will generate an Error.

Traceback -
```
UserError: Échec de rendu du modèle QWeb : <div style="margin: 0px; padding: 0px;">
  <p style="margin: 0px; padding: 0px; font-size: 12px;">
      Bonjour,
      <br><br>
      <t t-set="transaction" t-value="object.get_portal_last_transaction()">
      Votre commande <span style="font-weight:bold;" t-out="object.name or ''">S00049</span> d'un montant de <span style="font-weight:bold;" t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</span>
      <t t-if="object.state == 'sa...
File "<192>", line 126, in template_192
File "<192>", line 34, in template_192_content
File "odoo/addons/base/models/ir_qweb.py", line 2423, in _get_asset_nodes
  return self._generate_asset_nodes_cache(bundle, css, js, debug, async_load, defer_load, lazy_load, media)
File "<decorator-gen-67>", line 2, in _generate_asset_nodes_cache
File "odoo/tools/cache.py", line 96, in lookup
  value = d[key] = self.method(*args, **kwargs)
File "odoo/addons/base/models/ir_qweb.py", line 2478, in _generate_asset_nodes_cache
  return self._generate_asset_nodes(bundle, css, js, debug, async_load, defer_load, lazy_load, media)
File "odoo/addons/base/models/ir_qweb.py", line 2552, in _generate_asset_nodes
  return remains + asset.to_node(css=css, js=js, debug=debug, async_load=async_load, defer_load=defer_load, lazy_load=lazy_load)
File "odoo/addons/base/models/assetsbundle.py", line 159, in to_node
  css_attachments = self.css(is_minified=not is_debug_assets) or []
File "odoo/addons/base/models/assetsbundle.py", line 620, in css
  self.save_attachment(extension, css)
File "odoo/addons/base/models/assetsbundle.py", line 381, in save_attachment
  self.env.cr.commit()
File "odoo/sql_db.py", line 428, in commit
  self.flush()
File "odoo/sql_db.py", line 128, in flush
  self.transaction.flush()
File "odoo/api.py", line 844, in flush
  env_to_flush.flush_all()
File "odoo/api.py", line 706, in flush_all
  self._recompute_all()
File "odoo/api.py", line 702, in _recompute_all
  self[field.model_name]._recompute_field(field)
File "odoo/models.py", line 6197, in _recompute_field
  field.recompute(records)
File "odoo/fields.py", line 1365, in recompute
  apply_except_missing(self.compute_value, recs)
File "odoo/fields.py", line 1338, in apply_except_missing
  func(records)
File "odoo/fields.py", line 1387, in compute_value
  records._compute_field_value(self)
File "odoo/models.py", line 4312, in _compute_field_value
  fields.determine(field.compute, self)
File "odoo/fields.py", line 99, in determine
  return needle(*args)
File "addons/mail/wizard/mail_compose_message.py", line 231, in _compute_body
  composer._set_value_from_template('body_html', 'body')
File "addons/mail/wizard/mail_compose_message.py", line 1347, in _set_value_from_template
  self[composer_fname] = self.template_id._generate_template(
File "addons/mail/models/mail_template.py", line 491, in _generate_template
  generated_field_values = template._render_field(
File "addons/mail/models/mail_render_mixin.py", line 641, in _render_field
  return dict(
File "addons/mail/models/mail_render_mixin.py", line 644, in <genexpr>
  for res_id, rendered in template._render_template(
File "addons/mail/models/mail_render_mixin.py", line 529, in _render_template
  rendered = self._render_template_qweb(template_src, model, res_ids,
File "addons/mail/models/mail_render_mixin.py", line 326, in _render_template_qweb
  raise UserError(
```

Fix:-
To fix this problem we added a constraint. When a user tries to save a
faulty email template we give a ValidationError.

enterprise :- https://github.com/odoo/enterprise/pull/41822

sentry-4209891760