### PR TITLE
[FIX] account_edi_ubl_cii: Remove sentry code

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -160,7 +160,6 @@ class AccountMoveSend(models.Model):
             try:
                 writer.convert_to_pdfa()
             except Exception as e:
-                e.sentry_ignored = True
                 _logger.exception("Error while converting to PDF/A: %s", e)
 
             # Extra metadata to be Factur-x PDF-A compliant.


### PR DESCRIPTION
We don't need to use `sentry_ignored` since this can be done in internal code.

sentry-4172828056