### PR TITLE
[FIX] l10n_in: error handling when no gstin found under gst treatment

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -85,12 +85,14 @@ class AccountMove(models.Model):
                 raise RedirectWarning(msg, action, _('Go to Company configuration'))
             move.l10n_in_gstin = move.partner_id.vat
             if not move.l10n_in_gstin and move.l10n_in_gst_treatment in ['regular', 'composition', 'special_economic_zone', 'deemed_export']:
-                raise ValidationError(_(
+                exc = ValidationError(_(
                     "Partner %(partner_name)s (%(partner_id)s) GSTIN is required under GST Treatment %(name)s",
                     partner_name=move.partner_id.name,
                     partner_id=move.partner_id.id,
                     name=gst_treatment_name_mapping.get(move.l10n_in_gst_treatment)
                 ))
+                exc.sentry_ignored = True
+                raise exc
         return posted
 
     def _l10n_in_get_warehouse_address(self):


### PR DESCRIPTION
When there is no `l10n_in_gstin` found in under `l10n_in_gst_treatment` the error message generates, which will be caught by the sentry.
So we stop catching this message in sentry.

See traceback:
```
ValidationError: Partner Siddharth singh (3) GSTIN is required under GST Treatment Registered Business - Regular
  File "odoo/addons/base/models/ir_cron.py", line 373, in _callback
    self.env['ir.actions.server'].browse(server_action_id).run()
  File "odoo/addons/base/models/ir_actions.py", line 694, in run
    res = runner(run_self, eval_context=eval_context)
  File "addons/website/models/ir_actions_server.py", line 61, in _run_action_code_multi
    res = super(ServerAction, self)._run_action_code_multi(eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 564, in _run_action_code_multi
    raise e.with_traceback(e.__traceback__) from None
  File "odoo/addons/base/models/ir_actions.py", line 559, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(398,)", line 1, in <module>
  File "addons/account/models/account_move.py", line 3826, in _autopost_draft_entries
    records._post()
  File "addons/sale/models/account_move.py", line 99, in _post
    posted = super()._post(soft)
  File "addons/l10n_in/models/account_invoice.py", line 88, in _post
    raise ValidationError(_(
 ```

By applying this commit will fix this issue.

sentry-4217496754

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
