### PR TITLE
[IMP] l10n_in: prevent creating Place of Supply record directly

### DIFF
--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -8,7 +8,9 @@
             <xpath expr="//field[@name='ref']" position="after">
                 <field name="country_code" invisible="1"/>
                 <field name="l10n_in_journal_type" invisible="1"/>
-                <field name="l10n_in_state_id" domain="[('country_id.code', '=', 'IN')]"
+                <field name="l10n_in_state_id"
+                    domain="[('country_id.code', '=', 'IN')]"
+                    options="{'no_create': True}"
                     attrs="{'invisible': ['|', ('country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('country_code', '=', 'IN'), ('move_type', '!=', 'entry'), ('l10n_in_journal_type', 'in', ('sale', 'purchase'))], 'readonly': [('state', '!=', 'draft')]}"/>
                 <field name="l10n_in_gst_treatment"
                     attrs="{'invisible': ['|', ('country_code', '!=', 'IN'), ('move_type', '=', 'entry')], 'required': [('country_code', '=', 'IN'), ('move_type', '!=', 'entry')], 'readonly': [('state', '!=', 'draft')]}"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Based on [this task](https://www.odoo.com/web#id=3339099&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form).
- Prevent user from creating new Place of Supply record directly in the invoice field to avoid duplicate records.

Current behavior before PR:

- User can create new Place of Supply record in the invoice's Many2one field directly

Desired behavior after PR is merged:

- User will not be able to create new Place of Supply record from the invoice field. The Place of Supply field will be similar to a Selection field where user can only choose from the existing records.
