### PR TITLE
[FIX] product_expiry: apply dates on inventory adjustment

### DIFF
--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -32,19 +32,19 @@ class StockProductionLot(models.Model):
     def _get_dates(self, product_id=None):
         """Returns dates based on number of days configured in current lot's product."""
         mapped_fields = {
-            'expiration_date': 'expiration_time',
             'use_date': 'use_time',
             'removal_date': 'removal_time',
             'alert_date': 'alert_time'
         }
-        res = dict.fromkeys(mapped_fields, False)
+        res = {}
         product = self.env['product.product'].browse(product_id) or self.product_id
-        if product:
+        if product.use_expiration_date:
+            expiration_date = datetime.datetime.now() + datetime.timedelta(days=product.expiration_time)
+            res['expiration_date'] = fields.Datetime.to_string(expiration_date)
             for field in mapped_fields:
                 duration = getattr(product, mapped_fields[field])
-                if duration:
-                    date = datetime.datetime.now() + datetime.timedelta(days=duration)
-                    res[field] = fields.Datetime.to_string(date)
+                date = expiration_date - datetime.timedelta(days=duration)
+                res[field] = fields.Datetime.to_string(date)
         return res
 
     # Assign dates according to products data

--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -54,8 +54,8 @@ class StockMoveLine(models.Model):
         if self.expiration_date:
             res.update({
                 'expiration_date': self.expiration_date,
-                'use_date': self.product_id.use_time and self.expiration_date - datetime.timedelta(days=(self.product_id.expiration_time - self.product_id.use_time)),
-                'removal_date': self.product_id.removal_time and self.expiration_date - datetime.timedelta(days=(self.product_id.expiration_time - self.product_id.removal_time)),
-                'alert_date': self.product_id.alert_time and self.expiration_date - datetime.timedelta(days=(self.product_id.expiration_time - self.product_id.alert_time))
+                'use_date': self.expiration_date - datetime.timedelta(days=self.product_id.use_time),
+                'removal_date': self.expiration_date - datetime.timedelta(days=self.product_id.removal_time),
+                'alert_date': self.expiration_date - datetime.timedelta(days=self.product_id.alert_time),
             })
         return res

--- a/addons/product_expiry/tests/test_stock_production_lot.py
+++ b/addons/product_expiry/tests/test_stock_production_lot.py
@@ -240,17 +240,18 @@ class TestStockProductionLot(TestStockCommon):
         lot_form.company_id = self.env.company
         apple_lot = lot_form.save()
         # ...then checks date fields have the expected values.
+        exp_date = apple_lot.expiration_date
         self.assertAlmostEqual(
             today_date + timedelta(days=self.apple_product.expiration_time),
-            apple_lot.expiration_date, delta=time_gap)
+            exp_date, delta=time_gap)
         self.assertAlmostEqual(
-            today_date + timedelta(days=self.apple_product.use_time),
+            exp_date - timedelta(days=self.apple_product.use_time),
             apple_lot.use_date, delta=time_gap)
         self.assertAlmostEqual(
-            today_date + timedelta(days=self.apple_product.removal_time),
+            exp_date - timedelta(days=self.apple_product.removal_time),
             apple_lot.removal_date, delta=time_gap)
         self.assertAlmostEqual(
-            today_date + timedelta(days=self.apple_product.alert_time),
+            exp_date - timedelta(days=self.apple_product.alert_time),
             apple_lot.alert_date, delta=time_gap)
 
         difference = timedelta(days=20)
@@ -310,11 +311,11 @@ class TestStockProductionLot(TestStockCommon):
         self.assertAlmostEqual(
             apple_lot.expiration_date, expiration_date, delta=time_gap)
         self.assertAlmostEqual(
-            apple_lot.use_date, expiration_date - timedelta(days=5), delta=time_gap)
+            apple_lot.use_date, expiration_date - timedelta(days=self.apple_product.use_time), delta=time_gap)
         self.assertAlmostEqual(
-            apple_lot.removal_date, expiration_date - timedelta(days=2), delta=time_gap)
+            apple_lot.removal_date, expiration_date - timedelta(days=self.apple_product.removal_time), delta=time_gap)
         self.assertAlmostEqual(
-            apple_lot.alert_date, expiration_date - timedelta(days=6), delta=time_gap)
+            apple_lot.alert_date, expiration_date - timedelta(days=self.apple_product.alert_time), delta=time_gap)
 
     def test_04_2_expiration_date_on_receipt(self):
         """ Test we can set an expiration date on receipt even if all expiration
@@ -359,12 +360,12 @@ class TestStockProductionLot(TestStockCommon):
             apple_lot.expiration_date, expiration_date, delta=time_gap,
             msg="Must be define even if the product's `expiration_time` isn't set.")
         self.assertAlmostEqual(
-            apple_lot.use_date, expiration_date + timedelta(days=5), delta=time_gap)
+            apple_lot.use_date, expiration_date - timedelta(days=self.apple_product.use_time), delta=time_gap)
         self.assertAlmostEqual(
-            apple_lot.removal_date, expiration_date + timedelta(days=self.apple_product.removal_time), delta=time_gap,
+            apple_lot.removal_date, expiration_date - timedelta(days=self.apple_product.removal_time), delta=time_gap,
             msg="`removal_date` should always be calculated when an expiration date is defined")
         self.assertAlmostEqual(
-            apple_lot.alert_date, expiration_date + timedelta(days=4), delta=time_gap)
+            apple_lot.alert_date, expiration_date - timedelta(days=self.apple_product.alert_time), delta=time_gap)
 
     def test_05_confirmation_on_delivery(self):
         """ Test when user tries to delivery expired lot, he/she gets a
@@ -560,8 +561,30 @@ class TestStockProductionLot(TestStockCommon):
         self.assertAlmostEqual(
             lot.expiration_date, exp_date, delta=time_gap)
         self.assertAlmostEqual(
-            lot.use_date, today_date + timedelta(days=self.apple_product.use_time), delta=time_gap)
+            lot.use_date, exp_date - timedelta(days=self.apple_product.use_time), delta=time_gap)
         self.assertAlmostEqual(
-            lot.removal_date, today_date + timedelta(days=self.apple_product.removal_time), delta=time_gap)
+            lot.removal_date, exp_date - timedelta(days=self.apple_product.removal_time), delta=time_gap)
         self.assertAlmostEqual(
-            lot.alert_date, today_date + timedelta(days=self.apple_product.alert_time), delta=time_gap)
+            lot.alert_date, exp_date - timedelta(days=self.apple_product.alert_time), delta=time_gap)
+
+    def test_apply_same_date_on_expiry_fields(self):
+        expiration_time = 10
+        self.apple_product.write({
+            'expiration_time': expiration_time,
+            'use_time': 0,
+            'removal_time': 0,
+            'alert_time': 0,
+        })
+
+        lot = self.env['stock.production.lot'].create({
+            'product_id': self.apple_product.id,
+            'company_id': self.env.company.id,
+        })
+
+        delta = timedelta(seconds=10)
+        expiration_date = datetime.today() + timedelta(days=expiration_time)
+        err_msg = "The time on the product is set to 0, it means that the corresponding date should be the same as the expiration one"
+        self.assertAlmostEqual(lot.expiration_date, expiration_date, delta=delta)
+        self.assertAlmostEqual(lot.use_date, expiration_date, delta=delta, msg=err_msg)
+        self.assertAlmostEqual(lot.removal_date, expiration_date, delta=delta, msg=err_msg)
+        self.assertAlmostEqual(lot.alert_date, expiration_date, delta=delta, msg=err_msg)


### PR DESCRIPTION
Previous to this, alert date would be added to expiry date on lots.
Now, its substracts it as expected.
OPW-2990209

