### PR TITLE
[MERGE][IMP] web: improve properties selection options ordering

### DIFF
--- a/addons/web/static/src/views/fields/properties/property_definition_selection.js
+++ b/addons/web/static/src/views/fields/properties/property_definition_selection.js
@@ -12,18 +12,23 @@ export class PropertyDefinitionSelection extends Component {
         // when we create a new option, it's added in the state
         // when we have finished to edit it (blur / enter) we propagate
         // the new value in the props
-        this.state = useState({ newOption: null });
+        this.state = useState({
+            newOption: null,
+        });
 
         this.propertyDefinitionSelectionRef = useRef("propertyDefinitionSelection");
         this.addButtonRef = useRef("addButton");
 
         useEffect(() => {
             // automatically give the focus to the new option if it is empty
+            if (!this.state.newOption) {
+                return;
+            }
             const inputs = this.propertyDefinitionSelectionRef.el.querySelectorAll(
                 ".o_field_property_selection_option input"
             );
-            if (inputs && inputs.length && !inputs[inputs.length - 1].value) {
-                inputs[inputs.length - 1].focus();
+            if (inputs && inputs.length && !inputs[this.state.newOption.index].value) {
+                inputs[this.state.newOption.index].focus();
             }
         });
     }
@@ -51,7 +56,11 @@ export class PropertyDefinitionSelection extends Component {
      */
     get optionsVisible() {
         const options = this.options || [];
-        return this.state.newOption ? [...options, this.state.newOption] : options;
+        const newOption = this.state.newOption;
+        if (newOption) {
+            options.splice(newOption.index, 0, [newOption.name, ""]);
+        }
+        return options;
     }
 
     /* --------------------------------------------------------
@@ -61,8 +70,11 @@ export class PropertyDefinitionSelection extends Component {
     /**
      * Add a new empty selection option.
      */
-    onOptionCreate() {
-        this.state.newOption = [uuid(), ""];
+    onOptionCreate(index) {
+        this.state.newOption = {
+            index: index,
+            name: uuid(),
+        };
     }
 
     /**
@@ -93,7 +105,7 @@ export class PropertyDefinitionSelection extends Component {
         const nonEmptyOptions = options.filter((option) => option[1] && option[1].length);
         this.props.onOptionsChange(nonEmptyOptions);
 
-        if (this.state.newOption && this.state.newOption[1] && this.state.newOption[1].length) {
+        if (this.state.newOption) {
             // the new option has been propagated in the props
             this.state.newOption = null;
         }
@@ -117,7 +129,7 @@ export class PropertyDefinitionSelection extends Component {
             // if the value is empty, just ignore and cancel the event
             event.stopPropagation();
             event.preventDefault();
-        } else if (optionIndex >= this.options.length) {
+        } else if (optionIndex === this.state.newOption?.index) {
             // we remove the focus from the new empty option, remove it
             this.state.newOption = null;
         }
@@ -144,7 +156,7 @@ export class PropertyDefinitionSelection extends Component {
             }
 
             this.onOptionChange(event, optionIndex);
-            this.onOptionCreate();
+            this.onOptionCreate(optionIndex + 1);
         } else if (["ArrowUp", "ArrowDown"].includes(event.key)) {
             event.stopPropagation();
             event.preventDefault();

--- a/addons/web/static/src/views/fields/properties/property_definition_selection.scss
+++ b/addons/web/static/src/views/fields/properties/property_definition_selection.scss
@@ -3,3 +3,11 @@
         color: $o-main-favorite-color;
     }
 }
+
+.o_field_property_selection_drag {
+    @include o-grab-cursor;
+    color: #adb5bd;
+    &:hover {
+        color: $o-component-active-color;
+    }
+}

--- a/addons/web/static/src/views/fields/properties/property_definition_selection.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition_selection.xml
@@ -35,7 +35,7 @@
                 <button
                     t-if="!props.readonly"
                     class="btn btn-link btn-sm"
-                    t-on-click="onOptionCreate"
+                    t-on-click="() => this.onOptionCreate(this.options.length)"
                     t-ref="addButton">
                     <i class="fa fa-plus"/>
                     Add a Value

--- a/addons/web/static/src/views/fields/properties/property_definition_selection.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition_selection.xml
@@ -6,7 +6,10 @@
             <div class="w-100">
                 <div
                     t-foreach="optionsVisible" t-as="option" t-key="option[0]"
-                    class="o_field_property_selection_option d-flex flex-row align-items-center justify-content-between mb-2 rounded">
+                    class="o_field_property_selection_option d-flex flex-row align-items-center justify-content-between mb-2 rounded"
+                    t-att-option-name="option[0]">
+                    <i t-if="!props.readonly and props.canChangeDefinition"
+                        class="o_field_property_selection_drag oi oi-draggable ui-sortable-handle me-2 text-center"/>
                     <span t-if="props.readonly" t-out="option[1]"/>
                     <input
                         t-else=""

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -4,6 +4,7 @@ import {
     click,
     clickDiscard,
     clickSave,
+    dragAndDrop,
     editInput,
     editSelect,
     getFixture,
@@ -486,9 +487,16 @@ QUnit.module("Fields", (hooks) => {
         const type = popover.querySelector(".o_field_property_definition_type input");
         assert.strictEqual(type.value, "Selection");
 
+        const getOptions = () => {
+            return popover.querySelectorAll(".o_field_property_selection_option");
+        };
+        const getOptionsValues = () => {
+            return [...getOptions()].map((option) => option.querySelector("input").value);
+        };
+
         // Create a new selection option
         await click(target, ".o_field_property_selection .fa-plus");
-        let options = popover.querySelectorAll(".o_field_property_selection_option");
+        let options = getOptions();
         assert.strictEqual(options.length, 4, "Should have added the new option");
         assert.strictEqual(
             document.activeElement,
@@ -511,7 +519,7 @@ QUnit.module("Fields", (hooks) => {
         );
         await nextTick();
 
-        options = popover.querySelectorAll(".o_field_property_selection_option");
+        options = getOptions();
         assert.strictEqual(options.length, 5, "Should have added the new option on Enter");
         assert.strictEqual(
             document.activeElement,
@@ -530,12 +538,12 @@ QUnit.module("Fields", (hooks) => {
 
         await nextTick();
 
+        options = getOptions();
         assert.strictEqual(
             document.activeElement,
             options[3].querySelector("input"),
             "Should focus the previous option"
         );
-        options = popover.querySelectorAll(".o_field_property_selection_option");
         assert.strictEqual(
             options.length,
             4,
@@ -554,21 +562,18 @@ QUnit.module("Fields", (hooks) => {
         await nextTick();
 
         assert.strictEqual(document.activeElement, options[2].querySelector("input"));
-        options = popover.querySelectorAll(".o_field_property_selection_option");
-        assert.strictEqual(options.length, 4, "Should not remove any options");
+        assert.strictEqual(getOptions().length, 4, "Should not remove any options");
 
         // Remove the second option
         await click(target, ".o_field_property_selection_option:nth-child(2) .fa-trash-o");
-        options = popover.querySelectorAll(".o_field_property_selection_option");
-        assert.strictEqual(options.length, 3, "Should have removed the second option");
         assert.deepEqual(
-            [...options].map((option) => option.querySelector("input").value),
+            getOptionsValues(),
             ["A", "C", "New option"],
             "Should have removed the second option"
         );
 
         // focus should be in option C
-        assert.strictEqual(document.activeElement, options[1].querySelector("input"));
+        assert.strictEqual(document.activeElement, getOptions()[1].querySelector("input"));
         // test that pressing 'Enter' inserts a new option after the one currently focused (and not last).
         await triggerEvent(
             target,
@@ -581,13 +586,31 @@ QUnit.module("Fields", (hooks) => {
             ".o_field_property_selection_option:nth-child(3) input",
             "New option 2"
         );
-        options = popover.querySelectorAll(".o_field_property_selection_option");
-        assert.strictEqual(options.length, 4, "Should have added a new option");
         assert.deepEqual(
-            [...options].map((option) => option.querySelector("input").value),
+            getOptionsValues(),
             ["A", "C", "New option 2", "New option"],
             "Should have added a new option at the correct spot"
         );
+
+        await nextTick();
+        const getOptionDraggableElement = (index) => {
+            return target.querySelector(
+                `.o_field_property_selection_option:nth-child(${index + 1})` +
+                    " .o_field_property_selection_drag"
+            );
+        };
+
+        await dragAndDrop(getOptionDraggableElement(0), getOptionDraggableElement(2));
+        assert.deepEqual(getOptionsValues(), ["C", "New option 2", "A", "New option"]);
+
+        await dragAndDrop(getOptionDraggableElement(3), getOptionDraggableElement(0));
+        assert.deepEqual(getOptionsValues(), ["New option", "C", "New option 2", "A"]);
+
+        // create an empty option and move it
+        await click(target, ".o_field_property_selection > div > .btn-link");
+        assert.deepEqual(getOptionsValues(), ["New option", "C", "New option 2", "A", ""]);
+        await dragAndDrop(getOptionDraggableElement(4), getOptionDraggableElement(1));
+        assert.deepEqual(getOptionsValues(), ["New option", "", "C", "New option 2", "A"]);
     });
 
     /**

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -561,11 +561,32 @@ QUnit.module("Fields", (hooks) => {
         await click(target, ".o_field_property_selection_option:nth-child(2) .fa-trash-o");
         options = popover.querySelectorAll(".o_field_property_selection_option");
         assert.strictEqual(options.length, 3, "Should have removed the second option");
-        const optionValues = [...options].map((option) => option.querySelector("input").value);
         assert.deepEqual(
-            optionValues,
+            [...options].map((option) => option.querySelector("input").value),
             ["A", "C", "New option"],
             "Should have removed the second option"
+        );
+
+        // focus should be in option C
+        assert.strictEqual(document.activeElement, options[1].querySelector("input"));
+        // test that pressing 'Enter' inserts a new option after the one currently focused (and not last).
+        await triggerEvent(
+            target,
+            ".o_field_property_selection_option:nth-child(2) input",
+            "keydown",
+            { key: "Enter" }
+        );
+        await editInput(
+            target,
+            ".o_field_property_selection_option:nth-child(3) input",
+            "New option 2"
+        );
+        options = popover.querySelectorAll(".o_field_property_selection_option");
+        assert.strictEqual(options.length, 4, "Should have added a new option");
+        assert.deepEqual(
+            [...options].map((option) => option.querySelector("input").value),
+            ["A", "C", "New option 2", "New option"],
+            "Should have added a new option at the correct spot"
         );
     });
 


### PR DESCRIPTION
This merge commits contains 2 improvements aiming to simplify the ordering of
selection options for property fields:

- Correctly insert the new element at the right position when pressing enter
- Allow to drag & drop property values

See underlying commits for details.

Task-3338157