### PR TITLE
[FIX] web: fix `.bg-transparent` class

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -172,8 +172,8 @@ $-o-theme-text-colors: null;
 }
 
 .bg-transparent{
-    --bg-opacity: 0;
-    @extend %-bg-black;
+    @include o-print-color($o-black, background-color, bg-opacity-value);
+    --bg-opacity-value: 0;
 }
 
 // 2. Generate legacy opacity-variations classes for both white and black. We


### PR DESCRIPTION
== ISSUE ==

With the refactoring of the `utilities_custom.scss` file, we moved our custom `bg-*` classes to the `bootstrap_review_backend.scss` file.

In a previous commit, we reintroduced the class but also an issue if `.bg-transparent` is a parent of a `bg-*` class.
Since we set the CSS variable `--bg-opacity` to 0 on the `.bg-transparent` class, every `bg-*` used inside would get that `--bg-opacity`, making the background invisible.

== After this commit ==

We reintroduce the `.bg-transparent` class inside the `bootstrap_review_backend` file but with an other approach. We simply rename the `bg-opacity` variable to `--bg-opacity-value` and set it to 0, inside `.bg-transparent` only.

task-3326297
part of task-3326263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
