### PR TITLE
[FIX] tools: prevent attribute error when user delete report

### DIFF
--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -145,6 +145,7 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                             break
                         else:
                             comment = content
+                    assert spec_content
                     source = copy.deepcopy(spec_content)
                     # only keep the t-name of a template root node
                     t_name = node.get('t-name')


### PR DESCRIPTION
If applied, this commit will solve the AttributeError 'NoneType' object has
no attribute 'set', when user tries to delete the node of report.

Steps to reproduce the issue:

- Open Web Studio > Reports > Open any report
- Click on report > Options
- Click on ```<t-name>``` tag
- Click on 'Remove from View' button > Ok

See -
```AttributeError: 'NoneType' object has no attribute 'set'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/saas-16.2/web_studio/controllers/report.py", line 244, in edit_report_view
    self._set_studio_view(view, new_arch)
  File "home/odoo/src/enterprise/saas-16.2/web_studio/controllers/main.py", line 426, in _set_studio_view
    studio_view.arch_db = arch
  File "odoo/fields.py", line 1319, in __set__
    records.write({self.name: write_value})
  File "home/odoo/src/enterprise/saas-16.2/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 3847, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1352, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 447, in _check_xml
    combined_arch = view._get_combined_arch()
  File "odoo/addons/base/models/ir_ui_view.py", line 1013, in _get_combined_arch
    arch = root.with_prefetch(tree_views._prefetch_ids)._combine(hierarchy)
  File "odoo/addons/base/models/ir_ui_view.py", line 954, in _combine
    combined_arch = view.apply_inheritance_specs(combined_arch, arch)
  File "home/odoo/src/enterprise/saas-16.2/web_studio/models/ir_ui_view.py", line 595, in apply_inheritance_specs
    return self._apply_studio_specs(source, specs_tree)
  File "home/odoo/src/enterprise/saas-16.2/web_studio/models/ir_ui_view.py", line 578, in _apply_studio_specs
    source = super(View, self).apply_inheritance_specs(source, spec)
  File "odoo/addons/base/models/ir_ui_view.py", line 885, in apply_inheritance_specs
    source = apply_inheritance_specs(
  File "odoo/tools/template_inheritance.py", line 166, in apply_inheritance_specs
    source.set('t-name', t_name)
```

sentry-4049274369

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
