### PR TITLE
[IMP] web, website: provide field option to prevent dirty the model

### DIFF
--- a/addons/test_website/models/__init__.py
+++ b/addons/test_website/models/__init__.py
@@ -1,2 +1,3 @@
 from . import model
+from . import res_config_settings
 from . import website

--- a/addons/test_website/models/res_config_settings.py
+++ b/addons/test_website/models/res_config_settings.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    def action_website_test_setting(self):
+        return self.env['website'].get_client_action('/')

--- a/addons/test_website/static/tests/tours/website_settings.js
+++ b/addons/test_website/static/tests/tours/website_settings.js
@@ -1,0 +1,49 @@
+/** @odoo-module */
+
+import tour from "web_tour.tour";
+
+const websiteName = "Website Test 2";
+
+tour.register("website_settings_m2o_dirty", {
+    test: true,
+    url: "/web",
+},
+[
+    tour.stepUtils.showAppsMenuItem(),
+    {
+        content: "open settings",
+        trigger: ".o_app[data-menu-xmlid='base.menu_administration'",
+    }, {
+        content: "open website settings",
+        trigger: ".settings_tab .tab[data-key='website']",
+    }, {
+        content: "check that the 'Shared Customers Accounts' setting is checked",
+        trigger: "input#shared_user_account:checked",
+        run: function () {}, // it's a check
+    }, {
+        content: "open website switcher",
+        trigger: "input#website_id",
+    }, {
+        content: `select ${websiteName} in the website switcher`,
+        trigger: `li:has(.dropdown-item:contains('${websiteName}'))`,
+    }, {
+        content: `check that the settings of ${websiteName} are loaded (Shared Customers Accounts)`,
+        trigger: "input#shared_user_account:not(:checked)",
+        run: function () {}, // it's a check
+    }, {
+        content: "click on the fake website setting after checking the edited website",
+        trigger: "button[name='action_website_test_setting']",
+    }, {
+        content: "check that we are on '/'",
+        trigger: "iframe body div#wrap",
+        run: function () {
+            if (window.location.pathname !== "/") {
+                // If this fails, it's probably because the change of website
+                // in the settings dirty the record and so there is a dialog
+                // save/discard displayed. This test ensure that does not happen
+                // because it makes actions unreachable in multi website.
+                console.error("We should be on '/' the settings didn't work");
+            }
+        }
+    },
+]);

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -14,4 +14,5 @@ from . import test_performance
 from . import test_redirect
 from . import test_reset_views
 from . import test_session
+from . import test_settings
 from . import test_views_during_module_operation

--- a/addons/test_website/tests/test_settings.py
+++ b/addons/test_website/tests/test_settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+import odoo.tests
+
+@odoo.tests.tagged('-at_install', 'post_install')
+class TestWebsiteSettings(odoo.tests.HttpCase):
+    def test_01_multi_website_settings(self):
+        self.env['website'].create([
+            {'name': "Website Test 1", 'specific_user_account': False},
+            {'name': "Website Test 2", 'specific_user_account': True},
+        ])
+        self.start_tour("/web", 'website_settings_m2o_dirty', login="admin")

--- a/addons/test_website/views/templates.xml
+++ b/addons/test_website/views/templates.xml
@@ -18,4 +18,17 @@
             </t>
         </field>
     </record>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.test.website</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="website.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='plausbile_setting']" position="after">
+                <div class="col-12 col-lg-6 o_setting_box" id="website_test_setting">
+                    <button type="object" name="action_website_test_setting" string="Website test setting" class="btn-link" icon="fa-arrow-right"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -1589,7 +1589,16 @@ var BasicModel = AbstractModel.extend({
         options = options || {};
         record._changes = record._changes || {};
         if (!options.doNotSetDirty) {
-            record._isDirty = true;
+            // Check if the changes can dirty.
+            for (const fieldName of Object.keys(changes)) {
+                const fieldInfo = Object.values(record.fieldsInfo).find(el => el[fieldName]);
+                const fieldNameInfo = fieldInfo && fieldInfo[fieldName];
+                const fieldNameInfoOptions = fieldNameInfo && fieldNameInfo.options;
+                const changeCanDirty = !(fieldNameInfoOptions && fieldNameInfoOptions.no_dirty);
+                if (changeCanDirty) {
+                    record._isDirty = true;
+                }
+            }
         }
         var initialData = {};
         this._visitChildren(record, function (elem) {

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -26,7 +26,7 @@
                                 <div class="content-group">
                                     <div class="row flex-row flex-nowrap mt8 align-items-center">
                                         <label class="col ps-0 text-nowrap" string="Settings of Website" for="website_id"/>
-                                        <field name="website_id" class="w-50" options="{'no_open': True, 'no_create': True}" title="Settings on this page will apply to this website"/>
+                                        <field name="website_id" class="w-50" options="{'no_open': True, 'no_create': True, 'no_dirty': True}" title="Settings on this page will apply to this website"/>
                                         <button name="action_website_create_new" type="object" string="+ New Website" class="col-auto btn-link ms-2 text-nowrap" style="line-height: 0.5;"/>
                                     </div>
                                 </div>


### PR DESCRIPTION
In the website settings, one of the fields allows you to switch settings from one website to another. Unfortunately, as soon as the user did this the record was considered to have changed (dirty) and therefore required a save when it wasn't necessary. This commit adds an option in the XML fields declaration to notify that this field cannot change the record (it cannot make it dirty). Steps to reproduce the issue before this commit:
- Install website
- Have multiple websites
- Go to Settings > Website Settings
- Change the website

=> The user is notified that the record has changed and needs to be saved, which is not true.

task-3265100