### PR TITLE
[REM] base: empty default code in server action

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -426,19 +426,6 @@ class IrActionsServer(models.Model):
     _inherit = 'ir.actions.actions'
     _order = 'sequence,name'
 
-    DEFAULT_PYTHON_CODE = """# Available variables:
-#  - env: environment on which the action is triggered
-#  - model: model of the record on which the action is triggered; is a void recordset
-#  - record: record on which the action is triggered; may be void
-#  - records: recordset of all records on which the action is triggered in multi-mode; may be void
-#  - time, datetime, dateutil, timezone: useful Python libraries
-#  - float_compare: utility function to compare floats based on specific precision
-#  - log: log(message, level='info'): logging function to record debug information in ir.logging table
-#  - _logger: _logger.info(message): logger to emit messages in server logs
-#  - UserError: exception class for raising user-facing warning messages
-#  - Command: x2many commands namespace
-# To return an action, assign: action = {...}\n\n\n\n"""
-
     type = fields.Char(default='ir.actions.server')
     usage = fields.Selection([
         ('ir_actions_server', 'Server Action'),
@@ -468,7 +455,6 @@ class IrActionsServer(models.Model):
     model_name = fields.Char(related='model_id.model', string='Model Name', readonly=True, store=True)
     # Python code
     code = fields.Text(string='Python Code', groups='base.group_system',
-                       default=DEFAULT_PYTHON_CODE,
                        help="Write Python code that the action will execute. Some variables are "
                             "available for use; help about python expression is given in the help tab.")
     # Multi
@@ -556,7 +542,7 @@ class IrActionsServer(models.Model):
 
     def _run_action_code_multi(self, eval_context):
         try:
-            safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
+            safe_eval((self.code or "").strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
         except Exception as e:
             external_id = self.get_external_id().get(self.id)
             if not external_id or external_id.startswith('__export__'):

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -371,10 +371,8 @@
                                     </ul>
                                     <div attrs="{'invisible': [('state', '!=', 'code')]}">
                                         <p>Example of Python code</p>
-<code style='white-space: pre-wrap'>
-partner_name = record.name + '_code' \n
-env['res.partner'].create({'name': partner_name})
-</code>
+<code>partner_name = record.name + '_code'</code><br/>
+<code>env['res.partner'].create({'name': partner_name})</code>
                                     </div>
                                 </div>
                             </page>


### PR DESCRIPTION
Server actions allows user to make custom python code to execute. The code may use some variables. Information about those variables is already available at Help tab (at Server Actions form and Automated Actions form). No need to duplicated that information inside the code.

Particularly, this solves problem on sentry, when values of local variables are cut by sentry. So, instead of having custom code, sentry shows part of the default comments.

This commit also fixes issue with missed line break in the python code example at Help tab.

Example of a sentry issue: https://online.sentry.io/issues/4210083624

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
