### PR TITLE
[FIX] web_editor: mobile toolbar visibility over modals

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -411,7 +411,7 @@ $o-we-toolbar-color-clickable-active: $o-we-bg-darkest;
 
 
 body:not(.editor_has_snippets) {
-    .oe-toolbar {
+    > .oe-toolbar {
         // Bootstrap sets .modal z-index at 1050. Ensure toolbar is visible in
         // modals. Only apply this to the toolbar if it's not in a snippets menu.
         z-index: 1051;


### PR DESCRIPTION
When the editor is displayed in a modal, the floating toolbar needs a
higher z-index than the modal in order to be visible. This is due to the
fact that the toolbar is mounted on the 'body' element (therefore, behind
the modal in terms of z-index).

The mobile toolbar, on the other hand, is mounted as a sibling of the
editable's element, which means it is always visible when the html field
is in a modal, without the need for a z-index. In fact, the mobile
toolbar, being fixed (no auto-hide) and having a z-index higher than
modals, leads to the undersired effect of being visible over modals that
are displayed on top of the html field. And example can be seen in the
Project app, where the editor is inside the task's description tab and a
modal can be opened for the customer.

This commit fixes such undesired visibility of the mobile toolbar over
modals by not applying the z-index to the toolbar when it's not
necessary (when not a direct child of the 'body' element).

task-3346764