### PR TITLE
[IMP] mail: Data cleaning activities

### DIFF
--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -65,5 +65,18 @@
             <field name="code">model._send_notifications_cron()</field>
             <field name="state">code</field>
         </record>
+
+        <record id="ir_cron_activity_delete_of_archived_users" model="ir.cron">
+            <field name="name">Activity: Delete Activities Of Archived Users</field>
+            <field name="model_id" ref="mail.model_mail_activity"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_delete_activities_of_archived_users(batch_size=10000)</field>
+            <field name="active" eval="False"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -78,5 +78,18 @@
             <field name="numbercall">-1</field>
             <field name="doall" eval="False"/>
         </record>
+
+        <record id="ir_cron_activity_delete_old_overdue" model="ir.cron">
+            <field name="name">Activity: Delete Old Overdue Activities</field>
+            <field name="model_id" ref="mail.model_mail_activity"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_delete_overdue_activities(older_than_days=1095, time_window_days=3, batch_size=10000)</field>
+            <field name="active" eval="False"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/tests/test_mail_activity.py
+++ b/addons/mail/tests/test_mail_activity.py
@@ -1,6 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import tagged, HttpCase
+import random
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo.tests.common import tagged, HttpCase, TransactionCase
 
 
 @tagged("-at_install", "post_install")
@@ -18,3 +22,41 @@ class TestMailActivityChatter(HttpCase):
             "mail_activity_schedule_from_chatter",
             login="admin",
         )
+
+@tagged('-at_install', 'post_install')
+class TestMailActivity(TransactionCase):
+
+    def test_delete_activities_of_archived_users(self):
+        """
+        Validate the functionality of the cron `_cron_delete_activities_of_archived_users`
+        """
+
+        @contextmanager
+        def _mock_db_cursor():
+            with patch.object(type(self.env.cr), 'rollback', lambda x: None):
+                yield
+
+        users = self.env['res.users'].create([
+            {
+                'name': f"Clone Nr:{i}",
+                'login': f"clone_{i}@example.com",
+                'password': "S3cUr4DP@sSw0rD",
+            } for i in range(5)
+        ])
+        dummy_lead = self.env['crm.lead'].create({'name': 'dummy_lead'})
+        # for each user schedule 1 activity
+        for user in users:
+            dummy_lead.activity_schedule(user_id=user.id)
+        archived_users = self.env['res.users'].browse(
+            map(lambda x: x.id, random.sample(users, 2)))  # pick 2 users to archive
+        archived_users.action_archive()
+        active_users = users - archived_users
+        with _mock_db_cursor():
+            self.env['mail.activity']._cron_delete_activities_of_archived_users()
+        # activities of archived users should be deleted
+        activities = self.env['mail.activity'].search([('user_id', 'in', archived_users.ids)])
+        self.assertFalse(activities)
+        # activities of active users shouldn't be touched, each has exactly 1 activity present
+        for user in active_users:
+            activities = self.env['mail.activity'].search([('user_id', '=', user.id)])
+            self.assertEqual(len(activities), 1)


### PR DESCRIPTION
## Description
In the goal of freeing a bit of storage and minor search speeds ups, this PR adds a few handy crons to manage the housekeeping of activities, as those can be numerous and people tend to create and forget about them.

## Content
This PR is split into 2 commits, each representing a different type of cleaning routine

### Delete activities from archived users
Pretty self-explanatory, we don't have to keep any activities up of users that have been archived.

### Delete old overdue activities (older than 3 years by default):
If after 3 years the user hasn't done an activity he had scheduled, he never will. So we delete old overdue activities.

---
task-3337077

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
