### PR TITLE
[FIX] web: bring opacity control to the text-muted,body classes

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_backend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_backend.scss
@@ -208,6 +208,19 @@ $-o-grayscale-opacities: map-remove($o-opacities, 0, 100);
 // 3. Cleanup temporary map
 $-o-grayscale-opacities: null;
 
+// Bootstrap text-muted, text-body class
+// ============================================================================
+
+// 1. Allow the use of the --text-opacity CSS variable on the text-muted and
+// text-body.
+
+.text-muted {
+    @include o-print-color($o-main-text-color, color, text-opacity, 0.76);
+}
+
+.text-body {
+    @include o-print-color($o-main-text-color, color, text-opacity);
+}
 
 // Odoo custom text/bg colors classes generation
 // ============================================================================

--- a/addons/web/static/src/scss/functions.scss
+++ b/addons/web/static/src/scss/functions.scss
@@ -39,13 +39,15 @@
 /// way. It applies the desired color to a specified rule using CSS variables.
 /// ---------------------------------------------------------------------------
 /// @param {color} $-color
-///     Desidered color
+///     Desired color
 /// @param {string} $-rule
 ///     CSS property to be affected
 /// @param {string} $-css-opacity-var
-///     CSS varible defining the opacity
+///     CSS variable defining the opacity
+/// @param {number} $-opacity-value
+///     Optional change the default opacity
 /// ---------------------------------------------------------------------------
-@mixin o-print-color($-color, $-rule, $-css-opacity-var) {
-    --#{$-rule}: RGBA(#{to-rgb($-color)}, var(--#{$-css-opacity-var}, 1));
+@mixin o-print-color($-color, $-rule, $-css-opacity-var, $-opacity-value: 1) {
+    --#{$-rule}: RGBA(#{to-rgb($-color)}, var(--#{$-css-opacity-var}, #{$-opacity-value}));
     #{$-rule}: var(--#{$-rule}) !important;
 }

--- a/addons/web/static/src/scss/utilities_custom_backend.scss
+++ b/addons/web/static/src/scss/utilities_custom_backend.scss
@@ -10,12 +10,7 @@ $utilities: map-merge(
         "color": (
             property: color,
             class: text,
-            local-vars: (
-                "text-opacity": 1
-            ),
             values: (
-                "body": $body-color,
-                "muted": $text-muted,
                 "reset": inherit,
             ),
         ),
@@ -25,4 +20,3 @@ $utilities: map-merge(
         "background-color": null
     )
 );
-


### PR DESCRIPTION
The utilities overrides in utilites_custom_backend doesn't allow control
over the --text-opacity variable because $body-color and $text-muted are
not defined with their `--color` CSS variable from the o-print-color 
mixin.

Additionally The text-muted class in milk is using an opacity variation 
of the $o-main-text-color which requires to define --text-opacity 
appropriately.

This commit uses the o-print-color mixin to bring back this possibility
on the text-body and text-muted using the same logic we use for
text-white and text-black. 

task-3347508

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
