### PR TITLE
[FIX] website_forum: fix new post button popover

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -51,7 +51,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
 
         // Initialize forum's tooltips
         this.$('[data-toggle="tooltip"]').tooltip({delay: 0});
-        this.$('[data-toggle="popover"]').popover({offset: 8});
+        this.$('[data-toggle="popover"]').popover({offset: '8'});
 
         $('input.js_select2').select2({
             tags: true,


### PR DESCRIPTION
When a portal user asks a question (e.g. on the Help demo forum) and go back to the forum's home page while their post is to be validated before they can post again, they're hit with a traceback (because the offset argument type is incorrect).

Task-3347773
