### PR TITLE
[FIX] base,website_sale,gamification: prevent traceback when missing model name

### DIFF
--- a/addons/gamification/views/gamification_goal_definition_views.xml
+++ b/addons/gamification/views/gamification_goal_definition_views.xml
@@ -49,7 +49,7 @@
                             <field name="model_id" class="oe_inline"
                                 attrs="{'invisible':[('computation_mode','not in',('sum', 'count'))], 'required':[('computation_mode','in',('sum', 'count'))]}"/>
                             <field name="model_inherited_ids" invisible="1"/>
-                            <field name="field_id" class="oe_inline"
+                            <field name="field_id" class="oe_inline" options="{'no_quick_create': True}"
                                 attrs="{'invisible':[('computation_mode','!=','sum')], 'required':[('computation_mode','=','sum')]}"/>
                             <field name="field_date_id" class="oe_inline" attrs="{'invisible':[('computation_mode','not in',('sum', 'count'))]}"/>
                             <field name="domain" attrs="{'invisible':[('computation_mode','not in',('sum', 'count'))], 'required':[('computation_mode','in',('sum', 'count'))]}" class="oe_inline"/>

--- a/addons/website_sale/views/website_views.xml
+++ b/addons/website_sale/views/website_views.xml
@@ -11,7 +11,7 @@
                     <field name="shop_extra_field_ids" context="{'default_website_id': active_id}">
                         <tree editable="bottom">
                             <field name="sequence" widget="handle"/>
-                            <field name="field_id" required="1"/>
+                            <field name="field_id" required="1" options="{'no_quick_create': True}"/>
                         </tree>
                     </field>
                 </page>

--- a/odoo/addons/base/views/ir_default_views.xml
+++ b/odoo/addons/base/views/ir_default_views.xml
@@ -9,7 +9,7 @@
             <sheet>
                 <group>
                     <group name="field_value">
-                        <field name="field_id"/>
+                        <field name="field_id" options="{'no_quick_create': True}"/>
                         <field name="json_value"/>
                     </group>
                     <group name="user_company_details">

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -419,7 +419,7 @@
                 <form string="Fields" duplicate="false">
                     <sheet>
                         <group>
-                            <field name="field_id"/>
+                            <field name="field_id" options="{'no_quick_create': True}"/>
                             <field name="value" groups="base.group_no_one"/>
                             <field name="name"/>
                             <field name="sequence" groups="base.group_no_one"/>


### PR DESCRIPTION
When user tries to quick create a field where model is not specified, the error will occur.

Steps to reproduce:
1. Turn on developer mode.
2. Go to Settings > Technical > Fields Selection.
3. Create a new record and quick create a field.

Traceback will be generated.
See this traceback:
```
AssertionError: missing model name for {'field_description': 'image'}
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 1603, in name_create
    record = self.create({self._rec_name: name})
  File "<decorator-gen-32>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "odoo/addons/base/models/ir_model.py", line 890, in create
    assert vals.get('model'), f"missing model name for {vals}"
```

Applying this commit will fix this issue.

sentry-3956146718

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
