### PR TITLE
[IMP] stock: Get location from putaway on outgoing consumable moves

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1368,6 +1368,9 @@ class StockMove(models.Model):
                 package_id=package.id or False,
                 owner_id =reserved_quant.owner_id.id or False,
             )
+        if self.product_id.detailed_type == "consu" and self.location_id.usage == "internal":
+            putaway_loc = self.location_id._get_putaway_strategy(self.product_id)
+            vals["location_id"] = putaway_loc.id
         return vals
 
     def _update_reserved_quantity(self, need, available_quantity, location_id, lot_id=None, package_id=None, owner_id=None, strict=True):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -271,6 +271,83 @@ class StockMove(TransactionCase):
         # there should be no quant amymore in the stock location
         self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0.0)
         self.assertEqual(len(self.gather_relevant(self.product, self.stock_location)), 0.0)
+    
+    def test_in_out_consu_putaway(self):
+        """ Send a consumable product to a client. Check that a move line is created using
+            putaway location as source
+        """
+        self.product.type = 'consu'
+        shelf_location = self.env.ref("stock.stock_location_components")
+        putaway = self.env["stock.putaway.rule"].create(
+            {
+                "product_id": self.product.id,
+                "location_in_id": self.stock_location.id,
+                "location_out_id": shelf_location.id,
+            }
+        )
+        # creation
+        move_in = self.env['stock.move'].create({
+            'name': 'test_in_1',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_id': self.product.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 100.0,
+        })
+        self.assertEqual(move_in.state, 'draft')
+
+        # confirmation
+        move_in._action_confirm()
+        self.assertEqual(move_in.state, 'assigned')
+        self.assertEqual(len(move_in.move_line_ids), 1)
+        # fill the move line
+        move_line = move_in.move_line_ids[0]
+        self.assertEqual(move_line.location_id, self.supplier_location)
+        self.assertEqual(move_line.location_dest_id, shelf_location)
+        self.assertEqual(move_line.product_qty, 100.0)
+        self.assertEqual(move_line.qty_done, 0.0)
+        move_line.qty_done = 100.0
+
+        # validation
+        move_in._action_done()
+        self.assertEqual(move_in.state, 'done')
+        # no quants are created in the stock location since it's a consumable
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, shelf_location), 0.0)
+        self.assertEqual(len(self.gather_relevant(self.product, shelf_location)), 0.0)
+        
+        # creation
+        move_out = self.env['stock.move'].create({
+            'name': 'test_out_1',
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.customer_location.id,
+            'product_id': self.product.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 100.0,
+        })
+        self.assertEqual(move_out.state, 'draft')
+
+        # confirmation
+        move_out._action_confirm()
+        self.assertEqual(move_out.state, 'assigned')
+        self.assertEqual(len(move_out.move_line_ids), 1)
+        # fill the move line
+        move_line = move_out.move_line_ids[0]
+        self.assertEqual(move_line.location_id, shelf_location)
+        self.assertEqual(move_line.location_dest_id, self.customer_location)
+        self.assertEqual(move_line.product_qty, 100.0)
+        self.assertEqual(move_line.qty_done, 0.0)
+        move_line.qty_done = 100.0
+
+        # validation
+        move_out._action_done()
+        self.assertEqual(move_out.state, 'done')
+
+        # no quants are created in the customer location since it's a consumable
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.customer_location), 0.0)
+        self.assertEqual(len(self.gather_relevant(self.product, self.customer_location)), 0.0)
+        # there should be no quant amymore in the stock location
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product, self.stock_location), 0.0)
+        self.assertEqual(len(self.gather_relevant(self.product, self.stock_location)), 0.0)
 
     def test_mixed_tracking_reservation_1(self):
         """ Send products tracked by lot to a customer. In your stock, there are tracked and


### PR DESCRIPTION
By looking for a putaway location for the origin location of moves for consumable products, we ensure that the stock move line origin location of outgoing move will use the same location as the destination location of incoming moves.

Description of the issue/feature this PR addresses:

As it's allowed to use putaway rules for consumable products to change the destination location of incoming moves, therefore changing the destination location on stock move lines, this putaway location will never be used as the origin location of outgoing moves, because stock level is not managed on such products and there is nothing to reserve.

Current behavior before PR:

Outgoing move lines of consumable product always use the origin location of the stock move

Desired behavior after PR is merged:

Outgoing move lines of consumable product use the putaway location related to the origin location of the stock move


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
