### PR TITLE
[FIX] web: disable date picker autocomplete

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -134,6 +134,7 @@
             t-ref="input"
             t-on-change="_onInputChange"
             t-on-click="_onInputClick"
+            autocomplete="off"
         />
         <span t-if="props.warn_future and state.warning" class="fa fa-exclamation-triangle o_tz_warning o_datepicker_warning">
             <t>This date is on the future. Make sure it is what you expected.</t>


### PR DESCRIPTION
before this commit, in date field browser is
showing previously selected values as autocomplete suggestions, which makes hard for end user to
select date from the date picker

after this commit, browser autocomplete is
disabled from date picker


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
