### PR TITLE
[IMP] website_forum: show icon in validation queue filter

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -105,7 +105,7 @@
                                 <a class="nav-link spam_menu" id="country-tab" data-bs-toggle="tab" href="#spam_country" role="tab" aria-controls="spam_country" aria-selected="false"><i class="fa fa-flag"/> Country</a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link spam_menu" id="character-tab" data-bs-toggle="tab" href="#spam_character" role="tab" aria-controls="spam_character" aria-selected="false">圾 Text</a>
+                                <a class="nav-link spam_menu" id="character-tab" data-bs-toggle="tab" href="#spam_character" role="tab" aria-controls="spam_character" aria-selected="false"><i class="fa fa-font"/> Text</a>
                             </li>
                         </ul>
                         <button type="button" class="btn-close align-self-start" data-bs-dismiss="modal"></button>


### PR DESCRIPTION
before this commit, in the forum validation queue filter, along with the text filter instead of icon some hard coded value(圾) is shown as text.

* create a user with very minimum XP
* create a post from new user login
* from admin login, click validation queue in the forum
* click on filter in the validation queue

after this commit, the text will be replaced with fa-font icon, so that all filters will look similar.


Before:
![Screenshot from 2023-06-04 21-41-15](https://github.com/odoo/odoo/assets/27989791/9a544af7-9022-4c79-b133-d47bff8d1b19)

After:
![Screenshot from 2023-06-04 21-40-48](https://github.com/odoo/odoo/assets/27989791/8c5113a6-a5a8-42f8-9713-a52c8c081438)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
