### PR TITLE
[FIX] hr_holidays: colors issues

### DIFF
--- a/addons/hr_holidays/static/src/scss/accrual_plan_level.scss
+++ b/addons/hr_holidays/static/src/scss/accrual_plan_level.scss
@@ -1,17 +1,10 @@
 $o-hr-holidays-border-color: map-get($grays, '300');
 
 .o_hr_holidays_hierarchy {
-    margin-left: -$o-horizontal-padding;
-    margin-right: -$o-horizontal-padding;
-    @include media-breakpoint-up(lg, $o-extra-grid-breakpoints) {
-        margin-left: -$o-horizontal-padding*2;
-        margin-right: -$o-horizontal-padding*2;
-    }
-    margin-bottom:-24px;
-    padding: 10px 0px 24px 16px;
-    background-color: rgba(128, 128, 128, 0.15);
-    box-shadow: 0px 1px 1px rgba(17, 17, 17, 0.23);
-    overflow-x: auto;
+    margin-left:calc(var(--formView-sheet-padding-x) * -1);
+    margin-right: calc(var(--formView-sheet-padding-x) * -1);
+    margin-bottom: calc(var(--formView-sheet-padding-x) * -1);
+    padding: var(--formView-sheet-padding-x);
     .o_hr_holidays_title {
         padding: 0px 0px 0px  86px;
         font-size: 18px;
@@ -46,7 +39,7 @@ $o-hr-holidays-border-color: map-get($grays, '300');
                 @include o-position-absolute;
                 height: 100%;
                 margin-left: 8px;
-                border-left: 1px dashed darken($o-hr-holidays-border-color, 10%);
+                border-left: 1px dashed darken($o-view-background-color, 10%);
             }
 
             .o_hr_holidays_plan_level_level::before {
@@ -64,8 +57,6 @@ $o-hr-holidays-border-color: map-get($grays, '300');
                     width: 90px;
                     padding: 3px 0px;
                     border-radius: 3px;
-                    background-color: $o-gray-200;
-                    box-shadow: 0 1px 2px rgba(0,0,0,.1);
                 }
 
                 // Actual kanban card
@@ -74,19 +65,17 @@ $o-hr-holidays-border-color: map-get($grays, '300');
                     margin-left: 22px;
                     margin-right: 2px;
                     width: 500px;
-                    border-radius: 3px;
-                    background-color: $o-gray-200;
-                    box-shadow: 0 1px 2px rgba(0,0,0,.1);
 
                     // Triangle
                     &:before {
                         content: '';
-                        @include o-position-absolute($top: 12px, $left: -17px);
+                        @include o-position-absolute($top: 12px, $left: -18px);
                         margin-left: 10px;
                         width: 14px;
                         height: 14px;
-                        background-color: $o-gray-200;
-                        border-bottom: 1px solid $o-hr-holidays-border-color;
+                        background: $o-view-background-color;
+                        border-bottom: 1px solid $gray-300;
+                        border-left: 1px solid $gray-300;
                         transform: rotate(45deg);
                     }
 
@@ -98,13 +87,11 @@ $o-hr-holidays-border-color: map-get($grays, '300');
                         height: 12px;
                         border: 2px solid $o-brand-primary;
                         border-radius: 10px;
-                        background: $o-gray-200;
+                        background: $o-view-background-color;
                     }
 
                     .content {
                         position: relative;
-                        background-color: $o-gray-200;
-                        padding: 5px 7px;
                         font-size: 14px;
                     }
                 }

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -99,7 +99,7 @@
                     </group>
                     <span class="oe_grey" invisible="1">
                     </span>
-                    <div class="o_hr_holidays_hierarchy">
+                    <div class="o_hr_holidays_hierarchy rounded-bottom bg-100 overflow-auto">
                         <div class="o_hr_holidays_title">Rules</div>
                         <div class="o_hr_holidays_hierarchy_readonly" attrs="{'invisible': [('level_ids', '!=', [])]}">
                             <p>
@@ -132,7 +132,7 @@
                                 <templates>
                                     <div t-name="kanban-box" class="border-0 bg-transparent">
                                         <div class="o_hr_holidays_body oe_kanban_global_click">
-                                            <div class="o_hr_holidays_timeline text-center">
+                                            <div class="o_hr_holidays_timeline border bg-view bg-opacity-100 text-center">
                                                 Level <span class="o_hr_holidays_plan_level_level"/>
                                             </div>
                                             <t t-if="!read_only_mode">
@@ -146,7 +146,7 @@
                                         </div>
                                     </div>
                                     <t t-name="level_content">
-                                        <div class="o_hr_holidays_card">
+                                        <div class="o_hr_holidays_card px-3 py-2 border bg-view bg-opacity-100">
                                             <div class="content">
                                                 <div>
                                                     <t t-if="record.start_count.value > 0">


### PR DESCRIPTION
=== ISSUE 1 ===

If you navigate to Time Off > Configuration > Accrual Plans and select a plan, there is a grey background which extends outside its container.

This is due to old `calc` which are no more up to date with the new values.


=== ISSUE 2 ===

On the same page, there is a color contrast issue. The cards items are grey on a grey background, which makes them blend and not stand out.

Since these items are cards, they should look like kanban items.

=== AFTER ===

We fix the margin of the element  with the correct values and add a `rounded-bottom` to fix the bottom corner issue.

For the cards, we use a `.bg-view` background + `.bg-opacity-100` class to make it `opacity:1`. We also remove some shadows to make our cards look like kanban items.

task-3326315
part of task-3326263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
