### PR TITLE
[FIX] mail: handle fetch mail error using exception

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -222,7 +222,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         try:
                             imap_server.close()
                             imap_server.logout()
-                        except OSError:
+                        except Exception:
                             _logger.warning('Failed to properly finish imap connection: %s.', server.name, exc_info=True)
             elif connection_type == 'pop':
                 try:
@@ -255,7 +255,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                     if pop_server:
                         try:
                             pop_server.quit()
-                        except OSError:
+                        except Exception:
                             _logger.warning('Failed to properly finish pop connection: %s.', server.name, exc_info=True)
             server.write({'date': fields.Datetime.now()})
         return True


### PR DESCRIPTION
This error 'socket error: EOF occurred in violation of protocol (_ssl.c:2396) while evaluating model._fetch_mails()' is being caught in sentry and causes unnecessary noise. So instead of OSError it is handled using Exception.

patch fixing issue using OSError
https://github.com/odoo/odoo/commit/0c30529cc9256c0b2483c2fcbbc599b87c1f8577

Stack trace:
```
ValueError: <class 'imaplib.IMAP4.abort'>: "socket error: EOF occurred in violation of protocol (_ssl.c:2396)" while evaluating
'model._fetch_mails()'
  File "odoo/addons/base/models/ir_cron.py", line 373, in _callback
    self.env['ir.actions.server'].browse(server_action_id).run()
  File "odoo/addons/base/models/ir_actions.py", line 694, in run
    res = runner(run_self, eval_context=eval_context)
  File "addons/website/models/ir_actions_server.py", line 61, in _run_action_code_multi
    res = super(ServerAction, self)._run_action_code_multi(eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 564, in _run_action_code_multi
    raise e.with_traceback(e.__traceback__) from None
  File "odoo/addons/base/models/ir_actions.py", line 559, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```

Sentry-4199424952


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
