### PR TITLE
[IMP] project: adds the burnup chart option in the burndown chart view

### DIFF
--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -26,6 +26,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
         ('1_canceled', 'Cancelled'),
         ('02_changes_requested', 'Changes Requested'),
     ], string='State', readonly=True)
+    is_closed = fields.Selection([('closed', 'Closed tasks'), ('open', 'Open tasks')], string="Closing Stage", readonly=True)
     milestone_id = fields.Many2one('project.milestone', readonly=True)
     partner_id = fields.Many2one('res.partner', string='Customer', readonly=True)
     project_id = fields.Many2one('project.project', readonly=True)
@@ -97,7 +98,8 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                         project_id,
                         %(date_begin)s as date_begin,
                         %(date_end)s as date_end,
-                        stage_id
+                        stage_id,
+                        is_closed
                    FROM (
                             -- Gathers the stage_ids history per task_id. This query gets:
                             -- * All changes except the last one for those for which we have at least a mail
@@ -109,7 +111,8 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                                    project_id,
                                    %(date_begin)s as date_begin,
                                    %(date_end)s as date_end,
-                                   first_value(stage_id) OVER task_date_begin_window AS stage_id
+                                   first_value(stage_id) OVER task_date_begin_window AS stage_id,
+                                   is_closed
                               FROM (
                                      SELECT pt.id as task_id,
                                             pt.allocated_hours,
@@ -120,7 +123,13 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                                             END as date_end,
                                             CASE WHEN mtv.id IS NOT NULL THEN mtv.old_value_integer
                                                ELSE pt.stage_id
-                                            END as stage_id
+                                            END as stage_id,
+                                            CASE
+                                                WHEN mtv.id IS NOT NULL AND mtv.old_value_char IN ('1_done', '1_canceled') THEN 'closed'
+                                                WHEN mtv.id IS NOT NULL AND mtv.old_value_char NOT IN ('1_done', '1_canceled') THEN 'open'
+                                                WHEN mtv.id IS NULL AND pt.state IN ('1_done', '1_canceled') THEN 'closed'
+                                                ELSE 'open'
+                                            END as is_closed
                                        FROM project_task pt
                                                 LEFT JOIN (
                                                     mail_message mm
@@ -137,7 +146,8 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                                    project_id,
                                    %(date_begin)s,
                                    %(date_end)s,
-                                   stage_id
+                                   stage_id,
+                                   is_closed
                             WINDOW task_date_begin_window AS (PARTITION BY task_id, %(date_begin)s)
                           UNION ALL
                             -- Gathers the current stage_ids per task_id for those which values changed at least
@@ -148,9 +158,11 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                                    pt.project_id,
                                    last_stage_id_change_mail_message.date as date_begin,
                                    (now() at time zone 'utc')::date + INTERVAL '%(interval)s' as date_end,
-                                   pt.stage_id as old_value_integer
+                                   pt.stage_id as old_value_integer,
+                                   CASE WHEN pt.state IN ('1_done', '1_canceled') THEN 'closed'
+                                       ELSE 'open'
+                                   END as is_closed
                               FROM project_task pt
-                                   JOIN project_task_type ptt ON ptt.id = pt.stage_id
                                    JOIN LATERAL (
                                        SELECT mm.date
                                        FROM mail_message mm
@@ -168,12 +180,14 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
                         project_id,
                         %(date_begin)s,
                         %(date_end)s,
-                        stage_id
+                        stage_id,
+                        is_closed
               )
               SELECT (project_id*10^13 + stage_id*10^7 + to_char(date, 'YYMMDD')::integer)::bigint as id,
                      allocated_hours,
                      project_id,
                      stage_id,
+                     is_closed,
                      date,
                      __count
                 FROM all_stage_task_moves t
@@ -202,18 +216,17 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
 
         :param groupby: List of group by fields.
         """
-        stage_id_in_groupby = False
-        date_in_groupby = False
 
+        is_closed_or_stage_in_groupby = False
+        date_in_groupby = False
         for gb in groupby:
             if gb.startswith('date'):
                 date_in_groupby = True
-            else:
-                if gb == 'stage_id':
-                    stage_id_in_groupby = True
+            elif gb in ['stage_id', 'is_closed']:
+                is_closed_or_stage_in_groupby = True
 
-        if not date_in_groupby or not stage_id_in_groupby:
-            raise UserError(_('The view must be grouped by date and by stage_id'))
+        if not date_in_groupby or not is_closed_or_stage_in_groupby:
+            raise UserError(_('The view must be grouped by date and by Stage - Burndown chart or Is Closed - Burnup chart'))
 
     @api.model
     def _determine_domains(self, domain):

--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -9,6 +9,7 @@
                 <field name="tag_ids"/>
                 <field name="user_ids"/>
                 <field name="stage_id" />
+                <field name="is_closed"/>
                 <field name="project_id" />
                 <field name="milestone_id" groups="project.group_project_milestone"/>
                 <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
@@ -25,7 +26,8 @@
                 <filter string="Closed Tasks" name="closed_tasks" domain="[('state', 'in', ['1_done', '1_canceled'])]"/>
                 <group expand="0" string="Group By">
                     <filter string="Date" name="date" context="{'group_by': 'date'}" />
-                    <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}" invisible="1"/>
+                    <filter string="Stage (Burndown Chart)" name="stage" context="{'group_by': 'stage_id'}"/>
+                    <filter string="Is Closed (Burn-up Chart)" name="is_closed" context="{'group_by': 'is_closed'}"/>
                 </group>
             </search>
         </field>
@@ -38,6 +40,7 @@
             <graph string="Burndown Chart" type="line" sample="1" disable_linking="1" js_class="burndown_chart">
                 <field name="date" string="Date" interval="month"/>
                 <field name="stage_id"/>
+                <field name="is_closed"/>
             </graph>
         </field>
     </record>

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -30,16 +30,16 @@ registry.category("web_tour.tours").add('burndown_chart_tour', {
     trigger: '.o_searchview_autocomplete .o_menu_item:contains("Project")',
 }, {
     content: 'Remove the group by "Date: Month > Stage"',
-    trigger: '.o_searchview_facet:contains("Date: Month") .o_facet_remove',
+    trigger: '.o_searchview_facet:contains("Stage") .o_facet_remove',
 }, {
     content: 'A "The Burndown Chart must be grouped by Date and Stage" notification is shown when trying to remove the group by "Date: Month > Stage"',
-    trigger: '.o_notification_manager .o_notification:contains("The Burndown Chart must be grouped by Date and Stage") button.o_notification_close',
+    trigger: '.o_notification_manager .o_notification:contains("The report should be grouped either by ") button.o_notification_close',
 }, {
     content: 'Open the search panel menu',
     trigger: '.o_control_panel .o_searchview_dropdown_toggler',
 }, {
-    content: 'The Stage group menu item is invisible',
-    trigger: '.o_group_by_menu:not(:has(.o_menu_item:contains("Stage")))',
+    content: 'The Stage group menu item is visible',
+    trigger: '.o_group_by_menu .o_menu_item:contains("Stage")',
 }, {
     content: 'Open the Date group by sub menu',
     trigger: '.o_group_by_menu button.o_menu_item:contains("Date")',

--- a/addons/project/tests/test_burndown_chart.py
+++ b/addons/project/tests/test_burndown_chart.py
@@ -46,14 +46,14 @@ class TestBurndownChartCommon(TestProjectCommon):
         cls.project = cls.env['project.project'].create({
             'name': 'Burndown Chart Test',
             'privacy_visibility': 'employees',
-            'alias_name': 'project+burndown_chart',
+            'alias_name': 'project_burndown_chart',
             'type_ids': [Command.link(stage_id) for stage_id in cls.stages.ids],
         })
         cls.set_create_date('project_project', cls.project.id, create_date)
         cls.project.invalidate_model()
         cls.milestone = cls.env['project.milestone'].with_context({'mail_create_nolog': True}).create({
             'name': 'Test Milestone',
-            'project_id': cls.project_pigs.id,
+            'project_id': cls.project.id,
         })
         cls.task_a = cls.env['project.task'].create({
             'name': 'Task A',
@@ -86,19 +86,19 @@ class TestBurndownChartCommon(TestProjectCommon):
         cls.set_create_date('project_task', cls.task_e.id, create_date)
 
         # Create a new task to check if a task without changing its stage is taken into account
-        task_f = cls.env['project.task'].create({
+        cls.task_f = cls.env['project.task'].create({
             'name': 'Task F',
             'priority': 0,
             'project_id': cls.project.id,
             'milestone_id': cls.milestone.id,
             'stage_id': cls.todo_stage.id,
         })
-        cls.set_create_date('project_task', task_f.id, datetime(cls.current_year - 1, 12, 20))
+        cls.set_create_date('project_task', cls.task_f.id, datetime(cls.current_year - 1, 12, 20))
 
         cls.project_2 = cls.env['project.project'].create({
             'name': 'Burndown Chart Test 2 mySearchTag',
             'privacy_visibility': 'employees',
-            'alias_name': 'project+burndown_chart+2',
+            'alias_name': 'project_burndown_chart_2',
             'type_ids': [Command.link(stage_id) for stage_id in cls.stages.ids],
         })
         cls.set_create_date('project_project', cls.project_2.id, create_date)
@@ -116,6 +116,41 @@ class TestBurndownChartCommon(TestProjectCommon):
             'user_ids': [Command.link(cls.user_projectmanager.id)],
         })
         cls.set_create_date('project_task', cls.task_h.id, create_date)
+
+        cls.stage_1, cls.stage_2, cls.stage_3, cls.stage_4 = Stage.create([{
+            'sequence': 1,
+            'name': '1',
+        }, {
+            'sequence': 10,
+            'name': '2',
+        }, {
+            'sequence': 20,
+            'name': '3',
+        }, {
+            'sequence': 20,
+            'name': '4',
+        }])
+        cls.stages_bis = cls.stage_1 | cls.stage_2 | cls.stage_3 | cls.stage_4
+        cls.set_create_date('project_task_type', cls.stage_1.id, create_date)
+        cls.set_create_date('project_task_type', cls.stage_2.id, create_date)
+        cls.set_create_date('project_task_type', cls.stage_3.id, create_date)
+        cls.set_create_date('project_task_type', cls.stage_4.id, create_date)
+        cls.project_1 = cls.env['project.project'].create({
+            'name': 'Burndown Chart Test',
+            'privacy_visibility': 'employees',
+            'alias_name': 'project_burndown_chart_bis',
+            'type_ids': [Command.link(stage_id) for stage_id in cls.stages_bis.ids],
+        })
+        cls.set_create_date('project_project', cls.project_1.id, create_date)
+        cls.task_bis = cls.env['project.task'].create({
+            'name': 'Task',
+            'priority': 0,
+            'project_id': cls.project_1.id,
+            'stage_id': cls.stage_1.id,
+        })
+        cls.set_create_date('project_task', cls.task_bis.id, create_date)
+
+        cls.deleted_domain = AND([[('project_id', '!=', False)], [('project_id', '=', cls.project_1.id)]])
 
         # Precommit to have the records in db and allow to rollback at the end of test
         cls.env.cr.flush()
@@ -149,43 +184,62 @@ class TestBurndownChartCommon(TestProjectCommon):
             cls.env.cr.flush()
 
         with freeze_time('%s-08-01' % (cls.current_year - 1)):
-            cls.task_a.write({'stage_id': cls.done_stage.id})
+            cls.task_a.write({'stage_id': cls.done_stage.id, 'state': '1_done'})
             cls.env.cr.flush()
 
         with freeze_time('%s-09-10' % (cls.current_year - 1)):
-            cls.task_b.write({'stage_id': cls.done_stage.id})
+            cls.task_b.write({'stage_id': cls.done_stage.id, 'state': '1_done'})
             cls.env.cr.flush()
 
         with freeze_time('%s-10-05' % (cls.current_year - 1)):
-            cls.task_c.write({'stage_id': cls.done_stage.id})
+            cls.task_c.write({'stage_id': cls.done_stage.id, 'state': '1_done'})
+            cls.task_a.write({'state': '1_canceled'})
             cls.env.cr.flush()
 
         with freeze_time('%s-11-25' % (cls.current_year - 1)):
-            cls.task_d.write({'stage_id': cls.done_stage.id})
+            cls.task_d.write({'stage_id': cls.done_stage.id, 'state': '1_done'})
+            cls.task_b.write({'state': '1_canceled'})
             cls.env.cr.flush()
 
         with freeze_time('%s-12-12' % (cls.current_year - 1)):
-            cls.task_e.write({'stage_id': cls.done_stage.id})
+            cls.task_e.write({'stage_id': cls.done_stage.id, 'state': '1_done'})
             cls.env.cr.flush()
 
+        with freeze_time('%s-12-24' % (cls.current_year - 1)):
+            cls.task_f.write({'state': '1_canceled'})
+            cls.env.cr.flush()
+
+        with freeze_time('%s-02-10' % (cls.current_year - 1)):
+            cls.task_bis.write({'stage_id': cls.stage_2.id})
+            cls.env.cr.flush()
+
+        with freeze_time('%s-03-10' % (cls.current_year - 1)):
+            (cls.task_bis).write({'stage_id': cls.stage_3.id})
+            cls.env.cr.flush()
+
+        with freeze_time('%s-04-10' % (cls.current_year - 1)):
+            (cls.task_bis).write({'stage_id': cls.stage_4.id})
+            cls.env.cr.flush()
 
 class TestBurndownChart(TestBurndownChartCommon):
 
     def map_read_group_result(self, read_group_result):
-        return {(res['date:month'], res['stage_id'][0]): res['__count'] for res in read_group_result if res['stage_id'][1]}
+        return {(res['date:month'], res['stage_id'][0]): int(res['__count']) for res in read_group_result if res['stage_id'][1]}
+
+    def map_read_group_is_closed_result(self, read_group_result):
+        return {(res['date:month'], res['is_closed']): int(res['__count']) for res in read_group_result}
 
     def check_read_group_results(self, domain, expected_results_dict):
-        stages_dict = {stage.id: stage.name for stage in self.stages}
         read_group_result = self.env['project.task.burndown.chart.report'].read_group(
             domain, ['date', 'stage_id'], ['date:month', 'stage_id'], lazy=False)
         read_group_result_dict = self.map_read_group_result(read_group_result)
-        for (month, stage_id), __count in read_group_result_dict.items():
-            expected_count = expected_results_dict.get((month, stage_id), 100000)
-            self.assertEqual(
-                __count,
-                expected_count,
-                'In %s, the number of tasks should be equal to %s in %s stage.' % (month, expected_count, stages_dict.get(stage_id, 'Unknown'))
-            )
+        self.assertDictEqual(read_group_result_dict, expected_results_dict)
+
+    def check_read_group_is_closed_results(self, domain, expected_results_dict):
+        read_group_result = self.env['project.task.burndown.chart.report'].read_group(
+            domain, ['date', 'is_closed'], ['date:month', 'is_closed'], lazy=False)
+        read_group_result_dict = self.map_read_group_is_closed_result(read_group_result)
+        self.assertDictEqual(read_group_result_dict, expected_results_dict)
 
     def test_burndown_chart(self):
         burndown_chart_domain = [('project_id', '!=', False)]
@@ -194,111 +248,75 @@ class TestBurndownChart(TestBurndownChartCommon):
         # Check that we get the expected results for the complete data of `self.project`.
         project_expected_dict = {
             ('January %s' % (self.current_year - 1), self.todo_stage.id): 5,
-            ('January %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
-            ('January %s' % (self.current_year - 1), self.testing_stage.id): 0,
-            ('January %s' % (self.current_year - 1), self.done_stage.id): 0,
             ('February %s' % (self.current_year - 1), self.todo_stage.id): 2,
             ('February %s' % (self.current_year - 1), self.in_progress_stage.id): 3,
-            ('February %s' % (self.current_year - 1), self.testing_stage.id): 0,
-            ('February %s' % (self.current_year - 1), self.done_stage.id): 0,
-            ('March %s' % (self.current_year - 1), self.todo_stage.id): 0,
             ('March %s' % (self.current_year - 1), self.in_progress_stage.id): 5,
-            ('March %s' % (self.current_year - 1), self.testing_stage.id): 0,
-            ('March %s' % (self.current_year - 1), self.done_stage.id): 0,
-            ('April %s' % (self.current_year - 1), self.todo_stage.id): 0,
             ('April %s' % (self.current_year - 1), self.in_progress_stage.id): 3,
             ('April %s' % (self.current_year - 1), self.testing_stage.id): 2,
-            ('April %s' % (self.current_year - 1), self.done_stage.id): 0,
-            ('May %s' % (self.current_year - 1), self.todo_stage.id): 0,
             ('May %s' % (self.current_year - 1), self.in_progress_stage.id): 2,
             ('May %s' % (self.current_year - 1), self.testing_stage.id): 3,
-            ('May %s' % (self.current_year - 1), self.done_stage.id): 0,
-            ('June %s' % (self.current_year - 1), self.todo_stage.id): 0,
             ('June %s' % (self.current_year - 1), self.in_progress_stage.id): 1,
             ('June %s' % (self.current_year - 1), self.testing_stage.id): 4,
-            ('June %s' % (self.current_year - 1), self.done_stage.id): 0,
-            ('July %s' % (self.current_year - 1), self.todo_stage.id): 0,
-            ('July %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
             ('July %s' % (self.current_year - 1), self.testing_stage.id): 5,
-            ('July %s' % (self.current_year - 1), self.done_stage.id): 0,
-            ('August %s' % (self.current_year - 1), self.todo_stage.id): 0,
-            ('August %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
             ('August %s' % (self.current_year - 1), self.testing_stage.id): 4,
             ('August %s' % (self.current_year - 1), self.done_stage.id): 1,
-            ('September %s' % (self.current_year - 1), self.todo_stage.id): 0,
-            ('September %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
             ('September %s' % (self.current_year - 1), self.testing_stage.id): 3,
             ('September %s' % (self.current_year - 1), self.done_stage.id): 2,
-            ('October %s' % (self.current_year - 1), self.todo_stage.id): 0,
-            ('October %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
             ('October %s' % (self.current_year - 1), self.testing_stage.id): 2,
             ('October %s' % (self.current_year - 1), self.done_stage.id): 3,
-            ('November %s' % (self.current_year - 1), self.todo_stage.id): 0,
-            ('November %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
             ('November %s' % (self.current_year - 1), self.testing_stage.id): 1,
             ('November %s' % (self.current_year - 1), self.done_stage.id): 4,
-            ('December %s' % (self.current_year - 1), self.todo_stage.id): 0,
-            ('December %s' % (self.current_year - 1), self.in_progress_stage.id): 0,
-            ('December %s' % (self.current_year - 1), self.done_stage.id): 5,
             ('December %s' % (self.current_year - 1), self.todo_stage.id): 1,
-            ('January %s' % (self.current_year), self.todo_stage.id): 0,
-            ('January %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('January %s' % (self.current_year), self.done_stage.id): 5,
-            ('January %s' % (self.current_year), self.todo_stage.id): 1,
-            ('February %s' % (self.current_year), self.todo_stage.id): 0,
-            ('February %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('February %s' % (self.current_year), self.done_stage.id): 5,
-            ('February %s' % (self.current_year), self.todo_stage.id): 1,
-            ('March %s' % (self.current_year), self.todo_stage.id): 0,
-            ('March %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('March %s' % (self.current_year), self.done_stage.id): 5,
-            ('March %s' % (self.current_year), self.todo_stage.id): 1,
-            ('April %s' % (self.current_year), self.todo_stage.id): 0,
-            ('April %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('April %s' % (self.current_year), self.done_stage.id): 5,
-            ('April %s' % (self.current_year), self.todo_stage.id): 1,
-            ('May %s' % (self.current_year), self.todo_stage.id): 0,
-            ('May %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('May %s' % (self.current_year), self.done_stage.id): 5,
-            ('May %s' % (self.current_year), self.todo_stage.id): 1,
-            ('June %s' % (self.current_year), self.todo_stage.id): 0,
-            ('June %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('June %s' % (self.current_year), self.done_stage.id): 5,
-            ('June %s' % (self.current_year), self.todo_stage.id): 1,
-            ('July %s' % (self.current_year), self.todo_stage.id): 0,
-            ('July %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('July %s' % (self.current_year), self.done_stage.id): 5,
-            ('July %s' % (self.current_year), self.todo_stage.id): 1,
-            ('August %s' % (self.current_year), self.todo_stage.id): 0,
-            ('August %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('August %s' % (self.current_year), self.done_stage.id): 5,
-            ('August %s' % (self.current_year), self.todo_stage.id): 1,
-            ('September %s' % (self.current_year), self.todo_stage.id): 0,
-            ('September %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('September %s' % (self.current_year), self.done_stage.id): 5,
-            ('September %s' % (self.current_year), self.todo_stage.id): 1,
-            ('October %s' % (self.current_year), self.todo_stage.id): 0,
-            ('October %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('October %s' % (self.current_year), self.done_stage.id): 5,
-            ('October %s' % (self.current_year), self.todo_stage.id): 1,
-            ('November %s' % (self.current_year), self.todo_stage.id): 0,
-            ('November %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('November %s' % (self.current_year), self.done_stage.id): 5,
-            ('November %s' % (self.current_year), self.todo_stage.id): 1,
-            ('December %s' % (self.current_year), self.todo_stage.id): 0,
-            ('December %s' % (self.current_year), self.in_progress_stage.id): 0,
-            ('December %s' % (self.current_year), self.done_stage.id): 5,
-            ('December %s' % (self.current_year), self.todo_stage.id): 1,
+            ('December %s' % (self.current_year - 1), self.done_stage.id): 5,
         }
+        project_expected_is_closed_dict = {
+            ('January %s' % (self.current_year - 1), 'open'): 5,
+            ('February %s' % (self.current_year - 1), 'open'): 5,
+            ('March %s' % (self.current_year - 1), 'open'): 5,
+            ('April %s' % (self.current_year - 1), 'open'): 5,
+            ('May %s' % (self.current_year - 1), 'open'): 5,
+            ('June %s' % (self.current_year - 1), 'open'): 5,
+            ('July %s' % (self.current_year - 1), 'open'): 5,
+            ('August %s' % (self.current_year - 1), 'open'): 4,
+            ('August %s' % (self.current_year - 1), 'closed'): 1,
+            ('September %s' % (self.current_year - 1), 'open'): 3,
+            ('September %s' % (self.current_year - 1), 'closed'): 2,
+            ('October %s' % (self.current_year - 1), 'open'): 2,
+            ('October %s' % (self.current_year - 1), 'closed'): 3,
+            ('November %s' % (self.current_year - 1), 'open'): 1,
+            ('November %s' % (self.current_year - 1), 'closed'): 4,
+            ('December %s' % (self.current_year - 1), 'closed'): 6,
+        }
+        months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October',
+                  'November', 'December']
+        current_month = datetime.now().month
+        for i in range(current_month):
+            month_key = f"{months[i]} {self.current_year}"
+            project_expected_dict[(month_key, self.todo_stage.id)] = 1
+            project_expected_dict[(month_key, self.done_stage.id)] = 5
+            project_expected_is_closed_dict[(month_key, 'closed')] = 6
+
+        # Check that we get the expected results for the complete data of `self.project`.
         self.check_read_group_results(AND([burndown_chart_domain, project_domain]), project_expected_dict)
+        self.check_read_group_is_closed_results(AND([burndown_chart_domain, project_domain]), project_expected_is_closed_dict)
 
         # Check that we get the expected results for the complete data of `self.project` & `self.project_2` using an
         # `ilike` in the domain.
         all_projects_domain_with_ilike = OR([project_domain, [('project_id', 'ilike', 'mySearchTag')]])
         project_expected_dict = {key: val if key[1] != self.todo_stage.id else val + 2 for key, val in project_expected_dict.items()}
+        project_expected_is_closed_dict = {key: val if key[1] == 'closed' else val + 2 for key, val in project_expected_is_closed_dict.items()}
+        for i in range(2, 11):
+            month_key = f"{months[i]} {self.current_year - 1}"
+            project_expected_dict[(month_key, self.todo_stage.id)] = 2
+        project_expected_is_closed_dict[(f"{months[11]} {self.current_year - 1}", 'open')] = 2
+        for i in range(current_month):
+            project_expected_is_closed_dict[(f"{months[i]} {self.current_year}", 'open')] = 2
         self.check_read_group_results(AND([burndown_chart_domain, all_projects_domain_with_ilike]), project_expected_dict)
+        self.check_read_group_is_closed_results(AND([burndown_chart_domain, all_projects_domain_with_ilike]), project_expected_is_closed_dict)
 
-        date_from, date_to = ('%s-01-01' % (self.current_year - 1), '%s-02-01' % (self.current_year - 1))
+        date_from, date_to = ('%s-01-01' % (self.current_year - 1), '%s-03-01' % (self.current_year - 1))
+        date_from_is_closed, date_to_is_closed = ('%s-10-01' % (self.current_year - 1), '%s-12-01' % (self.current_year - 1))
+
         date_and_user_domain = [('date', '>=', date_from), ('date', '<', date_to), ('user_ids', 'ilike', 'ProjectUser')]
         complex_domain_expected_dict = {
             ('January %s' % (self.current_year - 1), self.todo_stage.id): 3,
@@ -308,6 +326,16 @@ class TestBurndownChart(TestBurndownChartCommon):
         complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain])
         self.check_read_group_results(complex_domain, complex_domain_expected_dict)
 
+        date_and_user_domain = [('date', '>=', date_from_is_closed), ('date', '<', date_to_is_closed), ('user_ids', 'ilike', 'ProjectUser')]
+        complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain])
+        complex_domain_expected_dict = {
+            ('October 2022', 'closed'): 2.0,
+            ('October 2022', 'open'): 1.0,
+            ('November 2022', 'closed'): 2.0,
+            ('November 2022', 'open'): 1.0
+        }
+        self.check_read_group_is_closed_results(complex_domain, complex_domain_expected_dict)
+
         date_and_user_domain = [('date', '>=', date_from), ('date', '<', date_to), ('user_ids', 'ilike', 'ProjectManager')]
         milestone_domain = [('milestone_id', 'ilike', 'Test')]
         complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain, milestone_domain])
@@ -316,6 +344,89 @@ class TestBurndownChart(TestBurndownChartCommon):
             ('February %s' % (self.current_year - 1), self.todo_stage.id): 1,
         }
         self.check_read_group_results(complex_domain, complex_domain_expected_dict)
+
+        date_and_user_domain = [('date', '>=', date_from_is_closed), ('date', '<', date_to_is_closed), ('user_ids', 'ilike', 'ProjectManager')]
+        milestone_domain = [('milestone_id', 'ilike', 'Test')]
+        complex_domain = AND([burndown_chart_domain, all_projects_domain_with_ilike, date_and_user_domain, milestone_domain])
+        complex_domain_expected_dict = {
+            ('October 2022', 'open'): 1.0,
+            ('November 2022', 'closed'): 1.0
+        }
+        self.check_read_group_is_closed_results(complex_domain, complex_domain_expected_dict)
+
+    def burndown_chart_stage_delete_stage_1(self):
+        """
+        Currently, this behavior is not working as expected. The key 'Jan year-1, stage_1.id' is not present as expected, but there's an extra unwanted key
+        'Jan year-1, stage_2.id' is present instead
+        """
+        with freeze_time('%s-08-10' % (self.current_year - 1)):
+            self.stage_1.unlink()
+            self.env.cr.flush()
+        expected_dict = self.get_expected_dict()
+        del expected_dict[('January %s' % (self.current_year - 1), self.stage_1.id)]
+        self.check_read_group_results(self.deleted_domain, expected_dict)
+
+    def burndown_chart_stage_delete_stage_2(self):
+        """
+        Currently, this behavior is not working as expected. The key 'Feb year-1, stage_2.id' is not present as expected, but there's an extra unwanted key
+        'Feb year-1, stage_3.id' is present instead
+        """
+        with freeze_time('%s-08-10' % (self.current_year - 1)):
+            self.stage_2.unlink()
+            self.env.cr.flush()
+        expected_dict = self.get_expected_dict()
+        del expected_dict[('February %s' % (self.current_year - 1), self.stage_2.id)]
+        self.check_read_group_results(self.deleted_domain, expected_dict)
+
+    def test_burndown_chart_stage_deleted_3(self):
+        with freeze_time('%s-08-10' % (self.current_year - 1)):
+            self.stage_3.unlink()
+            self.env.cr.flush()
+        expected_dict = self.get_expected_dict()
+        del expected_dict[('March %s' % (self.current_year - 1), self.stage_3.id)]
+        self.check_read_group_results(self.deleted_domain, expected_dict)
+
+    def burndown_chart_all_stage_deleted(self):
+        """
+        Currently, this behavior is not working as expected. An extra task is added for every month fetched by the query.
+        e.a. If the expected dict is :
+        {('April 2022', 390): 1, ('May 2022', 390): 1, ('June 2022', 390): 1, ('July 2022', 390): 1, ('August 2022', 390): 1, ('September 2022', 390): 1, etc : 1}
+        The fetched dict will be :
+        {('January 2022', 389): 1, ('February 2022', 389): 1, ('March 2022', 389): 1, ('April 2022', 390): 2, ('May 2022', 390): 2, ('June 2022', 390): 2, ('July 2022', 390): 2,
+        ('August 2022', 390): 2, ('September 2022', 390): 2, etc :2 }
+        """
+        with freeze_time('%s-08-10' % (self.current_year - 1)):
+            (self.stage_1 | self.stage_2 | self.stage_3).unlink()
+            self.env.cr.flush()
+        expected_dict = self.get_expected_dict()
+        del expected_dict[('January %s' % (self.current_year - 1), self.stage_1.id)]
+        del expected_dict[('February %s' % (self.current_year - 1), self.stage_2.id)]
+        del expected_dict[('March %s' % (self.current_year - 1), self.stage_3.id)]
+        self.check_read_group_results(self.deleted_domain, expected_dict)
+
+    def get_expected_dict(self):
+        expected_dict = {
+            ('January %s' % (self.current_year - 1), self.stage_1.id): 1,
+            ('February %s' % (self.current_year - 1), self.stage_2.id): 1,
+            ('March %s' % (self.current_year - 1), self.stage_3.id): 1,
+            ('April %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('May %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('June %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('July %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('August %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('September %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('October %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('November %s' % (self.current_year - 1), self.stage_4.id): 1,
+            ('December %s' % (self.current_year - 1), self.stage_4.id): 1,
+        }
+        months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October',
+                  'November', 'December']
+        current_month = datetime.now().month
+
+        for i in range(current_month):
+            month_key = f"{months[i]} {self.current_year}"
+            expected_dict[(month_key, self.stage_4.id)] = 1
+        return expected_dict
 
 
 @tagged('-at_install', 'post_install')


### PR DESCRIPTION
This commit's purpose is to add a group by is_closed to transform the burndown chart into a burn up chart (a burnup chart is a visual representation of your project’s progress that highlights the work completed and the total project work), thus providing insightful information to the user

task-3186701

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
