### PR TITLE
[FIX] hr_contract: show total amount with currency symbol

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -273,7 +273,8 @@
                     <field name="date_start" readonly="1"/>
                     <field name="date_end" readonly="1"/>
                     <field name="contract_type_id" optional="show"/>
-                    <field name="wage" widget="monetary" readonly="1" optional="hidden"/>
+                    <field name="currency_id" invisible="1"/>
+                    <field name="wage" widget="monetary" readonly="1" sum="Total wage" optional="hidden"/>
                     <field name="resource_calendar_id" optional="show"/>
                     <field name="structure_type_id" optional="hidden"/>
                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'close'" decoration-success="state == 'open'"/>


### PR DESCRIPTION
Before this commit, the contract template list view missing the currency symbol for monetary fields and showing `unknown` for the total amount. 
After this commit, it shows the total amount with a currency symbol.

task-3347262
PR:[123673](https://github.com/odoo/odoo/pull/123673)
