### PR TITLE
[FIX] auth_oauth: ignore exception of 'invalid_request' in sentry tra…

### DIFF
--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -46,7 +46,9 @@ class ResUsers(models.Model):
         oauth_provider = self.env['auth.oauth.provider'].browse(provider)
         validation = self._auth_oauth_rpc(oauth_provider.validation_endpoint, access_token)
         if validation.get("error"):
-            raise Exception(validation['error'])
+            e = Exception(validation['error'])
+            e.sentry_ignored = True
+            raise e
         if oauth_provider.data_endpoint:
             data = self._auth_oauth_rpc(oauth_provider.data_endpoint, access_token)
             validation.update(data)


### PR DESCRIPTION
Currently while doing 'sign-in', 'invalid_request' exception will raise which will be caught by sentry and causes unnecessary traffic.

Trackback :
```
Exception: invalid_request
  File "addons/auth_oauth/controllers/main.py", line 134, in signin
    db, login, key = env['res.users'].sudo().auth_oauth(provider, kw)
  File "home/odoo/src/custom/trial/saas_trial/models/res_users.py", line 332, in auth_oauth
    db, login, _ = super(ResUsers, self).auth_oauth(provider, params)
  File "addons/auth_oauth/models/res_users.py", line 124, in auth_oauth
    validation = self._auth_oauth_validate(provider, access_token)
  File "addons/auth_oauth/models/res_users.py", line 49, in _auth_oauth_validate
    raise Exception(validation['error'])
```

So, we stop catching this 'invalid_request' exception which are supposed to be generated by User's Mistakes.

sentry-4027786065

