### PR TITLE
[FIX] base: prevent operational error log on sentry

### DIFF
--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -135,7 +135,8 @@ def retrying(func, env):
                     env.cr.flush()  # submit the changes to the database
                 break
             except (IntegrityError, OperationalError) as exc:
-                if env.cr._closed:
+                if env.cr.closed:
+                    exc.sentry_ignored = True
                     raise
                 env.cr.rollback()
                 env.registry.reset_changes()


### PR DESCRIPTION
When the cursor connection is closed then, it's closed status must be checked by
'closed' property insted of '_closed' attribute which will give proper cursor
connection status (closed). 

As per the sentry  log (https://bit.ly/3NnNKYW) after 'Operational Error' 
when the code execution is in 'except' block of 'retrying' function, we can see that 
line  'env.cr.rollback()' is getting executed.  After 'Operational Error' we come to 
know that connection is cosed, so the if condition 'if env.cr._closed' must evaluate 
to True and then exception should be raised with the help of 'raise' 
keyword. And if the exception is raised then the code below it, in except 
should not be executed.  But, unfortunately for an unknown reason 
'_closed' attribute was not updated properly. Because of it, the if condition 
'if env.cr._closed' was evaluated to be false. As a consequnce, the exception
was not raised and 'env.cr.rollback()' got executed and then user faced 
'InterFace Error'.

The reason behind using the 'closed' property here
is that, for unknown reason it might be that '_closed' attribute is not updated
properly. But if we use 'closed' property instead, then it will return proper
status for cursor and the connection.

```
KeyError: ('res.users', <function Users._has_group at 0x7f748972b7f0>, 2, 'base.group_public')
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
OperationalError: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "addons/bus/websocket.py", line 777, in _serve_ir_websocket
    ir_websocket._update_bus_presence(**data)
  File "addons/mail/models/ir_websocket.py", line 39, in _update_bus_presence
    super()._update_bus_presence(inactivity_period, im_status_ids_by_model)
  File "addons/bus/models/ir_websocket.py", line 42, in _update_bus_presence
    if self.env.user and not self.env.user._is_public():
  File "odoo/addons/base/models/res_users.py", line 1037, in _is_public
    return self.has_group('base.group_public')
  File "odoo/addons/base/models/res_users.py", line 952, in has_group
    return self._has_group(group_ext_id)
  File "<decorator-gen-108>", line 2, in _has_group
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/res_users.py", line 967, in _has_group
    self._cr.execute("""SELECT 1 FROM res_groups_users_rel WHERE uid=%s AND gid IN
  File "odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
  File "__init__.py", line 39, in gevent_wait_callback
    state = conn.poll()
InterfaceError: connection already closed
  File "addons/bus/websocket.py", line 887, in _serve_forever
    req.serve_websocket_message(message)
  File "addons/bus/websocket.py", line 760, in serve_websocket_message
    service_model.retrying(
  File "odoo/service/model.py", line 141, in retrying
    env.cr.rollback()
  File "odoo/sql_db.py", line 442, in rollback
    result = self._cnx.rollback()
```

sentry-4207661000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
