### PR TITLE
[FIX] web: rename cancel button in RedirectWarning to discard

### DIFF
--- a/addons/web/static/src/js/services/crash_manager.js
+++ b/addons/web/static/src/js/services/crash_manager.js
@@ -362,7 +362,7 @@ var RedirectWarningHandler = Widget.extend(ExceptionHandler, {
                         });
                         self.destroy();
                 }, close: true},
-                {text: _t("Cancel"), click: function() { self.destroy(); }, close: true}
+                {text: _t("Discard"), click: function() { self.destroy(); }, close: true}
             ]
         }, {
             message: error.data.arguments[0],


### PR DESCRIPTION
"Cancel" button in the RedirectWarningHandler is renamed to "Discard"

task-3339621