### PR TITLE
[FIX] l10n_in: Remove unwanted Indian fields from non-Indian companies

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -295,6 +295,15 @@ class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
+    fiscal_country_codes = fields.Char(compute='_compute_fiscal_country_codes')
+
+    @api.depends('company_id')
+    @api.depends_context('allowed_company_ids')
+    def _compute_fiscal_country_codes(self):
+        for record in self:
+            allowed_companies = record.company_id or self.env.companies
+            record.fiscal_country_codes = ",".join(allowed_companies.mapped('account_fiscal_country_id.code'))
+
     @api.depends_context('company')
     def _credit_debit_get(self):
         tables, where_clause, where_params = self.env['account.move.line'].with_context(state='posted', company_id=self.env.company.id)._query_get()

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -10,7 +10,8 @@
                 <attribute name="attrs">{'required':[('l10n_in_gst_treatment', 'in', ['regular', 'composition', 'special_economic_zone', 'deemed_export'])], 'readonly': [('parent_id', '!=', False)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='vat']" position="before">
-                <field name="l10n_in_gst_treatment" attrs="{'readonly': [('parent_id', '!=', False)]}"/>
+                <field name="fiscal_country_codes" invisible="1"/>
+                <field name="l10n_in_gst_treatment" attrs="{'readonly': [('parent_id', '!=', False)], 'invisible': ['!', ('fiscal_country_codes', 'ilike', 'IN')]}"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -11,7 +11,7 @@
             </xpath>
             <xpath expr="//notebook/page[@name='other_info']" position="before">
                 <page string="eWayBill" name="l10n_in_edi_ewaybill_page"
-                    attrs="{'invisible':[('move_type', '=', 'entry'), ('country_code', '!=', 'IN')]}">
+                    attrs="{'invisible':['|', ('move_type', '=', 'entry'), ('country_code', '!=', 'IN')]}">
                     <field name="l10n_in_edi_ewaybill_direct_api" invisible="1"/>
                     <group name="ewaybill_group">
                         <group string="Transaction Details" name="Transaction_group" 


### PR DESCRIPTION
This commit removes the unwanted GST treatment field in res.partner and the E-waybill tab in account.move for non-Indian running companies. These fields are specific to Indian requirements and are not relevant for companies operating outside of India. By removing these fields, we ensure a cleaner and more focused user interface for our non-Indian users, improving their overall experience.

Task-id: 3208950



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
