### PR TITLE
[IMP] website_slides: add _rec_name for model

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -22,6 +22,7 @@ class ChannelUsersRelation(models.Model):
     _name = 'slide.channel.partner'
     _description = 'Channel / Partners (Members)'
     _table = 'slide_channel_partner'
+    _rec_name = 'partner_id'
 
     active = fields.Boolean(string='Active', default=True)
     channel_id = fields.Many2one('slide.channel', string='Course', index=True, required=True, ondelete='cascade')


### PR DESCRIPTION
before this commit, _rec_name was not added for
slide.channel.partner

* open any course in e-learning, click on invite button
* from the popup tick send email
* open email template from the bottom
* click on preview in the email template
* in the test record field value will be shown as slide.channel.partner,1

![WhatsApp Image 2023-06-05 at 10 05 17 PM](https://github.com/odoo/odoo/assets/99093808/05822d7d-9b26-42d0-895a-a56bde9048fd)


 
after this commit, _rec_name is added





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
