### PR TITLE
[FIX] partner_autocomplete: update log when sending partner to sync fails

### DIFF
--- a/addons/partner_autocomplete/models/res_partner_autocomplete_sync.py
+++ b/addons/partner_autocomplete/models/res_partner_autocomplete_sync.py
@@ -27,7 +27,7 @@ class ResPartnerAutocompleteSync(models.Model):
                 params['vat'] = partner.vat
                 result, error = partner._rpc_remote_api('update', params)
                 if error:
-                    _logger.error('Send Partner to sync failed: %s' % str(error))
+                    _logger.warning('Send Partner to sync failed: %s', str(error))
 
             to_sync_item.write({'synched': True})
 


### PR DESCRIPTION
In the start_sync method, the logger is updated to use the 'warning' level instead of the 'error' level. This change reflects a less severe logging level for cases where sending a partner to sync fails.

The changes have been made to reduce the noise level in the sentry.

sentry-3955309841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
