### PR TITLE
[IMP] i18n: Update translation terms for fr_FR

### DIFF
--- a/addons/web/i18n/fr.po
+++ b/addons/web/i18n/fr.po
@@ -5693,7 +5693,7 @@ msgstr "il y a une heure environ"
 #: code:addons/web/static/src/core/domain_selector/domain_selector.xml:0
 #, python-format
 msgid "all"
-msgstr "tous"
+msgstr "toutes"
 
 #. module: web
 #. odoo-javascript
@@ -5710,7 +5710,7 @@ msgstr "tous les enregistrements"
 #: code:addons/web/static/src/core/domain_selector/domain_selector.xml:0
 #, python-format
 msgid "any"
-msgstr "tous"
+msgstr "au moins un"
 
 #. module: web
 #. odoo-javascript


### PR DESCRIPTION

Before this commit, the translation appeared the same in the base automation action's domain.

After this commit, we corrected the translation for `ANY` and `ALL` in the base automation action's domain.

![image](https://github.com/odoo/odoo/assets/68278259/a460cf13-d018-47a7-a4e6-429b9baee893)

![image](https://github.com/odoo/odoo/assets/68278259/3b49ddbb-a659-4257-98de-f1f5180cbc2e)

Suitable translation copy from the:
https://github.com/odoo/odoo/blob/saas-15.2/addons/web/i18n/fr.po#L406
https://github.com/odoo/odoo/blob/16.0/addons/web/i18n/fr.po#L6191

TaskId: 3344859



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
