### PR TITLE
[FIX][15.0] website: language when configuring the website for the first time

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -274,8 +274,9 @@ class Website(Home):
         website_id = request.env['website'].get_current_website()
         if website_id.configurator_done:
             return request.redirect('/')
-        if request.env.lang != website_id.default_lang_id.code:
-            return request.redirect('/%s%s' % (website_id.default_lang_id.url_code, request.httprequest.path))
+        if request.env.lang != request.env.user.lang:
+            url_code = request.env['res.lang']._lang_get(request.env.user.lang).url_code
+            return request.redirect('/%s%s' % (url_code, request.httprequest.path))
         return request.render('website.website_configurator')
 
     @http.route(['/website/social/<string:social>'], type='http', auth="public", website=True, sitemap=False)


### PR DESCRIPTION
The language configuration of the website should reflect the perspective of the user setting up the website. It should be the language of the user instead of the default language.

Reproduction steps:

- Create a new database with the original language.
- Set up a different language.
- Install the Website module. => The website configuration interface appears, but it is not in the currently set user language. From the perspective of users, such as customers, they will not be able to understand and perceive it as an error.

With this commit, the language for the website configuration interface would be the language of the current user's settings instead of the default language of the website.

Current behavior before PR:

https://github.com/odoo/odoo/assets/41574005/4a4eb620-d4fe-40c1-8e31-ab6c149c4bfa

Desired behavior after PR is merged:

https://github.com/odoo/odoo/assets/41574005/f61bc244-b8d1-4c37-9556-614c4b9deb8b





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
