### PR TITLE
[FIX] account_edi: don't allow to change in sequence

### DIFF
--- a/addons/account_edi/__init__.py
+++ b/addons/account_edi/__init__.py
@@ -1,3 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 from . import models
+from . import wizard

--- a/addons/account_edi/i18n/account_edi.pot
+++ b/addons/account_edi/i18n/account_edi.pot
@@ -385,6 +385,13 @@ msgid ""
 msgstr ""
 
 #. module: account_edi
+#: code:addons/account_edi/wizard/account_resequence.py:0
+#, python-format
+msgid ""
+"The following documents have already been sent and cannot be resequenced: %s"
+msgstr ""
+
+#. module: account_edi
 #: model_terms:ir.ui.view,arch_db:account_edi.view_move_form_inherit
 msgid ""
 "The invoice will be processed asynchronously by the following E-invoicing "

--- a/addons/account_edi/wizard/__init__.py
+++ b/addons/account_edi/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import account_resequence

--- a/addons/account_edi/wizard/account_resequence.py
+++ b/addons/account_edi/wizard/account_resequence.py
@@ -1,0 +1,13 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+class ReSequenceWizard(models.TransientModel):
+    _inherit = 'account.resequence.wizard'
+
+    def resequence(self):
+        edi_sent_moves = self.move_ids.edi_document_ids.filtered(lambda d: d.edi_format_id._needs_web_services() and d.state == 'sent')
+        if edi_sent_moves:
+            raise UserError(_("The following documents have already been sent and cannot be resequenced: %s")
+                % ", ".join(set(edi_sent_moves.move_id.mapped('name')))
+            )
+        return super().resequence()


### PR DESCRIPTION
Before PR:
---
If the invoice has already been sent to the government, then it's allowed to change in sequence.

After PR:
---
The sequence can't be changed once the invoice is created and sent to the government.

task ID :- 3254322
