### PR TITLE
[FIX] mail:  check for 'reply_model' before creating 'dest_aliases'

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -959,7 +959,7 @@ class MailThread(models.AbstractModel):
                 is_a_reply = False
                 rcpt_tos_valid_localparts = [to for to in rcpt_tos_valid_localparts if to in other_model_aliases.mapped('alias_name')]
 
-        if is_a_reply:
+        if reply_model and is_a_reply:
             dest_aliases = self.env['mail.alias'].search([
                 ('alias_name', 'in', rcpt_tos_localparts),
                 ('alias_model_id.model', '=', reply_model)


### PR DESCRIPTION
When the message route is being prepared the
model is getting none as value . So because of this we are facing the issue :
'UndefinedFunction odoo.sql_db in execute'


```
KeyError: ('ir.model', <function IrModel._get_id at 0x7efd51b8e320>, False)
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
UndefinedFunction: operator does not exist: character varying = boolean
LINE 1: SELECT id FROM ir_model WHERE model=false
                                           ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.

  File "odoo/http.py", line 2118, in __call__
    response = request._serve_nodb()
  File "odoo/http.py", line 1667, in _serve_nodb
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1925, in dispatch
    result = endpoint(**self.request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/custom/default/saas_worker/controllers/main.py", line 2239, in smtp
    proxy.message_process(None, message)
  File "addons/mail/models/mail_thread.py", line 1242, in message_process
    routes = self.message_route(message, msg_dict, model, thread_id, custom_values)
  File "home/odoo/src/custom/trial/saas_trial/models/mail.py", line 159, in message_route
    return super(MailThread, self).message_route(message, message_dict, model=model, thread_id=thread_id,
  File "addons/mail/models/mail_thread.py", line 1046, in message_route
    reply_model_id = self.env['ir.model']._get_id(reply_model)
  File "<decorator-gen-29>", line 2, in _get_id
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 282, in _get_id
    self.env.cr.execute("SELECT id FROM ir_model WHERE model=%s", (name,))
  File "odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)

```

Applying this commit will resolve the issue.

sentry-3958887561

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
