### PR TITLE
[FIX] account: sequence gap warning query

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -104,7 +104,7 @@ class account_journal(models.Model):
               FROM account_move move
               JOIN res_company company ON company.id = move.company_id
              WHERE move.journal_id = ANY(%(journal_ids)s)
-               AND move.state = 'posted'
+               AND move.posted_before = true
                AND (company.fiscalyear_lock_date IS NULL OR move.date > company.fiscalyear_lock_date)
           GROUP BY move.journal_id, move.sequence_prefix
             HAVING COUNT(*) != MAX(move.sequence_number) - MIN(move.sequence_number) + 1


### PR DESCRIPTION
The issue:
in the accounting dashboard, there is a sequence gap warning, and that's because the query doesn't take into account the moves that have been posted once and then canceled

The fix:
including the canceled invoices or at least the invoices that have been posted once

opw-3316757