### PR TITLE
web_editor: adjust toolbar visibility outside modals

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -315,6 +315,7 @@ export class ListRenderer extends Component {
         const sortedThs = [...table.querySelectorAll("thead th:not(.o_list_button)")].sort(
             (a, b) => getWidth(b) - getWidth(a)
         );
+
         const allowedWidth = table.parentNode.getBoundingClientRect().width;
 
         let totalWidth = getTotalWidth();

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -398,9 +398,15 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
 
 body:not(.editor_has_snippets) {
     .oe-toolbar {
-        // Bootstrap sets .modal z-index at 1055. Ensure toolbar is visible in
-        // modals. Only apply this to the toolbar if it's not in a snippets menu.
         z-index: 1056;
+    }
+    .oe-toolbar.oe-floating {
+        z-index: 990;
+        .modal & {
+            // Bootstrap sets .modal z-index at 1055. Ensure toolbar is visible in
+            // modals. Only apply this to the toolbar if it's not in a snippets menu.
+            z-index: 1056;
+        }
     }
 }
 @media only screen and (max-width: 767px) {


### PR DESCRIPTION
Some overlayed elements such as the editor toolbar and the tablepicker have a z-index specifically chosen so that they are still visible inside bootstrap modals (with z-index: 1055). As a consequence, toolbars outside modals will also be overlayed on top of the modal when their visibility is not restricted in another way. This is the case, for example, on mobile devices.