### PR TITLE
[FIX] web_editor: ensure dynamic placeholder focus

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -365,6 +365,9 @@ export class HtmlField extends Component {
     }
     onDynamicPlaceholderValidate(chain, defaultValue) {
         if (chain) {
+            // Ensure the focus is in the editable document
+            // before inserting the <t> element.
+            this.wysiwyg.focus();
             let dynamicPlaceholder = "object." + chain.join('.');
             dynamicPlaceholder += defaultValue && defaultValue !== '' ? ` or '''${defaultValue}'''` : '';
             const t = document.createElement('T');


### PR DESCRIPTION
When inserting a dynamic placeholder in the editable document we need to ensure the said document currently hold the focus and have an active selection range.

This was previously handle by the `onDynamicPlaceholderClose()` method which used to be called before `onDynamicPlaceholderValidate()`.

This seems to have changed from 16.1 to 16.2.

In order to fix the problem and ensure the focus in any situation, we add a `wysiwyg.focus()` call at the beginning of the validate method.

task-3222474


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
