### PR TITLE
[FIX] l10n_fr_pos_cert: correctly show old price unit when price changes

### DIFF
--- a/addons/l10n_fr_pos_cert/__manifest__.py
+++ b/addons/l10n_fr_pos_cert/__manifest__.py
@@ -44,6 +44,9 @@ The module adds following features:
         'web.assets_qweb': [
             'l10n_fr_pos_cert/static/src/xml/**/*',
         ],
+        'web.assets_tests': [
+            'l10n_fr_pos_cert/static/src/tests/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/l10n_fr_pos_cert/static/src/tests/helpers/ProductScreenTourMethods.js
+++ b/addons/l10n_fr_pos_cert/static/src/tests/helpers/ProductScreenTourMethods.js
@@ -1,0 +1,22 @@
+odoo.define('l10n_pos_fr_cert.tour.ProductScreenTourMethods', function (require) {
+    'use strict';
+
+    const { createTourMethods } = require('point_of_sale.tour.utils');
+    const { Do, Check, Execute } = require('point_of_sale.tour.ProductScreenTourMethods');
+
+    class CheckExt extends Check {
+        OldUnitPriceIsShown(old) {
+            return [
+                {
+                    content: `check old unit price is shown`,
+                    trigger: `li.info:contains(' Old unit price: ')`,
+                },
+                {
+                    content: `check old unit price value`,
+                    trigger: `li.info:contains('${old}')`,
+                }
+            ];
+        }
+    }
+    return createTourMethods('ProductScreen', Do, CheckExt, Execute);
+});

--- a/addons/l10n_fr_pos_cert/static/src/tests/tours/l10n_fr_pos_cert.tours.js
+++ b/addons/l10n_fr_pos_cert/static/src/tests/tours/l10n_fr_pos_cert.tours.js
@@ -1,0 +1,18 @@
+odoo.define('l10n_fr_pos_cert.tour.ProductScreen', function (require) {
+    'use strict';
+
+    const { ProductScreen } = require('l10n_pos_fr_cert.tour.ProductScreenTourMethods');
+    const { getSteps, startSteps } = require('point_of_sale.tour.utils');
+    var Tour = require('web_tour.tour');
+
+    // signal to start generating steps
+    // when finished, steps can be taken from getSteps
+    startSteps();
+
+    ProductScreen.do.clickDisplayedProduct('Product A');
+    ProductScreen.do.clickPricelistButton();
+    ProductScreen.do.selectPriceList('special_pricelist');
+    ProductScreen.check.OldUnitPriceIsShown('10.00');
+
+    Tour.register('OldPriceProductTour', { test: true, url: '/pos/ui' }, getSteps());
+});

--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -11,7 +11,7 @@
 
     <t t-name="OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
         <xpath expr="//t[@t-foreach='receipt.orderlines']" position="inside">
-            <t t-if="receipt.l10n_fr_hash !== false and line.price_manually_set">
+            <t t-if="receipt.l10n_fr_hash !== false and line.price !== line.fixed_lst_price">
                 <div class="pos-receipt-right-padding">
                     Old unit price:
                     <span class="oldPrice">

--- a/addons/l10n_fr_pos_cert/static/src/xml/Orderline.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/Orderline.xml
@@ -3,7 +3,7 @@
 
     <t t-name="Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension" owl="1">
         <xpath expr="//ul[hasclass('info-list')]" position="inside">
-            <t t-if="env.pos.is_french_country() !== false and props.line.price_manually_set">
+            <t t-if="env.pos.is_french_country() !== false and props.line.price !== props.line.get_fixed_lst_price()">
                 <li class="info">
                     Old unit price:
                     <span style="font-weight: bold;">

--- a/addons/l10n_fr_pos_cert/tests/__init__.py
+++ b/addons/l10n_fr_pos_cert/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_frontend

--- a/addons/l10n_fr_pos_cert/tests/test_frontend.py
+++ b/addons/l10n_fr_pos_cert/tests/test_frontend.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+import odoo.tests
+
+@odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
+class TestFrenchPoS(TestPointOfSaleHttpCommon):
+    def test_old_price_display(self):
+
+        #change company country to France
+        self.env.user.company_id.country_id = self.env.ref('base.fr')
+        self.assertEqual(self.env.user.company_id.country_id, self.env.ref('base.fr'))
+        #create product A with price 10€ and a pricelist that set the price of this product to 5€
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'list_price': 10,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+        base_pricelist = self.env['product.pricelist'].create({
+            'name': 'base_pricelist',
+            'discount_policy': 'without_discount',
+        })
+        special_pricelist = self.env['product.pricelist'].create({
+            'name': 'special_pricelist',
+            'item_ids': [(0, 0, {
+                'applied_on': '0_product_variant',
+                'product_id': product_a.id,
+                'compute_price': 'fixed',
+                'fixed_price': 5,
+            })],
+        })
+        #add the price list to the pos config
+        self.main_pos_config.write({
+            'pricelist_id': base_pricelist.id,
+            'available_pricelist_ids': [(6, 0, [base_pricelist.id, special_pricelist.id])],
+        })
+        self.main_pos_config.open_session_cb()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "OldPriceProductTour",
+            login="accountman",
+        )


### PR DESCRIPTION
Current behavior:
When the price is modified manually via the numeric pad, or when the pricelist is changed, the old price unit should be shown. It is not the case for the pricelist changes.

Steps to reproduce:
- Create product A with price 10
- Create pricelist B with price 5 for product A
- Open the PoS
- Create a POS order with product A
- Change the pricelist to B
- The old unit price should be shown on the order line.

opw-3335526
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
