### PR TITLE
[FIX] tools: prevent traceback when view architecture has encoding declaration

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -21718,6 +21718,16 @@ msgid ""
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/translate.py:0
+#, python-format
+msgid ""
+"The provided input contains Unicode strings with encoding declarations, "
+"which are not supported. Please use bytes or XML fragments without any "
+"encoding declaration."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_res_currency_rate__rate
 msgid "The rate of the currency to the currency of rate 1"
 msgstr ""

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -27,6 +27,7 @@ from psycopg2.extras import Json
 
 import odoo
 from odoo.modules.module import get_resource_path
+from odoo.exceptions import ValidationError
 from . import config, pycompat
 from .misc import file_open, get_iso_codes, SKIPPED_ELEMENT_TYPES
 
@@ -316,6 +317,8 @@ def xml_translate(callback, value):
         result = translate_xml_node(root, callback, parse_xml, serialize_xml)
         # remove tags <div> and </div> from result
         return serialize_xml(result)[5:-6]
+    except ValueError:
+        raise ValidationError(_("The provided input contains Unicode strings with encoding declarations, which are not supported. Please use bytes or XML fragments without any encoding declaration."))
 
 def xml_term_converter(value):
     """ Convert the HTML fragment ``value`` to XML if necessary


### PR DESCRIPTION
When user add encoding declaration (for example: encoding=utf-8) in view architecture and try to save it the error occurs.

Steps to reproduce:
1. Turn on developer mode.
2. Go to Settings/ Technical/ User Interface/ Views.
3. Open a view and in architecture add `<?xml version=1.0 encoding="utf-8"?>`
4. Then save manually traceback will be generated.

See this traceback:
```
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
  File "odoo/http.py", line 2114, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1921, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/website/models/theme_models.py", line 376, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 111, in write
    super(View, view).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4041, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1396, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 345, in _inverse_arch
    view.write(data)
  File "addons/website/models/theme_models.py", line 376, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 111, in write
    super(View, view).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4009, in write
    field.write(self, value)
  File "odoo/fields.py", line 1800, in write
    cache_value = self.translate(lambda t: None, cache_value)
  File "odoo/tools/translate.py", line 310, in xml_translate
    root = parse_xml(value)
  File "odoo/tools/translate.py", line 288, in parse_xml
    return etree.fromstring(text)
  File "src/lxml/etree.pyx", line 3252, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1908, in lxml.etree._parseMemoryDocument
```

Applying this commit will fix this issue.

sentry-4167873852

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
