### PR TITLE
[IMP] sale: add customer reference in portal view

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -432,7 +432,12 @@
                             t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                     </div>
                 </div>
-
+                <div class="row" t-if="sale_order.client_order_ref">
+                    <div class="col-lg-6">
+                        <strong class="d-block mb-1">Your Reference:</strong>
+                        <t t-out="sale_order.client_order_ref"/>
+                    </div>
+                </div>
                 <t t-set="invoices" t-value="sale_order.invoice_ids.filtered(lambda i: i.state not in ['draft', 'cancel'])"/>
                 <div t-if="invoices" class="row">
                     <div class="col">


### PR DESCRIPTION
Purpose
=======
The customer reference is a string that can be added to a SO (in Other info page). It is well visible when downloading or printing a SO but not in the overview in the Portal. 

Specification
=============
Add the Customer Reference in Sales Order and Quotations if it has been filled.

Task-3355199