### PR TITLE
[IMP] base: allow to specify the model in the "default_xxx" context

### DIFF
--- a/odoo/addons/test_new_api/tests/test_onchange.py
+++ b/odoo/addons/test_new_api/tests/test_onchange.py
@@ -843,6 +843,14 @@ class TestComputeOnchange(common.TransactionCase):
         self.assertEqual(form.bar, "foor")
         self.assertEqual(form.baz, "baz")
 
+        form = common.Form(self.env['test_new_api.compute.onchange'].with_context(
+            default_test_new_api_compute_onchange__foo="foo",
+            default_foo="foo 2",  # model based default have priority
+            default_wrong_model__baz="baz",
+        ))
+        self.assertEqual(form.foo, "foo")
+        self.assertFalse(form.baz)
+
     def test_onchange_once(self):
         """ Modifies `foo` field which will trigger an onchange method and
         checks it was triggered only one time. """

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1434,7 +1434,14 @@ class BaseModel(metaclass=MetaModel):
 
         for name in fields_list:
             # 1. look up context
-            key = 'default_' + name
+            model_name = self._name.replace(".", "_")
+            key = f'default_{model_name}__{name}'
+            if key not in self._context:
+                key = f'default_{name}'
+            if key in self._context:
+                defaults[name] = self._context[key]
+                continue
+
             if key in self._context:
                 defaults[name] = self._context[key]
                 continue


### PR DESCRIPTION
Purpose
=======
The `default_` context key set the default value for a specific field, but currently, for all model having that field.

For example, if you navigate in Odoo and you have `default_parent_id` in the context to set the parent_id on `res.partner`, then you go to the knowledge and you create an article, because article also have a `parent_id` field, it will be set to the value in the context, even if this context was set for the `res.partner` model.

This change allow us to reduce a lot the collision that can happen (if 2 models have fields with the same name, and if a default_ context key was set for one of those model).

A double underscore is used to separate the model and the field (because a field / model can itself contain underscore).

Task-3358295