### PR TITLE
[FIX] http_routing:  check for presence of lang attribute in request

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -631,7 +631,8 @@ class IrHttp(models.AbstractModel):
         if not request.uid:
             cls._auth_method_public()
         cls._handle_debug()
-        cls._frontend_pre_dispatch()
+        if hasattr(request, 'lang'):
+            cls._frontend_pre_dispatch()
         request.params = request.get_http_params()
 
         code, values = cls._get_exception_code_values(exception)


### PR DESCRIPTION
In `_match` when `_get_default_lang` is called to assign `default_lang`
then we will face 'UndefinedColumn' error. As a consequence, the 
`request.lang` attribute is not prepared. So, When the `_handle_error` 
function tries to handle the exception and calls `_frontend_pre_dispatch,` 
it expects the `request.lang` attribute to be available. However, since `lang` 
was not prepared in the first place, an AttributeError occurs, stating that the 
'Request' object has no attribute 'lang'.

```
KeyError: ('website', <function Website._get_cached_values at 0x7f8b507469e0>, 1)
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: 1
  File "odoo/api.py", line 958, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'website(1,).user_id'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 965, in get
    raise CacheMiss(record, field)
UndefinedColumn: column website.channel_id does not exist
LINE 1: ...", "website"."write_uid", "website"."write_date", "website"....
                                                             ^

  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1713, in _serve_ir_http
    rule, args = ir_http._match(self.httprequest.path)
  File "addons/website/models/ir_http.py", line 174, in _match
    return super()._match(path)
  File "addons/http_routing/models/ir_http.py", line 440, in _match
    default_lang = cls._get_default_lang()
  File "addons/website/models/ir_http.py", line 256, in _get_default_lang
    return request.env['res.lang'].browse([website._get_cached('default_lang_id')])
  File "addons/website/models/website.py", line 1376, in _get_cached
    return self._get_cached_values()[field]
  File "<decorator-gen-326>", line 2, in _get_cached_values
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "addons/website/models/website.py", line 1369, in _get_cached_values
    'user_id': self.user_id.id,
  File "odoo/fields.py", line 2772, in __get__
    return super().__get__(records, owner)
  File "odoo/fields.py", line 1183, in __get__
    recs._fetch_field(self)
  File "odoo/models.py", line 3207, in _fetch_field
    self.fetch(fnames)
  File "odoo/models.py", line 3257, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
  File "odoo/models.py", line 3348, in _fetch_query
    self.env.cr.execute(query_str, params)
  File "odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
AttributeError: 'Request' object has no attribute 'lang'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1702, in _serve_db
    exc.error_response = self.registry['ir.http']._handle_error(exc)
  File "addons/http_routing/models/ir_http.py", line 637, in _handle_error
    cls._frontend_pre_dispatch()
  File "addons/website/models/ir_http.py", line 201, in _frontend_pre_dispatch
    super()._frontend_pre_dispatch()
  File "addons/http_routing/models/ir_http.py", line 576, in _frontend_pre_dispatch
    request.update_context(lang=request.lang._get_cached('code'))

```
sentry-4213837433

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
