### PR TITLE
[IMP] sales: confirm on down payment

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -77,6 +77,7 @@ This module contains all the common features of Sales Management and eCommerce.
         'web.assets_frontend': [
             'sale/static/src/scss/sale_portal.scss',
             'sale/static/src/js/sale_portal_sidebar.js',
+            'sale/static/src/js/sale_portal_prepayment.js',
             'sale/static/src/js/sale_portal.js',
             'sale/static/src/js/payment_form.js',
         ],

--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResCompany(models.Model):
@@ -16,6 +17,10 @@ class ResCompany(models.Model):
 
     portal_confirmation_sign = fields.Boolean(string="Online Signature", default=True)
     portal_confirmation_pay = fields.Boolean(string="Online Payment")
+    prepayment_percent = fields.Float(
+        string="Prepayment percentage",
+        default=1.0,
+        help="The percentage of the amount needed to be paid to confirm quotations.")
     quotation_validity_days = fields.Integer(
         string="Default Quotation Validity",
         default=30,
@@ -43,3 +48,9 @@ class ResCompany(models.Model):
             ('manual', "Manual Payment"),
         ],
         string="Sale onboarding selected payment method")
+
+    @api.constrains('prepayment_percent')
+    def _check_prepayment_percent(self):
+        for company in self:
+            if company.portal_confirmation_pay and not (0 < company.prepayment_percent <= 1.0):
+                raise ValidationError(_("Prepayment percentage must be a valid percentage."))

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -978,6 +978,9 @@ class SaleOrderLine(models.Model):
                 vals['product_uom_qty'] = 0.0
 
         lines = super().create(vals_list)
+        if self.env.context.get('sale_no_log_for_new_lines'):
+            return lines
+
         for line in lines:
             if line.product_id and line.state == 'sale':
                 msg = _("Extra line with %s", line.product_id.display_name)
@@ -985,6 +988,7 @@ class SaleOrderLine(models.Model):
                 # create an analytic account if at least an expense product
                 if line.product_id.expense_policy not in [False, 'no'] and not line.order_id.analytic_account_id:
                     line.order_id._create_analytic_account()
+
         return lines
 
     def write(self, values):

--- a/addons/sale/static/src/js/sale_portal_prepayment.js
+++ b/addons/sale/static/src/js/sale_portal_prepayment.js
@@ -1,0 +1,81 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.PortalPrepayment = publicWidget.Widget.extend({
+    selector: '.o_portal_sale_sidebar',
+    events: Object.assign({}, publicWidget.Widget.prototype.events, {
+        'click button[name="o_sale_portal_amount_prepayment_button"]': '_onClickAmountPrepaymentButton',
+        'click button[name="o_sale_portal_amount_total_button"]': '_onClickAmountTotalButton',
+    }),
+
+    start: async function () {
+        this.AmountTotalButton = document.querySelector(
+            'button[name="o_sale_portal_amount_total_button"]'
+        );
+        this.AmountPrepaymentButton = document.querySelector(
+            'button[name="o_sale_portal_amount_prepayment_button"]'
+        );
+
+        if (!this.AmountTotalButton) {
+            // Button not available in dom => confirmed SO or partial payment not enabled on this SO
+            // this widget has nothing to manage
+            return;
+        }
+
+        const params = new URLSearchParams(window.location.search);
+        const isPartialPayment = params.has('downpayment') ? params.get('downpayment') === 'true': true;
+        const showPaymentModal = params.get('showPaymentModal') === 'true';
+
+        // Prepare the modal to show if the down payment amount is selected or not.
+        if (isPartialPayment) {
+            this._onClickAmountPrepaymentButton(false);
+        } else {
+            this._onClickAmountTotalButton(false);
+        }
+
+        // When updating the amount re-open the modal.
+        if (showPaymentModal) {
+            const payNowButton = this.$('#o_sale_portal_paynow')[0];
+            payNowButton && payNowButton.click();
+        }
+    },
+
+    _onClickAmountPrepaymentButton: function (doReload=true) {
+        this.AmountTotalButton?.classList.add('opacity-50');
+        this.AmountPrepaymentButton?.classList.remove('opacity-50');
+
+        if (doReload) {
+            this._reloadAmount(true);
+        } else {
+            this.$('div[id="o_sale_portal_use_amount_total"]').hide();
+            this.$('div[id="o_sale_portal_use_amount_prepayment"]').show();
+        }
+    },
+
+    _onClickAmountTotalButton: function(doReload=true) {
+        this.AmountTotalButton?.classList.remove('opacity-50');
+        this.AmountPrepaymentButton?.classList.add('opacity-50');
+
+        if (doReload) {
+            this._reloadAmount(false);
+        } else {
+            this.$('div[id="o_sale_portal_use_amount_total"]').show();
+            this.$('div[id="o_sale_portal_use_amount_prepayment"]').hide();
+        }
+    },
+
+    _reloadAmount: function (partialPayment) {
+        const searchParams = new URLSearchParams(window.location.search);
+
+        if (partialPayment) {
+            searchParams.set('downpayment', true);
+        } else {
+            searchParams.set('downpayment', false);
+        }
+        searchParams.set('showPaymentModal', true);
+
+        window.location.search = searchParams.toString();
+    },
+});
+export default publicWidget.registry.PortalPrepayment;

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.fields import Command
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tests import tagged, Form
 from odoo.tools import float_compare
 
@@ -577,3 +577,12 @@ class TestSalesTeam(SaleCommon):
 
         with self.assertRaises(UserError):
             sol.tax_id = tax_b
+
+    def test_downpayment_amount_constraints(self):
+        """Down payment amounts should be in the interval ]0, 1]."""
+
+        self.sale_order.require_payment = True
+        with self.assertRaises(ValidationError):
+            self.sale_order.prepayment_percent = -1
+        with self.assertRaises(ValidationError):
+            self.sale_order.prepayment_percent = 1.01

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -669,13 +669,16 @@
                                 <field name="user_id" widget="many2one_avatar_user"/>
                                 <field name="team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}" options="{'no_create': True}"/>
                                 <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
-                                <label for="require_signature" string="Online confirmation"/>
-                                <div>
-                                    <field name="require_signature" class="oe_inline" readonly="state in ['cancel', 'sale']"/>
-                                    <span>Signature</span>
-                                    <field name="require_payment" class="oe_inline ms-3" readonly="state in ['cancel', 'sale']"/>
-                                    <span>Payment</span>
-                                </div>
+                                <field name="require_signature"
+                                       readonly="state in ['cancel', 'sale']"/>
+                                <field name="require_payment"
+                                       readonly="state in ['cancel', 'sale']"/>
+                                <field name="prepayment_percent"
+                                       readonly="state in ['cancel', 'sale']"
+                                       invisible="not require_payment"
+                                       widget="percentage"
+                                       string="Prepayment amount"
+                                       style="width: 3rem"/>
                                 <field name="reference" readonly="1" invisible="not reference"/>
                                 <field name="client_order_ref"/>
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -238,8 +238,37 @@
                                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                 </header>
                                 <main class="modal-body" id="sign-dialog">
+                                    <t t-set="prepayment_amount" t-value="sale_order._get_prepayment_required_amount()"/>
+                                    <t t-set="prepayment_available" t-value="sale_order.prepayment_percent and sale_order.prepayment_percent != 1.0"/>
+                                    <!-- Display choices only if a pre payment can confirm the order. -->
+                                    <div t-if="prepayment_available"
+                                         id="o_sale_portal_prepayment_buttons"
+                                         class="d-flex justify-content-center d-grid gap-2 btn-group"
+                                    >
+                                        <button name="o_sale_portal_amount_prepayment_button" class="btn btn-primary rounded">
+                                            Down payment <br/>
+                                            <span t-esc="prepayment_amount" class="fw-bold"
+                                                  t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"/>
+                                        </button>
+                                        <button name="o_sale_portal_amount_total_button" class="btn btn-primary rounded">
+                                            Full amount <br/>
+                                            <span t-field="sale_order.amount_total"/>
+                                        </button>
+                                    </div>
                                     <p>
-                                        <span>By paying this proposal, I agree to the following terms:</span>
+                                        <!-- The widget associated with this modal will hide and show divs in function of the amount selected. -->
+                                        <div id="o_sale_portal_use_amount_total">
+                                            By paying this proposal, I agree to the following terms:
+                                        </div>
+                                        <div t-if="prepayment_available"
+                                             id="o_sale_portal_use_amount_prepayment"
+                                        >
+                                            By paying this <u>down payment</u> of
+                                            <span t-esc="prepayment_amount" class="fw-bold"
+                                                  t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"/>
+                                            (<b t-esc="sale_order.prepayment_percent * 100"/> %)
+                                            for this proposal, I agree to the following terms:
+                                        </div>
                                         <ul>
                                             <li>
                                                 <span>Accepted on the behalf of:</span> <b t-field="sale_order.partner_id.commercial_partner_id"/>

--- a/addons/sale/wizard/payment_link_wizard_views.xml
+++ b/addons/sale/wizard/payment_link_wizard_views.xml
@@ -17,15 +17,14 @@
         <field name="inherit_id" ref="payment.payment_link_wizard_view_form"/>
         <field name="arch" type="xml">
             <field name="amount" position="after">
-                <field name="show_confirmation_message" invisible="1"/>
                 <field name="amount_paid" invisible="amount_paid &lt;= 0"/>
             </field>
             <div name="payment_link_warning_information" position="after">
-                <div class="alert alert-info text-center fw-bold"
-                     role="alert"
-                     invisible="not show_confirmation_message">
-                    <span>This payment will confirm the quotation.</span>
-                </div>
+                <span class="text-info text-center fw-bold"
+                      role="alert"
+                      invisible="not confirmation_message">
+                    <field name="confirmation_message"/>
+                </span>
             </div>
         </field>
     </record>

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -57,6 +57,9 @@ class ResConfigSettings(models.TransientModel):
     portal_confirmation_pay = fields.Boolean(
         related='company_id.portal_confirmation_pay',
         readonly=False)
+    prepayment_percent = fields.Float(
+        related='company_id.prepayment_percent',
+        readonly=False)
 
     # Modules
     module_delivery = fields.Boolean("Delivery Methods")
@@ -75,6 +78,15 @@ class ResConfigSettings(models.TransientModel):
     module_sale_margin = fields.Boolean("Margins")
 
     #=== ONCHANGE METHODS ===#
+
+    @api.onchange('portal_confirmation_pay')
+    def _onchange_portal_confirmation_pay(self):
+        self.prepayment_percent = self.prepayment_percent or 1.0
+
+    @api.onchange('prepayment_percent')
+    def _onchange_prepayment_percent(self):
+        if not self.prepayment_percent:
+            self.portal_confirmation_pay = False
 
     @api.onchange('quotation_validity_days')
     def _onchange_quotation_validity_days(self):

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -88,7 +88,11 @@
                                            target="_blank"/>
                                 </div>
                                 <div class="text-muted">
-                                    Request an online payment to confirm orders
+                                    Request an online prepayment from your customers to confirm orders. You can ask them to fully pay the order or partially with a downpayment
+                                </div>
+                                <div invisible="not portal_confirmation_pay" class="text-nowrap fw-bold">
+                                    Prepayment amount
+                                    <field name="prepayment_percent" widget="percentage" style="width: 3rem"/>
                                 </div>
                                 <div class="mt8" invisible="not portal_confirmation_pay">
                                     <button name='%(payment.action_payment_provider)d' icon="oi-arrow-right" type="action" string="Payment Providers" class="btn-link"/>

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -55,6 +55,13 @@ class SaleOrder(models.Model):
             order.require_payment = order.sale_order_template_id.require_payment
 
     @api.depends('sale_order_template_id')
+    def _compute_prepayment_percent(self):
+        super()._compute_prepayment_percent()
+        for order in self.filtered('sale_order_template_id'):
+            if order.require_payment:
+                order.prepayment_percent = order.sale_order_template_id.prepayment_percent
+
+    @api.depends('sale_order_template_id')
     def _compute_validity_date(self):
         super()._compute_validity_date()
         for order in self.filtered('sale_order_template_id'):

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -36,13 +36,13 @@
                                 <field name="number_of_days" style="width: 3rem;"/>
                                 <div class="d-inline-block">days</div>
                             </div>
-                            <label for="require_signature" string="Online confirmation"/>
-                            <div>
-                                <field name="require_signature" class="oe_inline"/>
-                                <span>Signature</span>
-                                <field name="require_payment" class="oe_inline ms-3"/>
-                                <span>Payment</span>
-                            </div>
+                            <field name="require_signature"/>
+                            <field name="require_payment"/>
+                            <field name="prepayment_percent"
+                                   invisible="not require_payment"
+                                   widget="percentage"
+                                   string="Prepayment amount"
+                                   style="width: 3rem"/>
                             <field name="mail_template_id" context="{'default_model': 'sale.order'}"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>


### PR DESCRIPTION
Some businesses requires customers to pay a down payment in order to confirm the order. In the case of odoo today this implies to:
 - sending a payment link
 - waiting & Checking if the payment has been done
 - confirming the order
 - creating the down payment invoice A lot of time consuming manual operations with a high risk of errors.

This commit introduces the functionality for sales orders to be confirmed on down payments and automatizes the flow to minimize the errors due to human manipulation.

Task - 3087716


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
