### PR TITLE
[IMP] hr_timesheet,project,*: improve task analysis and list view

### DIFF
--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -10,6 +10,7 @@
                     <attribute name="js_class">hr_timesheet_graphview</attribute>
                 </xpath>
                 <xpath expr="//field[@name='project_id']" position='after'>
+                    <field name="remaining_hours_percentage" invisible="1"/>
                     <field name="planned_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
@@ -23,9 +24,12 @@
             <field name="inherit_id" ref="project.view_task_project_user_pivot"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='project_id']" position='after'>
+                    <field name="remaining_hours_percentage" invisible="1"/>
                     <field name="planned_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" type="measure"/>
+                    <field name="overtime" widget="timesheet_uom" type="measure"/>
                 </xpath>
              </field>
         </record>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -173,7 +173,7 @@
                     <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-Tasks Total Effective Hours" optional="hide"/>
                     <field name="total_hours_spent" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
                     <field name="remaining_hours" widget="timesheet_uom" sum="Total Remaining Hours" optional="hide" decoration-danger="progress &gt;= 100" decoration-warning="progress &gt;= 80 and progress &lt; 100" attrs="{'invisible' : [('planned_hours', '=', 0)]}"/>
-                    <field name="progress" widget="progressbar" optional="show" groups="hr_timesheet.group_hr_timesheet_user" attrs="{'invisible' : [('planned_hours', '=', 0)]}" options="{'overflow_class': 'bg-danger'}" />
+                    <field name="progress" widget="progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" attrs="{'invisible' : [('planned_hours', '=', 0)]}" options="{'overflow_class': 'bg-danger'}" />
                 </field>
             </field>
         </record>

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -7,6 +7,9 @@
             <field name="arch" type="xml">
                 <pivot string="Tasks Analysis" display_quantity="1" sample="1" disable_linking="1">
                     <field name="project_id" type="row"/>
+                    <field name="working_hours_open" widget="timesheet_uom"/>
+                    <field name="working_hours_close" widget="timesheet_uom"/>
+                    <field name="nbr" invisible="1"/>
                 </pivot>
             </field>
         </record>

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -30,6 +30,7 @@ have real delivered quantities in sales orders.
         'views/project_sharing_views.xml',
         'views/project_portal_templates.xml',
         'report/report_timesheet_templates.xml',
+        'report/project_report_view.xml',
         'wizard/project_create_sale_order_views.xml',
         'wizard/project_create_invoice_views.xml',
         'wizard/sale_make_invoice_advance_views.xml',

--- a/addons/sale_timesheet/report/project_report_view.xml
+++ b/addons/sale_timesheet/report/project_report_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_task_project_user_pivot_inherited" model="ir.ui.view">
+            <field name="name">report.project.task.user.pivot.inherited</field>
+            <field name="model">report.project.task.user</field>
+            <field name="inherit_id" ref="project.view_task_project_user_pivot"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='total_hours_spent']" position='before'>
+                    <field name="remaining_hours_so" widget="timesheet_uom"/>
+                </xpath>
+             </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
*=sale_timesheet.

In this commit improve following UI in task analysis and list view,

- aggregate the sum of following fields in project.task list view, hours spent on sub-tasks, total hours, remaining hours on SO, progress.
- in project.task list view move 'id' after the 'state'.
- from task analysis remove the measure 'remaining hours percentage' from graph and pivot view.

task-3330295

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
