### PR TITLE
[IMP] point_of_sale: closing entry with product

### DIFF
--- a/addons/l10n_in_pos/__init__.py
+++ b/addons/l10n_in_pos/__init__.py
@@ -1,4 +1,13 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import models
+
+
+def pos_config_setting(env):
+    for config in env['pos.config'].search([('company_id.account_fiscal_country_id.code', '=', 'IN')]):
+        config.write({
+            'is_closing_entry_by_product': True
+        })
+
+
+def post_init(env):
+    pos_config_setting(env)

--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -13,6 +13,7 @@
     'data': [
         'views/pos_order_line_views.xml',
         'data/pos_bill_data.xml',
+        'views/res_config_settings_views.xml',
     ],
     'demo': [
         'data/product_demo.xml',
@@ -25,4 +26,5 @@
         ],
     },
     'license': 'LGPL-3',
+    'post_init_hook': 'post_init',
 }

--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -5,3 +5,5 @@ from . import pos_order
 from . import pos_order_line
 from . import pos_session
 from . import product_product
+from . import pos_config
+from . import product_template

--- a/addons/l10n_in_pos/models/pos_config.py
+++ b/addons/l10n_in_pos/models/pos_config.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+from odoo.exceptions import UserError
+from odoo.tools.translate import _
+
+
+class PosConfig(models.Model):
+    _inherit = 'pos.config'
+
+    @api.constrains('is_closing_entry_by_product')
+    def _check_journal_entry_with_product_line(self):
+        for config in self:
+            if config.company_id.country_code == 'IN' and not config.is_closing_entry_by_product:
+                raise UserError(_("You can't deactivate the 'Closing Entry by product' option for Indian Companies."))
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in list(vals_list):
+            if self.env.company.country_code == 'IN':
+                vals.update({
+                    'is_closing_entry_by_product': True
+                })
+        pos_configs = super().create(vals_list)
+        return pos_configs

--- a/addons/l10n_in_pos/models/product_template.py
+++ b/addons/l10n_in_pos/models/product_template.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    @api.onchange('l10n_in_hsn_code')
+    def _onchange_l10n_in_hsn_code(self):
+        if self._origin.l10n_in_hsn_code and self.env['pos.session'].search_count([('state', '!=', 'closed')]):
+            raise UserError(_("Unable to change the HSN/SAC code. Please ensure all POS sessions are closed before proceeding."))

--- a/addons/l10n_in_pos/views/res_config_settings_views.xml
+++ b/addons/l10n_in_pos/views/res_config_settings_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit_pos" model="ir.ui.view">
+        <field name="name">res.config.settings.form.inherit.l10n_in_pos</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@id='pos_closeing_entry_by_product']" position="attributes">
+                <attribute name="invisible">company_country_code == 'IN'</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -188,6 +188,10 @@ class PosConfig(models.Model):
     show_product_images = fields.Boolean(string="Show Product Images", help="Show product images in the Point of Sale interface.", default=True)
     show_category_images = fields.Boolean(string="Show Category Images", help="Show category images in the Point of Sale interface.", default=True)
     note_ids = fields.Many2many('pos.note', string='Note Models', help='The predefined notes of this point of sale.')
+    is_closing_entry_by_product = fields.Boolean(
+        string='Closing Entry by product',
+        default=False,
+        help="Activate this setting to display the breakdown of sales lines by product in the automatically generated closing entry.")
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
 from datetime import timedelta
-from itertools import groupby
+from itertools import groupby, starmap
 
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -853,12 +853,15 @@ class PosSession(models.Model):
                         # for taxes
                         tuple(base_line['record'].tax_ids_after_fiscal_position.flatten_taxes_hierarchy().ids),
                         tuple(to_update['tax_tag_ids'][0][2]),
+                        base_line['product'].id if self.config_id.is_closing_entry_by_product else False,
                     )
                     sales[sale_key] = self._update_amounts(
                         sales[sale_key],
                         {'amount': to_update['price_subtotal']},
                         order.date_order,
                     )
+                    if self.config_id.is_closing_entry_by_product:
+                        sales[sale_key] = self._update_quantities(sales[sale_key], base_line['quantity'])
 
                 # Combine tax lines
                 for tax_line in tax_results['tax_lines_to_add']:
@@ -974,7 +977,7 @@ class PosSession(models.Model):
             rounding_vals = [self._get_rounding_difference_vals(rounding_difference['amount'], rounding_difference['amount_converted'])]
 
         MoveLine.create(tax_vals)
-        move_line_ids = MoveLine.create([self._get_sale_vals(key, amounts['amount'], amounts['amount_converted']) for key, amounts in sales.items()])
+        move_line_ids = MoveLine.create(list(starmap(self._get_sale_vals, sales.items())))
         for key, ml_id in zip(sales.keys(), move_line_ids.ids):
             sales[key]['move_line_id'] = ml_id
         MoveLine.create(
@@ -1297,7 +1300,8 @@ class PosSession(models.Model):
         partial_vals = {
             'account_id': self._get_receivable_account(payment_method).id,
             'move_id': self.move_id.id,
-            'name': '%s - %s' % (self.name, payment_method.name)
+            'name': '%s - %s' % (self.name, payment_method.name),
+            'display_type': 'payment_term',
         }
         return self._debit_amounts(partial_vals, amount, amount_converted)
 
@@ -1306,23 +1310,38 @@ class PosSession(models.Model):
             'account_id': self.company_id.account_default_pos_receivable_account_id.id,
             'move_id': self.move_id.id,
             'name': _('From invoice payments'),
+            'display_type': 'payment_term',
         }
         return self._credit_amounts(partial_vals, amount, amount_converted)
 
-    def _get_sale_vals(self, key, amount, amount_converted):
-        account_id, sign, tax_ids, base_tag_ids = key
+    def _get_sale_vals(self, key, sale_vals):
+        account_id, sign, tax_ids, base_tag_ids, product_id = key
+        amount = sale_vals['amount']
+        amount_converted = sale_vals['amount_converted']
         applied_taxes = self.env['account.tax'].browse(tax_ids)
+        if product_id:
+            product = self.env['product.product'].browse(product_id)
+            product_name = product.display_name
+            product_uom = product.uom_id.id
+        else:
+            product_name = ""
+            product_uom = False
         title = 'Sales' if sign == 1 else 'Refund'
         name = '%s untaxed' % title
         if applied_taxes:
-            name = '%s with %s' % (title, ', '.join([tax.name for tax in applied_taxes]))
+            name = '%s %s with %s' % (title, product_name, ', '.join([tax.name for tax in applied_taxes]))
         partial_vals = {
             'name': name,
             'account_id': account_id,
             'move_id': self.move_id.id,
             'tax_ids': [(6, 0, tax_ids)],
             'tax_tag_ids': [(6, 0, base_tag_ids)],
+            'product_id': product_id,
+            'display_type': 'product',
+            'product_uom_id': product_uom
         }
+        if partial_vals.get('product_id'):
+            partial_vals['quantity'] = sale_vals.get('quantity') or 1
         return self._credit_amounts(partial_vals, amount, amount_converted)
 
     def _get_tax_vals(self, key, amount, amount_converted, base_amount_converted):
@@ -1336,6 +1355,7 @@ class PosSession(models.Model):
             'tax_base_amount': abs(base_amount_converted),
             'tax_repartition_line_id': repartition_line_id,
             'tax_tag_ids': [(6, 0, tag_ids)],
+            'display_type': 'tax',
         }
         return self._debit_amounts(partial_args, amount, amount_converted)
 
@@ -1368,6 +1388,12 @@ class PosSession(models.Model):
             'counterpart_account_id': accounting_partner.property_account_receivable_id.id,
             'partner_id': accounting_partner.id,
         }
+
+    def _update_quantities(self, vals, qty_to_add):
+        vals.setdefault('quantity', 0)
+        # update quantity
+        vals['quantity'] += qty_to_add
+        return vals
 
     def _update_amounts(self, old_amounts, amounts_to_add, date, round=True, force_company_currency=False):
         """Responsible for adding `amounts_to_add` to `old_amounts` considering the currency of the session.

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -111,6 +111,7 @@ class ResConfigSettings(models.TransientModel):
     pos_show_product_images = fields.Boolean(related='pos_config_id.show_product_images', readonly=False)
     pos_show_category_images = fields.Boolean(related='pos_config_id.show_category_images', readonly=False)
     pos_note_ids = fields.Many2many(related='pos_config_id.note_ids', readonly=False)
+    pos_is_closing_entry_by_product = fields.Boolean(related='pos_config_id.is_closing_entry_by_product', readonly=False)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1082,6 +1082,7 @@ class TestPoSBasicConfig(TestPoSCommon):
             {'account_id': self.tax_received_account.id, 'balance': -9.72, 'reconciled': False},
             {'account_id': self.receivable_account.id, 'balance': 117.72, 'reconciled': True},
         ])
+
     def test_closing_entry_by_product(self):
         # set the Group by Product at Closing Entry
         self.config.is_closing_entry_by_product = True

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1082,3 +1082,82 @@ class TestPoSBasicConfig(TestPoSCommon):
             {'account_id': self.tax_received_account.id, 'balance': -9.72, 'reconciled': False},
             {'account_id': self.receivable_account.id, 'balance': 117.72, 'reconciled': True},
         ])
+    def test_closing_entry_by_product(self):
+        # set the Group by Product at Closing Entry
+        self.config.is_closing_entry_by_product = True
+        self.open_new_session()
+
+        # 4 orders
+
+        # Orders
+        # ======
+        # +---------+----------+---------------+----------+-----+-------+
+        # | order   | payments | invoiced?     | product  | qty | total |
+        # +---------+----------+---------------+----------+-----+-------+
+        # | order 1 | bank     | no            | product1 |   2 |    60 |
+        # |         |          |               | product4 |   3 | 39.84 |
+        # +---------+----------+---------------+----------+-----+-------+
+        # | order 2 | bank     | yes           | product4 |   1 | 29.88 |
+        # |         |          |               | product2 |   5 |   400 |
+        # +---------+----------+---------------+----------+-----+-------+
+        # | order 3 | bank     | yes           | product1 |   3 | 29.88 |
+        # |         |          |               | product2 |  10 |   400 |
+        # +---------+----------+---------------+----------+-----+-------+
+        # | order 4 | bank     | yes           | product1 |   5 | 29.88 |
+        # |         |          |               | product0 |  10|   400 |
+        # +---------+----------+---------------+----------+-----+-------+
+
+        # Expected Output
+        # +---------------+-----------+
+        # | invoice_line  | Quantity  |
+        # +---------------+-----------+
+        # | Product 0     |      10   |
+        # +---------------+-----------+
+        # | Product 1     |      10   |
+        # +---------------+-----------+
+        # | Product 2     |      15   |
+        # +---------------+-----------+
+        # | Product 4     |       4   |
+        # +---------------+-----------+
+
+        # create orders
+        orders = []
+
+        # create orders
+        orders = []
+        orders.append(self.create_ui_order_data(
+            [(self.product1, 2), (self.product4, 3)],
+            payments=[(self.bank_pm1, 49.88)]
+        ))
+        orders.append(self.create_ui_order_data(
+            [(self.product4, 1), (self.product2, 5)],
+            payments=[(self.bank_pm1, 109.96)]
+        ))
+        orders.append(self.create_ui_order_data(
+            [(self.product1, 3), (self.product2, 10)],
+            payments=[(self.bank_pm1, 230)]
+        ))
+        orders.append(self.create_ui_order_data(
+            [(self.product1, 5), (self.product0, 10)],
+            payments=[(self.bank_pm1, 50)]
+        ))
+
+        # sync orders
+        self.env['pos.order'].sync_from_ui(orders)
+        # close the session
+        self.pos_session.action_pos_session_validate()
+
+        # check values after the session is closed
+        session_account_move = self.pos_session.move_id
+
+        # Define expected quantities for each product
+        expected_product_quantity = {
+            self.product0: 10,
+            self.product1: 10,
+            self.product2: 15,
+            self.product4: 4,
+        }
+        # Iterate through invoice lines and assert the expected quantities
+        for i in session_account_move.line_ids:
+            if i.product_id and expected_product_quantity.get(i.product_id):
+                self.assertEqual(i.quantity, expected_product_quantity.get(i.product_id), f"Unexpected quantity for {i.product_id.name}")

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -16,6 +16,7 @@
                     <field name="pos_iface_print_via_proxy" invisible="1"/>
                     <field name="pos_company_has_template" invisible="1"/>
                     <field name="group_cash_rounding" invisible="1"/>
+                    <field name="company_country_code" invisible="1"/>
                 </t>
 
                 <app data-string="Point of sale" string="Point of Sale" name="point_of_sale" groups="point_of_sale.group_pos_manager">
@@ -207,6 +208,9 @@
                                             context="{'default_company_id': company_id, 'default_type': 'sale'}"/>
                                     </div>
                                 </div>
+                            </setting>
+                            <setting string="Closing Entry by product" id="pos_closeing_entry_by_product" help="Activate this setting to display the breakdown of sales lines by product in the automatically generated closing entry.">
+                                <field name="pos_is_closing_entry_by_product"/>
                             </setting>
                         </block>
 


### PR DESCRIPTION
Before PR:
---
When closing a session, one creates a journal entry with the total sales. 

After PR:
---
- Introduced a new configuration option, 'closing entry with product lines' in the point-of-sale module
- When enabled, the system now generates a journal entry with one line per product. upon session closure
- This change enhances the accuracy and granularity of financial reporting in the POS system

task ID :- [3359658](https://www.odoo.com/web#id=3359658&cids=2&menu_id=6478&action=4043&model=project.task&view_type=form)