### PR TITLE
[IMP] account: change placeholder terms

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -8671,6 +8671,11 @@ msgid "Payment term explanation for the customer..."
 msgstr ""
 
 #. module: account
+#: model_terms:ir.ui.view,arch_db:account.view_move_form
+msgid "Payment terms"
+msgstr ""
+
+#. module: account
 #: model:account.payment.term,note:account.account_payment_term_15days
 msgid "Payment terms: 15 Days"
 msgstr ""
@@ -11465,7 +11470,6 @@ msgstr ""
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_payment_term__line_ids
-#: model_terms:ir.ui.view,arch_db:account.view_move_form
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_form
 msgid "Terms"
 msgstr ""

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -691,8 +691,12 @@
                                        }"/>
 
                                 <!-- Invoice payment terms (only invoices) + due date (only invoices / receipts) -->
-                                <label for="invoice_payment_term_id" string="Due Date"
-                                       attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}"/>
+                                <div class="o_td_label" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}">
+                                    <label for="invoice_date_due" string="Due Date"
+                                           attrs="{'invisible': [('invoice_payment_term_id', '!=', False)]}"/>
+                                    <label for="invoice_payment_term_id" string="Payment terms"
+                                           attrs="{'invisible': [('invoice_payment_term_id', '=', False)]}"/>
+                                </div>
                                 <div class="d-flex" attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}">
                                     <field name="invoice_date_due" force_save="1"
                                            placeholder="Date"
@@ -700,7 +704,7 @@
                                     <span class="o_form_label mx-3 oe_edit_only"
                                           attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('invoice_payment_term_id', '!=', False)]}"> or </span>
                                     <field name="invoice_payment_term_id"
-                                           placeholder="Terms"/>
+                                           placeholder="Payment Terms"/>
                                 </div>
 
                                 <label for="journal_id"


### PR DESCRIPTION
Currently, if we have a look at the field "Due date" Or "payment terms", the placeholder "terms" seems confusing, no one knows that it will open the "payment terms" list from there as a label of the field is "Due date"

task-id: 3340547


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
