### PR TITLE
[IMP] website: make static page url translatable

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -22,7 +22,7 @@ class Page(models.Model):
     _description = 'Page'
     _order = 'website_id'
 
-    url = fields.Char('Page URL')
+    url = fields.Char('Page URL', translate=True)
     view_id = fields.Many2one('ir.ui.view', string='View', required=True, ondelete="cascade")
     website_indexed = fields.Boolean('Is Indexed', default=True)
     date_publish = fields.Datetime('Publishing Date')

--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -6,6 +6,7 @@ import {useInputField} from '@web/views/fields/input_field_hook';
 import {useService} from '@web/core/utils/hooks';
 import {Switch} from '@website/components/switch/switch';
 import {registry} from '@web/core/registry';
+import {TranslationButton} from "@web/views/fields/translation_button";
 
 const {Component, useState} = owl;
 
@@ -31,6 +32,9 @@ class PageUrlField extends Component {
     get enableRedirect() {
         return this.state.url !== this.pageUrl;
     }
+    get isTranslatable() {
+        return this.props.record.fields[this.props.name].translate;
+    }
 
     onChangeRedirectOldUrl(value) {
         this.state.redirect_old_url = value;
@@ -49,7 +53,7 @@ class PageUrlField extends Component {
     }
 }
 
-PageUrlField.components = {Switch, PageDependencies};
+PageUrlField.components = {Switch, PageDependencies, TranslationButton};
 PageUrlField.template = 'website.PageUrlField';
 PageUrlField.props = {
     ...standardFieldProps,

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -20,6 +20,12 @@
                 t-model="state.url"
                 t-ref="input"
             />
+            <t t-if="isTranslatable">
+                <TranslationButton
+                    fieldName="props.name"
+                    record="props.record"
+                />
+            </t>
         </div>
         <div t-if="enableRedirect">
             <div class="d-flex mt-4">


### PR DESCRIPTION
After this commit, the static page URL will be translatable depending upon language the user chooses.

Users can translate URLs from,
1. website.page form view
2. website page properties popup

PR:[124462](https://github.com/odoo/odoo/pull/124462)
task-3355343