### PR TITLE
[FIX] mass_mailing: links opening inside iframe

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_widget.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_widget.js
@@ -168,7 +168,19 @@ var MassMailingFieldHtml = FieldHtml.extend({
         if (!this.value) {
             this.value = this.recordData[this.nodeOptions['inline-field']];
         }
-        return this._super.apply(this, arguments);
+        const res =  this._super.apply(this, arguments);
+        this.iframeReadOnlyPromise.then(() => {
+            if (!this.$iframe) {
+                return;
+            }
+            // Ensure all links are opened in a new tab.
+            // The base element sets the behaviour for all links in the document.
+            const head = this.$iframe[0].contentDocument.head;
+            const base = document.createElement('base');
+            base.setAttribute('target', '_blank');
+            head.appendChild(base);
+        });
+        return res;
     },
     /**
      * @override

--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -307,7 +307,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
 
         this.$el.empty();
         var resolver;
-        var def = new Promise(function (resolve) {
+        this.iframeReadOnlyPromise = new Promise(function (resolve) {
             resolver = resolve;
         });
         const externalLinkSelector = `a:not([href^="${location.origin}"]):not([href^="/"])`;
@@ -319,7 +319,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
 
             // inject content in iframe
 
-            this.$iframe.data('loadDef', def); // for unit test
+            this.$iframe.data('loadDef', this.iframeReadOnlyPromise); // for unit test
             window.top[this._onUpdateIframeId] = function (_avoidDoubleLoad) {
                 if (_avoidDoubleLoad !== avoidDoubleLoad) {
                     console.warn('Wysiwyg iframe double load detected');
@@ -397,7 +397,7 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
             resolver();
         }
 
-        def.then(function () {
+        this.iframeReadOnlyPromise.then(function () {
             if (!self.hasReadonlyModifier) {
                 self.$content.on('click', 'ul.o_checklist > li', self._onReadonlyClickChecklist.bind(self));
             }


### PR DESCRIPTION
Before this commit, when viewing a mailing in read-only mode (a sent mailing, for example), links that did not have the target attribute set to "_blank" would be opened inside the iframe, which is undesired.

This commit ensures that, when in read-only mode, all links are opened in a new tab, regardless of their "target" attribute. This prevents links from opening within the iframe.

task-3323602
