### PR TITLE
[FIX] mass_mailing: links opening inside iframe

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -614,6 +614,11 @@ export class MassMailingHtmlField extends HtmlField {
             this.props.value = this.props.record.data.body_html;
         }
         await super._setupReadonlyIframe();
+        // Ensure that all links are opened in a new tab.
+        // The base element sets the target for all links in the document.
+        const head = this.iframeRef.el.contentDocument.head;
+        const base = head.querySelector('base') || head.appendChild(document.createElement('base'));
+        base.setAttribute('target', '_blank');
     }
 }
 


### PR DESCRIPTION
Before this commit, when viewing a mailing in read-only mode (a sent mailing, for example), links that did not have the target attribute set to "_blank" would be opened inside the iframe, which is undesired.

This commit ensures that, when in read-only mode, all links are opened in a new tab, regardless of their "target" attribute. This prevents links from opening within the iframe.

task-3323602
