### PR TITLE
[IMP] mrp: display Ready to Produce qty in MO Overview Report

### DIFF
--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
@@ -14,10 +14,10 @@
                 </div>
             </t>
 
-            <div class="py-3 py-lg-5 overflow-auto border-bottom bg-view">
+            <div class="overflow-auto border-bottom bg-view">
                 <div class="container-fluid">
                     <table class="table">
-                        <thead>
+                        <thead class="o_mrp_mo_overview_thead">
                             <tr>
                                 <th class="text-start"/>
                                 <th class="text-center" t-if="showReplenishments">Status</th>

--- a/addons/mrp/static/src/scss/mrp_mo_overview.scss
+++ b/addons/mrp/static/src/scss/mrp_mo_overview.scss
@@ -1,0 +1,3 @@
+.o_mrp_mo_overview_thead {
+    background-color: #{$o-webclient-background-color};
+}


### PR DESCRIPTION
Before this commit
==================
Currently, There is no way to know how many qty users can produce with the current stock.

After this commit
=================
With this commit, In the MO Overview report, the following stages are added:
'Ready', 'Not Ready', and '{X} Ready'. the Ready to Produce qty is based on
the component reserved quantity + component free quantity. Furthermore, the
table header in the MO status overview report has been slightly highlighted for
improved visibility.

task-3356499