### PR TITLE
[IMP] stock: move multiple quants at once

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -67,6 +67,7 @@
         'wizard/stock_inventory_warning.xml',
         'wizard/stock_label_type.xml',
         'wizard/stock_lot_label_layout.xml',
+        'wizard/stock_quant_relocate.xml',
 
         'views/res_partner_views.xml',
         'views/product_strategy_views.xml',

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -742,7 +742,7 @@ class StockMoveLine(models.Model):
         ml_ids_to_ignore |= self.ids
 
         # Check the available quantity, with the `strict` kw set to `True`. If the available
-        # quantity is greather than the quantity now unavailable, there is nothing to do.
+        # quantity is greater than the quantity now unavailable, there is nothing to do.
         available_quantity = self.env['stock.quant']._get_available_quantity(
             product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True
         )

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -91,3 +91,4 @@ access_stock_replenishment_info,stock.replenishment.info,model_stock_replenishme
 access_stock_picking_label_type_user,picking.label.type.user,model_picking_label_type,stock.group_stock_user,1,1,1,0
 access_stock_lot_label_layout_user,lot.label.layout.user,model_lot_label_layout,stock.group_stock_user,1,1,1,0
 access_stock_replenish_option,stock.replenishment.option,model_stock_replenishment_option,stock.group_stock_user,1,1,1,0
+access_stock_quant_relocate,access.stock.quant.relocate,model_stock_quant_relocate,stock.group_stock_manager,1,1,1,0

--- a/addons/stock/tests/test_stock_lot.py
+++ b/addons/stock/tests/test_stock_lot.py
@@ -57,7 +57,7 @@ class TestLotSerial(TestStockCommon):
         self.assertEqual(self.lot_p_b.quant_ids.filtered(lambda q: q.quantity > 0).location_id, self.locationB)
 
         # testing changing the location from the quant
-        self.lot_p_b.quant_ids._move_quants(self.locationC, 'test_quant_move')
+        self.lot_p_b.quant_ids.move_quants(location_dest_id=self.locationC, message='test_quant_move')
         self.assertEqual(self.lot_p_b.location_id, self.locationC)
 
         # testing having the lot in multiple locations
@@ -70,7 +70,7 @@ class TestLotSerial(TestStockCommon):
         self.assertEqual(self.lot_p_a.location_id.id, False)
 
         # testing having the lot back in a single location
-        self.lot_p_a.quant_ids.filtered(lambda q: q.location_id == self.locationA)._move_quants(self.locationC)
+        self.lot_p_a.quant_ids.filtered(lambda q: q.location_id == self.locationA).move_quants(location_dest_id=self.locationC)
         self.StockQuantObj.invalidate_model()
         self.StockQuantObj._unlink_zero_quants()
         self.assertEqual(self.lot_p_a.location_id, self.locationC)

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -117,6 +117,7 @@
                             invisible="((context.get('inventory_mode') and not context.get('inventory_report_mode')) or context.get('no_at_date'))"
                             class="btn-primary ms-1"
                             display="always"/>
+                    <button name="action_stock_quant_relocate" string="Relocate" type="object" groups="stock.group_stock_manager" invisible="context.get('hide_location', False)" context="{'action_ref': 'stock.action_view_quants'}"/>
                 </header>
                 <field name="create_date" column_invisible="True"/>
                 <field name="write_date" column_invisible="True"/>
@@ -418,6 +419,7 @@ in this location. That leads to a negative stock.
                     <button name="stock.action_stock_inventory_adjustement_name" groups="stock.group_stock_manager" type="action" string="Apply"/>
                     <button name="action_reset" type="object" string="Clear"/>
                     <button name="stock.action_stock_request_count" groups="stock.group_stock_manager" type="action" string="Request a Count"/>
+                    <button name="action_stock_quant_relocate" string="Relocate" type="object" groups="stock.group_stock_manager" invisible="context.get('hide_location', False)" context="{'action_ref': 'stock.action_view_inventory_tree'}"/>
                 </header>
                 <field name="create_date" column_invisible="True"/>
                 <field name="write_date" column_invisible="True"/>
@@ -455,7 +457,7 @@ in this location. That leads to a negative stock.
                 <button name="action_inventory_history" type="object" class="btn btn-link text-info" icon="fa-history" string="History"/>
                 <button name="action_apply_inventory" groups="stock.group_stock_manager" type="object" string="Apply" class="btn btn-link" icon="fa-save" invisible="not inventory_quantity_set"/>
                 <button name="action_set_inventory_quantity" type="object" string="Set" class="btn btn-link" icon="fa-bullseye" invisible="inventory_quantity_set"/>
-                <button name="action_set_inventory_quantity_to_zero" type="object" string="Clear" class="btn text-warning" icon="fa-times" invisible="not inventory_quantity_set"/>
+                <button name="action_clear_inventory_quantity" type="object" string="Clear" class="btn text-warning" icon="fa-times" invisible="not inventory_quantity_set"/>
             </tree>
         </field>
     </record>

--- a/addons/stock/wizard/__init__.py
+++ b/addons/stock/wizard/__init__.py
@@ -22,3 +22,4 @@ from . import stock_package_destination
 from . import stock_orderpoint_snooze
 from . import stock_request_count
 from . import stock_replenishment_info
+from . import stock_quant_relocate

--- a/addons/stock/wizard/stock_inventory_warning.py
+++ b/addons/stock/wizard/stock_inventory_warning.py
@@ -11,7 +11,7 @@ class StockInventoryWarning(models.TransientModel):
     quant_ids = fields.Many2many('stock.quant')
 
     def action_reset(self):
-        return self.quant_ids.action_set_inventory_quantity_to_zero()
+        return self.quant_ids.action_clear_inventory_quantity()
 
     def action_set(self):
         valid_quants = self.quant_ids.filtered(lambda quant: not quant.inventory_quantity_set)

--- a/addons/stock/wizard/stock_quant_relocate.py
+++ b/addons/stock/wizard/stock_quant_relocate.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from ast import literal_eval
+
+from odoo import fields, models, api
+
+
+class RelocateStockQuant(models.TransientModel):
+    _name = 'stock.quant.relocate'
+    _description = 'Stock Quantity Relocation'
+
+    quant_ids = fields.Many2many('stock.quant')
+    company_id = fields.Many2one(related="quant_ids.company_id")
+    dest_location_id = fields.Many2one('stock.location', domain="[('usage', '=', 'internal'), ('company_id', '=', company_id)]")
+    dest_package_id_domain = fields.Char(compute="_compute_dest_package_id_domain")
+    dest_package_id = fields.Many2one('stock.quant.package', domain="dest_package_id_domain", compute="_compute_dest_package_id", store=True)
+    message = fields.Text('Reason for relocation')
+    is_partial_package = fields.Boolean(compute='_compute_is_partial_package')
+    partial_package_names = fields.Char(compute="_compute_is_partial_package")
+    is_multi_location = fields.Boolean(compute='_compute_is_multi_location')
+
+    @api.depends('quant_ids')
+    def _compute_is_partial_package(self):
+        self.is_partial_package = False
+        self.partial_package_names = ''
+        for wizard in self:
+            packages = wizard.quant_ids.package_id
+            incomplete_packages = packages.filtered(lambda p: any(q not in wizard.quant_ids.ids for q in p.quant_ids.ids))
+            if packages and incomplete_packages:
+                wizard.is_partial_package = True
+                wizard.partial_package_names = ', '.join(incomplete_packages.mapped('display_name'))
+
+    @api.depends('dest_location_id', 'quant_ids')
+    def _compute_is_multi_location(self):
+        self.is_multi_location = False
+        for wizard in self:
+            if len(wizard.quant_ids.location_id) > 1 and not wizard.dest_location_id:
+                wizard.is_multi_location = True
+
+    @api.depends('dest_location_id', 'quant_ids')
+    def _compute_dest_package_id_domain(self):
+        for wizard in self:
+            domain = ['|', ('company_id', '=', wizard.company_id.id), ('company_id', '=', False)]
+            if wizard.dest_location_id:
+                domain += ['|', ('location_id', '=', False), ('location_id', '=', wizard.dest_location_id.id)]
+            elif len(wizard.quant_ids.location_id) == 1:
+                domain += ['|', ('location_id', '=', False), ('location_id', '=', wizard.quant_ids.location_id.id)]
+            wizard.dest_package_id_domain = domain
+
+    @api.depends('dest_package_id_domain')
+    def _compute_dest_package_id(self):
+        for wizard in self:
+            if wizard.dest_package_id and wizard.dest_package_id not in wizard.dest_package_id.search(literal_eval(wizard.dest_package_id_domain)):
+                wizard.dest_package_id = False
+
+    def action_relocate_quants(self):
+        self.ensure_one()
+        lot_ids = self.quant_ids.lot_id
+        product_ids = self.quant_ids.product_id
+
+        if not self.dest_location_id and not self.dest_package_id:
+            return
+        self.quant_ids.action_clear_inventory_quantity()
+
+        if self.is_partial_package and not self.dest_package_id:
+            quants_to_unpack = self.quant_ids.filtered(lambda q: not all(sub_q in self.quant_ids.ids for sub_q in q.package_id.quant_ids.ids))
+            quants_to_unpack.move_quants(location_dest_id=self.dest_location_id, message=self.message, unpack=True)
+            self.quant_ids -= quants_to_unpack
+        self.quant_ids.move_quants(location_dest_id=self.dest_location_id, package_dest_id=self.dest_package_id, message=self.message)
+
+        if self.env.context.get('default_lot_id', False) and len(lot_ids) == 1:
+            return lot_ids.action_lot_open_quants()
+        elif self.env.context.get('single_product', False) and len(product_ids) == 1:
+            return product_ids.action_update_quantity_on_hand()
+        return self.env['ir.actions.server']._for_xml_id(self.env.context.get('action_ref', 'stock.action_view_quants'))

--- a/addons/stock/wizard/stock_quant_relocate.xml
+++ b/addons/stock/wizard/stock_quant_relocate.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock_quant_relocate_view_form" model="ir.ui.view">
+        <field name="name">Stock Relocation</field>
+        <field name="model">stock.quant.relocate</field>
+        <field name="arch" type="xml">
+            <form string="Relocate your stock">
+                <group>
+                    <field name="quant_ids" invisible="1"/>
+                    <field name="company_id" invisible="1"/>
+                    <field name="dest_location_id" string="To Location" options="{'no_create': True}"/>
+                    <field name="dest_package_id_domain" invisible="1"/>
+                    <field name="dest_package_id" string="To Package" groups="stock.group_tracking_lot" readonly="is_multi_location"/>
+                    <field name="message" placeholder="Product Relocated"/>
+                </group>
+                <field name="is_partial_package" invisible="1"/>
+                <field name="is_multi_location" invisible="1"/>
+                <div class="alert alert-danger mb8" role="alert" groups="stock.group_tracking_lot" invisible="not is_partial_package">
+                    You are about to move quantities in a package without moving the full package.
+                    Those quantities will be removed from the following package(s):
+                    <field name="partial_package_names"/>
+                </div>
+                <div class="alert alert-danger mb8" role="alert" groups="stock.group_tracking_lot" invisible="not is_multi_location">
+                    The quantities selected do not all belong to the same location.
+                    You may not assign them a package without moving them to a common location.
+                </div>
+                <footer>
+                    <button name="action_relocate_quants" string="Confirm" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -76,8 +76,8 @@ class StockQuant(models.Model):
             else:
                 super(StockQuant, inventories)._apply_inventory()
 
-    def _get_inventory_move_values(self, qty, location_id, location_dest_id, out=False):
-        res_move = super()._get_inventory_move_values(qty, location_id, location_dest_id, out)
+    def _get_inventory_move_values(self, qty, location_id, location_dest_id, package_id=False, package_dest_id=False):
+        res_move = super()._get_inventory_move_values(qty, location_id, location_dest_id, package_id, package_dest_id)
         if not self.env.context.get('inventory_name'):
             force_period_date = self.env.context.get('force_period_date', False)
             if force_period_date:


### PR DESCRIPTION
Add a new button Relocate on the stock.quant views.
This button appears when selecting 1+ quants and allows to create a stock.move to another location.
This button also allows to change the package of the quant(s) selected.

LIMITS:
- if a quant has reserved quantities, it will unreserved along with the related smls
- if a package is not fully moved to a new location, the quants selected will be unpacked
- no intercompany moves are allowed
- only available for stock manager roles

Addendum: there are 2 functions with almost identical names:
- action_set_inventory_quantity_to_zero
- action_set_inventory_quantity_zero

renaming action_set_inventory_quantity_to_zero to action_clear_inventory_quantity to make them easier to differentiate

task 3346212

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
