### PR TITLE
[FIX] [15.0] sale_quotation_builder: fix translation for `website_description` field

### DIFF
--- a/addons/sale_quotation_builder/models/product_template.py
+++ b/addons/sale_quotation_builder/models/product_template.py
@@ -17,8 +17,8 @@ class ProductTemplate(models.Model):
     def _compute_quotation_description(self):
         for record in self:
             if record.quotation_only_description:
-                record.quotation_description = record.quotation_only_description
+                record.quotation_description = record.with_context(lang=self.env.lang).quotation_only_description
             elif hasattr(record, 'website_description') and record.website_description:
-                record.quotation_description = record.website_description
+                record.quotation_description = record.with_context(lang=self.env.lang).website_description
             else:
                 record.quotation_description = ''

--- a/addons/sale_quotation_builder/models/sale_order.py
+++ b/addons/sale_quotation_builder/models/sale_order.py
@@ -8,55 +8,23 @@ from odoo.tools.translate import html_translate
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate, sanitize_form=False,
+                                      compute='_compute_website_description')
 
-    @api.onchange('partner_id')
-    def onchange_update_description_lang(self):
-        if not self.sale_order_template_id:
-            return
-        else:
-            template = self.sale_order_template_id.with_context(lang=self.partner_id.lang)
-            self.website_description = template.website_description
-
-    def _compute_line_data_for_template_change(self, line):
-        vals = super(SaleOrder, self)._compute_line_data_for_template_change(line)
-        vals.update(website_description=line.website_description)
-        return vals
-
-    def _compute_option_data_for_template_change(self, option):
-        vals = super(SaleOrder, self)._compute_option_data_for_template_change(option)
-        vals.update(website_description=option.website_description)
-        return vals
-
-    @api.onchange('sale_order_template_id')
-    def onchange_sale_order_template_id(self):
-        ret = super(SaleOrder, self).onchange_sale_order_template_id()
-        if self.sale_order_template_id:
-            template = self.sale_order_template_id.with_context(lang=self.partner_id.lang)
-            self.website_description = template.website_description
-        return ret
+    def _compute_website_description(self):
+        for r in self:
+            r.website_description = r.sale_order_template_id.with_context(lang=self.env.lang).website_description
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    website_description = fields.Html('Website Description', sanitize=False, translate=html_translate, sanitize_form=False)
+    website_description = fields.Html('Website Description', sanitize=False, translate=html_translate, sanitize_form=False,
+                                      compute='_compute_website_description')
 
-    @api.model
-    def create(self, values):
-        values = self._inject_quotation_description(values)
-        return super(SaleOrderLine, self).create(values)
-
-    def write(self, values):
-        values = self._inject_quotation_description(values)
-        return super(SaleOrderLine, self).write(values)
-
-    def _inject_quotation_description(self, values):
-        values = dict(values or {})
-        if not values.get('website_description') and values.get('product_id'):
-            product = self.env['product.product'].browse(values['product_id'])
-            values.update(website_description=product.quotation_description)
-        return values
+    def _compute_website_description(self):
+        for r in self:
+            r.website_description = r.product_id.with_context(lang=self.env.lang).quotation_description
 
 
 class SaleOrderOption(models.Model):
@@ -64,15 +32,6 @@ class SaleOrderOption(models.Model):
 
     website_description = fields.Html('Website Description', sanitize_attributes=False, translate=html_translate)
 
-    @api.onchange('product_id', 'uom_id')
-    def _onchange_product_id(self):
-        ret = super(SaleOrderOption, self)._onchange_product_id()
-        if self.product_id:
-            product = self.product_id.with_context(lang=self.order_id.partner_id.lang)
-            self.website_description = product.quotation_description
-        return ret
-
-    def _get_values_to_add_to_order(self):
-        values = super(SaleOrderOption, self)._get_values_to_add_to_order()
-        values.update(website_description=self.website_description)
-        return values
+    def _compute_website_description(self):
+        for r in self:
+            r.website_description = r.product_id.with_context(lang=self.env.lang).quotation_description


### PR DESCRIPTION
Current behavior before PR:
- With current logic, all translations of field `website_description` will follow the translation in the client's language.
- This won't be a problem if the client doesn't change their language outside of the portal page.
- When they change to another language, the Sale Order information will get mixed up in multiple languages, which will annoy them.

Solution:
- set compute store=false for `website_description` field, each time this translation is viewed, it will be based on the language in the environment.
- This I find not affected much in terms of design

Desired behavior after PR is merged: Information of Sell Orders will always be in the same language.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
