### PR TITLE
[FIX] web: prevent autocomplete crash on selection

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -89,6 +89,11 @@ export class AutoComplete extends Component {
         return false;
     }
 
+    get activeOption() {
+        const [sourceIndex, optionIndex] = this.state.activeSourceOption;
+        return this.sources[sourceIndex].options[optionIndex];
+    }
+
     open(useInput = false) {
         this.state.open = true;
         return this.loadSources(useInput);
@@ -166,8 +171,7 @@ export class AutoComplete extends Component {
             this.state.activeSourceOption[1] === optionIndex
         );
     }
-    selectOption(indices, params = {}) {
-        const option = this.sources[indices[0]].options[indices[1]];
+    selectOption(option, params = {}) {
         if (option.unselectable) {
             this.inputRef.el.value = "";
             this.close();
@@ -283,7 +287,7 @@ export class AutoComplete extends Component {
                 if (!this.isOpened || !this.state.activeSourceOption) {
                     return;
                 }
-                this.selectOption(this.state.activeSourceOption);
+                this.selectOption(this.activeOption);
                 break;
             case "escape":
                 if (!this.isOpened) {
@@ -300,7 +304,7 @@ export class AutoComplete extends Component {
                     this.state.activeSourceOption &&
                     (this.state.navigationRev > 0 || this.inputRef.el.value.length > 0)
                 ) {
-                    this.selectOption(this.state.activeSourceOption);
+                    this.selectOption(this.activeOption);
                 }
                 this.close();
                 return;
@@ -330,8 +334,8 @@ export class AutoComplete extends Component {
     onOptionMouseLeave() {
         this.state.activeSourceOption = null;
     }
-    onOptionClick(indices) {
-        this.selectOption(indices);
+    onOptionClick(option) {
+        this.selectOption(option);
         this.inputRef.el.focus();
     }
 

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -45,7 +45,7 @@
                                     t-att-class="option.classList"
                                     t-on-mouseenter="() => this.onOptionMouseEnter([source_index, option_index])"
                                     t-on-mouseleave="() => this.onOptionMouseLeave([source_index, option_index])"
-                                    t-on-click="() => this.onOptionClick([source_index, option_index])"
+                                    t-on-click="() => this.onOptionClick(option)"
                                     t-on-pointerdown="() => this.ignoreBlur = true"
                                 >
                                     <a


### PR DESCRIPTION
Before this commit, it could happen that the autocomplete does not find the option to select. Now, we give the option to select so we're sure that the option exists when we select it.

runbot errors: 5759, 102534, 111418