### PR TITLE
[IMP] hr_holidays: allow allocation validation from calendar popover

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1027,7 +1027,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         current_employee = self.env.user.employee_id
         self.filtered(lambda hol: hol.validation_type == 'both').write({'state': 'validate1', 'first_approver_id': current_employee.id})
 
-        self.filtered(lambda hol: not hol.validation_type == 'both').action_validate()
+        self.filtered(lambda hol: hol.validation_type != 'both').action_validate(check_state)
         if not self.env.context.get('leave_fast_create'):
             self.activity_update()
         return True
@@ -1117,13 +1117,12 @@ Attempting to double-book your time off won't magically make your vacation 2x be
 
         split_leaves.filtered(lambda l: l.state in 'validate')._validate_leave_request()
 
-    def action_validate(self):
+    def action_validate(self, check_state=True):
         current_employee = self.env.user.employee_id
         leaves = self._get_leaves_on_public_holiday()
         if leaves:
             raise ValidationError(_('The following employees are not supposed to work during that period:\n %s') % ','.join(leaves.mapped('employee_id.name')))
-
-        if any(holiday.state not in ['confirm', 'validate1'] and holiday.validation_type != 'no_validation' for holiday in self):
+        if check_state and any(holiday.state not in ['confirm', 'validate1'] and holiday.validation_type != 'no_validation' for holiday in self):
             raise UserError(_('Time off request must be confirmed in order to approve it.'))
 
         self.write({'state': 'validate'})

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -17,6 +17,8 @@
                 <field name="name"/>
                 <field name="employee_id" filters="1" invisible="1"/>
                 <field name="is_hatched" invisible="1"/>
+                <field name="state" invisible="1"/>
+                <field name="leave_manager_id" invisible="1"/>
             </calendar>
         </field>
     </record>
@@ -26,13 +28,23 @@
         <field name="model">hr.leave.report.calendar</field>
         <field name="arch" type="xml">
             <form string="Time Off">
-                <group>
-                    <field name="name"/>
-                    <field name="start_datetime"/>
-                    <field name="stop_datetime"/>
-                    <field name="employee_id" />
-                    <field name="description"/>
-                </group>
+                <sheet class="py-0 pe-0 overflow-hidden">
+                    <widget name="web_ribbon" title="Cancelled" bg_color="text-bg-danger" invisible="state != 'cancel'"/>
+                    <widget name="web_ribbon" title="Refused" bg_color="bg-danger" invisible="state != 'refuse'"/>
+                    <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
+                    <group>
+                        <field name="name"/>
+                        <field name="start_datetime"/>
+                        <field name="stop_datetime"/>
+                        <field name="employee_id" />
+                        <field name="description"/>
+                    </group>
+                    <footer class="d-flex justify-content-end gap-1">
+                        <button name="action_approve" string="Approve" type="object" close="1" invisible="state not in ['confirm', 'refuse'] or not is_manager"/>
+                        <button name="action_validate" string="Validate" type="object" close="1" invisible="state != 'validate1' or not is_manager"/>
+                        <button name="action_refuse" string="Refuse" type="object" close="1" invisible="state == 'refuse' or not is_manager"/>
+                    </footer>
+                </sheet>
             </form>
         </field>
     </record>
@@ -54,6 +66,7 @@
                 <filter string="Off Today" name="off_today" domain="[('is_absent', '=', True)]" help="Employees Off Today"/>
                 <separator/>
                 <filter string="Approved" name="validate" domain="[('state', '=', 'validate')]" help="validate"/>
+                <filter name="refused_leaves" string="Refused" domain="[('state', '=', 'refuse')]"/>
                 <filter string="Waiting for Approval" name="approve" domain="[('state','in',('confirm','validate1'))]"/>
                 <filter name="groupby_job_id" string="Job Position" context="{'group_by': 'job_id'}"/>
                 <filter name="groupby_company_id" string="Company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>

--- a/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.js
+++ b/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.js
@@ -1,25 +1,37 @@
-/** @odoo-module */
-
 import { CalendarCommonPopover } from "@web/views/calendar/calendar_common/calendar_common_popover";
-
+import { onWillStart } from "@odoo/owl";
+import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 
 export class TimeOffCalendarCommonPopover extends CalendarCommonPopover {
+    static subTemplates = {
+        ...CalendarCommonPopover.subTemplates,
+        footer: "hr_holidays.TimeOffCalendarCommonPopover.footer",
+    };
+
     setup() {
         super.setup();
-
-        this.dialog = useService('dialog');
-        this.action = useService('action');
+        this.orm = useService("orm");
+        this.viewType = "calendar";
+        onWillStart(async () => {
+            this.record = this.props.record.rawRecord;
+            this.state = this.record.state;
+            this.isManager = (await user.hasGroup("hr_holidays.group_hr_holidays_user")) || this.record.leave_manager_id?.[0] === user.userId;
+        });
     }
 
     get isEventDeletable() {
-        const record = this.props.record.rawRecord;
-        const state = record.state;
-        return record.can_cancel || state && !['validate', 'refuse', 'cancel'].includes(state);
+        return this.props.record.rawRecord.can_cancel || this.state && !['validate', 'refuse', 'cancel'].includes(this.state);
     }
 
     get isEventEditable() {
-        const state = this.props.record.rawRecord.state;
-        return state !== undefined;
+        return this.state !== undefined;
+    }
+
+    async onClickButton(ev) {
+        const args = (ev.target.name === "action_approve") ? [this.record.id, false] : [this.record.id];
+        await this.orm.call("hr.leave", ev.target.name, args);
+        await this.props.model.load();
+        this.props.close();
     }
 }

--- a/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.xml
+++ b/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_holidays.TimeOffCalendarCommonPopover.footer" t-inherit="web.CalendarCommonPopover.footer" t-inherit-mode="primary" owl="1">
+        <xpath expr="//t" position="inside">
+            <button t-attf-class="btn btn-secondary"
+                t-if="isManager and ['confirm', 'refuse'].includes(state)"
+                name="action_approve" t-on-click="onClickButton" data-hotkey="g">Approve</button>
+            <button t-attf-class="btn btn-secondary"
+                t-if="isManager and state === 'validate1'"
+                name="action_validate" t-on-click="onClickButton" data-hotkey="g">Validate</button>
+            <button t-attf-class="btn btn-secondary"
+                t-if="isManager and state !== 'refuse'"
+                name="action_refuse" t-on-click="onClickButton" data-hotkey="z">Refuse</button>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
In this commit, a validation, approval, and refuse button have been added to the footer of the popover.
These buttons are visible to both the administrator and the leave manager of the employee

task-3329594

see odoo/enterprise#41181

