### PR TITLE
[FIX] stock_account: update cost after fifo product revaluation

### DIFF
--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -218,7 +218,7 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         revaluation_wizard.account_id = self.stock_valuation_account
         revaluation_wizard.save().action_validate_revaluation()
 
-        self.assertEqual(self.product1.standard_price, 2)
+        self.assertEqual(self.product1.standard_price, 3)
 
         # Check the creation of stock.valuation.layer
         new_layer = self.env['stock.valuation.layer'].search([('product_id', '=', self.product1.id)], order="create_date desc, id desc", limit=1)

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3877,3 +3877,53 @@ class TestStockValuation(SavepointCase):
         self._make_in_move(self.product1, 2, unit_cost=6)
         self.product1.write({'standard_price': 7})
         self.assertEqual(self.product1.value_svl, 49)
+
+    def test_average_manual_revaluation(self):
+        self.product1.categ_id.property_cost_method = 'average'
+
+        self._make_in_move(self.product1, 1, unit_cost=20)
+        self._make_in_move(self.product1, 1, unit_cost=30)
+        self.assertEqual(self.product1.standard_price, 25)
+
+        Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            'default_product_id': self.product1.id,
+            'default_company_id': self.env.company.id,
+            'default_account_id': self.stock_valuation_account,
+            'default_added_value': -10.0,
+        })).save().action_validate_revaluation()
+
+        self.assertEqual(self.product1.standard_price, 20)
+
+    def test_fifo_manual_revaluation(self):
+        revaluation_vals = {
+            'default_product_id': self.product1.id,
+            'default_company_id': self.env.company.id,
+            'default_account_id': self.stock_valuation_account,
+        }
+        self.product1.categ_id.property_cost_method = 'fifo'
+
+        self._make_in_move(self.product1, 1, unit_cost=15)
+        self._make_in_move(self.product1, 1, unit_cost=30)
+        self.assertEqual(self.product1.standard_price, 15)
+
+        Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            **revaluation_vals,
+            'default_added_value': -10.0,
+        })).save().action_validate_revaluation()
+
+        self.assertEqual(self.product1.standard_price, 10)
+
+        Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            **revaluation_vals,
+            'default_added_value': -25.0,
+        })).save().action_validate_revaluation()
+
+        self.assertEqual(self.product1.standard_price, 0)
+
+        revaluation = Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            **revaluation_vals,
+            'default_added_value': -15.0,
+        })).save()
+
+        with self.assertRaises(UserError):
+            revaluation.action_validate_revaluation()


### PR DESCRIPTION
When performing a manual stock revaluation, the resulting product cost does not reflect the value difference as it is currently the case for products with the costing method set to average.

Running the `_run_fifo` method with a zero quantity after a manual revaluation results in the correct product cost update.