### PR TITLE
[IMP] calendar: update resource in mails

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -27,6 +27,11 @@
             <t t-if="is_online and object.state != 'accepted' and object.event_id.appointment_type_id.resource_manual_confirmation">
                 You will receive a mail of confirmation with more details when your appointment will be confirmed.
             </t>
+            <t t-if="is_online and object.event_id.children_ids.appointment_resource_id">
+                <br/><br/>
+                You will also receive emails for each resource that was required for your requested number of attendees.
+                Canceling any of these will cancel all of them.
+            </t>
         </t>
         <t t-elif="is_online and target_responsible">
             <t t-if="customer">
@@ -112,12 +117,20 @@
                     </li>
                 </ul></li>
                 <li t-if="is_online and object.event_id.appointment_type_id.resource_manage_capacity">
-                    For: <t t-out="object.event_id.resource_total_capacity_reserved"/> people
+                    For: <t t-out="object.event_id.resource_capacity_reserved"/> people
                 </li>
                 <li t-if="is_online and object.event_id.appointment_type_id.assign_method != 'time_auto_assign'">
                     Resources
                     <ul>
-                        <li t-foreach="object.event_id.appointment_resource_ids" t-as="resource">
+                        <li t-foreach="object.event_id.appointment_resource_id" t-as="resource">
+                            <span style="margin-left:5px" t-out="resource.name or ''">Table 1</span>
+                        </li>
+                    </ul>
+                </li>
+                <li t-if="is_online and object.event_id.appointment_type_id.assign_method != 'time_auto_assign'">
+                    Resources
+                    <ul>
+                        <li t-foreach="object.event_id.appointment_resource_id" t-as="resource">
                             <span style="margin-left:5px" t-out="resource.name or ''">Table 1</span>
                         </li>
                     </ul>

--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -27,11 +27,6 @@
             <t t-if="is_online and object.state != 'accepted' and object.event_id.appointment_type_id.resource_manual_confirmation">
                 You will receive a mail of confirmation with more details when your appointment will be confirmed.
             </t>
-            <t t-if="is_online and object.event_id.children_ids.appointment_resource_id">
-                <br/><br/>
-                You will also receive emails for each resource that was required for your requested number of attendees.
-                Canceling any of these will cancel all of them.
-            </t>
         </t>
         <t t-elif="is_online and target_responsible">
             <t t-if="customer">
@@ -117,20 +112,12 @@
                     </li>
                 </ul></li>
                 <li t-if="is_online and object.event_id.appointment_type_id.resource_manage_capacity">
-                    For: <t t-out="object.event_id.resource_capacity_reserved"/> people
+                    For: <t t-out="object.event_id.resource_total_capacity_reserved"/> people
                 </li>
                 <li t-if="is_online and object.event_id.appointment_type_id.assign_method != 'time_auto_assign'">
                     Resources
                     <ul>
-                        <li t-foreach="object.event_id.appointment_resource_id" t-as="resource">
-                            <span style="margin-left:5px" t-out="resource.name or ''">Table 1</span>
-                        </li>
-                    </ul>
-                </li>
-                <li t-if="is_online and object.event_id.appointment_type_id.assign_method != 'time_auto_assign'">
-                    Resources
-                    <ul>
-                        <li t-foreach="object.event_id.appointment_resource_id" t-as="resource">
+                        <li t-foreach="object.event_id.appointment_resource_ids" t-as="resource">
                             <span style="margin-left:5px" t-out="resource.name or ''">Table 1</span>
                         </li>
                     </ul>

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=94, admin=98):
+        with self.assertQueryCount(__system__=95, admin=99):
             leave.action_validate()
         leave.action_refuse()
 

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=95, admin=99):
+        with self.assertQueryCount(__system__=94, admin=98):
             leave.action_validate()
         leave.action_refuse()
 


### PR DESCRIPTION
A change in the data structure to represent resource bookings
requires we update the mail template that uses them.

As bookings for multiple resources will now send multiple confirmations
we add a note in the last email to specify the other emails are linked.

task-338900
