### PR TITLE
[FIX] base: duplicate file uploading not blocked

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -5926,6 +5926,12 @@ msgid "), are you sure to create a new one?"
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_attachment.py:0
+#, python-format
+msgid "(copy)"
+msgstr ""
+
+#. module: base
 #: model_terms:ir.ui.view,arch_db:base.wizard_lang_export
 msgid ", or your preferred text editor"
 msgstr ""


### PR DESCRIPTION
Reproduction:
1. Install Email Marketing, create a new mailing
2. Choose a template and edit it
3. Add a picture to the mail body and choose upload an image
4. Upload the same image again, save the template
5. Go to Settings -> Technical -> Attachment
6. The same image was uploaded twice

Fix: currently when we have the same file uploaded and it exists in the
file system, we create an attachment and link this new attachment to the
file in the file system. The clients get confused since there are two
identical attachment file even if the actual file is only uploaded once
This fix will add a `(copy)` to the display name when the exact file
exists in the file system for images

opw-3171496
task-3223449


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
