### PR TITLE
[REF] base: Speed-up attachments searches bypassing "unaccent" method call

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -400,7 +400,7 @@ class IrAttachment(models.Model):
     type = fields.Selection([('url', 'URL'), ('binary', 'File')],
                             string='Type', required=True, default='binary', change_default=True,
                             help="You can either upload a file from your computer or copy/paste an internet link to your file.")
-    url = fields.Char('Url', index='btree_not_null', size=1024)
+    url = fields.Char('Url', index='btree_not_null', size=1024, unaccent=False)
     public = fields.Boolean('Is public document')
 
     # for external access


### PR DESCRIPTION
Original query using unaccent method:

```sql
SELECT  "ir_attachment".id
FROM "ir_attachment"
WHERE "ir_attachment"."res_field" IS NULL
  AND unaccent("ir_attachment"."url" :: text) like unaccent('/web/assets/%-%/web.report_assets_common.min.css')
  AND NOT unaccent("ir_attachment"."url" :: text) like unaccent('/web/assets/%-f9fe706/%%%')
ORDER BY "ir_attachment"."id" DESC
````

Result analyze:

    Gather Merge  (cost=157378.67..157425.49 rows=391 width=4) (actual time=664.876..700.333 rows=1 loops=1)
    Workers Planned: 4
    Workers Launched: 4
    ->  Sort  (cost=156378.62..156378.86 rows=98 width=4) (actual time=633.389..633.390 rows=0 loops=5)
            Sort Key: id DESC
            Sort Method: quicksort  Memory: 25kB
            Worker 0:  Sort Method: quicksort  Memory: 25kB
            Worker 1:  Sort Method: quicksort  Memory: 25kB
            Worker 2:  Sort Method: quicksort  Memory: 25kB
            Worker 3:  Sort Method: quicksort  Memory: 25kB
            ->  Parallel Seq Scan on ir_attachment  (cost=0.00..156375.38 rows=98 width=4) (actual time=633.272..633.290 rows=0 loops=5)
                Filter: ((res_field IS NULL) AND (unaccent((url)::text) ~~ unaccent('/web/assets/%-%/web.report_assets_common.min.css'::text)) AND (unaccent((url)::text) !~~ unaccent('/web/assets/%-f9fe706/%%%'::text)))
                Rows Removed by Filter: 822111
    Planning Time: 0.183 ms
    JIT:
    Functions: 20
    Options: Inlining false, Optimization false, Expressions true, Deforming true
    Timing: Generation 2.846 ms, Inlining 0.000 ms, Optimization 1.948 ms, Emission 27.531 ms, Total 32.324 ms
    Execution Time: 701.255 ms

New query bypassing unaccent method:

```sql
SELECT "ir_attachment".id
FROM "ir_attachment"
WHERE "ir_attachment"."res_field" IS NULL
    AND "ir_attachment"."url" :: text like '/web/assets/%-%/web.report_assets_common.min.css'
    AND NOT "ir_attachment"."url" :: text like '/web/assets/%-f9fe706/%%%'
ORDER BY  "ir_attachment"."id" DESC
```

Result analyze:

    Sort  (cost=10.57..10.74 rows=66 width=4) (actual time=0.662..0.663 rows=1 loops=1)
    Sort Key: id DESC
    Sort Method: quicksort  Memory: 25kB
    ->  Index Scan using ir_attachment_url_index on ir_attachment  (cost=0.56..8.58 rows=66 width=4) (actual time=0.644..0.655 rows=1 loops=1)
            Index Cond: (((url)::text >= '/web/assets/'::text) AND ((url)::text < '/web/assets0'::text))
            Filter: ((res_field IS NULL) AND ((url)::text ~~ '/web/assets/%-%/web.report_assets_common.min.css'::text) AND ((url)::text !~~ '/web/assets/%-f9fe706/%%%'::text))
            Rows Removed by Filter: 310
    Planning Time: 0.403 ms
    Execution Time: 0.693 ms

Stats from production database this query could be executed 30k times
 - ![Screenshot 2023-05-19 at 9 58 51](https://github.com/odoo/odoo/assets/6644187/5b7d782a-0a70-4b92-ab80-353309718ada)

Using unaccent method the cumulative time is:
 - 30k*700ms=350minutes (cumulative)

Bypassing unaccent method the cumulative time is:
    30k*1ms=0.5minutes  (cumulative)

It is ~700x faster

Notice it could be worse for a database not tuned
`SET max_parallel_workers_per_gather = 0;`
The result is 2853.736 ms
It means it could be ~2600x faster

Also, starting profiler with postgresql.log and pgbadger this query could be in the TOP:
 - <img width="1092" alt="Screen Shot 2023-05-19 at 11 20 19" src="https://github.com/odoo/odoo/assets/6644187/0b9751a1-4892-43c8-8929-acadcaff05e4">


Related to https://github.com/odoo/odoo/pull/121846
Continuation from https://github.com/odoo/odoo/pull/121867#issuecomment-1576111262
