### PR TITLE
[FIX] base_import: raise ImportValidationError if user select invalid seperator

### DIFF
--- a/addons/base_import/i18n/base_import.pot
+++ b/addons/base_import/i18n/base_import.pot
@@ -533,6 +533,12 @@ msgid "Invalid cell value at row %(row)s, column %(col)s: %(cell_value)s"
 msgstr ""
 
 #. module: base_import
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
+msgid "Invalid separator or text delimiter"
+msgstr ""
+
+#. module: base_import
 #. openerp-web
 #: code:addons/base_import/static/src/legacy/js/import_action.js:0
 #, python-format
@@ -799,6 +805,12 @@ msgstr ""
 #. module: base_import
 #: model:ir.model.fields,field_description:base_import.field_base_import_tests_models_preview__somevalue
 msgid "Some Value"
+msgstr ""
+
+#. module: base_import
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
+msgid "Sorry, something went wrong"
 msgstr ""
 
 #. module: base_import

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1042,12 +1042,17 @@ class Import(models.TransientModel):
 
         if options.get('has_headers'):
             rows_to_import = rows_to_import[1:]
-        data = [
-            list(row) for row in map(mapper, rows_to_import)
-            # don't try inserting completely empty rows (e.g. from
-            # filtering out o2m fields)
-            if any(row)
-        ]
+        try:
+            data = [
+                list(row) for row in map(mapper, rows_to_import)
+                # don't try inserting completely empty rows (e.g. from
+                # filtering out o2m fields)
+                if any(row)
+            ]
+        except IndexError:
+            raise ImportValidationError(_("Invalid separator or text delimiter"))
+        except Exception:
+            raise ImportValidationError(_("Sorry, something went wrong"))
 
         # slicing needs to happen after filtering out empty rows as the
         # data offsets from load are post-filtering


### PR DESCRIPTION
When a user tries to import the CSV file with a different separator at that time, the values in `mapper` and `rows_to_import` are not correctly mapped. So the traceback will be generated.

Steps to reproduce:
1. Install the `accounting` module.
2. Click on import in the bank statement.
3. Select any CSV file for the bank statement line or can download and import
this file https://drive.google.com/file/d/1lnScw4RN6T01pOkyNON8vvb3FQOPiy1O/view?usp=drive_link
4. Select `semicolon` in the separator.
5. Click on the `test` or `Import` button. 

Error: A traceback appears  `IndexError: list index out of range.`
 
Traceback will be generated.
```
Traceback (most recent call last):
  File "/home/odoo/odoo/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/home/odoo/odoo/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/home/odoo/odoo/odoo/odoo/http.py", line 368, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/odoo/odoo/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/odoo/odoo/odoo/odoo/http.py", line 357, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/odoo/odoo/odoo/odoo/http.py", line 921, in __call__
    return self.method(*args, **kw)
  File "/home/odoo/odoo/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/odoo/odoo/addons/web/controllers/main.py", line 1324, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/odoo/odoo/addons/web/controllers/main.py", line 1316, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/odoo/odoo/odoo/api.py", line 464, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/odoo/odoo/odoo/api.py", line 451, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/odoo/enterprise/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py", line 158, in execute_import
    res = super(AccountBankStmtImportCSV, self.with_context(bank_statement_id=statement.id)).execute_import(fields, columns, options, dryrun=dryrun)
  File "/home/odoo/odoo/odoo/addons/base_import/models/base_import.py", line 1303, in execute_import
    input_file_data, import_fields = self._convert_import_data(fields, options)
  File "/home/odoo/odoo/odoo/addons/base_import/models/base_import.py", line 1046, in _convert_import_data
    data = [
  File "/home/odoo/odoo/odoo/addons/base_import/models/base_import.py", line 1046, in <listcomp>
    data = [
```

This commit fixes the above issue by throwing 'ImportValidationError' if the user selects an invalid separator at the time of importing data from CSV.

sentry-4021250095
