### PR TITLE
[FIX] base:  handle unlink action  for reporting views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -913,6 +913,8 @@ actual arch.
 
         if node.tag in ('kanban', 'tree', 'form', 'activity', 'calendar'):
             for action, operation in (('create', 'create'), ('delete', 'unlink'), ('edit', 'write')):
+                if action == 'delete' and not Model._auto:
+                    node.set('delete', 'false')
                 if (not node.get(action) and
                         not Model.check_access_rights(operation, raise_exception=False) or
                         not self._context.get(action, True) and is_base_model):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3423,7 +3423,8 @@ Fields:
         """
         if not self:
             return True
-
+        if not self._auto:
+            raise ValidationError(_('You cannot delete these records.'))
         self.check_access_rights('unlink')
         self.check_access_rule('unlink')
         self._check_concurrency()

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3423,6 +3423,7 @@ Fields:
         """
         if not self:
             return True
+
         if not self._auto:
             raise ValidationError(_('You cannot delete these records.'))
         self.check_access_rights('unlink')


### PR DESCRIPTION
When the user tries to delete a record(s) from the reporting views, this
traceback will be generated. 

Steps to produce:

- Settings > Technical > Actions > Window Actions
- Search for the Work Entries Analysis. Open it and add a 'tree' as view_mode
 in that action.
- Payroll > Reporting > Work Entries Analysis menu and select the tree view.
- Select one or more records and try to delete these records.

Error:  A traceback appears: "cannot delete from view "hr_work_entry_report"

Sentry Traceback: 
```ObjectNotInPrerequisiteState: cannot delete from view "hr_work_entry_report"
DETAIL:  Views that do not select from a single table or view are not automatically updatable.
HINT:  To enable deleting from the view, provide an INSTEAD OF DELETE trigger or an unconditional ON DELETE DO INSTEAD rule.

  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 3649, in unlink
    cr.execute(query, (sub_ids,))
  File "odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
```

Solution 1:
Solved this issue by hiding the 'Delete' button from the action menu
on the reporting models.
https://github.com/odoo-dev/odoo/commit/73959ead0c4437421384b749467e4c3600f6d479

Solution 2:
Solved this issue by adding the validation message on click of the Delete button
for reporting models.
https://github.com/odoo-dev/odoo/commit/2f65e5cf5e23d4a5d939327550e9ba2e75037e7a

I provided two alternative solutions  like  solution 1
and solution 2 commit wisely respectively.

Sentry-3975590063