### PR TITLE
[FIX] mrp: incorrect quantity on multiple finished moves

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -474,6 +474,11 @@ class StockMoveLine(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_done_or_cancel(self):
         for ml in self:
+            rounding = ml.product_uom_id.rounding
+            # it's ok to delete move lines with 0 qty_done and 0 quantity reserved
+            if float_is_zero(ml.product_uom_qty, precision_rounding=rounding) and float_is_zero(ml.qty_done, precision_rounding=rounding):
+                continue
+
             if ml.state in ('done', 'cancel'):
                 raise UserError(_('You can not delete product moves if the picking is done. You can only correct the done quantities.'))
 


### PR DESCRIPTION
### Before this commit:
When changing the quantity produced on a manufacturing order that has multiple finished move lines, all lines are set to the quantity produced, resulting in an incorrect total quantity.

### After this commit:
When changing the quantity produced, the first line is set to the quantity produced, and other lines are set to 0.

OPW-3338440
