### PR TITLE
[REF] allow global specification for field options

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -69,7 +69,7 @@
                                         <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                                         <field name="deprecated"/>
                                         <field name="group_id"/>
-                                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                        <field name="company_id" groups="base.group_multi_company"/>
                                     </group>
                                 </group>
                             </page>
@@ -101,7 +101,7 @@
                     <field name="tag_ids" optional="hide" widget="many2many_tags"/>
                     <field name="allowed_journal_ids" optional="hide" widget="many2many_tags"/>
                     <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
-                    <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                     <button name="action_read_account" type="object" string="Setup" class="float-end btn-secondary"/>
                 </tree>
             </field>

--- a/addons/account/views/account_group_views.xml
+++ b/addons/account/views/account_group_views.xml
@@ -14,7 +14,7 @@
                         <div>
                             From <field name="code_prefix_start" class="oe_inline"/> to <field name="code_prefix_end" class="oe_inline"/>
                         </div>
-                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                 </sheet>
                 </form>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -51,7 +51,7 @@
                                 <field name="type"/>
                             </group>
                             <group>
-                                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="country_code" invisible="1"/>
                             </group>
                         </group>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -414,7 +414,7 @@
                     <field name="ref" optional="hide"/>
                     <field name="invoice_user_id" optional="hide" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Salesperson" widget="many2one_avatar_user"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
-                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="hide"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                     <field name="company_id" groups="!base.group_multi_company" invisible="1"/>
                     <field name="amount_untaxed_signed" string="Tax Excluded" sum="Total" optional="show"/>
                     <field name="amount_tax_signed" string="Tax" sum="Total" optional="hide"/>

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -41,7 +41,7 @@
                             <h1><field name="name" nolabel="1" placeholder="e.g. 30 days"/></h1>
                         </div>
                         <group>
-                            <field name="company_id" options="{'no_create': True}" class="w-25" groups="base.group_multi_company"/>
+                            <field name="company_id" class="w-25" groups="base.group_multi_company"/>
                             <label for="early_discount"/>
                             <div class="o_field_highlight">
                                 <field name="early_discount"/>

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -13,7 +13,7 @@
                     <field name="type_tax_use"/>
                     <field name="tax_scope"/>
                     <field name="invoice_label"/>
-                    <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                     <field name="country_id" optional="hide"/>
                     <field name="active" widget="boolean_toggle"/>
                 </tree>
@@ -179,7 +179,7 @@
                                     <field name="invoice_label" attrs="{'invisible':[('amount_type','=', 'group')]}"/>
                                     <field name="tax_group_id" attrs="{'invisible': [('amount_type', '=', 'group')], 'required': [('amount_type', '!=', 'group')]}"/>
                                     <field name="analytic" attrs="{'invisible':[('amount_type','=', 'group')]}" groups="analytic.group_analytic_accounting" />
-                                    <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                    <field name="company_id" groups="base.group_multi_company"/>
                                     <field name="country_id" required="True"/>
                                 </group>
                                 <group name="advanced_booleans">

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -46,7 +46,7 @@
                             <field name="fiscal_country_codes" invisible="1"/>
                             <field name="foreign_vat_header_mode" invisible="1"/>
                             <field name="name"/>
-                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <group>
                             <field name="auto_apply"/>
@@ -133,7 +133,7 @@
                 <tree string="Fiscal Position">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
-                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
             </field>
         </record>

--- a/addons/analytic/views/analytic_account_views.xml
+++ b/addons/analytic/views/analytic_account_views.xml
@@ -33,7 +33,7 @@
                             </group>
                             <group>
                                 <field name="plan_id" options="{'no_quick_create': True}"/>
-                                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="currency_id" options="{'no_create': True}" groups="base.group_multi_currency"/>
                             </group>
                         </group>

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -111,7 +111,7 @@
                         <field name="campaign_id"/>
                         <field name="medium_id"/>
                         <field name="source_id"/>
-                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
                         <newline/>
                         <field name="create_date"/>
                         <field name="date_open"/>

--- a/addons/digest/views/digest_views.xml
+++ b/addons/digest/views/digest_views.xml
@@ -40,7 +40,7 @@
                     <group>
                         <group>
                             <field name="periodicity" widget="radio" options="{'horizontal': true}"/>
-                            <field name="company_id" options="{'no_create': True}" invisible="1"/>
+                            <field name="company_id" invisible="1"/>
                         </group>
                         <group>
                             <field name="next_run_date" groups="base.group_system"/>

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -54,7 +54,7 @@
                     <group string="For any of these Events">
                         <group>
                             <field name="event_type_ids" widget="many2many_tags"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <group>
                             <field name="event_id" options="{'no_create': True}"/>

--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -24,7 +24,7 @@
                                 <field name="manager_id" widget="many2one_avatar_user"/>
                                 <field name="parent_id"/>
                                 <field name="child_ids" invisible="1"/>
-                                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                             <div attrs="{'invisible': ['|', ('id', '=', False), '&amp;', '&amp;', ('id', '!=', False), ('child_ids', '=', []), ('parent_id', '=', False)]}">
                                 <widget name="hr_department_chart"/>

--- a/addons/hr/views/hr_job_views.xml
+++ b/addons/hr/views/hr_job_views.xml
@@ -20,7 +20,7 @@
                             <page string="Recruitment" name="recruitment_page">
                                 <group>
                                     <group name="recruitment">
-                                        <field name="company_id" options="{'no_create': True}" invisible="1" groups="base.group_multi_company"/>
+                                        <field name="company_id" invisible="1" groups="base.group_multi_company"/>
                                         <field name="department_id"/>
                                         <field name="contract_type_id"/>
                                     </group>

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -94,7 +94,7 @@
                             <field name="transition_mode" widget="radio" attrs="{'invisible': [('show_transition_mode', '=', False)]}"/>
                         </group>
                         <group>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company" />
                         </group>
                     </group>
                     <span class="oe_grey" invisible="1">

--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -53,7 +53,7 @@
                 <field name="date" string="Accounting Date" optional="show"/>
                 <field name="payment_reference" optional="hide"/>
                 <field name="invoice_user_id" optional="show" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Sales Person"/>
-                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
+                <field name="company_id" groups="base.group_multi_company" optional="show"/>
                 <field name="invoice_origin" optional="show" string="Source Document"/>
                 <field name="amount_untaxed_signed" string="Amount Untaxed" sum="Total" optional="show"/>
                 <field name="amount_tax_signed" string="Tax" sum="Total" optional="show"/>

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -98,7 +98,7 @@
                             </div>
                             <field name="priority" widget="priority"/>
                             <field name="email_cc" string="Email cc" groups="base.group_no_one"/>
-                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                     <group>
@@ -351,7 +351,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="category_id" options="{&quot;no_open&quot;: True}" context="{'default_company_id':company_id}"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="owner_user_id" string="Owner"/>
                         </group>
                         <group>
@@ -594,7 +594,7 @@
                 </div>
                 <group>
                     <field name="technician_user_id" class="oe_inline" domain="[('share', '=', False)]"/>
-                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" class="oe_inline"/>
+                    <field name="company_id" groups="base.group_multi_company" class="oe_inline"/>
                 </group>
                 <group name="group_alias" attrs="{'invisible': [('alias_domain', '=', False)]}" groups="base.group_no_one">
                     <label for="alias_name" string="Email Alias"/>
@@ -761,7 +761,7 @@
                         <field name="member_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True}" domain="[('share', '=', False)]"/>
                     </group>
                     <group>
-                        <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
                     </group>
                 </group>
                 </sheet>
@@ -776,7 +776,7 @@
             <tree string="Maintenance Team" editable="bottom">
                 <field name="name"/>
                 <field name="member_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create': True}" domain="[('share', '=', False)]"/>
-                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
     </record>

--- a/addons/mrp/views/ir_attachment_view.xml
+++ b/addons/mrp/views/ir_attachment_view.xml
@@ -73,7 +73,7 @@
                         </group>
                         <group string="Attached To" groups="base.group_no_one">
                             <field name="res_name"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                         <group string="History" groups="base.group_no_one" attrs="{'invisible':[('create_date','=',False)]}">
                             <label for="create_uid" string="Creation"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -448,7 +448,7 @@
                                         attrs="{'invisible': ['|', ('state', 'in', ('done', 'cancel')), ('date_deadline', '=', False)]}"
                                         decoration-danger="date_deadline and date_deadline &lt; current_date"
                                         decoration-bf="date_deadline and date_deadline &lt; current_date"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}" force_save="1"/>
+                                    <field name="company_id" groups="base.group_multi_company" attrs="{'readonly': [('state', '!=', 'draft')]}" force_save="1"/>
 
                                 </group>
                             </group>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -436,10 +436,10 @@
                             <group>
                                 <group>
                                     <field name="picking_type_id" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                    <field name="location_src_id" groups="stock.group_stock_multi_locations" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                    <field name="location_src_id" groups="stock.group_stock_multi_locations" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                     <field name="location_src_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
                                     <field name="warehouse_id" invisible="1"/>
-                                    <field name="location_dest_id" groups="stock.group_stock_multi_locations" options="{'no_create': True}" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                    <field name="location_dest_id" groups="stock.group_stock_multi_locations" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                     <field name="location_dest_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
                                 </group>
                                 <group>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -117,8 +117,8 @@
                             </group>
                             <group>
                                 <field name="mo_id"/>
-                                <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                                <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                                <field name="location_id" groups="stock.group_stock_multi_locations"/>
+                                <field name="location_dest_id" groups="stock.group_stock_multi_locations"/>
                                 <field name="has_tracking" invisible="1"/>
                                 <field name="lot_id" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')], 'readonly':['|', ('mo_id','!=',False), ('state', '=', 'done')]}" groups="stock.group_production_lot" force_save="1"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
@@ -156,8 +156,8 @@
                             </group>
                             <group>
                                 <field name="mo_id" invisible="1"/>
-                                <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                                <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                                <field name="location_id" groups="stock.group_stock_multi_locations"/>
+                                <field name="location_dest_id" groups="stock.group_stock_multi_locations"/>
                                 <field name="has_tracking" invisible="1"/>
                                 <field name="lot_id" readonly="1" attrs="{'invisible': [('has_tracking', '=', 'none')], 'required': [('has_tracking', '!=', 'none')]}" groups="stock.group_production_lot"/>
                                 <field name="company_id" groups="base.group_multi_company" readonly="1"/>
@@ -185,7 +185,7 @@
                     <field name="lot_id" groups="stock.group_production_lot"/>
                     <field name="product_qty"/>
                     <field name="product_uom_id" groups="uom.group_uom"/>
-                    <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                    <field name="location_id" groups="stock.group_stock_multi_locations"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="state" widget='badge' decoration-success="state == 'done'" decoration-info="state == 'draft'"/>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -349,7 +349,7 @@
                             <group>
                                 <field name="code"/>
                                 <field name="resource_calendar_id" required="1"/>
-                                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                         </group>
                         <notebook>

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -109,7 +109,7 @@
         <field name="arch" type="xml">
             <tree string="Point of Sale Configuration">
                 <field name="name" />
-                <field name="company_id"  options="{'no_create': True}" groups="base.group_multi_company"/>
+                <field name="company_id"  groups="base.group_multi_company"/>
             </tree>
         </field>
     </record>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -67,7 +67,7 @@
                         <group name="pricelist_settings">
                             <field name="currency_id" groups="base.group_multi_currency"/>
                             <field name="active" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                     <notebook>

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -32,7 +32,7 @@
                             </div>
                             <label for="date_start" string="Validity"/>
                             <div class="o_row"><field name="date_start" class="oe_inline"/> to <field name="date_end" class="oe_inline"/></div>
-                            <field name="company_id" options="{'no_create': True}"/>
+                            <field name="company_id"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -17,7 +17,7 @@
                 <field name="default_code" optional="show"/>
                 <field name="product_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                 <field name="barcode" optional="hide" attrs="{'readonly': [('product_variant_count', '!=', 1)]}"/>
-                <field name="company_id" options="{'no_create': True}"
+                <field name="company_id"
                     groups="base.group_multi_company" optional="hide"/>
                 <field name="list_price" string="Sales Price" widget='monetary' options="{'currency_field': 'currency_id'}" optional="show" decoration-muted="not sale_ok"/>
                 <field name="standard_price" widget='monetary' options="{'currency_field': 'cost_currency_id'}" optional="show" readonly="1"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -445,7 +445,7 @@
                                 <group>
                                     <field name="parent_id" groups="base.group_no_one" context="{'search_view_ref' : 'project.view_task_search_form','search_default_project_id': project_id}"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id}"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                    <field name="company_id" groups="base.group_multi_company"/>
                                     <field name="sequence" groups="base.group_no_one"/>
                                     <field name="email_cc" groups="base.group_no_one"/>
                                     <field name="displayed_image_id" groups="base.group_no_one" options="{'no_create': True}"/>

--- a/addons/purchase/report/purchase_bill_views.xml
+++ b/addons/purchase/report/purchase_bill_views.xml
@@ -28,7 +28,7 @@
                 <field name="date"/>
                 <field name="amount"/>
                 <field name="currency_id" invisible="1"/>
-                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
     </record>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -392,7 +392,7 @@
                             <group>
                                 <group name="other_info">
                                     <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                    <field name="company_id" groups="base.group_multi_company"/>
                                     <field name="origin"/>
                                 </group>
                                 <group name="invoice_info">
@@ -561,7 +561,7 @@
                     <field name="date_order" invisible="not context.get('quotation_only', False)" optional="show"/>
                     <field name="date_approve" invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="partner_id" readonly="1"/>
-                    <field name="company_id" readonly="1" options="{'no_create': True}"
+                    <field name="company_id" readonly="1"
                         groups="base.group_multi_company" optional="show"/>
                     <field name="user_id" optional="show"/>
                     <field name="origin" optional="show"/>
@@ -594,7 +594,7 @@
                     <field name="name" string="Reference" readonly="1" decoration-bf="1"/>
                     <field name="date_approve" invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="partner_id" readonly="1"/>
-                    <field name="company_id" readonly="1" options="{'no_create': True}"
+                    <field name="company_id" readonly="1"
                         groups="base.group_multi_company" optional="show"/>
                     <field name="company_id" groups="!base.group_multi_company" invisible="1"/>
                     <field name="date_planned" invisible="context.get('quotation_only', False)" optional="show"/>
@@ -630,7 +630,7 @@
                     <field name="name" string="Reference" readonly="1" decoration-bf="1" decoration-info="state in ('draft','sent')"/>
                     <field name="date_approve" widget="date" invisible="context.get('quotation_only', False)" optional="show"/>
                     <field name="partner_id"/>
-                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="company_id" groups="!base.group_multi_company" invisible="1"/>
                     <field name="user_id" widget="many2one_avatar_user" optional="show"/>
                     <field name="date_order" invisible="not context.get('quotation_only', False)" optional="show"/>
@@ -753,7 +753,7 @@
                                 <field name="taxes_id" widget="many2many_tags"
                                     domain="[('type_tax_use', '=', 'purchase')]"/>
                                 <field name="date_planned" widget="date" readonly="1"/>
-                                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="analytic_distribution" widget="analytic_distribution"
                                        groups="analytic.group_analytic_accounting"
                                        options="{'product_field': 'product_id', 'business_domain': 'purchase_order'}"/>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -145,7 +145,7 @@
                         <field name="ordering_date" attrs="{'readonly': [('state','not in',('draft','in_progress','open','ongoing'))]}"/>
                         <field name="schedule_date" attrs="{'readonly': [('state','not in',('draft','in_progress','open','ongoing'))]}"/>
                         <field name="origin" placeholder="e.g. PO0025" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                        <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('state','not in',('draft'))]}"/>
+                        <field name="company_id" groups="base.group_multi_company" attrs="{'readonly': [('state','not in',('draft'))]}"/>
                     </group>
                 </group>
                 <notebook>
@@ -178,7 +178,7 @@
                                     <field name="analytic_distribution" widget="analytic_distribution"
                                            groups="analytic.group_analytic_accounting"
                                            options="{'product_field': 'product_id', 'business_domain': 'purchase_order'}"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                    <field name="company_id" groups="base.group_multi_company"/>
                                 </group>
                             </form>
                         </field>
@@ -203,7 +203,7 @@
                 <field name="message_needaction" invisible="1"/>
                 <field name="name" decoration-bf="1"/>
                 <field name="user_id" optional="show" widget='many2one_avatar_user'/>
-                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
+                <field name="company_id" groups="base.group_multi_company" optional="show"/>
                 <field name="ordering_date" optional="show"/>
                 <field name="schedule_date" optional="hide"/>
                 <field name="date_end" optional="show" widget='remaining_days' decoration-danger="date_end and date_end&lt;current_date" attrs="{'invisible': [('state','in', ('done', 'cancel'))]}"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -98,7 +98,7 @@
                         <group>
                             <field name="schedule_date"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
-                            <field name="location_id" options="{'no_create': True}"/>
+                            <field name="location_id"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                             <field name="guarantee_limit"/>
                             <field name="invoice_method"/>
@@ -133,8 +133,8 @@
                                     </group>
                                     <group>
                                         <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot"/>
-                                        <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                                        <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                                        <field name="location_id" groups="stock.group_stock_multi_locations"/>
+                                        <field name="location_dest_id" groups="stock.group_stock_multi_locations"/>
                                     </group>
                                 </group>
                                 <group name="History" string="History" attrs="{'invisible':[('move_id','=', False)]}">
@@ -150,8 +150,8 @@
                                 <field name="product_uom_category_id" invisible="1"/>
                                 <field name="tracking" invisible="1"/>
                                 <field name="lot_id" context="{'default_product_id': product_id, 'default_company_id': company_id}" groups="stock.group_production_lot" attrs="{'readonly':[('tracking', 'not in', ['serial', 'lot'])]}"/>
-                                <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" optional="show"/>
-                                <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" optional="show"/>
+                                <field name="location_id" groups="stock.group_stock_multi_locations" optional="show"/>
+                                <field name="location_dest_id" groups="stock.group_stock_multi_locations" optional="show"/>
                                 <field name="product_uom_qty" string="Quantity"/>
                                 <field name="product_uom" string="UoM" groups="uom.group_uom" optional="show"/>
                                 <field name="price_unit"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -99,7 +99,7 @@
                             <field name="schedule_date"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                             <field name="location_id" options="{'no_create': True}"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="guarantee_limit"/>
                             <field name="invoice_method"/>
                             <field name="partner_invoice_id" attrs="{'invisible':[('invoice_method','=', 'none')],'required':[('invoice_method','!=','none')]}" groups="account.group_delivery_invoice_address"/>

--- a/addons/resource/views/resource_calendar_leaves_views.xml
+++ b/addons/resource/views/resource_calendar_leaves_views.xml
@@ -42,7 +42,7 @@
                     <group name="leave_details">
                         <field name="name" string="Reason"/>
                         <field name="calendar_id"/>
-                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" attrs="{'invisible':[('calendar_id','=',False)]}"/>
+                        <field name="company_id" groups="base.group_multi_company" attrs="{'invisible':[('calendar_id','=',False)]}"/>
                         <field name="resource_id"/>
                     </group>
                     <group name="leave_dates">

--- a/addons/resource/views/resource_resource_views.xml
+++ b/addons/resource/views/resource_resource_views.xml
@@ -39,7 +39,7 @@
                     <group name="user_details">
                         <field name="name"/>
                         <field name="user_id" attrs="{'required':[('resource_type','=','user')], 'invisible': [('resource_type','=','material')]}"/>
-                        <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
                         <field name="resource_type" />
                     </group>
                     <group name="resource_details">

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -41,7 +41,7 @@
                             <field name="qty_delivered" readonly="1"/>
                             <field name="qty_invoiced"/>
                             <field name="product_uom" readonly="1"/>
-                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="order_partner_id" invisible="1"/>
                             <field name="display_type" invisible="1"/>
                             <field name="product_updatable" invisible="1"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -660,7 +660,7 @@
                             <group name="sales_person" string="Sales">
                                 <field name="user_id" widget="many2one_avatar_user"/>
                                 <field name="team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}" options="{'no_create': True}"/>
-                                <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                                 <label for="require_signature" string="Online confirmation"/>
                                 <div>
                                     <field name="require_signature" class="oe_inline"/>

--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -44,7 +44,7 @@
                                 <span>Payment</span>
                             </div>
                             <field name="mail_template_id" context="{'default_model': 'sale.order'}"/>
-                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                     <notebook name="main_book">

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -43,7 +43,7 @@
                             <field name="sequence" invisible="1"/>
                             <field name="is_membership_multi" invisible="1"/>
                             <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
-                            <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="member_company_ids" invisible="1"/>
                         </group>

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -21,6 +21,7 @@ class Location(models.Model):
     _rec_name = 'complete_name'
     _rec_names_search = ['complete_name', 'barcode']
     _check_company_auto = True
+    _view_options = {'no_create': True}
 
     @api.model
     def default_get(self, fields):

--- a/addons/stock/views/product_strategy_views.xml
+++ b/addons/stock/views/product_strategy_views.xml
@@ -34,7 +34,7 @@
                        groups="stock.group_stock_storage_categories"
                        options="{'no_create': True}"
                        optional="show"/>
-                <field name="company_id" groups="stock.group_stock_multi_locations" force_save="1" readonly="context.get('fixed_location', False)" options="{'no_create': True}" optional="show"/>
+                <field name="company_id" groups="stock.group_stock_multi_locations" force_save="1" readonly="context.get('fixed_location', False)" optional="show"/>
             </tree>
         </field>
     </record>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -202,7 +202,7 @@
             <field name="inherit_id" ref="product.product_search_form_view"/>
             <field name="arch" type="xml">
                 <filter name="activities_overdue" position="after">
-                    <field name="location_id" options="{'no_create': True}" context="{'location': self}" filter_domain="[]"/>
+                    <field name="location_id" context="{'location': self}" filter_domain="[]"/>
                     <field name="warehouse_id" context="{'warehouse': self}" filter_domain="[]"/>
                 </filter>
             </field>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -30,7 +30,7 @@
                     <label for="name"/>
                     <h1><field name="name" placeholder="e.g. Spare Stock"/></h1>
                     <label for="location_id"/>
-                    <h2><field name="location_id" placeholder="e.g. Physical Locations" options="{'no_create': True}"/></h2>
+                    <h2><field name="location_id" placeholder="e.g. Physical Locations"/></h2>
 
                     <group>
                         <group string="Additional Information" name="additional_info">
@@ -214,8 +214,8 @@
                             <tree>
                                 <field name="sequence" widget="handle"/>
                                 <field name="action"/>
-                                <field name="location_src_id" options="{'no_create': True}"/>
-                                <field name="location_dest_id" options="{'no_create': True}"/>
+                                <field name="location_src_id"/>
+                                <field name="location_dest_id"/>
                             </tree>
                         </field>
                     </group>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -37,7 +37,7 @@
                             <field name="active" invisible="1"/>
                             <field name="usage"/>
                             <field name="storage_category_id" attrs="{'invisible': [('usage', '!=', 'internal')]}" groups="stock.group_stock_storage_categories"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="scrap_location" attrs="{'invisible': [('usage', 'not in', ('inventory', 'internal'))]}"/>
                             <field name="return_location"/>
                             <field name="replenish_location" attrs="{'invisible': [('usage', '!=', 'internal')]}"/>
@@ -189,7 +189,7 @@
                             <field name="sequence" string="Sequence" groups="base.group_no_one"/>
                             <field name="supplied_wh_id" groups="base.group_no_one"/>
                             <field name="active" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>
                     <group string="Applicable On" name="route_selector">

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -79,8 +79,8 @@
                             <field name="reference" string="Reference"/>
                             <field name="origin"/>
                             <field name="product_id"/>
-                            <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                            <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                            <field name="location_id" groups="stock.group_stock_multi_locations"/>
+                            <field name="location_dest_id" groups="stock.group_stock_multi_locations"/>
                         </group>
                         <group>
                             <label for="reserved_uom_qty" string="Quantity Reserved" attrs="{'invisible': [('state', '=', 'done')]}"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -37,9 +37,9 @@
                     <field name="location_usage" invisible="1"/>
                     <field name="location_dest_usage" invisible="1"/>
                     <field name="product_id"/>
-                    <field name="location_id" options="{'no_create': True}" string="From"
+                    <field name="location_id" string="From"
                         decoration-muted="location_usage not in ('internal','transit')"/>
-                    <field name="location_dest_id" options="{'no_create': True}" string="To"
+                    <field name="location_dest_id" string="To"
                         decoration-muted="location_dest_usage not in ('internal','transit')"/>
                     <field name="product_packaging_id" groups="product.group_stock_packaging"
                         optional="hide" context="{'default_product_id': product_id}"
@@ -281,8 +281,8 @@
                     <field name="result_package_id" invisible="1"/>
                     <field name="location_id" invisible="1"/>
                     <field name="location_dest_id" invisible="1"/>
-                    <field name="location_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
-                    <field name="location_dest_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
+                    <field name="location_id" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
+                    <field name="location_dest_id" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
                     <field name="package_id" groups="stock.group_tracking_lot"/>
                     <field name="result_package_id" groups="stock.group_tracking_lot"/>
                     <field name="lots_visible" invisible="1"/>
@@ -316,8 +316,8 @@
                         <group name="main_grp" colspan="2">
                             <group name="main_grp_col1">
                                 <field name="reference"/>
-                                <field name="location_id" options="{'no_create': True}"/>
-                                <field name="location_dest_id" options="{'no_create': True}"/>
+                                <field name="location_id"/>
+                                <field name="location_dest_id"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                             </group>
                             <group name="main_grp_col2">
@@ -473,7 +473,7 @@
                     <field name="product_id"/>
                     <field name="product_uom_qty"/>
                     <field name="product_uom" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
-                    <field name="location_id" options="{'no_create': True}" invisible="1"/>
+                    <field name="location_id" invisible="1"/>
                     <field name="location_dest_id" invisible="1"/>
                     <field name="state" optional="show"/>
                     <field name="company_id" invisible="1"/>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -167,7 +167,7 @@
                             <div groups="base.group_no_one">
                                 <field name="group_id" groups="stock.group_adv_location"/>
                             </div>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="visibility_days"/>
                         </group>
                     </group>

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -45,7 +45,7 @@
                 <field name="product_tmpl_id" invisible="1"/>
                 <field name="unwanted_replenish" invisible="1"/>
                 <field name="product_id" attrs="{'readonly': [('product_id', '!=', False)]}" force_save="1"/>
-                <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                <field name="location_id" groups="stock.group_stock_multi_locations"/>
                 <field name="warehouse_id" options="{'no_create': True}" groups="stock.group_stock_multi_warehouses" optional="hide"/>
                 <field name="qty_on_hand" force_save="1"/>
                 <field name="qty_forecast" force_save="1"/>
@@ -162,7 +162,7 @@
                         <group>
                             <field name="allowed_location_ids" invisible="1"/>
                             <field name="warehouse_id" options="{'no_open': True, 'no_create': True}" groups="stock.group_stock_multi_locations"/>
-                            <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" domain="[('id', 'in', allowed_location_ids)]"/>
+                            <field name="location_id" groups="stock.group_stock_multi_locations" domain="[('id', 'in', allowed_location_ids)]"/>
                             <label for="group_id" groups="base.group_no_one"/>
                             <div groups="base.group_no_one">
                                 <field name="group_id" groups="stock.group_adv_location"/>

--- a/addons/stock/views/stock_package_level_views.xml
+++ b/addons/stock/views/stock_package_level_views.xml
@@ -16,8 +16,8 @@
                     <field name="picking_type_code" invisible="1"/>
                     <group>
                         <field name="package_id"/>
-                        <field name="location_id" options="{'no_create': True}" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations"/>
-                        <field name="location_dest_id" options="{'no_create': True}" attrs="{'invisible': [('picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations"/>
+                        <field name="location_id" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations"/>
+                        <field name="location_dest_id" attrs="{'invisible': [('picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations"/>
                         <field name="is_done"/>
                         <field name="company_id" groups="base.group_multi_company"/>
                     </group>
@@ -72,8 +72,8 @@
                 <field name="is_fresh_package" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="package_id" attrs="{'readonly': [('state', 'in', ('confirmed', 'assigned', 'done', 'cancel'))]}" options="{'no_create': True}"/>
-                <field name="location_id" options="{'no_create': True}" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations"/>
-                <field name="location_dest_id" options="{'no_create': True}"  attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations"/>
+                <field name="location_id" attrs="{'column_invisible': [('parent.picking_type_code', '=', 'incoming')]}" groups="stock.group_stock_multi_locations"/>
+                <field name="location_dest_id"  attrs="{'column_invisible': [('parent.picking_type_code', '=', 'outgoing')]}" groups="stock.group_stock_multi_locations"/>
                 <field name="state"/>
                 <field name="is_done" attrs="{'readonly': ['|', ('parent.state', 'in', ('draft', 'new', 'done')), ('is_fresh_package', '=', True)]}"/>
                 <button name="action_show_package_details" title="Display package content" type="object" icon="fa-list" />

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -96,7 +96,7 @@
                             </div>
                         </group>
                         <group>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field attrs='{"invisible": [("code", "not in", ["incoming", "outgoing", "internal"])]}' name="return_picking_type_id" string="Returns Type"/>
                             <field name="create_backorder"/>
                             <field name="show_operations"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -351,7 +351,7 @@
                                     <field name="move_type" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}"/>
                                     <field name="user_id" domain="[('share', '=', False)]"/>
                                     <field name="group_id" groups="base.group_no_one"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" force_save="1"/>
+                                    <field name="company_id" groups="base.group_multi_company" force_save="1"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -68,8 +68,8 @@
                     <field name="company_id" invisible="1"/>
                     <field name="priority" optional="show" widget="priority" nolabel="1"/>
                     <field name="name" decoration-bf="1"/>
-                    <field name="location_id" options="{'no_create': True}" string="From" groups="stock.group_stock_multi_locations" optional="show"/>
-                    <field name="location_dest_id" options="{'no_create': True}" string="To" groups="stock.group_stock_multi_locations" optional="show"/>
+                    <field name="location_id" string="From" groups="stock.group_stock_multi_locations" optional="show"/>
+                    <field name="location_dest_id" string="To" groups="stock.group_stock_multi_locations" optional="show"/>
                     <field name="partner_id" optional="show"/>
                     <field name="is_signed" string="Signed" optional="hide" groups="stock.group_stock_sign_delivery"/>
                     <field name="user_id" optional="hide" widget="many2one_avatar_user"/>
@@ -209,8 +209,8 @@
                                    domain="context.get('restricted_picking_type_code', []) and [('code', '=', context.get('restricted_picking_type_code'))]"/>
                             <field name="location_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
                             <field name="location_dest_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
-                            <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}"/>
-                            <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('picking_type_code', '=', 'outgoing')]}"/>
+                            <field name="location_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}"/>
+                            <field name="location_dest_id" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('picking_type_code', '=', 'outgoing')]}"/>
                             <field name="backorder_id" attrs="{'invisible': [('backorder_id','=',False)]}"/>
                         </group>
                         <group>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -69,7 +69,7 @@
                             <field name="tracking" invisible="1"/>
                             <field name="company_id" invisible="1"/>
                             <field name="product_id" readonly="0" options="{'no_create': True}"/>
-                            <field name="location_id" readonly="0" options="{'no_create': True}"/>
+                            <field name="location_id" readonly="0"/>
                             <field name="lot_id" groups="stock.group_production_lot"
                                 attrs="{'readonly': [('tracking', 'not in', ['serial', 'lot'])], 'required': [('tracking', '!=', 'none')]}"
                                 context="{'default_product_id': product_id, 'default_company_id': company_id}"/>
@@ -286,7 +286,7 @@
                             <field name="package_type_id"/>
                             <field name='company_id' groups="base.group_multi_company"/>
                             <field name='owner_id' groups="stock.group_tracking_owner"/>
-                            <field name="location_id" options="{'no_create': True}"/>
+                            <field name="location_id"/>
                         </group>
                         <group>
                             <field name="pack_date"/>
@@ -314,7 +314,7 @@
             <tree string="Package" sample="1">
                 <field name="display_name"/>
                 <field name="package_type_id"/>
-                <field name="location_id" options="{'no_create': True}"/>
+                <field name="location_id"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -425,7 +425,7 @@ in this location. That leads to a negative stock.
                 <field name="tracking" invisible="1"/>
                 <field name="inventory_quantity_set" invisible="1"/>
                 <field name="company_id" invisible="1"/>
-                <field name="location_id" domain="[('usage', 'in', ['internal', 'transit'])]" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)" options="{'no_create': True}"/>
+                <field name="location_id" domain="[('usage', 'in', ['internal', 'transit'])]" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)"/>
                 <field name="storage_category_id" groups="stock.group_stock_storage_categories" invisible="context.get('hide_location', False)" options="{'no_create': True}" optional="hidden"/>
                 <field name="cyclic_inventory_frequency" invisible="context.get('hide_location', False)" options="{'no_create': True}" optional="hidden"/>
                 <field name="priority" widget="priority" nolabel="1" optional="hidden"/>

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -92,7 +92,7 @@
                                 <field name="route_id"/>
                                 <field name="warehouse_id" attrs="{'invisible': [('action', '=', 'push')]}" groups="base.group_no_one"/>
                                 <field name="route_company_id" invisible="1"/>
-                                <field name="company_id" options="{'no_create': True}" attrs="{'required': [('action', '=', 'push')]}" groups="base.group_multi_company"/>
+                                <field name="company_id" attrs="{'required': [('action', '=', 'push')]}" groups="base.group_multi_company"/>
                                 <field name="sequence" string="Sequence" groups="base.group_no_one"/>
                             </group>
                             <group name="propagation_group" string="Propagation" attrs="{'invisible': [('action', '=', 'push')]}" groups="base.group_no_one">

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -47,8 +47,8 @@
             <field name="arch" type="xml">
                 <tree string="Rules">
                     <field name="action"/>
-                    <field name="location_src_id" options="{'no_create': True}"/>
-                    <field name="location_dest_id" options="{'no_create': True}"/>
+                    <field name="location_src_id"/>
+                    <field name="location_dest_id"/>
                     <field name="route_id"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                 </tree>
@@ -73,8 +73,8 @@
                                 <field name="picking_type_code_domain" invisible="1"/>
                                 <field name="action"/>
                                 <field name="picking_type_id"/>
-                                <field name="location_src_id" options="{'no_create': True}" attrs="{'required': [('action', 'in', ['pull', 'push', 'pull_push'])]}"/>
-                                <field name="location_dest_id" options="{'no_create': True}"/>
+                                <field name="location_src_id" attrs="{'required': [('action', 'in', ['pull', 'push', 'pull_push'])]}"/>
+                                <field name="location_dest_id"/>
                                 <field name="auto" attrs="{'invisible': [('action', 'not in', ['push', 'pull_push'])]}"/>
                                 <field name="procure_method" attrs="{'invisible': [('action', 'not in', ['pull', 'pull_push'])]}"/>
                             </group>

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -133,7 +133,7 @@
                     <field name="product_id" readonly="1"/>
                     <field name="scrap_qty"/>
                     <field name="product_uom_id" groups="uom.group_uom"/>
-                    <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
+                    <field name="location_id" groups="stock.group_stock_multi_locations"/>
                     <field name="scrap_location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company"/>
                     <field name="state" widget="badge" decoration-success="state == 'done'" decoration-muted="state == 'draft'"/>

--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -28,7 +28,7 @@
                                 <field name="code" placeholder="e.g. CW"/>
                             </group>
                             <group>
-                                <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="partner_id"/>
                             </group>
                         </group>

--- a/addons/stock/wizard/stock_inventory_conflict.xml
+++ b/addons/stock/wizard/stock_inventory_conflict.xml
@@ -26,7 +26,7 @@
                             <field name="tracking" invisible="1"/>
                             <field name="company_id" invisible="1"/>
                             <field name="product_id" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('single_product', False)" readonly="context.get('single_product', False)" force_save="1" options="{'no_create': True}"/>
-                            <field name="location_id" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)" options="{'no_create': True}"/>
+                            <field name="location_id" attrs="{'readonly': [('id', '!=', False)]}" invisible="context.get('hide_location', False)"/>
                             <field name="lot_id" groups="stock.group_production_lot" attrs="{
                                 'readonly': ['|', ('id', '!=', False), ('tracking', 'not in', ['serial', 'lot'])],
                                 'required': [('tracking', '!=', 'none')]

--- a/addons/stock/wizard/stock_warn_insufficient_qty_views.xml
+++ b/addons/stock/wizard/stock_warn_insufficient_qty_views.xml
@@ -16,7 +16,7 @@
                     <strong>Current Inventory: </strong>
                     <field name="quant_ids" style="margin-top:10px;">
                         <tree>
-                            <field name="location_id" options="{'no_create': True}"/>
+                            <field name="location_id"/>
                             <field name="lot_id" groups="stock.group_production_lot"/>
                             <field name="quantity"/>
                         </tree>

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1304,6 +1304,15 @@ actual arch.
                     for arch, _view in self._get_x2many_missing_view_archs(field, node, node_info):
                         node.append(arch)
 
+                if (
+                    field.relational
+                    and not node.get('options')
+                ):
+                    model = self.env[field.comodel_name]
+                    options = model._view_options
+                    if options:
+                        node.set('options', str(options))
+
                 for child in node:
                     if child.tag in ('form', 'tree', 'graph', 'kanban', 'calendar'):
                         node_info['children'] = []
@@ -2349,6 +2358,8 @@ class Model(models.AbstractModel):
     _inherit = 'base'
 
     _date_name = 'date'         #: field to use for default calendar view
+    # default UI options for the views that have relational fields to the model
+    _view_options = {}
 
     def _get_access_action(self, access_uid=None, force_website=False):
         """ Return an action to open the document. This method is meant to be

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -22,6 +22,7 @@ class Company(models.Model):
     _name = "res.company"
     _description = 'Companies'
     _order = 'sequence, name'
+    _view_options = {'no_create': True}
 
     def copy(self, default=None):
         raise UserError(_('Duplicating a company is not allowed. Please create a new company instead.'))

--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -22,7 +22,7 @@
                             <field name="res_field"/>
                             <field name="res_id"/>
                             <field name="res_name"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="public"/>
                         </group>
                         <group string="History" groups="base.group_no_one" attrs="{'invisible':[('create_date','=',False)]}">

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -92,7 +92,7 @@
                             <field name="partner_id"/>
                         </group>
                         <group>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <field name="currency_id" groups="base.group_multi_currency" options="{'no_create': True}"/>
                             <field name="allow_out_payment" widget="boolean_toggle"/>
                             <field name="active" invisible="1"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -362,7 +362,7 @@
                                 <group name="misc" string="Misc">
                                     <field name="company_registry" attrs="{'invisible': [('parent_id','!=',False)]}"/>
                                     <field name="ref" string="Reference"/>
-                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'readonly': [('parent_id', '!=', False)]}" force_save="1"/>
+                                    <field name="company_id" groups="base.group_multi_company" attrs="{'readonly': [('parent_id', '!=', False)]}" force_save="1"/>
                                     <field name="industry_id" attrs="{'invisible': [('is_company', '=', False)]}" options="{'no_create': True}"/>
                                 </group>
                             </group>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -482,7 +482,7 @@
                                 <field name="signature" readonly="0" options="{'style-inline': true, 'codeview': true}"/>
                             </group>
                             <group name="status" string="Status" invisible="1">
-                                <field name="company_id" options="{'no_create': True}" readonly="0"
+                                <field name="company_id" readonly="0"
                                     groups="base.group_multi_company"/>
                             </group>
                             <group name="preference_contact"></group>


### PR DESCRIPTION
Clean up view definitions by forcing `options="{'no_create': True}"` globally on model level.