### PR TITLE
[FIX] web: keep pager offset when applicable

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -3483,7 +3483,11 @@ export class RelationalModel extends Model {
      * @returns {Promise<void>}
      */
     async load(params = {}) {
+        const extraState = {};
         const rootParams = { ...this.rootParams, ...params };
+        if ((params.groupBy || []).join(' ') !== (this.rootParams.groupBy || []).join(' ')) {
+            extraState.offset = 0;
+        }
         if (this.defaultOrderBy && !(params.orderBy && params.orderBy.length)) {
             rootParams.orderBy = this.defaultOrderBy;
         }
@@ -3511,7 +3515,7 @@ export class RelationalModel extends Model {
             },
         };
         const state = this.root
-            ? Object.assign(this.root.exportState(), { offset: 0 })
+            ? Object.assign(this.root.exportState(), extraState)
             : this.initialRootState;
 
         const newRoot = this.createDataPoint(this.rootType, rootParams, state);

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -17333,4 +17333,44 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(input, document.activeElement);
         assert.strictEqual(input.value, 'Value 1');
     });
+
+    QUnit.test("keep the offset after activating a filter", async function (assert) {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                <list limit="2">
+                    <field name="foo"/>
+                    <field name="bar"/>
+                </list>
+            `,
+            searchViewArch: `
+                <search>
+                    <filter name="always_true" string="True" domain="[('id', '>', -1)]"/>
+                </search>
+            `,
+        });
+        assert.containsN(target, "tbody .o_data_row", 2);
+        assert.deepEqual(
+            [...target.querySelectorAll("tbody .o_data_row")].map((el) => el.innerText.trim()),
+            ["yop", "blip"]
+        );
+
+        await pagerNext(target);
+        assert.containsN(target, "tbody .o_data_row", 2);
+        assert.deepEqual(
+            [...target.querySelectorAll("tbody .o_data_row")].map((el) => el.innerText.trim()),
+            ["gnap", "blip"]
+        );
+
+        await toggleFilterMenu(target);
+        await toggleMenuItem(target, "True");
+        assert.containsN(target, "tbody .o_data_row", 2);
+        assert.strictEqual(target.querySelector(".o_pager_value").innerText, '3-4');
+        assert.deepEqual(
+            [...target.querySelectorAll("tbody .o_data_row")].map((el) => el.innerText.trim()),
+            ["gnap", "blip"]
+        );
+    });
 });


### PR DESCRIPTION
The `RelationalModel` discards the offset state as of [commit 1] whenever there is no `initialRootState`. This avoids a bug where the offset is too big after changing the group by parameters, resulting in an empty view.

However, in other cases the offset should definitely be kept, for example:
* When applying a filter, as in the added test
* When calling load manually, as is the case in `onClickAddActivityButton`

[commit 1]: https://github.com/odoo/odoo/commit/bda0bd21c8e6772cbfb0680a2b8b497dbbcfd628

opw-3359567