### PR TITLE
[FIX] point_of_sale: use correct decimal/thousands separator in input

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -596,7 +596,7 @@ class PosGlobalState extends PosModel {
         // component state and refs definition
         const state = {notes: '', acceptClosing: false, payments: {}};
         if (cashControl) {
-            state.payments[defaultCashDetails.id] = {counted: 0, difference: -defaultCashDetails.amount, number: 0};
+            state.payments[defaultCashDetails.id] = {counted: "0", difference: -defaultCashDetails.amount, number: 0};
         }
         if (otherPaymentMethods.length > 0) {
             otherPaymentMethods.forEach(pm => {

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -3837,10 +3837,25 @@ td {
     margin-bottom: 10px;
 }
 
-.cash-move .error-message {
+.error-message {
     color: rgb(197, 52, 0);
     text-align: left;
     padding-left: 5px;
+}
+
+.opening-cash-control .error-message,
+.close-pos-popup .error-message {
+    margin-right: 5px;
+    float:left;
+    width: 110px;
+    height: 40px;
+    line-height:40px;
+    text-align:center;
+    margin-top:10px;
+    margin-right:10px;
+
+    font-size:   14px;
+    font-weight: bold;
 }
 
 .pos .popup footer.cash-move {

--- a/addons/point_of_sale/static/src/xml/Popups/CashOpeningPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/CashOpeningPopup.xml
@@ -9,7 +9,7 @@
                     <div class="opening-cash-section">
                         <span class="info-title">Opening cash</span>
                         <div class="cash-input-sub-section" t-on-input="handleInputChange">
-                            <input class="pos-input" type="number" t-model.number="state.openingCash"/>
+                            <input class="pos-input" type="text" t-model="this.state.openingCash"/>
                             <div class="button icon" t-on-click="openDetailsPopup">
                                 <i class="fa fa-calculator" role="img" title="Open the money details popup"/>
                             </div>
@@ -18,6 +18,9 @@
                     <textarea placeholder="Add an opening note..." class="opening-cash-notes" t-model="state.notes"/>
                 </main>
                 <footer class="footer">
+                    <span t-if="state.inputHasError" class="error-message">
+                        <t t-esc="errorMessage" />
+                    </span>
                     <div class="button" t-on-click="confirm">Open session</div>
                 </footer>
             </div>

--- a/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
+++ b/addons/point_of_sale/static/src/xml/Popups/ClosePosPopup.xml
@@ -27,7 +27,7 @@
                                         <td t-esc="defaultCashDetails.name"/>
                                         <td t-esc="env.pos.format_currency(defaultCashDetails.amount)"/>
                                         <td class="flex" t-on-input="() => this.handleInputChange(defaultCashDetails.id)">
-                                            <input class="pos-input" type="number" t-model.number="state.payments[defaultCashDetails.id].counted"/>
+                                            <input class="pos-input" type="text" t-model="this.state.payments[defaultCashDetails.id].counted"/>
                                             <div class="button icon" t-on-click="openDetailsPopup">
                                                 <i class="fa fa-calculator" role="img" title="Open the money details popup"/>
                                             </div>
@@ -65,7 +65,7 @@
                                     <td t-esc="pm.name"/>
                                     <td t-esc="env.pos.format_currency(pm.amount)"/>
                                     <t t-set="_showDiff" t-value="_getShowDiff(pm)" />
-                                    <td t-if="_showDiff" t-on-input="() => this.handleInputChange(pm.id)"><input class="pos-input" type="number" t-model.number="state.payments[pm.id].counted"/></td>
+                                    <td t-if="_showDiff" t-on-input="() => this.handleInputChange(pm.id)"><input class="pos-input" type="text" t-model="this.state.payments[pm.id].counted"/></td>
                                     <td t-if="_showDiff" t-esc="env.pos.format_currency(state.payments[pm.id].difference)" t-att-class="{'warning': state.payments[pm.id].difference}"/>
                                 </tr>
                             </tbody>
@@ -82,9 +82,12 @@
                     <div class="button highlight" t-on-click="confirm">Close Session</div>
                     <div class="button" t-on-click="closePos" title="Visit the Backend but keep session open">Backend</div>
                     <div class="button" t-att-class="{'disabled': !canCancel()}" t-on-click="cancel">Discard</div>
+                    <span t-if="state.inputHasError" class="error-message">
+                        <t t-esc="errorMessage" />
+                    </span>
                     <!-- Download Sale Details -->
-                    <div class="small button icon" 
-                        t-on-click="downloadSalesReport" 
+                    <div class="small button icon"
+                        t-on-click="downloadSalesReport"
                         title="Download a report with all the sales of the current PoS Session">
                             <i class="fa fa-download" role="img"/>
                     </div>


### PR DESCRIPTION
Current behavior:
Some inputs in the PoS were not using the language decimal/thousands separators. They were using plain number input.

Steps to reproduce:
- Change language to a language that uses "," as a decimal separator (German/German(CH))
- Start PoS
- In the CashOpeningPopup you could not input a number using the ","
- When closing the PoS you have the same issue, you cannot enter a number using the ",".

opw-3330373
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
