### PR TITLE
[16.0][IMP] to_stock_landed_costs: On change verdor bill fill data cost lines

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 
-from odoo import api, fields, models, tools, _
+from odoo import api, Command, fields, models, tools, _
 from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_is_zero
 
@@ -82,6 +82,13 @@ class StockLandedCost(models.Model):
     def _onchange_target_model(self):
         if self.target_model != 'picking':
             self.picking_ids = False
+
+    @api.onchange('vendor_bill_id')
+    def _onchange_vendor_bill_id(self):
+        if self.vendor_bill_id:
+            self.write({'cost_lines': [Command.clear()] + [Command.create(line_vals)
+                for line_vals in self.vendor_bill_id._prepare_value_cost_lines()]
+            })
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Before commit: select vendor bill system does not generate data in lines

Desired behavior after PR is merged:
After committing

https://github.com/odoo/odoo/assets/11542778/bf7c0682-8f5f-4738-9c6f-56217318f270





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
