### PR TITLE
[FIX] crm_iap_lead_enrich: logger error to warning on batch of leads not enrich

### DIFF
--- a/addons/crm_iap_lead_enrich/models/crm_lead.py
+++ b/addons/crm_iap_lead_enrich/models/crm_lead.py
@@ -99,7 +99,7 @@ class Lead(models.Model):
                             _logger.info('Sent batch %s enrich requests: success', len(lead_emails))
                             self._iap_enrich_from_response(iap_response)
                 except OperationalError:
-                    _logger.error('A batch of leads could not be enriched :%s', repr(leads))
+                    _logger.warning('A batch of leads could not be enriched :%s', repr(leads))
                     continue
             # Commit processed batch to avoid complete rollbacks and therefore losing credits.
             if not self.env.registry.in_test_mode():


### PR DESCRIPTION
When a huge batch of leads is processed and if it is not enriched, The logger error will occur.

Logger error is changed to warning, so it will reduce the noise level in sentry.

Logger error message:

```
A batch of leads could not be enriched :crm.lead(2,)
```

sentry-4134493974

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
