### PR TITLE
[FIX] mail: pass props to thread actions

### DIFF
--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -35,7 +35,9 @@ function transformAction(component, id, action) {
             return this.isActive && this.component && this.condition && !this.popover;
         },
         /** Props to pass to the component of this action. */
-        componentProps: action.componentProps,
+        get componentProps() {
+            return action.componentProps?.(action);
+        },
         /** Condition to display this action. */
         get condition() {
             return action.condition(component);

--- a/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
@@ -30,6 +30,24 @@ QUnit.test(
 );
 
 QUnit.test(
+    "should display channel invitation form after clicking on chat window button",
+    async (assert) => {
+        const pyEnv = await startServer();
+        pyEnv["discuss.channel"].create({
+            name: "TestChanel",
+            channel_member_ids: [
+                Command.create({ partner_id: pyEnv.currentPartnerId, is_minimized: true }),
+            ],
+            channel_type: "channel",
+        });
+        await start();
+        await click("[title='More actions']");
+        await click("[title='Add Users']");
+        assert.containsOnce($, ".o-discuss-ChannelInvitation");
+    }
+);
+
+QUnit.test(
     "should be able to search for a new user to invite from an existing chat",
     async (assert) => {
         const pyEnv = await startServer();


### PR DESCRIPTION
Since [1] thread actions are stored in a specific registry. Some of those actions require props to be passed to their component.

Those props are not correctly passed as the `componentProps` key is in fact a function that returns the props but is treated as the props themselves.

This commit fixes this issue by transforming `componentProps` into a getter, so that `action` is internally passed to `componentProps` definition. The templates using thread actions can still use `t-props="componentProps"` as getter, as the active action is deduced by transform automatically.

[1]: https://github.com/odoo/odoo/pull/123454