### PR TITLE
[FIX] osv: logger error to warning for searching non stored fields

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1105,7 +1105,7 @@ class expression(object):
                 # Non-stored field should provide an implementation of search.
                 if not field.search:
                     # field does not support search!
-                    _logger.error("Non-stored field %s cannot be searched.", field, exc_info=True)
+                    _logger.warning("Non-stored field %s cannot be searched.", field, exc_info=True)
                     if _logger.isEnabledFor(logging.DEBUG):
                         _logger.debug(''.join(traceback.format_stack()))
                     # Ignore it: generate a dummy leaf.


### PR DESCRIPTION
When user tries to search non-stored fields in searchbar, the logger error will occur.

Logger error is changed to warning, so it will reduce the noise in sentry.

Logger error Message:

```
Non-stored field stock.move.lot_ids cannot be searched.
```

sentry-4239766984
