### PR TITLE
[IMP] point_of_sale: correct ir sequence when same name

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -378,19 +378,27 @@ class PosConfig(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        def set_ir_sequence_name(default_name, sequence_name, number):
+            if self.env['ir.sequence'].search([('prefix', '=', sequence_name + '/')]):
+                sequence_name = default_name + ' ' + str(number)
+                return set_ir_sequence_name(default_name, sequence_name, number + 1)
+            else:
+                return sequence_name
+
         for vals in vals_list:
             IrSequence = self.env['ir.sequence'].sudo()
+            name = set_ir_sequence_name(vals['name'], vals['name'], 1)
             val = {
-                'name': _('POS Order %s', vals['name']),
+                'name': _('POS Order %s', name),
                 'padding': 4,
-                'prefix': "%s/" % vals['name'],
+                'prefix': "%s/" % name,
                 'code': "pos.order",
                 'company_id': vals.get('company_id', False),
             }
             # force sequence_id field to new pos.order sequence
             vals['sequence_id'] = IrSequence.create(val).id
 
-            val.update(name=_('POS order line %s', vals['name']), code='pos.order.line')
+            val.update(name=_('POS order line %s', name), code='pos.order.line')
             vals['sequence_line_id'] = IrSequence.create(val).id
         pos_configs = super().create(vals_list)
         pos_configs.sudo()._check_modules_to_install()

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -366,6 +366,14 @@ class PosConfig(models.Model):
                 if trusted_config.currency_id != config.currency_id:
                     raise ValidationError(_("You cannot share open orders with configuration that does not use the same currency."))
 
+
+    @api.onchange('name')
+    def _onchange_name(self):
+        self.sequence_id.name = _('POS Order %s', self.name),
+        self.sequence_id.prefix = "%s/" % self.name
+        self.sequence_line_id.name = _('POS order line %s', self.name)
+        self.sequence_line_id.prefix = "%s/" % self.name
+
     def name_get(self):
         result = []
         for config in self:


### PR DESCRIPTION
When two configs are created with the same name, it creates two different ir_sequence with the same name. Now, when we create a new pos config, we check the name of the existing ir_sequence. If it does exist, we will add an incremental number behind the name:
 Shop
 Shop 1
 Shop 2
 ...

It is especially useful in the order view. Now we can see that the orders come from different pos even if the name of the config is the same.

 task-id: 3339613

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
