### PR TITLE
[FIX] mrp: tablet redirect when backorder

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -154,6 +154,7 @@ class MrpWorkorder(models.Model):
                                      column1="blocked_by_id", column2="workorder_id", string="Blocks",
                                      domain="[('allow_workorder_dependencies', '=', True), ('id', '!=', id), ('production_id', '=', production_id)]",
                                      copy=False)
+    procurement_name = fields.Char("Manufacturing order name", related='production_id.procurement_group_id.name')
 
     @api.depends('production_availability', 'blocked_by_workorder_ids', 'blocked_by_workorder_ids.state')
     def _compute_state(self):

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -8,6 +8,7 @@
                 <field name="production_id"/>
                 <field name="workcenter_id"/>
                 <field name="product_id"/>
+                <field name="procurement_name"/>
                 <filter string="Ready" name="ready" domain="[('state','=','ready')]"/>
                 <filter string="Waiting" name="waiting" domain="[('state','=','waiting')]"/>
                 <filter string="Pending" name="pending" domain="[('state','=','pending')]"/>


### PR DESCRIPTION
[FIX] mrp: tablet redirect when backorder
This commit changes the behavior of backorders in the tablet view.

If we click on the `record production` of the tablet view, it
automatically create and open the tablet view of a backorder.

This comportement is now changed to going back to the previous view
(kanban/list) with a filter on the Manufacturing order.

Task-3302401

Enterprise : https://github.com/odoo/enterprise/pull/41573
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
