### PR TITLE
[IMP] mail: message notification double escape issue

### DIFF
--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -5,7 +5,7 @@ import { htmlToTextContentInline } from "@mail/utils/common/format";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { escape, sprintf, unescapeHTML } from "@web/core/utils/strings";
+import { sprintf, unescapeHTML } from "@web/core/utils/strings";
 import { url } from "@web/core/utils/urls";
 
 const PREVIEW_MSG_MAX_SIZE = 350; // optimal for native English speakers
@@ -47,8 +47,9 @@ export class OutOfFocusService {
                 notificationTitle = author.name;
             }
         }
-        const notificationContent = escape(
-            htmlToTextContentInline(message.body).substr(0, PREVIEW_MSG_MAX_SIZE)
+        const notificationContent = htmlToTextContentInline(message.body).substring(
+            0,
+            PREVIEW_MSG_MAX_SIZE
         );
         this.sendNotification({
             message: notificationContent,


### PR DESCRIPTION
**Before this commit:**
In discuss when a user receives a message containing strings from any of these '>,<,&' it gets converted to `>,<,&`  respectively. For example, if a user sends '<abc>', when the chat is out of focus, the toaster notification will show a notification with an escaped message i.e.`<abc>`.

**After this commit:**
The message will be shown as it is, in the toaster notification.

**Task**-3284244