### PR TITLE
[IMP] stock_account: Allow tracking COGS Journal Items origin

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -146,6 +146,7 @@ class AccountMove(models.Model):
                     'account_id': debit_interim_account.id,
                     'display_type': 'cogs',
                     'tax_ids': [],
+                    'cogs_origin_id': line.id,
                 })
 
                 # Add expense account line.
@@ -162,6 +163,7 @@ class AccountMove(models.Model):
                     'analytic_distribution': line.analytic_distribution,
                     'display_type': 'cogs',
                     'tax_ids': [],
+                    'cogs_origin_id': line.id,
                 })
         return lines_vals_list
 
@@ -232,6 +234,9 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'account_move_line_id', string='Stock Valuation Layer')
+    cogs_origin_id = fields.Many2one(  # technical field used to keep track in the originating line of the anglo-saxon lines
+        "account.move.line", copy=False,
+    )
 
     def _compute_account_id(self):
         super()._compute_account_id()


### PR DESCRIPTION
Main
-

[IMP] stock_account: Allow to keep track of the COGS Journal Items origin

Explain
-

So far It is quite cumbersome to try to figure out which lines are coming from where for the COGS journal items. It becomes more difficult to find them out when there are several lines from the same product with the same quantities and similar characteristics.

By having what invoice line originated which COGS Journal Items you can auditing and analysis in a more thorough way.

- You can figure out which Sale Line o Invoice Line was more profitable. Based on the actual revenue and the actual COGS.
- What COGS line was mistakenly created. For instance, when the invoice is created prior delivery, you can figure out how to surgically fix the of COGS journal items that that were wrong.
- To try to reconcile properly the lines in a Sale Order Line when there is drift and reconciliation is not properly made because there were differences and they cannot be easily spotted because you get lost in middle of several COGS lines but you do not know where they are really coming from.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
