### PR TITLE
[IMP] web_editor, website: permit to drag images

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -819,6 +819,8 @@ var SnippetEditor = Widget.extend({
                     return false;
                 }
                 this.dragStarted = true;
+                this.mousePositionYOnElement = ev.originalEvent.clientY - ui.offset.top;
+                this.mousePositionXOnElement = ev.originalEvent.clientX - ui.offset.left;
                 this._onDragAndDropStart();
             },
             stop: (...args) => {
@@ -1634,15 +1636,15 @@ var SnippetEditor = Widget.extend({
         const borderWidth = parseFloat(window.getComputedStyle(columnEl).borderWidth);
         const columnHeight = columnEl.clientHeight + 2 * borderWidth;
         const columnWidth = columnEl.clientWidth + 2 * borderWidth;
-        const columnMiddle = columnWidth / 2;
 
         // Placing the column where the mouse is.
-        const top = ev.pageY - rowElTop;
+        let top = ev.pageY - rowElTop - this.mousePositionYOnElement;
         const bottom = top + columnHeight;
-        let left = ev.pageX - rowElLeft - columnMiddle;
+        let left = ev.pageX - rowElLeft - this.mousePositionXOnElement;
 
-        // Horizontal overflow.
+        // Horizontal & vertical overflow.
         left = clamp(left, 0, rowEl.clientWidth - columnWidth);
+        top = clamp(top, 0, rowEl.clientHeight - columnHeight);
 
         columnEl.style.top = top + 'px';
         columnEl.style.left = left + 'px';

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -54,6 +54,19 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         };
         this.$body[0].ownerDocument.addEventListener('selectionchange', this.__onSelectionChange);
 
+        // Even if we prevented the drag via the css, we have to override the
+        // dragstart event because if one of the image ancestor has a dragstart
+        // listener, the dragstart handler can be called with the image as
+        // target. So we didn't prevent the drag with the css but with the
+        // following handler.
+        this.__onDragStart = ev => {
+            if (ev.target.nodeName === "IMG") {
+                ev.preventDefault();
+                ev.stopPropagation();
+            }
+        };
+        this.$body[0].addEventListener("dragstart", this.__onDragStart);
+
         // editor_has_snippets is, amongst other things, in charge of hiding the
         // backend navbar with a CSS animation. But we also need to make it
         // display: none when the animation finishes for efficiency but also so
@@ -70,6 +83,7 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
     destroy() {
         this._super(...arguments);
         this.$body[0].ownerDocument.removeEventListener('selectionchange', this.__onSelectionChange);
+        this.$body[0].removeEventListener("dragstart", this.__onDragStart);
         this.$body[0].classList.remove('o_animated_text_highlighted');
         clearTimeout(this._hideBackendNavbarTimeout);
         this.el.ownerDocument.body.classList.remove('editor_has_snippets_hide_backend_navbar');


### PR DESCRIPTION
This commit permits to drag and drop images without using the
`o_move_handle`. The user can directly drag the image in edit mode by
grabbing the image itself.

---

Before this commit when the user was dragging an image in the editor,
the image was always dragged from the top middle of the image. Now the
user can drag the image from anywhere on it.

---

By default, images on websites can be dragged and dropped in browsers.
As we have a custom drag & drop system, this commit removes the default
drag & drop behavior during the edition of a website page.

---

task-3369600