### PR TITLE
[FIX] event,event_sms: reference field not set properly

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -36,6 +36,13 @@ class EventTypeMail(models.Model):
     def _selection_template_model(self):
         return [('mail.template', 'Mail')]
 
+    @api.onchange('notification_type', 'template_ref')
+    def set_template_ref_model(self):
+        mail_model = self.env['mail.template']
+        if self.notification_type == 'mail':
+            record = mail_model.search([('model', '=', 'event.registration')], limit=1)
+            self.template_ref = "{},{}".format('mail.template', record.id) if record else False
+
     event_type_id = fields.Many2one(
         'event.type', string='Event Type',
         ondelete='cascade', required=True)
@@ -82,7 +89,7 @@ class EventMailScheduler(models.Model):
     def _selection_template_model(self):
         return [('mail.template', 'Mail')]
 
-    @api.onchange('notification_type')
+    @api.onchange('notification_type', 'template_ref')
     def set_template_ref_model(self):
         mail_model = self.env['mail.template']
         if self.notification_type == 'mail':

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -11,6 +11,14 @@ class EventTypeMail(models.Model):
     def _selection_template_model(self):
         return super(EventTypeMail, self)._selection_template_model() + [('sms.template', 'SMS')]
 
+    @api.onchange('notification_type', 'template_ref')
+    def set_template_ref_model(self):
+        super().set_template_ref_model()
+        mail_model = self.env['sms.template']
+        if self.notification_type == 'sms':
+            record = mail_model.search([('model', '=', 'event.registration')], limit=1)
+            self.template_ref = "{},{}".format('sms.template', record.id) if record else False
+
     notification_type = fields.Selection(selection_add=[('sms', 'SMS')], ondelete={'sms': 'set default'})
 
     @api.depends('notification_type')
@@ -60,7 +68,7 @@ class EventMailScheduler(models.Model):
 
         return super(EventMailScheduler, self).execute()
 
-    @api.onchange('notification_type')
+    @api.onchange('notification_type', 'template_ref')
     def set_template_ref_model(self):
         super().set_template_ref_model()
         mail_model = self.env['sms.template']


### PR DESCRIPTION
The following changes were made to resolve the issue:
- Calling onchange method set_template_ref_model even if template_ref is changed in event and event_sms modules.
- Added onchange set_template_ref_model method in the event.type.mail in events module to set template_ref  as mail.template if notification_type is "mail".
- override set_template_ref_model in event_sms to set template_ref as sms.template if notification_type is "SMS".

Description of the issue/feature this PR addresses:
This commit addresses an issue where the reference field was not being set correctly in the event and event_sms modules. The problem occurred when the template_ref field was modified.

Current behavior before PR:
The issue is that when selecting "SMS" as the notification type, the template_ref field is automatically populated. However, if the template is removed and the user clicks outside, then selects a template again, templates from the mail.template category is shown instead of sms.template, which is incorrect behavior. Additionally, if there are no sms.template models associated with the event.registration event, the template_ref field will display templates from the mail.template category.
Also, adding "SMS" in event templates from the configuration, makes the page unresponsive.

Desired behavior after PR is merged:
After the PR is merged, the desired behavior will be that when selecting "SMS" as the notification type and removing the template, clicking outside, and then selecting a template again, only templates from the sms.template category will be displayed, ensuring correct behavior and alignment with the intended functionality.
The second issue is WIP.(No records in sms.template)

Please refer below link to review the Issue:
https://www.awesomescreenshot.com/video/18356106?key=9db772e4a19e3718777b88c9a573cea3