### PR TITLE
[DRAFT][FIX] web, odoo: fix translations for duplicate records

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -444,6 +444,7 @@ var BasicModel = AbstractModel.extend({
         var self = this;
         var record = this.localData[recordID];
         var context = this._getContext(record);
+        context.is_duplicate = true;
         return this._rpc({
                 model: record.model,
                 method: 'copy',

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1764,6 +1764,13 @@ class _String(Field):
         if not self.translate or value is False or value is None:
             super().write(records, value)
             return
+        if self.translate is True and records.env.context.get('is_duplicate'):
+            translations = {lang: False for lang, _ in records.env['res.lang'].get_installed()}
+            translations['en_US'] = value
+            translations[records.env.lang or 'en_US'] = value
+            for record in records.with_context(is_duplicate=False):
+                record.update_field_translations(self.name, translations)
+            return
         cache = records.env.cache
         cache_value = self.convert_to_cache(value, records)
         records = cache.get_records_different_from(records, self, cache_value)


### PR DESCRIPTION
This commit ensures that changes in translated fields on a freshly duplicated record will apply to all translation even when the user language is not en_US.

Steps to reproduce:
- go to accounting -> configuration -> taxes in other language than en_US
- open any record in form view
- dupplicate the record
- change the name of the record and save
- ensure that the name is the same in all languages

opw-3339736

