### PR TITLE
[IMP] base,test_new_api,website:prevent merge of partners with more than 1 user

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -310,6 +310,10 @@ class MergePartnerAutomatic(models.TransientModel):
         if partner_ids & child_ids:
             raise UserError(_("You cannot merge a contact with one of his parent."))
 
+        # check if the list of partners to merge are linked to more than one user
+        if len(partner_ids.with_context(active_test=False).user_ids) > 1:
+            raise UserError(_("You cannot merge contacts linked to more than one user even if only one is active."))
+
         if extra_checks and len(set(partner.email for partner in partner_ids)) > 1:
             raise UserError(_("All contacts must have the same email. Only the Administrator can merge contacts with different emails."))
 


### PR DESCRIPTION
We prevent to merge partner linked to more than one user (by raising an exception) to avoid having multiple user pointing to the same partner as a consequence of a merge.

We want to avoid this situation because it generates weird behaviors. As res.user inherits from res.partner, having multiple user pointing to the same partner makes the fields of that partner shared with all those users. This was decided following the tentative to improve partner merge in website_slides (odoo/odoo#114840), where we also noticed strange behavior like completing a lesson with one user were adding karma to all the users linked to a same partner.

We have also adapted WebsiteVisitorTests tests in website that were failing because they were merging partners with more than one user: simply by merging partners with only one user.

Task-3167160