### PR TITLE
[FIX] account : display correct date format in email

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4199,7 +4199,7 @@ class AccountMove(models.Model):
         if self.invoice_date_due and self.payment_state not in ('in_payment', 'paid'):
             subtitles.append(_('%(amount)s due\N{NO-BREAK SPACE}%(date)s',
                            amount=format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang')),
-                           date=format_date(self.env, self.invoice_date_due, date_format='short', lang_code=render_context.get('lang'))
+                           date=format_date(self.env, self.invoice_date_due, lang_code=render_context.get('lang'))
                           ))
         else:
             subtitles.append(format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang')))


### PR DESCRIPTION
When you change the date format for english language for example , and you send an invoice in email to a customer it will always display the date in the default format.

Steps to reproduce the error :
1 - change the date format for en_US to %d/%m/%Y
2 - send and invoice by email to a client.
3 - go to mailcatcher or mailhog and see the email , in the top section you will "due ...." will be in the default format

The problem is that providing "short" as a date_format will use a dict which will have the default formats and will ignore the update that we made to the language. But with the current fix it will show the medium format and no the short format.

opw-3368523
