### PR TITLE
[FIX] sale_project, project, portal: fix long name issue and selecting SOL field may result in none 

### DIFF
--- a/addons/portal/static/src/xml/portal_chatter.xml
+++ b/addons/portal/static/src/xml/portal_chatter.xml
@@ -81,11 +81,11 @@
             <t t-foreach="widget.get('messages') || []" t-as="message">
                 <div class="d-flex o_portal_chatter_message" t-att-id="'message-' + message.id">
                     <img class="o_portal_chatter_avatar" t-att-src="message.author_avatar_url" alt="avatar"/>
-                    <div class="flex-grow-1">
+                    <div class="flex-grow-1 w-75">
                         <t t-call="portal.chatter_internal_toggle" t-if="widget.options['is_user_employee']"/>
 
                         <div class="o_portal_chatter_message_title">
-                            <h5 class='mb-1'><t t-esc="message.author_id[1]"/></h5>
+                            <h5 class='mb-1 text-truncate' t-att-title="message.author_id[1]"><t t-esc="message.author_id[1]"/></h5>
                             <p class="o_portal_chatter_puslished_date"><t t-esc="message.published_date_str"/></p>
                         </div>
                         <t t-out="message.body"/>

--- a/addons/project/views/project_portal_templates.xml
+++ b/addons/project/views/project_portal_templates.xml
@@ -167,9 +167,9 @@
                                 </td>
                                 <td>
                                     <t t-set="assignees" t-value="task.sudo().user_ids"/>
-                                    <div t-if="assignees" class="row flex-nowrap ps-3">
+                                    <div t-if="assignees" class="row flex-nowrap ps-3 w-100">
                                         <img class="rounded-circle o_portal_contact_img me-2 px-0" t-attf-src="#{image_data_uri(assignees[:1].avatar_128)}" alt="User" style="width: 20px; height: 20px;"/>
-                                        <span t-out="'%s%s' % (assignees[:1].name, ' + %s others' % len(assignees[1:]) if len(assignees.user_ids) > 1 else '')" t-att-title="'\n'.join(assignees.mapped('name'))"/>
+                                        <span class="text-truncate px-0" t-out="'%s%s' % (assignees[:1].name, ' + %s others' % len(assignees[1:]) if len(assignees.user_ids) > 1 else '')" t-att-title="'\n'.join(assignees.mapped('name'))"/>
                                     </div>
                                 </td>
                                 <td t-if="groupby != 'milestone' and allow_milestone" name="project_portal_milestones">


### PR DESCRIPTION
This PR address the following issue:
1) triple dot(...) missing for long usernames in list view of task and name overflowing in portal view of projects > task > chatter

In this PR :

1. The name is now shortened by applying the 'text-truncate' Bootstrap class



Task-3366464
