### PR TITLE
[FIX] base: properly handle bad value in attrs view attribute

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1763,7 +1763,16 @@ actual arch.
                 self._validate_classes(node, expr)
 
             elif attr == 'attrs':
-                for key, val_ast in get_dict_asts(expr).items():
+                try:
+                    parsed_dict = get_dict_asts(expr)
+                except ValueError:
+                    msg = _(
+                        '"attrs" value must be dictionary %(attribute)s=%(value)r',
+                        attribute=attr, value=expr,
+                    )
+                    self._raise_view_error(msg, node)
+
+                for key, val_ast in parsed_dict.items():
                     if isinstance(val_ast, ast.List):
                         # domains in attrs are used for readonly, invisible, ...
                         # and thus are only executed client side


### PR DESCRIPTION
View specification may have `attrs` attributes, where we specify domain when extra properties must be applied. Example:

```
<button ... attrs="{'invisible': [('has_accounting_entries','=', False)]}"/>
```

Since Odoo provides admin tools to modify view by user, the view is validated before saving. If there is an error, user will see error message explaining what is wrong with the changes.

Such an error message wasn't clear if user passes random string to `attrs` value. One of the examples caught by sentry [1]:

```
<button ... attrs="'{mobiel}'"/>
```

Before this commit, the user get traceback

```
AttributeError
'ValueError' object has no attribute 'context'
```
with traceback pointing to another error processing [2]

After this commit the error message points exactly to the badly formatted dictionary.

[1]: https://online.sentry.io/issues/3942045631/
[2]: https://github.com/odoo/odoo/blob/57a89dd6011442fc261cce4891a7d14b2e9ffabd/odoo/addons/base/models/ir_ui_view.py#L480

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
