### PR TITLE
[FIX] portal,web: load raw image for portal reports

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -15,6 +15,8 @@ from odoo.exceptions import ValidationError, AccessError, MissingError, UserErro
 from odoo.http import content_disposition, Controller, request, route
 from odoo.tools import consteq
 
+from odoo.addons.web.models.ir_qweb import IMAGE_RAW
+
 # --------------------------------------------------
 # Misc tools
 # --------------------------------------------------
@@ -423,7 +425,7 @@ class CustomerPortal(Controller):
         if report_type not in ('html', 'pdf', 'text'):
             raise UserError(_("Invalid report type: %s", report_type))
 
-        report_sudo = request.env.ref(report_ref).with_user(SUPERUSER_ID)
+        report_sudo = request.env.ref(report_ref).with_user(SUPERUSER_ID).with_context(qweb_img_raw_data=IMAGE_RAW)
 
         if not isinstance(report_sudo, type(request.env['ir.actions.report'])):
             raise UserError(_("%s is not the reference of a report", report_ref))

--- a/addons/web/models/ir_qweb.py
+++ b/addons/web/models/ir_qweb.py
@@ -10,6 +10,8 @@ from odoo import api, models
 from odoo.tools import pycompat
 from odoo.tools import html_escape as escape
 
+IMAGE_RAW = object()
+
 
 class Image(models.AbstractModel):
     """
@@ -64,7 +66,7 @@ class Image(models.AbstractModel):
             "That is because the image goes into the tag, or it gets the " \
             "hose again."
 
-        if options.get('qweb_img_raw_data', False):
+        if options.get('qweb_img_raw_data', False) or self.env.context.get('qweb_img_raw_data') is IMAGE_RAW:
             return super(Image, self).record_to_html(record, field_name, options)
 
         aclasses = ['img', 'img-fluid'] if options.get('qweb_img_responsive', True) else ['img']


### PR DESCRIPTION
The sale order report (and other reports) generated in the portal page does not render the images that could have been added with Studio

Steps to reproduce:
1. Install Sales and Studio
2. Go to Sales and open any quotation
3. Toggle Studio and add an image field anywhere in the form
4. Go to reports and edit "Quotation / Order"
5. Add the new image field in the report and close Studio
6. Create a quotation for Joel Willis, add an image and a product
7. Send the quotation by mail
8. Open the sent mail (Settings > Technical > Email > Emails)
9. Open the sale order link in a new incognito tab
10. Download the sale order with the button at the top left of the page
11. The report doesn't contain the image

Solution:
Load the raw data of the image instead of the src url

Problem:
When generating the html that will be used to render the pdf, the image field is rendered with a src url. This url will then be resolved in the content_image route but the user is public so he has no rights on the field. Hence, the placeholder image is returned.

opw-3100989