### PR TITLE
[FIX] stock: removed operation types and stock rules

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -324,7 +324,7 @@ class Picking(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         required=True, readonly=True,
-        states={'draft': [('readonly', False)]})
+        states={'draft': [('readonly', False)]}, ondelete='cascade')
     picking_type_code = fields.Selection(
         related='picking_type_id.code',
         readonly=True)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -75,7 +75,7 @@ class StockRule(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         required=True, check_company=True,
-        domain="[('code', '=?', picking_type_code_domain)]")
+        domain="[('code', '=?', picking_type_code_domain)]", ondelete='cascade')
     picking_type_code_domain = fields.Char(compute='_compute_picking_type_code_domain')
     delay = fields.Integer('Lead Time', default=0, help="The expected date of the created transfer will be computed based on this lead time.")
     partner_address_id = fields.Many2one(


### PR DESCRIPTION
When user uninstall the module 'Manufacturing' the relevant records are not deleted from the Operation Types, Transfers and Stock Rules.

To produce in sass-16.2:

- Install the 'Manufacturing' module
- Create mrp order and validate it.
- Now uninstall the 'Manufacturing' module.
- Operation Type 'Manufactuing' is still showing. (14.0 to master)
- Create a new 'stock.picking' record with 'Operation Type' as 'Manufacturing'
Error: A traceback appears: 'Wrong value for stock.picking.picking_type_code: Manufacturing'

Fixed this issue by using `ondelete` attribute on the `picking_type_id` field on `stock.rule` and `stock.picking` object as it was violates foreign key constraint `stock_rule_picking_type_id_fkey` on table `stock_rule`

sentry-4167898386
task-3318858

Traceback comes in sentry from stock_dropshipping:
```
KeyError: 1
  File "odoo/api.py", line 958, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'stock.picking(1,).picking_type_code'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 965, in get
    raise CacheMiss(record, field)
ValueError: Wrong value for stock.picking.picking_type_code: 'dropship'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 24, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 54, in web_search_read
    records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "odoo/models.py", line 5089, in search_read
    return records._read_format(fnames=fields, **read_kwargs)
  File "odoo/models.py", line 3181, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "odoo/models.py", line 5932, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1209, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1368, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4302, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 102, in determine
    return needle(records, *args)
  File "odoo/fields.py", line 706, in _compute_related
    record[self.name] = self._process_related(value[self.related_field.name])
  File "odoo/models.py", line 5941, in __setitem__
    return self._fields[key].__set__(self, value)
  File "odoo/fields.py", line 1300, in __set__
    self.write(protected_records, value)
  File "odoo/fields.py", line 1124, in write
    cache_value = self.convert_to_cache(value, records)
  File "odoo/fields.py", line 2704, in convert_to_cache
    raise ValueError("Wrong value for %s: %r" % (self, value))
```
