### PR TITLE
[FIX] core: read dev_mode from config file

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -530,9 +530,6 @@ class configmanager(object):
         self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()
 
-        dev_split = [s.strip() for s in opt.dev_mode.split(',')] if opt.dev_mode else []
-        self.options['dev_mode'] = dev_split + (['reload', 'qweb', 'xml'] if 'all' in dev_split else [])
-
         if opt.pg_path:
             self.options['pg_path'] = opt.pg_path
 
@@ -544,6 +541,11 @@ class configmanager(object):
         # normalize path options
         for key in ['data_dir', 'logfile', 'pidfile', 'test_file', 'screencasts', 'screenshots', 'pg_path', 'translate_out', 'translate_in', 'geoip_city_db', 'geoip_country_db']:
             self.options[key] = self._normalize(self.options[key])
+
+        dev_split = [s.strip() for s in (self.options['dev_mode'] or '').split(',') if s]
+        dev_mode = dev_split + (['reload', 'qweb', 'xml'] if 'all' in dev_split else [])
+        conf.dev_mode = dev_mode
+        self.options['dev_mode'] = dev_mode
 
         conf.addons_paths = self.options['addons_path'].split(',')
 


### PR DESCRIPTION
before this commit, the dev_mode is only read
from the CLI.

dev_split = [s.strip() for s in opt.dev_mode.split(',')]
 if opt.dev_mode else []

in the above line of code, if there is no dev_mode in the CLI it is replaced by an empty list and thus we lost the dev_mode read from the config file.

after this commit, the dev_mode is also read
from the config file. the priority is given for the dev_mode from the CLI.

Issue: https://github.com/odoo/odoo/issues/120216

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
