### PR TITLE
[FIX] hr_timesheet: fix the border color in kanban view remaining hou…

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -193,8 +193,8 @@
                 <div class="oe_kanban_bottom_left" position="inside">
                    <t name="planned_hours" t-if="record.planned_hours.raw_value &gt; 0 and record.allow_timesheets.raw_value">
                         <t t-set="badge" t-value=""/>
-                        <t t-set="badge" t-value="'bg-warning'" t-if="record.progress.raw_value &gt;= 80 and record.progress.raw_value &lt;= 100"/>
-                        <t t-set="badge" t-value="'bg-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
+                        <t t-set="badge" t-value="'border border-warning'" t-if="record.progress.raw_value &gt;= 80 and record.progress.raw_value &lt;= 100"/>
+                        <t t-set="badge" t-value="'border border-danger'" t-if="record.remaining_hours.raw_value &lt; 0"/>
                         <t t-set="title" t-value="'Remaining days'" t-if="record.encode_uom_in_days.raw_value"/>
                         <t t-set="title" t-value="'Remaining hours'" t-else=""/>
                         <div t-attf-class="oe_kanban_align badge {{ badge }}" t-att-title="title">


### PR DESCRIPTION
…r field

In the Kanban view of the project module, the remaining hour's widget should have the frame colored orange, while the rest of the widget should have no color

task-

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
