### PR TITLE
[FIX] base_import_module: warning while import module with unmet dependencies

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -224,7 +224,7 @@ class IrModule(models.Model):
                         if self._import_module(mod_name, path, force=force):
                             success.append(mod_name)
                     except Exception as e:
-                        _logger.exception('Error while importing module')
+                        _logger.warning('Error while importing module %r: %s', mod_name, e)
                         errors[mod_name] = exception_to_unicode(e)
         r = ["Successfully imported module '%s'" % mod for mod in success]
         for mod, error in errors.items():


### PR DESCRIPTION
When user tries to import some third party module from 'Import Module' and has unmet dependencies or module contains some error.

Steps to reproduce:
1) Install 'base_import_module' module.
2) Go to 'Apps' in 'Apps' > 'Third-Party Apps'.
3) Download any incompatible version third-party free app. 
4) Now, Click on 'Import Module' in 'Apps'.
5) Now in import module wizard, Upload your zip file by clicking
  'UPLOAD YOUR FILE' button.
6) Click on 'IMPORT APP' button and the error will be generated in
  the backend.

```
File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 451, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/home/odoo/odoo/odoo/odoo/models.py", line 4651, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/home/odoo/odoo/odoo/odoo/models.py", line 4573, in _load_records_create
    return self.create(values)
  File "<decorator-gen-47>", line 2, in create
  File "/home/odoo/odoo/odoo/odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/odoo/odoo/odoo/addons/base/models/ir_ui_view.py", line 568, in create
    result = super(View, self.with_context(ir_ui_view_partial_validation=True)).create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "/home/odoo/odoo/odoo/odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "/home/odoo/odoo/odoo/odoo/models.py", line 4207, in create
    records = self._create(data_list)
  File "/home/odoo/odoo/odoo/odoo/models.py", line 4387, in _create
    colval = field.convert_to_column(stored[fname], self, stored)
  File "/home/odoo/odoo/odoo/odoo/fields.py", line 2722, in convert_to_column
    value = self.convert_to_cache(value, record)
  File "/home/odoo/odoo/odoo/odoo/fields.py", line 2732, in convert_to_cache
    raise ValueError("Wrong value for %s: %r" % (self, value))
ValueError: Wrong value for ir.ui.view.type: 'google_map'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/odoo/odoo/addons/base_import_module/models/ir_module.py", line 235, in import_zipfile
    if self._import_module(mod_name, path, force=force):
  File "/home/odoo/odoo/odoo/addons/base_import_module/models/ir_module.py", line 110, in _import_module
    convert_xml_import(self.env, module, fp, idref, mode, noupdate)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "/home/odoo/odoo/odoo/odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
odoo.tools.convert.ParseError: while parsing /tmp/tmpdllogur1/web_google_maps/views/res_partner.xml:3, somewhere inside
<record id="view_res_partner_google_map" model="ir.ui.view">
        <field name="name">view.res.partner.google_map</field>
        <field name="model">res.partner</field>
        <field name="arch" type="xml">
            <google_map class="o_res_partner_map" string="Contacts" lat="partner_latitude" lng="partner_longitude" colors="blue:company_type=='person';green:company_type=='company';" sidebar_title="display_name" sidebar_subtitle="contact_address">
```

Sentry-4254922962

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
```