### PR TITLE
[FIX] tools: handle decompression bomb error for large image size

### DIFF
--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -79,7 +79,7 @@ class ImageProcess():
         else:
             try:
                 self.image = Image.open(io.BytesIO(source))
-            except (OSError, binascii.Error):
+            except (OSError, binascii.Error, Image.DecompressionBombError):
                 raise UserError(_("This file could not be decoded as an image file."))
 
             # Original format has to be saved before fixing the orientation or


### PR DESCRIPTION
When user adds an image of large size as an attachment and it exceeds the decompression range.

Steps to reproduce:
1) Install 'invoicing' module.
2) Open 'Invoicing' module > open any one invoice. 
3) Click on attachment icon on top right corner.
4) Now,  upload an large image file (ex. more than 178956970 pixels image file),
   traceback will be genrerated in the backend.

```
DecompressionBombError: Image size (464999070 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
  File "odoo/http.py", line 2114, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1921, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 459, in call_kw
    result = _call_kw_model_create(method, model, args, kwargs)
  File "odoo/api.py", line 439, in _call_kw_model_create
    result = method(recs, *args, **kwargs)
  File "<decorator-gen-159>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "home/odoo/src/enterprise/saas-16.3/account_accountant/models/res_config_settings.py", line 88, in create
    return super().create(vals_list)
  File "<decorator-gen-99>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/res_config.py", line 758, in create
    return super().create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4238, in create
    next(iter(fields)).determine_inverse(batch_recs)
  File "odoo/fields.py", line 1396, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 102, in determine
    return needle(records, *args)
  File "odoo/fields.py", line 721, in _inverse_related
    target[field.name] = record_value[record]
  File "odoo/models.py", line 6131, in __setitem__
    return self._fields[key].__set__(self, value)
  File "odoo/fields.py", line 1320, in __set__
    records.write({self.name: write_value})
  File "addons/website/models/website.py", line 217, in write
    self._handle_create_write(values)
  File "addons/website/models/website.py", line 261, in _handle_create_write
    self._handle_favicon(vals)
  File "addons/website/models/website.py", line 268, in _handle_favicon
    vals['favicon'] = base64.b64encode(tools.image_process(base64.b64decode(vals['favicon']), size=(256, 256), crop='center', output_format='ICO'))
  File "odoo/tools/image.py", line 264, in image_process
    image = ImageProcess(source, verify_resolution)
  File "odoo/tools/image.py", line 81, in __init__
    self.image = Image.open(io.BytesIO(source))
  File "PIL/Image.py", line 2994, in open
    im = _open_core(fp, filename, prefix, formats)
  File "PIL/Image.py", line 2981, in _open_core
    _decompression_bomb_check(im.size)
  File "PIL/Image.py", line 2890, in _decompression_bomb_check
    raise DecompressionBombError(
```

Sentry-4258016666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
