### PR TITLE
[FIX] pos_self_order: check if pos_config_id is available or not

### DIFF
--- a/addons/pos_self_order/controllers/controllers.py
+++ b/addons/pos_self_order/controllers/controllers.py
@@ -43,6 +43,8 @@ class PosSelfOrderController(http.Controller):
         :return: the rendered template
         """
         _, pos_config_id = unslug(pos_name)
+        if not pos_config_id:
+            raise werkzeug.exceptions.NotFound()
         pos_config_sudo = self._get_pos_config_sudo(pos_config_id)
         session_info = request.env["ir.http"].get_frontend_session_info()
         session_info.update({


### PR DESCRIPTION
If a user gets 'pos_config_id' None, then traceback will appear.

https://github.com/odoo/odoo/blob/e27cb2181a899a6573df0ac6ecb0cf1ba05fd2c2/addons/pos_self_order/controllers/controllers.py#L46

```
Error: int() argument must be a string, a bytes-like object or a real number,
       not 'NoneType'
```

See Traceback:-

```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
  File "odoo/http.py", line 2114, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/pos_self_order/controllers/controllers.py", line 46, in pos_self_order_start
    pos_config_sudo = self._get_pos_config_sudo(pos_config_id)
  File "addons/pos_self_order/controllers/controllers.py", line 126, in _get_pos_config_sudo
    int(pos_config_id))

```

In the 'pos_self_order_start' function if  'pos_config_id' is none then traceback will raise:

https://github.com/odoo/odoo/blob/saas-16.3/addons/pos_self_order/controllers/controllers.py#L46

Therefore, in the above use case, applying the condition will check if 'pos_config_id' is available or not

sentry-4235926588

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
