### PR TITLE
[FIX] web: respect image aspect ratio in list views

### DIFF
--- a/addons/web/static/src/legacy/js/fields/basic_fields.js
+++ b/addons/web/static/src/legacy/js/fields/basic_fields.js
@@ -2284,7 +2284,7 @@ var FieldBinaryImage = AbstractFieldBinary.extend({
             $img.attr('height', height);
             $img.css('max-height', height + 'px');
             if (!width) {
-                $img.css('width', 'auto');
+                $img[0].style.setProperty('width', 'auto', 'important');
                 $img.css('max-width', '100%');
             }
         }
@@ -2402,7 +2402,7 @@ var CharImageUrl = AbstractField.extend({
                 $img.attr('height', height);
                 $img.css('max-height', height + 'px');
                 if (!width) {
-                    $img.css('width', 'auto');
+                    $img[0].style.setProperty('width', 'auto', 'important');
                     $img.css('max-width', '100%');
                 }
             }

--- a/addons/web/static/tests/legacy/fields/basic_fields_tests.js
+++ b/addons/web/static/tests/legacy/fields/basic_fields_tests.js
@@ -3232,7 +3232,7 @@ QUnit.module('Legacy basic_fields', {
         assert.hasAttrValue(form.$('div[name="picture"] > img'), 'height', "270",
             "the image should correctly set its attributes");
         const image2Style = form.$('div[name="picture"] > img').attr('style');
-        assert.ok(['max-height: 270px', 'width: auto', 'max-width: 100%'].every(e => image2Style.includes(e)),
+        assert.ok(['max-height: 270px', 'width: auto !important', 'max-width: 100%'].every(e => image2Style.includes(e)),
             "the image should correctly set its style");
 
         form.destroy();
@@ -3492,7 +3492,7 @@ QUnit.module('Legacy basic_fields', {
         assert.hasAttrValue(form.$('div[name="tortue"] > img'), 'height', "270",
             "the image should correctly set its attributes");
         const image2Style = form.$('div[name="tortue"] > img').attr('style');
-        assert.ok(['max-height: 270px', 'width: auto', 'max-width: 100%'].every(e => image2Style.includes(e)),
+        assert.ok(['max-height: 270px', 'width: auto !important', 'max-width: 100%'].every(e => image2Style.includes(e)),
             "the image should correctly set its style");
 
         form.destroy();


### PR DESCRIPTION
Image fields can appear stretched on safari browsers. This happens when the max-height inline css property takes effect. The resulting offending css is a a result of the following styles:

```css
element.style {
    max-height: 90px;
    width: auto;
    max-width: 100%;
}
.w-100 {
    width: 100% !important;
}
.img-fluid {
    max-width: 100%;
    height: auto;
}
```

As we can see the inline width property is overridden by the w-100 class. The problem can be resolved by marking the inline width as !important as it will take precendence over the w-100 styles.

opw-3332123