### PR TITLE
[FIX] web: use correct method name for orm service

### DIFF
--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -211,13 +211,13 @@ export const ormService = {
     async: [
         "call",
         "create",
-        "name_get",
+        "nameGet",
         "read",
         "readGroup",
         "search",
         "searchRead",
         "unlink",
-        "web_search_read",
+        "webSearchRead",
         "write",
     ],
     start(env, { rpc, user }) {


### PR DESCRIPTION
Before this commit, the method name used to indicate that a method is async was snake cased instead of camel cased. This commit fixes this.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
