### PR TITLE
[IMP] project_todo: add a create to-do command on the command palette

### DIFF
--- a/addons/project_todo/__init__.py
+++ b/addons/project_todo/__init__.py
@@ -1,5 +1,6 @@
 from . import controllers
 from . import models
+from . import wizard
 
 def _todo_uninstall(env):
     # The record rule project.task_visibility_rule needs to apply to all rights and not just read after uninstallation

--- a/addons/project_todo/__manifest__.py
+++ b/addons/project_todo/__manifest__.py
@@ -18,6 +18,7 @@
         'data/todo_template.xml',
         'views/project_task_views.xml',
         'views/project_todo_menus.xml',
+        'wizard/mail_activity_todo_create.xml',
     ],
     'installable': True,
     'application': True,

--- a/addons/project_todo/security/ir.model.access.csv
+++ b/addons/project_todo/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_project_task_type_user,project.task.type.user,project.model_project_task_type,base.group_user,1,1,1,1
 access_task_on_partner,project.task on partners,project.model_project_task,base.group_user,1,1,1,1
 access_project_tags_user,project.project_tags_user,project.model_project_tags,base.group_user,1,1,1,1
+access_mail_activity_todo_create,mail.activity.todo.create,model_mail_activity_todo_create,base.group_user,1,1,1,0

--- a/addons/project_todo/static/src/views/todo_activity_wizard/todo_activity_wizard_controller.js
+++ b/addons/project_todo/static/src/views/todo_activity_wizard/todo_activity_wizard_controller.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { onMounted } from "@odoo/owl";
+import { FormController } from "@web/views/form/form_controller";
+
+export class TodoActivityWizardController extends FormController {
+    setup() {
+        super.setup();
+        onMounted(() => {
+            const firstInput = document.querySelector('div.o_field_widget input');
+            firstInput.focus();
+        });
+    }
+}

--- a/addons/project_todo/static/src/views/todo_activity_wizard/todo_activity_wizard_view.js
+++ b/addons/project_todo/static/src/views/todo_activity_wizard/todo_activity_wizard_view.js
@@ -1,0 +1,12 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { formView } from "@web/views/form/form_view";
+import { TodoActivityWizardController } from "./todo_activity_wizard_controller";
+
+export const todoActivityWizardView = {
+    ...formView,
+    Controller: TodoActivityWizardController,
+};
+
+registry.category("views").add("todo_activity_wizard", todoActivityWizardView);

--- a/addons/project_todo/wizard/__init__.py
+++ b/addons/project_todo/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import mail_activity_todo_create

--- a/addons/project_todo/wizard/mail_activity_todo_create.py
+++ b/addons/project_todo/wizard/mail_activity_todo_create.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _
+
+class MailActivityTodoCreate(models.TransientModel):
+    _name = 'mail.activity.todo.create'
+    _description = 'Create activity and todo at the same time'
+
+    summary = fields.Char()
+    date_deadline = fields.Date('Due Date', index=True, required=True, default=fields.Date.context_today)
+    user_id = fields.Many2one('res.users', 'Assigned to', default=lambda self: self.env.user, required=True, readonly=True)
+    note = fields.Html(sanitize_style=True)
+
+    def create_todo_activity(self):
+        todo = self.env['project.task'].create({
+            'name': self.summary,
+            'description': self.note,
+            'date_deadline': self.date_deadline,
+            'user_ids': self.user_id.ids,
+        })
+        self.env['mail.activity'].create({
+            'res_model_id': self.env['ir.model']._get('project.task').id,
+            'res_id': todo.id,
+            'summary': self.summary,
+            'user_id': self.user_id.id,
+            'date_deadline': self.date_deadline,
+            'activity_type_id': self.env['mail.activity']._default_activity_type_for_model('project.task').id,
+        })
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': _("Your to-do has been successfully added to your pipeline."),
+            },
+        }

--- a/addons/project_todo/wizard/mail_activity_todo_create.xml
+++ b/addons/project_todo/wizard/mail_activity_todo_create.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="mail_activity_todo_create_popup" model="ir.ui.view">
+        <field name="name">mail.activity.todo.create.popup</field>
+        <field name="model">mail.activity.todo.create</field>
+        <field name="arch" type="xml">
+            <form js_class="todo_activity_wizard">
+                <group>
+                    <field name="summary" placeholder="Reminder to..." required="1"/>
+                    <field name="date_deadline"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_open': 1}"/>
+                </group>
+                <field name="note" class="oe-bordered-editor" placeholder="Add details about your to-do..."/>
+                <footer>
+                    <button class="btn btn-primary" type="object" name="create_todo_activity" close="1">Add To-Do</button>
+                    <button class="btn btn-secondary" special="cancel" close="1">Discard</button>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This task adds a new command on the command palette, which
allows the user to create a to-do and schedule an activity for it.

The command opens a new wizard to create a to-do.

task-3330177