### PR TITLE
[FIX] mrp_subcontracting: give user error while subcontracting immediate transfer

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -153,8 +153,7 @@ class StockMove(models.Model):
             bom = move._get_subcontract_bom()
             if not bom:
                 continue
-            if float_is_zero(move.product_qty, precision_rounding=move.product_uom.rounding) and\
-                    move.picking_id.immediate_transfer is True:
+            if move.picking_id.immediate_transfer is True:
                 raise UserError(_("To subcontract, use a planned transfer."))
             move.write({
                 'is_subcontract': True,


### PR DESCRIPTION
Before this commit
=================
When user creates a subcontracting product and places an immediate transfer,
while recording a component it creates several back-orders

After this commit
==================
With this commit, the user cannot directly process the subcontracting product 
with an immediate transfer.

Task - 3326615
