### PR TITLE
[FIX] mrp: work center smart buttons

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -306,13 +306,19 @@
                                 class="oe_stat_button" icon="fa-cog"/>
                             <button name="%(mrp_workcenter_productivity_report_oee)d" type="action" class="oe_stat_button" icon="fa-pie-chart">
                                 <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="oee" widget="statinfo" nolabel="1"/>%</span>
+                                    <span class="o_stat_value d-flex gap-1">
+                                        <field name="oee" widget="statinfo" nolabel="1"/>
+                                        <span>%</span>
+                                    </span>
                                     <span class="o_stat_text">OEE</span>
                                 </div>
                             </button>
                             <button name="%(mrp_workcenter_productivity_report_blocked)d" type="action" class="oe_stat_button" icon="fa-bar-chart">
                                 <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="blocked_time" widget="statinfo" nolabel="1"/> Hours</span>
+                                    <span class="o_stat_value d-flex gap-1">
+                                        <field name="blocked_time" widget="statinfo" nolabel="1"/>
+                                        <span>Hours</span>
+                                    </span>
                                     <span class="o_stat_text">Lost</span>
                                 </div>
                             </button>
@@ -323,13 +329,19 @@
                                           'search_default_pending': True,
                                           'search_default_progress': True}">
                                 <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="workcenter_load" widget="statinfo" nolabel="1"/> Minutes</span>
+                                    <span class="o_stat_value d-flex gap-1">
+                                        <field name="workcenter_load" widget="statinfo" nolabel="1"/>
+                                        <span>Minutes</span>
+                                    </span>
                                     <span class="o_stat_text">Load</span>
                                 </div>
                             </button>
                             <button name="%(mrp_workorder_report)d" type="action" class="oe_stat_button" icon="fa-bar-chart" context="{'search_default_workcenter_id': id, 'search_default_thisyear': True}">
                                 <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value"><field name="performance" widget="statinfo" nolabel="1"/>%</span>
+                                    <span class="o_stat_value d-flex gap-1">
+                                        <field name="performance" widget="statinfo" nolabel="1"/>
+                                        <span>%</span>
+                                    </span>
                                     <span class="o_stat_text">Performance</span>
                                 </div>
                             </button>


### PR DESCRIPTION
Before:
Smart button's text is wrapping and displaying out of the container

After:
Smart button's text is not wrapping and displays correctly in the button container

Issue: [mgm] MRP - Work Center smartbuttons : https://tinyurl.com/2bo3jtaa 