### PR TITLE
[IMP] web: improve patch function

### DIFF
--- a/addons/account/static/tests/account_move_form_tests.js
+++ b/addons/account/static/tests/account_move_form_tests.js
@@ -32,7 +32,7 @@ QUnit.module("Views", {}, function (hooks) {
         });
         patchWithCleanup(AccountMoveFormRenderer.prototype, {
             saveBeforeTabChange() {
-                this._super();
+                super.saveBeforeTabChange();
                 assert.step("tab saved");
             },
         });

--- a/addons/barcodes/static/tests/basic/float_scannable_field_test.js
+++ b/addons/barcodes/static/tests/basic/float_scannable_field_test.js
@@ -104,7 +104,7 @@ QUnit.module("Fields", (hooks) => {
         patchWithCleanup(FormController.prototype, {
             onPagerUpdate() {
                 assert.step("update");
-                return this._super.apply(this, arguments);
+                return super.onPagerUpdate(...arguments);
             },
         });
 

--- a/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
@@ -7,7 +7,7 @@ export class GS1BarcodeError extends Error {};
 
 export const FNC1_CHAR = String.fromCharCode(29);
 
-patch(BarcodeParser, "barcodes_gs1_nomenclature.BarcodeParser static", {
+patch(BarcodeParser, {
     barcodeNomenclatureFields: [
         ...BarcodeParser.barcodeNomenclatureFields,
         "is_gs1_nomenclature",
@@ -21,14 +21,14 @@ patch(BarcodeParser, "barcodes_gs1_nomenclature.BarcodeParser static", {
     ],
 });
 
-patch(BarcodeParser.prototype, "barcodes_gs1_nomenclature.BarcodeParser", {
+patch(BarcodeParser.prototype, {
     /**
      * Convert YYMMDD GS1 date into a Date object
      *
      * @param {string} gs1Date YYMMDD string date, length must be 6
      * @returns {Date}
      */
-    gs1_date_to_date: function(gs1Date) {
+    gs1_date_to_date(gs1Date) {
         // See 7.12 Determination of century in dates:
         // https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdfDetermination of century
         const now = new Date();
@@ -58,7 +58,7 @@ patch(BarcodeParser.prototype, "barcodes_gs1_nomenclature.BarcodeParser", {
      * @param {Object} rule Matched Barcode Rule
      * @returns {Object|null}
      */
-    parse_gs1_rule_pattern: function(match, rule) {
+    parse_gs1_rule_pattern(match, rule) {
         const result = {
             rule: Object.assign({}, rule),
             ai: match[1],
@@ -103,7 +103,7 @@ patch(BarcodeParser.prototype, "barcodes_gs1_nomenclature.BarcodeParser", {
      * @param {string} barcode
      * @returns {Array} Array of object
      */
-    gs1_decompose_extanded: function(barcode) {
+    gs1_decompose_extanded(barcode) {
         const results = [];
         const rules = this.nomenclature.rules.filter(rule => rule.encoding === 'gs1-128');
         const separatorReg = FNC1_CHAR + "?";
@@ -137,10 +137,10 @@ patch(BarcodeParser.prototype, "barcodes_gs1_nomenclature.BarcodeParser", {
      * @override
      * @returns {Object|Array|null} If nomenclature is GS1, returns an array or null
      */
-    parse_barcode: function(barcode){
+    parse_barcode(barcode) {
         if (this.nomenclature && this.nomenclature.is_gs1_nomenclature) {
             return this.gs1_decompose_extanded(barcode);
         }
-        return this._super(...arguments);
+        return super.parse_barcode(...arguments);
     },
 });

--- a/addons/barcodes_gs1_nomenclature/static/src/js/barcode_service.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/barcode_service.js
@@ -7,12 +7,12 @@ import { barcodeService } from '@barcodes/barcode_service';
 import { FNC1_CHAR } from "@barcodes_gs1_nomenclature/js/barcode_parser";
 
 
-patch(barcodeService, 'barcodes_gs1_nomenclature', {
+patch(barcodeService, {
     // Use the regex given by the session, else use an impossible one
     gs1SeparatorRegex: new RegExp(session.gs1_group_separator_encodings || '.^', 'g'),
 
-    cleanBarcode: function(barcode) {
+    cleanBarcode(barcode) {
         barcode = barcode.replace(barcodeService.gs1SeparatorRegex, FNC1_CHAR);
-        return this._super(barcode);
+        return super.cleanBarcode(barcode);
     },
 });

--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -78,7 +78,7 @@ QUnit.module("base_automation", {}, function () {
                     errorContext,
                     "Received the correct error context"
                 );
-                this._super();
+                super.setup();
             },
         });
 

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -1054,7 +1054,7 @@ QUnit.module("Base Import Tests", (hooks) => {
 
         patchWithCleanup(ImportBlockUI.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 if (this.props.message === "Importing") {
                     assert.step("Block UI received the right text");
                 }
@@ -1063,7 +1063,7 @@ QUnit.module("Base Import Tests", (hooks) => {
 
         patchWithCleanup(ImportDataProgress.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 useEffect(
                     () => {
                         if (this.props.importProgress.step === 1) {
@@ -1146,7 +1146,7 @@ QUnit.module("Base Import Tests", (hooks) => {
 
         patchWithCleanup(ImportBlockUI.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 if (this.props.message === "Testing") {
                     assert.step("Block UI received the right text");
                 }
@@ -1155,7 +1155,7 @@ QUnit.module("Base Import Tests", (hooks) => {
 
         patchWithCleanup(ImportDataProgress.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 useEffect(
                     () => {
                         if (this.props.importProgress.step === 1) {

--- a/addons/bus/static/tests/assets_watchdog_tests.js
+++ b/addons/bus/static/tests/assets_watchdog_tests.js
@@ -24,7 +24,7 @@ QUnit.module("Bus Assets WatchDog", (hooks) => {
         serviceRegistry.add("multi_tab", multiTabService);
         patchWithCleanup(browser, {
             setTimeout(fn) {
-                return this._super(fn, 0);
+                return super.setTimeout(fn, 0);
             },
             location: {
                 reload: () => assert.step("reloadPage"),

--- a/addons/bus/static/tests/helpers/mock_server.js
+++ b/addons/bus/static/tests/helpers/mock_server.js
@@ -6,15 +6,15 @@ import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_webs
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "bus", {
+patch(MockServer.prototype, {
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         Object.assign(this, TEST_USER_IDS);
         const self = this;
         this.websocketWorker = patchWebsocketWorkerWithCleanup({
             _sendToServer(message) {
                 self._performWebsocketRequest(message);
-                this._super(message);
+                super._sendToServer(message);
             },
         });
         this.notificationsToBeResolved = [];

--- a/addons/bus/static/tests/helpers/mock_server/models/ir_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_server/models/ir_websocket.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "bus/models/ir_websocket", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_update_presence` on `ir.websocket`.
      *

--- a/addons/bus/static/tests/helpers/mock_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_websocket.js
@@ -69,8 +69,7 @@ export function patchWebsocketWorkerWithCleanup(params = {}) {
             WebSocket: function () {
                 return new WebSocketMock();
             },
-        },
-        { pure: true }
+        }
     );
     patchWithCleanup(websocketWorker || WebsocketWorker.prototype, params);
     websocketWorker = websocketWorker || new WebsocketWorker();
@@ -85,8 +84,7 @@ export function patchWebsocketWorkerWithCleanup(params = {}) {
                 });
                 return sharedWorker;
             },
-        },
-        { pure: true }
+        }
     );
     registerCleanup(() => {
         if (websocketWorker) {

--- a/addons/bus/static/tests/multi_tab_service_tests.js
+++ b/addons/bus/static/tests/multi_tab_service_tests.js
@@ -27,7 +27,7 @@ QUnit.module("bus", function () {
                 if (eventName === "pagehide") {
                     return;
                 }
-                this._super(eventName, callback);
+                super.addEventListener(eventName, callback);
             },
         });
         const secondTabEnv = await makeTestEnv();
@@ -95,7 +95,7 @@ QUnit.module("bus", function () {
                 if (eventName === "pagehide") {
                     return;
                 }
-                this._super(eventName, callback);
+                super.addEventListener(eventName, callback);
             },
         });
         const secondTabEnv = await makeTestEnv();

--- a/addons/bus/static/tests/simple_notification_tests.js
+++ b/addons/bus/static/tests/simple_notification_tests.js
@@ -70,7 +70,7 @@ QUnit.test("receive and display simple notification as sticky", async (assert) =
              * Sticky notifications are removed after a delay. If the notification is still
              * present when this delay is set to 0 it means it is a sticky one.
              */
-            return this._super(fn, 0);
+            return super.setTimeout(fn, 0);
         },
     });
     await afterNextRender(() => {

--- a/addons/calendar/static/src/activity/activity_list_popover_item_patch.js
+++ b/addons/calendar/static/src/activity/activity_list_popover_item_patch.js
@@ -3,9 +3,9 @@
 import { ActivityListPopoverItem } from "@mail/core/web/activity_list_popover_item";
 import { patch } from "@web/core/utils/patch";
 
-patch(ActivityListPopoverItem.prototype, "calendar", {
+patch(ActivityListPopoverItem.prototype, {
     get hasEditButton() {
-        return this._super() && !this.props.activity.calendar_event_id;
+        return super.hasEditButton && !this.props.activity.calendar_event_id;
     },
 
     async onClickReschedule() {

--- a/addons/calendar/static/src/activity/activity_menu_patch.js
+++ b/addons/calendar/static/src/activity/activity_menu_patch.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { deserializeDateTime, formatDateTime } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
 
-patch(ActivityMenu.prototype, "calendar", {
+patch(ActivityMenu.prototype, {
     async fetchSystrayActivities() {
-        await this._super();
+        await super.fetchSystrayActivities();
         for (const group of Object.values(this.store.activityGroups)) {
             if (group.type === "meeting") {
                 for (const meeting of group.meetings) {
@@ -31,7 +31,7 @@ patch(ActivityMenu.prototype, "calendar", {
                 clearBreadcrumbs: true,
             });
         } else {
-            this._super(...arguments);
+            super.openActivityGroup(...arguments);
         }
     },
 });

--- a/addons/calendar/static/src/activity/activity_patch.js
+++ b/addons/calendar/static/src/activity/activity_patch.js
@@ -4,9 +4,9 @@ import { Activity } from "@mail/core/web/activity";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 
-patch(Activity.prototype, "calendar", {
+patch(Activity.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.orm = useService("orm");
     },
     async onClickReschedule() {
@@ -20,7 +20,7 @@ patch(Activity.prototype, "calendar", {
             await this.orm.call("mail.activity", "unlink_w_meeting", [[this.props.data.id]]);
             this.props.onUpdate();
         } else {
-            this._super();
+            super.unlink();
         }
     },
 });

--- a/addons/calendar/static/src/activity/activity_service_patch.js
+++ b/addons/calendar/static/src/activity/activity_service_patch.js
@@ -3,9 +3,9 @@
 import { ActivityService } from "@mail/core/web/activity_service";
 import { patch } from "@web/core/utils/patch";
 
-patch(ActivityService.prototype, "calendar/activity_service", {
+patch(ActivityService.prototype, {
     insert(data) {
-        const activity = this._super(...arguments);
+        const activity = super.insert(...arguments);
         const { calendar_event_id: calendarEventId } = data;
         if (calendarEventId) {
             activity["calendar_event_id"] = calendarEventId;

--- a/addons/calendar/static/tests/activity_widget_tests.js
+++ b/addons/calendar/static/tests/activity_widget_tests.js
@@ -50,7 +50,7 @@ QUnit.test("list activity widget: reschedule button in dropdown", async (assert)
     const { openView } = await start({ serverData: { views } });
     patchWithCleanup(ListController.prototype, {
         setup() {
-            this._super();
+            super.setup();
             const selectRecord = this.props.selectRecord;
             this.props.selectRecord = (...args) => {
                 assert.step(`select_record ${JSON.stringify(args)}`);

--- a/addons/calendar/static/tests/calendar_notification_tests.js
+++ b/addons/calendar/static/tests/calendar_notification_tests.js
@@ -27,7 +27,7 @@ QUnit.module("Calendar Notification", (hooks) => {
         serviceRegistry.add("multi_tab", multiTabService);
         patchWithCleanup(browser, {
             setTimeout(fn) {
-                this._super(fn, 0);
+                super.setTimeout(fn, 0);
             },
         });
     });

--- a/addons/calendar/static/tests/helpers/mock_server/models/calendar_event.js
+++ b/addons/calendar/static/tests/helpers/mock_server/models/calendar_event.js
@@ -1,9 +1,9 @@
 /** @odoo-module **/
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { MockServer } from '@web/../tests/helpers/mock_server';
 
-patch(MockServer.prototype, 'calendar/models/calendar_event', {
+patch(MockServer.prototype, {
     /**
      * @override
      */
@@ -12,6 +12,6 @@ patch(MockServer.prototype, 'calendar/models/calendar_event', {
         if (args.model === 'calendar.event' && args.method === 'check_access_rights') {
             return true;
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/calendar/static/tests/helpers/mock_server/models/mail_activity.js
+++ b/addons/calendar/static/tests/helpers/mock_server/models/mail_activity.js
@@ -3,10 +3,10 @@
 // ensure mail override is applied first.
 import '@mail/../tests/helpers/mock_server/models/mail_activity';
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { MockServer } from '@web/../tests/helpers/mock_server';
 
-patch(MockServer.prototype, 'calendar/models/mail_activity', {
+patch(MockServer.prototype, {
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -25,6 +25,6 @@ patch(MockServer.prototype, 'calendar/models/mail_activity', {
                 target: 'current',
             };
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/calendar/static/tests/helpers/mock_server/models/res_users.js
+++ b/addons/calendar/static/tests/helpers/mock_server/models/res_users.js
@@ -3,12 +3,12 @@
 // ensure mail override is applied first.
 import '@mail/../tests/helpers/mock_server/models/res_users';
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { MockServer } from '@web/../tests/helpers/mock_server';
 
 import { datetime_to_str } from '@web/legacy/js/core/time';
 
-patch(MockServer.prototype, 'calendar/models/res_users', {
+patch(MockServer.prototype, {
     /**
      * Simulates `_systray_get_calendar_event_domain` on `res.users`.
      *
@@ -41,7 +41,7 @@ patch(MockServer.prototype, 'calendar/models/res_users', {
      * @override
      */
     _mockResUsersSystrayGetActivities() {
-        const activities = this._super(...arguments);
+        const activities = super._mockResUsersSystrayGetActivities(...arguments);
         const meetingsLines = this.pyEnv['calendar.event'].searchRead(
             this._mockResUsers_SystrayGetCalendarEventDomain(),
             {

--- a/addons/crm/static/src/activity_menu_patch.js
+++ b/addons/crm/static/src/activity_menu_patch.js
@@ -3,7 +3,7 @@
 import { ActivityMenu } from "@mail/core/web/activity_menu";
 import { patch } from "@web/core/utils/patch";
 
-patch(ActivityMenu.prototype, "crm", {
+patch(ActivityMenu.prototype, {
     availableViews(group) {
         if (group.model === "crm.lead") {
             return [
@@ -16,7 +16,7 @@ patch(ActivityMenu.prototype, "crm", {
                 [false, "activity"],
             ];
         }
-        return this._super(...arguments);
+        return super.availableViews(...arguments);
     },
 
     openActivityGroup(group, filter = "all") {
@@ -38,7 +38,7 @@ patch(ActivityMenu.prototype, "crm", {
                 clearBreadcrumbs: true,
             });
         } else {
-            return this._super(group, filter);
+            return super.openActivityGroup(group, filter);
         }
     },
 });

--- a/addons/crm/static/tests/mock_server.js
+++ b/addons/crm/static/tests/mock_server.js
@@ -4,7 +4,7 @@ import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 
-patch(MockServer.prototype, "CRM", {
+patch(MockServer.prototype, {
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -51,6 +51,6 @@ patch(MockServer.prototype, "CRM", {
             }
             return message;
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/crm_iap_mine/static/src/js/tours/crm_iap_lead.js
+++ b/addons/crm_iap_mine/static/src/js/tours/crm_iap_lead.js
@@ -9,9 +9,9 @@ import "@crm/js/tours/crm";
 import { patch } from "@web/core/utils/patch";
 var _t = core._t;
 
-patch(registry.category("web_tour.tours").get("crm_tour"), "patch_crm_tour", {
+patch(registry.category("web_tour.tours").get("crm_tour"), {
     steps() {
-        const originalSteps = this._super();
+        const originalSteps = super.steps();
         const DragOppToWonStepIndex = originalSteps.findIndex(
             (step) => step.id === "drag_opportunity_to_won_step"
         );

--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -5,24 +5,24 @@ import { x2ManyCommands } from "@web/core/orm_service";
 import { patch } from "@web/core/utils/patch";
 
 
-patch(SaleOrderLineProductField.prototype, 'event_booth_sale', {
+patch(SaleOrderLineProductField.prototype, {
 
     async _onProductUpdate() {
-        this._super(...arguments);
+        super._onProductUpdate(...arguments);
         if (this.props.record.data.product_type === 'event_booth') {
             this._openEventBoothConfigurator(false);
         }
     },
 
     _editLineConfiguration() {
-        this._super(...arguments);
+        super._editLineConfiguration(...arguments);
         if (this.props.record.data.product_type === 'event_booth') {
             this._openEventBoothConfigurator(true);
         }
     },
 
     get isConfigurableLine() {
-        return this._super(...arguments) || this.props.record.data.product_type === 'event_booth';
+        return super.isConfigurableLine || this.props.record.data.product_type === 'event_booth';
     },
 
     async _openEventBoothConfigurator(edit) {

--- a/addons/event_sale/static/src/js/sale_product_field.js
+++ b/addons/event_sale/static/src/js/sale_product_field.js
@@ -4,24 +4,24 @@ import { patch } from "@web/core/utils/patch";
 import { SaleOrderLineProductField } from '@sale/js/sale_product_field';
 
 
-patch(SaleOrderLineProductField.prototype, 'event_sale', {
+patch(SaleOrderLineProductField.prototype, {
 
     async _onProductUpdate() {
-        this._super(...arguments);
+        super._onProductUpdate(...arguments);
         if (this.props.record.data.product_type === 'event') {
             this._openEventConfigurator();
         }
     },
 
     _editLineConfiguration() {
-        this._super(...arguments);
+        super._editLineConfiguration(...arguments);
         if (this.props.record.data.product_type === 'event') {
             this._openEventConfigurator();
         }
     },
 
     get isConfigurableLine() {
-        return this._super(...arguments) || this.props.record.data.product_type === 'event';
+        return super.isConfigurableLine || this.props.record.data.product_type === 'event';
     },
 
     async _openEventConfigurator() {

--- a/addons/google_calendar/static/src/views/google_calendar/common/google_calendar_common_popover.js
+++ b/addons/google_calendar/static/src/views/google_calendar/common/google_calendar_common_popover.js
@@ -3,8 +3,8 @@
 import { AttendeeCalendarCommonPopover } from "@calendar/views/attendee_calendar/common/attendee_calendar_common_popover";
 import { patch } from "@web/core/utils/patch";
 
-patch(AttendeeCalendarCommonPopover.prototype, "google_calendar_google_calendar_common_popover", {
+patch(AttendeeCalendarCommonPopover.prototype, {
     get isEventArchivable() {
-        return this._super() || (this.isCurrentUserOrganizer && this.props.record.rawRecord.google_id);
+        return super.isEventArchivable || (this.isCurrentUserOrganizer && this.props.record.rawRecord.google_id);
     },
 });

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog, AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-patch(AttendeeCalendarController.prototype, "google_calendar_google_calendar_controller", {
+patch(AttendeeCalendarController.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.dialog = useService("dialog");
         this.notification = useService("notification");
     },

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
@@ -3,13 +3,13 @@
 import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attendee_calendar_model";
 import { patch } from "@web/core/utils/patch";
 
-patch(AttendeeCalendarModel, "google_calendar_google_calendar_model", {
+patch(AttendeeCalendarModel, {
     services: [...AttendeeCalendarModel.services, "rpc"],
 });
 
-patch(AttendeeCalendarModel.prototype, "google_calendar_google_calendar_model_functions", {
+patch(AttendeeCalendarModel.prototype, {
     setup(params, { rpc }) {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.rpc = rpc;
         this.googleIsSync = true;
         this.googlePendingSync = false;
@@ -19,9 +19,8 @@ patch(AttendeeCalendarModel.prototype, "google_calendar_google_calendar_model_fu
      * @override
      */
     async updateData() {
-        const _super = this._super.bind(this);
         if (this.googlePendingSync) {
-            return _super(...arguments);
+            return super.updateData(...arguments);
         }
         try {
             await Promise.race([
@@ -35,7 +34,7 @@ patch(AttendeeCalendarModel.prototype, "google_calendar_google_calendar_model_fu
             console.error("Could not synchronize Google events now.", error);
             this.googlePendingSync = false;
         }
-        return _super(...arguments);
+        return super.updateData(...arguments);
     },
 
     async syncGoogleCalendar(silent = false) {

--- a/addons/google_calendar/static/tests/google_calendar_mock_server.js
+++ b/addons/google_calendar/static/tests/google_calendar_mock_server.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "google_calendar_mock_server", {
+patch(MockServer.prototype, {
     /**
      * Simulate the creation of a custom appointment type
      * by receiving a list of slots.
@@ -13,6 +13,6 @@ patch(MockServer.prototype, "google_calendar_mock_server", {
         if (route === '/google_calendar/sync_data') {
             return Promise.resolve({status: 'no_new_event_from_google'});
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -6,12 +6,12 @@ import { useService } from "@web/core/utils/hooks";
 
 export const patchAvatarCardPopover = {
     setup() {
-        this._super();
+        super.setup();
         this.userInfoTemplate = "hr.avatarCardUserInfos",
         this.actionService = useService("action");
     },
     get fieldNames(){
-        let fields = this._super();
+        let fields = super.fieldNames;
         return fields.concat([
             "work_phone", 
             "job_title", 
@@ -27,4 +27,4 @@ export const patchAvatarCardPopover = {
     }
 };
 
-patch(AvatarCardPopover.prototype, "hr", patchAvatarCardPopover);
+export const unpatchAvatarCardPopover = patch(AvatarCardPopover.prototype, patchAvatarCardPopover);

--- a/addons/hr/static/src/core/common/persona_model_patch.js
+++ b/addons/hr/static/src/core/common/persona_model_patch.js
@@ -4,6 +4,6 @@ import { Persona } from "@mail/core/common/persona_model";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Persona.prototype, "hr", {
+patch(Persona.prototype, {
     employeeId: undefined,
 });

--- a/addons/hr/static/src/views/open_chat_hook.js
+++ b/addons/hr/static/src/views/open_chat_hook.js
@@ -3,16 +3,16 @@
 import { helpers } from "@mail/core/web/open_chat_hook";
 import { patch } from "@web/core/utils/patch";
 
-patch(helpers, "hr_m2x_avatar_employee", {
+patch(helpers, {
     SUPPORTED_M2X_AVATAR_MODELS: [
         ...helpers.SUPPORTED_M2X_AVATAR_MODELS,
         "hr.employee",
         "hr.employee.public",
     ],
-    buildOpenChatParams: function (resModel, id) {
+    buildOpenChatParams(resModel, id) {
         if (["hr.employee", "hr.employee.public"].includes(resModel)) {
             return { employeeId: id };
         }
-        return this._super(...arguments);
-    },
+        return super.buildOpenChatParams(...arguments);
+    }
 });

--- a/addons/hr/static/tests/disable_patch.js
+++ b/addons/hr/static/tests/disable_patch.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { unpatch } from "@web/core/utils/patch";
-import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
+import { unpatchAvatarCardPopover } from "@hr/components/avatar_card/avatar_card_popover_patch";
 
-unpatch(AvatarCardPopover.prototype, "hr");
+unpatchAvatarCardPopover();

--- a/addons/hr/static/tests/tours/user_modify_own_profile_tour.js
+++ b/addons/hr/static/tests/tours/user_modify_own_profile_tour.js
@@ -8,7 +8,7 @@ import { patch } from "@web/core/utils/patch";
  * As 'hr' changes the flow a bit and displays the user preferences form in a full view instead of
  * a modal, we adapt the steps of the original tour accordingly.
  */
-patch(registry.category("web_tour.tours").get("mail/static/tests/tours/user_modify_own_profile_tour.js"), "patch_user_modify_own_profile_tour", {
+patch(registry.category("web_tour.tours").get("mail/static/tests/tours/user_modify_own_profile_tour.js"), {
     steps() {
         return [
             {

--- a/addons/hr_expense/static/src/mixins/document_upload.js
+++ b/addons/hr_expense/static/src/mixins/document_upload.js
@@ -4,9 +4,9 @@ import { useBus, useService } from '@web/core/utils/hooks';
 
 const { useRef, useEffect, useState } = owl;
 
-export const ExpenseDocumentDropZone = {
+export const ExpenseDocumentDropZone = (T) => class ExpenseDocumentDropZone extends T {
     setup() {
-        this._super();
+        super.setup();
         this.dragState = useState({
             showDragZone: false,
         });
@@ -31,31 +31,31 @@ export const ExpenseDocumentDropZone = {
             },
             () => [document.querySelector('.o_content')]
         );
-    },
+    }
 
     highlight(ev) {
         ev.stopPropagation();
         ev.preventDefault();
         this.dragState.showDragZone = true;
-    },
+    }
 
     unhighlight(ev) {
         ev.stopPropagation();
         ev.preventDefault();
         this.dragState.showDragZone = false;
-    },
+    }
 
     async onDrop(ev) {
         ev.preventDefault();
         await this.env.bus.trigger("change_file_input", {
             files: ev.dataTransfer.files,
         });        
-    },
+    }
 };
 
-export const ExpenseDocumentUpload = {
+export const ExpenseDocumentUpload = (T) => class ExpenseDocumentUpload extends T {
     setup() {
-        this._super();
+        super.setup();
         this.actionService = useService('action');
         this.notification = useService('notification');
         this.orm = useService('orm');
@@ -67,11 +67,11 @@ export const ExpenseDocumentUpload = {
             this.fileInput.el.files = ev.detail.files;
             await this.onChangeFileInput();
         });
-    },
+    }
 
     uploadDocument() {
         this.fileInput.el.click();
-    },
+    }
 
     async onChangeFileInput() {
         const params = {
@@ -87,7 +87,7 @@ export const ExpenseDocumentUpload = {
             throw new Error(attachments.error);
         }
         this.onUpload(attachments);
-    },
+    }
 
     async onUpload(attachments) {
         const attachmentIds = attachments.map((a) => a.id);
@@ -100,5 +100,5 @@ export const ExpenseDocumentUpload = {
 
         const action = await this.orm.call('hr.expense', 'create_expense_from_attachments', ["", attachmentIds]);
         this.actionService.doAction(action);
-    },
+    }
 };

--- a/addons/hr_expense/static/src/mixins/qrcode.js
+++ b/addons/hr_expense/static/src/mixins/qrcode.js
@@ -4,15 +4,15 @@ import { useService } from "@web/core/utils/hooks";
 
 const { onMounted, onPatched, useRef } = owl;
 
-export const ExpenseMobileQRCode = {
+export const ExpenseMobileQRCode = (T) => class ExpenseMobileQRCode extends T {
     setup() {
-        this._super();
+        super.setup();
         this.root = useRef('root');
         this.actionService = useService('action');
 
         onMounted(this.bindAppsIcons);
         onPatched(this.bindAppsIcons);
-    },
+    }
 
     bindAppsIcons() {
         const apps = this.root.el.querySelectorAll('.o_expense_mobile_app');
@@ -24,7 +24,7 @@ export const ExpenseMobileQRCode = {
         for (const app of apps) {
             app.addEventListener('click', handler);
         }
-    },
+    }
 
     handleClick(ev) {
         ev.preventDefault();

--- a/addons/hr_expense/static/src/views/kanban.js
+++ b/addons/hr_expense/static/src/views/kanban.js
@@ -1,7 +1,6 @@
 /** @odoo-module */
 
 import { registry } from '@web/core/registry';
-import { patch } from '@web/core/utils/patch';
 
 import { ExpenseDashboard } from '../components/expense_dashboard';
 import { ExpenseMobileQRCode } from '../mixins/qrcode';
@@ -11,12 +10,9 @@ import { kanbanView } from '@web/views/kanban/kanban_view';
 import { KanbanController } from '@web/views/kanban/kanban_controller';
 import { KanbanRenderer } from '@web/views/kanban/kanban_renderer';
 
-export class ExpenseKanbanController extends KanbanController {}
-patch(ExpenseKanbanController.prototype, 'expense_kanban_controller_upload', ExpenseDocumentUpload);
+export class ExpenseKanbanController extends ExpenseDocumentUpload(KanbanController) {}
 
-export class ExpenseKanbanRenderer extends KanbanRenderer {}
-patch(ExpenseKanbanRenderer.prototype, 'expense_kanban_renderer_qrcode', ExpenseMobileQRCode);
-patch(ExpenseKanbanRenderer.prototype, 'expense_kanban_renderer_qrcode_dzone', ExpenseDocumentDropZone);
+export class ExpenseKanbanRenderer extends ExpenseDocumentDropZone(ExpenseMobileQRCode(KanbanRenderer)) {}
 ExpenseKanbanRenderer.template = 'hr_expense.KanbanRenderer';
 
 export class ExpenseDashboardKanbanRenderer extends ExpenseKanbanRenderer {}

--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -5,7 +5,6 @@ import { ExpenseMobileQRCode } from '../mixins/qrcode';
 import { ExpenseDocumentUpload, ExpenseDocumentDropZone } from '../mixins/document_upload';
 
 import { registry } from '@web/core/registry';
-import { patch } from '@web/core/utils/patch';
 import { useService } from '@web/core/utils/hooks';
 import { listView } from "@web/views/list/list_view";
 
@@ -14,7 +13,7 @@ import { ListRenderer } from "@web/views/list/list_renderer";
 
 const { onWillStart } = owl;
 
-export class ExpenseListController extends ListController {
+export class ExpenseListController extends ExpenseDocumentUpload(ListController) {
     setup() {
         super.setup();
         this.orm = useService('orm');
@@ -81,11 +80,8 @@ export class ExpenseListController extends ListController {
         }
     }
 }
-patch(ExpenseListController.prototype, 'expense_list_controller_upload', ExpenseDocumentUpload);
 
-export class ExpenseListRenderer extends ListRenderer {}
-patch(ExpenseListRenderer.prototype, 'expense_list_renderer_qrcode', ExpenseMobileQRCode);
-patch(ExpenseListRenderer.prototype, 'expense_list_renderer_qrcode_dzone', ExpenseDocumentDropZone);
+export class ExpenseListRenderer extends ExpenseDocumentDropZone(ExpenseMobileQRCode(ListRenderer)) {}
 ExpenseListRenderer.template = 'hr_expense.ListRenderer';
 
 export class ExpenseDashboardListRenderer extends ExpenseListRenderer {}

--- a/addons/hr_holidays/static/src/persona_service_patch.js
+++ b/addons/hr_holidays/static/src/persona_service_patch.js
@@ -8,13 +8,13 @@ import { sprintf } from "@web/core/utils/strings";
 
 const { DateTime } = luxon;
 
-patch(personaService, "hr_holidays", {
+patch(personaService, {
     dependencies: [...new Set([...personaService.dependencies, "user"])],
 });
 
-patch(PersonaService.prototype, "hr_holidays", {
+patch(PersonaService.prototype, {
     setup(env, services) {
-        this._super(env, services);
+        super.setup(env, services);
         this.userService = services.user;
     },
 

--- a/addons/hr_holidays/static/src/thread_patch.js
+++ b/addons/hr_holidays/static/src/thread_patch.js
@@ -4,9 +4,9 @@ import { Thread } from "@mail/core/common/thread";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 
-patch(Thread.prototype, "hr_holidays", {
+patch(Thread.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.personaService = useService("mail.persona");
     },
 });

--- a/addons/hr_holidays/static/tests/helpers/mock_server/models/res_partner.js
+++ b/addons/hr_holidays/static/tests/helpers/mock_server/models/res_partner.js
@@ -5,14 +5,14 @@ import '@mail/../tests/helpers/mock_server/models/res_partner'; // ensure mail o
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, 'hr_holidays/models/res_partner', {
+patch(MockServer.prototype, {
     /**
      * Overrides to add out of office to employees.
      *
      * @override
      */
     _mockResPartnerMailPartnerFormat(ids) {
-        const partnerFormats = this._super(...arguments);
+        const partnerFormats = super._mockResPartnerMailPartnerFormat(...arguments);
         const partners = this.getRecords(
             'res.partner',
             [['id', 'in', ids]],

--- a/addons/hr_homeworking/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_homeworking/static/src/calendar/common/calendar_common_renderer.js
@@ -3,9 +3,10 @@
 import { AttendeeCalendarCommonRenderer } from "@calendar/views/attendee_calendar/common/attendee_calendar_common_renderer"
 import { patch } from "@web/core/utils/patch";
 import { renderToString } from "@web/core/utils/render";
-patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_renderer", {
+
+patch(AttendeeCalendarCommonRenderer.prototype, {
     get options(){
-        let a = Object.assign(this._super(), {
+        let a = Object.assign(super.options, {
             columnHeaderHtml: function(date) {
                 if (this.props.model.scale === 'week'){
                       return "<div>" + moment(date).format("ddd DD") +"</div>" + renderToString(this.constructor.HeaderCalendarTemplate, {date: date, today : new Date()});
@@ -31,7 +32,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_
         })
     },
     fcEventToRecord(event) {
-        const res = this._super(...arguments);
+        const res = super.fcEventToRecord(...arguments);
         res.homework = event.homework;
         return res;
     },
@@ -53,7 +54,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_
         return events;
     },
     mapRecordsToEvents() {
-        let event = this._super(...arguments);
+        let event = super.mapRecordsToEvents(...arguments);
         let work = [];
         if (this.props.model.multiCalendar) {
             for (const day in this.props.model.worklocations) {
@@ -114,7 +115,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_
             const {children } = new DOMParser().parseFromString(content, "text/html").body
             box.appendChild(...children)
         }
-        this._super(...arguments);
+        super.onDayRender(...arguments);
     },
     onEventRender(info) {
         const { el, event } = info;
@@ -149,14 +150,14 @@ patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_
             const { children } = domParser.parseFromString(injectedContentStr, "text/html").body;
             el.querySelector(".fc-content").replaceWith(...children);
         } else {
-            this._super(...arguments);
+            super.onEventRender(...arguments);
         }
     },
     onDblClick(info) {
         if (info.event.extendedProps.worklocation) {
             this.onClick(info);
         } else {
-            this._super(...arguments);
+            super.onDblClick(...arguments);
         }
     },
     onClick(info){
@@ -185,7 +186,7 @@ patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_
             this.openPopover(info.el, wl);
             this.highlightEvent(info.event, "o_cw_custom_highlight");
         } else {
-            this._super(...arguments);
+            super.onClick(...arguments);
         }
     },
     onDateClick(info){
@@ -193,12 +194,11 @@ patch(AttendeeCalendarCommonRenderer.prototype, "hr_homeworking_calendar_common_
             info.homework = true
             this.props.createRecord(this.fcEventToRecord(info));
         } else {
-            this._super(...arguments)
+            super.onDateClick(...arguments)
         }
     }
-},
+});
 
-AttendeeCalendarCommonRenderer.WorklocationTemplate = "hr.homeworking.CalendarCommonRenderer.worklocation",
-AttendeeCalendarCommonRenderer.HeaderCalendarTemplate = "hr.homeworking.CalendarCommonRenderer.buttonWorklocation",
-AttendeeCalendarCommonRenderer.ButtonWorklocationTemplate = "hr.homeworking.CalendarCommonRenderer.buttonWorklocation",
-)
+AttendeeCalendarCommonRenderer.WorklocationTemplate = "hr.homeworking.CalendarCommonRenderer.worklocation";
+AttendeeCalendarCommonRenderer.HeaderCalendarTemplate = "hr.homeworking.CalendarCommonRenderer.buttonWorklocation";
+AttendeeCalendarCommonRenderer.ButtonWorklocationTemplate = "hr.homeworking.CalendarCommonRenderer.buttonWorklocation";

--- a/addons/hr_homeworking/static/src/calendar/common/calendar_model.js
+++ b/addons/hr_homeworking/static/src/calendar/common/calendar_model.js
@@ -4,7 +4,7 @@ import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attende
 import { serializeDateTime, deserializeDate } from "@web/core/l10n/dates";
 import { patch } from "@web/core/utils/patch";
 
-patch(AttendeeCalendarModel.prototype, "calendar_model_calendarApp", {
+patch(AttendeeCalendarModel.prototype, {
     fetchEventLocation(data) {
         let attendeeIds;
         const filters = data.filterSections.partner_ids.filters;
@@ -92,7 +92,7 @@ patch(AttendeeCalendarModel.prototype, "calendar_model_calendarApp", {
      * @override
      */
     async updateData(data){
-        await this._super(...arguments)
+        await super.updateData(...arguments)
         this.partnerColorMap = this.mapPartnersToColor(data);
         data.worklocations = await this.loadWorkLocations(data);
     }

--- a/addons/hr_homeworking/static/src/calendar/common/popover/calendar_common_popover.js
+++ b/addons/hr_homeworking/static/src/calendar/common/popover/calendar_common_popover.js
@@ -4,10 +4,10 @@ import { patch } from "@web/core/utils/patch";
 import { AttendeeCalendarCommonPopover } from "@calendar/views/attendee_calendar/common/attendee_calendar_common_popover";
 import { Field } from "@web/views/fields/field"
 
-patch(AttendeeCalendarCommonPopover.prototype, "hr_homeworking_calendar_common_popover",{
+patch(AttendeeCalendarCommonPopover.prototype, {
     setup() {
         this.fieldNames = ["work_location_id", "work_location_name", "work_location_type", "employee_id", "weekday", "weekly", "start_date", "employee_name"];
-        this._super(...arguments)
+        super.setup(...arguments)
     },
     isWorkLocationEvent(){
         return this.props.record.rawRecord['resModel'] === 'hr.employee.location';
@@ -19,19 +19,19 @@ patch(AttendeeCalendarCommonPopover.prototype, "hr_homeworking_calendar_common_p
         return this.isWorkLocationEvent() && this.props.record.userId === this.slot.record.model.user.userId;
     },
     get isEventEditable() {
-        return ('resModel' in this.props.record.rawRecord) || this._super(...arguments)
+        return ('resModel' in this.props.record.rawRecord) || super.isEventEditable;
     },
     get isEventViewable() {
-        return !('resModel' in this.props.record.rawRecord) || this._super(...arguments)
+        return !('resModel' in this.props.record.rawRecord) || super.isEventViewable;
     },
     get isEventDeletable() {
-        return ('resModel' in this.props.record.rawRecord) || this._super(...arguments)
+        return ('resModel' in this.props.record.rawRecord) || super.isEventDeletable;
     },
     get displayAttendeeAnswerChoice() {
-        return !('resModel' in this.props.record.rawRecord) && this._super(...arguments)
+        return !('resModel' in this.props.record.rawRecord) && super.displayAttendeeAnswerChoice;
     },
     get isCurrentUserAttendee() {
-        return !('resModel' in this.props.record.rawRecord) && this._super(...arguments)
+        return !('resModel' in this.props.record.rawRecord) && super.isCurrentUserAttendee;
     }
 })
 

--- a/addons/hr_homeworking/static/src/calendar/hr_homeworking_calendar_controller.js
+++ b/addons/hr_homeworking/static/src/calendar/hr_homeworking_calendar_controller.js
@@ -6,9 +6,9 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 import { AttendeeCalendarController } from "@calendar/views/attendee_calendar/attendee_calendar_controller"
 import { serializeDate} from "@web/core/l10n/dates";
 
-patch(AttendeeCalendarController.prototype, "hr_homeworking_calendar_controller",{
+patch(AttendeeCalendarController.prototype, {
     setup() {
-        this._super()
+        super.setup()
         this.action = useService("action");
     },
     async editRecord(record, context = {}, shouldFetchFormViewId = true) {
@@ -26,7 +26,7 @@ patch(AttendeeCalendarController.prototype, "hr_homeworking_calendar_controller"
                 },
             });
         }
-        return this._super(...arguments)
+        return super.editRecord(...arguments)
     },
     createRecord(record) {
         if (record.homework) {
@@ -42,7 +42,7 @@ patch(AttendeeCalendarController.prototype, "hr_homeworking_calendar_controller"
                 },
             });
         } else {
-            return this._super(record);
+            return super.createRecord(record);
         }
     },
     deleteRecord(record) {
@@ -64,7 +64,7 @@ patch(AttendeeCalendarController.prototype, "hr_homeworking_calendar_controller"
                 });
             }
         } else {
-            this._super(...arguments)
+            super.deleteRecord(...arguments)
         }
     },
 

--- a/addons/hr_homeworking/static/tests/hr_org_chart_tests.js
+++ b/addons/hr_homeworking/static/tests/hr_org_chart_tests.js
@@ -3,11 +3,11 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "hr_homeworking", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.method === "get_worklocation") {
             return Promise.resolve()
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/im_livechat/static/src/chat_window/chat_window_patch.js
+++ b/addons/im_livechat/static/src/chat_window/chat_window_patch.js
@@ -4,9 +4,9 @@ import { ChatWindow } from "@mail/core/common/chat_window";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(ChatWindow.prototype, "im_livechat", {
+patch(ChatWindow.prototype, {
     close(options) {
-        this._super(options);
+        super.close(options);
         if (
             this.thread?.type === "livechat" &&
             this.thread.isLoaded &&

--- a/addons/im_livechat/static/src/composer/composer_patch.js
+++ b/addons/im_livechat/static/src/composer/composer_patch.js
@@ -4,13 +4,13 @@ import { Composer } from "@mail/core/common/composer";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Composer.prototype, "im_livechat", {
+patch(Composer.prototype, {
     get allowUpload() {
-        return this.thread?.type !== "livechat" && this._super();
+        return this.thread?.type !== "livechat" && super.allowUpload;
     },
 
     onKeydown(ev) {
-        this._super(ev);
+        super.onKeydown(ev);
         if (
             ev.key === "Tab" &&
             this.thread?.type === "livechat" &&

--- a/addons/im_livechat/static/src/composer/suggestion_service_patch.js
+++ b/addons/im_livechat/static/src/composer/suggestion_service_patch.js
@@ -6,11 +6,11 @@ import { cleanTerm } from "@mail/utils/common/format";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(SuggestionService.prototype, "im_livechat", {
+patch(SuggestionService.prototype, {
     getSupportedDelimiters(thread) {
         return thread?.model !== "discuss.channel" || thread.type === "livechat"
-            ? [...this._super(...arguments), [":"]]
-            : this._super(...arguments);
+            ? [...super.getSupportedDelimiters(...arguments), [":"]]
+            : super.getSupportedDelimiters(...arguments);
     },
     /**
      * Returns suggestions that match the given search term from specified type.
@@ -27,7 +27,7 @@ patch(SuggestionService.prototype, "im_livechat", {
         if (delimiter === ":") {
             return this.searchCannedResponseSuggestions(cleanTerm(term), sort);
         }
-        return this._super(...arguments);
+        return super.searchSuggestions(...arguments);
     },
 
     searchCannedResponseSuggestions(cleanedSearchTerm, sort) {

--- a/addons/im_livechat/static/src/core/channel_member_list_patch.js
+++ b/addons/im_livechat/static/src/core/channel_member_list_patch.js
@@ -3,8 +3,8 @@
 import { ChannelMemberList } from "@mail/discuss/core/common/channel_member_list";
 import { patch } from "@web/core/utils/patch";
 
-patch(ChannelMemberList.prototype, "im_livechat", {
+patch(ChannelMemberList.prototype, {
     canOpenChatWith(member) {
-        return this._super(member) && !member.persona.is_public;
+        return super.canOpenChatWith(member) && !member.persona.is_public;
     },
 });

--- a/addons/im_livechat/static/src/core/channel_member_service_patch.js
+++ b/addons/im_livechat/static/src/core/channel_member_service_patch.js
@@ -3,10 +3,10 @@
 import { ChannelMemberService } from "@mail/core/common/channel_member_service";
 import { patch } from "@web/core/utils/patch";
 
-patch(ChannelMemberService.prototype, "im_livechat", {
+patch(ChannelMemberService.prototype, {
     getName(member) {
         if (member.thread.type !== "livechat") {
-            return this._super(member);
+            return super.getName(member);
         }
         if (member.persona.user_livechat_username) {
             return member.persona.user_livechat_username;
@@ -14,6 +14,6 @@ patch(ChannelMemberService.prototype, "im_livechat", {
         if (member.persona.is_public) {
             return member.thread.anonymous_name;
         }
-        return this._super(member);
+        return super.getName(member);
     },
 });

--- a/addons/im_livechat/static/src/core/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/store_service_patch.js
@@ -5,9 +5,9 @@ import { Store } from "@mail/core/common/store_service";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(Store.prototype, "im_livechat", {
+patch(Store.prototype, {
     setup(env) {
-        this._super(env);
+        super.setup(env);
         this.discuss.livechat = {
             extraClass: "o-mail-DiscussSidebarCategory-livechat",
             id: "livechat",

--- a/addons/im_livechat/static/src/core/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/thread_model_patch.js
@@ -5,37 +5,37 @@ import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Thread.prototype, "im_livechat", {
+patch(Thread.prototype, {
     get isChannel() {
-        return this.type === "livechat" || this._super();
+        return this.type === "livechat" || super.isChannel;
     },
 
     get hasMemberList() {
-        return this.type === "livechat" || this._super();
+        return this.type === "livechat" || super.hasMemberList;
     },
 
     get isChatChannel() {
-        return this.type === "livechat" || this._super();
+        return this.type === "livechat" || super.isChatChannel;
     },
 
     get allowSetLastSeenMessage() {
-        return this.type === "livechat" || this._super();
+        return this.type === "livechat" || super.allowSetLastSeenMessage;
     },
 
     get allowReactions() {
-        return this.type === "livechat" ? false : this._super();
+        return this.type === "livechat" ? false : super.allowReactions;
     },
 
     get allowReplies() {
-        return this.type === "livechat" ? false : this._super();
+        return this.type === "livechat" ? false : super.allowReplies;
     },
 
     get correspondents() {
-        return this._super().filter((correspondent) => !correspondent.is_bot);
+        return super.correspondents.filter((correspondent) => !correspondent.is_bot);
     },
 
     get correspondent() {
-        let correspondent = this._super();
+        let correspondent = super.correspondent;
         if (this.type === "livechat" && !correspondent) {
             // For livechat threads, the correspondent is the first
             // channel member that is not the operator.
@@ -52,7 +52,7 @@ patch(Thread.prototype, "im_livechat", {
 
     get displayName() {
         if (this.type !== "livechat" || !this.correspondent) {
-            return this._super();
+            return super.displayName;
         }
         if (!this.correspondent.is_public && this.correspondent.country) {
             return `${this.getMemberName(this.correspondent)} (${this.correspondent.country.name})`;
@@ -67,7 +67,7 @@ patch(Thread.prototype, "im_livechat", {
 
     get imgUrl() {
         if (this.type !== "livechat") {
-            return this._super();
+            return super.imgUrl;
         }
         return this.correspondent && !this.correspondent.is_public
             ? `/web/image/res.partner/${this.correspondent.id}/avatar_128`
@@ -80,7 +80,7 @@ patch(Thread.prototype, "im_livechat", {
      */
     getMemberName(persona) {
         if (this.type !== "livechat") {
-            return this._super(persona);
+            return super.getMemberName(persona);
         }
         if (persona.user_livechat_username) {
             return persona.user_livechat_username;
@@ -88,6 +88,6 @@ patch(Thread.prototype, "im_livechat", {
         if (persona.is_public && this.anonymous_name) {
             return this.anonymous_name;
         }
-        return this._super(persona);
+        return super.getMemberName(persona);
     },
 });

--- a/addons/im_livechat/static/src/core/thread_service_patch.js
+++ b/addons/im_livechat/static/src/core/thread_service_patch.js
@@ -6,10 +6,10 @@ import { assignDefined, createLocalId } from "@mail/utils/common/misc";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(ThreadService.prototype, "im_livechat", {
+patch(ThreadService.prototype, {
     insert(data) {
         const isUnknown = !(createLocalId(data.model, data.id) in this.store.threads);
-        const thread = this._super(data);
+        const thread = super.insert(data);
         if (thread.type === "livechat") {
             if (data?.channel) {
                 assignDefined(thread, data.channel, ["anonymous_name"]);
@@ -34,7 +34,7 @@ patch(ThreadService.prototype, "im_livechat", {
      * @param {boolean} pushState
      */
     setDiscussThread(thread, pushState) {
-        this._super(thread, pushState);
+        super.setDiscussThread(thread, pushState);
         if (this.ui.isSmall && thread.type === "livechat") {
             this.store.discuss.activeTab = "livechat";
         }
@@ -43,29 +43,29 @@ patch(ThreadService.prototype, "im_livechat", {
         if (thread.type === "livechat") {
             removeFromArray(this.store.discuss.livechat.threads, thread.localId);
         }
-        this._super(thread);
+        super.remove(thread);
     },
 
     canLeave(thread) {
-        return thread.type !== "livechat" && this._super(thread);
+        return thread.type !== "livechat" && super.canLeave(thread);
     },
 
     canUnpin(thread) {
         if (thread.type === "livechat") {
             return thread.message_unread_counter === 0;
         }
-        return this._super(thread);
+        return super.canUnpin(thread);
     },
 
     getCounter(thread) {
         if (thread.type === "livechat") {
             return thread.message_unread_counter;
         }
-        return this._super(thread);
+        return super.getCounter(thread);
     },
 
     sortChannels() {
-        this._super();
+        super.sortChannels();
         // Live chats are sorted by most recent interest date time in the sidebar.
         this.store.discuss.livechat.threads.sort((localId_1, localId_2) => {
             const thread1 = this.store.threads[localId_1];

--- a/addons/im_livechat/static/src/embed/chat_window/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/chat_window/chat_window_patch.js
@@ -12,9 +12,9 @@ import { patch } from "@web/core/utils/patch";
 
 Object.assign(ChatWindow.components, { FeedbackPanel });
 
-patch(ChatWindow.prototype, "im_livechat", {
+patch(ChatWindow.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.livechatService = useService("im_livechat.livechat");
         this.chatbotService = useState(useService("im_livechat.chatbot"));
         this.livechatState = useState({
@@ -24,13 +24,13 @@ patch(ChatWindow.prototype, "im_livechat", {
 
     close() {
         if (this.thread?.type !== "livechat") {
-            return this._super();
+            return super.close();
         }
         if (this.livechatService.state === SESSION_STATE.PERSISTED) {
             this.livechatState.hasFeedbackPanel = true;
             this.chatWindowService.show(this.props.chatWindow);
         } else {
-            this._super();
+            super.close();
         }
         this.livechatService.leaveSession();
         this.chatbotService.stop();

--- a/addons/im_livechat/static/src/embed/core/composer_patch.js
+++ b/addons/im_livechat/static/src/embed/core/composer_patch.js
@@ -7,10 +7,10 @@ import { Composer } from "@mail/core/common/composer";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(Composer.prototype, "im_livechat", {
+patch(Composer.prototype, {
     get placeholder() {
         if (this.thread?.type !== "livechat") {
-            return this._super();
+            return super.placeholder;
         }
         return options.input_placeholder || _t("Say something...");
     },

--- a/addons/im_livechat/static/src/embed/core/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/core/disabled_features.js
@@ -9,25 +9,25 @@ import { ThreadService } from "@mail/core/common/thread_service";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Composer.prototype, "im_livechat/disabled", {
+patch(Composer.prototype, {
     get allowUpload() {
         return false;
     },
 });
 
-patch(MessageModel.prototype, "im_livechat/disabled", {
+patch(MessageModel.prototype, {
     get hasActions() {
         return false;
     },
 });
 
-patch(Thread.prototype, "im_livechat/disabled", {
+patch(Thread.prototype, {
     get hasMemberList() {
         return false;
     },
 });
 
-patch(ThreadService.prototype, "im_livechat/disabled", {
+patch(ThreadService.prototype, {
     async fetchNewMessages(thread) {
         return;
     },
@@ -36,9 +36,9 @@ patch(ThreadService.prototype, "im_livechat/disabled", {
     },
 });
 
-patch(Store.prototype, "im_livechat/disabled", {
+patch(Store.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.hasLinkPreviewFeature = false;
     },
 });

--- a/addons/im_livechat/static/src/embed/core/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/core/message_model_patch.js
@@ -5,10 +5,10 @@ import { Message } from "@mail/core/common/message_model";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
-patch(Message.prototype, "im_livechat", {
+patch(Message.prototype, {
     get isSelfAuthored() {
         if (this.originThread.type !== "livechat") {
-            return this._super();
+            return super.isSelfAuthored;
         }
         return !this.author || this.author?.id === session.livechatData.options.current_partner_id;
     },

--- a/addons/im_livechat/static/src/embed/core/message_service_patch.js
+++ b/addons/im_livechat/static/src/embed/core/message_service_patch.js
@@ -6,9 +6,9 @@ import { MessageService } from "@mail/core/common/message_service";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(MessageService.prototype, "im_livechat", {
+patch(MessageService.prototype, {
     insert(data) {
-        const message = this._super(data);
+        const message = super.insert(data);
         if (data.chatbotStep) {
             message.chatbotStep = new ChatbotStep(data.chatbotStep);
         }

--- a/addons/im_livechat/static/src/embed/core/messaging_service_patch.js
+++ b/addons/im_livechat/static/src/embed/core/messaging_service_patch.js
@@ -5,7 +5,7 @@ import { Messaging } from "@mail/core/common/messaging_service";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
-patch(Messaging.prototype, "im_livechat", {
+patch(Messaging.prototype, {
     initialize() {
         if (session.livechatData?.options.current_partner_id) {
             this.store.user = this.personaService.insert({

--- a/addons/im_livechat/static/src/embed/core/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/core/thread_model_patch.js
@@ -5,27 +5,27 @@ import { Thread } from "@mail/core/common/thread_model";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
-patch(Thread.prototype, "im_livechat", {
+patch(Thread.prototype, {
     chatbotScriptId: null,
 
     get isChannel() {
-        return this.type === "livechat" || this._super();
+        return this.type === "livechat" || super.isChannel;
     },
 
     get isChatChannel() {
-        return this.type === "livechat" || this._super();
+        return this.type === "livechat" || super.isChatChannel;
     },
 
     get isLastMessageFromCustomer() {
         if (this.type !== "livechat") {
-            return this._super();
+            return super.isLastMessageFromCustomer;
         }
         return this.newestMessage?.isSelfAuthored;
     },
 
     get imgUrl() {
         if (this.type !== "livechat") {
-            return this._super();
+            return super.imgUrl;
         }
         return `${session.origin}/im_livechat/operator/${this.operator.id}/avatar`;
     },

--- a/addons/im_livechat/static/src/embed/core/thread_service_patch.js
+++ b/addons/im_livechat/static/src/embed/core/thread_service_patch.js
@@ -19,7 +19,7 @@ threadService.dependencies.push(
     "notification"
 );
 
-patch(ThreadService.prototype, "im_livechat", {
+patch(ThreadService.prototype, {
     TEMPORARY_ID: "livechat_temporary_thread",
 
     /**
@@ -32,7 +32,7 @@ patch(ThreadService.prototype, "im_livechat", {
      * }} services
      */
     setup(env, services) {
-        this._super(env, services);
+        super.setup(env, services);
         this.livechatService = services["im_livechat.livechat"];
         this.chatWindowService = services["mail.chat_window"];
         this.chatbotService = services["im_livechat.chatbot"];
@@ -41,14 +41,14 @@ patch(ThreadService.prototype, "im_livechat", {
 
     getMessagePostRoute(thread) {
         if (thread.type !== "livechat") {
-            return this._super(...arguments);
+            return super.getMessagePostRoute(...arguments);
         }
         return "/im_livechat/chat_post";
     },
 
     async getMessagePostParams({ thread, body }) {
         if (thread.type !== "livechat") {
-            return this._super(...arguments);
+            return super.getMessagePostParams(...arguments);
         }
         return {
             uuid: thread.uuid,
@@ -60,7 +60,6 @@ patch(ThreadService.prototype, "im_livechat", {
      * @returns {Promise<import("@mail/core/common/message_model").Message}
      */
     async post(thread, body, params) {
-        const _super = this._super;
         const chatWindow = this.store.chatWindows.find((c) => c.threadLocalId === thread.localId);
         if (
             this.livechatService.state !== SESSION_STATE.PERSISTED &&
@@ -80,7 +79,7 @@ patch(ThreadService.prototype, "im_livechat", {
                 await this.chatbotService.postWelcomeSteps();
             }
         }
-        const message = await _super(thread, body, params);
+        const message = await super.post(thread, body, params);
         if (!message) {
             this.notificationService.add(_t("Session expired... Please refresh and try again."));
             this.chatWindowService.close(chatWindow);
@@ -111,7 +110,7 @@ patch(ThreadService.prototype, "im_livechat", {
 
     insert(data) {
         const isUnknown = !(createLocalId(data.model, data.id) in this.store.threads);
-        const thread = this._super(...arguments);
+        const thread = super.insert(...arguments);
         if (thread.type === "livechat" && isUnknown) {
             if (
                 this.livechatService.displayWelcomeMessage &&
@@ -154,7 +153,7 @@ patch(ThreadService.prototype, "im_livechat", {
     },
 
     async update(thread, data) {
-        this._super(...arguments);
+        super.update(...arguments);
         if (data.operator_pid) {
             thread.operator = this.personaService.insert({
                 type: "partner",
@@ -166,7 +165,7 @@ patch(ThreadService.prototype, "im_livechat", {
 
     avatarUrl(author, thread) {
         if (thread.type !== "livechat") {
-            return this._super(...arguments);
+            return super.avatarUrl(...arguments);
         }
         const isFromOperator =
             author && author.id !== this.livechatService.options.current_partner_id;

--- a/addons/im_livechat/static/src/embed/core_ui/message_patch.js
+++ b/addons/im_livechat/static/src/embed/core_ui/message_patch.js
@@ -7,9 +7,9 @@ import { session } from "@web/session";
 
 Message.props.push("isTypingMessage?");
 
-patch(Message.prototype, "im_livechat", {
+patch(Message.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.session = session;
     },
 

--- a/addons/im_livechat/static/src/embed/core_ui/thread_patch.js
+++ b/addons/im_livechat/static/src/embed/core_ui/thread_patch.js
@@ -8,9 +8,9 @@ import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
-patch(Thread.prototype, "im_livechat", {
+patch(Thread.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.session = session;
         this.chatbotService = useState(useService("im_livechat.chatbot"));
         this.livechatService = useState(useService("im_livechat.livechat"));

--- a/addons/im_livechat/static/src/embed/external/bus_parameters_service_patch.js
+++ b/addons/im_livechat/static/src/embed/external/bus_parameters_service_patch.js
@@ -6,10 +6,10 @@ import { serverUrl } from "@im_livechat/embed/livechat_data";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(busParametersService, "im_livechat", {
+patch(busParametersService, {
     start() {
         return {
-            ...this._super(...arguments),
+            ...super.start(...arguments),
             serverURL: serverUrl.replace(/\/+$/, ""),
         };
     },

--- a/addons/im_livechat/static/src/embed/external/emoji_loader_patch.js
+++ b/addons/im_livechat/static/src/embed/external/emoji_loader_patch.js
@@ -7,7 +7,7 @@ import { memoize } from "@web/core/utils/functions";
 import { patch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
-patch(loader, "im_livechat/emoji_loader", {
+patch(loader, {
     loadEmoji: memoize(() =>
         loadBundle({
             jsLibs: [`${session.origin}/im_livechat/emoji_bundle`],

--- a/addons/im_livechat/static/src/embed/frontend/overlay_container_patch.js
+++ b/addons/im_livechat/static/src/embed/frontend/overlay_container_patch.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { OverlayContainer } from "@web/core/overlay/overlay_container";
 
-patch(OverlayContainer.prototype, "im_livechat", {
+patch(OverlayContainer.prototype, {
     isVisible(overlay) {
         const targetInShadow = overlay.props.target?.getRootNode() instanceof ShadowRoot;
         return targetInShadow ? this.env.inShadow : !this.env.inShadow;

--- a/addons/im_livechat/static/src/js/im_livechat_chatbot_steps_one2many.js
+++ b/addons/im_livechat/static/src/js/im_livechat_chatbot_steps_one2many.js
@@ -12,7 +12,7 @@ import { ListRenderer } from "@web/views/list/list_renderer";
 
 const fieldRegistry = registry.category("fields");
 
-patch(X2ManyFieldDialog.prototype, "chatbot_script_step_sequence", {
+patch(X2ManyFieldDialog.prototype, {
     /**
      * Dirty patching of the 'X2ManyFieldDialog'.
      * It is done to force the "save and new" to close the dialog first, and then click again on
@@ -24,7 +24,7 @@ patch(X2ManyFieldDialog.prototype, "chatbot_script_step_sequence", {
      */
     async save({ saveAndNew }) {
         if (this.record.resModel !== "chatbot.script.step") {
-            return this._super(...arguments);
+            return super.save(...arguments);
         }
 
         if (await this.record.checkValidity()) {

--- a/addons/im_livechat/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/messaging_menu/messaging_menu_patch.js
@@ -5,12 +5,12 @@ import { MessagingMenu } from "@mail/core/web/messaging_menu";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(MessagingMenu.prototype, "im_livechat", {
+patch(MessagingMenu.prototype, {
     /**
      * @override
      */
     tabToThreadType(tab) {
-        const threadTypes = this._super(tab);
+        const threadTypes = super.tabToThreadType(tab);
         if (tab === "chat" && !this.ui.isSmall) {
             threadTypes.push("livechat");
         }
@@ -23,7 +23,7 @@ patch(MessagingMenu.prototype, "im_livechat", {
      * @override
      */
     get tabs() {
-        const items = this._super();
+        const items = super.tabs;
         const hasLivechats = Object.values(this.store.threads).some(
             ({ type }) => type === "livechat"
         );

--- a/addons/im_livechat/static/src/web/message_patch.js
+++ b/addons/im_livechat/static/src/web/message_patch.js
@@ -5,10 +5,10 @@ import "@mail/discuss/core/web/message_patch"; // dependency ordering
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Message.prototype, "im_livechat/web", {
+patch(Message.prototype, {
     hasOpenChatFeature() {
         return this.message.originThread?.channel?.channel_type === "livechat"
             ? false
-            : this._super();
+            : super.hasOpenChatFeature();
     },
 });

--- a/addons/im_livechat/static/tests/embed/helper/test_utils.js
+++ b/addons/im_livechat/static/tests/embed/helper/test_utils.js
@@ -69,10 +69,10 @@ export async function loadDefaultConfig() {
     return livechatChannelId;
 }
 
-patch(App.prototype, "im_livechat", {
+patch(App.prototype, {
     mount() {
         registerCleanup(() => this.destroy());
-        return this._super(...arguments);
+        return super.mount(...arguments);
     },
 });
 
@@ -108,7 +108,7 @@ export async function start({ mockRPC } = {}) {
     const livechatButtonAvailableDeferred = makeDeferred();
     patchWithCleanup(LivechatButton.prototype, {
         setup() {
-            this._super(...arguments);
+            super.setup(...arguments);
             onMounted(() => livechatButtonAvailableDeferred.resolve());
         },
     });

--- a/addons/im_livechat/static/tests/helpers/mock_server/controllers/main.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/controllers/main.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "im_livechat/controllers/main", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
@@ -50,7 +50,7 @@ patch(MockServer.prototype, "im_livechat/controllers/main", {
         if (route === "/im_livechat/chat_history") {
             return this._mockRouteImLivechatChatHistory(args.uuid, args.last_id, args.limit);
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
     /**
      * Simulates the `/im_livechat/get_session` route.

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -5,12 +5,12 @@ import "@mail/../tests/helpers/mock_server/models/discuss_channel"; // ensure ma
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "im_livechat/models/discuss_channel", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
     _mockDiscussChannelChannelInfo(ids) {
-        const channelInfos = this._super(...arguments);
+        const channelInfos = super._mockDiscussChannelChannelInfo(...arguments);
         for (const channelInfo of channelInfos) {
             const channel = this.getRecords("discuss.channel", [["id", "=", channelInfo.id]])[0];
             channelInfo["channel"]["anonymous_name"] = channel.anonymous_name;

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/discuss_channel_member.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/discuss_channel_member.js
@@ -5,7 +5,7 @@ import "@mail/../tests/helpers/mock_server/models/discuss_channel_member"; // en
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "im_livechat/models/discuss_channel_member", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
@@ -37,6 +37,6 @@ patch(MockServer.prototype, "im_livechat/models/discuss_channel_member", {
             }
             return data;
         }
-        return this._super(ids);
+        return super._mockDiscussChannelMember_GetPartnerData(ids);
     },
 });

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/im_livechat_channel.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "im_livechat/models/im_livechat_channel", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_compute_available_operator_ids` on `im_livechat.channel`.
      *

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/res_partner.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/res_partner.js
@@ -5,7 +5,7 @@ import "@mail/../tests/helpers/mock_server/models/res_partner"; // ensure mail o
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "im_livechat/models/res_partner", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
@@ -19,13 +19,13 @@ patch(MockServer.prototype, "im_livechat/models/res_partner", {
             ["channel_type", "=", "livechat"],
             ["channel_member_ids", "in", members.map((member) => member.id)],
         ]);
-        return [...this._super(ids), ...livechats];
+        return [...super._mockResPartner_GetChannelsAsMember(ids), ...livechats];
     },
     /**
      * @override
      */
     _mockResPartnerSearchForChannelInvite(search_term, channel_id, limit = 30) {
-        const result = this._super(search_term, channel_id, limit);
+        const result = super._mockResPartnerSearchForChannelInvite(search_term, channel_id, limit);
         const [channel] = this.pyEnv["discuss.channel"].searchRead([["id", "=", channel_id]]);
         if (channel.channel_type !== "livechat") {
             return result;

--- a/addons/l10n_ar/static/src/js/tours/account.js
+++ b/addons/l10n_ar/static/src/js/tours/account.js
@@ -3,9 +3,9 @@ import { patch } from "@web/core/utils/patch";
 import { registry } from "@web/core/registry";
 import "@account/js/tours/account";
 
-patch(registry.category("web_tour.tours").get("account_tour"), "patch_account_tour", {
+patch(registry.category("web_tour.tours").get("account_tour"), {
     steps() {
-        const originalSteps = this._super();
+        const originalSteps = super.steps();
         // Remove the step suggesting to change the name as it is done another way (document number)
         const filteredSteps = originalSteps.filter((step) => step.trigger != "input[name=name]");
         const stepIndex = filteredSteps.findIndex((step) => step.trigger == 'div[name=partner_id] input');

--- a/addons/l10n_co_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_co_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -3,9 +3,8 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentScreen.prototype, "l10n_co_pos.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     async _postPushOrderResolve(order, order_server_ids) {
-        const _super = this._super;
         try {
             if (this.pos.is_colombian_country()) {
                 const result = await this.orm.searchRead(
@@ -18,6 +17,6 @@ patch(PaymentScreen.prototype, "l10n_co_pos.PaymentScreen", {
         } catch {
             // FIXME this doesn't seem correct but is equivalent to return in finally which we had before.
         }
-        return _super(...arguments);
+        return super._postPushOrderResolve(...arguments);
     },
 });

--- a/addons/l10n_co_pos/static/src/overrides/models/pos.js
+++ b/addons/l10n_co_pos/static/src/overrides/models/pos.js
@@ -4,15 +4,15 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(PosStore.prototype, "l10n_co_pos.PosStore", {
+patch(PosStore.prototype, {
     is_colombian_country() {
         return this.company.country?.code === "CO";
     },
 });
 
-patch(Order.prototype, "l10n_co_pos.Order", {
+patch(Order.prototype, {
     export_for_printing() {
-        const result = this._super(...arguments);
+        const result = super.export_for_printing(...arguments);
         result.l10n_co_dian = this.get_l10n_co_dian();
         return result;
     },
@@ -23,7 +23,7 @@ patch(Order.prototype, "l10n_co_pos.Order", {
         return this.l10n_co_dian;
     },
     wait_for_push_order() {
-        var result = this._super(...arguments);
+        var result = super.wait_for_push_order(...arguments);
         result = Boolean(result || this.pos.is_colombian_country());
         return result;
     },

--- a/addons/l10n_fr_pos_cert/static/src/js/Chrome.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/Chrome.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { ClosePosPopup } from "@point_of_sale/app/navbar/closing_popup/closing_popup";
 import { onMounted } from "@odoo/owl";
 
-patch(Chrome.prototype, "l10n_fr_pos_cert.Chrome", {
+patch(Chrome.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         onMounted(async () => {
             if (this.pos.is_french_country() && this.pos.pos_session.start_at) {
                 const now = Date.now();

--- a/addons/l10n_fr_pos_cert/static/src/js/PaymentScreen.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/PaymentScreen.js
@@ -3,9 +3,8 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentScreen.prototype, "l10n_fr_pos_cert.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     async _postPushOrderResolve(order, order_server_ids) {
-        const _super = this._super;
         try {
             if (this.pos.is_french_country()) {
                 const result = await this.orm.searchRead(
@@ -18,6 +17,6 @@ patch(PaymentScreen.prototype, "l10n_fr_pos_cert.PaymentScreen", {
         } catch {
             // FIXME this doesn't seem correct but is equivalent to return in finally which we had before.
         }
-        return _super(...arguments);
+        return super._postPushOrderResolve(...arguments);
     },
 });

--- a/addons/l10n_fr_pos_cert/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/Popups/ClosePosPopup.js
@@ -3,7 +3,7 @@
 import { ClosePosPopup } from "@point_of_sale/app/navbar/closing_popup/closing_popup";
 import { patch } from "@web/core/utils/patch";
 
-patch(ClosePosPopup.prototype, "l10n_fr_pos_cert.ClosePosPopup", {
+patch(ClosePosPopup.prototype, {
     sessionIsOutdated() {
         let isOutdated = false;
         if (this.pos.is_french_country() && this.pos.pos_session.start_at) {
@@ -15,6 +15,6 @@ patch(ClosePosPopup.prototype, "l10n_fr_pos_cert.ClosePosPopup", {
         return isOutdated;
     },
     canCancel() {
-        return this._super(...arguments) && !this.sessionIsOutdated();
+        return super.canCancel(...arguments) && !this.sessionIsOutdated();
     },
 });

--- a/addons/l10n_fr_pos_cert/static/src/js/TicketScreen.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/TicketScreen.js
@@ -3,8 +3,8 @@
 import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(TicketScreen.prototype, "l10n_fr_pos_cert.TicketScreen", {
+patch(TicketScreen.prototype, {
     shouldHideDeleteButton() {
-        return this.pos.is_french_country() || this._super(...arguments);
+        return this.pos.is_french_country() || super.shouldHideDeleteButton(...arguments);
     }
 });

--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -7,7 +7,7 @@ import { patch } from "@web/core/utils/patch";
 import { sprintf } from "@web/core/utils/strings";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 
-patch(PosStore.prototype, "l10n_fr_pos_cert.PosStore", {
+patch(PosStore.prototype, {
     is_french_country() {
         var french_countries = ["FR", "MF", "MQ", "NC", "PF", "RE", "GF", "GP", "TF"];
         if (!this.company.country) {
@@ -20,19 +20,19 @@ patch(PosStore.prototype, "l10n_fr_pos_cert.PosStore", {
         return french_countries.includes(this.company.country?.code);
     },
     disallowLineQuantityChange() {
-        const result = this._super(...arguments);
+        const result = super.disallowLineQuantityChange(...arguments);
         return this.is_french_country() || result;
     },
 });
 
-patch(Order.prototype, "l10n_fr_pos_cert.Order", {
+patch(Order.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.l10n_fr_hash = this.l10n_fr_hash || false;
         this.save_to_db();
     },
     export_for_printing() {
-        var result = this._super(...arguments);
+        var result = super.export_for_printing(...arguments);
         result.l10n_fr_hash = this.get_l10n_fr_hash();
         return result;
     },
@@ -43,16 +43,16 @@ patch(Order.prototype, "l10n_fr_pos_cert.Order", {
         return this.l10n_fr_hash;
     },
     wait_for_push_order() {
-        var result = this._super(...arguments);
+        var result = super.wait_for_push_order(...arguments);
         result = Boolean(result || this.pos.is_french_country());
         return result;
     },
 });
 
-patch(Orderline.prototype, "l10n_fr_pos_cert.Orderline", {
+patch(Orderline.prototype, {
     can_be_merged_with(orderline) {
         if (!this.pos.is_french_country()) {
-            return this._super(...arguments);
+            return super.can_be_merged_with(...arguments);
         }
         const order = this.pos.get_order();
         const orderlines = order.orderlines;
@@ -61,7 +61,7 @@ patch(Orderline.prototype, "l10n_fr_pos_cert.Orderline", {
         if (lastOrderline.product.id !== orderline.product.id || lastOrderline.quantity < 0) {
             return false;
         } else {
-            return this._super(...arguments);
+            return super.can_be_merged_with(...arguments);
         }
     },
 });

--- a/addons/l10n_gcc_pos/static/src/overrides/components/order_receipt/order_receipt.js
+++ b/addons/l10n_gcc_pos/static/src/overrides/components/order_receipt/order_receipt.js
@@ -3,9 +3,9 @@
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt";
 import { patch } from "@web/core/utils/patch";
 
-patch(OrderReceipt.prototype, "l10n_gcc_pos.OrderReceipt", {
+patch(OrderReceipt.prototype, {
     get receiptEnv() {
-        const receipt_render_env = this._super(...arguments);
+        const receipt_render_env = super.receiptEnv;
         const receipt = receipt_render_env.receipt;
         const country = receipt_render_env.order.pos.company.country;
         receipt.is_gcc_country = country

--- a/addons/l10n_in_pos/static/src/overrides/models/orderline.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/orderline.js
@@ -3,9 +3,9 @@
 import { Orderline } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(Orderline.prototype, "l10n_in_pos.Orderline", {
+patch(Orderline.prototype, {
     export_for_printing() {
-        const line = this._super(...arguments);
+        const line = super.export_for_printing(...arguments);
         line.l10n_in_hsn_code = this.get_product().l10n_in_hsn_code;
         return line;
     },

--- a/addons/l10n_sa_pos/static/src/overrides/models/models.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/models.js
@@ -3,9 +3,9 @@
 import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(Order.prototype, "l10n_sa_pos.Order", {
+patch(Order.prototype, {
     export_for_printing() {
-        const result = this._super(...arguments);
+        const result = super.export_for_printing(...arguments);
         if (this.pos.company.country && this.pos.company.country.code === "SA") {
             result.is_settlement = this.is_settlement();
             if (!result.is_settlement) {

--- a/addons/lunch/static/src/mixins/lunch_renderer_mixin.js
+++ b/addons/lunch/static/src/mixins/lunch_renderer_mixin.js
@@ -2,13 +2,13 @@
 
 import { useBus, useService } from "@web/core/utils/hooks";
 
-export const LunchRendererMixin = {
+export const LunchRendererMixin = (T) => class LunchRendererMixin extends T {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
 
         this.action = useService("action");
         useBus(this.env.bus, 'lunch_open_order', (ev) => this.openOrderLine(ev.detail.productId));
-    },
+    }
 
     openOrderLine(productId, orderId) {
         let context = {};
@@ -36,5 +36,5 @@ export const LunchRendererMixin = {
         this.action.doAction(action, {
             onClose: () => this.env.bus.trigger('lunch_update_dashboard')
         });
-    },
-}
+    }
+};

--- a/addons/lunch/static/src/views/kanban.js
+++ b/addons/lunch/static/src/views/kanban.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { patch } from '@web/core/utils/patch';
 import { registry } from '@web/core/registry';
 
 import { kanbanView } from '@web/views/kanban/kanban_view';
@@ -19,8 +18,7 @@ export class LunchKanbanRecord extends KanbanRecord {
     }
 }
 
-export class LunchKanbanRenderer extends KanbanRenderer {}
-patch(LunchKanbanRenderer.prototype, 'lunch_kanban_renderer_mixin', LunchRendererMixin);
+export class LunchKanbanRenderer extends LunchRendererMixin(KanbanRenderer) {}
 
 LunchKanbanRenderer.template = 'lunch.KanbanRenderer';
 LunchKanbanRenderer.components = {

--- a/addons/lunch/static/src/views/list.js
+++ b/addons/lunch/static/src/views/list.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { patch } from '@web/core/utils/patch';
 import { registry } from '@web/core/registry';
 
 import { listView } from '@web/views/list/list_view';
@@ -12,12 +11,11 @@ import { LunchRendererMixin } from '../mixins/lunch_renderer_mixin';
 import { LunchSearchModel } from './search_model';
 
 
-export class LunchListRenderer extends ListRenderer {
+export class LunchListRenderer extends LunchRendererMixin(ListRenderer) {
     onCellClicked(record, column) {
         this.openOrderLine(record.resId);
     }
 }
-patch(LunchListRenderer.prototype, 'lunch_list_renderer_mixin', LunchRendererMixin);
 
 LunchListRenderer.template = 'lunch.ListRenderer';
 LunchListRenderer.components = {

--- a/addons/mail/static/src/core/web/chat_window_patch.js
+++ b/addons/mail/static/src/core/web/chat_window_patch.js
@@ -5,9 +5,9 @@ import { ChatWindow } from "@mail/core/common/chat_window";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 
-patch(ChatWindow.prototype, "mail/core/web", {
+patch(ChatWindow.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.actionService = useService("action");
     },
 });

--- a/addons/mail/static/src/core/web/chat_window_service_patch.js
+++ b/addons/mail/static/src/core/web/chat_window_service_patch.js
@@ -4,9 +4,8 @@ import { ChatWindowService } from "@mail/core/common/chat_window_service";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(ChatWindowService.prototype, "mail/core/web", {
+patch(ChatWindowService.prototype, {
     async close() {
-        const _super = this._super.bind(this);
         if (this.ui.isSmall && !this.store.discuss.isActive) {
             // If we are in mobile and discuss is not open, it means the
             // chat window was opened from the messaging menu. In that
@@ -16,6 +15,6 @@ patch(ChatWindowService.prototype, "mail/core/web", {
             // ensure messaging menu is opened before chat window is closed
             await Promise.resolve();
         }
-        await _super(...arguments);
+        await super.close(...arguments);
     },
 });

--- a/addons/mail/static/src/core/web/dialog_patch.js
+++ b/addons/mail/static/src/core/web/dialog_patch.js
@@ -3,7 +3,7 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { patch } from "@web/core/utils/patch";
 
-patch(Dialog.prototype, "mail/views/web", {
+patch(Dialog.prototype, {
     /**
      * @override
      */
@@ -11,6 +11,6 @@ patch(Dialog.prototype, "mail/views/web", {
         if (this.data.model === "mail.compose.message") {
             return;
         }
-        this._super();
+        super.onEscape();
     },
 });

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -14,9 +14,9 @@ import fieldUtils from "@web/legacy/js/fields/field_utils";
 const format = fieldUtils.format
 const formatters = registry.category("formatters");
 
-patch(Message.prototype, "mail/core/web", {
+patch(Message.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.action = useService("action");
         this.userService = useService("user");
     },

--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -4,7 +4,7 @@ import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Thread.prototype, "mail/core/web", {
+patch(Thread.prototype, {
     /**
      * @returns {import("@mail/core/web/activity_model").Activity[]}
      */

--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -12,9 +12,9 @@ import { patch } from "@web/core/utils/patch";
 
 let nextId = 1;
 
-patch(ThreadService.prototype, "mail/core/web", {
+patch(ThreadService.prototype, {
     setup(env, services) {
-        this._super(env, services);
+        super.setup(env, services);
         this.action = services.action;
         /** @type {import("@mail/core/common/attachment_service").AttachmentService} */
         this.attachmentService = services["mail.attachment"];
@@ -182,7 +182,7 @@ patch(ThreadService.prototype, "mail/core/web", {
         if (chatWindow) {
             this.chatWindowService.close(chatWindow);
         }
-        this._super(...arguments);
+        super.leaveChannel(...arguments);
     },
     async loadMoreFollowers(thread) {
         const followers = await this.orm.call(thread.model, "message_get_followers", [
@@ -217,7 +217,7 @@ patch(ThreadService.prototype, "mail/core/web", {
             });
             return;
         }
-        this._super(thread, replaceNewMessageChatWindow);
+        super.open(thread, replaceNewMessageChatWindow);
     },
     /**
      * @param {import("@mail/core/common/follower_model").Follower} follower
@@ -240,7 +240,7 @@ patch(ThreadService.prototype, "mail/core/web", {
         if (chatWindow) {
             this.chatWindowService.close(chatWindow);
         }
-        this._super(...arguments);
+        super.unpin(...arguments);
     },
     _openChatWindow(thread, replaceNewMessageChatWindow) {
         const chatWindow = this.chatWindowService.insert({
@@ -256,7 +256,7 @@ patch(ThreadService.prototype, "mail/core/web", {
     },
 });
 
-patch(threadService, "mail/core/web", {
+patch(threadService, {
     dependencies: [
         ...threadService.dependencies,
         "action",

--- a/addons/mail/static/src/discuss/call/common/discuss_patch.js
+++ b/addons/mail/static/src/discuss/call/common/discuss_patch.js
@@ -8,9 +8,9 @@ import { patch } from "@web/core/utils/patch";
 
 Object.assign(Discuss.components, { Call });
 
-patch(Discuss.prototype, "discuss/call/common", {
+patch(Discuss.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.rtc = useRtc();
     },
 });

--- a/addons/mail/static/src/discuss/call/public/discuss_public_patch.js
+++ b/addons/mail/static/src/discuss/call/public/discuss_public_patch.js
@@ -6,13 +6,13 @@ import { useRtc } from "@mail/discuss/call/common/rtc_hook";
 import { browser } from "@web/core/browser/browser";
 import { patch } from "@web/core/utils/patch";
 
-patch(DiscussPublic.prototype, "discuss/call/public", {
+patch(DiscussPublic.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.rtc = useRtc();
     },
     async displayChannel() {
-        this._super();
+        super.displayChannel();
         const video = browser.localStorage.getItem("discuss_call_preview_join_video");
         const mute = browser.localStorage.getItem("discuss_call_preview_join_mute");
         if (this.thread.defaultDisplayMode === "video_full_screen") {

--- a/addons/mail/static/src/discuss/call/web/discuss_patch.js
+++ b/addons/mail/static/src/discuss/call/web/discuss_patch.js
@@ -5,9 +5,9 @@ import { useChildSubEnv, useEffect, useState } from "@odoo/owl";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Discuss.prototype, "discuss/call/web", {
+patch(Discuss.prototype, {
     setup(...args) {
-        this._super(...args);
+        super.setup(...args);
         const state = useState({ openInviteButton: 0 });
         useChildSubEnv({
             onStartMeeting: () => {

--- a/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_model_patch.js
@@ -4,12 +4,12 @@ import { Attachment } from "@mail/core/common/attachment_model";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Attachment.prototype, "discuss/core/common", {
+patch(Attachment.prototype, {
     get isDeletable() {
         if (this.message && this.originThread?.model === "discuss.channel") {
             return this.message.editable;
         }
-        return this._super();
+        return super.isDeletable;
     },
     get urlRoute() {
         if (!this.accessToken && this.originThread?.model === "discuss.channel") {
@@ -17,6 +17,6 @@ patch(Attachment.prototype, "discuss/core/common", {
                 ? `/discuss/channel/${this.originThread.id}/image/${this.id}`
                 : `/discuss/channel/${this.originThread.id}/attachment/${this.id}`;
         }
-        return this._super();
+        return super.urlRoute;
     },
 });

--- a/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/suggestion_service_patch.js
@@ -8,9 +8,9 @@ import { patch } from "@web/core/utils/patch";
 
 const commandRegistry = registry.category("discuss.channel_commands");
 
-patch(SuggestionService.prototype, "discuss/core/common", {
+patch(SuggestionService.prototype, {
     getSupportedDelimiters(thread) {
-        const res = this._super(thread);
+        const res = super.getSupportedDelimiters(thread);
         return thread?.model === "discuss.channel" ? [...res, ["/", 0]] : res;
     },
     /**
@@ -20,7 +20,7 @@ patch(SuggestionService.prototype, "discuss/core/common", {
         if (delimiter === "/") {
             return this.searchChannelCommand(cleanTerm(term), thread, sort);
         }
-        return this._super(...arguments);
+        return super.searchSuggestions(...arguments);
     },
     searchChannelCommand(cleanedSearchTerm, thread, sort) {
         if (!thread.isChannel) {

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -6,7 +6,7 @@ import { assignDefined } from "@mail/utils/common/misc";
 import { patch } from "@web/core/utils/patch";
 import { url } from "@web/core/utils/urls";
 
-patch(Thread.prototype, "discuss/core/common", {
+patch(Thread.prototype, {
     get imgUrl() {
         if (this.type === "channel" || this.type === "group") {
             return url(
@@ -17,6 +17,6 @@ patch(Thread.prototype, "discuss/core/common", {
         if (this.type === "chat") {
             return `/web/image/res.partner/${this.chatPartnerId}/avatar_128`;
         }
-        return this._super();
+        return super.imgUrl;
     },
 });

--- a/addons/mail/static/src/discuss/core/common/thread_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_service_patch.js
@@ -7,7 +7,7 @@ import { patch } from "@web/core/utils/patch";
 
 const commandRegistry = registry.category("discuss.channel_commands");
 
-patch(ThreadService.prototype, "discuss/core/common", {
+patch(ThreadService.prototype, {
     /**
      * @override
      * @param {import("@mail/core/common/thread_model").Thread} thread
@@ -25,6 +25,6 @@ patch(ThreadService.prototype, "discuss/core/common", {
                 return;
             }
         }
-        return this._super(...arguments);
+        return super.post(...arguments);
     },
 });

--- a/addons/mail/static/src/discuss/core/web/chat_window_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/chat_window_service_patch.js
@@ -4,13 +4,13 @@ import { ChatWindowService } from "@mail/core/common/chat_window_service";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(ChatWindowService.prototype, "discuss/core/web", {
+patch(ChatWindowService.prototype, {
     close(chatWindow) {
-        this._super(...arguments);
+        super.close(...arguments);
         this.notifyState(chatWindow);
     },
     hide(chatWindow) {
-        this._super(...arguments);
+        super.hide(...arguments);
         this.notifyState(chatWindow);
     },
     notifyState(chatWindow) {
@@ -29,15 +29,15 @@ patch(ChatWindowService.prototype, "discuss/core/web", {
         }
     },
     open() {
-        const chatWindow = this._super(...arguments);
+        const chatWindow = super.open(...arguments);
         this.notifyState(chatWindow);
     },
     show(chatWindow) {
-        this._super(...arguments);
+        super.show(...arguments);
         this.notifyState(chatWindow);
     },
     toggleFold(chatWindow) {
-        this._super(...arguments);
+        super.toggleFold(...arguments);
         this.notifyState(chatWindow);
     },
 });

--- a/addons/mail/static/src/discuss/core/web/message_patch.js
+++ b/addons/mail/static/src/discuss/core/web/message_patch.js
@@ -7,13 +7,13 @@ import { markEventHandled } from "@web/core/utils/misc";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(Message.prototype, "discuss/core/web", {
+patch(Message.prototype, {
     getAuthorText() {
-        return this.hasOpenChatFeature() ? _t("Open chat") : this._super();
+        return this.hasOpenChatFeature() ? _t("Open chat") : super.getAuthorText();
     },
     hasAuthorClickable() {
         return (
-            this._super() &&
+            super.hasAuthorClickable() &&
             this.message.author.type !== "guest" &&
             this.message.originThread?.channel?.channel_type !== "chat"
         );
@@ -27,6 +27,6 @@ patch(Message.prototype, "discuss/core/web", {
             this.threadService.openChat({ partnerId: this.message.author.id });
             return;
         }
-        return this._super(ev);
+        return super.onClickAuthor(ev);
     },
 });

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -15,7 +15,7 @@ Object.assign(Composer.components, { GifPicker });
 /** @type {Composer} */
 const composerPatch = {
     setup() {
-        this._super();
+        super.setup();
         Object.assign(this.KEYBOARD, { GIF: "Gif" });
         onExternalClick("gif-picker", () => (this.state.keyboard = this.KEYBOARD.NONE));
         this.ui = useState(useService("ui"));
@@ -30,7 +30,7 @@ const composerPatch = {
      */
     isEventHandledByPicker(ev) {
         return (
-            this._super(ev) ||
+            super.isEventHandledByPicker(ev) ||
             isEventHandled(ev, "Composer.onClickAddGif") ||
             isEventHandled(ev, "GifPicker.onClick")
         );
@@ -53,4 +53,4 @@ const composerPatch = {
         });
     },
 };
-patch(Composer.prototype, "GifPicker", composerPatch);
+patch(Composer.prototype, composerPatch);

--- a/addons/mail/static/src/discuss/message_pin/common/message_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_patch.js
@@ -6,13 +6,13 @@ import { useMessagePinService } from "@mail/discuss/message_pin/common/message_p
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(Message, "discuss/message_pin/common", {
+patch(Message, {
     components: { ...Message.components },
 });
 
-patch(Message.prototype, "discuss/message_pin/common", {
+patch(Message.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.messagePinService = useMessagePinService();
     },
     onClickPin() {
@@ -24,7 +24,7 @@ patch(Message.prototype, "discuss/message_pin/common", {
         }
     },
     get attClass() {
-        const res = this._super();
+        const res = super.attClass;
         return Object.assign(res, {
             "o-cancelSelfAuthored": this.env.pinnedPanel,
             "mt-1": res["mt-1"] && !this.env.pinnedPanel,
@@ -32,7 +32,7 @@ patch(Message.prototype, "discuss/message_pin/common", {
         });
     },
     get isAlignedRight() {
-        return !this.env.pinnedPanel && this._super();
+        return !this.env.pinnedPanel && super.isAlignedRight;
     },
     getPinOptionText() {
         return this.messagePinService.getPinnedAt(this.message.id) ? _t("Unpin") : _t("Pin");
@@ -41,6 +41,6 @@ patch(Message.prototype, "discuss/message_pin/common", {
         if (this.env.pinnedPanel) {
             return true;
         }
-        return this._super();
+        return super.shouldDisplayAuthorName;
     },
 });

--- a/addons/mail/static/src/discuss/message_pin/common/thread_patch.js
+++ b/addons/mail/static/src/discuss/message_pin/common/thread_patch.js
@@ -4,7 +4,7 @@ import { Thread } from "@mail/core/common/thread";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Thread.prototype, "discuss/message_pin/common", {
+patch(Thread.prototype, {
     /**
      * @override
      * @param {MouseEvent} ev

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.js
@@ -13,16 +13,16 @@ const commandRegistry = registry.category("discuss.channel_commands");
 export const SHORT_TYPING = 5000;
 export const LONG_TYPING = 50000;
 
-patch(Composer, "discuss/typing/common", {
+patch(Composer, {
     components: { ...Composer.components, Typing },
 });
 
-patch(Composer.prototype, "discuss/typing/common", {
+patch(Composer.prototype, {
     /**
      * @override
      */
     setup() {
-        this._super();
+        super.setup();
         this.typingNotified = false;
         this.stopTypingDebounced = useDebounced(this.stopTyping.bind(this), SHORT_TYPING);
     },
@@ -71,7 +71,7 @@ patch(Composer.prototype, "discuss/typing/common", {
      * @override
      */
     async sendMessage() {
-        await this._super();
+        await super.sendMessage();
         this.stopTyping();
     },
     stopTyping() {

--- a/addons/mail/static/src/discuss/typing/common/thread_icon_patch.js
+++ b/addons/mail/static/src/discuss/typing/common/thread_icon_patch.js
@@ -6,16 +6,16 @@ import { useTypingService } from "@mail/discuss/typing/common/typing_service";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(ThreadIcon, "discuss/typing/common", {
+patch(ThreadIcon, {
     components: { ...ThreadIcon.components, Typing },
 });
 
-patch(ThreadIcon.prototype, "discuss/typing/common", {
+patch(ThreadIcon.prototype, {
     /**
      * @override
      */
     setup() {
-        this._super();
+        super.setup();
         this.typingService = useTypingService();
     },
 });

--- a/addons/mail/static/src/js/emojis_mixin.js
+++ b/addons/mail/static/src/js/emojis_mixin.js
@@ -3,36 +3,24 @@
 import { escape } from "@web/core/utils/strings";
 
 /**
- * This mixin gathers a few methods that are used to handle emojis.
+ * Adds a span with a CSS class around chains of emojis in the message for styling purposes.
+ * The input is first passed through 'escape' to prevent unwanted injections into the HTML
  *
- * It's currently used to format text and wrap the emojis around <span class="o_mail_emoji"> to make them look nicer
+ * Sequences of emojis are wrapped instead of individual ones to prevent compound emojis
+ * such as 👩🏿 = 👩 + 🏿 [dark skin tone character] from being separated.
  *
+ * This will only match characters that have a different presentation from normal text, unlike ®
+ * For alternatives, see: https://www.unicode.org/reports/tr51/#Emoji_Properties_and_Data_Files
+ *
+ * @param {String} message a text message to format
  */
-export default {
-    //--------------------------------------------------------------------------
-    // Private
-    //--------------------------------------------------------------------------
+export function formatText(message) {
+    message = escape(message);
+    message = message.replaceAll(
+        /(\p{Emoji_Presentation}+)/gu,
+        "<span class='o_mail_emoji'>$1</span>"
+    );
+    message = message.replace(/(?:\r\n|\r|\n)/g, "<br>");
 
-    /**
-     * Adds a span with a CSS class around chains of emojis in the message for styling purposes.
-     * The input is first passed through 'escape' to prevent unwanted injections into the HTML
-     *
-     * Sequences of emojis are wrapped instead of individual ones to prevent compound emojis
-     * such as 👩🏿 = 👩 + 🏿 [dark skin tone character] from being separated.
-     *
-     * This will only match characters that have a different presentation from normal text, unlike ®
-     * For alternatives, see: https://www.unicode.org/reports/tr51/#Emoji_Properties_and_Data_Files
-     *
-     * @param {String} message a text message to format
-     */
-    _formatText(message) {
-        message = escape(message);
-        message = message.replaceAll(
-            /(\p{Emoji_Presentation}+)/gu,
-            "<span class='o_mail_emoji'>$1</span>"
-        );
-        message = message.replace(/(?:\r\n|\r|\n)/g, "<br>");
-
-        return message;
-    },
-};
+    return message;
+}

--- a/addons/mail/static/src/js/onchange_on_keydown.js
+++ b/addons/mail/static/src/js/onchange_on_keydown.js
@@ -14,9 +14,9 @@ const { useEffect } = owl;
  * (or 2 seconds by default) when typing ends.
  *
  */
-const onchangeOnKeydownMixin = {
+const onchangeOnKeydownMixin = () => ({
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
 
         if (this.props.onchangeOnKeydown) {
             const input = this.input || this.textareaRef;
@@ -34,10 +34,10 @@ const onchangeOnKeydownMixin = {
         const input = this.input || this.textareaRef;
         input.el.dispatchEvent(new Event("change"));
     },
-};
+});
 
-patch(CharField.prototype, "char_field_onchange_on_keydown", onchangeOnKeydownMixin);
-patch(TextField.prototype, "text_field_onchange_on_keydown", onchangeOnKeydownMixin);
+patch(CharField.prototype, onchangeOnKeydownMixin());
+patch(TextField.prototype, onchangeOnKeydownMixin());
 
 CharField.props = {
     ...CharField.props,

--- a/addons/mail/static/src/views/web/composer_patch.js
+++ b/addons/mail/static/src/views/web/composer_patch.js
@@ -4,7 +4,7 @@ import { Composer } from "@mail/core/common/composer";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(Composer.prototype, "web", {
+patch(Composer.prototype, {
     get placeholder() {
         if (this.thread && this.thread.model !== "discuss.channel") {
             if (this.props.type === "message") {
@@ -13,6 +13,6 @@ patch(Composer.prototype, "web", {
                 return _t("Log an internal note...");
             }
         }
-        return this._super();
+        return super.placeholder;
     },
 });

--- a/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.js
+++ b/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.js
@@ -1,18 +1,16 @@
 /* @odoo-module */
 
-import MailEmojisMixin from "@mail/js/emojis_mixin";
 import { EmojisFieldCommon } from "@mail/views/web/fields/emojis_field_common/emojis_field_common";
 
 import { useRef } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
-import { patch } from "@web/core/utils/patch";
 import { CharField, charField } from "@web/views/fields/char/char_field";
 
 /**
  * Extension of the FieldChar that will add emojis support
  */
-export class EmojisCharField extends CharField {
+export class EmojisCharField extends EmojisFieldCommon(CharField) {
     setup() {
         super.setup();
         this.targetEditElement = useRef("input");
@@ -20,8 +18,6 @@ export class EmojisCharField extends CharField {
     }
 }
 
-patch(EmojisCharField.prototype, "emojis_char_field_mail_mixin", MailEmojisMixin);
-patch(EmojisCharField.prototype, "emojis_char_field_field_mixin", EmojisFieldCommon);
 EmojisCharField.template = "mail.EmojisCharField";
 EmojisCharField.components = { ...CharField.components };
 

--- a/addons/mail/static/src/views/web/fields/emojis_field_common/emojis_field_common.js
+++ b/addons/mail/static/src/views/web/fields/emojis_field_common/emojis_field_common.js
@@ -7,7 +7,7 @@ import { useRef } from "@odoo/owl";
 /*
  * Common code for EmojisTextField and EmojisCharField
  */
-export const EmojisFieldCommon = {
+export const EmojisFieldCommon = (T) => class EmojisFieldCommon extends T {
     /**
      * Create an emoji textfield view to enable opening an emoji popover
      */
@@ -38,5 +38,5 @@ export const EmojisFieldCommon = {
                 position: "bottom",
             }
         );
-    },
+    }
 };

--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.js
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.js
@@ -1,16 +1,14 @@
 /* @odoo-module */
 
-import MailEmojisMixin from "@mail/js/emojis_mixin";
 import { EmojisFieldCommon } from "@mail/views/web/fields/emojis_field_common/emojis_field_common";
 
 import { registry } from "@web/core/registry";
-import { patch } from "@web/core/utils/patch";
 import { TextField, textField } from "@web/views/fields/text/text_field";
 
 /**
  * Extension of the FieldText that will add emojis support
  */
-export class EmojisTextField extends TextField {
+export class EmojisTextField extends EmojisFieldCommon(TextField) {
     setup() {
         super.setup();
         this.targetEditElement = this.textareaRef;
@@ -18,8 +16,6 @@ export class EmojisTextField extends TextField {
     }
 }
 
-patch(EmojisTextField.prototype, "emojis_char_field_mail_mixin", MailEmojisMixin);
-patch(EmojisTextField.prototype, "emojis_text_field_field_mixin", EmojisFieldCommon);
 EmojisTextField.template = "mail.EmojisTextField";
 EmojisTextField.components = { ...TextField.components };
 

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
@@ -5,7 +5,6 @@ import { useAssignUserCommand } from "@mail/views/web/fields/assign_user_command
 
 import { registry } from "@web/core/registry";
 import { TagsList } from "@web/core/tags_list/tags_list";
-import { patch } from "@web/core/utils/patch";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { browser } from "@web/core/browser/browser";
 import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
@@ -22,9 +21,9 @@ import {
 export class Many2ManyAvatarUserTagsList extends TagsList {}
 Many2ManyAvatarUserTagsList.template = "mail.Many2ManyAvatarUserTagsList";
 
-const userChatter = {
+const WithUserChatter = (T) => class UserChatterMixin extends T {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.openChat = useOpenChat(this.relation);
         if (this.props.withCommand) {
             useAssignUserCommand();
@@ -34,11 +33,11 @@ const userChatter = {
         });
         this.openTimeout = false;
         this.lastOpenedId = 0;
-    },
+    }
 
     getTagProps(record) {
         return {
-            ...this._super(...arguments),
+            ...super.getTagProps(...arguments),
             onImageClicked: () => this.openChat(record.resId),
             openCard: (ev) => {
                 if (this.env.isSmall) {
@@ -63,15 +62,15 @@ const userChatter = {
                 delete this.openTimeout;
             },
         };
-    },
-};
-export class Many2ManyTagsAvatarUserField extends Many2ManyTagsAvatarField {
+    }
+}
+
+export class Many2ManyTagsAvatarUserField extends WithUserChatter(Many2ManyTagsAvatarField) {
     static components = {
         ...Many2ManyTagsAvatarField.components,
         TagsList: Many2ManyAvatarUserTagsList,
     };
 }
-patch(Many2ManyTagsAvatarUserField.prototype, "mail/fields/web", userChatter);
 
 export const many2ManyTagsAvatarUserField = {
     ...many2ManyTagsAvatarField,
@@ -85,7 +84,7 @@ export class KanbanMany2ManyAvatarUserTagsList extends KanbanMany2ManyTagsAvatar
     static template = "mail.KanbanMany2ManyAvatarUserTagsList";
 }
 
-export class KanbanMany2ManyTagsAvatarUserField extends KanbanMany2ManyTagsAvatarField {
+export class KanbanMany2ManyTagsAvatarUserField extends WithUserChatter(KanbanMany2ManyTagsAvatarField) {
     static template = "mail.KanbanMany2ManyTagsAvatarUserField";
     static components = {
         ...KanbanMany2ManyTagsAvatarField.components,
@@ -95,7 +94,6 @@ export class KanbanMany2ManyTagsAvatarUserField extends KanbanMany2ManyTagsAvata
         return !this.props.readonly;
     }
 }
-patch(KanbanMany2ManyTagsAvatarUserField.prototype, "mail/fields/web", userChatter);
 export const kanbanMany2ManyTagsAvatarUserField = {
     ...kanbanMany2ManyTagsAvatarField,
     component: KanbanMany2ManyTagsAvatarUserField,
@@ -103,7 +101,7 @@ export const kanbanMany2ManyTagsAvatarUserField = {
 };
 registry.category("fields").add("kanban.many2many_avatar_user", kanbanMany2ManyTagsAvatarUserField);
 
-export class ListMany2ManyTagsAvatarUserField extends ListMany2ManyTagsAvatarField {
+export class ListMany2ManyTagsAvatarUserField extends WithUserChatter(ListMany2ManyTagsAvatarField) {
     static template = "mail.ListMany2ManyTagsAvatarUserField";
     static components = {
         ...ListMany2ManyTagsAvatarField.components,
@@ -114,7 +112,6 @@ export class ListMany2ManyTagsAvatarUserField extends ListMany2ManyTagsAvatarFie
         return this.props.record.data[this.props.name].records.length === 1 || !this.props.readonly;
     }
 }
-patch(ListMany2ManyTagsAvatarUserField.prototype, "mail/fields/web", userChatter);
 
 export const listMany2ManyTagsAvatarUserField = {
     ...listMany2ManyTagsAvatarField,

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -5,7 +5,6 @@ import { useAssignUserCommand } from "@mail/views/web/fields/assign_user_command
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { patch } from "@web/core/utils/patch";
 import {
     Many2OneAvatarField,
     many2OneAvatarField,
@@ -16,9 +15,9 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { browser } from "@web/core/browser/browser";
 import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 
-const userChatter = {
+const WithUserChatter = (T) => class extends T {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.openChat = useOpenChat(this.relation);
         if (this.props.withCommand) {
             useAssignUserCommand();
@@ -27,14 +26,14 @@ const userChatter = {
             closeOnHoverAway: true,
         });
         this.openTimeout = false;
-    },
+    }
 
     onClickAvatar() {
         const id = this.props.record.data[this.props.name][0] ?? false;
         if (id !== false) {
             this.openChat(id);
         }
-    },
+    }
 
     openCard(ev) {
         if (this.env.isSmall) {
@@ -49,15 +48,15 @@ const userChatter = {
                 });
             }
         }, 350);
-    },
+    }
 
     clearTimeout() {
         browser.clearTimeout(this.openTimeout);
         delete this.openTimeout;
-    },
+    }
 };
 
-export class Many2OneAvatarUserField extends Many2OneAvatarField {
+export class Many2OneAvatarUserField extends WithUserChatter(Many2OneAvatarField) {
     static template = "mail.Many2OneAvatarUserField";
     static props = {
         ...Many2OneAvatarField.props,
@@ -66,7 +65,6 @@ export class Many2OneAvatarUserField extends Many2OneAvatarField {
         withCommand: { type: Boolean, optional: true },
     };
 }
-patch(Many2OneAvatarUserField.prototype, "mail/fields/web", userChatter);
 
 export const many2OneAvatarUserField = {
     ...many2OneAvatarField,
@@ -83,7 +81,7 @@ export const many2OneAvatarUserField = {
 
 registry.category("fields").add("many2one_avatar_user", many2OneAvatarUserField);
 
-export class KanbanMany2OneAvatarUserField extends KanbanMany2OneAvatarField {
+export class KanbanMany2OneAvatarUserField extends WithUserChatter(KanbanMany2OneAvatarField) {
     static template = "mail.KanbanMany2OneAvatarUserField";
     static props = {
         ...KanbanMany2OneAvatarField.props,
@@ -99,7 +97,6 @@ export class KanbanMany2OneAvatarUserField extends KanbanMany2OneAvatarField {
         return props;
     }
 }
-patch(KanbanMany2OneAvatarUserField.prototype, "mail/fields/web", userChatter);
 
 export const kanbanMany2OneAvatarUserField = {
     ...kanbanMany2OneAvatarField,

--- a/addons/mail/static/src/views/web/fields/properties_field/property_value.js
+++ b/addons/mail/static/src/views/web/fields/properties_field/property_value.js
@@ -10,9 +10,9 @@ import { PropertyValue } from "@web/views/fields/properties/property_value";
  * Allow to open the chatter of the user when we click on the avatar of a Many2one
  * property (like we do for many2one_avatar_user widget).
  */
-patch(PropertyValue.prototype, "mail/views/web", {
+patch(PropertyValue.prototype, {
     setup() {
-        this._super();
+        super.setup();
 
         if (this.env.services["mail.thread"]) {
             // work only for the res.users model

--- a/addons/mail/static/src/views/web/form/form_compiler.js
+++ b/addons/mail/static/src/views/web/form/form_compiler.js
@@ -80,10 +80,10 @@ registry.category("form_compilers").add("attachment_preview_compiler", {
     fn: compileAttachmentPreview,
 });
 
-patch(FormCompiler.prototype, "mail/views/web", {
+patch(FormCompiler.prototype, {
     compile(node, params) {
         // TODO no chatter if in dialog?
-        const res = this._super(node, params);
+        const res = super.compile(node, params);
         const chatterContainerHookXml = res.querySelector(".o-mail-Form-chatter");
         if (!chatterContainerHookXml) {
             return res; // no chatter, keep the result as it is

--- a/addons/mail/static/src/views/web/form/form_controller.js
+++ b/addons/mail/static/src/views/web/form/form_controller.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { FormController } from "@web/views/form/form_controller";
 
-patch(FormController.prototype, "mail/views/web", {
+patch(FormController.prototype, {
     onWillLoadRoot(nextConfiguration) {
         const isSameThread =
             this.model.root?.resId === nextConfiguration.resId &&

--- a/addons/mail/static/src/views/web/form/form_renderer.js
+++ b/addons/mail/static/src/views/web/form/form_renderer.js
@@ -12,9 +12,9 @@ import { patch } from "@web/core/utils/patch";
 import { useDebounced } from "@web/core/utils/timing";
 import { FormRenderer } from "@web/views/form/form_renderer";
 
-patch(FormRenderer.prototype, "mail/views/web", {
+patch(FormRenderer.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.mailComponents = {
             AttachmentView,
             Chatter,
@@ -48,7 +48,7 @@ patch(FormRenderer.prototype, "mail/views/web", {
     },
 });
 
-patch(FormRenderer.props, "mail/views/web", {
+patch(FormRenderer.props, {
     // Template props : added by the FormCompiler
     saveButtonClicked: { type: Function, optional: true },
 });

--- a/addons/mail/static/src/views/web/list_renderer.js
+++ b/addons/mail/static/src/views/web/list_renderer.js
@@ -3,9 +3,9 @@
 import { patch } from "@web/core/utils/patch";
 import { ListRenderer } from "@web/views/list/list_renderer";
 
-patch(ListRenderer.prototype, "mail/views/web", {
+patch(ListRenderer.prototype, {
     getPropertyFieldColumns(_, list) {
-        const columns = this._super(...arguments);
+        const columns = super.getPropertyFieldColumns(...arguments);
         for (const column of columns) {
             const { relation, type } = list.fields[column.name];
             if (relation === "res.users") {

--- a/addons/mail/static/tests/activity/activity_tests.js
+++ b/addons/mail/static/tests/activity/activity_tests.js
@@ -521,7 +521,7 @@ QUnit.test("activity click on edit", async (assert) => {
             assert.strictEqual(action.type, "ir.actions.act_window");
             assert.strictEqual(action.res_model, "mail.activity");
             assert.strictEqual(action.res_id, activityId);
-            return this._super(...arguments);
+            return super.doAction(...arguments);
         },
     });
     assert.containsOnce($, ".o-mail-Activity");

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -129,8 +129,7 @@ QUnit.test("should display invitations", async (assert) => {
                     assert.step("play_sound_effect");
                 }
             },
-        },
-        { pure: true }
+        }
     );
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
@@ -88,7 +88,7 @@ QUnit.test("Jump to message", async (assert) => {
     // make scroll behavior instantaneous.
     patchWithCleanup(Element.prototype, {
         scrollIntoView() {
-            return this._super(true);
+            return super.scrollIntoView(true);
         },
     });
     const pyEnv = await startServer();
@@ -119,7 +119,7 @@ QUnit.test("Jump to message from notification", async (assert) => {
     // make scroll behavior instantaneous.
     patchWithCleanup(Element.prototype, {
         scrollIntoView() {
-            return this._super(true);
+            return super.scrollIntoView(true);
         },
     });
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
@@ -17,7 +17,7 @@ QUnit.test("Basic jump to present when scrolling to outdated messages", async (a
     // make scroll behavior instantaneous.
     patchWithCleanup(Element.prototype, {
         scrollIntoView() {
-            return this._super(true);
+            return super.scrollIntoView(true);
         },
     });
     const pyEnv = await startServer();
@@ -56,7 +56,7 @@ QUnit.test("Jump to old reply should prompt jump to presence", async (assert) =>
     // make scroll behavior instantaneous.
     patchWithCleanup(Element.prototype, {
         scrollIntoView() {
-            return this._super(true);
+            return super.scrollIntoView(true);
         },
     });
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/emoji/emojis_mixin_tests.js
+++ b/addons/mail/static/tests/emoji/emojis_mixin_tests.js
@@ -1,6 +1,6 @@
 /* @odoo-module */
 
-import EmojiMixin from "@mail/js/emojis_mixin";
+import { formatText } from "@mail/js/emojis_mixin";
 
 QUnit.module("emojis mixin");
 
@@ -8,5 +8,5 @@ QUnit.test("Emoji formatter handles compound emojis", (assert) => {
     const testString = "👩🏿test👩🏿👩t👩";
     const expectedString =
         "<span class='o_mail_emoji'>👩🏿</span>test<span class='o_mail_emoji'>👩🏿👩</span>t<span class='o_mail_emoji'>👩</span>";
-    assert.deepEqual(EmojiMixin._formatText(testString), expectedString);
+    assert.deepEqual(formatText(testString), expectedString);
 });

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/controllers/discuss", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
@@ -29,7 +29,7 @@ patch(MockServer.prototype, "mail/controllers/discuss", {
                 size: attachment.file_size,
             };
         }
-        return this._super(...arguments);
+        return super.performRPC(...arguments);
     },
     /**
      * @override
@@ -179,7 +179,7 @@ patch(MockServer.prototype, "mail/controllers/discuss", {
         if (route === "/discuss/gif/favorites") {
             return [[]];
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates the `/discuss/channel/pinned_messages` route.

--- a/addons/mail/static/tests/helpers/mock_server/mock_server.js
+++ b/addons/mail/static/tests/helpers/mock_server/mock_server.js
@@ -4,9 +4,9 @@ import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/mock_server_main", {
+patch(MockServer.prototype, {
     async performRPC(route, args) {
-        const rpcResult = await this._super(route, args);
+        const rpcResult = await super.performRPC(route, args);
         const methodName = args.method || route;
         const callbackFn =
             registry.category("mock_server_callbacks").get(`${args.model}/${methodName}`, null) ||

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -9,7 +9,7 @@ import { formatDate } from "@web/core/l10n/dates";
 import { Command } from "@mail/../tests/helpers/command";
 const { DateTime } = luxon;
 
-patch(MockServer.prototype, "mail/models/discuss_channel", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "discuss.channel" && args.method === "execute_command_help") {
             return this._mockDiscussChannelExecuteCommandHelp(args.args[0], args.model);
@@ -113,7 +113,7 @@ patch(MockServer.prototype, "mail/models/discuss_channel", {
         if (args.model === "discuss.channel" && args.method === "get_mention_suggestions") {
             return this._mockDiscussChannelGetMentionSuggestions(args);
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
 
     /**

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel_member.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel_member.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/discuss_channel_member", {
+patch(MockServer.prototype, {
     /**
      * Simulates `notify_typing` on `discuss.channel.member`.
      *

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel_rtc_session.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/discuss_channel_rtc_session", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_mail_rtc_session_format` on `discuss.channel.rtc.session`.
      *

--- a/addons/mail/static/tests/helpers/mock_server/models/ir_attachment.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/ir_attachment.js
@@ -3,13 +3,13 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/ir_attachment", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "ir.attachment" && args.method === "register_as_main_attachment") {
             const ids = args.args[0];
             return this._mockIrAttachmentRegisterAsMainAttachment(ids);
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates `_attachment_format` on `ir.attachment`.

--- a/addons/mail/static/tests/helpers/mock_server/models/ir_websocket.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/ir_websocket.js
@@ -6,7 +6,7 @@ import "@bus/../tests/helpers/mock_server";
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/ir_websocket", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_get_im_status` on `ir.websocket`.
      *
@@ -15,7 +15,7 @@ patch(MockServer.prototype, "mail/models/ir_websocket", {
      * should be monitored.
      */
     _mockIrWebsocket__getImStatus(imStatusIdsByModel) {
-        const imStatus = this._super(imStatusIdsByModel);
+        const imStatus = super._mockIrWebsocket__getImStatus(imStatusIdsByModel);
         const { "mail.guest": guestIds } = imStatusIdsByModel;
         if (guestIds) {
             imStatus["Guest"] = this.pyEnv["mail.guest"].searchRead([["id", "in", guestIds]], {

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_activity.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_activity.js
@@ -7,7 +7,7 @@ import { serializeDate, deserializeDate } from "@web/core/l10n/dates";
 
 const { DateTime} = luxon;
 
-patch(MockServer.prototype, "mail/models/mail_activity", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "mail.activity" && args.method === "action_feedback") {
             const ids = args.args[0];
@@ -26,7 +26,7 @@ patch(MockServer.prototype, "mail/models/mail_activity", {
             const domain = args.args[1] || args.kwargs.domain;
             return this._mockMailActivityGetActivityData(res_model, domain);
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates `activity_format` on `mail.activity`.

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_followers.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_followers.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/mail_followers", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_format_for_chatter` on `mail.followers`.
      *

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/mail_link_preview", {
+patch(MockServer.prototype, {
     /**
      * Simulates the `_link_preview_format` method of `mail.link.preview`.
      *

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_message.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_message.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/mail_message", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "mail.message" && args.method === "mark_all_as_read") {
             const domain = args.args[0] || args.kwargs.domain;
@@ -24,7 +24,7 @@ patch(MockServer.prototype, "mail/models/mail_message", {
         if (args.model === "mail.message" && args.method === "unstar_all") {
             return this._mockMailMessageUnstarAll();
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates `_message_reaction` on `mail.message`.

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_notification.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_notification.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/mail_notification", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_filtered_for_web_client` on `mail.notification`.
      *

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_thread.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_thread.js
@@ -5,7 +5,7 @@ import { MockServer } from "@web/../tests/helpers/mock_server";
 
 import { datetime_to_str } from "@web/legacy/js/core/time";
 
-patch(MockServer.prototype, "mail/models/mail_thread", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.method === "message_subscribe") {
             const ids = args.args[0];
@@ -37,7 +37,7 @@ patch(MockServer.prototype, "mail/models/mail_thread", {
                 args.kwargs.notification_type
             );
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates `_message_compute_author` on `mail.thread`.

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_tracking_value.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_tracking_value.js
@@ -3,12 +3,12 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/mail_tracking_value", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
     init(data, options) {
-        this._super(data, options);
+        super.init(data, options);
         if (this.currentPartnerId && this.models && "res.partner" in this.models) {
             this.currentPartner = this.getRecords("res.partner", [
                 ["id", "=", this.currentPartnerId],
@@ -29,7 +29,7 @@ patch(MockServer.prototype, "mail/models/mail_tracking_value", {
      */
     mockWrite(model) {
         const initialTrackedFieldValuesByRecordId = this._mockMailThread_TrackPrepare(model);
-        const mockWriteResult = this._super(...arguments);
+        const mockWriteResult = super.mockWrite(...arguments);
         if (initialTrackedFieldValuesByRecordId) {
             this._mockMailThread_TrackFinalize(model, initialTrackedFieldValuesByRecordId);
         }

--- a/addons/mail/static/tests/helpers/mock_server/models/models.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/models.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/models", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_mail_track` on `base`
      *

--- a/addons/mail/static/tests/helpers/mock_server/models/res_fake.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_fake.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/res_fake", {
+patch(MockServer.prototype, {
     /**
      * Simulates `_message_get_suggested_recipients` on `res.fake`.
      *
@@ -42,6 +42,6 @@ patch(MockServer.prototype, "mail/models/res_fake", {
         if (model === "res.fake") {
             return new Map(ids.map((id) => [id, "Custom Default Subject"]));
         }
-        return this._super(model, ids);
+        return super.mockMailThread_MessageComputeSubject(model, ids);
     },
 });

--- a/addons/mail/static/tests/helpers/mock_server/models/res_partner.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_partner.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/res_partner", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "res.partner" && args.method === "im_search") {
             const name = args.args[0] || args.kwargs.search;
@@ -26,7 +26,7 @@ patch(MockServer.prototype, "mail/models/res_partner", {
         ) {
             return this._mockResPartnerGetMentionSuggestionsFromChannel(args);
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
 
     /**

--- a/addons/mail/static/tests/helpers/mock_server/models/res_users.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_users.js
@@ -4,12 +4,12 @@ import { patch } from "@web/core/utils/patch";
 import { date_to_str } from "@web/legacy/js/core/time";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/res_users", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "res.users" && args.method === "systray_get_activities") {
             return this._mockResUsersSystrayGetActivities();
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates `_init_messaging` on `res.users`.

--- a/addons/mail/static/tests/helpers/mock_server/models/res_users_settings.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_users_settings.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/res_users_settings", {
+patch(MockServer.prototype, {
     async _performRPC(route, args) {
         if (args.model === "res.users.settings" && args.method === "_find_or_create_for_user") {
             const user_id = args.args[0][0];
@@ -14,7 +14,7 @@ patch(MockServer.prototype, "mail/models/res_users_settings", {
             const newSettings = args.kwargs.new_settings;
             return this._mockResUsersSettingsSetResUsersSettings(id, newSettings);
         }
-        return this._super(route, args);
+        return super._performRPC(route, args);
     },
     /**
      * Simulates `_find_or_create_for_user` on `res.users.settings`.

--- a/addons/mail/static/tests/helpers/mock_server/models/res_users_settings_volumes.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_users_settings_volumes.js
@@ -6,7 +6,7 @@ import "@bus/../tests/helpers/mock_server";
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "mail/models/res_users_settings_volumes", {
+patch(MockServer.prototype, {
     /**
      * Simulates `discuss_users_settings_volume_format` on `res.users.settings.volumes`.
      *

--- a/addons/mail/static/tests/helpers/patch_notifications.js
+++ b/addons/mail/static/tests/helpers/patch_notifications.js
@@ -18,7 +18,7 @@ export function patchBrowserNotification(permission = "default", requestPermissi
     const notificationQueries = [];
     patchWithCleanup(browser.navigator.permissions, {
         async query({ name }) {
-            const result = await this._super(...arguments);
+            const result = await super.query(...arguments);
             if (name === "notifications") {
                 Object.defineProperty(result, "state", {
                     get: () => (permission === "default" ? "prompt" : permission),
@@ -33,7 +33,7 @@ export function patchBrowserNotification(permission = "default", requestPermissi
         isPatched: true,
         requestPermission() {
             if (!requestPermissionResult) {
-                return this._super(...arguments);
+                return super.requestPermission(...arguments);
             }
             this.permission = requestPermissionResult;
             for (const query of notificationQueries) {

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -70,18 +70,17 @@ function getCreateXHR() {
         let route = "";
         const self = this;
         xhr.status = 200;
-        patch(xhr, "mail", {
+        patch(xhr, {
             open(method, dest) {
                 route = dest;
-                return this._super(method, dest);
+                return super.open(method, dest);
             },
             async send(data) {
-                const _super = this._super;
                 await new Promise(setTimeout);
                 response = JSON.stringify(
                     await self.env.services.rpc(route, { body: data, method: "POST" })
                 );
-                return _super(data);
+                return super.send(data);
             },
             upload: new EventTarget(),
             abort() {
@@ -141,8 +140,7 @@ export const setupManager = {
                     audio.play = () => {};
                     return audio;
                 },
-            },
-            { pure: true }
+            }
         );
         patchWithCleanup(session, { show_effect: true });
         services["messagingValues"] = services["messagingValues"] ?? {

--- a/addons/mail/static/tests/message/message_reply_tests.js
+++ b/addons/mail/static/tests/message/message_reply_tests.js
@@ -32,7 +32,7 @@ QUnit.test("click on message in reply to scroll to the parent message", async (a
     // make scroll behavior instantaneous.
     patchWithCleanup(Element.prototype, {
         scrollIntoView() {
-            return this._super(true);
+            return super.scrollIntoView(true);
         },
     });
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/web/activity/activity_widget_tests.js
+++ b/addons/mail/static/tests/web/activity/activity_widget_tests.js
@@ -208,7 +208,7 @@ QUnit.test("list activity widget: open dropdown", async (assert) => {
     });
     patchWithCleanup(ListController.prototype, {
         setup() {
-            this._super();
+            super.setup();
             const selectRecord = this.props.selectRecord;
             this.props.selectRecord = (...args) => {
                 assert.step(`select_record ${JSON.stringify(args)}`);

--- a/addons/mass_mailing/static/tests/mailing_mailing_view_form_tests.js
+++ b/addons/mass_mailing/static/tests/mailing_mailing_view_form_tests.js
@@ -51,11 +51,11 @@ QUnit.module("mass_mailing", {}, function () {
         QUnit.test("unregister ResizeObserver on unmount", async (assert) => {
             patchWithCleanup(MassMailingFullWidthViewController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     patchWithCleanup(this._resizeObserver, {
                         disconnect() {
                             assert.step("disconnect");
-                            return this._super(...arguments);
+                            return super.disconnect(...arguments);
                         },
                     });
                 },

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/common/microsoft_calendar_common_popover.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/common/microsoft_calendar_common_popover.js
@@ -3,8 +3,8 @@
 import { AttendeeCalendarCommonPopover } from "@calendar/views/attendee_calendar/common/attendee_calendar_common_popover";
 import { patch } from "@web/core/utils/patch";
 
-patch(AttendeeCalendarCommonPopover.prototype, "microsoft_calendar_microsoft_calendar_common_popover", {
+patch(AttendeeCalendarCommonPopover.prototype, {
     get isEventArchivable() {
-        return this._super() || (this.isCurrentUserOrganizer && this.props.record.rawRecord.microsoft_id);
+        return super.isEventArchivable || (this.isCurrentUserOrganizer && this.props.record.rawRecord.microsoft_id);
     },
 });

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog, AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-patch(AttendeeCalendarController.prototype, "microsoft_calendar_microsoft_calendar_controller", {
+patch(AttendeeCalendarController.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.dialog = useService("dialog");
         this.notification = useService("notification");
     },

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
@@ -3,13 +3,13 @@
 import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attendee_calendar_model";
 import { patch } from "@web/core/utils/patch";
 
-patch(AttendeeCalendarModel, "microsoft_calendar_microsoft_calendar_model", {
+patch(AttendeeCalendarModel, {
     services: [...AttendeeCalendarModel.services, "rpc"],
 });
 
-patch(AttendeeCalendarModel.prototype, "microsoft_calendar_microsoft_calendar_model_functions", {
+patch(AttendeeCalendarModel.prototype, {
     setup(params, { rpc }) {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.rpc = rpc;
         this.microsoftIsSync = true;
         this.microsoftPendingSync = false;
@@ -19,9 +19,8 @@ patch(AttendeeCalendarModel.prototype, "microsoft_calendar_microsoft_calendar_mo
      * @override
      */
     async updateData() {
-        const _super = this._super.bind(this);
         if (this.microsoftPendingSync) {
-            return _super(...arguments);
+            return super.updateData(...arguments);
         }
         try {
             await Promise.race([
@@ -35,7 +34,7 @@ patch(AttendeeCalendarModel.prototype, "microsoft_calendar_microsoft_calendar_mo
             console.error("Could not synchronize microsoft events now.", error);
             this.microsoftPendingSync = false;
         }
-        return _super(...arguments);
+        return super.updateData(...arguments);
     },
 
     async syncMicrosoftCalendar(silent = false) {

--- a/addons/microsoft_calendar/static/tests/microsoft_calendar_mock_server.js
+++ b/addons/microsoft_calendar/static/tests/microsoft_calendar_mock_server.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "microsoft_calendar_mock_server", {
+patch(MockServer.prototype, {
     /**
      * Simulate the creation of a custom appointment type
      * by receiving a list of slots.
@@ -13,6 +13,6 @@ patch(MockServer.prototype, "microsoft_calendar_mock_server", {
         if (route === '/microsoft_calendar/sync_data') {
             return Promise.resolve({status: 'no_new_event_from_microsoft'});
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
@@ -1,12 +1,12 @@
 /** @odoo-module **/
 import { ForecastedButtons } from "@stock/stock_forecasted/forecasted_buttons";
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 
 const { onWillStart } = owl;
 
-patch(ForecastedButtons.prototype, 'mrp.ForecastedButtons',{
+patch(ForecastedButtons.prototype, {
     setup() {
-        this._super.apply();
+        super.setup();
         onWillStart(async () =>{
             const fields = this.resModel === "product.template" ? ['bom_ids'] : ['bom_ids', 'variant_bom_ids'];
             const res = (await this.orm.call(this.resModel, 'read', [this.productId], { fields }))[0];

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_details.js
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_details.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
 import { ForecastedDetails } from '@stock/stock_forecasted/forecasted_details';
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 
-patch(ForecastedDetails.prototype, 'mrp.ForecastedDetails',{
+patch(ForecastedDetails.prototype, {
 
     canReserveOperation(line){
-        return this._super(line) || line.move_out?.raw_material_production_id;
+        return super.canReserveOperation(line) || line.move_out?.raw_material_production_id;
     }
 });

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.js
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.js
@@ -4,6 +4,6 @@ import { patch } from "@web/core/utils/patch";
 import { BomOverviewComponentsBlock } from "@mrp/components/bom_overview_components_block/mrp_bom_overview_components_block";
 import { BomOverviewSpecialLine } from "@mrp/components/bom_overview_special_line/mrp_bom_overview_special_line";
 
-patch(BomOverviewComponentsBlock, "mrp_subcontracting", {
+patch(BomOverviewComponentsBlock, {
     components: { ...BomOverviewComponentsBlock.components, BomOverviewSpecialLine },
 });

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_line/mrp_bom_overview_line.js
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_line/mrp_bom_overview_line.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overview_line";
 
-patch(BomOverviewLine.prototype, "mrp_subcontracting", {
+patch(BomOverviewLine.prototype, {
     /**
      * @override
      */
@@ -11,6 +11,6 @@ patch(BomOverviewLine.prototype, "mrp_subcontracting", {
         if (routeType == "subcontract") {
             return this.goToAction(this.data.link_id, this.data.link_model);
         }
-        return this._super(...arguments);
+        return super.goToRoute(...arguments);
     }
 });

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
@@ -4,9 +4,9 @@ import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
 import { BomOverviewSpecialLine } from "@mrp/components/bom_overview_special_line/mrp_bom_overview_special_line";
 
-patch(BomOverviewSpecialLine.prototype, "mrp_subcontracting", {
+patch(BomOverviewSpecialLine.prototype, {
     setup() {
-        this._super.apply();
+        super.setup();
         this.actionService = useService("action");
     },
 

--- a/addons/pos_adyen/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_adyen/static/src/overrides/components/payment_screen/payment_screen.js
@@ -4,9 +4,9 @@ import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment
 import { patch } from "@web/core/utils/patch";
 import { onMounted } from "@odoo/owl";
 
-patch(PaymentScreen.prototype, "pos_adyen.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         onMounted(() => {
             const pendingPaymentLine = this.currentOrder.paymentlines.find(
                 (paymentLine) =>

--- a/addons/pos_adyen/static/src/overrides/models/models.js
+++ b/addons/pos_adyen/static/src/overrides/models/models.js
@@ -6,14 +6,14 @@ import { patch } from "@web/core/utils/patch";
 
 register_payment_method("adyen", PaymentAdyen);
 
-patch(Payment.prototype, "pos_adyen.Payment", {
+patch(Payment.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.terminalServiceId = this.terminalServiceId || null;
     },
     //@override
     export_as_JSON() {
-        const json = this._super(...arguments);
+        const json = super.export_as_JSON(...arguments);
         if (json) {
             json.terminal_service_id = this.terminalServiceId;
         }
@@ -21,7 +21,7 @@ patch(Payment.prototype, "pos_adyen.Payment", {
     },
     //@override
     init_from_JSON(json) {
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
         this.terminalServiceId = json.terminal_service_id;
     },
     setTerminalServiceId(id) {

--- a/addons/pos_discount/static/src/overrides/models/models.js
+++ b/addons/pos_discount/static/src/overrides/models/models.js
@@ -3,7 +3,7 @@
 import { Orderline } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(Orderline.prototype, "pos_discount.Orderline", {
+patch(Orderline.prototype, {
     /**
      * Checks if the current line applies for a global discount from `pos_discount.DiscountButton`.
      * @returns Boolean

--- a/addons/pos_epson_printer/static/src/overrides/models/models.js
+++ b/addons/pos_epson_printer/static/src/overrides/models/models.js
@@ -4,10 +4,10 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 import { EpsonPrinter } from "@pos_epson_printer/app/epson_printer";
 import { patch } from "@web/core/utils/patch";
 
-patch(PosStore.prototype, "pos_epson_printer.PosStore", {
+patch(PosStore.prototype, {
     after_load_server_data() {
         var self = this;
-        return this._super(...arguments).then(function () {
+        return super.after_load_server_data(...arguments).then(function () {
             if (self.config.other_devices && self.config.epson_printer_ip) {
                 self.hardwareProxy.printer = new EpsonPrinter({ ip: self.config.epson_printer_ip });
             }
@@ -17,7 +17,7 @@ patch(PosStore.prototype, "pos_epson_printer.PosStore", {
         if (config.printer_type === "epson_epos") {
             return new EpsonPrinter({ ip: config.epson_printer_ip });
         } else {
-            return this._super(...arguments);
+            return super.create_printer(...arguments);
         }
     },
 });

--- a/addons/pos_hr/static/src/overrides/components/cashier_name/cashier_name.js
+++ b/addons/pos_hr/static/src/overrides/components/cashier_name/cashier_name.js
@@ -4,9 +4,9 @@ import { CashierName } from "@point_of_sale/app/navbar/cashier_name/cashier_name
 import { patch } from "@web/core/utils/patch";
 import { useCashierSelector } from "@pos_hr/app/select_cashier_mixin";
 
-patch(CashierName.prototype, "pos_hr.CashierName", {
+patch(CashierName.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.selectCashier = useCashierSelector();
     },
     //@Override
@@ -15,13 +15,13 @@ patch(CashierName.prototype, "pos_hr.CashierName", {
             const cashier = this.pos.get_cashier();
             return `/web/image/hr.employee/${cashier.id}/avatar_128`;
         }
-        return this._super(...arguments);
+        return super.avatar;
     },
     //@Override
     get cssClass() {
         if (this.pos.config.module_pos_hr) {
             return { oe_status: true };
         }
-        return this._super(...arguments);
+        return super.cssClass;
     },
 });

--- a/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_hr/static/src/overrides/components/navbar/navbar.js
@@ -3,10 +3,10 @@
 import { Navbar } from "@point_of_sale/app/navbar/navbar";
 import { patch } from "@web/core/utils/patch";
 
-patch(Navbar.prototype, "pos_hr.Navbar", {
+patch(Navbar.prototype, {
     get showCashMoveButton() {
         const { cashier } = this.pos;
-        return this._super(...arguments) && (!cashier || cashier.role == "manager");
+        return super.showCashMoveButton && (!cashier || cashier.role == "manager");
     },
     get showCloseSessionButton() {
         return (

--- a/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_hr/static/src/overrides/components/payment_screen/payment_screen.js
@@ -3,9 +3,9 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentScreen.prototype, "pos_hr.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     async validateOrder(isForceValidate) {
         this.currentOrder.cashier = this.pos.get_cashier();
-        await this._super(...arguments);
+        await super.validateOrder(...arguments);
     },
 });

--- a/addons/pos_hr/static/src/overrides/models/Chrome.js
+++ b/addons/pos_hr/static/src/overrides/models/Chrome.js
@@ -3,9 +3,9 @@
 import { Chrome } from "@point_of_sale/app/pos_app";
 import { patch } from "@web/core/utils/patch";
 
-patch(Chrome.prototype, "pos_hr.Chrome", {
+patch(Chrome.prototype, {
     get showCashMoveButton() {
         const { cashier } = this.pos;
-        return this._super(...arguments) && (!cashier || cashier.role == "manager");
+        return super.showCashMoveButton && (!cashier || cashier.role == "manager");
     },
 });

--- a/addons/pos_hr/static/src/overrides/models/models.js
+++ b/addons/pos_hr/static/src/overrides/models/models.js
@@ -3,21 +3,21 @@
 import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(Order.prototype, "pos_hr.Order", {
+patch(Order.prototype, {
     setup(options) {
-        this._super(...arguments);
+        super.setup(...arguments);
         if (!options.json && this.pos.config.module_pos_hr) {
             this.cashier = this.pos.get_cashier();
         }
     },
     init_from_JSON(json) {
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
         if (this.pos.config.module_pos_hr && json.employee_id) {
             this.cashier = this.pos.employee_by_id[json.employee_id];
         }
     },
     export_as_JSON() {
-        const json = this._super(...arguments);
+        const json = super.export_as_JSON(...arguments);
         if (this.pos.config.module_pos_hr) {
             json.employee_id = this.cashier ? this.cashier.id : false;
         }

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -3,15 +3,15 @@
 import { patch } from "@web/core/utils/patch";
 import { PosStore } from "@point_of_sale/app/store/pos_store";
 
-patch(PosStore.prototype, "pos_hr.PosStore", {
+patch(PosStore.prototype, {
     async setup() {
-        await this._super(...arguments);
+        await super.setup(...arguments);
         if (this.config.module_pos_hr) {
             this.showTempScreen("LoginScreen");
         }
     },
     async _processData(loadedData) {
-        await this._super(...arguments);
+        await super._processData(...arguments);
         if (this.config.module_pos_hr) {
             this.employees = loadedData["hr.employee"];
             this.employee_by_id = loadedData["employee_by_id"];
@@ -19,7 +19,7 @@ patch(PosStore.prototype, "pos_hr.PosStore", {
         }
     },
     async after_load_server_data() {
-        await this._super(...arguments);
+        await super.after_load_server_data(...arguments);
         if (this.config.module_pos_hr) {
             this.hasLoggedIn = !this.config.module_pos_hr;
         }
@@ -54,17 +54,17 @@ patch(PosStore.prototype, "pos_hr.PosStore", {
         if (this.config.module_pos_hr) {
             return this.cashier;
         }
-        return this._super(...arguments);
+        return super.get_cashier(...arguments);
     },
     get_cashier_user_id() {
         if (this.config.module_pos_hr) {
             return this.cashier.user_id ? this.cashier.user_id : null;
         }
-        return this._super(...arguments);
+        return super.get_cashier_user_id(...arguments);
     },
     async logEmployeeMessage(action, message) {
         if (!this.config.module_pos_hr) {
-            this._super(...arguments);
+            super.logEmployeeMessage(...arguments);
             return;
         }
         await this.orm.call("pos.session", "log_partner_message", [
@@ -80,8 +80,8 @@ patch(PosStore.prototype, "pos_hr.PosStore", {
      */
     shouldShowCashControl() {
         if (this.config.module_pos_hr) {
-            return this._super(...arguments) && this.hasLoggedIn;
+            return super.shouldShowCashControl(...arguments) && this.hasLoggedIn;
         }
-        return this._super(...arguments);
+        return super.shouldShowCashControl(...arguments);
     },
 });

--- a/addons/pos_hr_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr_restaurant/static/src/overrides/models/pos_store.js
@@ -4,8 +4,8 @@ import { patch } from "@web/core/utils/patch";
 import "@pos_restaurant/overrides/models/pos_store";
 import { PosStore } from "@point_of_sale/app/store/pos_store";
 
-patch(PosStore.prototype, "pos_hr_restaurant.PosStore", {
+patch(PosStore.prototype, {
     shouldResetIdleTimer() {
-        return this.tempScreen?.name !== "LoginScreen" && this._super(...arguments);
+        return this.tempScreen?.name !== "LoginScreen" && super.shouldResetIdleTimer(...arguments);
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/components/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/overrides/components/order_summary/order_summary.js
@@ -3,7 +3,7 @@
 import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 import { patch } from "@web/core/utils/patch";
 
-patch(OrderSummary.prototype, "pos_loyalty.OrderSummary", {
+patch(OrderSummary.prototype, {
     getLoyaltyPoints() {
         const order = this.pos.get_order();
         return order.getLoyaltyPoints();

--- a/addons/pos_loyalty/static/src/overrides/components/orderline/orderline.js
+++ b/addons/pos_loyalty/static/src/overrides/components/orderline/orderline.js
@@ -3,11 +3,11 @@
 import { Orderline } from "@point_of_sale/app/screens/product_screen/orderline/orderline";
 import { patch } from "@web/core/utils/patch";
 
-patch(Orderline.prototype, "pos_loyalty.Orderline", {
+patch(Orderline.prototype, {
     get addedClasses() {
         return Object.assign(
             { "program-reward": this.props.line.is_reward_line },
-            this._super(...arguments)
+            super.addedClasses
         );
     },
     _isGiftCardOrEWalletReward() {

--- a/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
@@ -6,9 +6,9 @@ import { patch } from "@web/core/utils/patch";
 import { sprintf } from "@web/core/utils/strings";
 import { formatFloat } from "@web/views/fields/formatters";
 
-patch(PartnerLine.prototype, "pos_loyalty.PartnerLine", {
+patch(PartnerLine.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.pos = usePos();
     },
     _getLoyaltyPointsRepr(loyaltyCard) {

--- a/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_list_screen/partner_list_screen.js
@@ -3,7 +3,7 @@
 import { PartnerListScreen } from "@point_of_sale/app/screens/partner_list/partner_list";
 import { patch } from "@web/core/utils/patch";
 
-patch(PartnerListScreen.prototype, "pos_loyalty.PartnerListScreen", {
+patch(PartnerListScreen.prototype, {
     /**
      * Needs to be set to true to show the loyalty points in the partner list.
      * @override

--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -5,10 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { PosLoyaltyCard } from "@pos_loyalty/overrides/models/loyalty";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 
-patch(PaymentScreen.prototype, "pos_loyalty.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     //@override
     async validateOrder(isForceValidate) {
-        const _super = this._super;
         const pointChanges = {};
         const newCodes = [];
         for (const pe of Object.values(this.currentOrder.couponPointChanges)) {
@@ -72,14 +71,13 @@ patch(PaymentScreen.prototype, "pos_loyalty.PaymentScreen", {
                 // it should not be blocking.
             }
         }
-        await _super(...arguments);
+        await super.validateOrder(...arguments);
     },
     /**
      * @override
      */
     async _postPushOrderResolve(order, server_ids) {
         // Compile data for our function
-        const _super = this._super;
         const { program_by_id, reward_by_id, couponCache } = this.pos;
         const rewardLines = order._get_reward_lines();
         const partner = order.get_partner();
@@ -163,6 +161,6 @@ patch(PaymentScreen.prototype, "pos_loyalty.PaymentScreen", {
             }
             order.new_coupon_info = payload.new_coupon_info;
         }
-        return _super(order, server_ids);
+        return super._postPushOrderResolve(order, server_ids);
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
@@ -7,9 +7,9 @@ import { ConfirmPopup } from "@point_of_sale/app/utils/confirm_popup/confirm_pop
 import { useService } from "@web/core/utils/hooks";
 import { sprintf } from "@web/core/utils/strings";
 
-patch(ProductScreen.prototype, "pos_loyalty.ProductScreen", {
+patch(ProductScreen.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.notification = useService("pos_notification");
         useBarcodeReader({
             coupon: this._onCouponScan,
@@ -20,7 +20,6 @@ patch(ProductScreen.prototype, "pos_loyalty.ProductScreen", {
         this.currentOrder.activateCode(code.base_code);
     },
     async updateSelectedOrderline({ buffer, key }) {
-        const _super = this._super;
         const selectedLine = this.currentOrder.get_selected_orderline();
         if (key === "-") {
             if (selectedLine && selectedLine.eWalletGiftCardProgram) {
@@ -60,10 +59,10 @@ patch(ProductScreen.prototype, "pos_loyalty.ProductScreen", {
                 return;
             }
         }
-        return _super({ buffer, key });
+        return super.updateSelectedOrderline({ buffer, key });
     },
     /**
-     * 1/ Perform the usual set value operation (this._super(val)) if the line being modified
+     * 1/ Perform the usual set value operation (super._setValue(val)) if the line being modified
      * is not a reward line or if it is a reward line, the `val` being set is '' or 'remove' only.
      *
      * 2/ Update activated programs and coupons when removing a reward line.
@@ -80,7 +79,7 @@ patch(ProductScreen.prototype, "pos_loyalty.ProductScreen", {
             !selectedLine.is_reward_line ||
             (selectedLine.is_reward_line && ["", "remove"].includes(val))
         ) {
-            this._super(val);
+            super._setValue(val);
         }
         if (!selectedLine) {
             return;
@@ -108,7 +107,7 @@ patch(ProductScreen.prototype, "pos_loyalty.ProductScreen", {
         }
     },
     async _barcodeProductAction(code) {
-        await this._super(code);
+        await super._barcodeProductAction(code);
         this.currentOrder._updateRewards();
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -7,9 +7,9 @@ import { patch } from "@web/core/utils/patch";
 /**
  * Prevent refunding ewallet/gift card lines.
  */
-patch(TicketScreen.prototype, "pos_loyalty.TicketScreen", {
+patch(TicketScreen.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.notification = useService("pos_notification");
     },
     _onUpdateSelectedOrderline() {
@@ -23,7 +23,7 @@ patch(TicketScreen.prototype, "pos_loyalty.TicketScreen", {
             this._showNotAllowedRefundNotification();
             return this.numberBuffer.reset();
         }
-        return this._super(...arguments);
+        return super._onUpdateSelectedOrderline(...arguments);
     },
     _prepareAutoRefundOnOrder(order) {
         const selectedOrderlineId = this.getSelectedOrderlineId();
@@ -32,7 +32,7 @@ patch(TicketScreen.prototype, "pos_loyalty.TicketScreen", {
             this._showNotAllowedRefundNotification();
             return false;
         }
-        return this._super(...arguments);
+        return super._prepareAutoRefundOnOrder(...arguments);
     },
     _showNotAllowedRefundNotification() {
         this.notification.add(

--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -76,9 +76,9 @@ function computeFreeQuantity(numberItems, n, m) {
     return Math.floor(free + adjustment);
 }
 
-patch(Orderline.prototype, "pos_loyalty.Orderline", {
+patch(Orderline.prototype, {
     export_as_JSON() {
-        const result = this._super(...arguments);
+        const result = super.export_as_JSON(...arguments);
         result.is_reward_line = this.is_reward_line;
         result.reward_id = this.reward_id;
         result.reward_product_id = this.reward_product_id;
@@ -106,7 +106,7 @@ patch(Orderline.prototype, "pos_loyalty.Orderline", {
         this.giftBarcode = json.giftBarcode;
         this.giftCardId = json.giftCardId;
         this.eWalletGiftCardProgram = this.pos.program_by_id[json.eWalletGiftCardProgramId];
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
     },
     set_quantity(quantity, keep_price) {
         if (quantity === "remove" && this.is_reward_line) {
@@ -126,7 +126,7 @@ patch(Orderline.prototype, "pos_loyalty.Orderline", {
                 this.order.orderlines.remove(line);
             }
         }
-        return this._super(...arguments);
+        return super.set_quantity(...arguments);
     },
     getEWalletGiftCardProgramType() {
         return this.eWalletGiftCardProgram && this.eWalletGiftCardProgram.program_type;
@@ -140,9 +140,9 @@ patch(Orderline.prototype, "pos_loyalty.Orderline", {
     },
 });
 
-patch(Order.prototype, "pos_loyalty.Order", {
+patch(Order.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this._initializePrograms({});
         // Always start with invalid coupons so that coupon for this
         // order is properly assigned. @see _checkMissingCoupons
@@ -151,13 +151,13 @@ patch(Order.prototype, "pos_loyalty.Order", {
 
     /** @override */
     getEmailItems() {
-        return this._super(...arguments).concat(
+        return super.getEmailItems(...arguments).concat(
             this.has_pdf_gift_card ? [_t("the gift cards")] : []
         );
     },
 
     export_as_JSON() {
-        const json = this._super(...arguments);
+        const json = super.export_as_JSON(...arguments);
         json.disabledRewards = [...this.disabledRewards];
         json.codeActivatedProgramRules = this.codeActivatedProgramRules;
         json.codeActivatedCoupons = this.codeActivatedCoupons;
@@ -184,7 +184,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
                 this.couponPointChanges[newId] = pe;
             }
         }
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
         delete this.oldCouponMapping;
         this.disabledRewards = new Set(json.disabledRewards);
         this.codeActivatedProgramRules = json.codeActivatedProgramRules;
@@ -209,7 +209,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
                 }
             }
         } else {
-            return this._super(...arguments);
+            return super.pay(...arguments);
         }
     },
     /**
@@ -220,7 +220,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
      */
     set_partner(partner) {
         const oldPartner = this.get_partner();
-        this._super(partner);
+        super.set_partner(partner);
         if (this.couponPointChanges && oldPartner !== this.get_partner()) {
             // Remove couponPointChanges for cards in is_nominative programs.
             // This makes sure that counting of points on loyalty and ewallet programs is updated after partner changes.
@@ -241,7 +241,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
         return (
             Object.keys(this.couponPointChanges || {}).length > 0 ||
             this._get_reward_lines().length ||
-            this._super(...arguments)
+            super.wait_for_push_order(...arguments)
         );
     },
     /**
@@ -250,7 +250,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
      * @override
      */
     export_for_printing() {
-        const result = this._super(...arguments);
+        const result = super.export_for_printing(...arguments);
         if (this.get_partner()) {
             result.loyaltyStats = this.getLoyaltyPoints();
         }
@@ -259,7 +259,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
     },
     //@override
     _get_ignored_product_ids_total_discount() {
-        const productIds = this._super(...arguments);
+        const productIds = super._get_ignored_product_ids_total_discount(...arguments);
         const giftCardPrograms = this.pos.programs.filter((p) => p.program_type === "gift_card");
         for (const program of giftCardPrograms) {
             const giftCardProductId = [...program.rules[0].valid_product_ids][0];
@@ -270,7 +270,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
         return productIds;
     },
     get_orderlines() {
-        const orderlines = this._super(this, arguments);
+        const orderlines = super.get_orderlines(this, arguments);
         const rewardLines = [];
         const nonRewardLines = [];
         for (const line of orderlines) {
@@ -302,7 +302,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
     },
     set_pricelist(pricelist) {
         const oldPricelist = this.pricelist
-        this._super(...arguments);
+        super.set_pricelist(...arguments);
         if (this.couponPointChanges && oldPricelist !== pricelist) {
             // Remove couponPointChanges for cards in no longer available programs.
             // This makes sure that counting of points on loyalty and ewallet programs is updated after pricelist changes.
@@ -321,7 +321,7 @@ patch(Order.prototype, "pos_loyalty.Order", {
         this._updateRewards();
     },
     set_orderline_options(line, options) {
-        this._super(...arguments);
+        super.set_orderline_options(...arguments);
         if (options && options.is_reward_line) {
             line.is_reward_line = options.is_reward_line;
             line.reward_id = options.reward_id;

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -12,9 +12,8 @@ import { PosLoyaltyCard } from "@pos_loyalty/overrides/models/loyalty";
 
 const COUPON_CACHE_MAX_SIZE = 4096; // Maximum coupon cache size, prevents long run memory issues and (to some extent) invalid data
 
-patch(PosStore.prototype, "pos_loyalty.PosStore", {
+patch(PosStore.prototype, {
     async addProductFromUi(product, options) {
-        const _super = this._super;
         const order = this.get_order();
         const linkedProgramIds = this.productId2ProgramIds[product.id] || [];
         const linkedPrograms = linkedProgramIds.map((id) => this.program_by_id[id]);
@@ -65,7 +64,7 @@ patch(PosStore.prototype, "pos_loyalty.PosStore", {
                 }
             }
         }
-        await _super(product, options);
+        await super.addProductFromUi(product, options);
         await order._updatePrograms();
         if (rewardsToApply.length == 1) {
             const reward = rewardsToApply[0];
@@ -209,7 +208,7 @@ patch(PosStore.prototype, "pos_loyalty.PosStore", {
             reward.all_discount_product_ids = new Set(reward.all_discount_product_ids);
         }
 
-        await this._super(loadedData);
+        await super._processData(loadedData);
         this.productId2ProgramIds = loadedData["product_id_to_program_ids"];
         this.programs = loadedData["loyalty.program"] || []; //TODO: rename to `loyaltyPrograms` etc
         this.rules = loadedData["loyalty.rule"] || [];
@@ -217,7 +216,7 @@ patch(PosStore.prototype, "pos_loyalty.PosStore", {
     },
 
     _loadProductProduct(products) {
-        this._super(...arguments);
+        super._loadProductProduct(...arguments);
 
         for (const reward of this.rewards) {
             this.compute_discount_product_ids(reward, products);
@@ -286,13 +285,13 @@ patch(PosStore.prototype, "pos_loyalty.PosStore", {
         }
     },
     async load_server_data() {
-        await this._super(...arguments);
+        await super.load_server_data(...arguments);
         if (this.selectedOrder) {
             this.selectedOrder._updateRewards();
         }
     },
     set_order(order) {
-        const result = this._super(...arguments);
+        const result = super.set_order(...arguments);
         // FIXME - JCB: This is a temporary fix.
         // When an order is selected, it doesn't always contain the reward lines.
         // And the list of active programs are not always correct. This is because
@@ -371,7 +370,7 @@ patch(PosStore.prototype, "pos_loyalty.PosStore", {
         return loyaltyCards;
     },
     addPartners(partners) {
-        const result = this._super(partners);
+        const result = super.addPartners(partners);
         // cache the loyalty cards of the partners
         for (const partner of partners) {
             for (const [couponId, { code, program_id, points }] of Object.entries(

--- a/addons/pos_mercury/static/src/overrides/components/order_receipt/order_receipt.js
+++ b/addons/pos_mercury/static/src/overrides/components/order_receipt/order_receipt.js
@@ -3,7 +3,7 @@
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt";
 import { patch } from "@web/core/utils/patch";
 
-patch(OrderReceipt.prototype, "pos_mercury.OrderReceipt", {
+patch(OrderReceipt.prototype, {
     /**
      * The receipt has signature if one of the paymentlines
      * is paid with mercury.

--- a/addons/pos_mercury/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_mercury/static/src/overrides/components/payment_screen/payment_screen.js
@@ -93,9 +93,9 @@ const lookUpCodeTransaction = {
     },
 };
 
-patch(PaymentScreen.prototype, "pos_mercury.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         if (this.pos.getOnlinePaymentMethods().length !== 0) {
             useBarcodeReader({
                 credit: this.credit_code_action,
@@ -117,7 +117,7 @@ patch(PaymentScreen.prototype, "pos_mercury.PaymentScreen", {
      * @override
      */
     get _getNumberBufferConfig() {
-        const res = this._super(...arguments);
+        const res = super._getNumberBufferConfig;
         res["useWithBarcode"] = true;
         return res;
     },
@@ -512,7 +512,7 @@ patch(PaymentScreen.prototype, "pos_mercury.PaymentScreen", {
         if (line.mercury_data) {
             this.do_reversal(line, false);
         } else {
-            this._super(cid);
+            super.deletePaymentLine(cid);
         }
     },
     /**
@@ -520,7 +520,7 @@ patch(PaymentScreen.prototype, "pos_mercury.PaymentScreen", {
      */
     addNewPaymentLine(paymentMethod) {
         const order = this.pos.get_order();
-        const res = this._super(...arguments);
+        const res = super.addNewPaymentLine(...arguments);
         if (res && paymentMethod.pos_mercury_config_id) {
             order.selected_paymentline.mercury_swipe_pending = true;
         }

--- a/addons/pos_mercury/static/src/overrides/components/payment_screen_payment_lines/payment_screen_payment_lines.js
+++ b/addons/pos_mercury/static/src/overrides/components/payment_screen_payment_lines/payment_screen_payment_lines.js
@@ -3,12 +3,12 @@
 import { PaymentScreenPaymentLines } from "@point_of_sale/app/screens/payment_screen/payment_lines/payment_lines";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentScreenPaymentLines.prototype, "pos_mercury.PaymentScreenPaymentLines", {
+patch(PaymentScreenPaymentLines.prototype, {
     /**
      * @override
      */
     selectedLineClass(line) {
-        return Object.assign({}, this._super(line), {
+        return Object.assign({}, super.selectedLineClass(line), {
             o_pos_mercury_swipe_pending: line.mercury_swipe_pending,
         });
     },
@@ -16,7 +16,7 @@ patch(PaymentScreenPaymentLines.prototype, "pos_mercury.PaymentScreenPaymentLine
      * @override
      */
     unselectedLineClass(line) {
-        return Object.assign({}, this._super(line), {
+        return Object.assign({}, super.unselectedLineClass(line), {
             o_pos_mercury_swipe_pending: line.mercury_swipe_pending,
         });
     },

--- a/addons/pos_mercury/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_mercury/static/src/overrides/components/product_screen/product_screen.js
@@ -5,9 +5,9 @@ import { useBarcodeReader } from "@point_of_sale/app/barcode/barcode_reader_hook
 import { patch } from "@web/core/utils/patch";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 
-patch(ProductScreen.prototype, "pos_mercury.ProductScreen", {
+patch(ProductScreen.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         useBarcodeReader({
             credit: this.credit_error_action,
         });

--- a/addons/pos_mercury/static/src/overrides/models/pos_mercury.js
+++ b/addons/pos_mercury/static/src/overrides/models/pos_mercury.js
@@ -4,7 +4,7 @@ import { PosStore } from "@point_of_sale/app/store/pos_store";
 import { Order, Payment } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(PosStore.prototype, "pos_mercury.PosStore", {
+patch(PosStore.prototype, {
     getOnlinePaymentMethods() {
         var online_payment_methods = [];
 
@@ -85,9 +85,9 @@ patch(PosStore.prototype, "pos_mercury.PosStore", {
     },
 });
 
-patch(Payment.prototype, "pos_mercury.Payment", {
+patch(Payment.prototype, {
     init_from_JSON(json) {
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
 
         this.paid = json.paid;
         this.mercury_card_number = json.mercury_card_number;
@@ -103,7 +103,7 @@ patch(Payment.prototype, "pos_mercury.Payment", {
         this.set_credit_card_name();
     },
     export_as_JSON() {
-        const result = this._super(...arguments);
+        const result = super.export_as_JSON(...arguments);
         if (!result) {
             return result;
         }
@@ -126,20 +126,20 @@ patch(Payment.prototype, "pos_mercury.Payment", {
         }
     },
     is_done() {
-        var res = this._super(...arguments);
+        var res = super.is_done(...arguments);
         return res && !this.mercury_swipe_pending;
     },
     export_for_printing() {
-        const result = this._super(...arguments);
+        const result = super.export_for_printing(...arguments);
         result.mercury_data = this.mercury_data;
         result.mercury_auth_code = this.mercury_auth_code;
         return result;
     },
 });
 
-patch(Order.prototype, "pos_mercury.Order", {
+patch(Order.prototype, {
     electronic_payment_in_progress() {
-        var res = this._super(...arguments);
+        var res = super.electronic_payment_in_progress(...arguments);
         return res || this.get_paymentlines().some((line) => line.mercury_swipe_pending);
     },
 });

--- a/addons/pos_online_payment/static/src/app/bus/pos_bus_service.js
+++ b/addons/pos_online_payment/static/src/app/bus/pos_bus_service.js
@@ -3,10 +3,10 @@
 import { patch } from "@web/core/utils/patch";
 import { PosBus } from "@point_of_sale/app/bus/pos_bus_service";
 
-patch(PosBus.prototype, "pos_online_payment.PosBus", {
+patch(PosBus.prototype, {
     //@override
     dispatch(message) {
-        this._super(...arguments);
+        super.dispatch(...arguments);
 
         if (message.type === "ONLINE_PAYMENTS_NOTIFICATION") {
             // The bus communication is only protected by the name of the channel.

--- a/addons/pos_online_payment/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/app/screens/payment_screen/payment_screen.js
@@ -8,7 +8,7 @@ import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import { floatIsZero } from "@web/core/utils/numbers";
 import { sprintf } from "@web/core/utils/strings";
 
-patch(PaymentScreen.prototype, "pos_online_payment.PaymentScreen", {
+patch(PaymentScreen.prototype, {
     getRemainingOnlinePaymentLines() {
         return this.paymentLines.filter(
             (line) => line.payment_method.is_online_payment && line.get_payment_status() !== "done"
@@ -40,7 +40,7 @@ patch(PaymentScreen.prototype, "pos_online_payment.PaymentScreen", {
     },
     //@override
     async _isOrderValid(isForceValidate) {
-        if (!await this._super(...arguments)) {
+        if (!await super._isOrderValid(...arguments)) {
             return false;
         }
 

--- a/addons/pos_online_payment/static/src/app/store/models.js
+++ b/addons/pos_online_payment/static/src/app/store/models.js
@@ -3,7 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { Order, Payment } from "@point_of_sale/app/store/models";
 import { floatIsZero } from "@web/core/utils/numbers";
 
-patch(Order.prototype, "pos_online_payment.Order", {
+patch(Order.prototype, {
     _get_online_payment_url() {
         return `${this.pos.base_url}/pos/pay/${this.server_id}?access_token=${this.access_token}`;
     },
@@ -91,13 +91,13 @@ patch(Order.prototype, "pos_online_payment.Order", {
     },
 });
 
-patch(Payment.prototype, "pos_online_payment.Payment", {
+patch(Payment.prototype, {
     //@override
     export_as_JSON() {
         if (this.payment_method.is_online_payment) {
             return null; // It is the role of the server to save the online payment, not the role of the POS session.
         } else {
-            return this._super();
+            return super.export_as_JSON();
         }
     },
     //@override
@@ -105,7 +105,7 @@ patch(Payment.prototype, "pos_online_payment.Payment", {
         if (this.payment_method.is_online_payment) {
             return false;
         } else {
-            return this._super();
+            return super.canBeAdjusted();
         }
     },
 });

--- a/addons/pos_online_payment_self_order/static/src/pages/order_cart/order_cart.js
+++ b/addons/pos_online_payment_self_order/static/src/pages/order_cart/order_cart.js
@@ -3,7 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { OrderCart } from "@pos_self_order/pages/order_cart/order_cart";
 import { _t } from "@web/core/l10n/translation";
 
-patch(OrderCart.prototype, "pos_online_payment_self_order.OrderCart", {
+patch(OrderCart.prototype, {
     get buttonToShow() {
         if (this.selfOrder.self_order_mode === "each") {
             return { label: _t("Pay"), disabled: false };
@@ -22,7 +22,7 @@ patch(OrderCart.prototype, "pos_online_payment_self_order.OrderCart", {
                 }
             }
         } else {
-            return this._super(...arguments);
+            return super.buttonToShow;
         }
     },
     async processOrder() {
@@ -54,7 +54,7 @@ patch(OrderCart.prototype, "pos_online_payment_self_order.OrderCart", {
             this.sendInProgress = false;
             this.checkAndOpenPaymentPage(order);
         } else {
-            return this._super(...arguments);
+            return super.processOrder(...arguments);
         }
     },
     checkAndOpenPaymentPage(order) {

--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -3,7 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { SelfOrder } from "@pos_self_order/self_order_service";
 import { session } from "@web/session";
 
-patch(SelfOrder.prototype, "pos_online_payment_self_order.SelfOrder", {
+patch(SelfOrder.prototype, {
     openOnlinePaymentPage({ id: order_id, access_token: order_access_token, pos_config_id: order_pos_config_id }) {
         const baseUrl = session.base_url;
         let exitRouteUrl = baseUrl + "/menu/" + order_pos_config_id + "?access_token=" + this.access_token;

--- a/addons/pos_restaurant/static/src/app/product_screen/order/order.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/order/order.js
@@ -5,7 +5,7 @@ import { OrderWidget } from "@point_of_sale/app/screens/product_screen/order/ord
 import { AlertPopup } from "@point_of_sale/app/utils/alert_popup/alert_popup";
 import { _t } from "@web/core/l10n/translation";
 
-patch(OrderWidget.prototype, "pos_restaurant.OrderWidget", {
+patch(OrderWidget.prototype, {
     releaseTable() {
         const currentTable = this.pos.table;
         const orderOnTable = this.pos.orders.filter(

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/back_button/back_button.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/back_button/back_button.js
@@ -5,7 +5,7 @@ import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product
 import { TipScreen } from "@pos_restaurant/app/tip_screen/tip_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(BackButton.prototype, "pos_restaurant.BackButton", {
+patch(BackButton.prototype, {
     get floor() {
         return this.table?.floor;
     },

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -3,7 +3,7 @@
 import { Navbar } from "@point_of_sale/app/navbar/navbar";
 import { patch } from "@web/core/utils/patch";
 
-patch(Navbar.prototype, "pos_restaurant.Navbar", {
+patch(Navbar.prototype, {
     /**
      * If no table is set to pos, which means the current main screen
      * is floor screen, then the order count should be based on all the orders.
@@ -12,10 +12,10 @@ patch(Navbar.prototype, "pos_restaurant.Navbar", {
         if (this.pos.config.module_pos_restaurant && this.pos.table) {
             return this.pos.getTableOrders(this.pos.table.id).length;
         }
-        return this._super(...arguments);
+        return super.orderCount;
     },
     _shouldLoadOrders() {
-        return this._super() || (this.pos.config.module_pos_restaurant && !this.pos.table);
+        return super._shouldLoadOrders() || (this.pos.config.module_pos_restaurant && !this.pos.table);
     },
     onSwitchButtonClick() {
         const mode = this.pos.floorPlanStyle == "kanban" ? "default" : "kanban";
@@ -27,7 +27,7 @@ patch(Navbar.prototype, "pos_restaurant.Navbar", {
     },
     showBackButton() {
         return (
-            this._super(...arguments) ||
+            super.showBackButton(...arguments) ||
             (this.pos.showBackButton() && this.pos.config.module_pos_restaurant)
         );
     },

--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
@@ -3,20 +3,17 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentScreen.prototype, "pos_restaurant.PaymentScreen", {
-    setup() {
-        this._super(...arguments);
-    },
+patch(PaymentScreen.prototype, {
     get nextScreen() {
         const order = this.currentOrder;
         if (!this.pos.config.set_tip_after_payment || order.is_tipped) {
-            return this._super(...arguments);
+            return super.nextScreen;
         }
         // Take the first payment method as the main payment.
         const mainPayment = order.get_paymentlines()[0];
         if (mainPayment.canBeAdjusted()) {
             return "TipScreen";
         }
-        return this._super(...arguments);
+        return super.nextScreen;
     },
 });

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -6,7 +6,7 @@ import { nbsp } from "@web/core/utils/strings";
  * @props partner
  */
 
-patch(ActionpadWidget.prototype, "point_of_sale.ActionpadWidget", {
+patch(ActionpadWidget.prototype, {
     get swapButton() {
         return this.props.actionType === "payment" && this.pos.config.module_pos_restaurant;
     },
@@ -45,7 +45,7 @@ patch(ActionpadWidget.prototype, "point_of_sale.ActionpadWidget", {
     },
     get highlightPay() {
         return (
-            this._super(...arguments) &&
+            super.highlightPay &&
             !this.currentOrder.hasChangesToPrint() &&
             this.hasQuantity(this.currentOrder)
         );

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
@@ -3,7 +3,7 @@
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { patch } from "@web/core/utils/patch";
 
-patch(ProductScreen.prototype, "pos_restaurant.ProductScreen", {
+patch(ProductScreen.prototype, {
     /**
      * @override
      */
@@ -23,7 +23,7 @@ patch(ProductScreen.prototype, "pos_restaurant.ProductScreen", {
             );
             return changes ? changes.quantity : false;
         }
-        return this._super(...arguments);
+        return super.selectedOrderlineQuantity;
     },
     get selectedOrderlineTotal() {
         return this.env.utils.formatCurrency(
@@ -42,7 +42,7 @@ patch(ProductScreen.prototype, "pos_restaurant.ProductScreen", {
     primaryPayButton() {
         return (
             !this.currentOrder.is_empty() &&
-            ((!this.swapButton && this._super(...arguments)) ||
+            ((!this.swapButton && super.primaryPayButton(...arguments)) ||
                 (this.swapButton && this.pos.get_order().getOrderChanges().count > 0))
         );
     },

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { onWillUnmount } from "@odoo/owl";
 import { FloorScreen } from "@pos_restaurant/app/floor_screen/floor_screen";
 
-patch(ReceiptScreen.prototype, "pos_restaurant.ReceiptScreen", {
+patch(ReceiptScreen.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         onWillUnmount(() => {
             // When leaving the receipt screen to the floor screen the order is paid and can be removed
             if (this.pos.mainScreen.component === FloorScreen && this.currentOrder.finalized) {
@@ -18,14 +18,14 @@ patch(ReceiptScreen.prototype, "pos_restaurant.ReceiptScreen", {
     //@override
     _addNewOrder() {
         if (!this.pos.config.module_pos_restaurant) {
-            this._super(...arguments);
+            super._addNewOrder(...arguments);
         }
     },
     isResumeVisible() {
         if (this.pos.config.module_pos_restaurant && this.pos.table) {
             return this.pos.getTableOrders(this.pos.table.id).length > 1;
         }
-        return this._super(...arguments);
+        return super.isResumeVisible(...arguments);
     },
     //@override
     get nextScreen() {
@@ -33,7 +33,7 @@ patch(ReceiptScreen.prototype, "pos_restaurant.ReceiptScreen", {
             const table = this.pos.table;
             return { name: "FloorScreen", props: { floor: table ? table.floor : null } };
         } else {
-            return this._super(...arguments);
+            return super.nextScreen;
         }
     },
 });

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -6,12 +6,12 @@ import { parseFloat } from "@web/views/fields/parsers";
 import { ConfirmPopup } from "@point_of_sale/app/utils/confirm_popup/confirm_popup";
 import { Component, useState } from "@odoo/owl";
 
-patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
+patch(TicketScreen.prototype, {
     _getScreenToStatusMap() {
-        return Object.assign(this._super(...arguments), {
+        return Object.assign(super._getScreenToStatusMap(...arguments), {
             PaymentScreen: this.pos.config.set_tip_after_payment
                 ? "OPEN"
-                : this._super(...arguments).PaymentScreen,
+                : super._getScreenToStatusMap(...arguments).PaymentScreen,
             TipScreen: "TIPPING",
         });
     },
@@ -31,9 +31,9 @@ patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
     //@override
     _getSearchFields() {
         if (!this.pos.config.module_pos_restaurant) {
-            return this._super(...arguments);
+            return super._getSearchFields(...arguments);
         }
-        return Object.assign({}, this._super(...arguments), {
+        return Object.assign({}, super._getSearchFields(...arguments), {
             TABLE: {
                 repr: this.getTable.bind(this),
                 displayName: this.env._t("Table"),
@@ -43,7 +43,7 @@ patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
     },
     async _setOrder(order) {
         if (!this.pos.config.module_pos_restaurant || this.pos.table) {
-            return this._super(...arguments);
+            return super._setOrder(...arguments);
         }
         // we came from the FloorScreen
         const orderTable = order.getTable();
@@ -53,13 +53,13 @@ patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
     get allowNewOrders() {
         return this.pos.config.module_pos_restaurant
             ? Boolean(this.pos.table)
-            : this._super(...arguments);
+            : super.allowNewOrders;
     },
     _getOrderList() {
         if (this.pos.table) {
             return this.pos.getTableOrders(this.pos.table.id);
         }
-        return this._super(...arguments);
+        return super._getOrderList(...arguments);
     },
     async settleTips() {
         // set tip in each order
@@ -115,7 +115,7 @@ patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
         await this.orm.call("pos.order", "set_no_tip", [serverId]);
     },
     _getOrderStates() {
-        const result = this._super(...arguments);
+        const result = super._getOrderStates(...arguments);
         if (this.pos.config.set_tip_after_payment) {
             result.delete("PAYMENT");
             result.set("OPEN", { text: this.env._t("Open"), indented: true });
@@ -128,13 +128,13 @@ patch(TicketScreen.prototype, "pos_restaurant.TicketScreen", {
         if (this.pos.config.module_pos_restaurant && order && !this.pos.table) {
             this.pos.setTable(order.table ? order.table : Object.values(this.pos.tables_by_id)[0]);
         }
-        this._super(...arguments);
+        super.onDoRefund(...arguments);
     },
     isDefaultOrderEmpty(order) {
         if (this.pos.config.module_pos_restaurant) {
             return false;
         }
-        return this._super(...arguments);
+        return super.isDefaultOrderEmpty(...arguments);
     },
 });
 
@@ -162,6 +162,6 @@ export class TipCell extends Component {
     }
 }
 
-patch(TicketScreen, "pos_restaurant.TicketScreen.components", {
+patch(TicketScreen, {
     components: { ...TicketScreen.components, TipCell },
 });

--- a/addons/pos_restaurant/static/src/overrides/models/models.js
+++ b/addons/pos_restaurant/static/src/overrides/models/models.js
@@ -4,9 +4,9 @@ import { Order, Orderline, Payment } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
 // New orders are now associated with the current table, if any.
-patch(Order.prototype, "pos_restaurant.Order", {
+patch(Order.prototype, {
     setup(options) {
-        this._super(...arguments);
+        super.setup(...arguments);
         if (this.pos.config.module_pos_restaurant) {
             if (!this.tableId && !options.json && this.pos.table) {
                 this.tableId = this.pos.table.id;
@@ -16,7 +16,7 @@ patch(Order.prototype, "pos_restaurant.Order", {
     },
     //@override
     export_as_JSON() {
-        const json = this._super(...arguments);
+        const json = super.export_as_JSON(...arguments);
         if (this.pos.config.module_pos_restaurant) {
             json.table_id = this.tableId;
             json.customer_count = this.customerCount;
@@ -26,7 +26,7 @@ patch(Order.prototype, "pos_restaurant.Order", {
     },
     //@override
     init_from_JSON(json) {
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
         if (this.pos.config.module_pos_restaurant) {
             this.tableId = json.table_id;
             this.validation_date = moment.utc(json.creation_date).local().toDate();
@@ -35,7 +35,7 @@ patch(Order.prototype, "pos_restaurant.Order", {
     },
     //@override
     export_for_printing() {
-        const json = this._super(...arguments);
+        const json = super.export_for_printing(...arguments);
         if (this.pos.config.module_pos_restaurant) {
             if (this.getTable()) {
                 json.table = this.getTable().name;
@@ -58,20 +58,20 @@ patch(Order.prototype, "pos_restaurant.Order", {
     },
 });
 
-patch(Orderline.prototype, "pos_restaurant.Orderline", {
+patch(Orderline.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.note = this.note || "";
     },
     //@override
     clone() {
-        const orderline = this._super(...arguments);
+        const orderline = super.clone(...arguments);
         orderline.note = this.note;
         return orderline;
     },
     //@override
     export_as_JSON() {
-        const json = this._super(...arguments);
+        const json = super.export_as_JSON(...arguments);
         json.note = this.note;
         if (this.pos.config.iface_printers) {
             json.uuid = this.uuid;
@@ -80,7 +80,7 @@ patch(Orderline.prototype, "pos_restaurant.Orderline", {
     },
     //@override
     init_from_JSON(json) {
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
         this.note = json.note;
         if (this.pos.config.iface_printers) {
             this.uuid = json.uuid;
@@ -95,7 +95,7 @@ patch(Orderline.prototype, "pos_restaurant.Orderline", {
     },
 });
 
-patch(Payment.prototype, "pos_restaurant.Payment", {
+patch(Payment.prototype, {
     /**
      * Override this method to be able to show the 'Adjust Authorisation' button
      * on a validated payment_line and to show the tip screen which allow

--- a/addons/pos_restaurant/static/src/overrides/models/payment.js
+++ b/addons/pos_restaurant/static/src/overrides/models/payment.js
@@ -3,7 +3,7 @@
 import { PaymentInterface } from "@point_of_sale/app/payment/payment_interface";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentInterface.prototype, "pos_restaurant.PaymentInterface", {
+patch(PaymentInterface.prototype, {
     /**
      * Return true if the amount that was authorized can be modified,
      * false otherwise

--- a/addons/pos_restaurant/static/src/overrides/models/popup_service.js
+++ b/addons/pos_restaurant/static/src/overrides/models/popup_service.js
@@ -3,9 +3,9 @@
 import { patch } from "@web/core/utils/patch";
 import { popupService } from "@point_of_sale/app/popup/popup_service";
 
-patch(popupService, "pos_restaurant.popupService", {
+patch(popupService, {
     start() {
-        return Object.assign(this._super(...arguments), {
+        return Object.assign(super.start(...arguments), {
             closePopupsButError() {
                 const popups = Object.values(this.popups);
                 const isErrorPopupOpen = popups.some((popup) =>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_bus.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_bus.js
@@ -3,10 +3,10 @@
 import { patch } from "@web/core/utils/patch";
 import { PosBus } from "@point_of_sale/app/bus/pos_bus_service";
 
-patch(PosBus.prototype, "pos_restaurant.PosBus", {
+patch(PosBus.prototype, {
     // Override
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
 
         if (this.pos.config.module_pos_restaurant) {
             this.initTableOrderCount();
@@ -25,7 +25,7 @@ patch(PosBus.prototype, "pos_restaurant.PosBus", {
 
     // Override
     dispatch(message) {
-        this._super(...arguments);
+        super.dispatch(...arguments);
 
         if (message.type === "TABLE_ORDER_COUNT") {
             this.ws_syncTableCount(message.payload);

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -20,12 +20,12 @@ const NON_IDLE_EVENTS = [
 ];
 let IDLE_TIMER_SETTER;
 
-patch(PosStore.prototype, "pos_restaurant.PosStore", {
+patch(PosStore.prototype, {
     /**
      * @override
      */
     async setup() {
-        await this._super(...arguments);
+        await super.setup(...arguments);
         if (this.config.module_pos_restaurant) {
             this.setActivityListeners();
             this.showScreen("FloorScreen", { floor: this.table?.floor || null });
@@ -71,18 +71,18 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
         );
     },
     showScreen(screenName) {
-        this._super(...arguments);
+        super.showScreen(...arguments);
         this.setIdleTimer();
     },
     closeScreen() {
         if (this.config.module_pos_restaurant && !this.get_order()) {
             return this.showScreen("FloorScreen");
         }
-        return this._super(...arguments);
+        return super.closeScreen(...arguments);
     },
     addOrderIfEmpty() {
         if (!this.config.module_pos_restaurant) {
-            return this._super(...arguments);
+            return super.addOrderIfEmpty(...arguments);
         }
     },
     /**
@@ -96,18 +96,18 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
                 window.removeEventListener(event, IDLE_TIMER_SETTER);
             }
         }
-        return this._super(...arguments);
+        return super.closePos(...arguments);
     },
     showBackButton() {
         return (
-            this._super(...arguments) ||
+            super.showBackButton(...arguments) ||
             this.mainScreen.component === TipScreen ||
             (this.mainScreen.component === ProductScreen && this.config.module_pos_restaurant)
         );
     },
     //@override
     async _processData(loadedData) {
-        await this._super(...arguments);
+        await super._processData(...arguments);
         if (this.config.module_pos_restaurant) {
             this.floors = loadedData["restaurant.floor"];
             this.loadRestaurantFloor();
@@ -115,7 +115,7 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
     },
     //@override
     async after_load_server_data() {
-        var res = await this._super(...arguments);
+        var res = await super.after_load_server_data(...arguments);
         if (this.config.module_pos_restaurant) {
             this.table = null;
         }
@@ -126,12 +126,12 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
     // set when the user selects a table.
     set_start_order() {
         if (!this.config.module_pos_restaurant) {
-            this._super(...arguments);
+            super.set_start_order(...arguments);
         }
     },
     //@override
     add_new_order() {
-        const order = this._super(...arguments);
+        const order = super.add_new_order(...arguments);
         this.ordersToUpdateSet.add(order);
         return order;
     },
@@ -184,23 +184,23 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
             const ordersJsons = await this._getTableOrdersFromServer(tableIds); // get all orders
             return ordersJsons;
         } else {
-            return await this._super();
+            return await super._getOrdersJson();
         }
     },
     _shouldRemoveOrder(order) {
-        return this._super(...arguments) && !this.transferredOrdersSet.has(order);
+        return super._shouldRemoveOrder(...arguments) && !this.transferredOrdersSet.has(order);
     },
     _shouldCreateOrder(json) {
         return (
             (!this._transferredOrder(json) || this._isSameTable(json)) &&
-            (!this.selectedOrder || this._super(...arguments))
+            (!this.selectedOrder || super._shouldCreateOrder(...arguments))
         );
     },
     _shouldRemoveSelectedOrder(removeSelected) {
-        return this.selectedOrder && this._super(...arguments);
+        return this.selectedOrder && super._shouldRemoveSelectedOrder(...arguments);
     },
     _isSelectedOrder(json) {
-        return !this.selectedOrder || this._super(...arguments);
+        return !this.selectedOrder || super._isSelectedOrder(...arguments);
     },
     _isSameTable(json) {
         const transferredOrder = this._transferredOrder(json);
@@ -215,7 +215,7 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
             // this means we transferred back to the original table, we'll prioritize the server state
             this.removeOrder(transferredOrder, false);
         }
-        return this._super(...arguments);
+        return super._createOrder(...arguments);
     },
     loadRestaurantFloor() {
         // we do this in the front end due to the circular/recursive reference needed
@@ -283,7 +283,7 @@ patch(PosStore.prototype, "pos_restaurant.PosStore", {
         return tableOrders.reduce((count, order) => count + order.getCustomerCount(), 0);
     },
     isOpenOrderShareable() {
-        return this._super(...arguments) || this.config.module_pos_restaurant;
+        return super.isOpenOrderShareable(...arguments) || this.config.module_pos_restaurant;
     },
     toggleEditMode() {
         this.isEditMode = !this.isEditMode;

--- a/addons/pos_restaurant_adyen/static/src/overrides/models/payment_adyen.js
+++ b/addons/pos_restaurant_adyen/static/src/overrides/models/payment_adyen.js
@@ -3,9 +3,9 @@
 import { PaymentAdyen } from "@pos_adyen/app/payment_adyen";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentAdyen.prototype, "pos_restaurant_adyen.PaymentAdyen", {
+patch(PaymentAdyen.prototype, {
     _adyen_pay_data() {
-        var data = this._super(...arguments);
+        var data = super._adyen_pay_data(...arguments);
 
         if (data.SaleToPOIRequest.PaymentRequest.SaleData.SaleToAcquirerData) {
             data.SaleToPOIRequest.PaymentRequest.SaleData.SaleToAcquirerData +=

--- a/addons/pos_restaurant_stripe/static/src/overrides/models/payment_stripe.js
+++ b/addons/pos_restaurant_stripe/static/src/overrides/models/payment_stripe.js
@@ -3,16 +3,16 @@
 import { PaymentStripe } from "@pos_stripe/app/payment_stripe";
 import { patch } from "@web/core/utils/patch";
 
-patch(PaymentStripe.prototype, "pos_restaurant_stripe.PaymentStripe", {
-    captureAfterPayment: async function (processPayment, line) {
+patch(PaymentStripe.prototype, {
+    async captureAfterPayment(processPayment, line) {
         // Don't capture if the customer can tip, in that case we
         // will capture later.
         if (!this.canBeAdjusted(line.cid)) {
-            return this._super(...arguments);
+            return super.captureAfterPayment(...arguments);
         }
     },
 
-    canBeAdjusted: function (cid) {
+    canBeAdjusted(cid) {
         var order = this.pos.get_order();
         var line = order.get_paymentline(cid);
         return (

--- a/addons/pos_sale/static/src/overrides/models/models.js
+++ b/addons/pos_sale/static/src/overrides/models/models.js
@@ -3,25 +3,25 @@
 import { Order, Orderline } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(Order.prototype, "pos_sale.Order", {
+patch(Order.prototype, {
     //@override
     select_orderline(orderline) {
-        this._super(...arguments);
+        super.select_orderline(...arguments);
         if (orderline && orderline.product.id === this.pos.config.down_payment_product_id[0]) {
             this.pos.numpadMode = "price";
         }
     },
     //@override
     _get_ignored_product_ids_total_discount() {
-        const productIds = this._super(...arguments);
+        const productIds = super._get_ignored_product_ids_total_discount(...arguments);
         productIds.push(this.pos.config.down_payment_product_id[0]);
         return productIds;
     },
 });
 
-patch(Orderline.prototype, "pos_sale.Orderline", {
+patch(Orderline.prototype, {
     setup(_defaultObj, options) {
-        this._super(...arguments);
+        super.setup(...arguments);
         // It is possible that this orderline is initialized using `init_from_JSON`,
         // meaning, it is loaded from localStorage or from export_for_ui. This means
         // that some fields has already been assigned. Therefore, we only set the options
@@ -35,14 +35,14 @@ patch(Orderline.prototype, "pos_sale.Orderline", {
         }
     },
     init_from_JSON(json) {
-        this._super(...arguments);
+        super.init_from_JSON(...arguments);
         this.sale_order_origin_id = json.sale_order_origin_id;
         this.sale_order_line_id = json.sale_order_line_id;
         this.down_payment_details =
             json.down_payment_details && JSON.parse(json.down_payment_details);
     },
     export_as_JSON() {
-        const json = this._super(...arguments);
+        const json = super.export_as_JSON(...arguments);
         json.sale_order_origin_id = this.sale_order_origin_id;
         json.sale_order_line_id = this.sale_order_line_id;
         json.down_payment_details =
@@ -61,7 +61,7 @@ patch(Orderline.prototype, "pos_sale.Orderline", {
         return false;
     },
     export_for_printing() {
-        var json = this._super(...arguments);
+        var json = super.export_for_printing(...arguments);
         json.down_payment_details = this.down_payment_details;
         if (this.sale_order_origin_id) {
             json.so_reference = this.sale_order_origin_id.name;

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -3,9 +3,9 @@
 import { PosStore } from "@point_of_sale/app/store/pos_store";
 import { patch } from "@web/core/utils/patch";
 
-patch(PosStore.prototype, "pos_sale.PosStore", {
+patch(PosStore.prototype, {
     async setup(...args) {
         this.orderManagement = { searchString: "", selectedOrder: null };
-        return await this._super(...args);
+        return await super.setup(...args);
     },
 });

--- a/addons/pos_sale_loyalty/static/src/overrides/models/models.js
+++ b/addons/pos_sale_loyalty/static/src/overrides/models/models.js
@@ -4,13 +4,13 @@
 import { Orderline } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(Orderline.prototype, "pos_sale_loyalty.Orderline", {
+patch(Orderline.prototype, {
     //@override
     ignoreLoyaltyPoints(args) {
         if (this.sale_order_origin_id) {
             return true;
         }
-        return this._super(args);
+        return super.ignoreLoyaltyPoints(args);
     },
     //@override
     setQuantityFromSOL(saleOrderLine) {
@@ -18,7 +18,7 @@ patch(Orderline.prototype, "pos_sale_loyalty.Orderline", {
         if (saleOrderLine.reward_id) {
             this.set_quantity(saleOrderLine.product_uom_qty);
         } else {
-            this._super(...arguments);
+            super.setQuantityFromSOL(...arguments);
         }
     },
 });

--- a/addons/pos_sale_product_configurator/static/src/overrides/components/product_info_button/product_info_button.js
+++ b/addons/pos_sale_product_configurator/static/src/overrides/components/product_info_button/product_info_button.js
@@ -3,7 +3,7 @@
 import { ProductInfoButton } from "@point_of_sale/app/screens/product_screen/control_buttons/product_info_button/product_info_button";
 import { patch } from "@web/core/utils/patch";
 
-patch(ProductInfoButton.prototype, "pos_sale_product_configurator.ProductInfoButton", {
+patch(ProductInfoButton.prototype, {
     hasOptionalProduct() {
         const orderline = this.pos.get_order().get_selected_orderline();
         if (orderline) {

--- a/addons/pos_six/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_six/static/src/overrides/components/navbar/navbar.js
@@ -4,6 +4,6 @@ import { Navbar } from "@point_of_sale/app/navbar/navbar";
 import { BalanceButton } from "@pos_six/app/balance_button/balance_button";
 import { patch } from "@web/core/utils/patch";
 
-patch(Navbar, "pos_six.Navbar", {
+patch(Navbar, {
     components: { ...Navbar.components, BalanceButton },
 });

--- a/addons/product/static/tests/product_pricelist_report_test.js
+++ b/addons/product/static/tests/product_pricelist_report_test.js
@@ -50,14 +50,14 @@ QUnit.module('Product Pricelist Report', {
 
         let Qty = [1, 5, 10]; // default quantities
         patchWithCleanup(ProductPricelistReport.prototype, {
-                onSelectPricelist: function (event) {
+                onSelectPricelist(event) {
                     assert.step('pricelist_changed');
-                    this._super(...arguments)
+                    super.onSelectPricelist(...arguments)
                 },
-                onClickAddQty: function (event) {
+                onClickAddQty(event) {
                     assert.deepEqual(this.quantities, Qty.sort((a, b) => a - b), "changed quantity should be same.");
                     assert.step('qty_added');
-                    this._super(...arguments);
+                    super.onClickAddQty(...arguments);
                 },
             });
 

--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_compiler.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_compiler.js
@@ -80,9 +80,9 @@ registry.category("form_compilers").add("portal_chatter_compiler", {
         }),
 });
 
-patch(FormCompiler.prototype, 'project_sharing_chatter', {
+patch(FormCompiler.prototype, {
     compile(node, params) {
-        const res = this._super(node, params);
+        const res = super.compile(node, params);
         const chatterContainerHookXml = res.querySelector('.o-mail-Form-chatter');
         if (!chatterContainerHookXml) {
             return res; // no chatter, keep the result as it is

--- a/addons/project_todo/static/src/web/activity/activity_menu_patch.js
+++ b/addons/project_todo/static/src/web/activity/activity_menu_patch.js
@@ -7,9 +7,9 @@ import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 
-patch(ActivityMenu.prototype, "todo", {
+patch(ActivityMenu.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.rpc = useService("rpc");
         this.state = useState({ addingTodo: false });
         this.todoInputRef = useRef("todoInput");
@@ -35,7 +35,7 @@ patch(ActivityMenu.prototype, "todo", {
     },
 
     sortActivityGroups() {
-        this._super();
+        super.sortActivityGroups();
         this.store.activityGroups.sort((g1, g2) => {
             if (g1.model === "project.task" ? true : false) {
                 return -1;

--- a/addons/project_todo/static/tests/helpers/mock_server/controller/project_todo.js
+++ b/addons/project_todo/static/tests/helpers/mock_server/controller/project_todo.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { MockServer } from '@web/../tests/helpers/mock_server';
 
 import { date_to_str } from '@web/legacy/js/core/time';
 
-patch(MockServer.prototype, 'project_todo/controller/project_todo', {
+patch(MockServer.prototype, {
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -17,7 +17,7 @@ patch(MockServer.prototype, 'project_todo/controller/project_todo', {
         if (route === '/project_todo/new') {
             return this._mockRouteTodoNew(args);
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/purchase_mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
+++ b/addons/purchase_mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { BomOverviewLine } from "@mrp/components/bom_overview_line/mrp_bom_overview_line";
 
-patch(BomOverviewLine.prototype, "purchase_mrp", {
+patch(BomOverviewLine.prototype, {
     /**
      * @override
      */
@@ -11,6 +11,6 @@ patch(BomOverviewLine.prototype, "purchase_mrp", {
         if (routeType == "buy") {
             return this.goToAction(this.data.link_id, this.data.link_model);
         }
-        return this._super(...arguments);
+        return super.goToRoute(...arguments);
     }
 });

--- a/addons/rating/static/tests/helpers/mock_server/models/mail_message.js
+++ b/addons/rating/static/tests/helpers/mock_server/models/mail_message.js
@@ -5,12 +5,12 @@ import '@mail/../tests/helpers/mock_server/models/mail_message'; // ensure mail 
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, 'rating/models/mail_message', {
+patch(MockServer.prototype, {
     /**
      * @override
      */
     _mockMailMessageMessageFormat(ids) {
-        const formattedMessages = this._super(...arguments);
+        const formattedMessages = super._mockMailMessageMessageFormat(...arguments);
         for (const formattedMessage of formattedMessages) {
             const [rating] = this.getRecords('rating.rating', [
                 ['message_id', '=', formattedMessage.id],

--- a/addons/sale_product_configurator/static/src/js/sale_product_field.js
+++ b/addons/sale_product_configurator/static/src/js/sale_product_field.js
@@ -37,17 +37,17 @@ async function applyProduct(record, product) {
     });
 };
 
-patch(SaleOrderLineProductField.prototype, 'sale_product_configurator', {
+patch(SaleOrderLineProductField.prototype, {
 
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
 
         this.dialog = useService("dialog");
         this.orm = useService("orm");
     },
 
     async _onProductTemplateUpdate() {
-        this._super(...arguments);
+        super._onProductTemplateUpdate(...arguments);
         const result = await this.orm.call(
             'product.template',
             'get_single_product_variant',
@@ -78,14 +78,14 @@ patch(SaleOrderLineProductField.prototype, 'sale_product_configurator', {
     },
 
     _editProductConfiguration() {
-        this._super(...arguments);
+        super._editProductConfiguration(...arguments);
         if (this.props.record.data.is_configurable_product) {
             this._openProductConfigurator(true);
         }
     },
 
     get isConfigurableTemplate() {
-        return this._super(...arguments) || this.props.record.data.is_configurable_product;
+        return super.isConfigurableTemplate || this.props.record.data.is_configurable_product;
     },
 
     async _openProductConfigurator(edit=false) {

--- a/addons/sale_product_matrix/static/src/js/sale_product_field.js
+++ b/addons/sale_product_matrix/static/src/js/sale_product_field.js
@@ -7,10 +7,10 @@ import { useService } from "@web/core/utils/hooks";
 import "@sale_product_configurator/js/sale_product_field";
 
 
-patch(SaleOrderLineProductField.prototype, 'sale_product_matrix', {
+patch(SaleOrderLineProductField.prototype, {
 
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.dialog = useService("dialog");
     },
 
@@ -50,7 +50,7 @@ patch(SaleOrderLineProductField.prototype, 'sale_product_matrix', {
         if (edit && this.props.record.data.product_add_mode == 'matrix') {
             this._openGridConfigurator(true);
         } else {
-            this._super(...arguments);
+            super._openProductConfigurator(...arguments);
         }
     },
 
@@ -64,7 +64,7 @@ patch(SaleOrderLineProductField.prototype, 'sale_product_matrix', {
      *
      * @private
     */
-    _openMatrixConfigurator: function (jsonInfo, productTemplateId, editedCellAttributes) {
+    _openMatrixConfigurator(jsonInfo, productTemplateId, editedCellAttributes) {
         const infos = JSON.parse(jsonInfo);
         this.dialog.add(ProductMatrixDialog, {
             header: infos.header,

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -1,10 +1,10 @@
 /** @odoo-module */
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { formatFloatTime, formatFloat } from "@web/views/fields/formatters";
 import { ProjectRightSidePanel } from '@project/components/project_right_side_panel/project_right_side_panel';
 
-patch(ProjectRightSidePanel.prototype, '@sale_project/components/project_right_side_panel/project_right_side_panel', {
+patch(ProjectRightSidePanel.prototype, {
     async _loadAdditionalSalesOrderItems() {
         const offset = this.state.data.sale_items.data.length;
         const totalRecords = this.state.data.sale_items.total;

--- a/addons/sale_project/static/tests/tours/project_tour.js
+++ b/addons/sale_project/static/tests/tours/project_tour.js
@@ -8,9 +8,9 @@ import { registry } from "@web/core/registry";
 import "@project/../tests/tours/project_tour";
 import { patch } from "@web/core/utils/patch";
 
-patch(registry.category("web_tour.tours").get("project_test_tour"), "patch_sale_project_tour", {
+patch(registry.category("web_tour.tours").get("project_test_tour"), {
     steps() {
-        const originalSteps = this._super();
+        const originalSteps = super.steps();
         const projectCreationStepIndex = originalSteps.findIndex((step) => step.id === "project_creation");
         originalSteps.splice(projectCreationStepIndex, 0, {
             trigger: "div[name='allow_billable'] input",

--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.js
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 import { formatMonetary } from "@web/views/fields/formatters";
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 
 import { ForecastedDetails } from "@stock/stock_forecasted/forecasted_details";
 
-patch(ForecastedDetails.prototype, 'sale_stock.ForecastedDetails', {
+patch(ForecastedDetails.prototype, {
     _formatMonetary(num, currencyId){
         return formatMonetary(num,{ currencyId: currencyId});
     }

--- a/addons/sms/static/src/components/phone_field/phone_field.js
+++ b/addons/sms/static/src/components/phone_field/phone_field.js
@@ -5,7 +5,7 @@ import { patch } from "@web/core/utils/patch";
 import { PhoneField, phoneField, formPhoneField } from "@web/views/fields/phone/phone_field";
 import { SendSMSButton } from '@sms/components/sms_button/sms_button';
 
-patch(PhoneField, "sms.PhoneField", {
+patch(PhoneField, {
     components: {
         ...PhoneField.components,
         SendSMSButton
@@ -20,9 +20,9 @@ patch(PhoneField, "sms.PhoneField", {
     },
 });
 
-const patchDescr = {
+const patchDescr = () => ({
     extractProps({ options }) {
-        const props = this._super(...arguments);
+        const props = super.extractProps(...arguments);
         props.enableButton = options.enable_sms;
         return props;
     },
@@ -32,7 +32,7 @@ const patchDescr = {
         type: "boolean",
         default: true,
     }],
-};
+});
 
-patch(phoneField, "sms.PhoneField", patchDescr);
-patch(formPhoneField, "sms.PhoneField", patchDescr);
+patch(phoneField, patchDescr());
+patch(formPhoneField, patchDescr());

--- a/addons/sms/static/src/core/notification_group_model_patch.js
+++ b/addons/sms/static/src/core/notification_group_model_patch.js
@@ -4,17 +4,17 @@ import { NotificationGroup } from "@mail/core/common/notification_group_model";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(NotificationGroup.prototype, "sms/notification_group_model", {
+patch(NotificationGroup.prototype, {
     get iconSrc() {
         if (this.type === "sms") {
             return "/sms/static/img/sms_failure.svg";
         }
-        return this._super();
+        return super.iconSrc;
     },
     get body() {
         if (this.type === "sms") {
             return _t("An error occurred when sending an SMS");
         }
-        return this._super();
+        return super.body;
     },
 });

--- a/addons/sms/static/src/core/notification_model_patch.js
+++ b/addons/sms/static/src/core/notification_model_patch.js
@@ -4,17 +4,17 @@ import { Notification } from "@mail/core/common/notification_model";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(Notification.prototype, "sms", {
+patch(Notification.prototype, {
     get icon() {
         if (this.notification_type === "sms") {
             return "fa fa-mobile";
         }
-        return this._super();
+        return super.icon;
     },
     get label() {
         if (this.notification_type === "sms") {
             return _t("SMS");
         }
-        return this._super();
+        return super.label;
     },
 });

--- a/addons/sms/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/sms/static/src/messaging_menu/messaging_menu_patch.js
@@ -4,10 +4,10 @@ import { MessagingMenu } from "@mail/core/web/messaging_menu";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(MessagingMenu.prototype, "sms/messaging_menu", {
+patch(MessagingMenu.prototype, {
     openFailureView(failure) {
         if (failure.type === "email") {
-            return this._super(failure);
+            return super.openFailureView(failure);
         }
         this.env.services.action.doAction({
             name: _t("SMS Failures"),

--- a/addons/sms/static/src/thread/message_patch.js
+++ b/addons/sms/static/src/thread/message_patch.js
@@ -4,7 +4,7 @@ import { Message } from "@mail/core/common/message";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Message.prototype, "sms", {
+patch(Message.prototype, {
     onClickFailure() {
         if (this.message.type === "sms") {
             this.env.services.action.doAction("sms.sms_resend_action", {
@@ -13,7 +13,7 @@ patch(Message.prototype, "sms", {
                 },
             });
         } else {
-            this._super(...arguments);
+            super.onClickFailure(...arguments);
         }
     },
 });

--- a/addons/snailmail/static/src/core/notification_group_model_patch.js
+++ b/addons/snailmail/static/src/core/notification_group_model_patch.js
@@ -4,17 +4,17 @@ import { NotificationGroup } from "@mail/core/common/notification_group_model";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(NotificationGroup.prototype, "snailmail", {
+patch(NotificationGroup.prototype, {
     get iconSrc() {
         if (this.type === "snail") {
             return "/snailmail/static/img/snailmail_failure.png";
         }
-        return this._super();
+        return super.iconSrc;
     },
     get body() {
         if (this.type === "snail") {
             return _t("An error occurred when sending a letter with Snailmail.");
         }
-        return this._super();
+        return super.body;
     },
 });

--- a/addons/snailmail/static/src/core/notification_model_patch.js
+++ b/addons/snailmail/static/src/core/notification_model_patch.js
@@ -4,12 +4,12 @@ import { Notification } from "@mail/core/common/notification_model";
 import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 
-patch(Notification.prototype, "snailmail", {
+patch(Notification.prototype, {
     get icon() {
         if (this.notification_type === "snail") {
             return "fa fa-paper-plane";
         }
-        return this._super();
+        return super.icon;
     },
 
     get statusIcon() {
@@ -25,7 +25,7 @@ patch(Notification.prototype, "snailmail", {
                     return "fa fa-exclamation text-danger";
             }
         }
-        return this._super();
+        return super.statusIcon;
     },
 
     get statusTitle() {
@@ -41,6 +41,6 @@ patch(Notification.prototype, "snailmail", {
                     return _t("Error");
             }
         }
-        return this._super();
+        return super.statusTitle;
     },
 });

--- a/addons/snailmail/static/src/core_ui/message_patch.js
+++ b/addons/snailmail/static/src/core_ui/message_patch.js
@@ -7,7 +7,7 @@ import { SnailmailNotificationPopover } from "./snailmail_notification_popover";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(Message.prototype, "snailmail", {
+patch(Message.prototype, {
     onClickFailure() {
         if (this.message.type === "snailmail") {
             const failureType = this.message.notifications[0].failure_type;
@@ -29,7 +29,7 @@ patch(Message.prototype, "snailmail", {
                     break;
             }
         } else {
-            this._super(...arguments);
+            super.onClickFailure(...arguments);
         }
     },
 

--- a/addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js
+++ b/addons/snailmail/static/src/messaging_menu/messaging_menu_patch.js
@@ -4,10 +4,10 @@ import { MessagingMenu } from "@mail/core/web/messaging_menu";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(MessagingMenu.prototype, "snailmail/messaging_menu", {
+patch(MessagingMenu.prototype, {
     openFailureView(failure) {
         if (failure.type !== "snail") {
-            return this._super(failure);
+            return super.openFailureView(failure);
         }
         this.env.services.action.doAction({
             name: _t("Snailmail Failures"),

--- a/addons/snailmail/static/tests/helpers/mock_server/models/mail_message.js
+++ b/addons/snailmail/static/tests/helpers/mock_server/models/mail_message.js
@@ -5,7 +5,7 @@ import '@mail/../tests/helpers/mock_server/models/mail_message'; // ensure mail 
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, 'snailmail/models/mail_message', {
+patch(MockServer.prototype, {
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -26,7 +26,7 @@ patch(MockServer.prototype, 'snailmail/models/mail_message', {
             // random value returned in order for the mock server to know that this route is implemented.
             return true;
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
@@ -4,9 +4,9 @@ import { patch } from "@web/core/utils/patch";
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { useService } from "@web/core/utils/hooks";
 
-patch(spreadsheet.components.FigureComponent.prototype, "spreadsheet.FigureComponent", {
+patch(spreadsheet.components.FigureComponent.prototype, {
     setup() {
-        this._super();
+        super.setup();
         this.menuService = useService("menu");
         this.actionService = useService("action");
     },

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.js
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 
 import { ForecastedHeader as Parent } from "@stock/stock_forecasted/forecasted_header";
 
 export class StockAccountForecastedHeader extends Parent{}
 
-patch(Parent.prototype, 'stock_account.ForecastedHeader', {
+patch(Parent.prototype, {
     async _onClickValuation() {
         const context = this._getActionContext();
         return this.action.doAction({

--- a/addons/survey/static/src/question_page/question_page_one2many_field.js
+++ b/addons/survey/static/src/question_page/question_page_one2many_field.js
@@ -8,7 +8,7 @@ import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field"
 
 const { useSubEnv } = owl;
 
-patch(X2ManyFieldDialog.prototype, 'survey_question_chaining_with_validation', {
+patch(X2ManyFieldDialog.prototype, {
     /**
      * Re-enable buttons after our error is thrown because blocking normal
      * behavior is required to not close the dialog and stay in edition but
@@ -17,7 +17,7 @@ patch(X2ManyFieldDialog.prototype, 'survey_question_chaining_with_validation', {
      * @override
      */
     async saveAndNew() {
-        const res = this._super(...arguments);
+        const res = super.saveAndNew(...arguments);
         if (this.record.resModel === 'survey.question') {
             const btns = this.modalRef.el.querySelectorAll(".modal-footer button"); // see XManyFieldDialog.disableButtons
             this.enableButtons(btns);

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -533,7 +533,7 @@ QUnit.module("test_mail", {}, function () {
             async load(params) {
                 // force params to have a groupBy set, the model should ignore this value during the load
                 params.groupBy = ["user_id"];
-                await this._super(params);
+                await super.load(params);
             },
         });
 
@@ -728,7 +728,7 @@ QUnit.module("test_mail", {}, function () {
 
         patchWithCleanup(ActivityRenderer.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 owl.onMounted(() => {
                     assert.step("mounted");
                 });

--- a/addons/test_website/static/tests/field_html_file_upload.js
+++ b/addons/test_website/static/tests/field_html_file_upload.js
@@ -46,8 +46,8 @@ QUnit.module('field html file upload', {
         assert.expect(4);
         const onAttachmentChangeTriggered = testUtils.makeTestPromise();
         patchWithCleanup(HtmlField.prototype, {
-            '_onAttachmentChange': function (event) {
-                this._super(event);
+            _onAttachmentChange(event) {
+                super._onAttachmentChange(event);
                 onAttachmentChangeTriggered.resolve(true);
             }
         });
@@ -55,13 +55,13 @@ QUnit.module('field html file upload', {
         const onChangeTriggered = testUtils.makeTestPromise();
         patchWithCleanup(FileSelectorControlPanel.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 useEffect(() => {
                     defFileSelector.resolve(true);
                 }, () => []);
             },
             async onChangeFileInput() {
-                this._super();
+                super.onChangeFileInput();
                 onChangeTriggered.resolve(true);
             }
         });

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { VideoSelector } from '@web_editor/components/media_dialog/video_selector';
 import wTourUtils from '@website/js/tours/tour_utils';
 
@@ -23,12 +23,12 @@ wTourUtils.registerWebsitePreviewTour('test_replace_media', {
             // specific to an URL only, it is acceptable).
             // TODO if we ever give the possibility to upload its own videos,
             // this won't be necessary anymore.
-            patch(VideoSelector.prototype, "Video selector patch", {
+            patch(VideoSelector.prototype, {
                 async _getVideoURLData(src, options) {
                     if (src === VIDEO_URL || src === 'about:blank') {
                         return {platform: 'youtube', embed_url: 'about:blank'};
                     }
-                    return this._super(...arguments);
+                    return super._getVideoURLData(...arguments);
                 },
             });
         },

--- a/addons/web/static/src/core/utils/patch.js
+++ b/addons/web/static/src/core/utils/patch.js
@@ -1,22 +1,60 @@
 /** @odoo-module **/
 
 /**
- * @typedef {{
- *   name: string;
- *   patch: object;
- *   pure: boolean;
- * }} PatchDescription
+ *  @typedef {{
+ *      originalProperties: Map<string, PropertyDescriptor>;
+ *      skeleton: object;
+ *      extensions: Set<object>;
+ *  }} PatchDescription
  */
+
+/** @type {WeakMap<object, PatchDescription>} */
+const patchDescriptions = new WeakMap();
 
 /**
- * @typedef {{
- *   original: object;
- *   patches: PatchDescription[];
- * }} ObjectPatchDescription
+ * Create or get the patch description for the given `objToPatch`.
+ * @param {object} objToPatch
+ * @returns {PatchDescription}
  */
+function getPatchDescription(objToPatch) {
+    if (!patchDescriptions.has(objToPatch)) {
+        patchDescriptions.set(objToPatch, {
+            originalProperties: new Map(),
+            skeleton: Object.create(Object.getPrototypeOf(objToPatch)),
+            extensions: new Set(),
+        });
+    }
+    return patchDescriptions.get(objToPatch);
+}
 
-/** @type {WeakMap<any, ObjectPatchDescription>} */
-const patchMap = new WeakMap();
+/**
+ * @param {object} objToPatch
+ * @returns {boolean}
+ */
+function isClassPrototype(objToPatch) {
+    // class A {}
+    // isClassPrototype(A) === false
+    // isClassPrototype(A.prototype) === true
+    // isClassPrototype(new A()) === false
+    // isClassPrototype({}) === false
+    return Object.hasOwn(objToPatch, "constructor") && objToPatch.constructor?.prototype === objToPatch;
+}
+
+/**
+ * Traverse the prototype chain to find a potential property.
+ * @param {object} objToPatch
+ * @param {string} key
+ * @returns {object}
+ */
+function findAncestorPropertyDescriptor(objToPatch, key) {
+    let descriptor = null;
+    let prototype = objToPatch;
+    do {
+        descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+        prototype = Object.getPrototypeOf(prototype);
+    } while (!descriptor && prototype);
+    return descriptor;
+}
 
 /**
  * Patch an object
@@ -25,135 +63,74 @@ const patchMap = new WeakMap();
  * you want to patch static properties/methods.
  *
  * @template T
- * @template {Partial<T>} U
- * @param {T} obj Object to patch
- * @param {string} patchName
- * @param {U} patchValue
- * @param {{pure?: boolean}} [options]
+ * @template {T} U
+ * @param {T} objToPatch The object to patch
+ * @param {U} extension The object containing the patched properties
+ * @returns {() => void} Returns an unpatch function
  */
-export function patch(obj, patchName, patchValue, options = {}) {
-    if (typeof patchName !== "string") {
-        throw new Error("Incorrect use of patch: second argument should be the patchName");
+export function patch(objToPatch, extension) {
+    if (typeof extension === "string") {
+        throw new Error(`Patch "${extension}": Second argument is not the patch name anymore, it should be the object containing the patched properties`);
     }
-    const pure = Boolean(options.pure);
-    if (!patchMap.has(obj)) {
-        patchMap.set(obj, {
-            original: {},
-            patches: [],
-        });
-    }
-    const objDesc = patchMap.get(obj);
-    if (objDesc.patches.some((p) => p.name === patchName)) {
-        throw new Error(`Class ${obj.name} already has a patch ${patchName}`);
-    }
-    objDesc.patches.push({
-        name: patchName,
-        patch: patchValue,
-        pure,
-    });
 
-    for (const k in patchValue) {
-        let prevDesc = null;
-        let proto = obj;
-        do {
-            prevDesc = Object.getOwnPropertyDescriptor(proto, k);
-            proto = Object.getPrototypeOf(proto);
-        } while (!prevDesc && proto);
+    const description = getPatchDescription(objToPatch);
+    description.extensions.add(extension);
 
-        let newDesc = Object.getOwnPropertyDescriptor(patchValue, k);
-        if (!Object.hasOwnProperty.call(objDesc.original, k)) {
-            objDesc.original[k] = Object.getOwnPropertyDescriptor(obj, k);
+    const properties = Object.getOwnPropertyDescriptors(extension);
+    for (const [key, newProperty] of Object.entries(properties)) {
+        const oldProperty = Object.getOwnPropertyDescriptor(objToPatch, key);
+        if (oldProperty) {
+            // Store the old property on the skeleton.
+            Object.defineProperty(description.skeleton, key, oldProperty);
         }
 
-        if (prevDesc) {
-            const patchedFnName = `${k} (patch ${patchName})`;
+        if (!description.originalProperties.has(key)) {
+            // Keep a trace of original property (prop before first patch), useful for unpatching.
+            description.originalProperties.set(key, oldProperty);
+        }
 
-            if (prevDesc.value && typeof newDesc.value === "function") {
-                newDesc = { ...prevDesc, value: newDesc.value };
-                makeIntermediateFunction("value", prevDesc, newDesc, patchedFnName);
-            }
-            if ((newDesc.get || newDesc.set) && (prevDesc.get || prevDesc.set)) {
-                // get and set are defined together. If they are both defined
-                // in the previous descriptor but only one in the new descriptor
-                // then the other will be undefined so we need to apply the
-                // previous descriptor in the new one.
-                newDesc = {
-                    ...prevDesc,
-                    get: newDesc.get || prevDesc.get,
-                    set: newDesc.set || prevDesc.set,
-                };
-                if (prevDesc.get && typeof newDesc.get === "function") {
-                    makeIntermediateFunction("get", prevDesc, newDesc, patchedFnName);
-                }
-                if (prevDesc.set && typeof newDesc.set === "function") {
-                    makeIntermediateFunction("set", prevDesc, newDesc, patchedFnName);
-                }
+        if (isClassPrototype(objToPatch)) {
+            // A property is enumerable on POJO ({ prop: 1 }) but not on classes (class A {}).
+            // Here, we only check if we patch a class prototype.
+            newProperty.enumerable = false;
+        }
+
+        if ((newProperty.get && 1) ^ (newProperty.set && 1)) {
+            // get and set are defined together. If they are both defined
+            // in the previous descriptor but only one in the new descriptor
+            // then the other will be undefined so we need to apply the
+            // previous descriptor in the new one.
+            const ancestorProperty = findAncestorPropertyDescriptor(objToPatch, key);
+            newProperty.get = newProperty.get ?? ancestorProperty?.get;
+            newProperty.set = newProperty.set ?? ancestorProperty?.set;
+        }
+
+        // Replace the old property by the new one.
+        Object.defineProperty(objToPatch, key, newProperty);
+    }
+
+    // Sets the current skeleton as the extension's prototype to make
+    // `super` keyword working and then set extension as the new skeleton.
+    description.skeleton = Object.setPrototypeOf(extension, description.skeleton);
+
+    return () => {
+        // Remove the description to start with a fresh base.
+        patchDescriptions.delete(objToPatch);
+
+        for (const [key, property] of description.originalProperties) {
+            if (property) {
+                // Restore the original property on the `objToPatch` object.
+                Object.defineProperty(objToPatch, key, property);
+            } else {
+                // Or remove the property if it did not exist at first.
+                delete objToPatch[key];
             }
         }
 
-        Object.defineProperty(obj, k, newDesc);
-    }
-
-    function makeIntermediateFunction(key, prevDesc, newDesc, patchedFnName) {
-        const _superFn = prevDesc[key];
-        const patchFn = newDesc[key];
-        if (pure) {
-            newDesc[key] = patchFn;
-        } else {
-            newDesc[key] = {
-                [patchedFnName](...args) {
-                    let prevSuper;
-                    if (this) {
-                        prevSuper = this._super;
-                        Object.defineProperty(this, "_super", {
-                            value: _superFn.bind(this),
-                            configurable: true,
-                            writable: true,
-                        });
-                    }
-                    const result = patchFn.call(this, ...args);
-                    if (this) {
-                        Object.defineProperty(this, "_super", {
-                            value: prevSuper,
-                            configurable: true,
-                            writable: true,
-                        });
-                    }
-                    return result;
-                },
-            }[patchedFnName];
+        // Re-apply the patches without the current one.
+        description.extensions.delete(extension);
+        for (const extension of description.extensions) {
+            patch(objToPatch, extension);
         }
-    }
-}
-
-/**
- * We define here an unpatch function.  This is mostly useful if we want to
- * remove a patch.  For example, for testing purposes
- *
- * @template T
- * @param {T} obj
- * @param {string} patchName
- */
-export function unpatch(obj, patchName) {
-    const objDesc = patchMap.get(obj);
-    if (!objDesc.patches.some((p) => p.name === patchName)) {
-        throw new Error(`Class ${obj.name} does not have any patch ${patchName}`);
-    }
-    patchMap.delete(obj);
-
-    // Restore original methods on the prototype and the class.
-    for (const k in objDesc.original) {
-        if (objDesc.original[k] === undefined) {
-            delete obj[k];
-        } else {
-            Object.defineProperty(obj, k, objDesc.original[k]);
-        }
-    }
-
-    // Re-apply the patches except the one to remove.
-    for (const patchDesc of objDesc.patches) {
-        if (patchDesc.name !== patchName) {
-            patch(obj, patchDesc.name, patchDesc.patch, { pure: patchDesc.pure });
-        }
-    }
+    };
 }

--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -52,15 +52,15 @@
         const { patch } = odoo.__DEBUG__.services["@web/core/utils/patch"];
         const { WithSearch } = odoo.__DEBUG__.services["@web/search/with_search/with_search"];
 
-        patch(WithSearch.prototype, "PatchedWithSearch", {
+        patch(WithSearch.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 onWillStart(() => {
                     viewUpdateCount++;
                 });
             },
             async render() {
-                await this._super(...arguments);
+                await super.render(...arguments);
                 viewUpdateCount++;
             },
         });

--- a/addons/web/static/tests/core/dialog_service_tests.js
+++ b/addons/web/static/tests/core/dialog_service_tests.js
@@ -210,7 +210,7 @@ QUnit.test("dialog component crashes", async (assert) => {
     const prom = makeDeferred();
     patchWithCleanup(ErrorDialog.prototype, {
         setup() {
-            this._super();
+            super.setup();
             onMounted(() => {
                 prom.resolve();
             });

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -89,7 +89,7 @@ QUnit.module("Components", ({ beforeEach }) => {
         patchWithCleanup(DropdownItem.prototype, {
             onClick(ev) {
                 assert.ok(!ev.defaultPrevented);
-                this._super(...arguments);
+                super.onClick(...arguments);
                 const href = ev.target.getAttribute("href");
                 // defaultPrevented only if props.href is defined
                 assert.ok(href !== null ? ev.defaultPrevented : !ev.defaultPrevented);
@@ -184,7 +184,7 @@ QUnit.module("Components", ({ beforeEach }) => {
         patchWithCleanup(Dropdown.prototype, {
             close() {
                 assert.step("dropdown will close");
-                this._super();
+                super.close();
             },
         });
         class Parent extends Component {
@@ -994,7 +994,7 @@ QUnit.module("Components", ({ beforeEach }) => {
         assert.expect(9);
         patchWithCleanup(Dropdown.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 const isSubmenu = Boolean(this.parentDropdown);
                 if (isSubmenu) {
                     onMounted(() => {
@@ -1123,7 +1123,7 @@ QUnit.module("Components", ({ beforeEach }) => {
         let hotkeyRegistrationsCount = 0;
         patchWithCleanup(env.services.hotkey, {
             add() {
-                const remove = this._super(...arguments);
+                const remove = super.add(...arguments);
                 hotkeyRegistrationsCount += 1;
                 return () => {
                     remove();

--- a/addons/web/static/tests/core/l10n/dates_tests.js
+++ b/addons/web/static/tests/core/l10n/dates_tests.js
@@ -12,7 +12,6 @@ import {
     strftimeToLuxonFormat,
 } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
-import { patch, unpatch } from "@web/core/utils/patch";
 import core from "@web/legacy/js/services/core";
 import field_utils from "@web/legacy/js/fields/field_utils";
 import session from "web.session";
@@ -165,7 +164,7 @@ QUnit.module(
         });
 
         QUnit.test("parseDateTime", async (assert) => {
-            patch(localization, "default loc", defaultLocalization);
+            patchWithCleanup(localization, { ...defaultLocalization });
 
             assert.throws(
                 function () {
@@ -197,14 +196,12 @@ QUnit.module(
             assert.equal(parseDateTime(dateStr).toISO(), expected, "Date with leading 0");
             dateStr = "1/13/2019 10:5:45";
             assert.equal(parseDateTime(dateStr).toISO(), expected, "Date without leading 0");
-
-            unpatch(localization, "default loc");
         });
 
         QUnit.test("parseDateTime (norwegian locale)", async (assert) => {
             const dateFormat = strftimeToLuxonFormat("%d. %b %Y");
             const timeFormat = strftimeToLuxonFormat("%H:%M:%S");
-            patch(localization, "weird loc", {
+            patchWithCleanup(localization, {
                 dateFormat,
                 timeFormat,
                 dateTimeFormat: `${dateFormat} ${timeFormat}`,
@@ -227,7 +224,6 @@ QUnit.module(
             );
 
             Settings.defaultLocale = originalLocale;
-            unpatch(localization, "weird loc");
         });
 
         QUnit.test("parseDate", async (assert) => {
@@ -243,7 +239,7 @@ QUnit.module(
         QUnit.test("parseDate without separator", async (assert) => {
             const dateFormat = strftimeToLuxonFormat("%d.%m/%Y");
             const timeFormat = strftimeToLuxonFormat("%H:%M:%S");
-            patch(localization, "patch loc", {
+            patchWithCleanup(localization, {
                 dateFormat,
                 timeFormat,
                 dateTimeFormat: `${dateFormat} ${timeFormat}`,
@@ -294,13 +290,12 @@ QUnit.module(
             assert.equal(parseDate("310197").toFormat(testDateFormat), "31.01/1997");
             assert.equal(parseDate("310117").toFormat(testDateFormat), "31.01/2017");
             assert.equal(parseDate("31011985").toFormat(testDateFormat), "31.01/1985");
-            unpatch(localization, "patch loc");
         });
 
         QUnit.test("parseDateTime without separator", async (assert) => {
             const dateFormat = strftimeToLuxonFormat("%d.%m/%Y");
             const timeFormat = strftimeToLuxonFormat("%H:%M:%S");
-            patch(localization, "patch loc", {
+            patchWithCleanup(localization, {
                 dateFormat,
                 timeFormat,
                 dateTimeFormat: `${dateFormat} ${timeFormat}`,
@@ -319,13 +314,12 @@ QUnit.module(
                 parseDateTime("31/01/1985 08").toFormat(dateTimeFormat),
                 "31.01/1985 08:00/00"
             );
-            unpatch(localization, "patch loc");
         });
 
         QUnit.test("parseDateTime with escaped characters (eg. Basque locale)", async (assert) => {
             const dateFormat = strftimeToLuxonFormat("%a, %Y.eko %bren %da");
             const timeFormat = strftimeToLuxonFormat("%H:%M:%S");
-            patch(localization, "patch loc", {
+            patchWithCleanup(localization, {
                 dateFormat,
                 timeFormat,
                 dateTimeFormat: `${dateFormat} ${timeFormat}`,
@@ -337,7 +331,6 @@ QUnit.module(
                 parseDateTime("1985-01-31 08:30:00").toFormat(dateTimeFormat),
                 "Thu, 1985.eko Janren 31a 08:30:00"
             );
-            unpatch(localization, "patch loc");
         });
 
         QUnit.test("parse smart date input", async (assert) => {
@@ -387,7 +380,7 @@ QUnit.module(
         });
 
         QUnit.test("parseDateTime SQL Format", async (assert) => {
-            patch(localization, "default loc", defaultLocalization);
+            patchWithCleanup(localization, { ...defaultLocalization });
 
             let dateStr = "2017-05-15 09:12:34";
             let expected = "2017-05-15T09:12:34.000+01:00";
@@ -400,8 +393,6 @@ QUnit.module(
                 expected,
                 "Date SQL format, check date is not confused with month"
             );
-
-            unpatch(localization, "default loc");
         });
 
         QUnit.test("serializeDate", async (assert) => {

--- a/addons/web/static/tests/core/l10n/translation_tests.js
+++ b/addons/web/static/tests/core/l10n/translation_tests.js
@@ -8,7 +8,6 @@ import { browser } from "@web/core/browser/browser";
 import { localizationService } from "@web/core/l10n/localization_service";
 import { translatedTerms, translationLoaded, _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { patch, unpatch } from "@web/core/utils/patch";
 import { session } from "@web/session";
 
 import { Component, xml } from "@odoo/owl";
@@ -59,11 +58,10 @@ QUnit.test("can translate a text node", async (assert) => {
     TestComponent.template = xml`<div>Hello</div>`;
     serviceRegistry.add("localization", makeFakeLocalizationService());
     const env = await makeTestEnv();
-    patch(translatedTerms, "add translations", terms);
+    patchWithCleanup(translatedTerms, { ...terms });
     const target = getFixture();
     await mount(TestComponent, target, { env });
     assert.strictEqual(target.innerText, "Bonjour");
-    unpatch(translatedTerms, "add translations");
 });
 
 QUnit.test("can lazy translate", async (assert) => {
@@ -77,12 +75,11 @@ QUnit.test("can lazy translate", async (assert) => {
 
     serviceRegistry.add("localization", makeFakeLocalizationService());
     const env = await makeTestEnv();
-    patch(translatedTerms, "add translations", terms);
+    patchWithCleanup(translatedTerms, { ...terms });
     translatedTerms[translationLoaded] = true;
     const target = getFixture();
     await mount(TestComponent, target, { env });
     assert.strictEqual(target.innerText, "Bonjour");
-    unpatch(translatedTerms, "add translations");
 });
 
 QUnit.test("_t is in env", async (assert) => {
@@ -90,11 +87,10 @@ QUnit.test("_t is in env", async (assert) => {
     TestComponent.template = xml`<div><t t-esc="env._t('Hello')"/></div>`;
     serviceRegistry.add("localization", makeFakeLocalizationService());
     const env = await makeTestEnv();
-    patch(translatedTerms, "add translations", terms);
+    patchWithCleanup(translatedTerms, { ...terms });
     const target = getFixture();
     await mount(TestComponent, target, { env });
     assert.strictEqual(target.innerText, "Bonjour");
-    unpatch(translatedTerms, "add translations");
 });
 
 QUnit.test("luxon is configured in the correct lang", async (assert) => {

--- a/addons/web/static/tests/core/main_components_container_tests.js
+++ b/addons/web/static/tests/core/main_components_container_tests.js
@@ -2,7 +2,7 @@
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { registry } from "@web/core/registry";
 import { clearRegistryWithCleanup, makeTestEnv } from "../helpers/mock_env";
-import { patch, unpatch } from "@web/core/utils/patch";
+import { patch } from "@web/core/utils/patch";
 import { getFixture, mount, nextTick } from "../helpers/utils";
 
 import { Component, useState, xml } from "@odoo/owl";
@@ -73,14 +73,14 @@ QUnit.module("Components", (hooks) => {
         window.addEventListener("unhandledrejection", handler);
         // fake error service so that the odoo qunit handlers don't think that they need to handle the error
         registry.category("services").add("error", { start: () => {} });
-        patch(QUnit, "MainComponentsContainer QUnit patch", {
+        const unpatch = patch(QUnit, {
             onUnhandledRejection: () => {},
         });
         compA.state.shouldThrow = true;
         await nextTick();
         window.removeEventListener("unhandledrejection", handler);
         // unpatch QUnit asap so any other errors can be caught by it
-        unpatch(QUnit, "MainComponentsContainer QUnit patch");
+        unpatch();
         assert.verifySteps([
             'An error occured in the owl lifecycle (see this Error\'s "cause" property)',
             "BOOM",
@@ -128,14 +128,14 @@ QUnit.module("Components", (hooks) => {
         window.addEventListener("unhandledrejection", handler);
         // fake error service so that the odoo qunit handlers don't think that they need to handle the error
         registry.category("services").add("error", { start: () => {} });
-        patch(QUnit, "MainComponentsContainer QUnit patch", {
+        const unpatch = patch(QUnit, {
             onUnhandledRejection: () => {},
         });
         compB.state.shouldThrow = true;
         await nextTick();
         window.removeEventListener("unhandledrejection", handler);
         // unpatch QUnit asap so any other errors can be caught by it
-        unpatch(QUnit, "MainComponentsContainer QUnit patch");
+        unpatch();
         assert.verifySteps([
             'An error occured in the owl lifecycle (see this Error\'s "cause" property)',
             "BOOM",

--- a/addons/web/static/tests/core/network/download_tests.js
+++ b/addons/web/static/tests/core/network/download_tests.js
@@ -18,13 +18,7 @@ QUnit.module("download", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         let error;
         try {
@@ -47,13 +41,7 @@ QUnit.module("download", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         let error;
         try {
@@ -87,13 +75,7 @@ QUnit.module("download", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         let error;
         try {
@@ -122,13 +104,7 @@ QUnit.module("download", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         let error;
         try {
@@ -161,13 +137,7 @@ QUnit.module("download", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         assert.containsNone(document.body, "a[download]");
 

--- a/addons/web/static/tests/core/network/rpc_service_tests.js
+++ b/addons/web/static/tests/core/network/rpc_service_tests.js
@@ -5,7 +5,6 @@ import { ConnectionAbortedError, ConnectionLostError, rpcService } from "@web/co
 import { notificationService } from "@web/core/notifications/notification_service";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { patch, unpatch } from "@web/core/utils/patch";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { makeMockXHR } from "../../helpers/mock_services";
 import {
@@ -20,7 +19,6 @@ import { registerCleanup } from "../../helpers/cleanup";
 
 import { Component, xml } from "@odoo/owl";
 
-let isXHRMocked = false;
 const serviceRegistry = registry.category("services");
 
 let isDeployed = false;
@@ -31,18 +29,7 @@ async function testRPC(route, params) {
         request = data;
         url = this.url;
     });
-    if (isXHRMocked) {
-        unpatch(browser, "mock.xhr");
-    }
-    patch(
-        browser,
-        "mock.xhr",
-        {
-            XMLHttpRequest: MockXHR,
-        },
-        { pure: true }
-    );
-    isXHRMocked = true;
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
     if (isDeployed) {
         clearRegistryWithCleanup(registry.category("main_components"));
@@ -66,12 +53,6 @@ QUnit.module("RPC", {
         serviceRegistry.add("notification", notificationService);
         serviceRegistry.add("rpc", rpcService);
     },
-    afterEach() {
-        if (isXHRMocked) {
-            unpatch(browser, "mock.xhr");
-            isXHRMocked = false;
-        }
-    },
 });
 
 QUnit.test("can perform a simple rpc", async (assert) => {
@@ -82,12 +63,11 @@ QUnit.test("can perform a simple rpc", async (assert) => {
         assert.ok(typeof request.id === "number");
     });
 
-    patch(browser, "mock.xhr", { XMLHttpRequest: MockXHR }, { pure: true });
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
     const env = await makeTestEnv({ serviceRegistry });
     const result = await env.services.rpc("/test/");
     assert.deepEqual(result, { action_id: 123 });
-    unpatch(browser, "mock.xhr");
 });
 
 QUnit.test("trigger an error when response has 'error' key", async (assert) => {
@@ -101,7 +81,7 @@ QUnit.test("trigger an error when response has 'error' key", async (assert) => {
         },
     };
     const MockXHR = makeMockXHR({ error });
-    patch(browser, "mock.xhr", { XMLHttpRequest: MockXHR }, { pure: true });
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
     const env = await makeTestEnv({
         serviceRegistry,
@@ -111,7 +91,6 @@ QUnit.test("trigger an error when response has 'error' key", async (assert) => {
     } catch {
         assert.ok(true);
     }
-    unpatch(browser, "mock.xhr");
 });
 
 QUnit.test("rpc with simple routes", async (assert) => {
@@ -133,7 +112,7 @@ QUnit.test("rpc coming from destroyed components are left pending", async (asser
     MyComponent.template = xml`<div/>`;
     const def = makeDeferred();
     const MockXHR = makeMockXHR({ result: "1" }, () => {}, def);
-    patch(browser, "mock.xhr", { XMLHttpRequest: MockXHR }, { pure: true });
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
     const env = await makeTestEnv({
         serviceRegistry,
@@ -157,7 +136,6 @@ QUnit.test("rpc coming from destroyed components are left pending", async (asser
     await nextTick();
     assert.strictEqual(isResolved, false);
     assert.strictEqual(isFailed, false);
-    unpatch(browser, "mock.xhr");
 });
 
 QUnit.test("rpc initiated from destroyed components throw exception", async (assert) => {
@@ -183,7 +161,7 @@ QUnit.test("rpc initiated from destroyed components throw exception", async (ass
 
 QUnit.test("check trigger RPC:REQUEST and RPC:RESPONSE for a simple rpc", async (assert) => {
     const MockXHR = makeMockXHR({ test: true }, () => 1);
-    patch(browser, "mock.xhr", { XMLHttpRequest: MockXHR }, { pure: true });
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
     const env = await makeTestEnv({
         serviceRegistry,
@@ -208,8 +186,6 @@ QUnit.test("check trigger RPC:REQUEST and RPC:RESPONSE for a simple rpc", async 
 
     await env.services.rpc("/test/", {}, { silent: true });
     assert.verifySteps(["RPC:REQUEST(silent)", "RPC:RESPONSE(silent)(ok)"]);
-
-    unpatch(browser, "mock.xhr");
 });
 
 QUnit.test("check trigger RPC:REQUEST and RPC:RESPONSE for a rpc with an error", async (assert) => {
@@ -222,7 +198,7 @@ QUnit.test("check trigger RPC:REQUEST and RPC:RESPONSE for a rpc with an error",
         },
     };
     const MockXHR = makeMockXHR({ error });
-    patch(browser, "mock.xhr", { XMLHttpRequest: MockXHR }, { pure: true });
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
     const env = await makeTestEnv({
         serviceRegistry,
     });
@@ -246,13 +222,12 @@ QUnit.test("check trigger RPC:REQUEST and RPC:RESPONSE for a rpc with an error",
     }
     assert.strictEqual(rpcIdsRequest.toString(), rpcIdsResponse.toString());
     assert.verifySteps(["RPC:REQUEST", "RPC:RESPONSE(ko)", "ok"]);
-    unpatch(browser, "mock.xhr");
 });
 
 QUnit.test("check connection aborted", async (assert) => {
     const def = makeDeferred();
     const MockXHR = makeMockXHR({}, () => {}, def);
-    patchWithCleanup(browser, { XMLHttpRequest: MockXHR }, { pure: true });
+    patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
     const env = await makeTestEnv({ serviceRegistry });
     env.bus.addEventListener("RPC:REQUEST", () => {
         assert.step("RPC:REQUEST");

--- a/addons/web/static/tests/core/tooltip/tooltip_service_tests.js
+++ b/addons/web/static/tests/core/tooltip/tooltip_service_tests.js
@@ -57,7 +57,7 @@ export async function makeParent(Child, options = {}) {
 
     patchWithCleanup(env.services.popover, {
         add(...args) {
-            const result = this._super(...args);
+            const result = super.add(...args);
             if (options.onPopoverAdded) {
                 options.onPopoverAdded(...args);
             }

--- a/addons/web/static/tests/core/utils/patch_tests.js
+++ b/addons/web/static/tests/core/utils/patch_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { patch, unpatch } from "@web/core/utils/patch";
+import { patch } from "@web/core/utils/patch";
 import legacyUtils from "@web/legacy/js/core/utils";
 
 function makeBaseClass(assert, assertInSetup) {
@@ -51,13 +51,13 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -72,24 +72,24 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass.prototype, "patch1", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch1.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch1.fn");
                 },
             });
 
-            patch(BaseClass.prototype, "patch2", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch2.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch2.fn");
                 },
             });
@@ -105,31 +105,18 @@ QUnit.module("utils", () => {
             ]);
         });
 
-        QUnit.test("two patches with same name on same base class", async function (assert) {
-            assert.expect(1);
-
-            const A = class {};
-
-            patch(A.prototype, "patch");
-
-            // keys should be unique
-            assert.throws(() => {
-                patch(A.prototype, "patch");
-            });
-        });
-
         QUnit.test("unpatch", async function (assert) {
             assert.expect(8);
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -137,7 +124,7 @@ QUnit.module("utils", () => {
             new BaseClass().fn();
 
             assert.verifySteps(["base.setup", "patch.setup", "base.fn", "patch.fn"]);
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             new BaseClass().fn();
 
@@ -149,24 +136,24 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass.prototype, "patch1", {
+            const unpatch1 = patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch1.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch1.fn");
                 },
             });
 
-            patch(BaseClass.prototype, "patch2", {
+            const unpatch2 = patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch2.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch2.fn");
                 },
             });
@@ -182,13 +169,13 @@ QUnit.module("utils", () => {
                 "patch2.fn",
             ]);
 
-            unpatch(BaseClass.prototype, "patch1");
+            unpatch1();
 
             new BaseClass().fn();
 
             assert.verifySteps(["base.setup", "patch2.setup", "base.fn", "patch2.fn"]);
 
-            unpatch(BaseClass.prototype, "patch2");
+            unpatch2();
 
             new BaseClass().fn();
 
@@ -202,24 +189,24 @@ QUnit.module("utils", () => {
 
                 const BaseClass = makeBaseClass(assert);
 
-                patch(BaseClass.prototype, "patch1", {
+                const unpatch1 = patch(BaseClass.prototype, {
                     setup() {
-                        this._super();
+                        super.setup();
                         assert.step("patch1.setup");
                     },
                     fn() {
-                        this._super();
+                        super.fn();
                         assert.step("patch1.fn");
                     },
                 });
 
-                patch(BaseClass.prototype, "patch2", {
+                const unpatch2 = patch(BaseClass.prototype, {
                     setup() {
-                        this._super();
+                        super.setup();
                         assert.step("patch2.setup");
                     },
                     fn() {
-                        this._super();
+                        super.fn();
                         assert.step("patch2.fn");
                     },
                 });
@@ -235,31 +222,19 @@ QUnit.module("utils", () => {
                     "patch2.fn",
                 ]);
 
-                unpatch(BaseClass.prototype, "patch1");
+                unpatch1();
 
                 new BaseClass().fn();
 
                 assert.verifySteps(["base.setup", "patch2.setup", "base.fn", "patch2.fn"]);
 
-                unpatch(BaseClass.prototype, "patch2");
+                unpatch2();
 
                 new BaseClass().fn();
 
                 assert.verifySteps(["base.setup", "base.fn"]);
             }
         );
-
-        QUnit.test("unpatch twice the same patch name", async function (assert) {
-            assert.expect(1);
-
-            const A = class {};
-            patch(A.prototype, "patch");
-
-            unpatch(A.prototype, "patch");
-            assert.throws(() => {
-                unpatch(A.prototype, "patch");
-            });
-        });
 
         QUnit.test("patch for specialization", async function (assert) {
             assert.expect(1);
@@ -275,9 +250,9 @@ QUnit.module("utils", () => {
                 }
             };
 
-            patch(A.prototype, "patch", {
+            patch(A.prototype, {
                 setup() {
-                    this._super("patch", ...arguments);
+                    super.setup("patch", ...arguments);
                 },
             });
 
@@ -290,9 +265,9 @@ QUnit.module("utils", () => {
             assert.expect(3);
 
             const BaseClass = makeBaseClass(assert, false);
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super(...arguments);
+                    super.setup(...arguments);
 
                     this.str += "patch";
                     this.arr.push("patch");
@@ -313,7 +288,7 @@ QUnit.module("utils", () => {
 
             assert.notOk(new BaseClass().f);
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 f() {
                     assert.step("patch.f");
                 },
@@ -322,7 +297,7 @@ QUnit.module("utils", () => {
             new BaseClass().f();
             assert.verifySteps(["patch.f"]);
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             assert.notOk(new BaseClass().f);
         });
@@ -335,9 +310,9 @@ QUnit.module("utils", () => {
             BaseClass.staticFn();
             assert.verifySteps(["base.staticFn"]);
 
-            patch(BaseClass, "patch", {
+            const unpatch = patch(BaseClass, {
                 staticFn() {
-                    this._super();
+                    super.staticFn();
                     assert.step("patch.staticFn");
                 },
             });
@@ -345,7 +320,7 @@ QUnit.module("utils", () => {
             BaseClass.staticFn();
             assert.verifySteps(["base.staticFn", "patch.staticFn"]);
 
-            unpatch(BaseClass, "patch");
+            unpatch();
 
             BaseClass.staticFn();
             assert.verifySteps(["base.staticFn"]);
@@ -356,7 +331,7 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass, "patch", {
+            const unpatch = patch(BaseClass, {
                 staticStr: BaseClass.staticStr + "patch",
                 staticArr: [...BaseClass.staticArr, "patch"],
                 staticObj: { ...BaseClass.staticObj, patch: "patch" },
@@ -366,7 +341,7 @@ QUnit.module("utils", () => {
             assert.deepEqual(BaseClass.staticArr, ["base", "patch"]);
             assert.deepEqual(BaseClass.staticObj, { base: "base", patch: "patch" });
 
-            unpatch(BaseClass, "patch");
+            unpatch();
 
             assert.strictEqual(BaseClass.staticStr, "base");
             assert.deepEqual(BaseClass.staticArr, ["base"]);
@@ -379,14 +354,14 @@ QUnit.module("utils", () => {
             const BaseClass = makeBaseClass(assert);
             const instance = new BaseClass();
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     // will not be called
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -394,7 +369,7 @@ QUnit.module("utils", () => {
             instance.fn();
             assert.verifySteps(["base.setup", "base.fn", "patch.fn"]);
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             instance.fn();
             assert.verifySteps(["base.fn"]);
@@ -405,16 +380,16 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert, false);
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 get dynamic() {
-                    return this._super() + "patch";
+                    return super.dynamic + "patch";
                 },
             });
 
             const instance = new BaseClass();
             assert.strictEqual(instance.dynamic, "basepatch");
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
             assert.strictEqual(instance.dynamic, "base");
         });
 
@@ -423,9 +398,9 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert, false);
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 set dynamic(value) {
-                    this._super("patch:" + value);
+                    super.dynamic = "patch:" + value;
                 },
             });
 
@@ -435,7 +410,7 @@ QUnit.module("utils", () => {
             instance.dynamic = "patch";
             assert.strictEqual(instance.dynamic, "patch:patch");
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             instance.dynamic = "base";
             assert.strictEqual(instance.dynamic, "base");
@@ -450,7 +425,7 @@ QUnit.module("utils", () => {
                 BaseClass.prototype,
                 "dynamic"
             );
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 dynamic: "patched",
             });
 
@@ -460,11 +435,11 @@ QUnit.module("utils", () => {
                 value: "patched",
                 writable: true,
                 configurable: true,
-                enumerable: true,
+                enumerable: false, // class properties are not enumerable
             });
             assert.equal(instance.dynamic, "patched");
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             instance.dynamic = "base";
             assert.deepEqual(
@@ -479,11 +454,10 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert, false);
 
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 async asyncFn() {
-                    const _super = this._super;
                     await Promise.resolve();
-                    await _super(...arguments);
+                    await super.asyncFn(...arguments);
                     assert.step("patch.asyncFn");
                 },
             });
@@ -500,20 +474,18 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert, false);
 
-            patch(BaseClass.prototype, "patch1", {
+            patch(BaseClass.prototype, {
                 async asyncFn() {
-                    const _super = this._super;
                     await Promise.resolve();
-                    await _super(...arguments);
+                    await super.asyncFn(...arguments);
                     // also check this binding
                     assert.step(`patch1.${this.str}`);
                 },
             });
-            patch(BaseClass.prototype, "patch2", {
+            patch(BaseClass.prototype, {
                 async asyncFn() {
-                    const _super = this._super;
                     await Promise.resolve();
-                    await _super(...arguments);
+                    await super.asyncFn(...arguments);
                     // also check this binding
                     assert.step(`patch2.${this.str}`);
                 },
@@ -524,6 +496,25 @@ QUnit.module("utils", () => {
             await instance.asyncFn();
 
             assert.verifySteps(["base.asyncFn", "patch1.asyncFn", "patch2.asyncFn"]);
+        });
+
+        QUnit.test("call another super method", async function (assert) {
+            const BaseClass = makeBaseClass(assert);
+            patch(BaseClass.prototype, {
+                setup() {
+                    assert.step("patch.setup");
+                    super.fn();
+                },
+                fn() {
+                    assert.step("patch.fn"); // should not called
+                },
+            });
+
+            new BaseClass();
+            assert.verifySteps([
+                "patch.setup",
+                "base.fn",
+            ]);
         });
 
         QUnit.module("inheritance");
@@ -547,13 +538,13 @@ QUnit.module("utils", () => {
             new Extension().fn();
             assert.verifySteps(["base.setup", "extension.setup", "base.fn", "extension.fn"]);
 
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -574,13 +565,13 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -627,13 +618,13 @@ QUnit.module("utils", () => {
             new Extension().fn();
             assert.verifySteps(["base.setup", "extension.setup", "base.fn", "extension.fn"]);
 
-            patch(Extension.prototype, "patch", {
+            patch(Extension.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -654,13 +645,13 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -676,13 +667,13 @@ QUnit.module("utils", () => {
                 }
             }
 
-            patch(Extension.prototype, "patch", {
+            patch(Extension.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.extension.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.extension.fn");
                 },
             });
@@ -696,6 +687,50 @@ QUnit.module("utils", () => {
                 "base.fn",
                 "patch.fn",
                 "extension.fn",
+                "patch.extension.fn",
+            ]);
+        });
+
+        QUnit.test("patch an inherited patched class 2", async function (assert) {
+            assert.expect(7);
+
+            const BaseClass = makeBaseClass(assert);
+
+            class Extension extends BaseClass {
+                // nothing in the prototype
+            }
+
+            // First patch Extension
+            patch(Extension.prototype, {
+                setup() {
+                    super.setup();
+                    assert.step("patch.extension.setup");
+                },
+                fn() {
+                    super.fn();
+                    assert.step("patch.extension.fn");
+                },
+            });
+
+            // Then patch BaseClass
+            patch(BaseClass.prototype, {
+                setup() {
+                    super.setup();
+                    assert.step("patch.setup");
+                },
+                fn() {
+                    super.fn();
+                    assert.step("patch.fn");
+                },
+            });
+
+            new Extension().fn();
+            assert.verifySteps([
+                "base.setup",
+                "patch.setup",
+                "patch.extension.setup",
+                "base.fn",
+                "patch.fn",
                 "patch.extension.fn",
             ]);
         });
@@ -716,13 +751,13 @@ QUnit.module("utils", () => {
                 }
             }
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -737,7 +772,7 @@ QUnit.module("utils", () => {
                 "extension.fn",
             ]);
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             new Extension().fn();
             assert.verifySteps(["base.setup", "extension.setup", "base.fn", "extension.fn"]);
@@ -759,13 +794,13 @@ QUnit.module("utils", () => {
                 }
             }
 
-            patch(Extension.prototype, "patch", {
+            const unpatch = patch(Extension.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -780,7 +815,7 @@ QUnit.module("utils", () => {
                 "patch.fn",
             ]);
 
-            unpatch(Extension.prototype, "patch");
+            unpatch();
 
             new Extension().fn();
             assert.verifySteps(["base.setup", "extension.setup", "base.fn", "extension.fn"]);
@@ -793,13 +828,13 @@ QUnit.module("utils", () => {
 
                 const BaseClass = makeBaseClass(assert);
 
-                patch(BaseClass.prototype, "patch.BaseClass", {
+                const unpatchBase = patch(BaseClass.prototype, {
                     setup() {
-                        this._super();
+                        super.setup();
                         assert.step("patch.setup");
                     },
                     fn() {
-                        this._super();
+                        super.fn();
                         assert.step("patch.fn");
                     },
                 });
@@ -815,13 +850,13 @@ QUnit.module("utils", () => {
                     }
                 }
 
-                patch(Extension.prototype, "patch.Extension", {
+                const unpatchExtension = patch(Extension.prototype, {
                     setup() {
-                        this._super();
+                        super.setup();
                         assert.step("patch.extension.setup");
                     },
                     fn() {
-                        this._super();
+                        super.fn();
                         assert.step("patch.extension.fn");
                     },
                 });
@@ -838,7 +873,7 @@ QUnit.module("utils", () => {
                     "patch.extension.fn",
                 ]);
 
-                unpatch(BaseClass.prototype, "patch.BaseClass");
+                unpatchBase();
 
                 new Extension().fn();
                 assert.verifySteps([
@@ -850,7 +885,7 @@ QUnit.module("utils", () => {
                     "patch.extension.fn",
                 ]);
 
-                unpatch(Extension.prototype, "patch.Extension");
+                unpatchExtension();
 
                 new Extension().fn();
                 assert.verifySteps(["base.setup", "extension.setup", "base.fn", "extension.fn"]);
@@ -864,13 +899,13 @@ QUnit.module("utils", () => {
 
                 const BaseClass = makeBaseClass(assert);
 
-                patch(BaseClass.prototype, "patch.BaseClass", {
+                const unpatchBase = patch(BaseClass.prototype, {
                     setup() {
-                        this._super();
+                        super.setup();
                         assert.step("patch.setup");
                     },
                     fn() {
-                        this._super();
+                        super.fn();
                         assert.step("patch.fn");
                     },
                 });
@@ -886,13 +921,13 @@ QUnit.module("utils", () => {
                     }
                 }
 
-                patch(Extension.prototype, "patch.Extension", {
+                const unpatchExtension = patch(Extension.prototype, {
                     setup() {
-                        this._super();
+                        super.setup();
                         assert.step("patch.extension.setup");
                     },
                     fn() {
-                        this._super();
+                        super.fn();
                         assert.step("patch.extension.fn");
                     },
                 });
@@ -909,7 +944,7 @@ QUnit.module("utils", () => {
                     "patch.extension.fn",
                 ]);
 
-                unpatch(Extension.prototype, "patch.Extension");
+                unpatchExtension();
 
                 new Extension().fn();
                 assert.verifySteps([
@@ -921,7 +956,7 @@ QUnit.module("utils", () => {
                     "extension.fn",
                 ]);
 
-                unpatch(BaseClass.prototype, "patch.BaseClass");
+                unpatchBase();
 
                 new Extension().fn();
                 assert.verifySteps(["base.setup", "extension.setup", "base.fn", "extension.fn"]);
@@ -940,16 +975,16 @@ QUnit.module("utils", () => {
                 }
             }
 
-            patch(BaseClass, "patch.BaseClass", {
+            const unpatchBase = patch(BaseClass, {
                 staticFn() {
-                    this._super();
+                    super.staticFn();
                     assert.step("patch.staticFn");
                 },
             });
 
-            patch(Extension, "patch.Extension", {
+            const unpatchExtension = patch(Extension, {
                 staticFn() {
-                    this._super();
+                    super.staticFn();
                     assert.step("patch.extension.staticFn");
                 },
             });
@@ -962,12 +997,12 @@ QUnit.module("utils", () => {
                 "patch.extension.staticFn",
             ]);
 
-            unpatch(BaseClass, "patch.BaseClass");
+            unpatchBase();
 
             Extension.staticFn();
             assert.verifySteps(["base.staticFn", "extension.staticFn", "patch.extension.staticFn"]);
 
-            unpatch(Extension, "patch.Extension");
+            unpatchExtension();
 
             Extension.staticFn();
             assert.verifySteps(["base.staticFn", "extension.staticFn"]);
@@ -978,7 +1013,7 @@ QUnit.module("utils", () => {
 
             const BaseClass = makeBaseClass(assert);
 
-            patch(BaseClass, "patch.BaseClass", {
+            const unpatch = patch(BaseClass, {
                 staticStr: BaseClass.staticStr + "patch",
                 staticArr: [...BaseClass.staticArr, "patch"],
                 staticObj: { ...BaseClass.staticObj, patch: "patch" },
@@ -997,7 +1032,7 @@ QUnit.module("utils", () => {
                 extension: "extension",
             });
 
-            unpatch(BaseClass, "patch.BaseClass");
+            unpatch();
 
             // /!\ WARNING /!\
             // If inherit comes after the patch then extension will still have
@@ -1024,7 +1059,7 @@ QUnit.module("utils", () => {
             // /!\ WARNING /!\
             // If patch comes after the inherit then extension won't have
             // the patched data.
-            patch(BaseClass, "patch.BaseClass", {
+            const unpatch = patch(BaseClass, {
                 staticStr: BaseClass.staticStr + "patch",
                 staticArr: [...BaseClass.staticArr, "patch"],
                 staticObj: { ...BaseClass.staticObj, patch: "patch" },
@@ -1034,7 +1069,7 @@ QUnit.module("utils", () => {
             assert.deepEqual(Extension.staticArr, ["base", "extension"]);
             assert.deepEqual(Extension.staticObj, { base: "base", extension: "extension" });
 
-            unpatch(BaseClass, "patch.BaseClass");
+            unpatch();
 
             assert.strictEqual(Extension.staticStr, "baseextension");
             assert.deepEqual(Extension.staticArr, ["base", "extension"]);
@@ -1058,14 +1093,14 @@ QUnit.module("utils", () => {
 
             const instance = new Extension();
 
-            patch(BaseClass.prototype, "patch", {
+            const unpatch = patch(BaseClass.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     // will not be called
                     assert.step("patch.setup");
                 },
                 fn() {
-                    this._super();
+                    super.fn();
                     assert.step("patch.fn");
                 },
             });
@@ -1079,7 +1114,7 @@ QUnit.module("utils", () => {
                 "extension.fn",
             ]);
 
-            unpatch(BaseClass.prototype, "patch");
+            unpatch();
 
             instance.fn();
             assert.verifySteps(["base.fn", "extension.fn"]);
@@ -1097,7 +1132,7 @@ QUnit.module("utils", () => {
             assert.strictEqual(descriptor.configurable, true);
             assert.strictEqual(descriptor.enumerable, false);
 
-            patch(BaseClass.prototype, "patch", {
+            patch(BaseClass.prototype, {
                 // getter declared in object are enumerable
                 get getter() {
                     return true;
@@ -1121,10 +1156,10 @@ QUnit.module("utils", () => {
                 },
             };
 
-            patch(obj, "patch", {
+            const unpatch = patch(obj, {
                 var: obj.var + "patch",
                 fn() {
-                    this._super(...arguments);
+                    super.fn(...arguments);
                     assert.step("patch");
                 },
             });
@@ -1134,7 +1169,7 @@ QUnit.module("utils", () => {
             obj.fn();
             assert.verifySteps(["obj", "patch"]);
 
-            unpatch(obj, "patch");
+            unpatch();
 
             assert.strictEqual(obj.var, "obj");
 
@@ -1153,7 +1188,7 @@ QUnit.module("utils", () => {
             };
 
             const originalFn = obj.fn;
-            patch(obj, "patch", {
+            patch(obj, {
                 fn() {
                     assert.step("patched");
                     originalFn();
@@ -1178,28 +1213,14 @@ QUnit.module("utils", () => {
                     assert.step("a.patch.legacy");
                 },
             });
-            patch(a, "a.patch", {
+            patch(a, {
                 doSomething() {
-                    this._super();
+                    super.doSomething();
                     assert.step("a.patch");
                 },
             });
             a.doSomething();
             assert.verifySteps(["a", "a.patch.legacy", "a.patch"]);
-        });
-
-        QUnit.module("patch 'pure' option");
-
-        QUnit.test("function objects are preserved with 'pure' patch", async function (assert) {
-            const obj1 = { a: () => {} };
-            const obj2 = { a: () => {} };
-            function someValue() {}
-
-            patch(obj1, "patch1", { a: someValue });
-            assert.notStrictEqual(obj1.a, someValue);
-
-            patch(obj2, "patch2", { a: someValue }, { pure: true });
-            assert.strictEqual(obj2.a, someValue);
         });
     });
 });

--- a/addons/web/static/tests/helpers/legacy_env_utils.js
+++ b/addons/web/static/tests/helpers/legacy_env_utils.js
@@ -2,7 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { uiService } from "@web/core/ui/ui_service";
-import { patch, unpatch } from "@web/core/utils/patch";
+import { patch } from "@web/core/utils/patch";
 import { makeLegacyDialogMappingService } from "@web/legacy/utils";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
 import core from "@web/legacy/js/services/core";
@@ -14,9 +14,9 @@ const serviceRegistry = registry.category("services");
 
 export async function makeLegacyDialogMappingTestEnv() {
     const coreBusListeners = [];
-    patch(core.bus, "legacy.core.bus.listeners", {
+    const unpatch = patch(core.bus, {
         on(eventName, thisArg, callback) {
-            this._super(...arguments);
+            super.on(...arguments);
             coreBusListeners.push({ eventName, callback });
         },
     });
@@ -34,7 +34,7 @@ export async function makeLegacyDialogMappingTestEnv() {
         for (const listener of coreBusListeners) {
             core.bus.off(listener.eventName, listener.callback);
         }
-        unpatch(core.bus, "legacy.core.bus.listeners");
+        unpatch();
     });
 
     return {

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -2598,7 +2598,7 @@ export async function makeMockServer(serverData, mockRPC) {
     if (mockRPC) {
         const { loadJS, loadCSS } = assets;
         patchWithCleanup(assets, {
-            loadJS: async function (resource) {
+            async loadJS(resource) {
                 let res = await mockRPC(resource, {});
                 if (res === undefined) {
                     res = await loadJS(resource);
@@ -2607,7 +2607,7 @@ export async function makeMockServer(serverData, mockRPC) {
                 }
                 return res;
             },
-            loadCSS: async function (resource) {
+            async loadCSS(resource) {
                 let res = await mockRPC(resource, {});
                 if (res === undefined) {
                     res = await loadCSS(resource);

--- a/addons/web/static/tests/helpers/session.js
+++ b/addons/web/static/tests/helpers/session.js
@@ -11,7 +11,7 @@ const initialSessionInfo = Object.assign({}, sessionInfo);
 import Session from "@web/legacy/js/core/session";
 import { patch } from "@web/core/utils/patch";
 
-patch(Session.prototype, "web.SessionTestPatch", {
+patch(Session.prototype, {
     async session_reload() {
         for (const key in sessionInfo) {
             delete sessionInfo[key];
@@ -19,6 +19,6 @@ patch(Session.prototype, "web.SessionTestPatch", {
         for (const key in initialSessionInfo) {
             sessionInfo[key] = initialSessionInfo[key];
         }
-        return await this._super(...arguments);
+        return await super.session_reload(...arguments);
     },
 });

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -5,7 +5,7 @@ import { browser } from "@web/core/browser/browser";
 import { isMacOS } from "@web/core/browser/feature_detection";
 import { download } from "@web/core/network/download";
 import { Deferred } from "@web/core/utils/concurrency";
-import { patch, unpatch } from "@web/core/utils/patch";
+import { patch } from "@web/core/utils/patch";
 import { isVisible } from "@web/core/utils/ui";
 import { registerCleanup } from "./cleanup";
 
@@ -129,19 +129,15 @@ export function patchTimeZone(offset) {
     patchWithCleanup(luxon.Settings, { defaultZone: new luxon.FixedOffsetZone.instance(offset) });
 }
 
-let nextId = 1;
-
 /**
  *
  * @param {Object} obj object to patch
  * @param {Object} patchValue the actual patch description
- * @param {{pure?: boolean}} [options]
  */
-export function patchWithCleanup(obj, patchValue, options) {
-    const patchName = `__test_patch_${nextId++}__`;
-    patch(obj, patchName, patchValue, options);
+export function patchWithCleanup(obj, patchValue) {
+    const unpatch = patch(obj, patchValue);
     registerCleanup(() => {
-        unpatch(obj, patchName);
+        unpatch();
     });
 }
 

--- a/addons/web/static/tests/mobile/views/calendar_view_tests.js
+++ b/addons/web/static/tests/mobile/views/calendar_view_tests.js
@@ -236,11 +236,11 @@ QUnit.module("Views", ({ beforeEach }) => {
         patchWithCleanup(CalendarCommonRenderer.prototype, {
             onDateClick(...args) {
                 assert.step("dateClick");
-                return this._super(...args);
+                return super.onDateClick(...args);
             },
             onSelect(...args) {
                 assert.step("select");
-                return this._super(...args);
+                return super.onSelect(...args);
             },
         });
 
@@ -266,20 +266,20 @@ QUnit.module("Views", ({ beforeEach }) => {
     QUnit.test('calendar: select range on "Free Zone" opens quick create', async function (assert) {
         patchWithCleanup(CalendarCommonRenderer.prototype, {
             get options() {
-                return Object.assign({}, this._super(), {
+                return Object.assign({}, super.options, {
                     selectLongPressDelay: 0,
                 });
             },
             onDateClick(info) {
                 assert.step("dateClick");
-                return this._super(info);
+                return super.onDateClick(info);
             },
             onSelect(info) {
                 assert.step("select");
                 const { startStr, endStr } = info;
                 assert.equal(startStr, "2016-12-12T01:00:00+01:00");
                 assert.equal(endStr, "2016-12-12T02:00:00+01:00");
-                return this._super(info);
+                return super.onSelect(info);
             },
         });
 
@@ -307,21 +307,21 @@ QUnit.module("Views", ({ beforeEach }) => {
     QUnit.test("calendar (year): select date range opens quick create", async function (assert) {
         patchWithCleanup(CalendarYearRenderer.prototype, {
             get options() {
-                return Object.assign({}, this._super(), {
+                return Object.assign({}, super.options, {
                     longPressDelay: 0,
                     selectLongPressDelay: 0,
                 });
             },
             onDateClick(info) {
                 assert.step("dateClick");
-                return this._super(info);
+                return super.onDateClick(info);
             },
             onSelect(info) {
                 assert.step("select");
                 const { startStr, endStr } = info;
                 assert.equal(startStr, "2016-02-02");
                 assert.equal(endStr, "2016-02-06"); // end date is exclusive
-                return this._super(info);
+                return super.onSelect(info);
             },
         });
 

--- a/addons/web/static/tests/mobile/views/form_view_tests.js
+++ b/addons/web/static/tests/mobile/views/form_view_tests.js
@@ -436,7 +436,7 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
         let fileInput;
         patchWithCleanup(AttachDocumentWidget.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 fileInput = this.fileInput;
             },
         });

--- a/addons/web/static/tests/mobile/views/widgets/signature_tests.js
+++ b/addons/web/static/tests/mobile/views/widgets/signature_tests.js
@@ -53,11 +53,11 @@ QUnit.module("Widgets", (hooks) => {
         assert.expect(7);
         patchWithCleanup(SignatureWidget.prototype, {
             async onClickSignature() {
-                await this._super.apply(this, arguments);
+                await super.onClickSignature(...arguments);
                 assert.step("onClickSignature");
             },
             async uploadSignature({signatureImage}) {
-                await this._super.apply(this, arguments);
+                await super.uploadSignature(...arguments);
                 assert.step("uploadSignature");
             },
         });

--- a/addons/web/static/tests/search/search_utils_tests.js
+++ b/addons/web/static/tests/search/search_utils_tests.js
@@ -1,11 +1,10 @@
 /** @odoo-module **/
 
 import { defaultLocalization } from "@web/../tests/helpers/mock_services";
-import { patchDate, patchTimeZone } from "@web/../tests/helpers/utils";
+import { patchDate, patchTimeZone, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { Domain } from "@web/core/domain";
 import { localization } from "@web/core/l10n/localization";
 import { translatedTerms } from "@web/core/l10n/translation";
-import { patch, unpatch } from "@web/core/utils/patch";
 import { constructDateDomain } from "@web/search/utils/dates";
 
 const { DateTime } = luxon;
@@ -487,7 +486,7 @@ QUnit.module("Search", () => {
     QUnit.test("Quarter option: custom translation", async function (assert) {
         patchDate(2020, 5, 1, 13, 0, 0);
         const referenceMoment = DateTime.local().setLocale("en");
-        patch(translatedTerms, "add_translations", { Q2: "Deuxième trimestre de l'an de grâce" });
+        patchWithCleanup(translatedTerms, { Q2: "Deuxième trimestre de l'an de grâce" });
         assert.deepEqual(
             constructDateDomain(referenceMoment, "date_field", "date", [
                 "second_quarter",
@@ -501,17 +500,12 @@ QUnit.module("Search", () => {
             },
             "Quarter term should be translated"
         );
-        unpatch(translatedTerms, "add_translations");
     });
 
     QUnit.test("Quarter option: right to left", async function (assert) {
         patchDate(2020, 5, 1, 13, 0, 0);
         const referenceMoment = DateTime.local().setLocale("en");
-        patch(
-            localization,
-            "rtl_localization",
-            Object.assign({}, defaultLocalization, { direction: "rtl" })
-        );
+        patchWithCleanup(localization, { ...defaultLocalization, direction: "rtl" });
         assert.deepEqual(
             constructDateDomain(referenceMoment, "date_field", "date", [
                 "second_quarter",
@@ -525,18 +519,13 @@ QUnit.module("Search", () => {
             },
             "Notation should be right to left"
         );
-        unpatch(localization, "rtl_localization");
     });
 
     QUnit.test("Quarter option: custom translation and right to left", async function (assert) {
         patchDate(2020, 5, 1, 13, 0, 0);
         const referenceMoment = DateTime.local().setLocale("en");
-        patch(
-            localization,
-            "rtl_localization",
-            Object.assign({}, defaultLocalization, { direction: "rtl" })
-        );
-        patch(translatedTerms, "add_translations", { Q2: "2e Trimestre" });
+        patchWithCleanup(localization, { ...defaultLocalization, direction: "rtl" });
+        patchWithCleanup(translatedTerms, { Q2: "2e Trimestre" });
         assert.deepEqual(
             constructDateDomain(referenceMoment, "date_field", "date", [
                 "second_quarter",
@@ -550,8 +539,6 @@ QUnit.module("Search", () => {
             },
             "Quarter term should be translated and notation should be right to left"
         );
-        unpatch(localization, "rtl_localization");
-        unpatch(translatedTerms, "add_translations");
     });
 
     QUnit.skip(

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -100,7 +100,7 @@ function patchOwlApp() {
     patchWithCleanup(App.prototype, {
         destroy() {
             if (!this.destroyed) {
-                this._super(...arguments);
+                super.destroy(...arguments);
                 this.destroyed = true;
             }
         },
@@ -108,7 +108,7 @@ function patchOwlApp() {
             registerCleanup(() => {
                 delete this.constructor.sharedTemplates[name];
             });
-            return this._super(...arguments);
+            return super.addTemplate(...arguments);
         },
     });
 }
@@ -199,8 +199,7 @@ function patchBrowserWithCleanup() {
                     registerCleanup(() => this.close());
                 }
             },
-        },
-        { pure: true }
+        }
     );
 }
 
@@ -226,7 +225,7 @@ function patchLegacyBus() {
     // during a test (e.g. during the deployment of a service)
     patchWithCleanup(LegacyBus.prototype, {
         on() {
-            this._super(...arguments);
+            super.on(...arguments);
             registerCleanup(() => {
                 this.off(...arguments);
             });
@@ -307,7 +306,7 @@ function removeUnwantedAttrsFromTemplates(attrs) {
 
 function patchAssets() {
     const { loadXML, getBundle, loadJS, loadCSS } = assets;
-    patch(assets, "TestAssetsLoadXML", {
+    patch(assets, {
         loadXML: function (templates) {
             console.log("%c[assets] fetch XML ressource", "color: #66e; font-weight: bold;");
             // Clean up new templates that might be added later.
@@ -355,7 +354,7 @@ function patchAssets() {
 function patchEventBus() {
     patchWithCleanup(EventBus.prototype, {
         addEventListener() {
-            this._super(...arguments);
+            super.addEventListener(...arguments);
             registerCleanup(() => this.removeEventListener(...arguments));
         },
     });

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -1089,7 +1089,7 @@ QUnit.module("Views", ({ beforeEach }) => {
         let counter = 0;
         patchWithCleanup(dialogService, {
             start() {
-                const result = this._super(...arguments);
+                const result = super.start(...arguments);
                 return {
                     ...result,
                     add() {

--- a/addons/web/static/tests/views/fields/binary_field_tests.js
+++ b/addons/web/static/tests/views/fields/binary_field_tests.js
@@ -96,13 +96,7 @@ QUnit.module("Fields", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         await makeView({
             serverData,
@@ -169,13 +163,7 @@ QUnit.module("Fields", (hooks) => {
         }
         const MockXHR = makeMockXHR("", send);
 
-        patchWithCleanup(
-            browser,
-            {
-                XMLHttpRequest: MockXHR,
-            },
-            { pure: true }
-        );
+        patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
         await makeView({
             serverData,
@@ -352,13 +340,7 @@ QUnit.module("Fields", (hooks) => {
             }
             const MockXHR = makeMockXHR("", download);
 
-            patchWithCleanup(
-                browser,
-                {
-                    XMLHttpRequest: MockXHR,
-                },
-                { pure: true }
-            );
+            patchWithCleanup(browser, { XMLHttpRequest: MockXHR });
 
             serverData.models.partner.onchanges = {
                 product_id: function (obj) {

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -2475,7 +2475,7 @@ QUnit.module("Fields", (hooks) => {
                     if (this.resModel === "turtle") {
                         assert.step(`${this.resId}`);
                     }
-                    return this._super(...arguments);
+                    return super._update(...arguments);
                 },
             });
 

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -1127,7 +1127,7 @@ QUnit.module("Fields", (hooks) => {
              * @override
              */
             setup() {
-                this._super();
+                super.setup();
                 assert.step(this.props.resModel);
             },
         });

--- a/addons/web/static/tests/views/fields/reference_field_tests.js
+++ b/addons/web/static/tests/views/fields/reference_field_tests.js
@@ -385,7 +385,7 @@ QUnit.module("Fields", (hooks) => {
 
         patchWithCleanup(actionService, {
             start() {
-                const service = this._super(...arguments);
+                const service = super.start(...arguments);
                 return {
                     ...service,
                     doAction(action) {

--- a/addons/web/static/tests/views/fields/signature_field_tests.js
+++ b/addons/web/static/tests/views/fields/signature_field_tests.js
@@ -115,7 +115,7 @@ QUnit.module("Fields", (hooks) => {
     QUnit.test("Set simple field in 'full_name' node option", async function (assert) {
         patchWithCleanup(NameAndSignature.prototype, {
             setup() {
-                this._super.apply(this, arguments);
+                super.setup(...arguments);
                 assert.step(this.props.signature.name);
             },
         });
@@ -159,7 +159,7 @@ QUnit.module("Fields", (hooks) => {
     QUnit.test("Set m2o field in 'full_name' node option", async function (assert) {
         patchWithCleanup(NameAndSignature.prototype, {
             setup() {
-                this._super.apply(this, arguments);
+                super.setup(...arguments);
                 assert.step(this.props.signature.name);
             },
         });

--- a/addons/web/static/tests/views/form/form_compiler_tests.js
+++ b/addons/web/static/tests/views/form/form_compiler_tests.js
@@ -469,7 +469,7 @@ QUnit.module("Form Renderer", (hooks) => {
     QUnit.test("invisible is correctly computed with another t-if", (assert) => {
         patchWithCleanup(FormCompiler.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 this.compilers.push({
                     selector: "myNode",
                     fn: () => {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -6762,7 +6762,7 @@ QUnit.module("Views", (hooks) => {
         let form;
         patchWithCleanup(FormController.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 form = this;
             },
         });
@@ -11105,13 +11105,13 @@ QUnit.module("Views", (hooks) => {
         "form view with inline tree view with optional fields and local storage mock",
         async function (assert) {
             patchWithCleanup(browser.localStorage, {
-                getItem: function (key) {
+                getItem(key) {
                     assert.step("getItem " + key);
-                    return this._super(key);
+                    return super.getItem(key);
                 },
-                setItem: function (key, value) {
+                setItem(key, value) {
                     assert.step("setItem " + key + " to " + value);
-                    return this._super(key, value);
+                    return super.setItem(key, value);
                 },
             });
 
@@ -11189,13 +11189,13 @@ QUnit.module("Views", (hooks) => {
         "form view with tree_view_ref with optional fields and local storage mock",
         async function (assert) {
             patchWithCleanup(browser.localStorage, {
-                getItem: function (key) {
+                getItem(key) {
                     assert.step("getItem " + key);
-                    return this._super(key);
+                    return super.getItem(key);
                 },
-                setItem: function (key, value) {
+                setItem(key, value) {
                     assert.step("setItem " + key + " to " + value);
-                    return this._super(key, value);
+                    return super.setItem(key, value);
                 },
             });
 
@@ -13467,7 +13467,7 @@ QUnit.module("Views", (hooks) => {
         function logLifeCycle(Component) {
             patchWithCleanup(Component.prototype, {
                 setup() {
-                    this._super(...arguments);
+                    super.setup(...arguments);
                     const prefix = `${this.constructor.name} ${this.props.name}`;
                     owl.onMounted(() => assert.step(`[${prefix}] onMounted`));
                     owl.onPatched(() => assert.step(`[${prefix}] onPatched`));
@@ -13524,7 +13524,7 @@ QUnit.module("Views", (hooks) => {
             function logLifeCycle(Component) {
                 patchWithCleanup(Component.prototype, {
                     setup() {
-                        this._super(...arguments);
+                        super.setup(...arguments);
                         const prefix = `${this.constructor.name} ${this.props.name}`;
                         owl.onMounted(() => assert.step(`[${prefix}] onMounted`));
                         owl.onPatched(() => assert.step(`[${prefix}] onPatched`));

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -4224,7 +4224,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.test("single chart rendering on search", async function (assert) {
         patchWithCleanup(GraphRenderer.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 onRendered(() => {
                     assert.step("rendering");
                 });

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -1047,7 +1047,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.test("view button and string interpolated attribute in kanban", async (assert) => {
         patchWithCleanup(ViewButton.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 assert.step(
                     `[${this.props.clickParams["name"]}] className: '${this.props.className}'`
                 );
@@ -13501,7 +13501,7 @@ QUnit.module("Views", (hooks) => {
 
         patchWithCleanup(SampleServer.prototype, {
             async _mockWebReadGroup() {
-                const result = await this._super(...arguments);
+                const result = await super._mockWebReadGroup(...arguments);
                 const { "date:month": dateValue } = result.groups[0];
                 assert.strictEqual(dateValue, "December 2022");
                 return result;

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -9375,7 +9375,7 @@ QUnit.module("Views", (hooks) => {
 
             patchWithCleanup(actionService, {
                 start() {
-                    const result = this._super(...arguments);
+                    const result = super.start(...arguments);
                     return {
                         ...result,
                         doAction(id, { additionalContext }) {
@@ -9458,7 +9458,7 @@ QUnit.module("Views", (hooks) => {
         async function (assert) {
             patchWithCleanup(actionService, {
                 start() {
-                    const result = this._super(...arguments);
+                    const result = super.start(...arguments);
                     return {
                         ...result,
                         doAction(id, { additionalContext }) {
@@ -13181,7 +13181,7 @@ QUnit.module("Views", (hooks) => {
     QUnit.test("list should ask to scroll to top on page changes", async function (assert) {
         patchWithCleanup(ListController.prototype, {
             onPageChangeScroll() {
-                this._super(...arguments);
+                super.onPageChangeScroll(...arguments);
                 assert.step("scroll");
             },
         });
@@ -16039,11 +16039,11 @@ QUnit.module("Views", (hooks) => {
             patchWithCleanup(browser.localStorage, {
                 getItem(key) {
                     assert.step("getItem " + key);
-                    return forceLocalStorage ? '["m2o"]' : this._super(arguments);
+                    return forceLocalStorage ? '["m2o"]' : super.getItem(arguments);
                 },
                 setItem(key, value) {
                     assert.step("setItem " + key + " to " + JSON.stringify(value));
-                    return this._super(arguments);
+                    return super.setItem(arguments);
                 },
             });
 

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog_tests.js
@@ -355,7 +355,7 @@ QUnit.module("ViewDialogs", (hooks) => {
 
         patchWithCleanup(listView.Controller.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 useSetupAction({
                     getContext: () => ({ shouldBeInFilterContext: true }),
                 });

--- a/addons/web/static/tests/views/view_tests.js
+++ b/addons/web/static/tests/views/view_tests.js
@@ -122,7 +122,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,false,toy"]);
                 assert.deepEqual(fields, {});
@@ -160,7 +160,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,1,toy"]);
                 assert.deepEqual(fields, {});
@@ -197,7 +197,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,1,toy"]);
                 assert.deepEqual(fields, {});
@@ -238,7 +238,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { arch, fields, info } = this.props;
                     assert.strictEqual(arch, serverData.views["animal,false,toy"]);
                     assert.deepEqual(fields, {});
@@ -281,7 +281,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,1,toy"]);
                 assert.deepEqual(fields, {});
@@ -327,7 +327,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, `<toy>Specific arch content</toy>`);
                 assert.deepEqual(fields, {});
@@ -360,7 +360,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { arch, fields, info } = this.props;
                 assert.strictEqual(arch, serverData.views["animal,false,toy"]);
                 assert.deepEqual(fields, {});
@@ -400,7 +400,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { arch, fields, info } = this.props;
                     assert.strictEqual(arch, `<toy>Specific arch content</toy>`);
                     assert.deepEqual(fields, {});
@@ -443,7 +443,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { arch, fields, info } = this.props;
                     assert.strictEqual(arch, `<toy>Specific arch content</toy>`);
                     assert.deepEqual(fields, {});
@@ -479,7 +479,7 @@ QUnit.module("Views", (hooks) => {
         const ToyController = viewRegistry.get("toy").Controller;
         patchWithCleanup(ToyController.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 const { irFilters, searchViewArch, searchViewFields, searchViewId } =
                     this.props.info;
                 assert.strictEqual(searchViewArch, serverData.views["animal,false,search"]);
@@ -523,7 +523,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { irFilters, searchViewArch, searchViewFields, searchViewId } =
                         this.props.info;
                     assert.strictEqual(searchViewArch, `<search/>`);
@@ -563,7 +563,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { irFilters, searchViewArch, searchViewFields, searchViewId } =
                         this.props.info;
                     assert.strictEqual(searchViewArch, `<search/>`);
@@ -602,7 +602,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { irFilters, searchViewArch, searchViewFields, searchViewId } =
                         this.props.info;
                     assert.strictEqual(searchViewArch, `<search/>`);
@@ -663,7 +663,7 @@ QUnit.module("Views", (hooks) => {
             const ToyController = viewRegistry.get("toy").Controller;
             patchWithCleanup(ToyController.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     const { irFilters, searchViewArch, searchViewFields, searchViewId } =
                         this.props.info;
                     assert.strictEqual(searchViewArch, `<search/>`);

--- a/addons/web/static/tests/views/widgets/attach_document_tests.js
+++ b/addons/web/static/tests/views/widgets/attach_document_tests.js
@@ -45,7 +45,7 @@ QUnit.module("Widgets", (hooks) => {
         let fileInput;
         patchWithCleanup(AttachDocumentWidget.prototype, {
             setup() {
-                this._super();
+                super.setup();
                 fileInput = this.fileInput;
             },
         });
@@ -103,7 +103,7 @@ QUnit.module("Widgets", (hooks) => {
             let fileInput;
             patchWithCleanup(AttachDocumentWidget.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     fileInput = this.fileInput;
                 },
             });

--- a/addons/web/static/tests/views/widgets/signature_tests.js
+++ b/addons/web/static/tests/views/widgets/signature_tests.js
@@ -54,7 +54,7 @@ QUnit.module("Widgets", (hooks) => {
 
         patchWithCleanup(NameAndSignature.prototype, {
             setup() {
-                this._super.apply(this, arguments);
+                super.setup(...arguments);
                 assert.strictEqual(this.props.signature.name, "");
             },
         });
@@ -96,7 +96,7 @@ QUnit.module("Widgets", (hooks) => {
     QUnit.test("Signature widget: full_name option", async function (assert) {
         patchWithCleanup(NameAndSignature.prototype, {
             setup() {
-                this._super.apply(this, arguments);
+                super.setup(...arguments);
                 assert.step(this.props.signature.name);
             },
         });

--- a/addons/web/static/tests/webclient/actions/close_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/close_action_tests.js
@@ -101,7 +101,7 @@ QUnit.module("ActionManager", (hooks) => {
         let form;
         patchWithCleanup(formView.Controller.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 form = this;
             },
         });
@@ -123,7 +123,7 @@ QUnit.module("ActionManager", (hooks) => {
         let list;
         patchWithCleanup(listView.Controller.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 list = this;
             },
         });
@@ -156,7 +156,7 @@ QUnit.module("ActionManager", (hooks) => {
             let list;
             patchWithCleanup(listView.Controller.prototype, {
                 setup() {
-                    this._super(...arguments);
+                    super.setup(...arguments);
                     list = this;
                 },
             });

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -506,11 +506,11 @@ QUnit.module("ActionManager", (hooks) => {
         patchWithCleanup(browser.sessionStorage, {
             getItem(k) {
                 assert.step(`getItem session ${k}`);
-                return this._super(k);
+                return super.getItem(k);
             },
             setItem(k, v) {
                 assert.step(`setItem session ${k}`);
-                return this._super(k, v);
+                return super.setItem(k, v);
             },
         });
         const mockRPC = async (route, { method, kwargs }) => {
@@ -866,7 +866,7 @@ QUnit.module("ActionManager", (hooks) => {
             patchWithCleanup(browser.sessionStorage, {
                 getItem(k) {
                     assert.step(`getItem session ${k}`);
-                    return this._super(k);
+                    return super.getItem(k);
                 },
             });
 

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -95,7 +95,7 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("properly handle case when action id does not exist", async (assert) => {
         assert.expect(2);
         const webClient = await createWebClient({ serverData });
-        patchWithCleanup(window, { console: hushConsole }, { pure: true });
+        patchWithCleanup(window, { console: hushConsole });
         patchWithCleanup(webClient.env.services.notification, {
             add(message) {
                 assert.strictEqual(message, "No action with id '4448' could be found");
@@ -246,7 +246,7 @@ QUnit.module("ActionManager", (hooks) => {
         let list;
         patchWithCleanup(listView.Controller.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 list = this;
             },
         });
@@ -418,7 +418,7 @@ QUnit.module("ActionManager", (hooks) => {
 
             patchWithCleanup(ClientAction.prototype, {
                 setup() {
-                    this._super();
+                    super.setup();
                     onWillStart(() => {
                         return def;
                     });

--- a/addons/web/static/tests/webclient/actions/reports/report_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/reports/report_action_tests.js
@@ -160,7 +160,7 @@ QUnit.module("ActionManager", (hooks) => {
             // attribute is removed right after)
             patchWithCleanup(ReportAction.prototype, {
                 setup() {
-                    this._super(...arguments);
+                    super.setup(...arguments);
                     this.env.services.rpc(this.reportUrl);
                     this.reportUrl = "about:blank";
                 },
@@ -218,7 +218,7 @@ QUnit.module("ActionManager", (hooks) => {
         // attribute is removed right after)
         patchWithCleanup(ReportAction.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 this.env.services.rpc(this.reportUrl);
                 this.reportUrl = "about:blank";
             },
@@ -350,7 +350,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         patchWithCleanup(ReportAction.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 this.env.services.rpc(this.reportUrl);
                 this.reportUrl = "about:blank";
             },
@@ -387,7 +387,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         patchWithCleanup(ReportAction.prototype, {
             init() {
-                this._super(...arguments);
+                super.init(...arguments);
                 this.reportUrl = "about:blank";
             },
         });

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -317,7 +317,7 @@ QUnit.module("ActionManager", (hooks) => {
         const errorDialogOpened = makeDeferred();
         patchWithCleanup(ClientErrorDialog.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 onMounted(() => errorDialogOpened.resolve());
             },
         });

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -1429,7 +1429,7 @@ QUnit.module("ActionManager", (hooks) => {
         patchWithCleanup(browser, { setTimeout: (fn) => fn() });
         patchWithCleanup(listView.Controller.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 useSetupAction({
                     getContext: () => ({ shouldBeInFilterContext: true }),
                 });

--- a/addons/web/static/tests/webclient/barcode/barcode_scanner_tests.js
+++ b/addons/web/static/tests/webclient/barcode/barcode_scanner_tests.js
@@ -72,13 +72,13 @@ QUnit.test("Barcode scanner crop overlay", async (assert) => {
 
     patchWithCleanup(BarcodeDialog.prototype, {
         async isVideoReady() {
-            return this._super(...arguments).then(() => {
+            return super.isVideoReady(...arguments).then(() => {
                 videoReady.resolve();
             });
         },
         onResize(overlayInfo) {
             assert.step(JSON.stringify(overlayInfo));
-            return this._super(...arguments);
+            return super.onResize(...arguments);
         },
     });
 

--- a/addons/web/static/tests/webclient/loading_indicator_tests.js
+++ b/addons/web/static/tests/webclient/loading_indicator_tests.js
@@ -3,7 +3,6 @@
 import { browser as originalBrowser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { uiService } from "@web/core/ui/ui_service";
-import { patch, unpatch } from "@web/core/utils/patch";
 import { LoadingIndicator } from "@web/webclient/loading_indicator/loading_indicator";
 import { makeTestEnv } from "../helpers/mock_env";
 import {
@@ -131,7 +130,7 @@ QUnit.test("displays the loading indicator for multi rpc in debug mode", async (
 
 QUnit.test("loading indicator blocks UI", async (assert) => {
     const env = await makeTestEnv();
-    patch(originalBrowser, "mock.settimeout", {
+    patchWithCleanup(originalBrowser, {
         setTimeout: async (callback, delay) => {
             assert.step(`set timeout ${delay}`);
             await Promise.resolve();
@@ -151,7 +150,6 @@ QUnit.test("loading indicator blocks UI", async (assert) => {
     env.bus.trigger("RPC:RESPONSE", payload(1));
     await nextTick();
     assert.verifySteps(["set timeout 250", "set timeout 3000", "block", "unblock"]);
-    unpatch(originalBrowser, "mock.settimeout");
 });
 
 QUnit.test("loading indicator doesn't unblock ui if it didn't block it", async (assert) => {

--- a/addons/web/static/tests/webclient/navbar_tests.js
+++ b/addons/web/static/tests/webclient/navbar_tests.js
@@ -231,7 +231,7 @@ QUnit.test("navbar updates after adding a systray item", async (assert) => {
                     systrayRegistry.add("addon.myitem2", { Component: MyItem2 });
                 }
             });
-            this._super();
+            super.setup();
         },
     });
 

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -1623,7 +1623,7 @@ QUnit.module("SettingsFormView", (hooks) => {
         let compiled = undefined;
         patchWithCleanup(SettingsFormCompiler.prototype, {
             compile() {
-                const _compiled = this._super(...arguments);
+                const _compiled = super.compile(...arguments);
                 compiled = _compiled;
                 return _compiled;
             },
@@ -1665,7 +1665,7 @@ QUnit.module("SettingsFormView", (hooks) => {
         let compiled = undefined;
         patchWithCleanup(SettingsFormCompiler.prototype, {
             compile() {
-                const _compiled = this._super(...arguments);
+                const _compiled = super.compile(...arguments);
                 compiled = _compiled;
                 return _compiled;
             },

--- a/addons/web/static/tests/webclient/webclient_tests.js
+++ b/addons/web/static/tests/webclient/webclient_tests.js
@@ -62,7 +62,7 @@ QUnit.test("control-click propagation stopped on <a href/>", async (assert) => {
     patchWithCleanup(WebClient.prototype, {
         /** @param {MouseEvent} ev */
         onGlobalClick(ev) {
-            this._super(ev);
+            super.onGlobalClick(ev);
             if (ev.ctrlKey) {
                 assert.ok(
                     ev.defaultPrevented === false,

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -11,7 +11,7 @@ var promiseJsAssets;
  * Add option (inIframe) to load Wysiwyg in an iframe.
  **/
 
-patch(Wysiwyg.prototype, 'wysiwyg_iframe.js', {
+patch(Wysiwyg.prototype, {
     /**
      * Add options to load Wysiwyg in an iframe.
      *
@@ -19,7 +19,7 @@ patch(Wysiwyg.prototype, 'wysiwyg_iframe.js', {
      * @param {boolean} options.inIframe
      **/
     init() {
-        this._super();
+        super.init();
         if (this.options.inIframe) {
             this._onUpdateIframeId = 'onLoad_' + this.id;
         }
@@ -28,14 +28,13 @@ patch(Wysiwyg.prototype, 'wysiwyg_iframe.js', {
      * @override
      **/
     async startEdition() {
-        const _super = this._super.bind(this);
         if (!this.options.inIframe) {
-            return _super();
+            return super.startEdition();
         } else {
             this.defAsset = this._getAssets();
             await this.defAsset;
             await this._loadIframe();
-            return _super();
+            return super.startEdition();
         }
     },
 
@@ -47,7 +46,7 @@ patch(Wysiwyg.prototype, 'wysiwyg_iframe.js', {
      * @override
      **/
     _getEditorOptions() {
-        const options = this._super.apply(this, arguments);
+        const options = super._getEditorOptions(...arguments);
         if (!("getContextFromParentRect" in options)) {
             options.getContextFromParentRect = () => {
                 return this.$iframe && this.$iframe.length ? this.$iframe[0].getBoundingClientRect() : { top: 0, left: 0 };
@@ -151,7 +150,7 @@ patch(Wysiwyg.prototype, 'wysiwyg_iframe.js', {
         if (this.options.inIframe) {
             return this.snippetsMenu.appendTo(this.$utilsZone);
         } else {
-            return this._super.apply(this, arguments);
+            return super._insertSnippetMenu(...arguments);
         }
     },
     /**
@@ -177,7 +176,7 @@ patch(Wysiwyg.prototype, 'wysiwyg_iframe.js', {
      */
     _bindOnBlur() {
         if (!this.options.inIframe) {
-            this._super.apply(this, arguments);
+            super._bindOnBlur(...arguments);
         } else {
             this.$iframe[0].contentWindow.addEventListener('blur', this._onBlur);
         }

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -129,8 +129,8 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         let togglePromiseId = 0;
         const writePromise = makeDeferred();
         patchWithCleanup(HtmlField.prototype, {
-            setup: function () {
-                this._super(...arguments);
+            setup() {
+                super.setup(...arguments);
                 onRendered(() => {
                     if (codeViewState !== this.state.showCodeView) {
                         togglePromises[togglePromiseId].resolve();
@@ -297,7 +297,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         // Patch to get the controller instance.
         patchWithCleanup(FormController.prototype, {
             setup() {
-                this._super(...arguments);
+                super.setup(...arguments);
                 formController = this;
             }
         });
@@ -306,7 +306,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const htmlFieldPromise = makeDeferred();
         patchWithCleanup(HtmlField.prototype, {
             async startWysiwyg() {
-                await this._super(...arguments);
+                await super.startWysiwyg(...arguments);
                 await nextTick();
                 htmlFieldPromise.resolve(this);
             }
@@ -460,7 +460,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const htmlFieldPromise = makeDeferred();
         patchWithCleanup(HtmlField.prototype, {
             async startWysiwyg() {
-                await this._super(...arguments);
+                await super.startWysiwyg(...arguments);
                 await nextTick();
                 htmlFieldPromise.resolve(this);
             }
@@ -471,7 +471,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         };
         patchWithCleanup(OdooEditor.prototype, {
             historyStep() {
-                this._super(...arguments);
+                super.historyStep(...arguments);
                 if (historyStepPromise) {
                     historyStepPromise.resolve();
                 }
@@ -523,7 +523,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const htmlFieldPromise = makeDeferred();
         patchWithCleanup(HtmlField.prototype, {
             async startWysiwyg() {
-                await this._super(...arguments);
+                await super.startWysiwyg(...arguments);
                 await nextTick();
                 htmlFieldPromise.resolve(this);
             }
@@ -534,7 +534,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         };
         patchWithCleanup(OdooEditor.prototype, {
             historyStep() {
-                this._super(...arguments);
+                super.historyStep(...arguments);
                 if (historyStepPromise) {
                     historyStepPromise.resolve();
                 }
@@ -586,7 +586,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         const htmlFieldPromise = makeDeferred();
         patchWithCleanup(HtmlField.prototype, {
             async startWysiwyg() {
-                await this._super(...arguments);
+                await super.startWysiwyg(...arguments);
                 await nextTick();
                 htmlFieldPromise.resolve(this);
             }
@@ -597,7 +597,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
         };
         patchWithCleanup(OdooEditor.prototype, {
             historyStep() {
-                this._super(...arguments);
+                super.historyStep(...arguments);
                 if (historyStepPromise) {
                     historyStepPromise.resolve();
                 }

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -95,7 +95,7 @@ const SNIPPETS_TEMPLATE = `
         </div>
     </div>`;
 
-coreUtils.patch(MockServer.prototype, 'web_editor', {
+coreUtils.patch(MockServer.prototype, {
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -114,7 +114,7 @@ coreUtils.patch(MockServer.prototype, 'web_editor', {
                 return SNIPPETS_TEMPLATE;
             }
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });
 MockServerLegacy.include({

--- a/addons/web_tour/static/tests/tour_service_tests.js
+++ b/addons/web_tour/static/tests/tour_service_tests.js
@@ -58,7 +58,7 @@ QUnit.module("Tour service", (hooks) => {
         let macroEngines = [];
         patchWithCleanup(MacroEngine.prototype, {
             start() {
-                this._super(...arguments);
+                super.start(...arguments);
                 macroEngines.push(this);
             }
         });

--- a/addons/website/static/src/components/media_dialog/image_selector.js
+++ b/addons/website/static/src/components/media_dialog/image_selector.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { ImageSelector } from '@web_editor/components/media_dialog/image_selector';
 
-patch(ImageSelector.prototype, 'media_dialog_website', {
+patch(ImageSelector.prototype, {
     get attachmentsDomain() {
-        const domain = this._super();
+        const domain = super.attachmentsDomain;
         domain.push('|', ['url', '=', false], '!', ['url', '=like', '/web/image/website.%']);
         domain.push(['key', '=', false]);
         return domain;

--- a/addons/website/static/src/components/wysiwyg_adapter/toolbar_patch.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/toolbar_patch.js
@@ -3,11 +3,11 @@
 import { patch } from "@web/core/utils/patch";
 import { Toolbar } from "@web_editor/js/editor/toolbar";
 
-patch(Toolbar.props, 'toolbar_patch.js', {
+patch(Toolbar.props, {
     ...Toolbar.props,
     showAnimateText: { type: Boolean, optional: true },
 });
-patch(Toolbar.defaultProps, 'toolbar_patch.js', {
+patch(Toolbar.defaultProps, {
     ...Toolbar.defaultProps,
     showAnimateText: false,
 });

--- a/addons/website/static/src/js/editor/editor.js
+++ b/addons/website/static/src/js/editor/editor.js
@@ -5,9 +5,9 @@ import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
 import wUtils from "@website/js/utils";
 
-patch(LinkDialog.prototype, "editor.js", {
+patch(LinkDialog.prototype, {
     setup() {
-        this._super(...arguments);
+        super.setup(...arguments);
         this.rpc = useService("rpc");
     },
     /**
@@ -15,11 +15,11 @@ patch(LinkDialog.prototype, "editor.js", {
      *
      * @override
      */
-    start: async function () {
+    async start() {
         const options = {
             body: this.$link && this.$link[0].ownerDocument.body,
         };
-        const result = await this._super.apply(this, arguments);
+        const result = await super.start(...arguments);
         // wUtils.autocompleteWithPages rely on a widget that has a _rpc and
         // trigger_up method.
         const fakeWidget = {

--- a/addons/website/static/src/js/editor/widget_link.js
+++ b/addons/website/static/src/js/editor/widget_link.js
@@ -9,11 +9,11 @@ import { debounce } from "@web/core/utils/timing";
 
 const LINK_DEBOUNCE = 1000;
 
-patch(LinkTools.prototype, 'website/static/src/js/editor/widget_link.js', {
+patch(LinkTools.prototype, {
     setup() {
         this.rpc = useService('rpc');
         this.rpc = this.env.services.rpc;
-        return this._super.apply(this, arguments);
+        return super.setup(...arguments);
     },
     /**
      *
@@ -21,7 +21,7 @@ patch(LinkTools.prototype, 'website/static/src/js/editor/widget_link.js', {
      */
     onWillStart() {
         this._adaptPageAnchor = debounce(this._adaptPageAnchor, LINK_DEBOUNCE);
-        return this._super.apply(this, arguments);
+        return super.onWillStart(...arguments);
     },
     /**
      * Allows the URL input to propose existing website pages.
@@ -29,7 +29,7 @@ patch(LinkTools.prototype, 'website/static/src/js/editor/widget_link.js', {
      * @override
      */
     async start() {
-        var def = await this._super.apply(this, arguments);
+        var def = await super.start(...arguments);
         const options = {
             position: {
                 collision: 'flip flipfit',
@@ -105,7 +105,7 @@ patch(LinkTools.prototype, 'website/static/src/js/editor/widget_link.js', {
      * @override
      */
     _onURLInput() {
-        this._super.apply(this, arguments);
+        super._onURLInput(...arguments);
         this._adaptPageAnchor();
     },
     /**
@@ -122,6 +122,6 @@ patch(LinkTools.prototype, 'website/static/src/js/editor/widget_link.js', {
             }
             $urlInput.val(urlInputValue + anchorValue);
         }
-        this._super(...arguments);
+        super._onPickSelectOption(...arguments);
     },
 });

--- a/addons/website/static/src/js/widgets/link_popover_widget.js
+++ b/addons/website/static/src/js/widgets/link_popover_widget.js
@@ -8,7 +8,7 @@ import { LinkPopoverWidget } from '@web_editor/js/wysiwyg/widgets/link_popover_w
 
 
 
-patch(LinkPopoverWidget.prototype, 'website_link_popower_widget', {
+patch(LinkPopoverWidget.prototype, {
     /**
      * @override
      */
@@ -24,7 +24,7 @@ patch(LinkPopoverWidget.prototype, 'website_link_popower_widget', {
         }
         this.$el.on('click', '.o_we_full_url, .o_we_url_link', this._onPreviewLinkClick.bind(this));
 
-        return this._super(...arguments);
+        return super.start(...arguments);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/services/chat_window_service_patch.js
+++ b/addons/website/static/src/services/chat_window_service_patch.js
@@ -4,8 +4,8 @@ import { ChatWindowService } from "@mail/core/common/chat_window_service";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(ChatWindowService.prototype, "website/chat_window_service", {
+patch(ChatWindowService.prototype, {
     get visible() {
-        return this.env.services.website?.context.isPreviewOpen ? [] : this._super();
+        return this.env.services.website?.context.isPreviewOpen ? [] : super.visible;
     },
 });

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -191,7 +191,7 @@ wTourUtils.registerWebsitePreviewTour('edit_link_popover', {
         extra_trigger: 'iframe .o_edit_menu_popover a.o_we_full_url[target="_blank"]',
         run: (actions) => {
             // We do not want to open a link in a tour
-            patch(browser, 'window_open_action', {
+            patch(browser, {
                 open: (url) => {
                     if (window.location.hostname === url.hostname && url.pathname.startsWith('/@/')) {
                         document.querySelector('body').classList.add('new_backend_window_opened');

--- a/addons/website/static/tests/website_service_mock.js
+++ b/addons/website/static/tests/website_service_mock.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { patch } from '@web/core/utils/patch';
+import { patch } from "@web/core/utils/patch";
 import { registry } from '@web/core/registry';
 import { utils, clearRegistryWithCleanup } from '@web/../tests/helpers/mock_env';
 
@@ -40,7 +40,7 @@ function makeFakeWebsiteCustomMenusService() {
 }
 
 const serviceRegistry = registry.category('services');
-patch(utils, 'website_test_registries', {
+patch(utils, {
     prepareRegistriesWithCleanup() {
         prepareRegistriesWithCleanup(...arguments);
         serviceRegistry.add('website', makeFakeWebsiteService());

--- a/addons/website_blog/static/src/js/wysiwyg.js
+++ b/addons/website_blog/static/src/js/wysiwyg.js
@@ -4,19 +4,19 @@ import { WysiwygAdapterComponent } from '@website/components/wysiwyg_adapter/wys
 import "@website/js/editor/snippets.options";
 import { patch } from "@web/core/utils/patch";
 
-patch(WysiwygAdapterComponent.prototype, 'website_blog/static/src/js/wysiwyg.js', {
+patch(WysiwygAdapterComponent.prototype, {
     /**
      * @override
      */
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         this.blogTagsPerBlogPost = {};
     },
     /**
      * @override
      */
     async startEdition() {
-        await this._super(...arguments);
+        await super.startEdition(...arguments);
         $('.js_tweet, .js_comment').off('mouseup').trigger('mousedown');
     },
 
@@ -28,7 +28,7 @@ patch(WysiwygAdapterComponent.prototype, 'website_blog/static/src/js/wysiwyg.js'
      * @override
      */
     async _saveViewBlocks() {
-        const ret = await this._super(...arguments);
+        const ret = await super._saveViewBlocks(...arguments);
         await this._saveBlogTags(); // Note: important to be called after save otherwise cleanForSave is not called before
         return ret;
     },
@@ -77,7 +77,7 @@ patch(WysiwygAdapterComponent.prototype, 'website_blog/static/src/js/wysiwyg.js'
             this._onSetBlogPostUpdatedTags(ev);
             return;
         } else {
-            return this._super(...arguments);
+            return super._trigger_up(...arguments);
         }
     },
 });

--- a/addons/website_livechat/static/src/core/channel_member_model_patch.js
+++ b/addons/website_livechat/static/src/core/channel_member_model_patch.js
@@ -3,11 +3,11 @@
 import { ChannelMember } from "@mail/core/common/channel_member_model";
 import { patch } from "@web/core/utils/patch";
 
-patch(ChannelMember.prototype, "website_livechat", {
+patch(ChannelMember.prototype, {
     getLangName() {
         if (this.persona.is_public && this.thread.visitor?.langName) {
             return this.thread.visitor.langName;
         }
-        return this._super(this);
+        return super.getLangName();
     },
 });

--- a/addons/website_livechat/static/src/core/persona_model_patch.js
+++ b/addons/website_livechat/static/src/core/persona_model_patch.js
@@ -5,7 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { sprintf } from "@web/core/utils/strings";
 
-patch(Persona.prototype, "website_livechat", {
+patch(Persona.prototype, {
     get countryFlagUrl() {
         const country = this.partner?.country ?? this.country;
         return country
@@ -16,6 +16,6 @@ patch(Persona.prototype, "website_livechat", {
         if (this.type === "visitor" && !this.name) {
             return sprintf(_t("Visitor #%s"), this.id);
         }
-        return this._super();
+        return super.nameOrDisplayName;
     },
 });

--- a/addons/website_livechat/static/src/core/persona_service_patch.js
+++ b/addons/website_livechat/static/src/core/persona_service_patch.js
@@ -3,9 +3,9 @@
 import { PersonaService } from "@mail/core/common/persona_service";
 import { patch } from "@web/core/utils/patch";
 
-patch(PersonaService.prototype, "website_livechat", {
+patch(PersonaService.prototype, {
     update(persona, data) {
-        this._super(persona, data);
+        super.update(persona, data);
         if (persona.type === "visitor") {
             persona.history = data.history ?? persona.history;
             persona.isConnected = data.is_connected ?? persona.isConnected;

--- a/addons/website_livechat/static/src/core/thread_service_patch.js
+++ b/addons/website_livechat/static/src/core/thread_service_patch.js
@@ -4,9 +4,9 @@ import { DEFAULT_AVATAR } from "@mail/core/common/persona_service";
 import { ThreadService } from "@mail/core/common/thread_service";
 import { patch } from "@web/core/utils/patch";
 
-patch(ThreadService.prototype, "website_livechat", {
+patch(ThreadService.prototype, {
     update(thread, data) {
-        this._super(thread, data);
+        super.update(thread, data);
         if (data?.visitor) {
             thread.visitor = this.personaService.insert({
                 ...data.visitor,
@@ -26,6 +26,6 @@ patch(ThreadService.prototype, "website_livechat", {
                   )}/avatar_128`
                 : DEFAULT_AVATAR;
         }
-        return this._super(persona, thread);
+        return super.avatarUrl(persona, thread);
     },
 });

--- a/addons/website_livechat/static/src/embed/livechat_button_patch.js
+++ b/addons/website_livechat/static/src/embed/livechat_button_patch.js
@@ -4,7 +4,7 @@ import { LivechatButton } from "@im_livechat/embed/core_ui/livechat_button";
 
 import { patch } from "@web/core/utils/patch";
 
-patch(LivechatButton.prototype, "website_livechat", {
+patch(LivechatButton.prototype, {
     get text() {
         return "";
     },

--- a/addons/website_livechat/static/src/embed/livechat_service_patch.js
+++ b/addons/website_livechat/static/src/embed/livechat_service_patch.js
@@ -3,9 +3,9 @@
 import { LivechatService } from "@im_livechat/embed/core/livechat_service";
 import { patch } from "@web/core/utils/patch";
 
-patch(LivechatService.prototype, "website_livechat/livechat_service", {
+patch(LivechatService.prototype, {
     setup(env, services) {
-        this._super(env, services);
+        super.setup(env, services);
         if (this.options?.chat_request_session) {
             this.updateSession(this.options.chat_request_session);
         }
@@ -14,7 +14,7 @@ patch(LivechatService.prototype, "website_livechat/livechat_service", {
     get displayWelcomeMessage() {
         return (
             (this.thread.messages.length === 0 || this.thread?.messages[0]?.isSelfAuthored) &&
-            this._super()
+            super.displayWelcomeMessage
         );
     },
 });

--- a/addons/website_livechat/static/tests/helpers/mock_server/controllers/dataset.js
+++ b/addons/website_livechat/static/tests/helpers/mock_server/controllers/dataset.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "website_livechat/controllers/dataset", {
+patch(MockServer.prototype, {
     /**
      * @override
      */
@@ -15,6 +15,6 @@ patch(MockServer.prototype, "website_livechat/controllers/dataset", {
         ) {
             return this._mockWebsiteVisitorActionSendChatRequest(args[0]);
         }
-        return this._super(...arguments);
+        return super._performRPC(...arguments);
     },
 });

--- a/addons/website_livechat/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/website_livechat/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -5,14 +5,14 @@ import "@im_livechat/../tests/helpers/mock_server/models/discuss_channel"; // en
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "website_livechat/models/discuss_channel", {
+patch(MockServer.prototype, {
     /**
      * Overrides to add visitor information to livechat channels.
      *
      * @override
      */
     _mockDiscussChannelChannelInfo(ids) {
-        const channelInfos = this._super(...arguments);
+        const channelInfos = super._mockDiscussChannelChannelInfo(...arguments);
         for (const channelInfo of channelInfos) {
             const channel = this.getRecords("discuss.channel", [["id", "=", channelInfo.id]])[0];
             if (channel.channel_type === "livechat" && channel.livechat_visitor_id) {

--- a/addons/website_livechat/static/tests/helpers/mock_server/models/website_visitor.js
+++ b/addons/website_livechat/static/tests/helpers/mock_server/models/website_visitor.js
@@ -3,7 +3,7 @@
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
-patch(MockServer.prototype, "website_livechat/models/website_visitor", {
+patch(MockServer.prototype, {
     /**
      * @private
      * @param {integer[]} ids

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -3,10 +3,10 @@
 import { patch } from "@web/core/utils/patch";
 import { RATING, LivechatService } from "@im_livechat/embed/core/livechat_service";
 
-patch(LivechatService.prototype, "website_livechat", {
+patch(LivechatService.prototype, {
     sendFeedback() {
         document.body.classList.add("feedback_sent");
-        return this._super(...arguments);
+        return super.sendFeedback(...arguments);
     },
 });
 

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -13,12 +13,12 @@ import "@website/js/editor/snippets.options";
 import { patch } from "@web/core/utils/patch";
 
 const { onRendered } = owl;
-patch(WysiwygAdapterComponent.prototype, 'website_sale/static/src/js/website_sale.editor.js', {
+patch(WysiwygAdapterComponent.prototype, {
     /**
      * @override
      */
     async init() {
-        await this._super(...arguments);
+        await super.init(...arguments);
 
         let ribbons = [];
         if (this._isProductListPage()) {
@@ -40,9 +40,8 @@ patch(WysiwygAdapterComponent.prototype, 'website_sale/static/src/js/website_sal
      * @override
      */
     async _saveViewBlocks() {
-        const _super = this._super.bind(this);
         await this._saveRibbons();
-        return _super(...arguments);
+        return super._saveViewBlocks(...arguments);
     },
 
     //--------------------------------------------------------------------------
@@ -206,7 +205,7 @@ patch(WysiwygAdapterComponent.prototype, 'website_sale/static/src/js/website_sal
         if (methods[ev.name]) {
             return methods[ev.name](ev);
         } else {
-            return this._super(...arguments);
+            return super._trigger_up(...arguments);
         }
     }
 });

--- a/addons/website_sale_product_configurator/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale_product_configurator/static/tests/tours/website_sale_buy.js
@@ -7,9 +7,9 @@ import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 import "@website_sale/../tests/tours/website_sale_buy";
 
-patch(registry.category("web_tour.tours").get("shop_buy_product"), "patch_shop_buy_product", {
+patch(registry.category("web_tour.tours").get("shop_buy_product"), {
     steps() {
-        const originalSteps = this._super();
+        const originalSteps = super.steps();
         const addCartStepIndex = originalSteps.findIndex((step) => step.id === "add_cart_step");
         originalSteps.splice(addCartStepIndex + 1, 1, {
             content: "click in modal on 'Proceed to checkout' button",

--- a/addons/website_sale_stock/static/src/js/website_sale_reorder.js
+++ b/addons/website_sale_stock/static/src/js/website_sale_reorder.js
@@ -4,12 +4,12 @@ import { ReorderDialog } from "@website_sale/js/website_sale_reorder";
 import { patch } from "@web/core/utils/patch";
 import { sprintf } from "@web/core/utils/strings";
 
-patch(ReorderDialog.prototype, "website_sale_stock_reorder", {
+patch(ReorderDialog.prototype, {
     /**
      * @override
      */
     async onWillStartHandler() {
-        const res = await this._super(...arguments);
+        const res = await super.onWillStartHandler(...arguments);
         for (const product of this.content.products) {
             this.stockCheckCombinationInfo(product);
         }
@@ -20,7 +20,7 @@ patch(ReorderDialog.prototype, "website_sale_stock_reorder", {
      * @override
      */
     async loadProductCombinationInfo(product) {
-        await this._super(...arguments);
+        await super.loadProductCombinationInfo(...arguments);
     },
 
     stockCheckCombinationInfo(product) {
@@ -55,7 +55,7 @@ patch(ReorderDialog.prototype, "website_sale_stock_reorder", {
         if (product.hasOwnProperty("max_quantity_available") && !product.max_quantity_available) {
             return this.env._t("This product is out of stock.");
         }
-        return this._super(...arguments);
+        return super.getWarningForProduct(...arguments);
     },
 
     /**
@@ -74,6 +74,6 @@ patch(ReorderDialog.prototype, "website_sale_stock_reorder", {
             product.qty_warning = false;
             product.stock_warning = false;
         }
-        this._super(product, newQty);
+        super.changeProductQty(product, newQty);
     },
 });

--- a/addons/website_slides/static/src/activity/activity_patch.js
+++ b/addons/website_slides/static/src/activity/activity_patch.js
@@ -28,4 +28,4 @@ const ActivityPatch = {
     },
 };
 
-patch(Activity.prototype, "website_slides", ActivityPatch);
+patch(Activity.prototype, ActivityPatch);


### PR DESCRIPTION
This PR refactors the patch function in order to simplify its code but also and most of all remove the `this._super` bound on each patched method call.
The patch function now supports the javascript keyword `super` to get the parent's property.
This removes constraints we had with `this._super`. We had to create a rather complicated intermediate function to bind `this._super` and this function was called each time before we called a patched method. It was annoying for debugging but necessary. Because of this intermediate function `this._super` was also had to re-bind each time we entered a patched method which was annoying with async method, we had to save the parent method in the patch before awaiting its execution. Finally, not a big issue but still, objects could not have a `_super` property as it would be hidden in the patch.

task 3410198