### PR TITLE
[FIX] mass_mailing: update iframe size on pick template

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -385,6 +385,7 @@ export class MassMailingHtmlField extends HtmlField {
                 }
                 // mark selection done for tour testing
                 $editable.addClass('theme_selection_done');
+                this.onIframeUpdated();
             }, 0);
         });
 


### PR DESCRIPTION
When picking a mailing template, the size of the contents of the iframe changes but we failed to signal it so the iframe could resize as well.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
