### PR TITLE
[FIX] stock_picking_batch: action_done

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -130,9 +130,6 @@ class StockPicking(models.Model):
             to_assign_ids.update(self.env.context['pickings_to_detach'])
 
         for picking in self:
-            # Avoid inconsistencies in states of the same batch when validating a single picking in a batch.
-            if picking.batch_id and any(p.state != 'done' for p in picking.batch_id.picking_ids):
-                picking.batch_id = None
             # If backorder were made, if auto-batch is enabled, seek a batch for each of them with the selected criterias.
             to_assign_ids.update(picking.backorder_ids.ids)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Create 2 sales orders and create a batch picking for the respective pickings. Then, unlock and increase the demand on one of the pickings. Validate be batch without a backorder.
The picking that got the quantity modified is now in done, but lost its batch_id.

Current behavior before PR:
As a result, the move and move lines "disappear" from the batch.

Desired behavior after PR is merged:
When there is no backorder, the batch_id is not removed.

OPW-3346255