### PR TITLE
[FIX] project: fix collaborate helper message

### DIFF
--- a/addons/project/views/project_collaborator_views.xml
+++ b/addons/project/views/project_collaborator_views.xml
@@ -38,7 +38,7 @@
                 No collaborators found
             </p>
             <p>
-                Collaborate efficiently with key stakeholders by sharing with them the Kanban view of your tasks. Collaborators will be able to edit parts of tasks and send messages.
+               By sharing all the tasks of Project and enabling stakeholders to edit the tasks and communicate through the platform, you can foster effective collaboration, improve transparency, and keep everyone aligned on the project progress.
             </p>
         </field>
     </record>


### PR DESCRIPTION
Before these commit if we go to the project and create or open the project and set the status to collaborators we will find some text like: Collaborate efficiently with key stakeholders by sharing with them the Kanban view of your tasks. Collaborators will be able to edit parts of tasks and send messages.
Fix:
->change the text to these : By sharing all the tasks of Project and enabling stakeholders to edit the tasks and communicate through the platform, you can
 foster effective collaboration, improve transparency, and keep everyone aligned
on the project progress.

task-3374490

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
