### PR TITLE
[FIX] discuss: channel name overflow in channel suggestions

### DIFF
--- a/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
+++ b/addons/mail/static/src/components/autocomplete_input/autocomplete_input.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AutocompleteInput" owl="1">
-        <input class="o_AutocompleteInput" t-on-blur="_onBlur" t-on-keydown="_onKeydown" t-att-placeholder="props.placeholder"/>
+        <input class="o_AutocompleteInput" t-on-blur="_onBlur" t-on-keydown="_onKeydown" t-att-placeholder="props.placeholder" maxlength="100"/>
     </t>
 
 </templates>

--- a/addons/web/static/src/scss/dropdown.scss
+++ b/addons/web/static/src/scss/dropdown.scss
@@ -9,6 +9,7 @@
     font-size: $font-size-base;
     padding: 5px 0px;
     box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.176);
+    word-wrap: break-word;
 
     .ui-menu-item {
         padding: 0;

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
@@ -1,0 +1,123 @@
+import { BasicEditor, testEditor } from '../utils.js';
+
+const setColor = (color, mode) => {
+    return async editor => {
+        await editor.execCommand('applyColor', color, mode);
+    };
+};
+
+describe('applyColor', () => {
+    it('should apply a color to a slice of text in a span in a font', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>a<font>b<span>c[def]g</span>h</font>i</p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'color'),
+            contentAfter: '<p>a<font>b<span>c</span></font>' +
+                '<font style="color: rgb(255, 0, 0);"><span>[def]</span></font>' +
+                '<font><span>g</span>h</font>i</p>',
+        });
+    });
+    it('should apply a background color to a slice of text in a span in a font', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>a<font>b<span>c[def]g</span>h</font>i</p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
+            contentAfter: '<p>a<font>b<span>c</span></font>' +
+                '<font style="background-color: rgb(255, 0, 0);"><span>[def]</span></font>' +
+                '<font><span>g</span>h</font>i</p>',
+        });
+    });
+    it('should get ready to type with a different color', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>ab[]cd</p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'color'),
+            contentAfter: '<p>ab<font style="color: rgb(255, 0, 0);">[]\u200B</font>cd</p>',
+        });
+    });
+    it('should get ready to type with a different background color', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>ab[]cd</p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
+            contentAfter: '<p>ab<font style="background-color: rgb(255, 0, 0);">[]\u200B</font>cd</p>',
+        });
+    });
+    it('should apply a color on empty selection', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>[<br></p><p><br></p><p>]<br></p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'color'),
+            contentAfterEdit: '<p><font oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">[\u200B</font></p>' +
+                              '<p><font oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
+                              '<p><font oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">]\u200B</font></p>',
+            contentAfter: '<p>[</p><p></p><p>]</p>',
+        });
+    });
+    it('should apply a background color on empty selection', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>[<br></p><p><br></p><p>]<br></p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'background-color'),
+            contentAfterEdit: '<p><font oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">[\u200B</font></p>' +
+                              '<p><font oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
+                              '<p><font oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">]\u200B</font></p>',
+            contentAfter: '<p>[</p><p></p><p>]</p>',
+        });
+    });
+    it('should not merge line on background color change', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><strong>[abcd</strong><br><strong>efghi]</strong></p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
+            contentAfter: '<p><strong><font style="background-color: rgb(255, 0, 0);">[abcd</font></strong><br>' +
+                          '<strong><font style="background-color: rgb(255, 0, 0);">efghi]</font></strong></p>',
+        });
+    });
+    it('should not merge line on color change', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><strong>[abcd</strong><br><strong>efghi]</strong></p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'color'),
+            contentAfter: '<p><strong><font style="color: rgb(255, 0, 0);">[abcd</font></strong><br>' +
+                          '<strong><font style="color: rgb(255, 0, 0);">efghi]</font></strong></p>',
+        });
+    });
+    it('should remove font tag after removing font color', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="color: rgb(255, 0, 0);">[abcabc]</font></p>',
+            stepFunction: setColor('', 'color'),
+            contentAfter: '<p>[abcabc]</p>',
+        });
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font class="text-400">[abcabc]</font></p>',
+            stepFunction: setColor('', 'color'),
+            contentAfter: '<p>[abcabc]</p>',
+        });
+    });
+    it('should remove font tag after removing background color applied as style', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="background-color: rgb(255, 0, 0);">[abcabc]</font></p>',
+            stepFunction: setColor('', 'backgroundColor'),
+            contentAfter: '<p>[abcabc]</p>',
+        });
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font class="bg-200">[abcabc]</font></p>',
+            stepFunction: setColor('', 'backgroundColor'),
+            contentAfter: '<p>[abcabc]</p>',
+        });
+    });
+    it('should remove font tag if font-color and background-color both are removed one by one', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="background-color: rgb(255, 0, 0); color: rgb(255, 0, 0);">[abcabc]</font></p>',
+            stepFunction: setColor('','backgroundColor'),
+            stepFunction: setColor('', 'color'),
+            
+            contentAfter: '<p>[abcabc]</p>',
+        });
+        // await testEditor(BasicEditor, {
+        //     contentBefore: '<p><font style="background-color: rgb(255, 0, 0);" class="text-200">[abcabc]</font></p>',
+        //     stepFunction: setColor('', 'backgroundColor'),
+        //     stepFunction: setColor('','color'),
+        //     contentAfter: '<p>[abcabc]</p>',
+        // });
+        // await testEditor(BasicEditor, {
+        //     contentBefore: '<p><font class="text-200 bg-400">[abcabc]</font></p>',
+        //     stepFunction: setColor('', 'backgroundColor'),
+        //     stepFunction: setColor('','color'),
+        //     contentAfter: '<p>[abcabc]</p>',
+        // });
+    })
+});


### PR DESCRIPTION
**Before this commit:**
The channel name used to overflow in the channel suggestion section and also there was also no limit on the lenght of how long the name of the channel can be.

**After this commit:**
The name will not overflow in the channnel suggestion section and the user will also have a certain limit on the length of channel name:

**Task id: 3366608**
