### PR TITLE
[FIX] google_calendar: KeyError on entryPointType

### DIFF
--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -225,8 +225,8 @@ class GoogleEvent(abc.Set):
     def get_meeting_url(self):
         if not self.conferenceData:
             return False
-        video_meeting = list(filter(lambda entryPoints: entryPoints['entryPointType'] == 'video', self.conferenceData['entryPoints']))
-        return video_meeting[0]['uri'] if video_meeting else False
+        video_meeting = list(filter(lambda entryPoints: entryPoints.get('entryPointType') == 'video', self.conferenceData.get('entryPoints')))
+        return video_meeting[0].get('uri') if video_meeting else False
 
     def is_available(self):
         return self.transparency == 'transparent'


### PR DESCRIPTION
Somehow, some Google events that are imported into Odoo don't have an entryPointType key in the conferenceData entryPoints list. Use get to safely access dict properties instead to access the key without testing its existence.

Description of the issue/feature this PR addresses:

Fix sync with google calendar

Current behavior before PR:

```
  File "/odoo/src/addons/google_calendar/controllers/main.py", line 45, in sync_data
    need_refresh = request.env.user.sudo()._sync_google_calendar(GoogleCal)
  File "/odoo/src/addons/google_calendar/models/res_users.py", line 69, in _sync_google_calendar
    synced_recurrences = self.env['calendar.recurrence']._sync_google2odoo(recurrences)
  File "/odoo/src/addons/google_calendar/models/google_sync.py", line 157, in _sync_google2odoo
    new_odoo = self.with_context(dont_notify=True)._create_from_google(new, odoo_values)
  File "/odoo/src/addons/google_calendar/models/calendar_recurrence_rule.py", line 155, in _create_from_google
    self.env['calendar.event']._odoo_values(gevent),  # FIXME default reminders
  File "/odoo/src/addons/google_calendar/models/calendar.py", line 98, in _odoo_values
    'videocall_location': google_event.get_meeting_url(),
  File "/odoo/src/addons/google_calendar/utils/google_event.py", line 226, in get_meeting_url
    video_meeting = list(filter(lambda entryPoints: entryPoints['entryPointType'] == 'video', self.conferenceData['entryPoints']))
  File "/odoo/src/addons/google_calendar/utils/google_event.py", line 226, in <lambda>
    video_meeting = list(filter(lambda entryPoints: entryPoints['entryPointType'] == 'video', self.conferenceData['entryPoints']))
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/odoo/src/odoo/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/odoo/src/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
KeyError: 'entryPointType'
```

Desired behavior after PR is merged:

No more stack trace.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
