### PR TITLE
[FIX] survey: wait longer for results to load in tour

### DIFF
--- a/addons/survey/static/tests/tours/survey_tour_session_manage.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_manage.js
@@ -243,8 +243,8 @@ registry.category("web_tour.tours").add('test_survey_session_manage_tour', {
     }
 }, {
     trigger: 'h1:contains("Scored Simple Choice")',
-    // Wait for Button to be updated ("late" enough DOM change after onNext() is triggered).
-    extra_trigger: '.o_survey_session_navigation_next_label:contains("Show Correct Answer(s)")',
+    // Same as above
+    extra_trigger: '.o_survey_session_progress_small[style*="width: 100%"]',
     run: () => {
         checkAnswers(getChartData(), [
             {value: 1, type: "regular"},
@@ -257,7 +257,7 @@ registry.category("web_tour.tours").add('test_survey_session_manage_tour', {
 }, {
     trigger: 'h1:contains("Scored Simple Choice")',
     // Same as above
-    extra_trigger: '.o_survey_session_navigation_next_label:contains("Show Leaderboard")',
+    extra_trigger: '.o_survey_session_progress_small[style*="width: 100%"]',
     run: () => {
         checkAnswers(getChartData(), [
             {value: 1, type: "correct"},


### PR DESCRIPTION
Followup of #119856

Looks like even if the button should be updated later, we've seen a few builds where it was still too fast (2 ms).

Therefore, we'll stick to using the progress bar completeness as
 trigger, as it takes at least the time of the animation.

If this doesn't work, we'll hit it harder.

Task-3378871