### PR TITLE
[IMP] web_editor, website: use consistent margins on buttons

### DIFF
--- a/addons/website/views/snippets/s_banner.xml
+++ b/addons/website/views/snippets/s_banner.xml
@@ -9,7 +9,7 @@
                 <div class="col-lg-6 jumbotron rounded o_cc o_cc1 pt32 pb32" data-name="Box">
                     <h1><font style="font-size: 62px;">Sell Online. Easily.</font></h1>
                     <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-                    <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">Contact Us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-esc="cta_btn_text">Contact Us</t></a>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_call_to_action.xml
+++ b/addons/website/views/snippets/s_call_to_action.xml
@@ -11,7 +11,7 @@
                 </div>
                 <div class="col-lg-3 pt8">
                     <p style="text-align: right;">
-                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg mb-2"><t t-esc="cta_btn_text">Contact us</t></a>
+                        <a t-att-href="cta_btn_href" class="btn btn-primary btn-lg"><t t-esc="cta_btn_text">Contact us</t></a>
                     </p>
                 </div>
             </div>

--- a/addons/website/views/snippets/s_carousel.xml
+++ b/addons/website/views/snippets/s_carousel.xml
@@ -21,7 +21,7 @@
                                  <h2><font style="font-size: 62px;">Slide Title</font></h2>
                                 <p class="lead">Use this snippet to presents your content in a slideshow-like format. Don't write about products or services here, write about solutions.</p>
                                 <p>
-                                    <a href="/contactus" class="btn btn-primary mb-2">Contact us</a>
+                                    <a href="/contactus" class="btn btn-primary">Contact us</a>
                                 </p>
                             </div>
                         </div>
@@ -37,7 +37,7 @@
                                     <hr class="w-25 mx-auto" style="border-top-width: 1px; border-top-style: solid;"/>
                                 </div>
                                 <p class="lead">Storytelling is powerful.<br/> It draws readers in and engages them.</p>
-                                <p><a href="/" class="btn btn-primary mb-2">Start your journey</a></p>
+                                <p><a href="/" class="btn btn-primary">Start your journey</a></p>
                             </div>
                         </div>
                     </div>

--- a/addons/website/views/snippets/s_color_blocks_2.xml
+++ b/addons/website/views/snippets/s_color_blocks_2.xml
@@ -9,13 +9,13 @@
                     <i class="fa fa-shield fa-5x m-3"/>
                     <h2>A color block</h2>
                     <p>Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
-                    <a href="#" class="btn btn-primary mb-2">More Details</a>
+                    <a href="#" class="btn btn-primary">More Details</a>
                 </div>
                 <div class="col-lg-6 o_cc o_cc5 text-center">
                     <i class="fa fa-cube fa-5x m-3"/>
                     <h2>Another color block</h2>
                     <p>Color blocks are a simple and effective way to <b>present and highlight your content</b>. Choose an image or a color for the background. You can even resize and duplicate the blocks to create your own layout. Add images or icons to customize the blocks.</p>
-                    <a href="#" class="btn btn-primary mb-2">More Details</a>
+                    <a href="#" class="btn btn-primary">More Details</a>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_comparisons.xml
+++ b/addons/website/views/snippets/s_comparisons.xml
@@ -24,7 +24,7 @@
                         </ul>
                         <div class="card-footer">
                             <p><i>Instant setup, satisfied or reimbursed.</i></p>
-                            <a href="/contactus" class="btn btn-primary mb-2">Order now</a>
+                            <a href="/contactus" class="btn btn-primary">Order now</a>
                         </div>
                     </div>
                 </div>
@@ -47,7 +47,7 @@
                         </ul>
                         <div class="card-footer">
                             <p><i>Instant setup, satisfied or reimbursed.</i></p>
-                            <a href="/contactus" class="btn btn-primary mb-2">Start now</a>
+                            <a href="/contactus" class="btn btn-primary">Start now</a>
                         </div>
                     </div>
                 </div>
@@ -70,7 +70,7 @@
                         </ul>
                         <div class="card-footer">
                             <p><i>Instant setup, satisfied or reimbursed.</i></p>
-                            <a href="/contactus" class="btn btn-primary mb-2">Contact us</a>
+                            <a href="/contactus" class="btn btn-primary">Contact us</a>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -9,7 +9,7 @@
             <h1 style="text-align: center;"><font style="font-size: 62px; font-weight: bold;">Catchy Headline</font></h1>
             <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
             <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">Contact us</t></a>
+                <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
             </p>
         </div>
     </section>

--- a/addons/website/views/snippets/s_image_text.xml
+++ b/addons/website/views/snippets/s_image_text.xml
@@ -12,7 +12,7 @@
                     <h2>Section Subtitle</h2>
                     <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p>Start with the customer – find out what they want and give it to them.</p>
-                    <p><a href="#" class="btn btn-primary mb-2">Discover more</a></p>
+                    <p><a href="#" class="btn btn-primary">Discover more</a></p>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_media_list.xml
+++ b/addons/website/views/snippets/s_media_list.xml
@@ -13,7 +13,7 @@
                         <div class="col-lg-8 s_media_list_body">
                             <h3>Media heading</h3>
                             <p>Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.</p>
-                            <a href="#" class="btn btn-primary mb-2">Discover</a>
+                            <a href="#" class="btn btn-primary">Discover</a>
                         </div>
                     </div>
                 </div>

--- a/addons/website/views/snippets/s_popup.xml
+++ b/addons/website/views/snippets/s_popup.xml
@@ -17,7 +17,7 @@
                                 <div class="col-lg-10 offset-lg-1 text-center o_cc o_cc1 jumbotron pt48 pb48">
                                     <h2><font style="font-size: 62px;">Win $20</font></h2>
                                     <p class="lead">Check out now and get $20 off your first order.</p>
-                                    <a href="#" class="btn btn-primary mb-2">New customer</a>
+                                    <a href="#" class="btn btn-primary">New customer</a>
                                 </div>
                             </div>
                         </div>

--- a/addons/website/views/snippets/s_showcase.xml
+++ b/addons/website/views/snippets/s_showcase.xml
@@ -49,7 +49,7 @@
         </div>
         <div class="container text-lg-center">
             <p><br/></p>
-            <a href="#" class="btn btn-primary mb-2">Discover all the features</a>
+            <a href="#" class="btn btn-primary">Discover all the features</a>
         </div>
     </section>
 </template>

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -8,7 +8,7 @@
                 <div class="o_colored_level o_cc o_cc_1 col-lg-4 pt160 pb160 px-5">
                     <h1><span style="font-size: 62px;">Sell Online. <br/>Easily.</span></h1>
                     <p class="lead">Write one or two paragraphs describing your product, services or a specific feature. To be successful your content needs to be useful to your readers.</p>
-                    <a t-att-href="cta_btn_href" class="btn btn-primary mb-2"><t t-esc="cta_btn_text">Contact us</t></a>
+                    <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
                 </div>
                 <div class="o_not_editable pt160 pb160 oe_img_bg col-lg-8 d-none d-md-block" style="background-image: url('/web/image/website.s_text_cover_default_image'); background-position: 100% 0;"/>
             </div>

--- a/addons/website/views/snippets/s_text_image.xml
+++ b/addons/website/views/snippets/s_text_image.xml
@@ -9,7 +9,7 @@
                     <h2>A Section Subtitle</h2>
                     <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p>Start with the customer – find out what they want and give it to them.</p>
-                    <p><a href="#" class="btn btn-primary mb-2">Learn more</a></p>
+                    <p><a href="#" class="btn btn-primary">Learn more</a></p>
                 </div>
                 <div class="col-lg-6 pt16 pb16">
                     <img src="/web/image/website.s_text_image_default_image" class="img img-fluid mx-auto" alt=""/>


### PR DESCRIPTION
Commit [1] added a margin-bottom on buttons within snippets to make some
breathing space when several buttons follow each other and appear on
multiple lines on mobile.
However, buttons added by the customer do not have a margin, which
causes misalignment when they add it next to a prebuilt button.

This commit checks that whenever a user adds a new button, if any of its
siblings is a button, the newly added button and its button siblings get
an appropriate margin-bottom.

task-3369604

[1]: https://github.com/odoo/odoo/commit/075e915