### PR TITLE
[IMP] l10n_in: set gst treatment type from contact master

### DIFF
--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -5,6 +5,15 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//header" position="after">
+                <field name="show_warning" invisible="1"/>
+                <div class="alert alert-warning mb-0" role="alert" style="margin-bottom:0px;"
+                    invisible="not show_warning">
+                    <div>The GST Treatment of the move differs from partner GST Treatment-
+                        <button type="object" name="update_gst_treatment" string="Update Now" class="oe_link ps-0 text-decoration-underline" />
+                    </div>
+                </div>
+            </xpath>
             <xpath expr="//field[@name='ref']" position="after">
                 <field name="country_code" invisible="1"/>
                 <field name="l10n_in_journal_type" invisible="1"/>
@@ -14,7 +23,6 @@
                     required="country_code == 'IN' and move_type != 'entry' and l10n_in_journal_type in ('sale', 'purchase')"/>
                 <field name="l10n_in_gst_treatment"
                     invisible="country_code != 'IN' or move_type == 'entry'"
-                    readonly="state != 'draft'"
                     required="country_code == 'IN' and move_type != 'entry'"/>
             </xpath>
             <xpath expr="//page[@id='other_tab']/group[@id='other_tab_group']" position="after">
@@ -36,5 +44,11 @@
                        readonly="state != 'draft'"/>
             </xpath>
         </field>
+    </record>
+    <record id="action_view_move" model="ir.actions.act_window">
+        <field name="name">View Moves</field>
+        <field name="res_model">account.move</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'group_by':['move_type']}</field>
     </record>
 </odoo>

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -6,15 +6,27 @@
         <field name="priority" eval="90"/>
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="l10n_in_view_partner_base_vat_form" model="ir.ui.view">
+        <field name="name">l10n.in.res.partner.base.vat.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base_vat.view_partner_base_vat_form"/>
+        <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="attributes">
                 <attribute name="readonly">parent_id</attribute>
                 <attribute name="required">l10n_in_gst_treatment in ['regular', 'composition', 'special_economic_zone', 'deemed_export']</attribute>
             </xpath>
-            <xpath expr="//field[@name='vat']" position="before">
-                <field name="l10n_in_gst_treatment" invisible="'IN' not in fiscal_country_codes" readonly="parent_id"/>
-            </xpath>
-            <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" />
+            <xpath expr="//label[@for='vat']" position="before">
+                <label for ="l10n_in_gst_treatment" invisible="'IN' not in fiscal_country_codes"/>
+                <div class ="o_row" invisible="'IN' not in fiscal_country_codes">
+                    <field name="l10n_in_gst_treatment" readonly="parent_id"/>
+                    <button type="object" name="update_draft_invoices" title="Update Draft Invoices" class="oe_link fa fa-fw fa-refresh" />
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before PR:
---
GST Treatment Type is editable in invoice form.

After PR:
---
As GST Treatment is directly coming form contact master we should not allow user to change GST Treatment type on invoice form.Else it would be hard to reconcile GSTR Reports with invoice posted based on GST Treatment type. In case where large invoices  are needed to change GST Treatement type a  button is  added in contact master which updates the GST Treatment in draft invoices.

task id: 3339052


