### PR TITLE
[FIX] website: restrict access to optimize SEO

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -20,7 +20,7 @@ from xml.etree import ElementTree as ET
 import odoo
 
 from odoo import http, models, fields, _
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.http import request, SessionExpiredException
 from odoo.osv import expression
 from odoo.tools import OrderedSet, escape_psql, html_escape as escape
@@ -678,6 +678,8 @@ class Website(Home):
             fields.extend(['website_indexed', 'website_id'])
 
         record = request.env[res_model].browse(res_id)
+        if res_model != 'website.page' and 'website.seo.metadata' not in request.env[res_model]._inherit_module.keys():
+            raise UserError(_("You can not optimize SEO."))
         res = record.read(fields)[0]
         res['has_social_default_image'] = request.website.has_social_default_image
 

--- a/addons/website/i18n/website.pot
+++ b/addons/website/i18n/website.pot
@@ -10779,6 +10779,13 @@ msgstr ""
 
 #. module: website
 #. odoo-python
+#: code:addons/website/controllers/main.py:0
+#, python-format
+msgid "You can not optimize SEO."
+msgstr ""
+
+#. module: website
+#. odoo-python
 #: code:addons/website/models/website_snippet_filter.py:0
 #, python-format
 msgid "You can only use template prefixed by dynamic_filter_template_ "


### PR DESCRIPTION
When user creates a new 'livechat channel' in website, and click on 'Optimize SEO' traceback will appear.

To reproduce the issue:

- Install 'website' and 'im_livechat' module
- Go to 'website' module
- Click on 'NEW' and then create a new 'Livechat Widget'
- Go to 'Site' and click on 'Optimize SEO'

Traceback in sentry-
```
ValueError: Invalid field 'website_meta_title' on model 'im_livechat.channel'
  File "odoo/http.py", line 2114, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1921, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/main.py", line 699, in get_seo_data
    res = record.read(fields)[0]
  File "odoo/models.py", line 3176, in read
    self.fetch(fields)
  File "odoo/models.py", line 3407, in fetch
    fields_to_fetch = self._determine_fields_to_fetch(field_names, ignore_when_in_cache=True)
  File "odoo/models.py", line 3474, in _determine_fields_to_fetch
    raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
```

When user create a new livechat channel in website module, the 'get_seo_data' method is called and the value of 'res_model' is passed as 'im_livechat.channel'. Fixed this issue by raising UserError when user tries to access 'Optimize SEO'.

sentry-4241511888

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
