### PR TITLE
[FIX] web: dynamic placeholder not switching to dark mode

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.scss
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.scss
@@ -9,7 +9,7 @@
 
 .o_field_selector_popover:not(.o_legacy_field_selector_popover) {
     width: 265px;
-    background: white;
+    background: $form-switch-checked-color;
     --o-input-background-color: white;
 
     &:focus {
@@ -28,13 +28,14 @@
             padding: 0px 35px;
             text-align: center;
         }
-        .o_field_selector_search {
+        .o_field_selector_search, .o_field_selector_default_value_input {
             padding-right: 0.4rem;
             > .o_input {
                 font-size: 13px;
                 padding: 5px 0.4rem;
                 text-align: left;
                 line-height: normal;
+                background-color: $form-switch-checked-color;
             }
         }
         .o_field_selector_popover_option {
@@ -67,7 +68,7 @@
                 cursor: pointer;
                 font-family: Arial;
                 font-size: 13px;
-                color: #444;
+                color: rgb(108, 117, 125);
                 border-bottom: 1px solid #eee;
                 &.active {
                     background: #f5f5f5;
@@ -92,6 +93,7 @@
             font-size: 13px;
             width: 100%;
             padding: 0 0.4rem;
+            background-color: $form-switch-checked-color;
         }
     }
 }

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
@@ -58,7 +58,7 @@
                                 t-att-data-name="fieldKey"
                                 t-attf-class="o_field_selector_item #{fieldKey === currentActiveField and ' active' or ''}">
                                 <t t-out="field.string" />
-                                <div t-if="props.isDebugMode" class="text-muted o_field_selector_item_title"><t t-out="fieldKey"/> (<t t-out="field.type"/>)</div>
+                                <div t-if="props.isDebugMode" class="o_field_selector_item_title"><t t-out="fieldKey"/> (<t t-out="field.type"/>)</div>
                                 <t t-if="field.relation and props.followRelations">
                                     <i
                                         class="fa fa-chevron-right o_field_selector_relation_icon"


### PR DESCRIPTION
**Current behavior before PR:**

When using dark mode, the text in the dynamic placeholder popover switches to
the dark mode color scheme, but the dynamic placeholder itself does not switch to
the dark mode.

**Desired behavior after PR is merged:**

In dark mode, both the text and the dynamic placeholder in the popover switch to
the appropriate color scheme.

Task-3342845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
