### PR TITLE
[IMP] mail: allow users to manage own templates 

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -6,7 +6,7 @@
     <data noupdate="1">
         <!--Email template -->
         <record id="email_template_edi_invoice" model="mail.template">
-            <field name="name">Invoice: Sending</field>
+            <field name="name">💰 Invoice: Sending</field>
             <field name="model_id" ref="account.model_account_move"/>
             <field name="email_from">{{ (object.invoice_user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>

--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -59,7 +59,8 @@
     <record id="group_account_manager" model="res.groups">
         <field name="name">Billing Administrator</field>
         <field name="category_id" ref="base.module_category_accounting_accounting"/>
-        <field name="implied_ids" eval="[(4, ref('group_account_invoice')),(4, ref('base.group_private_addresses'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_account_invoice')),(4, ref('base.group_private_addresses')),
+            (4, ref('mail.group_template_admin'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <!-- Email template for reset password -->
         <record id="reset_password_email" model="mail.template">
-            <field name="name">Settings: User Reset Password</field>
+            <field name="name">⚙️ Settings: User Reset Password</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Password reset</field>
             <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>
@@ -99,7 +99,7 @@
 
         <!-- Email template for new users -->
         <record id="set_password_email" model="mail.template">
-            <field name="name">Settings: New Portal Signup</field>
+            <field name="name">⚙️ Settings: New Portal Signup</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">{{ object.create_uid.name }} from {{ object.company_id.name }} invites you to connect to Odoo</field>
             <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>
@@ -195,7 +195,7 @@
 
         <!-- Email template for reminder of unregistered users -->
         <record id="mail_template_data_unregistered_users" model="mail.template">
-            <field name="name">Settings: Unregistered User Reminder</field>
+            <field name="name">⚙️ Settings: Unregistered User Reminder</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Reminder for unregistered users</field>
             <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>
@@ -247,7 +247,7 @@
 
         <!-- Email template for new users that used a signup token -->
         <record id="mail_template_user_signup_account_created" model="mail.template">
-            <field name="name">Settings: New User Invite</field>
+            <field name="name">⚙️ Settings: New User Invite</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">Welcome to {{ object.company_id.name }}!</field>
             <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>

--- a/addons/auth_totp_mail/data/mail_template_data.xml
+++ b/addons/auth_totp_mail/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
 <data noupdate="1">
     <record id="mail_template_totp_invite" model="mail.template">
-        <field name="name">Settings: 2Fa Invitation</field>
+        <field name="name">⚙️ Settings: 2Fa Invitation</field>
         <field name="model_id" ref="base.model_res_users" />
         <field name="email_from">{{ (object.company_id.email_formatted or user.email_formatted) }}</field>
         <field name="subject">Invitation to activate two-factor authentication on your Odoo account</field>

--- a/addons/auth_totp_mail_enforce/data/mail_template_data.xml
+++ b/addons/auth_totp_mail_enforce/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_totp_mail_code" model="mail.template">
-            <field name="name">Settings: 2Fa New Login</field>
+            <field name="name">⚙️ Settings: 2Fa New Login</field>
             <field name="model_id" ref="base.model_res_users" />
             <field name="subject">Your two-factor authentication code</field>
             <field name="email_to">{{ object.email_formatted }}</field>

--- a/addons/base_install_request/data/mail_template_data.xml
+++ b/addons/base_install_request/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_base_install_request" model="mail.template">
-            <field name="name">Mail: Install Request</field>
+            <field name="name">✉️ Mail: Install Request</field>
             <field name="model_id" ref="base_install_request.model_base_module_install_request"/>
             <field name="subject">Module Activation Request for "{{ object.module_id.shortdesc }}"</field>
             <field name="email_from">{{ object.user_id.email_formatted or user.email_formatted }}</field>

--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="calendar_template_meeting_invitation" model="mail.template">
-            <field name="name">Calendar: Meeting Invitation</field>
+            <field name="name">📆 Calendar: Meeting Invitation</field>
             <field name="model_id" ref="calendar.model_calendar_attendee"/>
             <field name="subject">Invitation to {{ object.event_id.name }}</field>
             <field name="email_from">{{ (object.event_id.user_id.email_formatted or user.email_formatted or '') }}</field>
@@ -150,7 +150,7 @@
         </record>
 
         <record id="calendar_template_meeting_changedate" model="mail.template">
-            <field name="name">Calendar: Date Updated</field>
+            <field name="name">📆 Calendar: Date Updated</field>
             <field name="model_id" ref="calendar.model_calendar_attendee"/>
             <field name="subject">{{ object.event_id.name }}: Date updated</field>
             <field name="email_from">{{ (object.event_id.user_id.email_formatted or user.email_formatted or '') }}</field>
@@ -281,7 +281,7 @@
         </record>
 
         <record id="calendar_template_meeting_reminder" model="mail.template">
-            <field name="name">Calendar: Reminder</field>
+            <field name="name">📆 Calendar: Reminder</field>
             <field name="model_id" ref="calendar.model_calendar_attendee"/>
             <field name="subject">{{ object.event_id.name }} - Reminder</field>
             <field name="email_from">{{ (object.event_id.user_id.email_formatted or user.email_formatted or '') }}</field>
@@ -388,7 +388,7 @@
         </record>
 
         <record id="calendar_template_meeting_update" model="mail.template">
-            <field name="name">Calendar: Event Update</field>
+            <field name="name">📆 Calendar: Event Update</field>
             <field name="model_id" ref="calendar.model_calendar_event"/>
             <field name="subject">{{object.name}}: Event update</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted or '') }}</field>

--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
 
         <record id="event_registration_mail_template_badge" model="mail.template">
-            <field name="name">Event: Registration Badge</field>
+            <field name="name">🎟️ Event: Registration Badge</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your badge for {{ object.event_id.name }}</field>
             <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
@@ -28,7 +28,7 @@
         </record>
 
         <record id="event_subscription" model="mail.template">
-            <field name="name">Event: Registration Confirmation</field>
+            <field name="name">🎟️ Event: Registration Confirmation</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your registration at {{ object.event_id.name }}</field>
             <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
@@ -261,7 +261,7 @@
         </record>
 
         <record id="event_reminder" model="mail.template">
-            <field name="name">Event: Reminder</field>
+            <field name="name">🎟️ Event: Reminder</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">{{ object.event_id.name }}: {{ object.get_date_range_str() }}</field>
             <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>

--- a/addons/event/security/event_security.xml
+++ b/addons/event/security/event_security.xml
@@ -21,7 +21,7 @@
         <record id="group_event_manager" model="res.groups">
             <field name="name">Administrator</field>
             <field name="category_id" ref="base.module_category_marketing_events"/>
-            <field name="implied_ids" eval="[(4, ref('group_event_user'))]"/>
+            <field name="implied_ids" eval="[(4, ref('group_event_user')), (4, ref('mail.group_template_admin'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
     </data>

--- a/addons/gamification/data/mail_template_data.xml
+++ b/addons/gamification/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="email_template_badge_received" model="mail.template">
-            <field name="name">Gamification: Badge Received</field>
+            <field name="name">🎯 Gamification: Badge Received</field>
             <field name="subject">New badge {{ object.badge_id.name }} granted</field>
             <field name="model_id" ref="gamification.model_gamification_badge_user"/>
             <field name="partner_to">{{ object.user_id.partner_id.id }}</field>
@@ -101,7 +101,7 @@
         </record>
 
         <record id="email_template_goal_reminder" model="mail.template">
-            <field name="name">Gamification: Reminder For Goal Update</field>
+            <field name="name">🎯 Gamification: Reminder For Goal Update</field>
             <field name="model_id" ref="gamification.model_gamification_goal"/>
             <field name="partner_to">{{ object.user_id.partner_id.id }}</field>
             <field name="description">Sent automatically to participant who haven't updated their goal</field>
@@ -121,7 +121,7 @@
         </record>
         
         <record id="simple_report_template" model="mail.template">
-            <field name="name">Gamification: Challenge Report</field>
+            <field name="name">🎯 Gamification: Challenge Report</field>
             <field name="model_id" ref="gamification.model_gamification_challenge"/>
             <field name="description">Send a challenge report to all participants</field>
             <field name="body_html" type="html">
@@ -320,7 +320,7 @@
         </record>
 
         <record id="mail_template_data_new_rank_reached" model="mail.template">
-            <field name="name">Gamification: New Rank Reached</field>
+            <field name="name">🎯 Gamification: New Rank Reached</field>
             <field name="model_id" ref="base.model_res_users"/>
             <field name="subject">New rank: {{ object.rank_id.name }}</field>
             <field name="email_to"></field>

--- a/addons/hr_recruitment/data/mail_template_data.xml
+++ b/addons/hr_recruitment/data/mail_template_data.xml
@@ -3,7 +3,7 @@
 
     <!-- Templates for interest / refusing applicants -->
     <record id="email_template_data_applicant_refuse" model="mail.template">
-        <field name="name">Recruitment: Refuse</field>
+        <field name="name">🔍 Recruitment: Refuse</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
@@ -58,7 +58,7 @@
     </record>
 
     <record id="email_template_data_applicant_interest" model="mail.template">
-        <field name="name">Recruitment: Interest</field>
+        <field name="name">🔍 Recruitment: Interest</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
@@ -150,7 +150,7 @@
     </record>
 
     <record id="email_template_data_applicant_congratulations" model="mail.template">
-        <field name="name">Recruitment: Application Acknowledgement</field>
+        <field name="name">🔍 Recruitment: Application Acknowledgement</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>
@@ -230,7 +230,7 @@
     </record>
 
     <record id="email_template_data_applicant_not_interested" model="mail.template">
-        <field name="name">Recruitment: Not interested anymore</field>
+        <field name="name">🔍 Recruitment: Not interested anymore</field>
         <field name="model_id" ref="hr_recruitment.model_hr_applicant"/>
         <field name="subject">Your Job Application: {{ object.job_id.name }}</field>
         <field name="email_to">{{ (not object.partner_id and object.email_from or '') }}</field>

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -28,7 +28,7 @@
     <record id="group_hr_recruitment_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="base.module_category_human_resources_recruitment"/>
-        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user')), (4, ref('mail.group_template_admin'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/lunch/data/mail_template_data.xml
+++ b/addons/lunch/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
 <data noupdate="0">
     <record id="lunch_order_mail_supplier" model="mail.template">
-        <field name="name">Lunch: Supplier Order</field>
+        <field name="name">🍴 Lunch: Supplier Order</field>
         <field name="model_id" ref="lunch.model_lunch_supplier"/>
         <field name="email_from">{{ ctx['order']['email_from'] }}</field>
         <field name="partner_to">{{ ctx['order']['supplier_id'] }}</field>

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -68,6 +68,7 @@ For more specific needs, you may also assign custom-defined actions
         'wizard/mail_resend_partner_views.xml',
         'wizard/mail_template_preview_views.xml',
         'wizard/mail_wizard_invite_views.xml',
+        'wizard/mail_template_name_prompt_views.xml',
         'wizard/mail_template_reset_views.xml',
         'views/fetchmail_views.xml',
         'views/mail_message_subtype_views.xml',

--- a/addons/mail/security/ir.model.access.csv
+++ b/addons/mail/security/ir.model.access.csv
@@ -39,6 +39,7 @@ access_publisher_warranty_contract_all,publisher.warranty.contract.all,model_pub
 access_mail_template,mail.template,model_mail_template,base.group_user,1,1,1,1
 access_mail_template_editor,mail.template_editor,model_mail_template,mail.group_mail_template_editor,1,1,1,1
 access_mail_template_system,mail.template_system,model_mail_template,base.group_system,1,1,1,1
+access_mail_template_name_prompt,mail.template.name.prompt,model_mail_template_name_prompt,base.group_user,1,1,1,0
 access_mail_shortcode,mail.shortcode,model_mail_shortcode,base.group_user,1,1,1,1
 access_mail_shortcode_portal,mail.shortcode.portal,model_mail_shortcode,base.group_portal,1,0,0,0
 access_mail_activity_all,mail.activity.all,model_mail_activity,,0,0,0,0

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
+        <!-- GROUPS -->
+        <record id="group_template_admin" model="res.groups">
+            <field name="name">Mail Templates Administrator</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+
         <!-- RULES -->
         <record id="discuss_channel_rule" model="ir.rule">
             <field name="name">discuss.channel: access only public and joined groups</field>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -8,44 +8,24 @@
                 <form string="Templates">
                     <header>
                         <field name="template_fs" invisible="1"/>
+                        <field name="current_user_is_template_admin" invisible="1"/>
+                        <button string="Preview"
+                                name="%(mail_template_preview_action)d" type="action"
+                                class="btn-primary" target="new"/>
                         <button string="Reset Template"
                                 name="%(mail_template_reset_action)d" type="action"
                                 groups="mail.group_mail_template_editor"
                                 attrs="{'invisible': [('template_fs', '=', False)]}"/>
+                        <button string="Delete"
+                                name="unlink" type="object"
+                                class="btn-secondary"
+                                attrs="{'invisible': &quot;[('current_user_is_template_admin', '=', False), ('user_id', '!=', uid)]&quot;}"
+                                help="Permanently delete this template"/>
                     </header>
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <field name="ref_ir_act_window" invisible="1"/>
-                            <button class="oe_stat_button"
-                                    groups="base.group_no_one"
-                                    name="create_action" type="object"
-                                    attrs="{'invisible':[('ref_ir_act_window','!=',False)]}" icon="fa-plus"
-                                    help="Display an option on related documents to open a composition wizard with this template">
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_text">Add</span>
-                                    <span class="o_stat_text">Context Action</span>
-                                </div>
-                            </button>
-                            <button name="unlink_action" type="object"
-                                    groups="base.group_no_one"
-                                    class="oe_stat_button" icon="fa-minus"
-                                    attrs="{'invisible':[('ref_ir_act_window','=',False)]}"
-                                    help="Remove the contextual action to use this template on related documents" widget="statinfo">
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_text">Remove</span>
-                                    <span class="o_stat_text">Context Action</span>
-                                </div>
-                            </button>
-                            <button class="oe_stat_button" name="%(mail_template_preview_action)d" icon="fa-search-plus"
-                                    type="action" target="new">
-                                    <div class="o_field_widget o_stat_info">
-                                        <span class="o_stat_text">Preview</span>
-                                    </div>
-                            </button>
-                        </div>
                         <div class="oe_title">
                             <label for="name"/>
-                            <h1><field name="name" class="w-100"
+                            <h1><field name="name" class="w-100" widget="char_emojis"
                                 required="1" placeholder='e.g. "Welcome email"'/></h1>
                             <group>
                                 <field name="model_id" placeholder="e.g. Contact" required="1" options="{'no_create': True}"/>
@@ -80,13 +60,19 @@
                                 </group>
                             </page>
                             <page string="Settings" name="email_settings">
-                                <group>
-                                    <field name="lang" placeholder="{{ object.partner_id.lang }}"/>
-                                    <field name="mail_server_id"/>
-                                    <field name="auto_delete"/>
-                                    <field name="report_template_ids" domain="[('model','=',model)]"
-                                        widget="many2many_tags"
-                                        options="{'no_create': True}"/>
+                                <group col="2">
+                                    <group>
+                                        <field name="lang" placeholder="{{ object.partner_id.lang }}"/>
+                                        <field name="mail_server_id"/>
+                                        <field name="auto_delete"/>
+                                        <field name="report_template_ids" domain="[('model','=',model)]"
+                                            widget="many2many_tags"
+                                            options="{'no_create': True}"/>
+                                    </group>
+                                    <group>
+                                        <field name="user_id" widget="many2one_avatar_user"
+                                            attrs="{'readonly': [('current_user_is_template_admin', '=', False)]}"/>
+                                    </group>
                                 </group>
                             </page>
                         </notebook>
@@ -137,6 +123,15 @@
             <field name="view_id" ref="email_template_tree" />
             <field name="search_view_id" ref="view_email_template_search"/>
             <field name="context">{'search_default_base_templates': 1}</field>
+        </record>
+
+        <record id="model_mail_template_action_add_context_action" model="ir.actions.server">
+            <field name="name">Add/Remove Context Action</field>
+            <field name="model_id" ref="mail.model_mail_template"/>
+            <field name="binding_model_id" ref="mail.model_mail_template"/>
+            <field name="binding_view_types">form</field>
+            <field name="state">code</field>
+            <field name="code">action = records.add_or_remove_context_action()</field>
         </record>
 
     </data>

--- a/addons/mail/wizard/__init__.py
+++ b/addons/mail/wizard/__init__.py
@@ -6,6 +6,7 @@ from . import base_partner_merge_automatic_wizard
 from . import mail_blacklist_remove
 from . import mail_compose_message
 from . import mail_resend_message
+from . import mail_template_name_prompt
 from . import mail_template_preview
 from . import mail_template_reset
 from . import mail_wizard_invite

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -80,8 +80,8 @@
                                 type="object" class="btn-primary" data-hotkey="q"
                                 attrs="{'invisible': [('subtype_is_log', '=', False)]}"/>
                         <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="z" />
-                        <button icon="fa-lg fa-save" type="object"
-                                name="action_save_as_template" string="Save as new template"
+                        <button icon="fa-cloud-upload" type="object"
+                                name="action_save_as_template" string="Save for me"
                                 attrs="{'invisible': [('can_edit_body', '=', False)]}"
                                 class="float-end btn-secondary" help="Save as a new template" data-hotkey="w"/>
                     </footer>

--- a/addons/mail/wizard/mail_template_name_prompt.py
+++ b/addons/mail/wizard/mail_template_name_prompt.py
@@ -1,0 +1,16 @@
+from odoo import models, fields
+
+
+class MailTemplateNamePrompt(models.TransientModel):
+    _name = 'mail.template.name.prompt'
+    _description = 'Prompt for inputting name when saving a template'
+
+    name = fields.Char('Name')
+
+    def save_template(self):
+        return self.env['mail.compose.message'].browse(
+            [self._context['mail_compose_message_id']],
+        )._save_as_template(self.name)
+
+    def cancel(self):
+        return self._context['reopen_composer']

--- a/addons/mail/wizard/mail_template_name_prompt_views.xml
+++ b/addons/mail/wizard/mail_template_name_prompt_views.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <record model="ir.ui.view" id="name_prompt_wizard_view_form">
+        <field name="name">mail.template.name.prompt.form</field>
+        <field name="model">mail.template.name.prompt</field>
+        <field name="arch" type="xml">
+            <form string="Name Prompt">
+                <group>
+                    <field name="name" widget="char_emojis"/>
+                </group>
+                <footer>
+                    <button name="save_template" string="Save" type="object" class="btn-primary"/>
+                    <button name="cancel" string="Cancel" type="object" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/mail_group/data/mail_template_data.xml
+++ b/addons/mail_group/data/mail_template_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="mail_template_guidelines" model="mail.template">
-        <field name="name">Mail Group: Send Guidelines</field>
+        <field name="name">✉️ Mail Group: Send Guidelines</field>
         <field name="model_id" ref="mail_group.model_mail_group_member"/>
         <field name="subject">Guidelines of group {{ object.mail_group_id.name }}</field>
         <field name="email_to">{{ object.email }}</field>
@@ -19,7 +19,7 @@
 
     <!-- Confirm subscription email -->
     <record id="mail_template_list_subscribe" model="mail.template">
-        <field name="name">Mail Group: Mailing List Subscription</field>
+        <field name="name">✉️ Mail Group: Mailing List Subscription</field>
         <field name="model_id" ref="mail_group.model_mail_group"/>
         <field name="subject">Confirm subscription to {{ object.name }}</field>
         <field name="description">Subscription confirmation to a mailing group</field>
@@ -38,7 +38,7 @@
 
     <!-- Confirm unsubscription email -->
     <record id="mail_template_list_unsubscribe" model="mail.template">
-        <field name="name">Mail Group: Mailing List Unsubscription</field>
+        <field name="name">✉️ Mail Group: Mailing List Unsubscription</field>
         <field name="model_id" ref="mail_group.model_mail_group"/>
         <field name="subject">Confirm unsubscription to {{ object.name }}</field>
         <field name="description">Sent to people who unsubscribed from a mailing group</field>

--- a/addons/project/data/mail_template_data.xml
+++ b/addons/project/data/mail_template_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <!-- Sample stage-related template -->
         <record id="mail_template_data_project_task" model="mail.template">
-            <field name="name">Project: Request Acknowledgment</field>
+            <field name="name">🧩 Project: Request Acknowledgment</field>
             <field name="model_id" ref="project.model_project_task"/>
             <field name="subject">Reception of {{ object.name }}</field>
             <field name="use_default_to" eval="True"/>
@@ -27,7 +27,7 @@
 
         <!-- Mail sent to request a rating for a task -->
         <record id="rating_project_request_email_template" model="mail.template">
-            <field name="name">Project: Task Rating Request</field>
+            <field name="name">🧩 Project: Task Rating Request</field>
             <field name="model_id" ref="project.model_project_task"/>
             <field name="active" eval="False"/>
             <field name="subject">{{ object.project_id.company_id.name }}: Satisfaction Survey</field>

--- a/addons/project/data/mail_template_demo.xml
+++ b/addons/project/data/mail_template_demo.xml
@@ -1,7 +1,7 @@
 <odoo>
     <data>        
         <record id="project_done_email_template" model="mail.template">
-            <field name="name">Project: Project Completed</field>
+            <field name="name">🧩 Project: Project Completed</field>
             <field name="model_id" ref="project.model_project_project"/>
             <field name="subject">Project status - {{ object.name }}</field>
             <field name="email_from">{{ (object.partner_id.email_formatted if object.partner_id else user.email_formatted) }}</field>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -15,7 +15,7 @@
     <record id="group_project_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="base.module_category_services_project"/>
-        <field name="implied_ids" eval="[(4, ref('group_project_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_project_user')), (4, ref('mail.group_template_admin'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="email_template_edi_purchase" model="mail.template">
-            <field name="name">Purchase: Request For Quotation</field>
+            <field name="name">💳 Purchase: Request For Quotation</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
             <field name="subject">{{ object.company_id.name }} Order (Ref {{ object.name or 'n/a' }})</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
@@ -36,7 +36,7 @@
         </record>
 
         <record id="email_template_edi_purchase_done" model="mail.template">
-            <field name="name">Purchase: Purchase Order</field>
+            <field name="name">💳 Purchase: Purchase Order</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
             <field name="subject">{{ object.company_id.name }} Order (Ref {{ object.name or 'n/a' }})</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>
@@ -74,7 +74,7 @@
         </record>
 
         <record id="email_template_edi_purchase_reminder" model="mail.template">
-            <field name="name">Purchase: Vendor Reminder</field>
+            <field name="name">💳 Purchase: Vendor Reminder</field>
             <field name="model_id" ref="purchase.model_purchase_order"/>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted) }}</field>
             <field name="subject">{{ object.company_id.name }} Order (Ref {{ object.name or 'n/a' }})</field>

--- a/addons/repair/data/mail_template_data.xml
+++ b/addons/repair/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_repair_quotation" model="mail.template">
-            <field name="name">Repair: Quotation</field>
+            <field name="name">🛠️ Repair: Quotation</field>
             <field name="model_id" ref="repair.model_repair_order"/>
             <field name="subject">{{ object.partner_id.name }} Repair Orders (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.create_uid.email_formatted or user.email_formatted) }}</field>

--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="email_template_edi_sale" model="mail.template">
-            <field name="name">Sales: Send Quotation</field>
+            <field name="name">🚀 Sales: Send Quotation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ object.state in ('draft', 'sent') and (ctx.get('proforma') and 'Proforma' or 'Quotation') or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
@@ -45,7 +45,7 @@
         </record>
 
         <record id="mail_template_sale_confirmation" model="mail.template">
-            <field name="name">Sales: Order Confirmation</field>
+            <field name="name">🚀 Sales: Order Confirmation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ (object.get_portal_last_transaction().state == 'pending') and 'Pending Order' or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
@@ -241,7 +241,7 @@
         </record>
 
         <record id="mail_template_sale_payment_executed" model="mail.template">
-            <field name="name">Sales: Payment Done</field>
+            <field name="name">🚀 Sales: Payment Done</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ (object.get_portal_last_transaction().state == 'pending') and 'Pending Order' or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or user.email_formatted) }}</field>
@@ -295,7 +295,7 @@
         </record>
 
         <record id="sale.mail_template_sale_cancellation" model="mail.template">
-            <field name="name">Sales: Order Cancellation</field>
+            <field name="name">🚀 Sales: Order Cancellation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">{{ object.company_id.name }} {{ object.type_name }} Cancelled (Ref {{ object.name or 'n/a' }})</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -23,7 +23,7 @@
             <field name="name">Administrator</field>
             <field name="comment">the user will have an access to the sales configuration as well as statistic reports.</field>
             <field name="category_id" ref="base.module_category_sales_sales"/>
-            <field name="implied_ids" eval="[(4, ref('group_sale_salesman_all_leads'))]"/>
+            <field name="implied_ids" eval="[(4, ref('group_sale_salesman_all_leads')), (4, ref('mail.group_template_admin'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 

--- a/addons/survey/data/mail_template_data.xml
+++ b/addons/survey/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data>
         <record id="mail_template_user_input_invite" model="mail.template">
-            <field name="name">Survey: Invite</field>
+            <field name="name">📋 Survey: Invite</field>
             <field name="model_id" ref="model_survey_user_input" />
             <field name="subject">Participate to {{ object.survey_id.display_name }} survey</field>
             <field name="email_to">{{ (object.partner_id.email_formatted or object.email) }}</field>
@@ -46,7 +46,7 @@
 
         <!-- Certification Email template -->
         <record id="mail_template_certification" model="mail.template">
-            <field name="name">Survey: Certification Success</field>
+            <field name="name">📋 Survey: Certification Success</field>
             <field name="model_id" ref="survey.model_survey_user_input"/>
             <field name="subject">Certification: {{ object.survey_id.display_name }}</field>
             <field name="email_from">{{ (object.survey_id.create_uid.email_formatted or user.email_formatted or user.company_id.catchall_formatted) }}</field>

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1167,14 +1167,14 @@ class TestComposerInternals(TestMailComposer):
         ).create({
             'subject': 'Template Subject',
             'body': '<p>Template Body</p>',
-        }).action_save_as_template()
+        })._save_as_template('template name')
 
         # Test: email_template subject, body_html, model
         template = self.env['mail.template'].search([
             ('model', '=', self.test_record._name),
             ('subject', '=', 'Template Subject')
         ], limit=1)
-        self.assertEqual(template.name, "%s: %s" % (self.env['ir.model']._get(self.test_record._name).name, 'Template Subject'))
+        self.assertEqual(template.name, 'template name')
         self.assertEqual(template.body_html, '<p>Template Body</p>', 'email_template incorrect body_html')
 
 

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -69,7 +69,7 @@ class TestMailTemplateCommon(MailCommon, TestRecipients):
 class TestMailTemplate(TestMailTemplateCommon):
 
     def test_template_add_context_action(self):
-        self.test_template.create_action()
+        self.test_template.add_or_remove_context_action()
 
         # check template act_window has been updated
         self.assertTrue(bool(self.test_template.ref_ir_act_window))

--- a/addons/website_crm_partner_assign/data/mail_template_data.xml
+++ b/addons/website_crm_partner_assign/data/mail_template_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="0">
         <!-- Technical template, keep updated -->
         <record id="email_template_lead_forward_mail" model="mail.template">
-            <field name="name">Lead Forward: Send to partner</field>
+            <field name="name">🤝 Lead Forward: Send to partner</field>
             <field name="model_id" ref="website_crm_partner_assign.model_crm_lead_forward_to_partner" />
             <field name="subject">Fwd: Lead: {{ ctx['partner_id'].name }}</field>
             <field name="email_from">{{ user.email_formatted }}</field>

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data noupdate="1">
     <record id="mail_template_data_track_confirmation" model="mail.template">
-        <field name="name">Event: Track Confirmation</field>
+        <field name="name">🎟️ Event: Track Confirmation</field>
         <field name="model_id" ref="website_event_track.model_event_track"/>
         <field name="subject">Confirmation of {{ object.name }}</field>
         <field name="use_default_to" eval="True"/>

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_sale_cart_recovery" model="mail.template">
-            <field name="name">Ecommerce: Cart Recovery</field>
+            <field name="name">🛒 Ecommerce: Cart Recovery</field>
             <field name="model_id" ref="sale.model_sale_order"/>
             <field name="subject">You left items in your cart!</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted or '') }}</field>

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
          <record id="slide_template_published" model="mail.template">
-            <field name="name">Elearning: New Course Content Notification</field>
+            <field name="name">👩‍🏫 Elearning: New Course Content Notification</field>
             <field name="model_id" ref="model_slide_slide"/>
             <field name="subject">New {{ object.slide_category }} published on {{ object.channel_id.name }}</field>
             <field name="description">Sent to attendees when new course is published</field>
@@ -35,7 +35,7 @@
         </record>
 
         <record id="slide_template_shared" model="mail.template">
-            <field name="name">Elearning: Course Share</field>
+            <field name="name">👩‍🏫 Elearning: Course Share</field>
             <field name="model_id" ref="model_slide_slide"/>
             <field name="subject">{{ user.name }} shared a {{ object.slide_category }} with you!</field>
             <field name="email_from">{{ user.email_formatted }}</field>
@@ -67,7 +67,7 @@
 
         <!-- Completed Channel Message -->
         <record id="mail_template_channel_completed" model="mail.template">
-            <field name="name">Elearning: Completed Course</field>
+            <field name="name">👩‍🏫 Elearning: Completed Course</field>
             <field name="model_id" ref="model_slide_channel_partner"/>
             <field name="subject">Congratulations! You completed {{ object.channel_id.name }}</field>
             <field name="email_from">{{ (object.channel_id.user_id.email_formatted or object.channel_id.user_id.company_id.catchall_formatted) }}</field>
@@ -133,7 +133,7 @@
 
         <!-- Slide channel invite feature -->
         <record id="mail_template_slide_channel_enroll" model="mail.template">
-            <field name="name">Elearning: Add Attendees to Course</field>
+            <field name="name">👩‍🏫 Elearning: Add Attendees to Course</field>
             <field name="model_id" ref="model_slide_channel_partner" />
             <field name="subject">You have been invited to join {{ object.channel_id.name }}</field>
             <field name="email_from">{{ user.email_formatted }}</field>
@@ -153,7 +153,7 @@
 
         <!-- Slide channel sharing feature -->
         <record id="mail_template_slide_channel_invite" model="mail.template">
-            <field name="name">Elearning: Promotional Course Invitation</field>
+            <field name="name">👩‍🏫 Elearning: Promotional Course Invitation</field>
             <field name="model_id" ref="model_slide_channel_partner" />
             <field name="subject">You have been invited to check out {{ object.channel_id.name }}</field>
             <field name="email_from">{{ user.email_formatted }}</field>

--- a/addons/website_slides_survey/data/mail_template_data.xml
+++ b/addons/website_slides_survey/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mail_template_user_input_certification_failed" model="mail.template">
-            <field name="name">Survey: Certification Failure</field>
+            <field name="name">📋 Survey: Certification Failure</field>
             <field name="model_id" ref="model_survey_user_input" />
             <field name="subject">You have failed the course: {{ object.slide_partner_id.channel_id.name }}</field>
             <field name="partner_to">{{ object.partner_id.id }}</field>


### PR DESCRIPTION
Before this commit, all mail templates were shared, which was cluttering the UI
for everyone.

Now, each user can have their own templates that they can edit and save through
modules that use the mail composer. In the mail composer wizard, users can only
access their own templates and templates that don't belong to anyone.

Some groups are considered as admins and can access all templates in
Settings/Technical/Email/Email Templates:

- Sales Admin
- Project Admins
- Helpdesk Admins
- Accountants
- Event Admins 
- Recruitment Admins

Besides, emojis were added to mail templates to better be able to differentiate
them.

Task-2504439