### PR TITLE
[FIX] website_sale:  fix product description from sales order portal view

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1098,7 +1098,7 @@
                         </div>
                     </div>
                 </section>
-                <div itemprop="description" t-field="product.website_description" class="oe_structure oe_empty mt16" id="product_full_description"/>
+                <div itemprop="description" class="oe_structure oe_empty mt16" id="product_full_description"/>
                 <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
             </div>
         </t>
@@ -1198,7 +1198,7 @@
 
     <!-- Product options: OpenChatter -->
     <template id="product_comment" inherit_id="website_sale.product" active="False" name="Discussion and Rating" priority="15">
-        <xpath expr="//div[@t-field='product.website_description']" position="after">
+        <xpath expr="//div[@id='product_full_description']" position="after">
             <div class="o_shop_discussion_rating" data-anchor='true'>
                 <section id="o_product_page_reviews" class="container pt32 pb32" data-anchor='true'>
                     <a class="o_product_page_reviews_title d-flex justify-content-between text-decoration-none collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#o_product_page_reviews_content" aria-expanded="false" aria-controls="o_product_page_reviews_content">


### PR DESCRIPTION

Before this commit if we go to website and purchase the product , the product description was also getting printed in sales order.

Steps:
Go to website and inside shop option add a product to cart. after checkout showing product description in sales order

Fix:
Added the class d-none for not displaying the product description.

 task-3188336

