### PR TITLE
[FIX] website_slides_survey: display rank badges page

### DIFF
--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -153,7 +153,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
 
         # 3. Remove certification badge from badges and keep only certification badge linked to opened survey
         badges = values['badges'] - certification_badges
-        certification_badges = certification_badges.filtered(lambda b: b.survey_id.state == 'open')
+        certification_badges = certification_badges.filtered(lambda b: b.survey_id.active)
 
         # 4. Getting all course url for each badge
         certification_slides = request.env['slide.slide'].sudo().search([('survey_id', 'in', certification_badges.mapped('survey_id').ids)])


### PR DESCRIPTION
Steps to reproduce:

  - Install `website_slides_survey`
  - Create a certification that grand a badge
  - Create a course with the above certification
  - Publish everything and pass the certification
  - Go to the course page and click on your rank

Issue:

  Error 505 (traceback in logs).

Cause:

  Since the ref-commit, the state attribute has been removed and use
  active attribute instead to know if a survey is in 'open' or 'close'
  state.

Solution:

  Check if survey is active instead.

ref-commit: https://github.com/odoo/odoo/commit/3010751e954bca0ecb934fcb34ec483b87b7b055

opw-3359735