### PR TITLE
[POC] core: support delay translation

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3465,9 +3465,9 @@ class TestViewTranslations(common.TransactionCase):
         # We need to flush `arch_db` before creating the translations otherwise the translation for which there is no value will be deleted,
         # while the `test_sync_update` specifically needs empty translations
         self.env.flush_all()
-        val = {'en_US': archf % terms}
+        val = {'en_US': archf % terms, '_en_US': archf % terms}
         for lang, trans_terms in kwargs.items():
-            val[lang] = archf % trans_terms
+            val['_' + lang] = val[lang] = archf % trans_terms
         query = "UPDATE ir_ui_view SET arch_db = %s WHERE id = %s"
         self.env.cr.execute(query, [Json(val), view.id])
         self.env.invalidate_all()
@@ -3547,6 +3547,7 @@ class TestViewTranslations(common.TransactionCase):
         # check whether translations have been reset
         self.assertEqual(view.with_env(env_nolang).arch, archf % terms_en)
         self.assertEqual(view.with_env(env_en).arch, archf % terms_en)
+        view.update_field_translations('arch_db', {'fr_FR': {}, 'nl_NL': {}})
         self.assertEqual(view.with_env(env_fr).arch, archf % terms_en)
         self.assertEqual(view.with_env(env_nl).arch, archf % terms_en)
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2788,7 +2788,7 @@ class BaseModel(metaclass=MetaModel):
                     return field.column_type[1] + (" NOT NULL" if field.required else "")
 
                 tools.create_model_table(cr, self._table, self._description, [
-                    (field.name, make_type(field), field.string)
+                    (field.name, make_type(field), field.string + (' (model_terms)' if callable(field.translate) else ''))
                     for field in sorted(self._fields.values(), key=lambda f: f.column_order)
                     if field.name != 'id' and field.store and field.column_type
                 ])

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1373,10 +1373,14 @@ class expression(object):
 
                     unaccent = self._unaccent(field) if sql_operator.endswith('like') else lambda x: x
                     lang = model.env.lang or 'en_US'
-                    if lang == 'en_US':
-                        left = unaccent(f""""{alias}"."{field.name}"->>'en_US'""")
+                    en_US = 'en_US'
+                    if (model.env.context.get('edit_translations') or model.env.context.get('check_translations')) and callable(field.translate):
+                        lang = '_' + lang
+                        en_US = '_' + en_US
+                    if lang == en_US:
+                        left = unaccent(f""""{alias}"."{field.name}"->>'{en_US}'""")
                     else:
-                        left = unaccent(f'''COALESCE("{alias}"."{field.name}"->>'{lang}', "{alias}"."{field.name}"->>'en_US')''')
+                        left = unaccent(f'''COALESCE("{alias}"."{field.name}"->>'{lang}', "{alias}"."{field.name}"->>'{en_US}')''')
 
                     if need_wildcard:
                         right = f'%{right}%'
@@ -1391,10 +1395,14 @@ class expression(object):
                     if params:
                         params = [field.convert_to_column(p, model, validate=False).adapted['en_US'] for p in params]
                         lang = model.env.lang or 'en_US'
-                        if lang == 'en_US':
-                            query = f'''("{alias}"."{field.name}"->>'en_US' {operator} %s)'''
+                        en_US = 'en_US'
+                        if (model.env.context.get('edit_translations') or model.env.context.get('check_translations')) and callable(field.translate):
+                            lang = '_' + lang
+                            en_US = '_' + en_US
+                        if lang == en_US:
+                            query = f'''("{alias}"."{field.name}"->>'{en_US}' {operator} %s)'''
                         else:
-                            query = f'''(COALESCE("{alias}"."{field.name}"->>'{lang}', "{alias}"."{field.name}"->>'en_US') {operator} %s)'''
+                            query = f'''(COALESCE("{alias}"."{field.name}"->>'{lang}', "{alias}"."{field.name}"->>'{en_US}') {operator} %s)'''
                         params = [tuple(params)]
                     else:
                         # The case for (left, 'in', []) or (left, 'not in', []).

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -149,11 +149,14 @@ def convert_column(cr, tablename, columnname, columntype):
     using = f'"{columnname}"::{columntype}'
     _convert_column(cr, tablename, columnname, columntype, using)
 
-def convert_column_translatable(cr, tablename, columnname, columntype):
+def convert_column_translatable(cr, tablename, columnname, columntype, is_model_terms):
     """ Convert the column from/to a 'jsonb' translated field column. """
     drop_index(cr, make_index_name(tablename, columnname), tablename)
     if columntype == "jsonb":
-        using = f"""CASE WHEN "{columnname}" IS NOT NULL THEN jsonb_build_object('en_US', "{columnname}"::varchar) END"""
+        if is_model_terms:
+            using = f"""CASE WHEN "{columnname}" IS NOT NULL THEN jsonb_build_object('en_US', "{columnname}"::varchar, '_en_US', "{columnname}"::varchar) END"""
+        else:
+            using = f"""CASE WHEN "{columnname}" IS NOT NULL THEN jsonb_build_object('en_US', "{columnname}"::varchar) END"""
     else:
         using = f""""{columnname}"->>'en_US'"""
     _convert_column(cr, tablename, columnname, columntype, using)


### PR DESCRIPTION
General idea:
Use _lang in jsonb to store the latest translation mappings with the same xml/html_structure Use lang in jsonb to store the old translations with different xml/html_structures

For all model_terms translated fields
Read:
	when not `edit_translations` and not `check_translations`
		COALESCE("field"->>'lang', "field"->>'en_US')
	when `edit_translations` or `check_translations`
		COALESCE("field"->>'_lang', "field"->>'_en_US')
Write:
	write `field` with `value_lang` in language `lang`
		all `_langs` will be updated to make sure they share the same xml/html_structure
		only current `lang` in `langs` will be udpated
Translate:
	when call `update_field_translation('field', translations)`
	for each lang in translations.keys():
		1. update translation for `_lang`
		2. copy value from `_lang` to `lang` as a translation confirmation

Valid database column values for field:
	("field"->>'lang' IS NULL) = ("field"->>'_lang' IS NULL)

Advantage:
for all model_terms translated fields

Disadvantage:
hard to upgrade or maintain the consistency for lang and _lang values more space for fields which don't need the delay translated feature

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
