### PR TITLE
[POC] website: support delay translation

### DIFF
--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -44,3 +44,9 @@ def post_init_hook(env):
     if request:
         env = env(context=request.default_context())
         request.website_routing = env['website'].get_current_website().id
+
+    env.cr.execute("""
+    UPDATE "ir_ui_view"
+    SET "arch_db_website" = "arch_db"
+    WHERE "website_id" IS NOT NULL;
+    """)

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1020,6 +1020,8 @@ class TestCowViewSaving(TestViewSavingCommon):
         self.env['ir.module.module']._load_module_terms(['website'], ['en_US', 'fr_BE', 'es_ES'], overwrite=True)
 
         specific_view.invalidate_model(['arch_db', 'arch'])
+        # update langs with empty translations to confirm existing translations imported by `_load_module_terms`
+        specific_view.update_field_translations('arch_db', {'en_US': {}, 'fr_BE': {}, 'es_ES': {}})
         self.assertEqual(specific_view.with_context(lang='fr_BE').arch, '<div>salut</div>',
                          "loading module translation copy translation from base to specific view")
 


### PR DESCRIPTION
General idea:
Use an extra model translated field `arch_db_website` to store the old translations with different xml_structures
the existing `arch_db` is still used to store the latest translation mappings with the same xml_structure

For website views
    view.website_id is not False
Read:
	when not `edit_translations`:
		`arch` is computed from `arch_db_website` (translate=True)
	when `edit_translations`:
		`arch` is computed from `arch_db` (translate=xml_translate)
Write:
	write `arch_db` with `value_lang` in language `lang` will trigger inverse to
	write `arch_db_website` with `value_lang` in language `lang`

Translate:
	when call `update_field_translation('arch_db', translations)`
	for each lang in translations.keys():
		1. update translations for `lang` of `arch_db`
		2. copy value from `arch_db` to `arch_db_website` as a translation confirmation

Valid database column values for ir_ui_view:
	("website_id" IS NULL) = ("arch_db_website" IS NULL)

Advantage:
all hacks are in the website, can even be an extra module to extend the feature of website

Disadvantage:
only for ir.ui.view.arch
for html fields e.g. product.template.website_description which are displayed in website requires extra similar hacks

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
