### PR TITLE
[FIX] base, portal: add access_token on report images

### DIFF
--- a/addons/portal/models/__init__.py
+++ b/addons/portal/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import ir_http
 from . import ir_ui_view
+from . import ir_qweb_fields
 from . import mail_thread
 from . import mail_message
 from . import portal_mixin

--- a/addons/portal/models/ir_http.py
+++ b/addons/portal/models/ir_http.py
@@ -3,6 +3,7 @@
 
 from odoo import models
 from odoo.http import request
+from odoo.tools import consteq
 
 
 class IrHttp(models.AbstractModel):
@@ -18,3 +19,11 @@ class IrHttp(models.AbstractModel):
         if request and request.is_frontend:
             return [lang[0] for lang in filter(lambda l: l[3], request.env['res.lang'].get_available())]
         return super()._get_frontend_langs()
+
+    def _check_access(self, model, record, field, access_token):
+        if isinstance(record, self.env.registry['portal.mixin']):
+            record_sudo = record.sudo()
+            attachment = self.sudo().env['ir.attachment'].search([('res_model', '=', model), ('res_id', '=', record.id), ('res_field', '=', field)])
+            if access_token and consteq(attachment.access_token or '', access_token):
+                return record_sudo
+        return super()._check_access(model, record, field, access_token)

--- a/addons/portal/models/ir_qweb_fields.py
+++ b/addons/portal/models/ir_qweb_fields.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import urllib.parse
+from odoo import models
+from odoo.http import request
+
+
+class Image(models.AbstractModel):
+    _inherit = 'ir.qweb.field.image'
+
+    def _get_src_urls(self, record, field_name, options):
+        src, src_zoom = super()._get_src_urls(record, field_name, options)
+        if isinstance(record, self.env.registry['portal.mixin']) and request and request.params.get('access_token'):
+            attachment = self.sudo().env['ir.attachment'].search([('res_model', '=', record._name), ('res_id', '=', record.id), ('res_field', '=', field_name)])
+            attachment.generate_access_token()
+            url = urllib.parse.urlsplit(src)
+            query = urllib.parse.parse_qs(url.query)
+            query['access_token'] = [attachment.access_token]
+            new_url = url._replace(query=urllib.parse.urlencode(query, doseq=True))
+            src = urllib.parse.urlunsplit(new_url)
+        return src, src_zoom


### PR DESCRIPTION
The sale order report (and other reports) generated in the portal page does not render the images that could have been added with Studio

Steps to reproduce:
1. Install Sales and Studio
2. Go to Sales and open any quotation
3. Toggle Studio and add an image field anywhere in the form
4. Go to reports and edit "Quotation / Order"
5. Add the new image field in the report and close Studio
6. Create a quotation for Joel Willis, add an image and a product
7. Send the quotation by mail
8. Open the sent mail (Settings > Technical > Email > Emails)
9. Open the sale order link in a new incognito tab
10. Download the sale order with the button at the top left of the page
11. The report doesn't contain the image

Solution:
Add an access token on the src url used in the report. That way, we can check that the user has correct access rights on the image in the `/web/image` controller. This solution is a backport inspired by DLE's work in https://github.com/odoo/odoo/pull/125970

Problem:
When generating the html that will be used to render the pdf, the image field is rendered with a src url. This url will then be resolved in the content_image route but the user is public so he has no rights on the field. Hence, the placeholder image is returned.

opw-3100989