### PR TITLE
[IMP] mail: allow users to manage own templates

### DIFF
--- a/addons/event/security/event_security.xml
+++ b/addons/event/security/event_security.xml
@@ -21,7 +21,7 @@
         <record id="group_event_manager" model="res.groups">
             <field name="name">Administrator</field>
             <field name="category_id" ref="base.module_category_marketing_events"/>
-            <field name="implied_ids" eval="[(4, ref('group_event_user'))]"/>
+            <field name="implied_ids" eval="[(4, ref('group_event_user')), (4, ref('mail.group_mail_template_editor'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
     </data>

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -28,7 +28,7 @@
     <record id="group_hr_recruitment_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="base.module_category_human_resources_recruitment"/>
-        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_hr_recruitment_user')), (4, ref('mail.group_mail_template_editor'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/mail/static/src/scss/composer.scss
+++ b/addons/mail/static/src/scss/composer.scss
@@ -48,6 +48,7 @@
 }
 
 .o_mail_composer_form .o_form_renderer  {
+    padding-bottom: 0px;
     .oe-bordered-editor[name=body] .o_readonly {
         border: 1px solid $o-gray-300;
         padding: 4px;

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -7,42 +7,35 @@
             <field name="arch" type="xml">
                 <form string="Templates">
                     <header>
+                        <field name="ref_ir_act_window" invisible="1"/>
                         <field name="template_fs" invisible="1"/>
+                        <field name="is_template_editor" invisible="1"/>
+                        <button string="Preview"
+                                name="%(mail_template_preview_action)d" type="action"
+                                class="btn-primary" target="new"/>
                         <button string="Reset Template"
                                 name="%(mail_template_reset_action)d" type="action"
                                 groups="mail.group_mail_template_editor"
                                 invisible="not template_fs"/>
+                        <button string="Delete"
+                                name="open_delete_confirmation_modal" type="object"
+                                class="btn btn-secondary"
+                                invisible="(user_id != uid and not is_template_editor) or template_fs"
+                                help="Permanently delete this template"/>
+                        <button string="Add Context Action"
+                                class="btn btn-secondary"
+                                name="create_action" type="object"
+                                groups="base.group_no_one"
+                                invisible="ref_ir_act_window"
+                                help="Display an option on related documents to open a composition wizard with this template"/>
+                        <button string="Remove Context Action"
+                                class="btn btn-secondary"
+                                name="unlink_action" type="object"
+                                groups="base.group_no_one"
+                                invisible="not ref_ir_act_window"
+                                help="Remove the contextual action to use this template on related documents"/>
                     </header>
                     <sheet>
-                        <div class="oe_button_box" name="button_box">
-                            <field name="ref_ir_act_window" invisible="1"/>
-                            <button class="oe_stat_button"
-                                    groups="base.group_no_one"
-                                    name="create_action" type="object"
-                                    invisible="ref_ir_act_window" icon="fa-plus"
-                                    help="Display an option on related documents to open a composition wizard with this template">
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_text">Add</span>
-                                    <span class="o_stat_text">Context Action</span>
-                                </div>
-                            </button>
-                            <button name="unlink_action" type="object"
-                                    groups="base.group_no_one"
-                                    class="oe_stat_button" icon="fa-minus"
-                                    invisible="not ref_ir_act_window"
-                                    help="Remove the contextual action to use this template on related documents" widget="statinfo">
-                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_text">Remove</span>
-                                    <span class="o_stat_text">Context Action</span>
-                                </div>
-                            </button>
-                            <button class="oe_stat_button" name="%(mail_template_preview_action)d" icon="fa-search-plus"
-                                    type="action" target="new">
-                                    <div class="o_field_widget o_stat_info">
-                                        <span class="o_stat_text">Preview</span>
-                                    </div>
-                            </button>
-                        </div>
                         <div class="oe_title">
                             <label for="name"/>
                             <h1><field name="name" class="w-100"
@@ -52,7 +45,6 @@
                                 <field name="subject" options="{'dynamic_placeholder': true}"
                                        placeholder='e.g. "Welcome to MyCompany" or "Nice to meet you, {{ object.name }}"'/>
                                 <field name="model" invisible="1"/>
-                                <field name="description"/>
                             </group>
                         </div>
                         <notebook>
@@ -80,17 +72,42 @@
                                 </group>
                             </page>
                             <page string="Settings" name="email_settings">
-                                <group>
-                                    <field name="lang" placeholder="{{ object.partner_id.lang }}"/>
-                                    <field name="mail_server_id"/>
-                                    <field name="auto_delete"/>
-                                    <field name="report_template_ids" domain="[('model','=',model)]"
-                                        widget="many2many_tags"
-                                        options="{'no_create': True}"/>
+                                <group col="2">
+                                    <group>
+                                        <field name="lang" placeholder="{{ object.partner_id.lang }}"/>
+                                        <field name="mail_server_id"/>
+                                        <field name="auto_delete"/>
+                                        <field name="report_template_ids" domain="[('model','=',model)]"
+                                            widget="many2many_tags"
+                                            options="{'no_create': True}"/>
+                                    </group>
+                                    <group>
+                                        <field name="user_id" widget="many2one_avatar_user"
+                                            readonly="not is_template_editor"
+                                            invisible="not is_template_editor"
+                                            placeholder="If not set, shared with all users."
+                                            help="If set, will restrict the template to this specific user.
+                                                  If not set, shared with all users."/>
+                                        <field name="description"/>
+                                    </group>
                                 </group>
                             </page>
                         </notebook>
                        </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record id="mail_template_view_form_confirm_delete" model="ir.ui.view">
+            <field name="name">mail.template.view.form.confirm.delete</field>
+            <field name="model">mail.template</field>
+            <field name="arch" type="xml">
+                <form string="Confirmation">
+                    <p>Are you sure you want to delete this Mail Template?</p>
+                    <footer>
+                        <button name="unlink" type="object" string="Delete" class="btn btn-primary"/>
+                        <button name="cancel_unlink" type="object" string="Cancel" class="btn btn-secondary"/>
+                    </footer>
                 </form>
             </field>
         </record>
@@ -103,6 +120,7 @@
                     <field name="mail_server_id" column_invisible="True"/>
                     <field name="name"/>
                     <field name="model_id" groups="base.group_no_one"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
                     <field name="description"/>
                     <field name="subject" optional="hidden"/>
                     <field name="email_from" optional="hidden"/>
@@ -120,6 +138,7 @@
                     <field name="name" filter_domain="['|', '|', ('name','ilike',self), ('subject','ilike',self), ('email_to','ilike',self)]" string="Templates"/>
                     <field name="lang"/>
                     <field name="model_id"/>
+                    <filter name="my_templates" string="My Templates" domain="[('user_id', '=', uid)]"/>
                     <filter name="base_templates" string="Base Templates" domain="[('template_category', '=', 'base_template')]"/>
                     <filter name="custom_templates" string="Custom Templates" domain="[('template_category', '=', 'custom_template')]"/>
                     <group expand="0" string="Group by...">

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -722,8 +722,10 @@ class MailComposer(models.TransientModel):
         }
 
     def create_mail_template(self):
-        """ creates a mail template with the information form the current mail composer """
+        """ creates a mail template with the current mail composer's fields """
         self.ensure_one()
+        if not self.model or not self.model in self.env:
+            raise UserError(_('Template creation from composer requires a valid model.'))
         model_id = self.env['ir.model']._get_id(self.model)
         values = {
             'name': self.subject,

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -46,7 +46,9 @@
                         <field name="body" class="oe-bordered-editor" placeholder="Write your message here..." options="{'style-inline': true}" readonly="not can_edit_body" force_save="1"/>
                         <group>
                             <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
-                            <field name="template_id" string="Load template" options="{'no_create': True}"
+                        </group>
+                        <group>
+                            <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
                                 context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
                         </group>
                     </div>
@@ -56,7 +58,9 @@
                                 <field name="body" class="oe-bordered-editor" placeholder="Write your message here..." options="{'style-inline': true}" readonly="not can_edit_body" force_save="1"/>
                                 <group>
                                     <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2"/>
-                                    <field name="template_id" string="Load template" options="{'no_create': True}"
+                                </group>
+                                <group>
+                                    <field name="template_id" string="Load template" options="{'no_create': True}" class="w-50"
                                         context="{'default_model': model, 'default_body_html': body, 'default_subject': subject}"/>
                                 </group>
                             </div>
@@ -80,10 +84,26 @@
                                 type="object" class="btn-primary" data-hotkey="q"
                                 invisible="not subtype_is_log"/>
                         <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
-                        <button icon="fa-lg fa-save" type="object"
-                                name="action_save_as_template" string="Save as new template"
+                        <button icon="fa-cloud-upload" type="object"
+                                name="open_template_creation_wizard" string="Save Template"
                                 invisible="not can_edit_body"
-                                class="float-end btn-secondary" help="Save as a new template" data-hotkey="w"/>
+                                class="float-end btn-secondary" data-hotkey="w" help="Save as a new template"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="mail_compose_message_view_form_template_save" model="ir.ui.view">
+            <field name="name">mail.compose.message.view.form.template.save</field>
+            <field name="model">mail.compose.message</field>
+            <field name="arch" type="xml">
+                <form string="Templates">
+                    <group>
+                        <field name="subject" placeholder="e.g. &quot;Welcome to MyCompany&quot; or &quot;Nice to meet you, {{ object.name }}&quot;"/>
+                    </group>
+                    <footer>
+                        <button name="create_mail_template" type="object" class="btn btn-primary" string="Save"/>
+                        <button name="cancel_save_template" type="object" class="btn btn-secondary" string="Cancel"/>
                     </footer>
                 </form>
             </field>

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -15,7 +15,7 @@
     <record id="group_project_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="category_id" ref="base.module_category_services_project"/>
-        <field name="implied_ids" eval="[(4, ref('group_project_user'))]"/>
+        <field name="implied_ids" eval="[(4, ref('group_project_user')), (4, ref('mail.group_mail_template_editor'))]"/>
         <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
     </record>
 

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -23,7 +23,8 @@
             <field name="name">Administrator</field>
             <field name="comment">the user will have an access to the sales configuration as well as statistic reports.</field>
             <field name="category_id" ref="base.module_category_sales_sales"/>
-            <field name="implied_ids" eval="[(4, ref('group_sale_salesman_all_leads'))]"/>
+            <field name="implied_ids" eval="[(4, ref('group_sale_salesman_all_leads')),
+                (4, ref('mail.group_mail_template_editor'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1176,14 +1176,14 @@ class TestComposerInternals(TestMailComposer):
         ).create({
             'subject': 'Template Subject',
             'body': '<p>Template Body</p>',
-        }).action_save_as_template()
+        }).create_mail_template()
 
         # Test: email_template subject, body_html, model
         template = self.env['mail.template'].search([
             ('model', '=', self.test_record._name),
             ('subject', '=', 'Template Subject')
         ], limit=1)
-        self.assertEqual(template.name, "%s: %s" % (self.env['ir.model']._get(self.test_record._name).name, 'Template Subject'))
+        self.assertEqual(template.name, 'Template Subject')
         self.assertEqual(template.body_html, '<p>Template Body</p>', 'email_template incorrect body_html')
 
     @users('erp_manager')


### PR DESCRIPTION
Before this commit, all mail templates were shared, which was cluttering the UI for everyone.

Now, each user can have their own templates that they can edit and save through modules that use the mail composer. In the mail composer wizard, users can only access their own templates and templates that don't belong to anyone.

Some groups are considered as admins and can access all templates in Settings/Technical/Email/Email Templates:

- Sales Admin
- Project Admins
- Helpdesk Admins
- Accountants
- Event Admins 
- Recruitment Admins

Task-2504439
