### PR TITLE
[FIX] survey: fix extract_filters_data permission for non-survey user

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -781,13 +781,13 @@ class Survey(http.Controller):
         # Add filters domain to the base domain
         if user_input_line_subdomains:
             all_required_lines_domains = [
-                [('user_input_line_ids', 'in', request.env['survey.user_input.line'].sudo()._search(subdomain))]
+                [('user_input_line_ids', 'in', request.env['survey.user_input.line']._search(subdomain))]
                 for subdomain in user_input_line_subdomains
             ]
             user_input_domain = expression.AND([user_input_domain, *all_required_lines_domains])
 
         # Get the matching user input lines
-        user_inputs_query = request.env['survey.user_input'].sudo()._search(user_input_domain)
+        user_inputs_query = request.env['survey.user_input']._search(user_input_domain)
         user_input_lines = request.env['survey.user_input.line'].search([('user_input_id', 'in', user_inputs_query)])
 
         return user_input_lines, search_filters


### PR DESCRIPTION

Remove useless sudos: If the user has acces to survey user input lines,
it's useless for him to not have access to the survey user input.
Sudo should not be used when not needed.


task-id: 3366427



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
