### PR TITLE
[IMP] hr_recruitment: Blacklist of providers

### DIFF
--- a/addons/hr_recruitment/data/hr_recruitment_data.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_data.xml
@@ -103,5 +103,10 @@
             <field name="template_id" ref="email_template_data_applicant_not_interested"/>
         </record>
 
+        <record model="ir.config_parameter" id="hr_recruitment_blacklisted_emails" forcecreate="False">
+            <field name="key">hr_recruitment.blacklisted_emails</field>
+            <field name="value"> </field>
+        </record>
+
 </data>
 </odoo>

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -16,6 +16,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
         domain="[('model', '=', 'hr.applicant')]")
     applicant_without_email = fields.Text(compute='_compute_applicant_without_email',
         string='Applicant(s) not having email')
+    applicant_emails = fields.Text(compute='_compute_applicant_emails')
 
     @api.depends('refuse_reason_id')
     def _compute_send_mail(self):
@@ -35,6 +36,11 @@ class ApplicantGetRefuseReason(models.TransientModel):
                 )
             else:
                 wizard.applicant_without_email = False
+
+    @api.depends('applicant_ids.email_from')
+    def _compute_applicant_emails(self):
+        for wizard in self:
+            wizard.applicant_emails = ', '.join(a.email_from for a in wizard.applicant_ids if a.email_from)
 
     def action_refuse_reason_apply(self):
         if self.send_mail:

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
@@ -7,8 +7,13 @@
                 <form string="Refuse Reason">
                     <group col="1">
                         <field name="refuse_reason_id" widget="selection_badge" options="{'horizontal': true, 'no_create': True, 'no_open': True}"/>
-                        <field name="send_mail" invisible="not refuse_reason_id"/>
-                        <field name="template_id" invisible="not send_mail" required="send_mail" />
+                        <label for="send_mail" invisible="not refuse_reason_id" colspan="1"/>
+                        <span colspan="1" class="text-nowrap" invisible="not refuse_reason_id">
+                            <field name="send_mail"/>
+                            to
+                            <field name="applicant_emails"/>
+                        </span>
+                        <field name="template_id" invisible="not send_mail" required="send_mail"/>
                         <field name="applicant_ids" invisible="1"/>
                     </group>
                     <div class="alert alert-danger" role="alert" invisible="not applicant_without_email">


### PR DESCRIPTION
- Create a system parameter called "blacklisted_emails" and holding all emails that we want to consider separated by a , 
- When an applicant is generated from an email, if the email is present on the system_parameter, don't create a partner automatically + don't use the blacklisted email on the field email either 
- When the field email is updated on the contact, or on the applicant and that the new value is not present in the blacklist, synchronize both records. (as long as we are obliged to use the partner to send the email, we need to keep it synchronized with applicant) 
- Display the used email on this screen

task-id: 3358086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
