### PR TITLE
[IMP] model_selector:  modified related model dropdown behaviour

### DIFF
--- a/addons/web/static/src/core/model_selector/model_selector.js
+++ b/addons/web/static/src/core/model_selector/model_selector.js
@@ -31,7 +31,7 @@ export class ModelSelector extends Component {
     }
 
     get placeholder() {
-        return _t("Search a Model...");
+        return _t("Type a model here...");
     }
 
     get sources() {
@@ -53,9 +53,17 @@ export class ModelSelector extends Component {
 
     filterModels(name) {
         if (!name) {
-            return this.models.slice(0, 8);
+            const visibleModels = this.models.slice(0, 8);
+            if (this.models.length - visibleModels.length > 0) {
+                visibleModels.push({
+                    label: _t("Start typing..."),
+                    unselectable: true,
+                    classList: "o_m2o_start_typing",
+                });
+            }
+            return visibleModels;
         }
-        return fuzzyLookup(name, this.models, (model) => model.technical + model.label).slice(0, 8);
+        return fuzzyLookup(name, this.models, (model) => model.technical + model.label);
     }
 
     loadOptionsSource(request) {

--- a/addons/web/static/src/core/model_selector/model_selector.scss
+++ b/addons/web/static/src/core/model_selector/model_selector.scss
@@ -1,0 +1,10 @@
+.o_model_selector {
+    .o-autocomplete--dropdown-menu {
+        width: 25ch;
+        max-height: 350px !important;
+        .o-autocomplete--dropdown-item a {
+            text-overflow: ellipsis;
+            width: inherit;
+        }
+    }
+}

--- a/addons/web/static/src/core/model_selector/model_selector.xml
+++ b/addons/web/static/src/core/model_selector/model_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="web.ModelSelector" owl="1">
-        <div class="o_sp_input_dropdown" t-ref="autocomplete_container">
+        <div class="o_model_selector" t-ref="autocomplete_container">
             <input t-if="env.isSmall"
                 type="text"
                 class="o_input"

--- a/addons/web/static/tests/core/model_selector_test.js
+++ b/addons/web/static/tests/core/model_selector_test.js
@@ -163,7 +163,11 @@ QUnit.test("model_selector: with more than 8 models", async function (assert) {
         "model_10",
     ]);
     await openAutocomplete();
-    assert.containsN(fixture, "li.o-autocomplete--dropdown-item", 8);
+    assert.containsN(fixture, "li.o-autocomplete--dropdown-item", 9);
+    assert.strictEqual(
+        fixture.querySelectorAll("li.o-autocomplete--dropdown-item")[8].innerText,
+        "Start typing..."
+    );
 });
 
 QUnit.test(
@@ -225,6 +229,31 @@ QUnit.test("model_selector: select a model", async function (assert) {
     await openAutocomplete();
     await click(fixture.querySelector(".o_model_selector_model_2"));
     assert.verifySteps(["model selected"]);
+});
+
+QUnit.test("model_selector: click on start typing", async function (assert) {
+    await mountModelSelector([
+        "model_1",
+        "model_2",
+        "model_3",
+        "model_4",
+        "model_5",
+        "model_6",
+        "model_7",
+        "model_8",
+        "model_9",
+        "model_10",
+        ]);
+    await openAutocomplete();
+    await click(fixture.querySelectorAll("li.o-autocomplete--dropdown-item")[8]);
+    assert.equal(fixture.querySelector(".o-autocomplete--input").value, "");
+    assert.equal(fixture.querySelector(".o-autocomplete.dropdown ul"), null);
+
+    //label must be empty
+    assert.equal(fixture.querySelector(".o_global_filter_label"), null);
+
+    //Default value and matching fields should not be available
+    assert.equal(fixture.querySelector(".o_side_panel_section"), null);
 });
 
 QUnit.test("model_selector: with an initial value", async function (assert) {


### PR DESCRIPTION
**Description**

Current behavior before PR:
When number of available domains exceeded the display limit, nothing in UI indicates that apart from visible domains, some more domains are available as well. Visible entries change only when user starts typing something.

Desired behavior after PR is merged:
A 'Start typing...' entry should be added after the visible models in dropdown menu whenever number of available models exceed the display limit, in order to provide a hint to the user.

Task ID : 3375332




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
