### PR TITLE
[IMP] product: show template field in product

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -378,8 +378,11 @@
                 <group name="packaging" position="attributes">
                     <attribute name="attrs">{'invisible': 0}</attribute>
                 </group>
-                <field name="name" position="after">
-                    <field name="product_tmpl_id" class="oe_inline" readonly="1" invisible="1" attrs="{'required': [('id', '!=', False)]}"/>
+                <field name="detailed_type" position="before">
+                    <field name="product_tmpl_id" readonly="1" attrs="{'required': [('id', '!=', False)]}"
+                           groups="base.group_no_one"/>
+                    <field name="product_tmpl_id" readonly="1" invisible="1" attrs="{'required': [('id', '!=', False)]}"
+                           groups="!base.group_no_one"/>
                 </field>
                 <xpath expr="//div[hasclass('oe_title')]" position="inside">
                     <field name="product_template_variant_value_ids" widget="many2many_tags" readonly="1" groups="product.group_product_variant"/>


### PR DESCRIPTION
before this commit, the product template field is
not shown in the product form and if user needs
to access some information from template or
open the product template, have to access through
the template menu and search and open from there.

after this commit, on debug mode the template m20
field is displayed in the product form and user can open the template just by clicking the m2o field

![Screenshot from 2023-06-23 11-18-23](https://github.com/odoo/odoo/assets/27989791/396dce33-9ee0-409f-9592-1fcc56fa2fe3)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
