### PR TITLE
[FIX] website_sale: prevent zero price display if attributes

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -269,7 +269,7 @@ class ProductTemplate(models.Model):
                     company_id,
                     fields.Date.today())
             has_discounted_price = pricelist.currency_id.compare_amounts(list_price, price) == 1
-            prevent_zero_price_sale = not price and current_website.prevent_zero_price_sale
+            prevent_zero_price_sale = not price and current_website.prevent_zero_price_sale and not product.attribute_line_ids
             combination_info.update(
                 base_unit_name=product.base_unit_name,
                 base_unit_price=product.base_unit_count and list_price / product.base_unit_count,

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -196,7 +196,8 @@
                                 <em class="small" t-esc="template_price_vals['base_price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
                             </del>
                         </t>
-                        <span class="h6 mb-0" t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale" t-esc="template_price_vals['price_reduce']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
+                        <span class="h6 mb-0" t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale or product.attribute_line_ids"
+                            t-esc="template_price_vals['price_reduce']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
                         <span class="h6 mb-0" t-else="" t-field="website.prevent_zero_price_sale_text"/>
                         <span itemprop="price" style="display:none;" t-esc="template_price_vals['price_reduce']" />
                         <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name" />


### PR DESCRIPTION
Steps to reproduce:
-------------------
- activate "Prevent Sale of Zero Priced Product" setting;
- create a product with a price equals to zero;
- add attribute for this product;
- go to ecommerce.

Issue:
------
The sentence "Not Available For Sale" is displayed on the shop page and in the search bar.
This is not correct as the product is available.
It has a price thanks to these attributes.

Solution:
---------
Use the `attribute_line_ids` to detect
if the product has attributes or not.

opw-3374137