### PR TITLE
[FIX] data_recycle: deleted root menu item in send notification

### DIFF
--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -174,7 +174,7 @@ class DataRecycleModel(models.Model):
         ])
         partner_ids = self.notify_user_ids.partner_id.ids if records_count else []
         if partner_ids:
-            menu_id = self.env.ref('data_recycle.menu_data_cleaning_root').id
+            menu = self.env.ref('data_recycle.menu_data_cleaning_root', raise_if_not_found=False)
             self.env['mail.thread'].message_notify(
                 body=self.env['ir.qweb']._render(
                     'data_recycle.notification',
@@ -182,7 +182,7 @@ class DataRecycleModel(models.Model):
                         'records_count': records_count,
                         'res_model_label': self.res_model_id.name,
                         'recycle_model_id': self.id,
-                        'menu_id': menu_id
+                        'menu_id': menu.id if menu else False
                     }
                 ),
                 model=self._name,


### PR DESCRIPTION
When the user deletes the "Data Cleaning" root menu item from menu items and creates a new "Recyle Records Rules" record and then the "Data Recycle: Clean Records" scheduled action executes the manually or automatically in that case traceback will be generated.

Steps to produce:
- Install the data_cleaning and sale_management module.
- Settings > Technical > User Interface > Menu Items
- Search for a "Data Cleaning" record and delete it from menu items.
- Data Cleaning > Configuration > Rules > Recycle Records
- Create a new record and fill up the required details. eg. select a sale order model
- Settings > Technical > Automation > Schedules Actions
- Search "Data Recycle: Clean Records"  and run manually it. After that, a traceback will be generated.

Error:
<class 'ValueError'>: "External ID not found in the system: data_recycle.menu_data_cleaning_root" while evaluating 'model._cron_recycle_records()'

This PR will resolve the "data_recycle.menu_data_cleaning_root" external id not found in the system,
and when the user creates a new  "Recyle Records Rules" record and executes on "Data Recycle: Clean Records" 
from the scheduled action/ corn job a traceback is generated and fixed.

Traceback:
```Traceback (most recent call last):
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/Sentry_RD_WORK/odoo/addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/Sentry_RD_WORK/odoo/addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/addons/base/models/ir_cron.py", line 91, in method_direct_trigger
    cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall}).ir_actions_server_id.run()
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/addons/base/models/ir_actions.py", line 694, in run
    res = runner(run_self, eval_context=eval_context)
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/addons/base/models/ir_actions.py", line 559, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "/home/odoo/Sentry_RD_WORK/odoo/odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
ValueError: <class 'ValueError'>: "External ID not found in the system: data_recycle.menu_data_cleaning_root" while evaluating
'model._cron_recycle_records()'
2023-06-23 09:05:50,679 52605 INFO saas-16.3_data_clean_v7 werkzeug: 127.0.0.1 - - [23/Jun/2023 09:05:50] "POST /web/dataset/call_button HTTP/1.1" 200 - 24 0.007 0.011
```

Sentry-4267040086

Enterprise:  https://github.com/odoo/enterprise/pull/43062
