### PR TITLE
[FIX] account_edi_ubl_cii: fix edi format change for other addresses

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -21,6 +21,7 @@ class ResPartner(models.Model):
         compute='_compute_ubl_cii_format',
         store=True,
         readonly=False,
+        recursive=True,
     )
     peppol_endpoint = fields.Char(
         string="Peppol Endpoint",
@@ -121,10 +122,12 @@ class ResPartner(models.Model):
         ]
     )
 
-    @api.depends('country_code')
+    @api.depends('country_code', 'parent_id.ubl_cii_format')
     def _compute_ubl_cii_format(self):
         for partner in self:
-            if partner.country_code == 'DE':
+            if partner.parent_id:
+                partner.ubl_cii_format = partner.parent_id.ubl_cii_format
+            elif partner.country_code == 'DE':
                 partner.ubl_cii_format = 'xrechnung'
             elif partner.country_code in ('AU', 'NZ'):
                 partner.ubl_cii_format = 'ubl_a_nz'


### PR DESCRIPTION
Currently, changing an EDI format on a parent partner does not trigger the change of edi format of their child addresses. Other contacts should have the same edi format as their parent partner, so a change in the partner's edi format should be propagated to every child.

opw-3369585



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
