### PR TITLE
[FIX] l10n_se,account: create suspense account with the right code

### DIFF
--- a/addons/l10n_se/data/account.account.template.csv
+++ b/addons/l10n_se/data/account.account.template.csv
@@ -55,6 +55,7 @@
 "a1910","1910","Kassa","account.data_account_type_liquidity","l10nse_chart_template","False"
 "a1920","1920","PlusGiro","account.data_account_type_liquidity","l10nse_chart_template","False"
 "a1930","1930","Företagskonto/checkkonto/affärskonto","account.data_account_type_liquidity","l10nse_chart_template","True"
+"a1932","1932","Bank Suspense Account","account.data_account_type_current_assets","l10nse_chart_template","True"
 "a1940","1940","Övriga bankkonton","account.data_account_type_liquidity","l10nse_chart_template","False"
 "a2070","2070","Ändamålsbestämda medel","account.data_account_type_equity","l10nse_chart_template","False"
 "a2081","2081","Aktiekapital","account.data_account_type_equity","l10nse_chart_template","False"

--- a/addons/l10n_se/data/account_chart_template_after_accounts.xml
+++ b/addons/l10n_se/data/account_chart_template_after_accounts.xml
@@ -12,6 +12,7 @@
             <field name="property_stock_account_output_categ_id" ref="a4960"/>
             <field name="property_stock_valuation_account_id" ref="a1410"/>
             <field name="default_pos_receivable_account_id" ref="a1910"/>
+            <field name="account_journal_suspense_account_id" ref="a1932"/>
         </record> 
     </data>
 </odoo>


### PR DESCRIPTION
Up until saas-16.2, the Bank suspense account is created before the Bank account
(which is created when loading default journals).
Hence, SE CoA has a Bank Suspense account with code 1931 and a Bank account with code 1932,
but change place in saas-16.2, where the loading order changed.

Account 1931 is supposed to have a bank and cash account type in Swedish CoA.
Adding the bank suspense account explicitly in the CoA solves this issue.

opw-3336373


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
