### PR TITLE
[FIX] base: delete fields related to custom field

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2930,6 +2930,7 @@ class BaseModel(metaclass=MetaModel):
                     related_sudo=False,
                     copy=field.copy,
                     readonly=field.readonly,
+                    manual=field.manual,
                 ))
 
     @api.model


### PR DESCRIPTION
It's impossible to delete related fields that have automatically been created because they are inherited from a custom field

Steps to reproduce:
1. Install Contacts and Studio
2. Open any contact and toggle Studio
3. Add a new field in the `res.partner` form and then remove it
4. Go to Settings > Technical > Database Structure > Fields
5. Search for fields with 'x_studio' in their name (a related field has also been created on model `res.users` and it's not custom)
6. Try to delete the fields, an error prevents the action

Solution:
Mark inherited fields as manual if they are related to a manual field. Allow the deletion of related fields if we are also deleting the field it is related to.

opw-3369689