### PR TITLE
[FIX] l10n_it_edi: global discount should not be taxed

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -726,6 +726,7 @@ class AccountEdiFormat(models.Model):
                         'sequence': sequence,
                         'name': 'SCONTO' if general_discount < 0 else 'MAGGIORAZIONE',
                         'price_unit': general_discount,
+                        'tax_ids': [],  # without this, a tax is automatically added to the line
                     })]
 
             new_invoice = invoice_form

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -137,13 +137,25 @@ class TestItEdiImport(TestItEdi):
                 <xpath expr="//FatturaElettronicaBody/DatiGenerali/DatiGeneraliDocumento" position="inside">
                     <ScontoMaggiorazione>
                         <Tipo>SC</Tipo>
-                        <Importo>10</Importo>
+                        <Importo>2</Importo>
                     </ScontoMaggiorazione>
                 </xpath>
             ''')
         invoices = self.edi_format._create_invoice_from_xml_tree(self.invoice_filename2, content)
 
-        discount_line = invoices.invoice_line_ids.filtered(lambda line: line.name == 'SCONTO')
-        self.assertRecordValues(discount_line, [{
-            'price_unit': -10,
+        self.assertRecordValues(invoices, [{
+            'amount_untaxed': 3.0,
+            'amount_tax': 1.1,
         }])
+        self.assertRecordValues(invoices.invoice_line_ids, [
+            {
+                'quantity': 5.0,
+                'name': 'DESCRIZIONE DELLA FORNITURA',
+                'price_unit': 1.0,
+            },
+            {
+                'quantity': 1.0,
+                'name': 'SCONTO',
+                'price_unit': -2,
+            }
+        ])


### PR DESCRIPTION
**Bug**
When importing a fatturapa XML that has a global discount, the discount should be applied on the taxed amount.

**Cause**
Currently, the system automatically adds a tax on the discount line.