### PR TITLE
[FIX] mail: properly handle errors on closing smtp connection

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -541,7 +541,10 @@ class MailMail(models.Model):
                     len(batch_ids), mail_server_id)
             finally:
                 if smtp_session:
-                    smtp_session.quit()
+                    try:
+                        smtp_session.quit()
+                    except Exception:
+                        _logger.warning("Failed to properly close stmp connection", exc_info=True)
 
     def _send(self, auto_commit=False, raise_exception=False, smtp_session=None):
         IrMailServer = self.env['ir.mail_server']


### PR DESCRIPTION
According to docs [1]:

> SMTP.quit()
> Terminate the SMTP session and close the connection. Return the result of the SMTP QUIT command.

[1]: https://docs.python.org/3/library/smtplib.html

https://online.sentry.io/issues/3964535560/
