### PR TITLE
[FIX] website: add test for website filter in list view

### DIFF
--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -29,6 +29,28 @@ const checkKanbanGroupBy = [{
     trigger: '.o_cp_searchview .o_facet_remove',
 }];
 
+const checkWebsiteFilter = [
+    {
+        content: "Click on the search options",
+        trigger: ".o_searchview_dropdown_toggler",
+    }, {
+        content: "Select My Website 2",
+        trigger: ".o_dropdown_container.o_website_menu > .dropdown-item:contains('My Website 2')",
+    }, {
+        content: "Check that the homepage is now the one of My Website 2",
+        trigger: ".o_list_table .o_data_row .o_data_cell[name=name]:contains('Home') " +
+                "~ .o_data_cell[name=website_id]:contains('My Website 2')",
+        run: () => null, // it's a check
+    }, {
+        content: "Check that the search options are still open",
+        trigger: ".o_search_bar_menu",
+        run: () => null, // it's a check
+    }, {
+        content: "Go back to My Website",
+        trigger: ".o_dropdown_container.o_website_menu > .dropdown-item:contains('My Website')",
+    },
+];
+
 const deleteSelectedPage = [
     {
         content: "Click on Action",
@@ -65,6 +87,7 @@ wTourUtils.registerWebsitePreviewTour('website_page_manager', {
         trigger: 'a.dropdown-item[data-menu-xmlid="website.menu_website_pages_list"]',
     },
     ...checkKanbanGroupBy,
+    ...checkWebsiteFilter,
     {
         content: "Click on Home Page",
         trigger: `.o_list_renderer ${homePage} td.o_list_record_selector input[type="checkbox"]`,


### PR DESCRIPTION
In order to prevent future breaks, this commit tests the possibility to filter by website_id in the list view (e.g. on website.pages). This commit is a modification of the test introduced in [1] after the redesign from [2].

task-3355253

[1]: https://github.com/odoo/odoo/pull/124839/commits/097822b
[2]: https://github.com/odoo/odoo/pull/123886/commits/8055801