### PR TITLE
[IMP] l10n_in_edi: remove mandatory state requirement  for export

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -226,7 +226,7 @@ class AccountEdiFormat(models.Model):
             message.append(_("\n- Street2 should be min 3 and max 100 characters"))
         if not re.match("^.{3,100}$", partner.city or ""):
             message.append(_("\n- City required min 3 and max 100 characters"))
-        if not re.match("^.{3,50}$", partner.state_id.name or ""):
+        if partner.country_id.code == "IN" and not re.match("^.{3,50}$", partner.state_id.name or ""):
             message.append(_("\n- State required min 3 and max 50 characters"))
         if partner.country_id.code == "IN" and not re.match("^[0-9]{6,}$", partner.zip or ""):
             message.append(_("\n- Zip code required 6 digits"))


### PR DESCRIPTION
Before commit:
---
For export the state must be provided else it will show error while sending e-invoice.

After commit:
---
The state is not mandatory to provide for export.

