### PR TITLE
[ADD] l10n_es_pos: Spanish localization for POS

### DIFF
--- a/addons/l10n_es_pos/__init__.py
+++ b/addons/l10n_es_pos/__init__.py
@@ -1,0 +1,5 @@
+from . import models
+from . import tests
+
+def _l10n_es_pos_set_sequence_post_init_hook(env):
+    env['pos.config'].search([])._set_simplified_l10n_es_sequence()

--- a/addons/l10n_es_pos/__manifest__.py
+++ b/addons/l10n_es_pos/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Spain - Point of Sale',
+    'countries': ['es'],
+    'author': 'Odoo, Odoo Community Association (OCA)',
+    'category': 'Accounting/Localizations/Point of Sale',
+    'summary': """Spanish localization for Point of Sale""",
+    'depends': ['point_of_sale', 'l10n_es'],
+    'auto_install': True,
+    'license': 'LGPL-3',
+    'post_init_hook': '_l10n_es_pos_set_sequence_post_init_hook',
+    'data': [
+        'views/res_config_settings_views.xml',
+        'views/pos_order_views.xml',
+    ],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'l10n_es_pos/static/src/**/*',
+        ],
+        'web.assets_tests': [
+            'l10n_es_pos/static/tests/**/*',
+        ],
+    },
+}

--- a/addons/l10n_es_pos/models/__init__.py
+++ b/addons/l10n_es_pos/models/__init__.py
@@ -1,0 +1,5 @@
+from . import ir_sequence
+from . import pos_config
+from . import pos_order
+from . import pos_session
+from . import res_config_settings

--- a/addons/l10n_es_pos/models/ir_sequence.py
+++ b/addons/l10n_es_pos/models/ir_sequence.py
@@ -1,0 +1,36 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class IrSequence(models.Model):
+    _inherit = "ir.sequence"
+
+    @api.constrains("prefix", "code")
+    def check_simplified_invoice_unique_prefix(self):
+        if self._context.get("copy_pos_config"):
+            return
+        for sequence in self.filtered(lambda x: x.code == "pos.config.simplified_invoice"):
+            if (
+                self.search_count(
+                    [
+                        ("code", "=", "pos.config.simplified_invoice"),
+                        ("prefix", "=", sequence.prefix),
+                    ]
+                )
+                > 1
+            ):
+                raise UserError(
+                    _(
+                        "There is already a simplified invoice "
+                        "sequence with that prefix and it should be "
+                        "unique."
+                    )
+                )
+
+    def _sanitize_prefix(self, initial_prefix):
+        prefix = initial_prefix
+        ith = 0
+        while self.env["ir.sequence"].search_count([("prefix", "=", prefix)]):
+            ith += 1
+            prefix = f"{initial_prefix}{ith}-"
+        return prefix

--- a/addons/l10n_es_pos/models/pos_config.py
+++ b/addons/l10n_es_pos/models/pos_config.py
@@ -1,0 +1,89 @@
+from odoo import _, api, fields, models
+
+
+class PosConfig(models.Model):
+    _inherit = "pos.config"
+
+    is_spanish = fields.Boolean(string="Company located in Spain", compute="_is_company_spanish")
+
+    def _is_company_spanish(self):
+        for pos in self:
+            pos.is_spanish = pos.company_id.country_id.code == "ES"
+
+    l10n_es_simplified_invoice_limit = fields.Float(
+        string="Sim.Inv limit amount",
+        digits="Account",
+        help="Over this amount is not legally possible to create a simplified invoice",
+        default=400,
+    )
+    l10n_es_simplified_invoice_sequence_id = fields.Many2one(
+        "ir.sequence",
+        string="Simplified Invoice IDs Sequence",
+        help="Autogenerate for each POS created",
+        copy=False,
+        readonly=True,
+    )
+
+    def get_l10n_es_simplified_invoice_number(self):
+        self.ensure_one()
+        return (
+            self.l10n_es_simplified_invoice_sequence_id._get_current_sequence().number_next_actual
+        )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._set_simplified_l10n_es_sequence()
+        return records
+
+    @api.model
+    def _set_simplified_l10n_es_sequence(self):
+        for record in self:
+            if record.is_spanish and not record.l10n_es_simplified_invoice_sequence_id:
+                sequence = self.env["ir.sequence"].create(
+                    {
+                        "name": _("Simplified Invoice %s") % record.name,
+                        "implementation": "standard",
+                        "padding": record._get_default_padding(),
+                        "prefix": record.env["ir.sequence"]._sanitize_prefix(
+                            f"{record.name}{record._get_default_prefix()}"
+                        ),
+                        "code": "pos.config.simplified_invoice",
+                        "company_id": record.company_id.id,
+                    }
+                )
+                record.l10n_es_simplified_invoice_sequence_id = sequence.id
+
+    def write(self, vals):
+        if not self._context.get("copy_pos_config") and "name" not in vals:
+            for pos in self:
+                sequence = pos.l10n_es_simplified_invoice_sequence_id
+                sequence.check_simplified_invoice_unique_prefix()
+        if "name" in vals:
+            prefix = self.l10n_es_simplified_invoice_prefix.replace(self.name, vals["name"])
+            if prefix != self.l10n_es_simplified_invoice_prefix:
+                self.l10n_es_simplified_invoice_sequence_id.update(
+                    {
+                        "prefix": prefix,
+                        "name": (
+                            self.l10n_es_simplified_invoice_sequence_id.name.replace(
+                                self.name, vals["name"]
+                            )
+                        ),
+                    }
+                )
+        return super().write(vals)
+
+    def unlink(self):
+        self.mapped("l10n_es_simplified_invoice_sequence_id").unlink()
+        return super().unlink()
+
+    def _get_default_padding(self):
+        return self.env["ir.config_parameter"].get_param(
+            "l10n_es_pos.simplified_invoice_sequence.padding", 4
+        )
+
+    def _get_default_prefix(self):
+        return self.env["ir.config_parameter"].get_param(
+            "l10n_es_pos.simplified_invoice_sequence.prefix", "-"
+        )

--- a/addons/l10n_es_pos/models/pos_order.py
+++ b/addons/l10n_es_pos/models/pos_order.py
@@ -1,0 +1,63 @@
+from odoo import api, fields, models
+from odoo.tools import float_compare
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    pos_is_spanish = fields.Boolean(
+        string="Spanish localization",
+        related="config_id.is_spanish",
+    )
+
+    is_l10n_es_simplified_invoice = fields.Boolean(
+        "Simplified invoice",
+        copy=False,
+        default=False,
+    )
+    l10n_es_unique_id = fields.Char(
+        "Simplified invoice number",
+        copy=False,
+    )
+
+    @api.model
+    def _simplified_limit_check(self, amount_total, limit):
+        return float_compare(amount_total, limit, precision_digits=self.env["decimal.precision"].precision_get("Account")) < 0
+
+    @api.model
+    def _order_fields(self, ui_order):
+        res = super(PosOrder, self)._order_fields(ui_order)
+        if ui_order.get("l10n_es_unique_id"):
+            res.update(
+                {
+                    "l10n_es_unique_id": ui_order["l10n_es_unique_id"],
+                    "is_l10n_es_simplified_invoice": True,
+                }
+            )
+        return res
+
+    @api.model
+    def _update_sequence_number(self, pos):
+        pos.l10n_es_simplified_invoice_sequence_id.next_by_id()
+
+    @api.model
+    def _process_order(self, pos_order, draft, existing_order):
+        order_data = pos_order.get("data", {})
+        if not order_data.get("l10n_es_unique_id"):
+            return super()._process_order(pos_order, draft, existing_order)
+        pos = self.env["pos.session"].browse(order_data.get("pos_session_id")).config_id
+        if self._simplified_limit_check(order_data.get("amount_total", 0), pos.l10n_es_simplified_invoice_limit):
+            pos_order["data"].update({"is_l10n_es_simplified_invoice": True})
+            self._update_sequence_number(pos)
+        return super()._process_order(pos_order, draft, existing_order)
+
+    def _get_fields_for_draft_order(self):
+        fields = super()._get_fields_for_draft_order()
+        fields += ["l10n_es_unique_id"]
+        return fields
+
+    def _export_for_ui(self, order):
+        res = super()._export_for_ui(order)
+        if self.config_id.is_spanish:
+            res.update({"l10n_es_unique_id": order.l10n_es_unique_id})
+        return res

--- a/addons/l10n_es_pos/models/pos_session.py
+++ b/addons/l10n_es_pos/models/pos_session.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class PosSession(models.Model):
+    _inherit = "pos.session"
+
+    def _loader_params_res_company(self):
+        res = super()._loader_params_res_company()
+        if not self.config_id.is_spanish:
+            return res
+        res["search_params"]["fields"] += ["street", "city", "zip"]
+        return res
+
+    def _pos_data_process(self, loaded_data):
+        super()._pos_data_process(loaded_data)
+        if not self.config_id.is_spanish:
+            return
+        seq = self.config_id.l10n_es_simplified_invoice_sequence_id
+        loaded_data["l10n_es_simplified_invoice"] = {
+            "number": seq._get_current_sequence().number_next_actual,
+            "prefix": seq._get_prefix_suffix()[0],
+            "padding": seq.padding,
+        }

--- a/addons/l10n_es_pos/models/res_config_settings.py
+++ b/addons/l10n_es_pos/models/res_config_settings.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    pos_is_spanish = fields.Boolean(
+        string="Consider the specific spanish legislation, such as the use of simplified invoices",
+        related="pos_config_id.is_spanish",
+    )
+
+    pos_l10n_es_simplified_invoice_limit = fields.Float(
+        related="pos_config_id.l10n_es_simplified_invoice_limit",
+        readonly=False,
+    )

--- a/addons/l10n_es_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_es_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates id="template" xml:space="preserve">
+    <t t-name="OrderReceipt" t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[hasclass('pos-receipt-contact')]" position="inside">
+            <t t-if="pos.config.is_spanish">
+                <t t-if="!receipt.to_invoice">
+                    <div t-esc='receipt.date.localestring' />
+                    <div>Simplified invoice</div>
+                    <div class="simplified-invoice-number" t-esc="receipt.l10n_es_unique_id" />
+                </t>
+                <div t-if="receipt.company.street" t-esc="receipt.company.street" />
+                <div t-if="receipt.company.zip" t-esc="receipt.company.zip" />  
+                <div t-if="receipt.company.city" t-esc="receipt.company.city" />
+                <div t-if="receipt.company.state_id">(<t t-esc="receipt.company.state_id[1]"/>)</div>
+            </t>
+        </xpath>
+        <xpath expr="//div[hasclass('pos-receipt-contact')]/div[hasclass('cashier')]" position="after">
+            <t t-set="partner" t-value="props.order.get_partner()"/>
+            <t t-if="pos.config.is_spanish and partner">
+                <div>Customer: <t t-esc="partner.name" /></div>
+                <div t-if="partner.vat">
+                    <t t-esc="receipt.company.vat_label" />:
+                    <t t-esc="partner.vat" />
+                </div>
+                <div t-if="partner.address" t-esc="partner.address"/>
+            </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/PaymentScreen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/PaymentScreen.js
@@ -1,0 +1,23 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
+
+patch(PaymentScreen.prototype, {
+    async validateOrder(isForceValidate) {
+        if (!this.pos.config.is_spanish) {
+            await super.validateOrder(...arguments);
+            return;
+        }
+        const below_limit =
+            this.currentOrder.get_total_with_tax() <=
+            this.pos.config.l10n_es_simplified_invoice_limit;
+        const order = this.currentOrder;
+        if (below_limit && !order.to_invoice) {
+            await order.set_simple_inv_number();
+        } else {
+            // Force invoice above limit. Online is needed.
+            order.to_invoice = true;
+        }
+        await super.validateOrder(...arguments);
+    },
+});

--- a/addons/l10n_es_pos/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -1,0 +1,18 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+
+patch(TicketScreen.prototype, {
+    _getSearchFields() {
+        const fields = super._getSearchFields(...arguments);
+        if (!this.pos.config.is_spanish) {
+            return fields;
+        }
+        fields.SIMPLIFIED_INVOICE = {
+            repr: (order) => order.name,
+            displayName: this.env._t("Simplified Invoice"),
+            modelField: "l10n_es_unique_id",
+        };
+        return fields;
+    },
+});

--- a/addons/l10n_es_pos/static/src/overrides/components/ticket_screen/ticket_screen.xml
+++ b/addons/l10n_es_pos/static/src/overrides/components/ticket_screen/ticket_screen.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="TicketScreen" t-inherit="point_of_sale.TicketScreen" t-inherit-mode="extension" owl="1">
+        <xpath expr="//div[hasclass('header-row')]/div[2]" position="after">
+            <div class="col p-2" t-if="pos.config.is_spanish">Simplified Invoice</div>
+        </xpath>
+        <xpath expr="//div[hasclass('order-row')]/div[2]" position="after">
+            <div t-if="pos.config.is_spanish" class="col p-2">
+                <t t-if="order.l10n_es_unique_id">
+                    <t t-if="ui.isSmall">Simplified Invoice: </t>
+                    <t t-esc="order.l10n_es_unique_id"/>
+                </t>
+            </div>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/l10n_es_pos/static/src/overrides/models/models.js
+++ b/addons/l10n_es_pos/static/src/overrides/models/models.js
@@ -1,0 +1,78 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { Order } from "@point_of_sale/app/store/models";
+import { identifyError } from "@point_of_sale/app/errors/error_handlers";
+import { ConnectionLostError } from "@web/core/network/rpc_service";
+
+patch(Order.prototype, {
+    /**
+     * We'll get the sequence number from DB only when we're online.
+     * Otherwise the sequence will run on the client side until the
+     * orders are synced.
+     */
+    async set_simple_inv_number() {
+        try {
+            const number = await this.pos.get_simple_inv_next_number();
+            this.pos._set_simplified_invoice_number(number);
+        } catch (error) {
+            if (!(identifyError(error) instanceof ConnectionLostError)) {
+                throw error;
+            }
+        } finally {
+            this.l10n_es_unique_id = this.pos._get_simplified_invoice_number();
+        }
+    },
+
+    get_base_by_tax() {
+        const base_by_tax = {};
+        this.get_orderlines().forEach(function (line) {
+            const tax_detail = line.get_tax_details();
+            const base_price = line.get_price_without_tax();
+            if (tax_detail) {
+                Object.keys(tax_detail).forEach(function (tax) {
+                    if (Object.keys(base_by_tax).includes(tax)) {
+                        base_by_tax[tax] += base_price;
+                    } else {
+                        base_by_tax[tax] = base_price;
+                    }
+                });
+            }
+        });
+        return base_by_tax;
+    },
+    init_from_JSON(json) {
+        super.init_from_JSON(...arguments);
+        if (!this.pos.config.is_spanish) {
+            return;
+        }
+        this.l10n_es_unique_id = json.l10n_es_unique_id;
+    },
+    export_as_JSON() {
+        const res = super.export_as_JSON(...arguments);
+        if (!this.pos.config.is_spanish) {
+            return res;
+        }
+        if (!this.is_to_invoice()) {
+            res.l10n_es_unique_id = this.l10n_es_unique_id;
+        }
+        return res;
+    },
+    export_for_printing() {
+        const result = super.export_for_printing(...arguments);
+        if (!this.pos.config.is_spanish) {
+            return result;
+        }
+        const company = this.pos.company;
+        result.l10n_es_unique_id = this.l10n_es_unique_id;
+        result.to_invoice = this.to_invoice;
+        result.company.street = company.street;
+        result.company.zip = company.zip;
+        result.company.city = company.city;
+        result.company.state_id = company.state_id;
+        const base_by_tax = this.get_base_by_tax();
+        for (const tax of result.tax_details) {
+            tax.base = base_by_tax[tax.tax.id];
+        }
+        return result;
+    },
+});

--- a/addons/l10n_es_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_es_pos/static/src/overrides/models/pos_store.js
@@ -1,0 +1,71 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+import { ConnectionLostError } from "@web/core/network/rpc_service";
+
+patch(PosStore.prototype, {
+    /**
+     * @override
+     */
+    async setup() {
+        await super.setup(...arguments);
+        if (!this.config.is_spanish) {
+            return;
+        }
+        this.pushed_simple_invoices = [];
+    },
+
+    /**
+     * @override
+     */
+    async _processData(loadedData) {
+        await super._processData(...arguments);
+        if (!this.config.is_spanish) {
+            return;
+        }
+        this.l10n_es_simplified_invoice = loadedData["l10n_es_simplified_invoice"];
+    },
+
+    get_simple_inv_next_number() {
+        // If we had pending orders to sync we want to avoid getting the next number
+        // from the DB as we'd be overlapping the sequence.
+        if (this.db.get_orders().length) {
+            return Promise.reject(new ConnectionLostError());
+        }
+        return this.orm.silent.call("pos.config", "get_l10n_es_simplified_invoice_number", [
+            [this.config.id],
+        ]);
+    },
+    _update_sequence_number() {
+        ++this.l10n_es_simplified_invoice.number;
+    },
+    push_simple_invoice(order) {
+        if (this.pushed_simple_invoices.indexOf(order.data.l10n_es_unique_id) === -1) {
+            this.pushed_simple_invoices.push(order.data.l10n_es_unique_id);
+            this._update_sequence_number();
+        }
+    },
+    _flush_orders(orders) {
+        // Save pushed orders numbers
+        if (!this.config.is_spanish) {
+            return super._flush_orders(...arguments);
+        }
+        orders.forEach((order) => {
+            if (!order.data.to_invoice) {
+                this.push_simple_invoice(order);
+            }
+        });
+        return super._flush_orders(...arguments);
+    },
+    _set_simplified_invoice_number(number) {
+        this.l10n_es_simplified_invoice.number = number;
+    },
+    _get_simplified_invoice_number() {
+        return (
+            this.l10n_es_simplified_invoice.prefix +
+            this.l10n_es_simplified_invoice.number
+                .toString()
+                .padStart(this.l10n_es_simplified_invoice.padding, "0")
+        );
+    },
+});

--- a/addons/l10n_es_pos/static/tests/tours/helpers/receipt_helpers.js
+++ b/addons/l10n_es_pos/static/tests/tours/helpers/receipt_helpers.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+
+import { ProductScreen } from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import { PaymentScreen } from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
+
+export function checkSimplifiedInvoiceNumber(number) {
+    return [
+        {
+            content: "verify that the simplified invoice number appears correctly on the receipt",
+            trigger: `.receipt-screen .simplified-invoice-number:contains('${number}')`,
+            isCheck: true,
+        },
+    ];
+}
+
+export function pay() {
+    return [
+        ...ProductScreen.do.clickPayButton(),
+        ...PaymentScreen.do.clickPaymentMethod("Bank"),
+        ...PaymentScreen.do.clickValidate(),
+    ];
+}

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -1,0 +1,51 @@
+/** @odoo-module */
+
+import { ProductScreen } from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import { ReceiptScreen } from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
+import { PaymentScreen } from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
+import { PartnerListScreen } from "@point_of_sale/../tests/tours/helpers/PartnerListScreenTourMethods";
+import { registry } from "@web/core/registry";
+import { checkSimplifiedInvoiceNumber, pay } from "./helpers/receipt_helpers";
+
+const SIMPLIFIED_INVOICE_LIMIT = 1000;
+
+registry.category("web_tour.tours").add("spanish_pos_tour", {
+    test: true,
+    steps: () => [
+        ...ProductScreen.do.confirmOpeningPopup(),
+
+        ...ProductScreen.exec.addOrderline("Desk Pad", "1"),
+        ...pay(),
+        ...checkSimplifiedInvoiceNumber("test-shop-12345-0001"),
+        ...ReceiptScreen.do.clickNextOrder(),
+
+        ...ProductScreen.exec.addOrderline("Desk Pad", "1", SIMPLIFIED_INVOICE_LIMIT - 1),
+        ...pay(),
+        ...checkSimplifiedInvoiceNumber("test-shop-12345-0002"),
+        ...ReceiptScreen.do.clickNextOrder(),
+
+        ...ProductScreen.exec.addOrderline("Desk Pad", "1", SIMPLIFIED_INVOICE_LIMIT + 1),
+        ...pay(),
+
+        {
+            content: "verify that the pos requires the selection of a partner",
+            trigger: `div.popup.popup-confirm .modal-header:contains('Please select the Customer') ~ footer div.button.confirm`,
+        },
+
+        ...PartnerListScreen.do.clickPartner("Lumber Inc"),
+
+        ...PaymentScreen.check.isInvoiceOptionSelected(),
+        ...PaymentScreen.do.clickValidate(),
+        {
+            content:
+                "verify that the simplified invoice number does not appear on the receipt, because this order is invoiced, so it does not have a simplified invoice number",
+            trigger: ".receipt-screen:not(:has(.simplified-invoice-number))",
+            isCheck: true,
+        },
+        ...ReceiptScreen.do.clickNextOrder(),
+
+        ...ProductScreen.exec.addOrderline("Desk Pad", "1"),
+        ...pay(),
+        ...checkSimplifiedInvoiceNumber("test-shop-12345-0003"),
+    ],
+});

--- a/addons/l10n_es_pos/tests/__init__.py
+++ b/addons/l10n_es_pos/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_frontend

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+    @classmethod
+    def _get_main_company(cls):
+        cls.company_data["company"].country_id = cls.env.ref("base.es").id
+        return cls.company_data["company"]
+
+    def test_spanish_pos(self):
+        self.main_pos_config.l10n_es_simplified_invoice_limit = 1000
+        self.main_pos_config.l10n_es_simplified_invoice_sequence_id.prefix="test-shop-12345-"
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", "spanish_pos_tour", login="pos_user")
+        self.assertEqual(self.main_pos_config.l10n_es_simplified_invoice_sequence_id.number_next_actual, 4)

--- a/addons/l10n_es_pos/views/pos_order_views.xml
+++ b/addons/l10n_es_pos/views/pos_order_views.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<odoo>
+    <!-- POS order form -->
+    <record id="view_pos_pos_form_simplified_invoice" model="ir.ui.view">
+        <field name="name">pos.order.form</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form" />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="l10n_es_unique_id" readonly="1" invisible="not l10n_es_unique_id" />
+            </field>
+        </field>
+    </record>
+    <!-- POS order tree -->
+    <record id="view_pos_order_tree" model="ir.ui.view">
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_tree" />
+        <field name="arch" type="xml">
+            <field name="pos_reference" position="before">
+                <field name="pos_is_spanish" column_invisible="True"/>
+                <!-- FIXME this invisible attr does not work -->
+                <field name="l10n_es_unique_id" invisible="not pos_is_spanish" />
+            </field>
+        </field>
+    </record>
+    <!-- POS order search -->
+    <record id="view_pos_order_filter_simplified_invoice" model="ir.ui.view">
+        <field name="name">pos.order.list.select</field>
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_order_filter" />
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <field name="date_order" position="after">
+                <separator />
+                <filter
+                    string="Invoices"
+                    name="invoices"
+                    domain="[('is_l10n_es_simplified_invoice', '=', False)]"
+                />
+                <filter
+                    string="Simplified invoices"
+                    name="invoices"
+                    domain="[('is_l10n_es_simplified_invoice', '!=', False)]"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_es_pos/views/res_config_settings_views.xml
+++ b/addons/l10n_es_pos/views/res_config_settings_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="point_of_sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//block[@id='pos_accounting_section']" position="inside">
+                <field name="pos_is_spanish" invisible="1" />
+                <!-- <setting string="Simplified Invoice Limit" title="" attrs="{'invisible': [('pos_is_spanish','=',False)]}"> -->
+                <setting string="Simplified Invoice Limit" title="" invisible="not pos_is_spanish">
+                    <div class="text-muted">
+                        Above this limit the simplified invoice won't be made
+                    </div>
+                    <field name="pos_l10n_es_simplified_invoice_limit" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -53,7 +53,7 @@ class PosController(PortalAccount):
             pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
         if not pos_session or config_id and not pos_config.active:
             return request.redirect('/web#action=point_of_sale.action_client_pos_menu')
-        # The POS only work in one company, so we enforce the one of the session in the context
+        # The POS only works in one company, so we enforce the one of the session in the context
         company = pos_session.company_id
         session_info = request.env['ir.http'].session_info()
         session_info['user_context']['allowed_company_ids'] = company.ids

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.xml
@@ -32,12 +32,10 @@
                 <t t-if="receipt.header">
                     <div style="white-space:pre-line"><t t-esc="receipt.header" /></div>
                 </t>
-                <t t-if="receipt.cashier">
-                    <div class="cashier">
-                        <div>--------------------------------</div>
-                        <div>Served by <t t-esc="receipt.cashier" /></div>
-                    </div>
-                </t>
+                <div t-if="receipt.cashier" class="cashier">
+                    <div>--------------------------------</div>
+                    <div>Served by <t t-esc="receipt.cashier" /></div>
+                </div>
             </div>
             <br /><br />
 

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1355,7 +1355,7 @@ export class Order extends PosModel {
         this.partner = partner;
 
         this.temporary = false; // FIXME
-        this.to_invoice = false; // FIXME
+        this.to_invoice = json.to_invoice || false;
         this.shippingDate = json.shipping_date;
 
         var orderlines = json.lines;

--- a/addons/point_of_sale/static/tests/tours/helpers/PaymentScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/PaymentScreenTourMethods.js
@@ -176,6 +176,15 @@ class Check {
             },
         ];
     }
+    isInvoiceOptionSelected() {
+        return [
+            {
+                content: "Invoice option is selected",
+                trigger: ".payment-buttons .js_invoice.highlight",
+                isCheck: true,
+            },
+        ];
+    }
 
     /**
      * Check if the remaining is the provided amount.

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -13,6 +13,10 @@ import odoo.tests
 class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 
     @classmethod
+    def _get_main_company(cls):
+        return cls.company_data['company']
+
+    @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
@@ -20,7 +24,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         cls.env.user.groups_id += env.ref('point_of_sale.group_pos_manager')
         journal_obj = env['account.journal']
         account_obj = env['account.account']
-        main_company = cls.company_data['company']
+        main_company = cls._get_main_company()
 
         account_receivable = account_obj.create({'code': 'X1012',
                                                  'name': 'Account Receivable - Test',
@@ -39,10 +43,11 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'groups_id': [
                 (4, cls.env.ref('base.group_user').id),
                 (4, cls.env.ref('point_of_sale.group_pos_user').id),
+                (4, cls.env.ref('account.group_account_invoice').id),
             ],
         })
         cls.pos_admin = cls.env['res.users'].create({
-            'name': 'A powerfull PoS man!',
+            'name': 'A powerful PoS man!',
             'login': 'pos_admin',
             'password': 'pos_admin',
             'groups_id': [


### PR DESCRIPTION
In Spain it's mandatory that POS systems generate a so called "Factura simplificada". This is similar to a regular ticket but has to comply with some special requirements.
Without this, POS isn't usable in Spain.

In this PR we introduce a Spanish localisation for the pos that handles the specific regulatory needs.

Task: 3131769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
