### PR TITLE
[FIX] account: date on cash basis move

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -407,7 +407,8 @@ class AccountPartialReconcile(models.Model):
                 partial = partial_values['partial']
 
                 # Init the journal entry.
-                move_date = partial.max_date if partial.max_date > (move.company_id.period_lock_date or date.min) else today
+                lock_date = move.company_id._get_user_fiscal_lock_date()
+                move_date = partial.max_date if partial.max_date > (lock_date or date.min) else today
                 move_vals = {
                     'move_type': 'entry',
                     'date': move_date,

--- a/addons/account/tests/test_account_move_date_algorithm.py
+++ b/addons/account/tests/test_account_move_date_algorithm.py
@@ -40,8 +40,9 @@ class TestAccountMoveDateAlgorithm(AccountTestInvoicingCommon):
             'date': date,
         })
 
-    def _set_lock_date(self, lock_date):
+    def _set_lock_date(self, lock_date, period_lock_date=None):
         self.env.company.fiscalyear_lock_date = fields.Date.from_string(lock_date)
+        self.env.company.period_lock_date = fields.Date.from_string(period_lock_date)
 
     def _reverse_invoice(self, invoice):
         move_reversal = self.env['account.move.reversal']\
@@ -231,3 +232,54 @@ class TestAccountMoveDateAlgorithm(AccountTestInvoicingCommon):
             'date': fields.Date.from_string('2017-02-28'),
             'amount_total_signed': 440.0,
         }])
+
+    @freezegun.freeze_time('2023-05-01')
+    def test_caba_with_different_lock_dates(self):
+        """
+        Test the date of the CABA move when reconciling a payment with an invoice
+        with date before fiscalyear_period but after period_lock_date either when
+        having accountant rights or not.
+        """
+        self.env.company.tax_exigibility = True
+
+        tax_waiting_account = self.env['account.account'].create({
+            'name': 'TAX_WAIT',
+            'code': 'TWAIT',
+            'account_type': 'liability_current',
+            'reconcile': True,
+        })
+        tax = self.env['account.tax'].create({
+            'name': 'cash basis 10%',
+            'type_tax_use': 'sale',
+            'amount': 10,
+            'tax_exigibility': 'on_payment',
+            'cash_basis_transition_account_id': tax_waiting_account.id,
+        })
+
+        self._set_lock_date('2023-01-01', '2023-02-01')
+
+        for group, expected_date in (
+                ('account.group_account_manager', '2023-01-30'),
+                ('account.group_account_invoice', '2023-05-01'),
+        ):
+            with self.subTest(group=group, expected_date=expected_date):
+                self.env.user.groups_id = [(6, 0, [self.env.ref(group).id])]
+
+                self.assertTrue(self.env.user.user_has_groups(group))
+
+                invoice = self._create_invoice(
+                    'out_invoice', '2023-01-02',
+                    invoice_line_ids=[{'tax_ids': [Command.set(tax.ids)]}],
+                )
+                payment = self._create_payment('2023-01-30', amount=invoice.amount_total)
+                (invoice + payment.move_id).action_post()
+
+                (invoice + payment.move_id).line_ids\
+                    .filtered(lambda x: x.account_id.account_type == 'asset_receivable')\
+                    .reconcile()
+
+                caba_move = self.env['account.move'].search([('tax_cash_basis_origin_move_id', '=', invoice.id)])
+
+                self.assertRecordValues(caba_move, [{
+                    'date': fields.Date.from_string(expected_date),
+                }])


### PR DESCRIPTION
When having lock date for non accountant
set before all user lock date, reconiling
lines between the two lock dates leads
to a wrong calculation of the cash basis
move, even for user with accountant rights.

Steps:

- With a company having cash basis activated
- Set a period_lock_date to a specific date
- Set a fiscalyear_lock_date one month later
  than period_lock_date
- With user having Accountant rights, create
  an invoice between the two lock dates
- Register a payment in the same period
-> Cash Basis move is created with date == today,
   it should be the date of the payment.

opw-3245409
