### PR TITLE
[IMP] calendar, repair: move action from root menu to new menu

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -471,8 +471,15 @@
         id="mail_menu_calendar"
         name="Calendar"
         sequence="10"
-        action="action_calendar_event"
         web_icon="calendar,static/description/icon.png"
+        groups="base.group_user"/>
+
+    <menuitem
+        id="calendar_event_menu"
+        name="Calendar"
+        sequence="10"
+        action="action_calendar_event"
+        parent="mail_menu_calendar"
         groups="base.group_user"/>
 
     <menuitem

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -368,8 +368,11 @@
             </field>
         </record>
 
-        <menuitem action="action_repair_order_tree" id="menu_repair_order" groups="stock.group_stock_user" name="Repairs" sequence="165"
-            web_icon="repair,static/description/icon.png"/>
+        <menuitem id="menu_repair_order" groups="stock.group_stock_user" name="Repairs" sequence="165"
+                  web_icon="repair,static/description/icon.png"/>
+
+        <menuitem id="repair_order_menu" name="Orders" action="action_repair_order_tree" groups="stock.group_stock_user"
+                  parent="menu_repair_order"/>
 
         <menuitem id="repair_menu_reporting" name="Reporting" parent="menu_repair_order" groups="stock.group_stock_manager"/>
 


### PR DESCRIPTION
before this commit, the repair orders is directly
linked with the root menu of repair application and if you user opens the repair app, repair orders
action is shown as it is linked with the main menu.

similarly in the calendar app, the calendar is linked
with the root menu calendar.

but now if user move to reporting or configuration menu of repair app, there is
 no menu to access the repair orders.

with the new milk redesign on clicking the root menu user will be taken to home screen, where us
there is hamburger menu in previous design to navigate to home screen.

so only way for user to access the repair order menu is to go back to home screen and come back.

similarly in the calendar app, if user takes the
configuration menu, in order to access the calendar, user
has to go to home screen and come back.

after this commit, a new sub menu is introduced in both
app and moved the action linked with root menu to
the newly added sub menu.

Issue:
https://github.com/odoo/odoo/assets/27989791/c21945d0-84f2-4037-a15e-b4d555590dfc


After this commit:
![Screenshot from 2023-06-24 12-06-00](https://github.com/odoo/odoo/assets/27989791/ed857cf5-6a99-4da3-ac3c-34c5d6373e33)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
