### PR TITLE
[IMP] web_editor: add preserveCursor callback return value

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -877,7 +877,7 @@ export function preserveCursor(document) {
         replace = replace || new Map();
         cursorPos[0] = replace.get(cursorPos[0]) || cursorPos[0];
         cursorPos[2] = replace.get(cursorPos[2]) || cursorPos[2];
-        setSelection(...cursorPos);
+        return setSelection(...cursorPos);
     };
 }
 


### PR DESCRIPTION
By returning the `setSelection` value in the callback returned by the
`preserveCursor`, we allow better control for the caller over the fact that the
selection was effectively restored or if it failed.

task-3383561