### PR TITLE
[IMP] account: Send & Print shows warning banner while async sending

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -506,6 +506,14 @@ class AccountMove(models.Model):
         tracking=True,
         help="It indicates that the invoice/payment has been sent or the PDF has been generated.",
     )
+    is_being_sent = fields.Boolean(
+        readonly=True,
+        default=False,
+        copy=False,
+        store=True,
+        help="Is the move being sent asynchronously",
+        compute='_compute_is_being_sent')
+
 
     invoice_user_id = fields.Many2one(
         string='Salesperson',
@@ -612,6 +620,12 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
+
+    @api.depends('is_move_sent')
+    def _compute_is_being_sent(self):
+        for move in self:
+            if move.is_move_sent:
+                move.is_being_sent = False
 
     def _compute_payment_reference(self):
         for move in self.filtered(lambda m: (

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -563,6 +563,8 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertRecordValues(wizard, [{'mode': 'invoice_multi'}])
 
         # Awaiting the CRON.
+        self.assertTrue(invoice1.is_being_sent)
+        self.assertTrue(invoice2.is_being_sent)
         self.assertFalse(invoice1.invoice_pdf_report_id)
         self.assertFalse(invoice2.invoice_pdf_report_id)
 
@@ -575,6 +577,8 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             ('res_field', '=', 'invoice_pdf_report_file'),
         ])
         self.assertEqual(len(invoice_attachments), 1)
+        self.assertFalse(invoice1.is_being_sent)
+        self.assertFalse(invoice2.is_being_sent)
         self.assertTrue(invoice2.invoice_pdf_report_id)
         invoice_attachments = self.env['ir.attachment'].search([
             ('res_model', '=', invoice2._name),

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -583,8 +583,14 @@
                         <button name="action_invoice_sent"
                                 type="object"
                                 string="Send &amp; Print"
-                                attrs="{'invisible':['|', '|', ('state', '!=', 'posted'), ('invoice_pdf_report_id', '!=', False), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
-                                class="oe_highlight"
+                                attrs="{'invisible':['|', '|', '|', ('is_being_sent', '=', True), ('state', '!=', 'posted'), ('invoice_pdf_report_id', '!=', False), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                                class="btn btn-primary"
+                                data-hotkey="y"/>
+                        <button name="action_invoice_sent"
+                                type="object"
+                                string="Send &amp; Print"
+                                attrs="{'invisible':['|', '|', '|', ('is_being_sent', '=', False), ('state', '!=', 'posted'), ('invoice_pdf_report_id', '!=', False), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                                class="btn btn-secondary"
                                 data-hotkey="y"/>
                         <button name="action_invoice_sent"
                                 type="object"
@@ -629,6 +635,9 @@
                                 string="one of those bills"
                                 class="btn btn-link p-0"
                         />
+                    </div>
+                    <div class="alert alert-info mb-0" role="alert" attrs="{'invisible': [('is_being_sent', '=', False)]}">
+                        This invoice is being sent in the background.
                     </div>
                     <!-- Invoice outstanding credits -->
                     <div groups="account.group_account_invoice,account.group_account_readonly"
@@ -758,6 +767,7 @@
                         <field name="hide_post_button" invisible="1"/>
                         <field name="duplicated_ref_ids" invisible="1"/>
                         <field name="quick_encoding_vals" invisible="1"/>
+                        <field name="is_being_sent" invisible="1"/>
 
                         <div class="oe_title">
                             <span class="o_form_label"><field name="move_type" attrs="{'invisible': [('move_type', '=', 'entry')]}" readonly="1" nolabel="1"/></span>

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -587,6 +587,8 @@ class AccountMoveSend(models.Model):
         else:
             for move in self.move_ids:
                 moves_data[move]['_form'] = self.new(self._get_available_field_values_in_multi(move))
+            # Marks moves as being sent asynchronously.
+            self.move_ids.is_being_sent = True
 
         if generate_invoice_documents:
             # Generate all invoice documents.


### PR DESCRIPTION
When you select multiple invoices in List view and use the Send & Print, the invoices will be sent asynchronously using a cron trigger. This can take some time. If the user opens one of the to-be-sent invoices, there is nothing telling the user that this invoice is part of a running batch and will be sent eventually. This might cause cases where the user will try to trigger the send & print manually again, causing some concurrency issue.
To at least mitigate the issue, we display a warning banner on the invoices telling that they are part of a running batch of a Send & Print.

task-3360179
