### PR TITLE
[FIX] project: task in folded stage should be closed

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1336,10 +1336,10 @@ class Task(models.Model):
         if self.state != '04_waiting_normal':
             self.state = '01_in_progress'
 
-    @api.depends('state')
+    @api.depends('state', 'stage_id')
     def _compute_is_closed(self):
         for task in self:
-            task.is_closed = task.state in CLOSED_STATES
+            task.is_closed = task.state in CLOSED_STATES or task.stage_id.fold
 
     def is_blocked_by_dependences(self):
         return any(blocking_task.state not in CLOSED_STATES for blocking_task in self.depend_on_ids)

--- a/addons/project/tests/test_project_task_type.py
+++ b/addons/project/tests/test_project_task_type.py
@@ -3,6 +3,7 @@
 
 from odoo.exceptions import UserError
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
+from odoo.tests.common import Form
 
 
 class TestProjectTaskType(TestProjectCommon):
@@ -57,3 +58,28 @@ class TestProjectTaskType(TestProjectCommon):
             self.stage_created.write({
                 'user_id': self.uid,
             })
+
+    def test_task_in_folded_stage_must_be_closed(self):
+        unfolded_stage = self.env['project.task.type'].create({'name': 'Progress', 'sequence': 1, 'fold': False})
+        folded_stage = self.env['project.task.type'].create({'name': 'Won', 'sequence': 2, 'fold': True})
+
+        project = self.env['project.project'].with_context({'mail_create_nolog': True}).create({
+            'name': 'rev',
+            'privacy_visibility': 'employees',
+            'alias_name': 'rev',
+            'partner_id': self.partner_1.id,
+            'type_ids': [unfolded_stage.id, folded_stage.id],
+        })
+
+        task = self.env['project.task'].with_context({'mail_create_nolog': True}).create({
+            'name': 'Pigs UserTask',
+            'user_ids': self.user_projectuser,
+            'project_id': project.id,
+            'stage_id': unfolded_stage.id})
+
+        self.assertFalse(task.is_closed)
+
+        with Form(task.with_context({'mail_create_nolog': True})) as task_form:
+            task_form.stage_id = folded_stage
+
+        self.assertTrue(task.is_closed, "task in folded stage should be closed")


### PR DESCRIPTION
To reproduce
============
- In the Projects app > Set the deadline for a task to a previous date
- Move the task to the "done" stage (or any floded stage)
- The "x days ago" on the task does not go away

Problem
=======
`task.is_closed` is computed based on `task.state` only, but it must be computed based on stage type too (folded or not).

Solution
========
add `task.stage_id.fold` to `task.is_closed` computation.

opw-3340531