### PR TITLE
[REF] web, project:  add hooks to calendar controler, fix css for filterPanel

### DIFF
--- a/addons/project/static/src/views/project_project_calendar/project_project_calendar_controller.js
+++ b/addons/project/static/src/views/project_project_calendar/project_project_calendar_controller.js
@@ -1,0 +1,10 @@
+/** @odoo-module **/
+
+import { CalendarController } from "@web/views/calendar/calendar_controller";
+import { _t } from "@web/core/l10n/translation";
+
+export class ProjectProjectCalendarController extends CalendarController {
+    get editRecordDefaultDisplayText() {
+        return _t("New Project");
+    }
+}

--- a/addons/project/static/src/views/project_project_calendar/project_project_calendar_view.js
+++ b/addons/project/static/src/views/project_project_calendar/project_project_calendar_view.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { calendarView } from "@web/views/calendar/calendar_view";
+import { ProjectProjectCalendarController } from "./project_project_calendar_controller";
+
+const viewRegistry = registry.category("views");
+
+const projectProjectCalendarView = {
+    ...calendarView,
+    Controller: ProjectProjectCalendarController,
+};
+
+viewRegistry.add("project_project_calendar", projectProjectCalendarView);

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
@@ -15,6 +15,10 @@ export class ProjectTaskCalendarController extends CalendarController {
         this.env.config.setDisplayName(this.env.config.getDisplayName() + _t(" - Tasks by Deadline"));
     }
 
+    get editRecordDefaultDisplayText() {
+        return _t("New Task");
+    }
+
     deleteRecord(record) {
         if  (!record.rawRecord.subtask_count) {
             return super.deleteRecord(record);

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -550,7 +550,8 @@
                     scales="month,year"
                     event_open_popup="true"
                     quick_add="false"
-                    color="color">
+                    color="color"
+                    js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id"/>
                     <field name="is_favorite" widget="boolean_favorite" nolabel="1" string="Favorite"/>

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -116,6 +116,10 @@ export class CalendarController extends Component {
         return this.props.className;
     }
 
+    get editRecordDefaultDisplayText() {
+        return _t("New Event");
+    }
+
     getQuickCreateProps(record) {
         return {
             record,
@@ -174,7 +178,9 @@ export class CalendarController extends Component {
                         resModel: this.model.resModel,
                         resId: record.id || false,
                         context,
-                        title: record.id ? _t("Open: %s", record.title) : _t("New Event"),
+                        title: record.id
+                            ? _t("Open: %s", record.title)
+                            : this.editRecordDefaultDisplayText,
                         viewId: this.model.formViewId,
                         onRecordSaved: () => this.model.load(),
                     },

--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -193,11 +193,14 @@ $o-cw-filter-avatar-size: 20px;
                     height: $o-cw-filter-avatar-size;
                     border-radius: 2px;
                     object-fit: cover;
+                    align-items: center;
                 }
             }
 
             input:not(:checked) + label .o_cw_filter_input_bg {
-                background: transparent !important;
+                &:not(.o_cw_filter_avatar) {
+                    background: transparent !important;
+                }
 
                 i.fa {
                     visibility: hidden;

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -554,6 +554,14 @@ export class CalendarModel extends Model {
         };
     }
 
+    /**
+     * @protected
+     */
+    addFilterFields(record, filterInfo) {
+        return {
+            colorIndex: record.colorIndex,
+        };
+    }
     //--------------------------------------------------------------------------
 
     /**
@@ -662,7 +670,7 @@ export class CalendarModel extends Model {
                     filters.push({
                         id: value,
                         [fieldName]: rawValue,
-                        colorIndex: record.colorIndex,
+                        ...this.addFilterFields(record, filterInfo),
                     });
                 }
             }

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -617,7 +617,7 @@
     }
 
     .o_cw_filter_color_#{$i - 1} {
-        .o_cw_filter_input_bg {
+        .o_cw_filter_input_bg:not(.no_filter_color) {
             border-color: $color;
             background: $color;
             color: color-contrast($color);

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -87,7 +87,7 @@
                 t-attf-for="o_calendar_filter_item_{{filterId}}"
             >
                 <span
-                    class="o_cw_filter_input_bg align-items-start d-flex flex-shrink-0 justify-content-center position-relative me-1 o_beside_avatar"
+                    class="o_cw_filter_input_bg d-flex flex-shrink-0 justify-content-center position-relative me-1 o_beside_avatar"
                     t-att-style="filter.colorIndex and typeof filter.colorIndex !== 'number' ? `border-color: ${filter.colorIndex}; background-color: ${filter.colorIndex};` : ''"
                 >
                     <i class="fa fa-check position-relative" />

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -4779,4 +4779,34 @@ QUnit.module("Views", ({ beforeEach }) => {
 
         assert.verifySteps(["onWillStartModel", "render"]);
     });
+
+    QUnit.test("check apply default record label", async (assert) => {
+        assert.expect(1);
+        class TestCalendarController extends CalendarController {
+            get editRecordDefaultDisplayText() {
+                return "Test Display";
+            }
+        }
+
+        viewRegistry.add("test_calendar_view", {
+            ...calendarView,
+            Controller: TestCalendarController,
+        });
+
+        await makeView({
+            type: "calendar",
+            resModel: "event",
+            serverData,
+            arch: `
+                <calendar js_class="test_calendar_view" date_start="start" date_stop="stop" all_day="allday" mode="month" quick_add="0" event_open_popup="1" />
+            `,
+        });
+
+        await clickDate(target, "2016-12-13");
+        assert.strictEqual(
+            target.querySelector(".modal-title").textContent,
+            "Test Display",
+            "The text in the title should be Test Display"
+        );
+    });
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- For the Planning app calendar we now need to be able to fetch specific fields from the filters record
we don't want to inherit the whole loadDynamicFilterSection method so we created an addFilterFields method
used to fetch specific fields from the record accroding to the filterInfo ()

- we also need to display specific text when creating a new record from the calendar view, for exemple in calendar 'New Shift' rather than 'New event' but we don't need to override the whole editRecord() method so we created a getter: editRecordDefaultDisplayText()

- For the css files, we lowered a bit the checkmark icon in the filters, and we added a new class that prevents the icons background to become invisible when the filter checkmark isn't changed

Task-3251698

See https://github.com/odoo/enterprise/pull/41304

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
