### PR TITLE
[IMP] hr_recruitment: improve applicant availability field

### DIFF
--- a/addons/hr_recruitment/data/hr_recruitment_demo.xml
+++ b/addons/hr_recruitment/data/hr_recruitment_demo.xml
@@ -85,6 +85,7 @@
         <field name="stage_id" ref="stage_job2"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=29)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=27)).strftime('%Y-%m-%d')"/>
+        <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_salesman1" model="hr.applicant">
         <field name="name">Sales</field>
@@ -98,6 +99,7 @@
         <field name="email_from">thing.thang.thong@gmail.example.com</field>
         <field name="partner_mobile">998655451</field>
         <field name="stage_id" ref="stage_job1"/>
+        <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_dev0" model="hr.applicant">
         <field name="name">Developer PHP</field>
@@ -112,6 +114,7 @@
         <field name="email_from">coincoin@gmail.example.com</field>
         <field name="partner_mobile">8955545</field>
         <field name="stage_id" ref="stage_job1"/>
+        <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_dev1" model="hr.applicant">
         <field name="name">Developer Fullstack</field>
@@ -168,6 +171,7 @@
         <field name="partner_phone">6633225</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=17)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=7)).strftime('%Y-%m-%d')"/>
+        <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_fresher0" model="hr.applicant">
         <field name="name">Fresher</field>
@@ -204,6 +208,7 @@
         <field name="email_from">st-hubertus@gmail.example.com</field>
         <field name="priority">3</field>
         <field name="stage_id" ref="stage_job3"/>
+        <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_yrsexperienceinphp0" model="hr.applicant">
         <field name="name">Marketing Job</field>
@@ -245,6 +250,7 @@
         <field name="email_from">david.strongarm@gmail.example.com</field>
         <field name="stage_id" ref="stage_job2"/>
         <field name="partner_phone">33968745</field>
+        <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_financejob1" model="hr.applicant">
         <field name="name">Finance</field>
@@ -259,6 +265,7 @@
         <field name="stage_id" ref="stage_job2"/>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=7)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=3)).strftime('%Y-%m-%d')"/>
+        <field name="availability" eval="(DateTime.today() + timedelta(days=15)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_traineemca1" model="hr.applicant">
         <field name="name">Trainee - MCA</field>
@@ -290,6 +297,7 @@
         <field name="salary_expected">11000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=13)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=4)).strftime('%Y-%m-%d')"/>
+        <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
     <record id="hr_case_advertisement" model="hr.applicant">
         <field name="name">Advertisement</field>
@@ -305,6 +313,7 @@
         <field name="salary_expected">11000.0</field>
         <field name="create_date" eval="DateTime.now() - relativedelta(days=4)"/>
         <field name="date_last_stage_update" eval="(DateTime.today() - timedelta(days=2)).strftime('%Y-%m-%d')"/>
+        <field name="availability" eval="(DateTime.today() + relativedelta(months=3)).strftime('%Y-%m-%d')"/>
     </record>
 
     <record id="hr_case_dev2_cv" model="ir.attachment">

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -136,7 +136,7 @@
                         <field name="priority" widget="priority"/>
                         <field name="source_id"/>
                         <field name="medium_id"/>
-                        <field name="availability"/>
+                        <field name="availability" placeholder="Directly Available"/>
                         <field name="categ_ids" placeholder="Tags" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                     </group>
                     <group string="Job">
@@ -232,6 +232,8 @@
                 <filter string="Ready for Next Stage" name="done" domain="[('kanban_state', '=', 'done')]"/>
                 <filter string="Blocked" name="blocked" domain="[('kanban_state', '=', 'blocked')]"/>
                 <filter string="Reserve" name="reserve" domain="[('job_id', '=', False)]"/>
+                <separator/>
+                <filter string="Directly Available" name="applicant_availability" domain="['|',('availability', '&lt;=', context_today().strftime('%Y-%m-%d')),('availability','=', False)]"/>
                 <separator/>
                 <filter string="Creation Date" name="filter_create" date="create_date"/>
                 <filter string="Last Stage Update" name="filter_date_last_stage_update" date="date_last_stage_update"/>


### PR DESCRIPTION
this PR focus on improvement in availability field for applicant. add a placeholder when availability field is empty to show the availability as "directly available". add demo data for applicant availability for testing and demonstration purposes. create a filter "Availability" to get the data of applicant who are available to start work.

task-3349713
