### PR TITLE
[FIX] web_editor: heading and p unwrapping on paste

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -91,21 +91,31 @@ function insert(editor, data, isText = true) {
     // In case the html inserted is all contained in a single root <p> or <li>
     // tag, we take the all content of the <p> or <li> and avoid inserting the
     // <p> or <li>. The same is true for a <pre> inside a <pre>.
+    const isBlockElement = (node) => isBlock(node) && !["TABLE", "UL", "OL"].includes(node.nodeName) && startNode.textContent !== "";
+
     if (fakeEl.childElementCount === 1 && (
         fakeEl.firstChild.nodeName === 'P' ||
         fakeEl.firstChild.nodeName === 'LI' ||
-        fakeEl.firstChild.nodeName === 'PRE' && closestElement(startNode, 'pre')
+        fakeEl.firstChild.nodeName === 'PRE' && closestElement(startNode, 'pre') ||
+        // In case <p>te[]st</p> -----> <h1>A<br>B<br>C</h1>(pasted text)--->  <p>teA<br>B<br>Cst</p>
+        isBlockElement(fakeEl.firstChild)
     )) {
         const p = fakeEl.firstElementChild;
         fakeEl.replaceChildren(...p.childNodes);
     } else if (fakeEl.childElementCount > 1) {
         // Grab the content of the first child block and isolate it.
-        if (isBlock(fakeEl.firstChild) && !['TABLE', 'UL', 'OL'].includes(fakeEl.firstChild.nodeName)) {
+        if (
+            isBlockElement(fakeEl.firstChild) ||
+            fakeEl.firstChild.nodeName === "P"
+        ) {
             fakeElFirstChild.replaceChildren(...fakeEl.firstElementChild.childNodes);
             fakeEl.firstElementChild.remove();
         }
         // Grab the content of the last child block and isolate it.
-        if (isBlock(fakeEl.lastChild) && !['TABLE', 'UL', 'OL'].includes(fakeEl.lastChild.nodeName)) {
+        if (
+            isBlockElement(fakeEl.lastChild) ||
+            fakeEl.lastChild.nodeName === 'P'
+        ) {
             fakeElLastChild.replaceChildren(...fakeEl.lastElementChild.childNodes);
             fakeEl.lastElementChild.remove();
         }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -1713,6 +1713,66 @@ describe('Copy and paste', () => {
             });
         });
     });
+    describe('Pasting h1', () => {
+        describe('range collapsed', async () => {
+            it('should paste h1 when pasting in empty p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>a</h1><h1>b</h1><h1>c</h1>');
+                    },
+                    contentAfter: '<h1>a</h1><h1>b</h1><h1>c</h1><p>[]<br></p>',
+                });
+            });
+            it('should paste first and last child into p when pasting h1 in p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>te[]st</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>a</h1><h1>b</h1><h1>c</h1>');
+                    },
+                    contentAfter: '<p>tea</p><h1>b</h1><p>c[]st</p>',
+                });
+            });
+            it('should convert single h1 into p  if p has content', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>te[]st</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>a<br>b<br>c</h1>');
+                    },
+                    contentAfter: '<p>tea<br>b<br>c[]st</p>',
+                });
+            });
+        });
+        describe('range not collapsed', async () => {
+            it('should paste h1 when pasting in empty p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[test]</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>a</h1><h1>b</h1><h1>c</h1>');
+                    },
+                    contentAfter: '<h1>a</h1><h1>b</h1><h1>c</h1><p>[]<br></p>',
+                });
+            });
+            it('should paste first and last child into p when pasting h1 in p', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>te[xx]st</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>a</h1><h1>b</h1><h1>c</h1>');
+                    },
+                    contentAfter: '<p>tea</p><h1>b</h1><p>c[]st</p>',
+                });
+            });
+            it('should convert single h1 into p if p has content', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>te[xx]st</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>a<br>b<br>c</h1>');
+                    },
+                    contentAfter: '<p>tea<br>b<br>c[]st</p>',
+                });
+            });
+        });
+    });
     describe('youtube video', () => {
         describe('range collapsed', async () => {
             it('should paste and transform a youtube URL in a p', async () => {


### PR DESCRIPTION
**Current behavior before PR:**

When we attempt to paste an H1 element into a P element, the H1 element
gets converted to a P element.

**Desired behavior after PR is merged:**

When we attempt to paste an H1 element onto a P element, the H1 element
will remain as an H1 element

task-3302332


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
