### PR TITLE
[FIX] web: prevent traceback after toggling export compatibility

### DIFF
--- a/addons/web/static/src/views/view_dialogs/export_data_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/export_data_dialog.js
@@ -202,6 +202,7 @@ export class ExportDataDialog extends Component {
     async fetchFields() {
         this.state.search = [];
         this.knownFields = {};
+        this.expandedFields = {};
         await this.loadFields();
         await this.setDefaultExportList();
         if (this.searchRef.el) {


### PR DESCRIPTION
Toggling the compatibility of the export format in the export dialog causes the fields to be fetched again by the `ExportDataDialog` component. Before this commit, the `fetchFields` method did not reset the `expandedFields` cache, a mechanism to avoid redundant rpc calls when toggling expandable fields.

When subfields are reloaded for a certain field, this results in the rpc call being skipped as the subfields are kept in the `expandedFields` cache. When this happens after a call to `fetchFields` was made (for example after toggling the format compatibility) a traceback will occur because the subfields returned from the `expandedFields` cache are no longer present in the `knownFields` cache.

As the available subfields themselves can be different depending on the format compatibility reusing the `expandedFields` in such a case is also wrong. This is why this fix resets the `expandedFields` cache resulting in a new rpc call being made.

opw-3378834