### PR TITLE
[IMP] website: use app icon instead of font awesome icons on +new modal

### DIFF
--- a/addons/website/static/src/systray_items/new_content.js
+++ b/addons/website/static/src/systray_items/new_content.js
@@ -33,6 +33,7 @@ NewContentElement.props = {
     onClick: Function,
     status: { type: String, optional: true },
     moduleXmlId: { type: String, optional: true },
+    moduleName: { type: String, optional: true },
     slots: Object,
 };
 NewContentElement.defaultProps = {
@@ -75,21 +76,18 @@ export class NewContentModal extends Component {
                     moduleName: 'website_blog',
                     moduleXmlId: 'base.module_website_blog',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa fa-newspaper-o"/>`,
                     title: this.env._t('Blog Post'),
                 },
                 {
                     moduleName: 'website_event',
                     moduleXmlId: 'base.module_website_event',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa fa-ticket"/>`,
                     title: this.env._t('Event'),
                 },
                 {
                     moduleName: 'website_forum',
                     moduleXmlId: 'base.module_website_forum',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa fa-comment"/>`,
                     redirectUrl: '/forum',
                     title: this.env._t('Forum'),
                 },
@@ -97,28 +95,24 @@ export class NewContentModal extends Component {
                     moduleName: 'website_hr_recruitment',
                     moduleXmlId: 'base.module_website_hr_recruitment',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa fa-briefcase"/>`,
                     title: this.env._t('Job Position'),
                 },
                 {
                     moduleName: 'website_sale',
                     moduleXmlId: 'base.module_website_sale',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa fa-shopping-cart"/>`,
                     title: this.env._t('Product'),
                 },
                 {
                     moduleName: 'website_slides',
                     moduleXmlId: 'base.module_website_slides',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa module_icon" style="background-image: url('/website/static/src/img/apps_thumbs/website_slide.svg');background-repeat: no-repeat; background-position: center;"/>`,
                     title: this.env._t('Course'),
                 },
                 {
                     moduleName: 'website_livechat',
                     moduleXmlId: 'base.module_website_livechat',
                     status: MODULE_STATUS.NOT_INSTALLED,
-                    icon: xml`<i class="fa fa-comments"/>`,
                     title: this.env._t('Livechat Widget'),
                     redirectUrl: '/livechat'
                 },

--- a/addons/website/static/src/systray_items/new_content.scss
+++ b/addons/website/static/src/systray_items/new_content.scss
@@ -36,7 +36,6 @@
 
         .o_uninstalled_module {
             filter: brightness(70%) contrast(60%);
-
         }
 
         .module_icon {
@@ -50,9 +49,10 @@
             text-align: center;
             text-decoration: none;
 
-            i {
+            i, img {
                 width: 110px;
                 height: 110px;
+                padding: 15px;
                 border: 3px solid lighten(#2C2C36, 10%);
                 border-radius: 100%;
                 line-height: 104px;
@@ -70,9 +70,12 @@
             &:hover, &:focus {
                 text-decoration: none;
                 outline: none; // remove ugly dotted border on Firefox
-                i {
+                i, img {
                     border-color: #1cc1a9;
                     box-shadow: 0 0 10px rgba(28, 193, 169, 0.46);
+                }
+                &.o_uninstalled_module {
+                    filter: unset;
                 }
             }
         }

--- a/addons/website/static/src/systray_items/new_content.xml
+++ b/addons/website/static/src/systray_items/new_content.xml
@@ -16,12 +16,13 @@
 <t t-name="website.NewContentModal" owl="1">
     <div id="o_new_content_menu_choices">
         <div class="container pt32 pb32">
+            <h1 class="text-white text-center pb32">Create a new:</h1>
             <div class="row">
                 <NewContentElement t-if="isDesigner"
                         name="'New Page'"
                         onClick="() => this.createNewPage()"
                         title="'New Page'">
-                    <i class="fa fa-file-o"/>
+                    <img src="/mrp/static/description/icon.png"/>
                     <p>Page</p>
                 </NewContentElement>
 
@@ -30,7 +31,7 @@
                         status="element.status"
                         title="element.title"
                         moduleXmlId="element.moduleXmlId">
-                        <t t-call="{{ element.icon }}"/>
+                        <img t-attf-src="/{{element.moduleName}}/static/description/icon.png"/>
                         <p><t t-esc="element.title"/></p>
                     </NewContentElement>
                 </t>


### PR DESCRIPTION
The "+New" modal shows a list of the records it is possible to create in the website builder.

Before this commit, it was using font awesome icon without much color in a old fashionned style.

This commit improves that by using the app icons directly instead, which seems to bring more dynamism and color to this "page".

It's a WIP, to debate spec, still need to:
- Create enterprise branche for Appointment Form
- Clean css/js/xml
- Ask design team to create a "Page" icon, now using MRP for the demo
- Rounded border + padding, need to fix or angles/edges are cut

task-2941442
