### PR TITLE
[FIX] web: remove abstract and transient models from model selector

### DIFF
--- a/addons/web/models/ir_model.py
+++ b/addons/web/models/ir_model.py
@@ -44,5 +44,11 @@ class IrModel(models.Model):
         Return the list of models the current user has access to, with their
         corresponding display name.
         """
-        accessible_models = [model for model in self.pool.keys() if self._check_model_access(model)]
+        accessible_models = [
+            model for model in self.pool.keys()
+            if model in self.env and
+            not self.env[model]._abstract and
+            not self.env[model]._transient and
+            self._check_model_access(model)
+        ]
         return self._display_name_for(accessible_models)


### PR DESCRIPTION
Steps to reproduce:

  - Open the Knowledge app
  - Click on Sales & Marketing and expand the section
  - Click on Sales Playbook
  - Add a property
  - Select field type "Many2one" or "Many2many"
  - Select modal "Show API key"

Issue:

  Traceback raised.

Cause:

  `Show API key` is an abstract model and therefore should not be
  present in the model selector.

Solution:

  Filter available models by removing abstract and transient models.

opw-3276995