### PR TITLE
[IMP] website: add a restricted editor to ease testing and debugging

### DIFF
--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <record id="partner_editor" model="res.partner">
+            <field name="name">Peter Editor</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="company_name">YourCompany</field>
+            <field name="street">3576 Buena Vista Avenue</field>
+            <field name="city">Eugene</field>
+            <field name="state_id"  model="res.country.state" search="[('code','ilike','OR')]"/>
+            <field name="zip">97401</field>
+            <field name="country_id" ref="base.us"/>
+            <field name="tz">Europe/Brussels</field>
+            <field name="email">peter.editor23@example.com</field>
+            <field name="phone">(441)-695-2335</field>
+        </record>
+
+        <record id="user_editor" model="res.users">
+            <field name="partner_id" ref="website.partner_editor"/>
+            <field name="login">editor</field>
+            <field name="password">editor</field>
+            <field name="signature" type="html"><span>-- <br/>+Mr Editor</span></field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="groups_id" eval="[Command.set([ref('base.group_user'), ref('website.group_website_restricted_editor')])]"/>
+            <field name="image_1920" type="base64" file="website/static/description/icon.png"/>
+        </record>
+
         <record id="bs_debug_view" model="ir.ui.view">
             <field name="name">BS Debug</field>
             <field name="type">qweb</field>

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -14,7 +14,7 @@
             <field name="email">peter.editor23@example.com</field>
             <field name="phone">(441)-695-2335</field>
         </record>
-
+        <!-- TODO can't use demo data in tour, need to create a common one in python -->
         <record id="user_editor" model="res.users">
             <field name="partner_id" ref="website.partner_editor"/>
             <field name="login">editor</field>

--- a/addons/website/tests/test_client_action.py
+++ b/addons/website/tests/test_client_action.py
@@ -21,7 +21,7 @@ class TestClientAction(odoo.tests.HttpCase):
             'url': '/test_client_action_redirect',
             'is_published': True,
         })
-        self.start_tour(page.url, 'client_action_redirect', login='admin')
+        self.start_tour(page.url, 'client_action_redirect', login='editor')
 
     def test_02_client_action_iframe_fallback(self):
-        self.start_tour('/@/', 'client_action_iframe_fallback', login='admin')
+        self.start_tour('/@/', 'client_action_iframe_fallback', login='editor')

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -60,11 +60,13 @@ class TestConfiguratorTranslation(TestConfiguratorCommon):
         }).lang_install()
         feature = self.env['website.configurator.feature'].search([('name', '=', 'Privacy Policy')])
         feature.with_context(lang='fr_FR').write({'name': 'Politique de confidentialité'})
-        self.env.ref('base.user_admin').write({'lang': self.env.ref('base.lang_fr').code})
+        # TODO: can't use demo in tests
+        tour_user = self.env.ref('website.user_editor')
+        tour_user.write({'lang': self.env.ref('base.lang_fr').code})
         website_fr = self.env['website'].create({
             'name': "New website",
         })
         # disable configurator todo to ensure this test goes through
         active_todo = self.env['ir.actions.todo'].search([('state', '=', 'open')], limit=1)
         active_todo.update({'state': 'done'})
-        self.start_tour('/website/force/%s?path=%%2Fwebsite%%2Fconfigurator' % website_fr.id, 'configurator_translation', login='admin')
+        self.start_tour('/website/force/%s?path=%%2Fwebsite%%2Fconfigurator' % website_fr.id, 'configurator_translation', login=tour_user.login)


### PR DESCRIPTION
We need an easy way to login as a restricted editor on website, both for showcasing, testing and debugging purpose.
It's a pain to have to setup a DB/runbot multiple time a day to do that.

Before Odoo 16 it was easily possible as our `demo` user was a restricted editor, but it's not the case anymore:
- since [1] in 2015 the base.default_user receives all manager groups in Odoo to ease the onboarding in SMEs. This user is used t bootstrap new users later.
- since [2] in Odoo 16.0, any groups change applied on that user will be replicated  on already created users which were created based on that default_user. It means that the demo user is now also manager, including website designer. He is no more a restricted editor.

Thus, this commit introduce an easy way to login as a restricted editor. It will in a later commit be used in our testing suite: we want to convert as many test as possible from `admin` to `editor` in order to better catch the error which only appears with the `editor` user.

[1]: https://github.com/odoo/odoo/commit/1ecba213f4f188ba7a235e0cf4fc029535f0bdba
[2]: https://github.com/odoo/odoo/commit/aefb05eb497a8a16a9359432f41024c09552ed70

