### PR TITLE
[FIX] base: Allow not showing address type if contact name is empty

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -847,7 +847,10 @@ class Partner(models.Model):
                 }
 
     def _get_contact_name(self, partner, name):
-        return "%s, %s" % (partner.commercial_company_name or partner.sudo().parent_id.name, name)
+        company_name = partner.commercial_company_name or partner.sudo().parent_id.name
+        if not name:
+            return company_name
+        return "%s, %s" % (company_name, name)
 
     def _get_name(self):
         """ Utility method to allow name_get to be overrided without re-browse the partner """
@@ -855,7 +858,7 @@ class Partner(models.Model):
         name = partner.name or ''
 
         if partner.company_name or partner.parent_id:
-            if not name and partner.type in ['invoice', 'delivery', 'other']:
+            if not name and partner.type in ['invoice', 'delivery', 'other'] and not self._context.get("no_address_type"):
                 types = dict(self._fields['type']._description_selection(self.env))
                 name = types[partner.type]
             if not partner.is_company:

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -122,6 +122,12 @@ class TestPartner(TransactionCase):
         res_bhide = test_partner_bhide.with_context(show_address=1, address_inline=1).name_get()
         self.assertEqual(res_bhide[0][1], "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
 
+        test_invoice_partner_no_name = self.env['res.partner'].create({'name': '', 'parent_id': test_partner_jetha.id, 'type': 'invoice'})
+        res_invoice_partner_no_name = test_invoice_partner_no_name.name_get()
+        self.assertEqual(res_invoice_partner_no_name[0][1], "Jethala, Invoice Address", "name should contain parent name and address type")
+        res_invoice_partner_no_name = test_invoice_partner_no_name.with_context(no_address_type=1).name_get()
+        self.assertEqual(res_invoice_partner_no_name[0][1], "Jethala", "name should contain only parent name and no address type")
+
     def test_company_change_propagation(self):
         """ Check propagation of company_id across children """
         User = self.env['res.users']


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In case a child contact (e.g. Invoicing or delivery address) does not require a dedicated name (but only a different address of the same company), we do not want to print "Company name, Address Type" but only "Company name".

Adding an extra context key allows to do such a customization.

Current behavior before PR:

Impossible not to display the address type if contact doesn't have name

Desired behavior after PR is merged:

Possible to not display the address type if contact doesn't have name



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
