### PR TITLE
Enable to drop inner content on grid dropzones

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -85,13 +85,15 @@ class IrQweb(models.AbstractModel):
         name = el.attrib.pop('string', view.name)
         thumbnail = el.attrib.pop('t-thumbnail', "oe-thumbnail")
         image_preview = el.attrib.pop('t-image-preview', None)
+        height_in_grid = el.attrib.pop('t-height-in-grid', None)
+        width_in_grid = el.attrib.pop('t-width-in-grid', None)
         # Forbid sanitize contains the specific reason:
         # - "true": always forbid
         # - "form": forbid if forms are sanitized
         forbid_sanitize = el.attrib.pop('t-forbid-sanitize', None)
         snippet_group = el.attrib.pop('snippet-group', None)
         group = el.attrib.pop('group', None)
-        div = Markup('<div name="%s" data-oe-type="snippet" data-o-image-preview="%s" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s" %s %s %s>') % (
+        div = Markup('<div name="%s" data-oe-type="snippet" data-o-image-preview="%s" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s" %s %s %s %s %s>') % (
             name,
             escape_silent(image_preview),
             thumbnail,
@@ -100,6 +102,8 @@ class IrQweb(models.AbstractModel):
             Markup('data-oe-forbid-sanitize="%s"') % forbid_sanitize if forbid_sanitize else '',
             Markup('data-o-snippet-group="%s"') % snippet_group if snippet_group else '',
             Markup('data-o-group="%s"') % group if group else '',
+            Markup('data-oe-height-in-grid="%s"') % height_in_grid if height_in_grid else '',
+            Markup('data-oe-width-in-grid="%s"') % width_in_grid if width_in_grid else '',
         )
         self._append_text(div, compile_context)
         code = self._compile_node(el, compile_context, indent)

--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -5,7 +5,7 @@ import {descendants, preserveCursor} from "@web_editor/js/editor/odoo-editor/src
 export const rowSize = 50; // 50px.
 // Maximum number of rows that can be added when dragging a grid item.
 export const additionalRowLimit = 10;
-const defaultGridPadding = 10; // 10px (see `--grid-item-padding-(x|y)` CSS variables).
+export const defaultGridPadding = 10; // 10px (see `--grid-item-padding-(x|y)` CSS variables).
 
 /**
  * Returns the grid properties: rowGap, rowSize, columnGap and columnSize.

--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -344,7 +344,7 @@ export function _checkIfImageColumn(columnEl) {
  * @private
  * @param {Element} columnEl a column containing only an image.
  */
-function _convertImageColumn(columnEl) {
+export function _convertImageColumn(columnEl) {
     columnEl.querySelectorAll('br').forEach(el => el.remove());
     const textNodeEls = [...columnEl.childNodes].filter(el => el.nodeType === Node.TEXT_NODE);
     textNodeEls.forEach(el => el.remove());

--- a/addons/web_editor/static/src/js/editor/drag_and_drop.js
+++ b/addons/web_editor/static/src/js/editor/drag_and_drop.js
@@ -211,7 +211,6 @@ export function useDragAndDrop(initialParams) {
 export class dragAndDropHelper {
     constructor(odooEditor, draggedItemEl, bodyEl) {
         this.dragState = {};
-        this.dropped = false;
         this.draggedItemEl = draggedItemEl;
         this.odooEditor = odooEditor;
         this.bodyEl = bodyEl;
@@ -249,7 +248,7 @@ export class dragAndDropHelper {
 
             gridUtils._gridCleanUp(rowEl, this.draggedItemEl);
             this._removeGridAndDragHelper(rowEl);
-        } else if (this.draggedItemEl.classList.contains("o_grid_item") && this.dropped) {
+        } else if (this.draggedItemEl.classList.contains("o_grid_item") && this.isDropped()) {
             // Case when dropping a grid item in a non-grid dropzone
             this.odooEditor.observerActive("dragAndDropMoveSnippet");
             gridUtils._convertToNormalColumn(this.draggedItemEl);
@@ -289,7 +288,7 @@ export class dragAndDropHelper {
             gridUtils._convertToNormalColumn(this.draggedItemEl);
             this.odooEditor.observerUnactive("dragAndDropMoveSnippet");
         }
-        this.dropped = true;
+        this.dragState.currentDropzoneEl = dropzoneEl;
     }
     /**
      * Handles the insertion of an element in a dropzone.
@@ -298,7 +297,6 @@ export class dragAndDropHelper {
      * dragged.
      */
     dropzoneOver(dropzoneEl) {
-        this.dropped = true;
         dropzoneEl.after(this.draggedItemEl);
         dropzoneEl.classList.add("invisible");
 
@@ -376,7 +374,6 @@ export class dragAndDropHelper {
             const rowCount = parseInt(rowEl.dataset.rowCount);
             dropzoneEl.style.gridRowEnd = Math.max(rowCount + 1, 1);
         }
-        this.dropped = false;
         this.draggedItemEl.remove();
         dropzoneEl.classList.remove("invisible");
 
@@ -412,6 +409,15 @@ export class dragAndDropHelper {
         filterOutSelectorGrids($selectorSiblings, (el) => el.parentElement);
         filterOutSelectorGrids($selectorChildren, (el) => el);
         return selectorGrids;
+    }
+    /**
+     * Checks if we are currently over a dropzone, that is, if
+     * `currentDropzoneEl` is defined.
+     *
+     * @returns {Boolean}
+     */
+    isDropped() {
+        return !!this.dragState.currentDropzoneEl;
     }
     /**
      * Places a column in a grid on mouse move.

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -116,7 +116,7 @@ var SnippetEditor = publicWidget.Widget.extend({
         this.isTargetParentEditable = this.$target.parent().is(':o_editable');
         this.isTargetMovable = this.isTargetParentEditable && this.isTargetMovable && !this.$target.hasClass('oe_unmovable');
         this.isTargetRemovable = this.isTargetParentEditable && !this.$target.parent().is('[data-oe-type="image"]') && !isUnremovable(this.$target[0]);
-        this.displayOverlayOptions = this.displayOverlayOptions || this.isTargetMovable || !this.isTargetParentEditable;
+        this.updateDisplayOverlayOptions();
 
         // Initialize move/clone/remove buttons
         if (this.isTargetMovable) {
@@ -555,6 +555,10 @@ var SnippetEditor = publicWidget.Widget.extend({
             this.$el.toggleClass('o_we_overlay_sticky', show);
             if (!this.displayOverlayOptions) {
                 this.$el.find('.o_overlay_options_wrap').addClass('o_we_hidden_overlay_options');
+            } else {
+                this.$el[0]
+                    .querySelector(".o_overlay_options_wrap")
+                    .classList.remove("o_we_hidden_overlay_options");
             }
         }
 
@@ -636,6 +640,16 @@ var SnippetEditor = publicWidget.Widget.extend({
         if (this.$el && !this.scrollingTimeout) {
             this.$el.toggleClass('o_overlay_hidden', (!show || this.$target[0].matches('.o_animating:not(.o_animate_on_scroll)')) && this.isShown());
         }
+    },
+    /**
+     * Updates the displayOverlayOptions attribute.
+     */
+    updateDisplayOverlayOptions() {
+        const isTargetSingleSnippetInColumn = this.$target[0].dataset.snippet
+            && this.$target[0].closest(".row.o_grid_mode")
+            && this.$target[0].parentNode.classList.contains("o_grid_item")
+            && this.$target[0].parentNode.children.length == 1;
+        this.displayOverlayOptions = (this.displayOverlayOptions || this.isTargetMovable || !this.isTargetParentEditable) && !isTargetSingleSnippetInColumn;
     },
     /**
      * Updates the UI of all the options according to the status of their
@@ -3536,6 +3550,7 @@ class SnippetsMenu extends Component {
                     this.$el.find('.oe_snippet_thumbnail').removeClass('o_we_ongoing_insertion');
                 }
                 this.dragState.restore();
+                this._updateEditorsDisplayOverlayOptions();
                 this._onDropZoneStop();
             },
         });
@@ -4030,6 +4045,7 @@ class SnippetsMenu extends Component {
         // Update the "Invisible Elements" panel as the order of invisible
         // snippets could have changed on the page.
         await this._updateInvisibleDOM();
+        this._updateEditorsDisplayOverlayOptions();
     }
     /**
      * Transforms an event coming from a touch screen into a mouse event.
@@ -4354,6 +4370,7 @@ class SnippetsMenu extends Component {
     _onSnippetRemoved() {
         this._disableUndroppableSnippets();
         this._updateInvisibleDOM();
+        this._updateEditorsDisplayOverlayOptions();
     }
     /**
      * @see _snippetOptionUpdate
@@ -4704,6 +4721,16 @@ class SnippetsMenu extends Component {
             this.$body[0],
             "dragAndDropCreateSnippet"
         );
+    }
+    /**
+     * Updates the display overlay options of the active editors.
+     *
+     * @private
+     */
+    _updateEditorsDisplayOverlayOptions() {
+        for (const snippetEditor of this.snippetEditors) {
+            snippetEditor.updateDisplayOverlayOptions();
+        }
     }
     /**
      * Allows other modules to react to drop zones being enabled

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -952,7 +952,7 @@ var SnippetEditor = publicWidget.Widget.extend({
                 this.dragAndDropHelper.dropzoneOver(dropzoneEl);
             },
             dropzoneOut: ({ dropzone }) => {
-                if (!this.dragState.currentDropzoneEl) {
+                if (!this.dragAndDropHelper.isDropped()) {
                     // The "over" has been cancelled due to glued dropzone ->
                     // don't do anything.
                     return;
@@ -1214,7 +1214,7 @@ var SnippetEditor = publicWidget.Widget.extend({
         this.dragAndDropHelper.dragAndDropStopGrid();
 
         // TODO lot of this is duplicated code of the d&d feature of snippets
-        if (!this.dragAndDropHelper.dropped) {
+        if (!this.dragAndDropHelper.isDropped()) {
             let $el = $(closest(this.$body[0].querySelectorAll('.oe_drop_zone'), {x, y}));
             // Some drop zones might have been disabled.
             $el = $el.filter(this.$dropZones);
@@ -1253,7 +1253,7 @@ var SnippetEditor = publicWidget.Widget.extend({
         $clone.remove();
 
         this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-        if (this.dragAndDropHelper.dropped) {
+        if (this.dragAndDropHelper.isDropped()) {
             if (prev) {
                 this.$target.insertAfter(prev);
             } else if (next) {

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -948,14 +948,14 @@ var SnippetEditor = publicWidget.Widget.extend({
                 const dropzoneEl = dropzone.el;
                 // Prevent a column to be trapped in an upper grid dropzone at
                 // the start of the drag.
-                if (this.dragState.isColumn && this.dragState.overFirstDropzone) {
+                if (this.dragState.overFirstDropzone) {
                     this.dragState.overFirstDropzone = false;
 
                     // The column is considered as glued to the dropzone if the
                     // dropzone is above and if the space between them is less
                     // than 25px (the move handle height is 22px so 25 is a
                     // safety margin).
-                    const columnTop = this.dragState.columnTop;
+                    const columnTop = this.dragState.draggedItemTop;
                     const dropzoneBottom = dropzoneEl.getBoundingClientRect().bottom;
                     const areDropzonesGlued = columnTop >= dropzoneBottom && columnTop - dropzoneBottom < 25;
 
@@ -1112,12 +1112,11 @@ var SnippetEditor = publicWidget.Widget.extend({
                 // Reload the images.
                 gridUtils._reloadLazyImages(this.$target[0]);
             }
-            // Storing the starting top position of the column.
-            this.dragState.columnTop = this.$target[0].getBoundingClientRect().top;
-            this.dragState.isColumn = true;
             // Deactivate the snippet so the overlay doesn't show.
             this.trigger_up('deactivate_snippet', {$snippet: self.$target});
         }
+        // Storing the starting top position of the dragged item.
+        this.dragState.draggedItemTop = this.$target[0].getBoundingClientRect().top;
         // Store the dragged element (or the image if the column only contains
         // an image) width and height to use them when the column goes over a
         // grid dropzone.

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1245,6 +1245,7 @@ var SnippetEditor = publicWidget.Widget.extend({
             this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
         }
 
+        this.$editable.find('.o_we_background_grid').remove();
         this.$editable.find('.oe_drop_zone').remove();
 
         const draggedItemEl = this.dragAndDropHelper.draggedItemEl;
@@ -3281,11 +3282,13 @@ class SnippetsMenu extends Component {
         const columnCount = 12;
         const rowCount = parseInt(rowEl.dataset.rowCount);
         let $dropzone = $('<div/>', {
-            'class': 'oe_drop_zone oe_insert oe_grid_zone',
+            'class': 'oe_drop_zone oe_insert oe_grid_zone invisible',
             'style': 'grid-area: ' + 1 + '/' + 1 + '/' + (rowCount + 1) + '/' + (columnCount + 1),
         });
         $dropzone[0].style.minHeight = window.getComputedStyle(rowEl).height;
         $dropzone[0].style.width = window.getComputedStyle(rowEl).width;
+        const backgroundGridEl = gridUtils._addBackgroundGrid(rowEl, 0);
+        gridUtils._setElementToMaxZindex(backgroundGridEl, rowEl);
         rowEl.append($dropzone[0]);
     }
     /**
@@ -3510,6 +3513,7 @@ class SnippetsMenu extends Component {
                     }
                 }
 
+                this.getEditableArea().find('.o_we_background_grid').remove();
                 this.getEditableArea().find('.oe_drop_zone').remove();
 
                 const draggedItemEl = this.dragAndDropHelper.draggedItemEl;

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -179,6 +179,8 @@
                                     t-on-click="this._onSnippetClick"
                                     t-att-data-tooltip="snippet.disabled ? disabledTooltip : false"
                                     t-att-data-snippet-group="snippet.snippetGroup"
+                                    t-att-data-oe-height-in-grid="snippet.heightInGrid"
+                                    t-att-data-oe-width-in-grid="snippet.widthInGrid"
                                     t-att-data-snippet-key="snippet.key">
                                     <t t-if="snippet.disabled">
                                         <img src="/web_editor/static/src/img/snippet_disabled.svg" class="o_snippet_undroppable"/>

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -345,6 +345,7 @@
             'website/static/src/xml/website.cookies_bar.xml',
             'website/static/src/js/editor/commands_overridden.js',
             'website/static/src/js/editor/odoo_editor.js',
+            'website/static/src/js/editor/drag_and_drop.js',
         ],
         'website.assets_all_wysiwyg': [
             ('include', 'web_editor.assets_wysiwyg'),

--- a/addons/website/static/src/js/editor/drag_and_drop.js
+++ b/addons/website/static/src/js/editor/drag_and_drop.js
@@ -1,0 +1,28 @@
+/** @odoo-module **/
+import { dragAndDropHelper } from "@web_editor/js/editor/drag_and_drop";
+
+export class dragAndDropHelperWebsite extends dragAndDropHelper {
+    /**
+     * Changes some behaviors before the drag and drop.
+     *
+     * @private
+     * @override
+     * @returns {Function} a function that restores what was changed when the
+     *  drag and drop is over.
+     */
+    prepareDrag() {
+        const restore = super.prepareDrag();
+        // Remove the footer scroll effect if it has one (because the footer
+        // dropzone flickers otherwise when it is in grid mode).
+        const wrapwrapEl = this.bodyEl.ownerDocument.defaultView.document.body.querySelector("#wrapwrap");
+        const hasFooterScrollEffect = wrapwrapEl && wrapwrapEl.classList.contains("o_footer_effect_enable");
+        if (hasFooterScrollEffect) {
+            wrapwrapEl.classList.remove("o_footer_effect_enable");
+            return () => {
+                wrapwrapEl.classList.add("o_footer_effect_enable");
+                restore();
+            };
+        }
+        return restore;
+    }
+}

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -11,6 +11,7 @@ import { Component, onMounted, onWillStart, useEffect, useRef, useState } from "
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { applyTextHighlight, switchTextHighlight } from "@website/js/text_processing";
 import { registry } from "@web/core/registry";
+import { dragAndDropHelperWebsite } from "@website/js/editor/drag_and_drop";
 
 const snippetsEditorRegistry = registry.category("snippets_editor");
 snippetsEditorRegistry.add("no_parent_editor_snippets", ["s_popup", "o_mega_menu"]);
@@ -737,27 +738,13 @@ weSnippetEditor.SnippetEditor.include({
         return this._super(...arguments);
     },
     /**
-     * Changes some behaviors before the drag and drop.
+     * Returns the drag and drop helper.
      *
      * @private
-     * @override
-     * @returns {Function} a function that restores what was changed when the
-     *  drag and drop is over.
+     * @returns {Object} the drag and drop helper.
      */
-    _prepareDrag() {
-        const restore = this._super(...arguments);
-        // Remove the footer scroll effect if it has one (because the footer
-        // dropzone flickers otherwise when it is in grid mode).
-        const wrapwrapEl = this.$body[0].ownerDocument.defaultView.document.body.querySelector('#wrapwrap');
-        const hasFooterScrollEffect = wrapwrapEl && wrapwrapEl.classList.contains('o_footer_effect_enable');
-        if (hasFooterScrollEffect) {
-            wrapwrapEl.classList.remove('o_footer_effect_enable');
-            return () => {
-                wrapwrapEl.classList.add('o_footer_effect_enable');
-                restore();
-            };
-        }
-        return restore;
+    _getDragAndDropHelper() {
+        return new dragAndDropHelperWebsite(this.options.wysiwyg.odooEditor, this.$target[0], this.$body[0]);
     },
 });
 

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -719,6 +719,20 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
     _onGetSwitchableRelatedViews(ev) {
         this.props.getSwitchableRelatedViews().then(ev.data.onSuccess);
     }
+    /**
+     * Returns the drag and drop helper.
+     *
+     * @private
+     * @returns {Object} the drag and drop helper.
+     */
+    _getDragAndDropHelper(draggedItemEl) {
+        return new dragAndDropHelperWebsite(
+            this.options.wysiwyg.odooEditor,
+            draggedItemEl,
+            this.$body[0],
+            "dragAndDropCreateSnippet"
+        );
+    }
 }
 
 weSnippetEditor.SnippetEditor.include({
@@ -744,7 +758,12 @@ weSnippetEditor.SnippetEditor.include({
      * @returns {Object} the drag and drop helper.
      */
     _getDragAndDropHelper() {
-        return new dragAndDropHelperWebsite(this.options.wysiwyg.odooEditor, this.$target[0], this.$body[0]);
+        return new dragAndDropHelperWebsite(
+            this.options.wysiwyg.odooEditor,
+            this.$target[0],
+            this.$body[0],
+            "dragAndDropMoveSnippet"
+        );
     },
 });
 

--- a/addons/website/static/src/snippets/s_image/options.js
+++ b/addons/website/static/src/snippets/s_image/options.js
@@ -2,6 +2,7 @@
 
 import options from "@web_editor/js/editor/snippets.options";
 import { MediaDialog } from "@web_editor/components/media_dialog/media_dialog";
+import * as gridUtils from "@web_editor/js/common/grid_layout_utils";
 
 options.registry.ImageSnippet = options.Class.extend({
     /**
@@ -16,9 +17,16 @@ options.registry.ImageSnippet = options.Class.extend({
                 onlyImages: true,
                 save: imageEl => {
                     isImageSaved = true;
+                    const parentEl = this.$target[0].parentNode;
                     // Replace the placeholder with the new image.
-                    this.$target[0].parentNode.insertBefore(imageEl, this.$target[0]);
-                    this.$target[0].parentNode.removeChild(this.$target[0]);
+                    parentEl.insertBefore(imageEl, this.$target[0]);
+                    parentEl.removeChild(this.$target[0]);
+                    // Adapt the image to a grid item image if it is dropped as
+                    // a grid item.
+                    if (parentEl.classList.contains("o_grid_item")
+                            && gridUtils._checkIfImageColumn(parentEl)) {
+                        gridUtils._convertImageColumn(parentEl);
+                    }
                 },
             }, {
                 onClose: () => {

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -997,7 +997,7 @@
         t-attf-data-selector="#{so_content_addition_selector}, .s_card"
         t-attf-data-drop-near="p, h1, h2, h3, ul, ol, div:not(.o_grid_item_image) > img, .btn, #{so_content_addition_selector}, .s_card:not(#{special_cards_selector})"
         t-attf-data-exclude="#{special_cards_selector}"
-        data-drop-in="nav"/>
+        data-drop-in="nav, .row.o_grid_mode"/>
 
     <div data-js="SnippetSave"
         data-selector="[data-snippet], a.btn"

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -370,20 +370,20 @@
             <snippets id="snippet_content" string="Inner content">
                 <t t-snippet="website.s_button" string="Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_button.svg"/>
                 <t t-snippet="website.s_image" string="Image" t-thumbnail="/website/static/src/img/snippets_thumbs/s_image.svg"/>
-                <t t-snippet="website.s_video" string="Video" t-thumbnail="/website/static/src/img/snippets_thumbs/s_video.svg"/>
+                <t t-snippet="website.s_video" string="Video" t-thumbnail="/website/static/src/img/snippets_thumbs/s_video.svg" t-height-in-grid="9"/>
                 <t t-snippet="website.s_hr" string="Separator" t-thumbnail="/website/static/src/img/snippets_thumbs/s_hr.svg"/>
                 <t t-snippet="website.s_accordion" string="Accordion" t-thumbnail="/website/static/src/img/snippets_thumbs/s_accordion.svg"/>
                 <t t-snippet="website.s_alert" string="Alert" t-thumbnail="/website/static/src/img/snippets_thumbs/s_alert.svg"/>
-                <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg"/>
+                <t t-snippet="website.s_rating" string="Rating" t-thumbnail="/website/static/src/img/snippets_thumbs/s_rating.svg" t-width-in-grid="2"/>
                 <t t-snippet="website.s_card" string="Card" t-thumbnail="/website/static/src/img/snippets_thumbs/s_card.svg"/>
-                <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg"/>
+                <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg" t-width-in-grid="4"/>
                 <t t-snippet="website.s_social_media" string="Social Media" t-thumbnail="/website/static/src/img/snippets_thumbs/s_social_media.svg"/>
                 <t t-snippet="website.s_facebook_page" string="Facebook" t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg"/>
                 <t t-snippet="website.s_searchbar_input" string="Search" t-thumbnail="/website/static/src/img/snippets_thumbs/s_searchbar_inline.svg" t-forbid-sanitize="form"/>
                 <t id="mass_mailing_newsletter_hook"/>
                 <t id="mail_group_hook"/>
                 <t t-snippet="website.s_text_highlight" string="Text Highlight" t-thumbnail="/website/static/src/img/snippets_thumbs/s_text_highlight.svg"/>
-                <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg"/>
+                <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg" t-height-in-grid="9" t-width-in-grid="7"/>
                 <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg"/>
                 <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg"/>
                 <t t-snippet="website.s_cta_badge" string="CTA Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_cta_badge.svg"/>

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -220,6 +220,7 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
             <t t-set="_exclude">.s_newsletter_block .s_newsletter_list, .o_newsletter_popup .s_newsletter_list</t>
         </t>
         <div data-selector=".js_subscribe" data-drop-near="p, h1, h2, h3, blockquote, .card"/>
+        <div data-selector=".s_newsletter_subscribe_form" data-drop-in=".row.o_grid_mode"/>
     </xpath>
 </template>
 

--- a/addons/website_payment/views/snippets/snippets.xml
+++ b/addons/website_payment/views/snippets/snippets.xml
@@ -10,7 +10,7 @@
         <t t-snippet="website_payment.s_donation" string="Donation" t-forbid-sanitize="form" group="contact_and_forms"/>
     </xpath>
     <xpath expr="//t[@id='snippet_donation_button_hook']" position="replace">
-        <t t-snippet="website_payment.s_donation_button" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg" t-forbid-sanitize="form"/>
+        <t t-snippet="website_payment.s_donation_button" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg" t-forbid-sanitize="form" t-width-in-grid="2"/>
     </xpath>
 </template>
 

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -10,7 +10,7 @@
         <t t-snippet="website_sale.s_dynamic_snippet_products" string="Products" group="products"/>
     </xpath>
     <xpath expr="//t[@id='snippet_add_to_cart_hook']" position="replace">
-        <t t-snippet="website_sale.s_add_to_cart" string="Add to Cart Button"  t-thumbnail="/website/static/src/img/snippets_thumbs/s_add_to_cart.svg"/>
+        <t t-snippet="website_sale.s_add_to_cart" string="Add to Cart Button"  t-thumbnail="/website/static/src/img/snippets_thumbs/s_add_to_cart.svg" t-width-in-grid="2"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
[REF] web_editor: extract code that will be common for the snippet menu

The goal of this commit is to extract in `dragAndDropHelper` the logic
related to the drag and drop of the `SnippetEditor` that will be common
for the `SnippetsMenu`.

This commit introduces the `_removeGridAndDragHelper()` method to handle
the common part of `dragAndDropStopGrid()`, `dropzoneOut()` and
`_outPreviousDropzone()`. It also introduces the
`_handleGridItemCreation()` method to handle the common part of
`droppedNear()` and `dropzoneOver()`.

task-3369611

-------------------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] web_editor: associate code that have the same purpose

The `if (dropzoneEl === prev[0])` condition is removed at the `out` of
a dropzone. Indeed, since [1], a check (`sameDropzoneAsCurrent`) has
been added in order to ensure that the dropzone we want to exit is the
same than the one that has been hovered. Due to it, the
`if (dropzone.el === prev[0])` condition can be removed as it is
redundant of the `sameDropzoneAsCurrent` check.

Now that this condition has been removed, we can gather two parts of the
code that have the same purpose; [1] and [2]. The goal of both commits
is to handle the case where an "over" event happens after another "over"
event. Instead of having "over" > "out" > "over", there is an "over" >
"over" > "out". This could happen when going really fast from a dropzone
to another or when the dropzones are glued to each other.

This gathering can be done as, since we removed the
`if (dropzone.el === prev[0])` condition, the `dropped` attribute of
`dragAndDropHelper` is always set when `currentDropzoneEl` is set and
vice versa. This commit also removes the `dropped` attribute and
introduces the `isDropped()` method as a replacement.

[1]: https://github.com/odoo/odoo/commit/3749d6d66c8cc49fd6613c8a8b6889ca5150fe99
[2]: https://github.com/odoo/odoo/commit/fed5854e32bcddf8b14b8311b2fe542eed990f77

task-3369611

-------------------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] web_editor,*: enable to drop inner content on grid dropzones
*website, website_mass_mailing

The goal of this commit is to be able to drag an "Inner content" snippet
as a grid element inside snippets that are in grid mode. To do so,
`.row.o_grid_mode` has been added as `data-drop-in` for those snippets
and the already existing logic of the "move" option of the
`SnippetEditor` has been reused for the `SnippetsMenu`. Here are
additional features added to the existing logic:
- When an item is dragged over a grid dropzone, it is wrapped in a `div`
column if it is a "raw" snippet. The dragged item is then replaced by
the wrapped element. The unwrapping is done if the dragged item leaves
the grid dropzone.
- For the drag and drop of a snippet that is already on the page, the
storage of the snippet width and height is always done (before this
commit, it was only the case if the snippet parent node had the `row`
class). Indeed, now, a snippet can start in a non-grid dropzone and then
be dragged over a grid dropzone where the `columnWidth` and
`columnHeight` parameters are needed.
- A hack has been used for the drag and drop of a snippet from the right
panel. When the snippet is dragged over a grid dropzone, we somehow need
to get its `width` and `height` to compute the number of rows and
columns needed inside the grid zone. To do so, the snippet can not be
inserted on the grid as it will try to fit in only one box. The hack is
to insert the snippet outside of the grid to get its "normal" `width`
and `height` and then on the grid again as the number of rows and
columns can now be determined. Note that the width of the items that
come from the right panel is restricted as we do not want them to appear
too big on the grid. This hack is not relevant for the drag and drop of
a snippet that is already on the page as we can directly get its `width`
and `height`.
- The grid dropzones are only activated if the user is not using the
mobile view.
- `displayOverlayOptions` has been modified to not show the overlay
option of snippets wrapped in a column.
- The `onDragEnd()` methods of the `SnippetEditor` and `SnippetsMenu`
have been adapted as the dragged item could have been changed during the
drag process (the item could have been dragged).

task-3369611

-------------------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] web_editor,*: set grid dimension of dynamically build snippets
*website, website_payment, website_sale

To compute the size of an item, the `_storeGridItemWidthAndHeight()`
function first inserts it on the DOM and then measures its size. The
problem is that some snippets are built dynamically (for example, the
"Chart" snippet) leading this function to not correctly set the size of
such items. To solve the problem, the `data-oe-width-grid` and
`data-oe-height-grid` attributes of such snippets are used to store the
size that the item will have on the grid. This system is also used for
other snippets in order to better size them on the grid.

task-3369611

-------------------------------------------------------------------------------------------------------------------------------------------------------------------

[FIX] web_editor, website: allow to drag image on grid

Now that it is possible to drop inner content snippet on grid dropzone,
a problem appears with the "Image" snippet.

Steps to reproduce:
- Add a "Text-Image" snippet on the website and change its "Layout" to
"Grid".
- Drop an "Image" snippet on the grid and add an image through the media
dialog.
- Drag the "Image" snippet.

-> Traceback appears.

The problem is that the template of the "Image" snippet does not contain
an image. Due to it, the `_convertImageColumn()` method does not apply
when the snippet is dragged over the dropzone. Consequently, the
dimensions of the dragged snippet are false at the
`storeItemWidthAndHeight()` execution during the start of the
`SnippetEditor` drag and drop. To solve the problem, the
`_convertImageColumn()` method is applied when the image is inserted on
the DOM.

task-3369611

