### PR TITLE
[FIX] website: don't block the Editor and Designer website group

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -865,6 +865,8 @@ class Website(models.Model):
                     website_domain if hasattr(Model, 'website_id') else [],
                 ]))
 
+            if self.env.user.has_group('website.group_website_designer'):
+                Model = Model.sudo()
             dependency_records = Model.search(OR(domains))
             if model == 'ir.ui.view':
                 dependency_records = _handle_views_and_pages(dependency_records)


### PR DESCRIPTION
Versions:
---------
- 16+

Steps to reproduce:
-------------------
- install hr_contract module;
- remove value for Contracts group in the user settings.
- have the "Editor and Designer" group for the user;
- try to modify the URL of a website page (via Properties). (It is an example)

Issue:
------
An access error is triggered.

Cause:
------
During the `search_url_dependencies` method,
we perform the `search` method on all models that
contain stored html fields
(and other conditions expressed within
the query of the `search_url_dependencies` method).

When we perform a `search` on the model 'hr.contract' (because it contains the html field `notes`),
we trigger the access error because we don't have
access to this model.

Solution:
---------
We can add a sudo to prevent the user with the
`Editor and Designer` group from being blocked
during `search`.

opw-3374599