### PR TITLE
[FIX] web: hide dropdown item in debug menu

### DIFF
--- a/addons/web/static/src/core/debug/debug_menu.xml
+++ b/addons/web/static/src/core/debug/debug_menu.xml
@@ -10,14 +10,16 @@
                 <i class="fa fa-bug"/>
             </t>
             <t t-foreach="elements" t-as="element" t-key="element_index">
-                <DropdownItem
-                    t-if="element.type == 'item'"
-                    t-on-dropdown-item-selected.stop="element.callback"
-                    href="element.href"
-                    t-esc="element.description"
-                />
-                <div t-if="element.type == 'separator'" role="separator" class="dropdown-divider"/>
-                <t t-if="element.type == 'component'" t-component="element.Component" t-props="element.props"/>
+                <t t-if="!element.hide">
+                    <DropdownItem
+                        t-if="element.type == 'item'"
+                        t-on-dropdown-item-selected.stop="element.callback"
+                        href="element.href"
+                        t-esc="element.description"
+                    />
+                    <div t-if="element.type == 'separator'" role="separator" class="dropdown-divider"/>
+                    <t t-if="element.type == 'component'" t-component="element.Component" t-props="element.props"/>
+                </t>
             </t>
         </Dropdown>
     </t>


### PR DESCRIPTION
To reproduce
============
- Log in as Marc Demo, In debug menu the button (Become Super User) shouldn't be there as Marc Demo doesn't have the right to.

Problem
=======
the `hide` prop is well set on the item but not used

Solution
========
following same logic on `user_menu` we check `hide` prop before rendering the item.

opw-3386362