### PR TITLE
[FIX] purchase_stock/sale_stock: forecast report with low permissions

### DIFF
--- a/addons/mrp/report/report_stock_forecasted.py
+++ b/addons/mrp/report/report_stock_forecasted.py
@@ -21,7 +21,7 @@ class ReplenishmentReport(models.AbstractModel):
 
         # Pending incoming quantity.
         mo_domain = domain + [('location_dest_id', 'in', wh_location_ids)]
-        grouped_mo = self.env['mrp.production'].read_group(mo_domain, ['product_qty:sum'], 'product_id')
+        grouped_mo = self.env['mrp.production'].sudo().read_group(mo_domain, ['product_qty:sum'], 'product_id')
         res['draft_production_qty']['in'] = sum(mo['product_qty'] for mo in grouped_mo)
 
         # Pending outgoing quantity.

--- a/addons/mrp/report/report_stock_forecasted.xml
+++ b/addons/mrp/report/report_stock_forecasted.xml
@@ -15,14 +15,14 @@
         </xpath>
          <xpath expr="//button[@name='unreserve_link']" position="after">
             <button t-if="line['move_out'] and line['move_out'].raw_material_production_id and line['move_out'].raw_material_production_id.unreserve_visible"
-                class="btn btn-sm btn-primary o_report_replenish_unreserve"
+                class="env.user.has_group('mrp.group_mrp_user') and btn btn-sm btn-primary o_report_replenish_unreserve"
                 t-attf-model="mrp.production"
                 t-att-model-id="line['move_out'].raw_material_production_id.id">
                 Unreserve
             </button>
         </xpath>
         <xpath expr="//button[@name='reserve_link']" position="after">
-            <button t-if="line['move_out'] and line['move_out'].raw_material_production_id and line['move_out'].raw_material_production_id.reserve_visible"
+            <button t-if="env.user.has_group('mrp.group_mrp_user') and line['move_out'] and line['move_out'].raw_material_production_id and line['move_out'].raw_material_production_id.reserve_visible"
                 class="btn btn-sm btn-primary o_report_replenish_reserve"
                 t-attf-model="mrp.production"
                 t-att-model-id="line['move_out'].raw_material_production_id.id">

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -125,7 +125,7 @@ class StockMove(models.Model):
 
     def _get_source_document(self):
         res = super()._get_source_document()
-        return self.purchase_line_id.order_id or res
+        return self.purchase_line_id.sudo().order_id or res
 
     def _get_valuation_price_and_qty(self, related_aml, to_curr):
         valuation_price_unit_total = 0

--- a/addons/purchase_stock/report/report_stock_forecasted.py
+++ b/addons/purchase_stock/report/report_stock_forecasted.py
@@ -14,7 +14,7 @@ class ReplenishmentReport(models.AbstractModel):
         warehouse_id = self.env.context.get('warehouse', False)
         if warehouse_id:
             domain += [('order_id.picking_type_id.warehouse_id', '=', warehouse_id)]
-        po_lines = self.env['purchase.order.line'].search(domain)
+        po_lines = self.env['purchase.order.line'].sudo().search(domain)
         in_sum = sum(po_lines.mapped('product_uom_qty'))
         res['draft_purchase_qty'] = in_sum
         res['draft_purchase_orders'] = po_lines.mapped("order_id").sorted(key=lambda po: po.name)

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -34,7 +34,7 @@ class StockMove(models.Model):
 
     def _get_source_document(self):
         res = super()._get_source_document()
-        return self.sale_line_id.order_id or res
+        return self.sale_line_id.sudo().order_id or res
 
     def _assign_picking_post_process(self, new=False):
         super(StockMove, self)._assign_picking_post_process(new=new)

--- a/addons/sale_stock/report/report_stock_forecasted.py
+++ b/addons/sale_stock/report/report_stock_forecasted.py
@@ -10,7 +10,7 @@ class ReplenishmentReport(models.AbstractModel):
     def _compute_draft_quantity_count(self, product_template_ids, product_variant_ids, wh_location_ids):
         res = super()._compute_draft_quantity_count(product_template_ids, product_variant_ids, wh_location_ids)
         domain = self._product_sale_domain(product_template_ids, product_variant_ids)
-        so_lines = self.env['sale.order.line'].search(domain)
+        so_lines = self.env['sale.order.line'].sudo().search(domain)
         out_sum = 0
         if so_lines:
             product_uom = so_lines[0].product_id.uom_id

--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -105,13 +105,13 @@
                         <tr t-foreach="docs['lines']" t-as="line" t-attf-class="#{line['is_matched'] and 'o_grid_match'}">
                             <td t-attf-class="#{line['is_late'] and 'o_grid_warning'}">
                                 <a t-if="line['document_in']"
-                                    t-attf-href="#" t-esc="line['document_in'].name"
+                                    t-attf-href="#" t-esc="line['document_in'].sudo().name"
                                     class="font-weight-bold" view-type="form"
                                     t-att-res-model="line['document_in']._name"
                                     t-att-res-id="line['document_in'].id"/>
                                 <t t-elif="line['reservation']">
                                     Reserved from stock
-                                    <button t-if="line['move_out'] and line['move_out'].picking_id"
+                                    <button t-if="env.user.has_group('stock.group_stock_user') and line['move_out'] and line['move_out'].picking_id"
                                         class="btn btn-sm btn-primary o_report_replenish_unreserve"
                                         t-attf-model="stock.picking"
                                         t-att-model-id="line['move_out'].picking_id.id"
@@ -121,7 +121,7 @@
                                 </t>
                                 <t t-elif="line['replenishment_filled']">
                                     <t t-if="line['document_out']">Inventory On Hand
-                                        <button t-if="line['move_out'] and line['move_out'].state in ('confirmed', 'partially_available') and line['move_out'].picking_id"
+                                        <button t-if="env.user.has_group('stock.group_stock_user') and line['move_out'] and line['move_out'].state in ('confirmed', 'partially_available') and line['move_out'].picking_id"
                                             class="btn btn-sm btn-primary o_report_replenish_reserve"
                                             t-attf-model="stock.picking"
                                             t-att-model-id="line['move_out'].picking_id.id"
@@ -145,7 +145,7 @@
                                     name="change_priority_link"
                                 />
                                 <a t-if="line['document_out']"
-                                    t-attf-href="#" t-esc="line['document_out'].name"
+                                    t-attf-href="#" t-esc="line['document_out'].sudo().name"
                                     class="font-weight-bold" view-type="form"
                                     t-att-res-model="line['document_out']._name"
                                     t-att-res-id="line['document_out'].id"/>


### PR DESCRIPTION
Targeted versions: 15.0, 16.0, master (17.0)

If we had a user with only sales permissions or only purchase permissions they'll hit an access error when they try to view the stock forecast from the order lines.

The same will happen with purchase users with no sales or mrp permissions and any permutation of this kind.

This fix grants the necessary access for the report render operations.

Another approach could be to hide the button for these users, although it implies to modify the widget xml templates which is not very possible in stable version.

Steps to reproduce the issue:

- Make a new user with just sales permissions (no stock, no purchase)
- Log in with that user.
- Make a new sales order with an storable product and save it.
- In the order line forcast widget popup, click on *View forecast* button.
- The user is redirect to the Forecast report but an access error raises, as he doesn't have permissions to read `purchase.order.line`:

```
odoo.exceptions.AccessError

odoo.exceptions.AccessError: You are not allowed to access 'Purchase Order Line' (purchase.order.line) records.

This operation is allowed for the following groups:
	- Inventory/User
	- Invoicing/Billing
	- Purchase/Administrator
	- Purchase/User
	- Technical/Show Accounting Features - Readonly
	- User types/Portal

Contact your administrator to request access if necessary.
```

cc @Tecnativa TT44084

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
