### PR TITLE
[FIX] web: fix project.task kanban cover image upload

### DIFF
--- a/addons/web/static/src/core/file_input/file_input.js
+++ b/addons/web/static/src/core/file_input/file_input.js
@@ -30,6 +30,7 @@ export class FileInput extends Component {
 
         onMounted(() => {
             if (this.props.autoOpen) {
+                this.props.state.fileInput = this.fileInputRef.el;
                 this.onTriggerClicked();
             }
         });

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
@@ -18,6 +18,7 @@ export class KanbanCoverImageDialog extends Component {
         this.state = useState({
             selectFile: false,
             selectedAttachmentId: attachment[0],
+            fileInput: false,
         });
         onWillStart(async () => {
             this.attachments = await this.orm.searchRead(
@@ -66,6 +67,9 @@ export class KanbanCoverImageDialog extends Component {
 
     uploadImage() {
         this.state.selectFile = true;
+        if (this.state.fileInput) {
+            this.state.fileInput.click();
+        }
     }
 }
 

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
@@ -23,6 +23,7 @@
                 autoOpen="true"
                 hidden="true"
                 onUpload.bind="onUpload"
+                state="state"
                 resModel="props.record.resModel"
                 resId="props.record.resId"
             />


### PR DESCRIPTION
Steps:
      - Install project app
      - Goto task kanban view toggle
      - click on the set cover image
      - Upload and set
      - Cancel
      - Again click on Upload and Set  button

   Issue-
         Once the user cancel the file dialog, he cannot be opened again.

Cause:
    When any element changes, the input file's 't-on-change="onFileInputChange"'
    triggers, but when we click the cancel button, nothing the trigger and the state
    of the element changes, therefore the input file is not triggered.

Fix:
  added state in child component, when the parent component's state changes, the
  child component's state will also change, triggering file input.


task-3258533
