### PR TITLE
[FIX]  account, l10n_be: Translate BE reconcile template

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -130,7 +130,7 @@ class AccountReconcileModel(models.Model):
 
     # Base fields.
     active = fields.Boolean(default=True)
-    name = fields.Char(string='Name', required=True)
+    name = fields.Char(string='Name', required=True, translate=True)
     sequence = fields.Integer(required=True, default=10)
     company_id = fields.Many2one(
         comodel_name='res.company',

--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -44,7 +44,7 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_be_reconcile_model(self):
         return {
             'escompte_template': {
-                'name': 'Escompte',
+                'name': 'Cash discount',
                 'line_ids': [
                     Command.create({
                         'account_id': 'a653',
@@ -53,9 +53,12 @@ class AccountChartTemplate(models.AbstractModel):
                         'label': 'Escompte accordé',
                     }),
                 ],
+                'name@fr': 'Escompte',
+                'name@nl': 'Betalingskorting',
+                'name@de': 'Skonto',
             },
             'frais_bancaires_htva_template': {
-                'name': 'Frais bancaires HTVA',
+                'name': 'Bank fees VAT excl.',
                 'line_ids': [
                     Command.create({
                         'account_id': 'a6560',
@@ -64,9 +67,12 @@ class AccountChartTemplate(models.AbstractModel):
                         'label': 'Frais bancaires HTVA',
                     }),
                 ],
+                'name@fr': 'Frais bancaires HTVA',
+                'name@nl': 'Bankkosten exclusief btw',
+                'name@de': 'Bankgebühren exkl. MwSt.',
             },
             'frais_bancaires_tva21_template': {
-                'name': 'Frais bancaires TVA21',
+                'name': 'Bank fees VAT 21 incl.',
                 'line_ids': [
                     Command.create({
                         'account_id': 'a6560',
@@ -80,9 +86,12 @@ class AccountChartTemplate(models.AbstractModel):
                         'label': 'Frais bancaires TVA21',
                     }),
                 ],
+                'name@fr': 'Frais bancaires TVA21',
+                'name@nl': 'Bankkosten inclusief 21% btw',
+                'name@de': 'Bankgebühren inkl. MwSt. 21 %',
             },
             'virements_internes_template': {
-                'name': 'Virements internes',
+                'name': 'Internal transfers',
                 'to_check': False,
                 'line_ids': [
                     Command.create({
@@ -92,6 +101,8 @@ class AccountChartTemplate(models.AbstractModel):
                         'label': 'Virements internes',
                     }),
                 ],
+                'name@fr': 'Virements internes',
                 'name@nl': 'Interne overboekingen',
+                'name@de': 'interne Überweisungen',
             },
         }


### PR DESCRIPTION
Versions:
---------
- saas~16.2+

Steps to reproduce:
-------------------
1. Install Belgium accounting module
2. Switch to the company with the template
2. Go to Accounting -> Bank -> Reconcile Items

Issue:
------
Translations are only being loaded in French

Cause:
------
There is no translation assigned to the other
expected language: English, German and Dutch,
and the field name of `account_reconcile_model`
did not have the parameter translate = True

Solution:
---------
To fix this issue we have to add the respective
translations using name@Lang and add the parameter
`translate = True` in the field name of
`account_reconcile_model` so that the translations
can be loaded to this field. 

OPW-3316716