### PR TITLE
[IMP] mrp: 'Split MO' Revamp

### DIFF
--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -58,6 +58,5 @@ access_mrp_workcenter_tag_group_user,access.mrp.workcenter.tag,model_mrp_workcen
 access_mrp_workcenter_tag_manager,access.mrp.workcenter.tag,model_mrp_workcenter_tag,mrp.group_mrp_manager,1,1,1,1
 access_mrp_production_split_multi,access.mrp.production.split.multi,model_mrp_production_split_multi,mrp.group_mrp_user,1,1,1,0
 access_mrp_production_split,access.mrp.production.split,model_mrp_production_split,mrp.group_mrp_user,1,1,1,0
-access_mrp_production_split_line,access.mrp.production.split.line,model_mrp_production_split_line,mrp.group_mrp_user,1,1,1,1
 access_mrp_workcenter_capacity_manager,mrp.workcenter.capacity.manager,model_mrp_workcenter_capacity,mrp.group_mrp_manager,1,1,1,1
 access_mrp_workcenter_capacity_group_user,mrp.workcenter.capacity,model_mrp_workcenter_capacity,mrp.group_mrp_user,1,0,0,0

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -453,31 +453,27 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.uom_unit.rounding = 1
         # Create a mo for 10 products
         mo, _, _, p1, p2 = self.generate_mo(qty_final=10)
-        # Split in 3 parts
+        # Split in 2 parts
         action = mo.action_split()
         wizard = Form(self.env[action['res_model']].with_context(action['context']))
-        wizard.counter = 3
+        wizard.first_qty = 6
         action = wizard.save().action_split()
-        # Should have 3 mos
-        self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 3)
+        # Should have 2 mos
+        self.assertEqual(len(mo.procurement_group_id.mrp_production_ids), 2)
         mo1 = mo.procurement_group_id.mrp_production_ids[0]
         mo2 = mo.procurement_group_id.mrp_production_ids[1]
-        mo3 = mo.procurement_group_id.mrp_production_ids[2]
         # Check quantities
-        self.assertEqual(mo1.product_qty, 3)
-        self.assertEqual(mo2.product_qty, 3)
-        self.assertEqual(mo3.product_qty, 4)
-        # Check raw movew quantities
-        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 12)
-        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 12)
-        self.assertEqual(mo3.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 16)
-        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 3)
-        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 3)
-        self.assertEqual(mo3.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 4)
+        self.assertEqual(mo1.product_qty, 6)
+        self.assertEqual(mo2.product_qty, 4)
+        # Check raw move quantities
+        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 24)
+        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p1).product_qty, 16)
+        self.assertEqual(mo1.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 6)
+        self.assertEqual(mo2.move_raw_ids.filtered(lambda m: m.product_id == p2).product_qty, 4)
 
         # Merge them back
-        expected_origin = ",".join([mo1.name, mo2.name, mo3.name])
-        action = (mo1 + mo2 + mo3).action_merge()
+        expected_origin = ",".join([mo1.name, mo2.name])
+        action = (mo1 + mo2).action_merge()
         mo = self.env[action['res_model']].browse(action['res_id'])
         # Check origin & initial quantity
         self.assertEqual(mo.origin, expected_origin)

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -173,10 +173,10 @@ class TestManualConsumption(TestMrpCommon):
         self.assertTrue(mo.move_raw_ids.filtered(lambda m: m.product_id == p1).manual_consumption)
         self.assertFalse(mo.move_raw_ids.filtered(lambda m: m.product_id == p2).manual_consumption)
 
-        # Split in 3 parts
+        # Split in 2 parts
         action = mo.action_split()
         wizard = Form(self.env[action['res_model']].with_context(action['context']))
-        wizard.counter = 3
+        wizard.first_qty = 6
         action = wizard.save().action_split()
         for production in mo.procurement_group_id.mrp_production_ids:
             self.assertTrue(production.move_raw_ids.filtered(lambda m: m.product_id == p1).manual_consumption)

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -22,54 +22,32 @@ class MrpProductionSplit(models.TransientModel):
     product_qty = fields.Float(related='production_id.product_qty')
     product_uom_id = fields.Many2one(related='production_id.product_uom_id')
     production_capacity = fields.Float(related='production_id.production_capacity')
-    counter = fields.Integer(
-        "Split #", default=0, compute="_compute_counter",
-        store=True, readonly=False)
-    production_detailed_vals_ids = fields.One2many(
-        'mrp.production.split.line', 'mrp_production_split_id',
-        'Split Details', compute="_compute_details", store=True, readonly=False)
+    first_qty = fields.Float(string="Quantity", compute="_compute_first_qty", store=True, readonly=False)
+    second_qty = fields.Float(compute="_compute_second_qty", store=True, readonly=False)
     valid_details = fields.Boolean("Valid", compute="_compute_valid_details")
 
-    @api.depends('production_detailed_vals_ids')
-    def _compute_counter(self):
+    @api.depends("production_capacity", "product_qty")
+    def _compute_first_qty(self):
         for wizard in self:
-            wizard.counter = len(wizard.production_detailed_vals_ids)
-
-    @api.depends('counter')
-    def _compute_details(self):
-        for wizard in self:
-            commands = [Command.clear()]
-            if wizard.counter < 1 or not wizard.production_id:
-                wizard.production_detailed_vals_ids = commands
+            if wizard.first_qty:
                 continue
-            quantity = float_round(wizard.product_qty / wizard.counter, precision_rounding=wizard.product_uom_id.rounding)
-            remaining_quantity = wizard.product_qty
-            for _ in range(wizard.counter - 1):
-                commands.append(Command.create({
-                    'quantity': quantity,
-                    'user_id': wizard.production_id.user_id,
-                    'date': wizard.production_id.date_start,
-                }))
-                remaining_quantity = float_round(remaining_quantity - quantity, precision_rounding=wizard.product_uom_id.rounding)
-            commands.append(Command.create({
-                'quantity': remaining_quantity,
-                'user_id': wizard.production_id.user_id,
-                'date': wizard.production_id.date_start,
-            }))
-            wizard.production_detailed_vals_ids = commands
+            if wizard.production_capacity and wizard.product_qty > wizard.production_capacity:
+                wizard.first_qty = wizard.production_capacity
+            else:
+                wizard.first_qty = wizard.product_qty / 2
 
-    @api.depends('production_detailed_vals_ids')
-    def _compute_valid_details(self):
-        self.valid_details = False
+    @api.depends('first_qty')
+    def _compute_second_qty(self):
         for wizard in self:
-            if wizard.production_detailed_vals_ids:
-                wizard.valid_details = float_compare(wizard.product_qty, sum(wizard.production_detailed_vals_ids.mapped('quantity')), precision_rounding=wizard.product_uom_id.rounding) == 0
+            wizard.second_qty = float_round(wizard.product_qty - wizard.first_qty, precision_rounding=wizard.product_uom_id.rounding)
+
+    @api.depends('first_qty', 'second_qty')
+    def _compute_valid_details(self):
+        for wizard in self:
+            wizard.valid_details = wizard.first_qty and wizard.second_qty and float_compare(wizard.product_qty, wizard.first_qty + wizard.second_qty, precision_rounding=wizard.product_uom_id.rounding) == 0
 
     def action_split(self):
-        productions = self.production_id._split_productions({self.production_id: [detail.quantity for detail in self.production_detailed_vals_ids]})
-        for production, detail in zip(productions, self.production_detailed_vals_ids):
-            production.user_id = detail.user_id
-            production.date_start = detail.date
+        self.production_id._split_productions({self.production_id: [self.first_qty, self.second_qty]})
         if self.production_split_multi_id:
             saved_production_split_multi_id = self.production_split_multi_id.id
             self.production_split_multi_id.production_ids = [Command.unlink(self.id)]
@@ -83,21 +61,6 @@ class MrpProductionSplit(models.TransientModel):
         return action
 
     def action_return_to_list(self):
-        self.production_detailed_vals_ids = [Command.clear()]
-        self.counter = 0
         action = self.env['ir.actions.actions']._for_xml_id('mrp.action_mrp_production_split_multi')
         action['res_id'] = self.production_split_multi_id.id
         return action
-
-
-class MrpProductionSplitLine(models.TransientModel):
-    _name = 'mrp.production.split.line'
-    _description = "Split Production Detail"
-
-    mrp_production_split_id = fields.Many2one(
-        'mrp.production.split', 'Split Production', required=True, ondelete="cascade")
-    quantity = fields.Float('Quantity To Produce', digits='Product Unit of Measure', required=True)
-    user_id = fields.Many2one(
-        'res.users', 'Responsible',
-        domain=lambda self: [('groups_id', 'in', self.env.ref('mrp.group_mrp_user').id)])
-    date = fields.Datetime('Schedule Date')

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -28,39 +28,23 @@
             <field name="name">Split Production</field>
             <field name="model">mrp.production.split</field>
             <field name="arch" type="xml">
-                <form string="Split Production">
-                    <group>
-                        <group>
-                            <field name="production_id" readonly="1"/>
-                        </group>
-                        <group>
-                            <field name="product_id"/>
-                            <label for="product_qty"/>
-                            <div class="o_row">
-                                <span><field name="product_qty"/></span>
-                                <span><field name="product_uom_id" groups="uom.group_uom"/></span>
-                            </div>
-                        </group>
-                        <group>
-                            <field name="counter"/>
-                        </group>
-                        <group>
-                            <label for="production_capacity"/>
-                            <div class="o_row">
-                                <span><field name="production_capacity"/></span>
-                                <span><field name="product_uom_id" groups="uom.group_uom"/></span>
-                            </div>
-                        </group>
-                    </group>
-                    <field name="production_detailed_vals_ids" attrs="{'invisible': [('counter', '=', 0)]}">
-                        <tree editable="top">
-                            <field name="date"/>
-                            <field name="user_id"/>
-                            <field name="quantity"/>
-                        </tree>
-                    </field>
+                <form string="Split manufacturing Order">
+                    <field name="production_id" invisible="1"/>
                     <field name="production_split_multi_id" invisible="1"/>
                     <field name="valid_details" invisible="1"/>
+                    <div style="margin-bottom:20px">
+                        Split <span  class="fw-bold"><field name="product_qty"/> <field name="product_uom_id" groups="uom.group_uom"/></span> of <span  class="fw-bold"><field name="product_id"/></span>, into 2 manufacturing orders.<br/>
+                        Components are avaliable for <span class="text-danger"><field name="production_capacity" readonly="1"/> Units </span>, how many do you want to produce first?
+                    </div>
+                    <group>
+                        <label for="first_qty"/>
+                        <div class="o_row">
+                            <span><field name="first_qty" style="width:100px;"/></span>
+                            <span>&amp;</span>
+                            <span><field name="second_qty" style="width:100px;"/></span>
+                            <span><field name="product_uom_id" groups="uom.group_uom"/></span>
+                        </div>
+                    </group>
                     <footer>
                         <button string="Split" class="btn-primary" type="object" name="action_split" data-hotkey="q" attrs="{'invisible': [('valid_details', '=', False)]}"/>
                         <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" attrs="{'invisible': [('production_split_multi_id', '!=', False)]}"/>


### PR DESCRIPTION
Before this commit
==================
The manufacturing order is divided according to the counts of backorder specified
in the split operation.

After this commit
=================
Now, quantities are divided into two parts. In the First qty wizard suggest
Production Capacity and in the Second qty that is remaining quantities.

task-3381804