### PR TITLE
[IMP] calendar: Synchronization pause button in settings page

### DIFF
--- a/addons/calendar/wizard/calendar_provider_config.py
+++ b/addons/calendar/wizard/calendar_provider_config.py
@@ -3,6 +3,7 @@
 
 from odoo import fields, models
 from odoo.addons.base.models.ir_module import assert_log_admin_access
+from odoo.tools import str2bool
 
 
 class CalendarProviderConfig(models.TransientModel):
@@ -21,12 +22,18 @@ class CalendarProviderConfig(models.TransientModel):
     cal_client_secret = fields.Char(
         "Google Client_key",
         default=lambda self: self.env['ir.config_parameter'].get_param('google_calendar_client_secret'))
+    cal_sync_paused = fields.Boolean(
+        "Google Synchronization Paused",
+        default=lambda self: str2bool(self.env['ir.config_parameter'].get_param('google_calendar_sync_paused'), default=False))
     microsoft_outlook_client_identifier = fields.Char(
         "Outlook Client Id",
         default=lambda self: self.env['ir.config_parameter'].get_param('microsoft_calendar_client_id'))
     microsoft_outlook_client_secret = fields.Char(
         "Outlook Client Secret",
         default=lambda self: self.env['ir.config_parameter'].get_param('microsoft_calendar_client_secret'))
+    microsoft_outlook_sync_paused = fields.Boolean(
+        "Outlook Synchronization Paused",
+        default=lambda self: str2bool(self.env['ir.config_parameter'].get_param('microsoft_calendar_sync_paused'), default=False))
 
     @assert_log_admin_access
     def action_calendar_prepare_external_provider_sync(self):
@@ -45,6 +52,8 @@ class CalendarProviderConfig(models.TransientModel):
         if self.external_calendar_provider == 'google':
             self.env['ir.config_parameter'].set_param('google_calendar_client_id', self.cal_client_id)
             self.env['ir.config_parameter'].set_param('google_calendar_client_secret', self.cal_client_secret)
+            self.env['ir.config_parameter'].set_param('google_calendar_sync_paused', self.cal_sync_paused)
         elif self.external_calendar_provider == 'microsoft':
             self.env['ir.config_parameter'].set_param('microsoft_calendar_client_id', self.microsoft_outlook_client_identifier)
             self.env['ir.config_parameter'].set_param('microsoft_calendar_client_secret', self.microsoft_outlook_client_secret)
+            self.env['ir.config_parameter'].set_param('microsoft_calendar_sync_paused', self.microsoft_outlook_sync_paused)

--- a/addons/calendar/wizard/calendar_provider_config.xml
+++ b/addons/calendar/wizard/calendar_provider_config.xml
@@ -16,6 +16,7 @@
                     <group>
                         <field name="cal_client_id" string="Client ID" required="external_calendar_provider == 'google'"/>
                         <field name="cal_client_secret" string="Client Secret" password="True" required="external_calendar_provider == 'google'"/>
+                        <field name="cal_sync_paused" required="external_calendar_provider == 'google'"/>
                     </group>
                 </div>
                 <div invisible="external_calendar_provider != 'microsoft'">
@@ -28,6 +29,7 @@
                     <group>
                         <field name="microsoft_outlook_client_identifier" string="Client ID" required="external_calendar_provider == 'microsoft'"/>
                         <field name="microsoft_outlook_client_secret" string="Client Secret" password="True" required="external_calendar_provider == 'microsoft'"/>
+                        <field name="microsoft_outlook_sync_paused" required="external_calendar_provider == 'microsoft'"/>
                     </group>
                 </div>
                 <footer>

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -44,10 +44,11 @@ class GoogleCalendarController(http.Controller):
             # If App authorized, and user access accepted, We launch the synchronization
             need_refresh = request.env.user.sudo()._sync_google_calendar(GoogleCal)
 
-            # If synchronization has been stopped
-            if not need_refresh and request.env.user.google_synchronization_stopped:
+            # If synchronization has been stopped or paused
+            sync_status = request.env.user._get_google_sync_status()
+            if not need_refresh and sync_status != "sync_active":
                 return {
-                    "status": "sync_stopped",
+                    "status": sync_status,
                     "url": ''
                 }
             return {

--- a/addons/google_calendar/models/res_config_settings.py
+++ b/addons/google_calendar/models/res_config_settings.py
@@ -9,3 +9,5 @@ class ResConfigSettings(models.TransientModel):
 
     cal_client_id = fields.Char("Client_id", config_parameter='google_calendar_client_id', default='')
     cal_client_secret = fields.Char("Client_key", config_parameter='google_calendar_client_secret', default='')
+    cal_sync_paused = fields.Boolean("Google Synchronization Paused", config_parameter='google_calendar_sync_paused',
+        help="Indicates if synchronization with Google Calendar is paused or not.")

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -11,6 +11,7 @@ patch(AttendeeCalendarController.prototype, {
         super.setup(...arguments);
         this.dialog = useService("dialog");
         this.notification = useService("notification");
+        this.rpc = useService("rpc");
     },
 
     async onGoogleSyncCalendar() {
@@ -59,5 +60,16 @@ patch(AttendeeCalendarController.prototype, {
                 await this.model.load();
             },
         });
+    },
+
+    onGoogleSyncUnpause() {
+        if (this.isSystemUser) {
+            this.env.services.action.doAction("base_setup.action_general_configuration");
+        } else {
+            this.dialog.add(AlertDialog, {
+                title: this.env._t("Configuration"),
+                body: this.env._t("Your administrator paused the synchronization with Google Calendar."),
+            });
+        }
     }
 });

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.xml
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.xml
@@ -6,7 +6,13 @@
         </xpath>
         <xpath expr="//div[@id='google_calendar_sync']" position="replace">
             <div id="google_calendar_sync" class="o_calendar_sync">
-                <button t-if="!model.googleIsSync" type="button" id="google_sync_pending" class="o_google_sync_button o_google_sync_pending btn btn-secondary text-nowrap" t-on-click="onGoogleSyncCalendar">
+                <button t-if="!model.googleIsSync and model.googleIsPaused" type="button" id="google_sync_paused" class="o_google_sync_button o_google_sync_paused btn btn-warning" t-on-click="onGoogleSyncUnpause">
+                    <b>
+                        <i id="google_paused" class='fa fa-pause'/>
+                        <span class="mx-1">Google</span>
+                    </b>
+                </button>
+                <button t-elif="!model.googleIsSync" type="button" id="google_sync_pending" class="o_google_sync_button o_google_sync_pending btn btn-secondary text-nowrap" t-on-click="onGoogleSyncCalendar">
                     <b><i class='fa fa-refresh'/> Google</b>
                 </button>
                 <!-- class change on hover -->

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
@@ -13,6 +13,7 @@ patch(AttendeeCalendarModel.prototype, {
         this.rpc = rpc;
         this.googleIsSync = true;
         this.googlePendingSync = false;
+        this.googleIsPaused = false;
     },
 
     /**
@@ -49,11 +50,12 @@ patch(AttendeeCalendarModel.prototype, {
                 silent,
             },
         );
-        if (["need_config_from_admin", "need_auth", "sync_stopped"].includes(result.status)) {
+        if (["need_config_from_admin", "need_auth", "sync_stopped", "sync_paused"].includes(result.status)) {
             this.googleIsSync = false;
         } else if (result.status === "no_new_event_from_google" || result.status === "need_refresh") {
             this.googleIsSync = true;
         }
+        this.googleIsPaused = result.status == "sync_paused";
         this.googlePendingSync = false;
         return result;
     },

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -23,6 +23,7 @@ class TestSyncGoogle(HttpCase):
     def setUp(self):
         super().setUp()
         self.google_service = GoogleCalendarService(self.env['google.service'])
+        self.env.user.sudo().unpause_google_synchronization()
 
     def assertGoogleEventDeleted(self, google_id):
         GoogleSync._google_delete.assert_called()

--- a/addons/google_calendar/views/res_config_settings_views.xml
+++ b/addons/google_calendar/views/res_config_settings_views.xml
@@ -15,6 +15,10 @@
                             <label for="cal_client_secret" string="Client Secret" class="col-3 col-lg-3 o_light_label"/>
                             <field name="cal_client_secret" password="True" nolabel="1"/>
                         </div>
+                        <div class="mt16 d-flex">
+                            <label for="cal_sync_paused" string="Pause Synchronization" class="o_light_label"/>
+                            <field name="cal_sync_paused" class="ml16"/>
+                        </div>
                     </div>
                 </div>
             </field>

--- a/addons/microsoft_calendar/controllers/main.py
+++ b/addons/microsoft_calendar/controllers/main.py
@@ -42,10 +42,11 @@ class MicrosoftCalendarController(http.Controller):
             # If App authorized, and user access accepted, We launch the synchronization
             need_refresh = request.env.user.sudo()._sync_microsoft_calendar()
 
-            # If synchronization has been stopped
-            if not need_refresh and request.env.user.microsoft_synchronization_stopped:
+            # If synchronization has been stopped or paused
+            sync_status = request.env.user._get_microsoft_sync_status()
+            if not need_refresh and sync_status != "sync_active":
                 return {
-                    "status": "sync_stopped",
+                    "status": sync_status,
                     "url": ''
                 }
             return {

--- a/addons/microsoft_calendar/models/res_config_settings.py
+++ b/addons/microsoft_calendar/models/res_config_settings.py
@@ -9,3 +9,5 @@ class ResConfigSettings(models.TransientModel):
 
     cal_microsoft_client_id = fields.Char("Microsoft Client_id", config_parameter='microsoft_calendar_client_id', default='')
     cal_microsoft_client_secret = fields.Char("Microsoft Client_key", config_parameter='microsoft_calendar_client_secret', default='')
+    cal_microsoft_sync_paused = fields.Boolean("Microsoft Synchronization Paused", config_parameter='microsoft_calendar_sync_paused',
+        help="Indicates if synchronization with Outlook Calendar is paused or not.")

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
@@ -59,5 +59,16 @@ patch(AttendeeCalendarController.prototype, {
                 await this.model.load();
             },
         });
+    },
+
+    onMicrosoftSyncUnpause() {
+        if (this.isSystemUser) {
+            this.env.services.action.doAction("base_setup.action_general_configuration");
+        } else {
+            this.dialog.add(AlertDialog, {
+                title: this.env._t("Configuration"),
+                body: this.env._t("Your administrator paused the synchronization with Outlook Calendar."),
+            });
+        }
     }
 });

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.xml
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.xml
@@ -6,7 +6,13 @@
         </xpath>
         <xpath expr="//div[@id='microsoft_calendar_sync']" position="replace">
             <div id="microsoft_calendar_sync" class="o_calendar_sync">
-                <button t-if="!model.microsoftIsSync" type="button" id="microsoft_sync_pending" class="o_microsoft_sync_button o_microsoft_sync_pending btn btn-secondary text-nowrap" t-on-click="onMicrosoftSyncCalendar">
+                <button t-if="!model.microsoftIsSync and model.microsoftIsPaused" type="button" id="microsoft_sync_paused" class="o_google_sync_button o_microsoft_sync_paused btn btn-warning" t-on-click="onMicrosoftSyncUnpause">
+                    <b>
+                        <i id="microsoft_paused" class='fa fa-pause'/>
+                        <span class="mx-1">Outlook</span>
+                    </b>
+                </button>
+                <button t-elif="!model.microsoftIsSync" type="button" id="microsoft_sync_pending" class="o_microsoft_sync_button o_microsoft_sync_pending btn btn-secondary text-nowrap" t-on-click="onMicrosoftSyncCalendar">
                     <b><i class='fa fa-refresh'/> Outlook</b>
                 </button>
                 <!-- class change on hover -->

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
@@ -13,6 +13,7 @@ patch(AttendeeCalendarModel.prototype, {
         this.rpc = rpc;
         this.microsoftIsSync = true;
         this.microsoftPendingSync = false;
+        this.microsoftIsPaused = false;
     },
 
     /**
@@ -49,11 +50,12 @@ patch(AttendeeCalendarModel.prototype, {
                 silent,
             },
         );
-        if (["need_config_from_admin", "need_auth", "sync_stopped"].includes(result.status)) {
+        if (["need_config_from_admin", "need_auth", "sync_stopped", "sync_paused"].includes(result.status)) {
             this.microsoftIsSync = false;
         } else if (result.status === "no_new_event_from_microsoft" || result.status === "need_refresh") {
             this.microsoftIsSync = true;
         }
+        this.microsoftIsPaused = result.status == "sync_paused";
         this.microsoftPendingSync = false;
         return result;
     },

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -35,6 +35,7 @@ class TestCommon(HttpCase):
     @patch_api
     def setUp(self):
         super(TestCommon, self).setUp()
+        self.env.user.unpause_microsoft_synchronization()
 
         # prepare users
         self.organizer_user = self.env["res.users"].search([("name", "=", "Mike Organizer")])

--- a/addons/microsoft_calendar/tests/test_delete_events.py
+++ b/addons/microsoft_calendar/tests/test_delete_events.py
@@ -297,3 +297,23 @@ class TestDeleteEvents(TestCommon):
             token=mock_get_token(self.organizer_user),
             timeout=ANY
         )
+
+    @patch.object(MicrosoftCalendarService, 'delete')
+    def test_delete_synced_event_with_sync_config_paused(self, mock_delete):
+        """
+        Deletes an event with the Outlook Calendar synchronization paused, the event must be archived completely.
+        """
+        # Set user synchronization configuration as active and pause it.
+        self.organizer_user.microsoft_synchronization_stopped = False
+        self.organizer_user.pause_microsoft_synchronization()
+
+        # Try to delete a simple event in Odoo Calendar.
+        self.simple_event.with_user(self.organizer_user).unlink()
+        self.call_post_commit_hooks()
+        self.simple_event.invalidate_recordset()
+
+        # Ensure that synchronization is paused, delete wasn't called and record doesn't exist anymore.
+        self.assertFalse(self.organizer_user.microsoft_synchronization_stopped)
+        self.assertEqual(self.organizer_user._get_microsoft_sync_status(), "sync_paused")
+        self.assertFalse(self.simple_event.exists(), "Event must be deleted from Odoo even though sync configuration is off")
+        mock_delete.assert_not_called()

--- a/addons/microsoft_calendar/views/res_config_settings_views.xml
+++ b/addons/microsoft_calendar/views/res_config_settings_views.xml
@@ -15,6 +15,10 @@
                             <label for="cal_microsoft_client_secret" string="Client Secret" class="col-3 col-lg-3 o_light_label"/>
                             <field name="cal_microsoft_client_secret" password="True" nolabel="1"/>
                         </div>
+                        <div class="mt16 d-flex">
+                            <label for="cal_microsoft_sync_paused" string="Pause Synchronization" class="o_light_label"/>
+                            <field name="cal_microsoft_sync_paused" class="ml16"/>
+                        </div>
                     </div>
                 </div>
             </field>


### PR DESCRIPTION
Before this commit, when there was a problem with Google Calendar or Outlook Calendar synchronizations, nothing could be done. This commit adds a button to manually pause each calendar synchronization in the Settings page. Additionaly, tests were added for checking if the events are properly set to be updated/deleted after the synchronization is unpaused.

Task-id: 3290898