### PR TITLE
[FIX] point_of_sale: correctly set partner on account move line

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1196,7 +1196,7 @@ class PosSession(models.Model):
                 return self._credit_amounts(partial_args, amount, amount_converted)
 
     def _get_split_receivable_vals(self, payment, amount, amount_converted):
-        accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
+        accounting_partner = payment.partner_id
         if not accounting_partner:
             raise UserError(_("You have enabled the \"Identify Customer\" option for %s payment method,"
                               "but the order %s does not contain a customer.") % (payment.payment_method_id.name,


### PR DESCRIPTION
Current behavior:
When using pay later payment method, the partner on the account move line was not always correct. If the user on the pos order had a parent company, the partner on the account move line was the parent company. And the amount due was not correct for the user selected on the pos order.

Steps to reproduce:
- Create a user with a parent company
- Open a pos session
- Create a pos order with the user created
- Select pay later payment method
- Validate the order
- Close the session
- Check the amount due on the customer

The same issue also appears when refunding an order usin customer account

opw-3330499
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
