### PR TITLE
[FIX] mrp_subcontracting_account: include subcontracting cost when marking mrp.production as done

### DIFF
--- a/addons/mrp_subcontracting_account/models/mrp_production.py
+++ b/addons/mrp_subcontracting_account/models/mrp_production.py
@@ -10,7 +10,7 @@ class MrpProduction(models.Model):
     def _cal_price(self, consumed_moves):
         finished_move = self.move_finished_ids.filtered(lambda x: x.product_id == self.product_id and x.state not in ('done', 'cancel') and x.quantity_done > 0)
         # Take the price unit of the reception move
-        last_done_receipt = finished_move.move_dest_ids.filtered(lambda m: m.state == 'done')[-1:]
+        last_done_receipt = finished_move.move_dest_ids.filtered(lambda m: m.state not in ['draft', 'cancel'])[-1:]
         if last_done_receipt.is_subcontract:
             self.extra_cost = last_done_receipt._get_price_unit()
         return super()._cal_price(consumed_moves=consumed_moves)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Previosly, the cost of subcontracting a manufactured product was only taken into account when validating the incoming picking without directly using the MRP module. But when the Manufacturing Order was marked as done, the cost was not considered in the Inventory Valuation because the condition would look for a stock.move with state == 'done'. In reality, the state could be any of draft, cancel, waiting, confirmed, partially_available, assigned and done.
We now consider any state except draft and cancel to be valid for obtaining the price from the purchase order.

Current behavior before PR:
Subcontracting cost is only taken into account when validating the incoming Transfer related to the Purchase Order of the subcontracted product, without modifying the Manufacturing Order first.
If the user manually marks the Manufacturing Order as done, the cost will not be taken into account even after you validate the incoming transfer. This directly impacts Inventory Valuation.

Desired behavior after PR is merged:
Subcontracting cost will be taken into account when manually marking a Manufacturing Order as Done.
Users will observe the same behavior when marking their Manufacturing Order as Done from the MRP module than when directly validating the incoming Transfer found in the Purchase Order.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
