### PR TITLE
[IMP] website_forum: show popover info only for public profile

### DIFF
--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -260,7 +260,7 @@ class Post(models.Model):
             post.can_comment = is_admin or user.karma >= post.karma_comment
             post.can_comment_convert = is_admin or user.karma >= post.karma_comment_convert
             post.can_view = is_admin or user.karma >= post.karma_close or (post_sudo.create_uid.karma > 0 and (post_sudo.active or post_sudo.create_uid == user))
-            post.can_display_biography = is_admin or post_sudo.create_uid.karma >= post.forum_id.karma_user_bio
+            post.can_display_biography = is_admin or (post_sudo.create_uid.karma >= post.forum_id.karma_user_bio and post_sudo.create_uid.website_published)
             post.can_post = is_admin or user.karma >= post.forum_id.karma_post
             post.can_flag = is_admin or user.karma >= post.forum_id.karma_flag
             post.can_moderate = is_admin or user.karma >= post.forum_id.karma_moderate

--- a/addons/website_forum/views/forum_forum_templates_tools.xml
+++ b/addons/website_forum/views/forum_forum_templates_tools.xml
@@ -126,7 +126,7 @@
 
 <template id="author_box">
     <t t-set="display_info" t-value="show_name or show_date or show_karma"/>
-    <t t-if="allow_biography and object.can_display_biography" t-set="bio_popover_data">
+    <t t-if="allow_biography and object.can_display_biography and request.env.user.karma >= website.karma_profile_min" t-set="bio_popover_data">
         <div class="o_wforum_bio_popover_wrap d-flex transition-fade">
             <div class="d-flex flex-column">
                 <img class="o_wforum_avatar flex-shrink-0 rounded me-3" t-att-src="request.website.image_url(object.create_uid, 'avatar_128', '60x60')" alt="Avatar"/>


### PR DESCRIPTION
before this commit, even it the user profile is not public, on hovering the move on the user image in
the post, the user details is shown in the pop over

after this commit, the pop over information is shown only if the user's profile is public profile

![Screenshot from 2023-06-28 09-08-12](https://github.com/odoo/odoo/assets/27989791/6bee25e7-81e7-4cc9-bf91-6390d29aa641)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
