### PR TITLE
[FIX] web_editor: properly restore table on delete range

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -66,6 +66,8 @@ import {
     getAdjacentCharacter,
     isLinkEligibleForZwnbsp,
     setCursorStart,
+    paragraphRelatedElements,
+    isUnbreakable,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -1530,7 +1532,11 @@ export class OdooEditor extends EventTarget {
             const parent = end.parentNode;
             end.remove();
             end = parent;
-            if (end.nodeName === 'TD' && !shouldRemoveEndTr) {
+            if (
+                (end.nodeName === 'TD' && !shouldRemoveEndTr) ||
+                (paragraphRelatedElements.includes(end.nodeName) &&
+                    end.previousSibling && isUnbreakable(end.previousSibling))
+            ) {
                 fillEmpty(end);
             }
         }

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -65,6 +65,7 @@ import {
     ZERO_WIDTH_CHARS_REGEX,
     getAdjacentCharacter,
     isLinkEligibleForZwnbsp,
+    setCursorStart,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -1439,8 +1440,25 @@ export class OdooEditor extends EventTarget {
         });
         if (!range) return;
         let { startContainer: start, startOffset, endContainer: end, endOffset } = range;
+        const startTr = closestElement(start, 'tr');
+        const endTr = closestElement(end, 'tr');
+        const startTrCells = startTr && [...startTr.cells];
+        const endTrCells = endTr && [...endTr.cells];
+        const startTable = closestElement(start, 'table');
+        const endTable = closestElement(end, 'table');
+        const shouldRemoveStartTr =
+            startTable && firstLeaf(startTable) === firstLeaf(start) &&
+            (!startTable.contains(end) || lastLeaf(startTable) === lastLeaf(end));
+        const shouldRemoveEndTr =
+            endTable && lastLeaf(endTable) === lastLeaf(end) &&
+            (!endTr.contains(start) || (firstLeaf(startTable) === firstLeaf(start)));
         const startBlock = closestBlock(start);
         const endBlock = closestBlock(end);
+        // Delete <br> if selection ends in an last empty <td> tag of <tr>.
+        // eg. `<td>]<br></td>`
+        if (shouldRemoveEndTr && end.nodeName === 'TD' && isEmptyBlock(end)) {
+            end.firstChild.remove();
+        }
         // Do not join blocks in the following cases:
         // 1. start and end share a common ancestor block with the range
         // 2. selection spans multiple TDs
@@ -1452,7 +1470,6 @@ export class OdooEditor extends EventTarget {
             && (startBlock.tagName !== 'TD' && endBlock.tagName !== 'TD')
             && !(firstLeaf(startBlock) === start && lastLeaf(endBlock) === end);
         let next = nextLeaf(end, this.editable);
-        const splitEndTd = closestElement(end, 'td') && end.nextSibling;
 
         // Get the boundaries of the range so as to get the state to restore.
         if (end.nodeType === Node.TEXT_NODE) {
@@ -1467,6 +1484,9 @@ export class OdooEditor extends EventTarget {
             ...boundariesOut(start).slice(0, 2),
             ...boundariesOut(end).slice(2, 4),
             { allowReenter: false, label: 'deleteRange' });
+
+        let startTd = closestElement(start, 'td');
+        const endTd = closestElement(end, 'td');
 
         // Let the DOM split and delete the range.
         const contents = range.extractContents();
@@ -1484,30 +1504,21 @@ export class OdooEditor extends EventTarget {
             closestBlock(range.endContainer).after(n);
             n.textContent = '';
         });
-        // Restore table contents removed by extractContents.
-        const tds = [...contents.querySelectorAll('td')].filter(n => !closestElement(n, 'table'));
-        let currentFragmentTr, currentTr;
-        const currentTd = closestElement(range.endContainer, 'td');
-        tds.forEach((td, i) => {
-            const parentFragmentTr = closestElement(td, 'tr');
-            // Skip the first and the last partially selected TD.
-            if (i && !(splitEndTd && i === tds.length - 1)) {
-                if (parentFragmentTr && parentFragmentTr !== currentFragmentTr && currentTr && [...parentFragmentTr.querySelectorAll('td')].every(td => tds.includes(td))) {
-                    currentTr.after(parentFragmentTr);
-                    currentTr = parentFragmentTr;
-                    parentFragmentTr.textContent = '';
-                } else {
-                    if (parentFragmentTr !== currentFragmentTr) {
-                        currentTr = currentTr
-                            ? currentTr.nextElementSibling
-                            : closestElement(range.endContainer, 'tr').nextElementSibling;
-                    }
-                    currentTr ? currentTr.prepend(td) : currentTd.after(td);
-                    td.textContent = '';
-                }
+        // Restore first and last TR's contents removed by extractContents.
+        const tds = [...contents.querySelectorAll('td')].filter(n => (
+            (startTrCells && !shouldRemoveStartTr && startTrCells.includes(n)) ||
+            (endTrCells && !shouldRemoveEndTr && endTrCells.includes(n))
+        ));
+        for (const td of tds) {
+            if (startTrCells && startTrCells.includes(td)) {
+                startTd.after(td);
+                startTd = td;
+            } else {
+                endTd.before(td);
             }
-            currentFragmentTr = parentFragmentTr;
-        });
+            td.textContent = '';
+            fillEmpty(td);
+        }
         this.observerFlush();
         this._toRollback = false; // Errors caught with observerFlush were already handled.
         // If the end container was fully selected, extractContents may have
@@ -1519,12 +1530,14 @@ export class OdooEditor extends EventTarget {
             const parent = end.parentNode;
             end.remove();
             end = parent;
+            if (end.nodeName === 'TD' && !shouldRemoveEndTr) {
+                fillEmpty(end);
+            }
         }
+        // To remove the table when fully selected the block should not be
+        // considered visible in order to remove it.
+        const noBlocks = shouldRemoveStartTr ? false : true;
         // Same with the start container
-        const table = closestElement(start, 'table');
-        // For selection starting at the beginning of the table and ending outside the
-        // table, the block should not be considered visible in order to remove the table.
-        const noBlocks = (table && firstLeaf(table) === start && !table.contains(end)) ? false : true;
         while (
             start &&
             isRemovableInvisible(start, noBlocks) &&
@@ -1533,6 +1546,12 @@ export class OdooEditor extends EventTarget {
             const parent = start.parentNode;
             start.remove();
             start = parent;
+        }
+        if (start === this.editable && !start.hasChildNodes()) {
+            const p = document.createElement('p');
+            start.appendChild(p);
+            setCursorStart(p);
+            start = p;
         }
         // Ensure empty blocks be given a <br> child.
         if (start) {
@@ -3115,6 +3134,18 @@ export class OdooEditor extends EventTarget {
 
     _onMouseup(ev) {
         this._currentMouseState = ev.type;
+
+        const selection = document.getSelection();
+        if (selection.rangeCount > 1) {
+            // Firefox selection in table works with multiple ranges.
+            const startRange = getDeepRange(this.editable, { range: selection.getRangeAt(0) });
+            const endRange = getDeepRange(this.editable, { range: selection.getRangeAt(selection.rangeCount - 1) });
+            const range = document.createRange();
+            range.setStart(startRange.startContainer, 0);
+            range.setEnd(endRange.startContainer, nodeSize(endRange.startContainer));
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
 
         this._fixFontAwesomeSelection();
     }

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2620,6 +2620,16 @@ export class OdooEditor extends EventTarget {
                     insertText(selection, ev.data === null ? ev.dataTransfer.getData('text/plain') : ev.data);
                     selection.collapseToEnd();
                 }
+                // Firefox does not remove trailing <br> on insertText in an
+                // empty line.
+                const focusNode = selection.focusNode;
+                if (
+                    focusNode.nextSibling &&
+                    focusNode.nextSibling.nodeName === 'BR' &&
+                    lastLeaf(focusNode.parentElement) === focusNode.nextSibling
+                ) {
+                    focusNode.nextSibling.remove();
+                }
                 // Check for url after user insert a space so we won't transform an incomplete url.
                 if (
                     ev.data &&

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1396,7 +1396,7 @@ export function isUnbreakable(node) {
     }
     return (
         isUnremovable(node) || // An unremovable node is always unbreakable.
-        ['THEAD', 'TBODY', 'TFOOT', 'TR', 'TH', 'TD', 'SECTION', 'DIV'].includes(node.tagName) ||
+        ['TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR', 'TH', 'TD', 'SECTION', 'DIV'].includes(node.tagName) ||
         node.hasAttribute('t') ||
         (node.nodeType === Node.ELEMENT_NODE &&
             (node.nodeName === 'T' ||
@@ -1487,7 +1487,7 @@ export function getInSelection(document, selector) {
 
 // This is a list of "paragraph-related elements", defined as elements that
 // behave like paragraphs.
-const paragraphRelatedElements = [
+export const paragraphRelatedElements = [
     'P',
     'H1',
     'H2',

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -1415,28 +1415,28 @@ X[]
                             '<table><tbody><tr><td>[ab</td><td>cd</td><td>e]f</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>[]<br></td><td></td><td>f</td></tr></tbody></table>',
+                            '<table><tbody><tr><td>[]<br></td><td><br></td><td>f</td></tr></tbody></table>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore:
                             '<table><tbody><tr><td>a[b</td><td>cd</td><td>e]f</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>a[]</td><td></td><td>f</td></tr></tbody></table>',
+                            '<table><tbody><tr><td>a[]</td><td><br></td><td>f</td></tr></tbody></table>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore:
                             '<table><tbody><tr><td>a[b</td><td>cd</td><td>ef]</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>a[]</td><td></td><td></td></tr></tbody></table>',
+                            '<table><tbody><tr><td>a[]</td><td><br></td><td><br></td></tr></tbody></table>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore:
                             '<table><tbody><tr><td>[ab</td><td>cd</td><td>ef]</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>[]<br></td><td></td><td></td></tr></tbody></table>',
+                            '<p>[]<br></p>',
                     });
                 });
                 it('should not break a table (cross rows)', async () => {
@@ -1445,21 +1445,235 @@ X[]
                             '<table><tbody><tr><td>[ab</td><td>cd</td><td>ef</td></tr><tr><td>gh</td><td>ij</td><td>k]l</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>[]<br></td><td></td><td></td></tr><tr><td></td><td></td><td>l</td></tr></tbody></table>',
+                            '<table><tbody><tr><td>[]<br></td><td><br></td><td><br></td></tr><tr><td><br></td><td><br></td><td>l</td></tr></tbody></table>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore:
                             '<table><tbody><tr><td>a[b</td><td>cd</td><td>ef</td></tr><tr><td>gh</td><td>ij</td><td>k]l</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>a[]</td><td></td><td></td></tr><tr><td></td><td></td><td>l</td></tr></tbody></table>',
+                            '<table><tbody><tr><td>a[]</td><td><br></td><td><br></td></tr><tr><td><br></td><td><br></td><td>l</td></tr></tbody></table>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore:
                             '<table><tbody><tr><td>a[b</td><td>cd</td><td>ef</td></tr><tr><td>gh</td><td>ij</td><td>kl]</td></tr></tbody></table>',
                         stepFunction: deleteBackward,
                         contentAfter:
-                            '<table><tbody><tr><td>a[]</td><td></td><td></td></tr><tr><td></td><td></td><td></td></tr></tbody></table>',
+                            '<table><tbody><tr><td>a[]</td><td><br></td><td><br></td></tr></tbody></table>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>[ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td>gh</td>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                    </tr>
+                                    <tr>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                        <td>qr]</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        `),
+                        stepFunction: deleteBackward,
+                        contentAfter:
+                            '<p>[]<br></p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef[</td>
+                                    </tr>
+                                    <tr>
+                                        <td>gh</td>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                    </tr>
+                                    <tr>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                        <td>qr]</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        `),
+                        stepFunction: deleteBackward,
+                        contentAfter: unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef[]</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        `),
+                    });
+                });
+                it('should not break a table (cross tables)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td>[gh</td>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                    </tr>
+                                    <tr>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                        <td>qr</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>st</td>
+                                        <td>uv</td>
+                                        <td>wx</td>
+                                        <td>yz</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                        <td>g]h</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                    </tr>
+                                </tbody>
+                            </table>`
+                        ),
+                        stepFunction: deleteBackward,
+                        contentAfter:unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td>[]<br></td>
+                                        <td><br></td>
+                                        <td><br></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td><br></td>
+                                        <td><br></td>
+                                        <td><br></td>
+                                        <td>h</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        `),
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef[</td>
+                                    </tr>
+                                    <tr>
+                                        <td>gh</td>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                    </tr>
+                                    <tr>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                        <td>qr</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>st</td>
+                                        <td>uv</td>
+                                        <td>wx</td>
+                                        <td>yz</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                        <td>g]h</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                    </tr>
+                                </tbody>
+                            </table>`
+                        ),
+                        stepFunction: deleteBackward,
+                        contentAfter:unformat(`
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef[]</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td><br></td>
+                                        <td><br></td>
+                                        <td><br></td>
+                                        <td>h</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ij</td>
+                                        <td>kl</td>
+                                        <td>mn</td>
+                                        <td>op</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        `),
                     });
                 });
                 it('should merge the following inline text node', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2870,6 +2870,20 @@ X[]
                                     </div>`,
                 });
             });
+            it('should not remove a paragraph element after a div', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: `<div>abc[def</div><p>ghi]</p>`,
+                    stepFunction: deleteBackward,
+                    contentAfter: `<div>abc[]</div><p><br></p>`,
+                });
+            });
+            it('should not remove a h1 element after a table', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: `<table><tbody><tr><td>ab</td><td>c[d</td><td>ef</td></tr></tbody></table><h1>ghi]</h1>`,
+                    stepFunction: deleteBackward,
+                    contentAfter: `<table><tbody><tr><td>ab</td><td>c[]</td><td><br></td></tr></tbody></table><h1><br></h1>`,
+                });
+            });
         });
 
     });


### PR DESCRIPTION
Current behavior before PR:

When deleting a selection in a table spanning across multiple table rows(tr's) the structure of the table breaks.

Desired behavior after PR is merged:

Deleting the selection within a table that spans across multiple rows now only preserves the first and last
partially selected rows of the table.

task-3291872