### PR TITLE
[IMP] website_sale: new ecommerce description

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -27,6 +27,8 @@ class ProductTemplate(models.Model):
         'Description for the website', translate=html_translate,
         sanitize_overridable=True,
         sanitize_attributes=False, sanitize_form=False)
+    description_ecommerce = fields.Html("eCommerce Description", translate=html_translate,
+        sanitize_overridable=True, sanitize_attributes=False, sanitize_form=False)
     alternative_product_ids = fields.Many2many(
         'product.template', 'product_alternative_rel', 'src_id', 'dest_id', check_company=True,
         string='Alternative Products', help='Suggest alternatives to your customer (upsell strategy). '

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -168,6 +168,12 @@
                 <group name="product_template_images" string="Extra Product Media" invisible="not sale_ok">
                     <field name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
                 </group>
+                <group string="eCommerce Description">
+                    <field name="description_ecommerce"
+                           placeholder="This note is added to the product page on your eCommerce shop"
+                           nolabel="1"
+                           colspan="2"/>
+                </group>
             </xpath>
         </field>
     </record>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1012,6 +1012,8 @@
                                 </a>
                             </t>
                             <p t-field="product.description_sale" class="text-muted my-2" placeholder="A short description that will also appear on documents." />
+                            <div t-field="product.description_ecommerce" class="oe_structure"
+                                placeholder="A detailed, formatted description to promote your product on this page. Use '/' to discover more features."/>
                             <form t-if="product._is_add_to_cart_possible()" action="/shop/cart/update" method="POST">
                                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
                                 <div class="js_product js_main_product mb-3">


### PR DESCRIPTION
Today, we have `sale_description` visible on the eCommerce
(below the product name) and in the PDF reports.
We alse have `website_description` that is only on eCommerce,
below the product information.

Issues:
  - you might want a very long eCommerce description that is
    not printed on the pdf;
  - you might want to use text formatting on that description:
    bold text, bulleted list, accordion, .. --> not possible at
    the moment.

We are thus adding an `ecommerce_description` (HTML field) to
the product that will be shown on the product page and in the
shop if the product is selected.

Task - 2906587


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
