### PR TITLE
[FIX] web: get empty id while upload background-image

### DIFF
--- a/addons/web/static/src/core/file_input/file_input.js
+++ b/addons/web/static/src/core/file_input/file_input.js
@@ -52,8 +52,8 @@ export class FileInput extends Component {
     async uploadFiles(params) {
         const fileData = await this.http.post(this.props.route, params, "text");
         const parsedFileData = JSON.parse(fileData);
-        if (parsedFileData.error) {
-            throw new Error(parsedFileData.error);
+        if (parsedFileData.length && parsedFileData[0].error) {
+                throw new Error(parsedFileData[0].error)
         }
         return parsedFileData;
     }


### PR DESCRIPTION
This error might occur when the user tries to change the background image of the odoo dashboard and in that scenario, if there will be no attachment_id then the error would be generated.

step to reproduce-
- Install web_studio
- Click on toggle studio(top-right side of odoo dashboard)
- Click on  Customizations(top-left side of odoo dashboard)
- Click on  Change Background
- Upload image

Sentry Traceback-
```
TypeError: WebStudioController.set_background_image() missing 1 required positional argument: 'attachment_id'
  File "odoo/http.py", line 2115, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1698, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1725, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1922, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 715, in route_wrapper
    result = endpoint(self, *args, **params_ok)
```


sentry:-3948343333
