### PR TITLE
[FIX] models: groupby date for pivot view

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2397,7 +2397,7 @@ class BaseModel(metaclass=MetaModel):
                 additional_domain = [(field_name, '=', value)]
 
                 if field.type in ('date', 'datetime'):
-                    if value:
+                    if value and isinstance(value, datetime.date):
                         range_start = value
                         range_end = value + interval
                         if field.type == 'datetime':


### PR DESCRIPTION
When user tries to apply any `Group By` as date or datetime in the pivot view and the column value of pivot view is also a date or dateime, the traceback will be generated.

To reproduce the issue:

- Install `Point of Sale`
- Go to 'Reporting' and clicks on 'Orders'
- Select pivot view
- Go to `Group By` and select 'Order Date' same as column value
- Issue can be produce in the same way in other modules, such as - 'sale', 'sale_subscription', 'crm', 'planning', 'hr_expense' etc.

Traceback in sentry -
```
TypeError: can only concatenate str (not "relativedelta") to str
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 2567, in read_group
    self._read_group_format_result(rows_dict, lazy_groupby)
  File "odoo/models.py", line 2402, in _read_group_format_result
    range_end = value + interval
```

When user selects value of `Group By` as date or datetime and when the column is also a date or datetime in pivot view, the `read_group` method is called. And the `read_group` method returns the 'value' as a string like 'June 2023'. When it concatenates the `value` with `interval` which is relativedelta, the error will be generated.

Fixed this issue by applying the condition when the 'value' is not passed as datetime.

sentry-4262719543