### PR TITLE
[FIX] web: add enable and disable hooks to autoresize effect

### DIFF
--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -48,9 +48,10 @@ export class TextField extends Component {
         });
         useSpellCheck({ refName: "textarea" });
 
-        if (!this.props.readonly) {
-            useAutoresize(this.textareaRef, { minimumHeight: this.minimumHeight });
-        }
+        const resizer = useAutoresize(this.textareaRef, { minimumHeight: this.minimumHeight });
+        useEffect(readonly => {
+            (readonly ? resizer.disable : resizer.enable)();
+        }, () => [this.props.readonly]);
     }
 
     get isTranslatable() {


### PR DESCRIPTION
An autoresize hook was introduced by [commit 1] and is used, for example, by the text field component. The hook is conditionally called in the setup method based on the edit mode of the text field. This, of course, is problematic: the edit mode can change during the lifetime of the component. As a consequence the autoresize does no longer work as of the aforementioned commit.

The problem is resolved by returning two callbacks from the autoresize hook, allowing the autoresize functionality to be enabled and disabled dynamiclly.

[commit 1]: https://github.com/odoo/odoo/commit/eaacaf122dff62adcdf885f0ffdcb4a506bded27
