### PR TITLE
[FIX] website_sale_stock: fixing stock quantity incorrect amount

### DIFF
--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -42,6 +42,16 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
         combination.product_id === parseInt(product_id);
 
     if (!this.isWebsite || !isMainProduct) {
+        loadXml().then(function (result) {
+            $('.oe_website_sale')
+                .find('.availability_message_' + combination.product_template)
+                .remove();
+            const $message = $(QWeb.render(
+                'website_sale_stock.product_availability',
+                combination
+            ));
+            $('div.availability_messages').html($message);
+        });
         return;
     }
 


### PR DESCRIPTION
[FIX] website_sale_stock: fixing stock quantity incorrect amount in website for non-existing variants

A user reported having a wrong quantity amount for non-existing variants. If the user clicks on an existing variant and then on a non-existing variant, the page will correctly display that the variant does not exist but it displays the quantity of the previously clicked variant. This is because, since the variant does not exist, it does not trigger the update of the message. Triggering the message when the existence of the variant is necessary to update the message and show the correct information.

opw-3378975



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
