### PR TITLE
[REM] calendar: remove attendee_status field

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1119,15 +1119,6 @@ class Meeting(models.Model):
     # TOOLS
     # ------------------------------------------------------------
 
-    # YTI TODO MASTER: Remove deprecated method
-    def _find_attendee(self):
-        """ Return the first attendee where the user connected has been invited
-            or the attendee selected in the filter that is the owner
-            from all the meeting_ids in parameters.
-        """
-        self.ensure_one()
-        return self._find_attendee_batch()[self.id]
-
     def _get_start_date(self):
         """Return the event starting date in the event's timezone.
         If no starting time is assigned (yet), return today as default

--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.js
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { onWillStart } from "@odoo/owl";
 import { CalendarCommonPopover } from "@web/views/calendar/calendar_common/calendar_common_popover";
 import { useService } from "@web/core/utils/hooks";
 import { useAskRecurrenceUpdatePolicy } from "@calendar/views/ask_recurrence_update_policy_hook";
@@ -12,8 +13,17 @@ export class AttendeeCalendarCommonPopover extends CalendarCommonPopover {
         this.user = useService("user");
         this.orm = useService("orm");
         this.askRecurrenceUpdatePolicy = useAskRecurrenceUpdatePolicy();
+
+        onWillStart(this.onWillStart);
+    }
+
+    async onWillStart() {
         // Show status dropdown if user is in attendees list
         if (this.isCurrentUserAttendee) {
+            const stateSelections = await this.env.services.orm.call(
+                this.props.model.resModel,
+                "get_state_selections",
+            );
             this.statusColors = {
                 accepted: "text-success",
                 declined: "text-danger",
@@ -21,7 +31,7 @@ export class AttendeeCalendarCommonPopover extends CalendarCommonPopover {
                 needsAction: "text-dark",
             };
             this.statusInfo = {};
-            for (const selection of this.props.model.fields.attendee_status.selection) {
+            for (const selection of stateSelections) {
                 this.statusInfo[selection[0]] = {
                     text: selection[1],
                     color: this.statusColors[selection[0]],

--- a/addons/calendar/static/tests/helpers/mock_server/models/res_users.js
+++ b/addons/calendar/static/tests/helpers/mock_server/models/res_users.js
@@ -19,7 +19,7 @@ patch(MockServer.prototype, {
         startDate.setUTCHours(0, 0, 0, 0);
         const endDate = new Date();
         endDate.setUTCHours(23, 59, 59, 999);
-        const currentPartnerAttendeeIds = this.pyEnv['calendar.attendee'].search([['partner_id', '=', this.pyEnv.currentPartnerId]]);
+        const currentPartnerAttendeeIds = this.pyEnv['calendar.attendee'].search([['partner_id', '=', this.pyEnv.currentPartnerId], ['state', '!=', 'declined']]);
         return [
             '&',
                 '|',
@@ -45,10 +45,10 @@ patch(MockServer.prototype, {
         const meetingsLines = this.pyEnv['calendar.event'].searchRead(
             this._mockResUsers_SystrayGetCalendarEventDomain(),
             {
-                fields: ['id', 'start', 'name', 'allday', 'attendee_status'],
+                fields: ['id', 'start', 'name', 'allday'],
                 order: 'start',
             }
-        ).filter(meetingLine => meetingLine['attendee_status'] !== 'declined');
+        )
         if (meetingsLines.length) {
             activities.unshift({
                 id: 'calendar.event', // for simplicity

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -112,7 +112,6 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" attrs="{'invisible': [('active', '=', True)]}"/>
                     <field name="res_model" invisible="1" />
                     <field name="res_id" invisible="1" />
-                    <field name="attendee_status" invisible="1"/>
                     <field name="active" invisible="1"/>
                     <field name="user_can_edit" invisible="1"/>
                     <div class="oe_title mb-3">
@@ -355,7 +354,6 @@
                 quick_add="%(calendar.view_calendar_event_form_quick_create)d"
                 color="partner_ids">
                 <field name="location" attrs="{'invisible': [('location', '=', False)]}" options="{'icon': 'fa fa-map-marker'}"/>
-                <field name="attendee_status" invisible="1"/>
                 <field name="attendees_count" invisible="1"/>
                 <field name="accepted_count" invisible="1"/>
                 <field name="declined_count" invisible="1"/>

--- a/addons/google_calendar/views/google_calendar_views.xml
+++ b/addons/google_calendar/views/google_calendar_views.xml
@@ -5,7 +5,7 @@
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_calendar"/>
         <field name="arch" type="xml">
-            <field name="attendee_status" position="after">
+            <field name="location" position="after">
                 <field name="google_id" invisible="1"/>
             </field>
         </field>

--- a/addons/microsoft_calendar/views/microsoft_calendar_views.xml
+++ b/addons/microsoft_calendar/views/microsoft_calendar_views.xml
@@ -5,7 +5,7 @@
         <field name="model">calendar.event</field>
         <field name="inherit_id" ref="calendar.view_calendar_event_calendar"/>
         <field name="arch" type="xml">
-            <field name="attendee_status" position="after">
+            <field name="location" position="after">
                 <field name="microsoft_id" invisible="1"/>
             </field>
         </field>


### PR DESCRIPTION
Purpose of this commit to remove `attendee_status` field
which was only useful in one place where it can be easily
replaceable and also this field contains some heavy
computation and added in calendar view which might be
cause some performance issues.

So, in this commit remove `attendee_status` field and its
related code and replace it be alternative which gives
desire output as before.

task-3390334