### PR TITLE
[FIX] account: invoice payment state on payment cancel

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -934,6 +934,8 @@ class AccountPayment(models.Model):
 
     def action_cancel(self):
         ''' draft -> cancelled '''
+        if self.move_id.state != 'draft':
+            self.move_id.button_draft()
         self.move_id.button_cancel()
 
     def action_draft(self):


### PR DESCRIPTION
**Setup**

- install eCommerce
- activate and set up a payment provider that supports refunds (ex: Authorize.net)

**Steps to reproduce**

1. Create an order in eCommerce and pay with the provider you configured.
2. Create and validate the invoice from the order. The invoice should be in the `in_payment` state
3. Go to the related Payment and refund it, using the 'REFUND' button on the form view.
4. Go back to the invoice

=> you should see that the invoice's payment state is still `in_payment`. (it should be `not_paid`).

opw-3180180