### PR TITLE
[FIX] website_slides_survey: group on parent element

### DIFF
--- a/addons/website_slides_survey/views/slide_channel_views.xml
+++ b/addons/website_slides_survey/views/slide_channel_views.xml
@@ -5,7 +5,7 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.view_slide_channel_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//span[@name='members_completed_count_label']" position="replace">
+            <xpath expr="//span[@name='members_completed_count_label']" position="replace" groups="website_slides.group_website_slides_officer">
                 <field  name="nbr_certification" invisible="1"/>
                 <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '>', 0)]}">Finished</span>
                 <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '=', 0)]}">Certified</span>


### PR DESCRIPTION
The button on which we change the the label has a group. Not having the group leads to a traceback.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
