### PR TITLE
[FIX] website: Prevent s_share to always replace the target url

### DIFF
--- a/addons/website/static/src/snippets/s_share/000.js
+++ b/addons/website/static/src/snippets/s_share/000.js
@@ -59,11 +59,18 @@ const ShareWidget = publicWidget.Widget.extend({
 
         const url = encodeURIComponent(window.location.href);
         const title = encodeURIComponent(document.title);
-        const media = encodeURIComponent(document.querySelector('meta[property="og:image"]').content);
+        const mediaEl = document.querySelector('meta[property="og:image"]');
+        let media = "";
+        if (mediaEl && mediaEl.content) {
+            media = encodeURIComponent(mediaEl.content);
+        }
 
         aEl.href = currentHref
             .replace(this.URL_REGEX, (match, a, b, c) => {
-                return a + url + c;
+                if (b === "{url}") {
+                    return a + url + c;
+                }
+                return a + b + c;
             })
             .replace(this.TITLE_REGEX, function (match, a, b, c) {
                 if (aEl.classList.contains('s_share_whatsapp')) {
@@ -74,10 +81,16 @@ const ShareWidget = publicWidget.Widget.extend({
                     // For more details, see https://faq.whatsapp.com/general/chats/how-to-use-click-to-chat/
                     return `${a + title}%20${url + c}`;
                 }
-                return a + title + c;
+                if (b === "{title}") {
+                    return a + title + c;
+                }
+                return a + b + c;
             })
             .replace(this.MEDIA_REGEX, (match, a, b, c) => {
-                return a + media + c;
+                if (b === "{media}") {
+                    return a + media + c;
+                }
+                return a + b + c;
             });
 
         window.open(aEl.href, aEl.target, 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=550,width=600');

--- a/addons/website_slides/static/src/xml/website_slides_share.xml
+++ b/addons/website_slides/static/src/xml/website_slides_share.xml
@@ -36,12 +36,12 @@
                             aria-label="Share on LinkedIn" title="Share on LinkedIn">
                             <i class="fa fa-linkedin fa-fw"/>
                         </a>
-                        <a t-attf-href="https://wa.me/?text=#{window.location.href}" social-key="whatsapp"
+                        <a t-attf-href="https://wa.me/?text=#{widget.slide.websiteShareUrl}" social-key="whatsapp"
                             class="btn border bg-white o_wslides_js_social_share"
                             aria-label="Share on Whatsapp" title="Share on Whatsapp">
                             <i class="fa fa-whatsapp fa-fw"/>
                         </a>
-                        <a t-attf-href="http://pinterest.com/pin/create/button/?url=#{window.location.href}" social-key="pinterest"
+                        <a t-attf-href="http://pinterest.com/pin/create/button/?url=#{widget.slide.websiteShareUrl}" social-key="pinterest"
                             class=" btn border bg-white o_wslides_js_social_share"
                             aria-label="Share on Pinterest" title="Share on Pinterest">
                             <i class="fa fa-pinterest fa-fw"/>
@@ -76,4 +76,3 @@
     </t>
 
 </templates>
-


### PR DESCRIPTION
The code snippet consistently substituted the target share URL with `window.location.href`, preventing a share button from targeting anything other than the current page. For example, it hindered the ability to share a certification link.

This commit also includes a fallback in case the page doesn't have an `og:image` attribute.

opw-3326724

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
