### PR TITLE
[IMP] stock: auto-printing and report cleanups

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2626,4 +2626,16 @@ class MrpProduction(models.Model):
             action = self.env.ref("mrp.action_report_production_order").report_action(productions_to_print.ids, config=False)
             clean_action(action, self.env)
             report_actions.append(action)
+        productions_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_done_mrp_product_labels)
+        productions_by_print_formats = productions_to_print.grouped(lambda p: p.picking_type_id.mrp_product_label_to_print)
+        for print_format in productions_to_print.picking_type_id.mapped('mrp_product_label_to_print'):
+            labels_to_print = productions_by_print_formats.get(print_format)
+            if print_format == 'pdf':
+                action = self.env.ref("mrp.action_report_finished_product").report_action(labels_to_print.ids, config=False)
+                clean_action(action, self.env)
+                report_actions.append(action)
+            elif print_format == 'zpl':
+                action = self.env.ref("mrp.label_manufacture_template").report_action(labels_to_print.ids, config=False)
+                clean_action(action, self.env)
+                report_actions.append(action)
         return report_actions

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1372,6 +1372,8 @@ class MrpProduction(models.Model):
         self._set_lot_producing()
         if self.product_id.tracking == 'serial':
             self._set_qty_producing()
+        if self.picking_type_id.auto_print_generated_mrp_lot:
+            return self._autoprint_generated_lot(self.lot_producing_id)
 
     def action_confirm(self):
         self._check_company()
@@ -2667,3 +2669,14 @@ class MrpProduction(models.Model):
                     clean_action(action, self.env)
                     report_actions.append(action)
         return report_actions
+
+    def _autoprint_generated_lot(self, lot_id):
+        self.ensure_one()
+        if self.picking_type_id.generated_mrp_lot_label_to_print == 'pdf':
+            action = self.env.ref("stock.action_report_lot_label").report_action(lot_id.id, config=False)
+            clean_action(action, self.env)
+            return action
+        elif self.picking_type_id.generated_mrp_lot_label_to_print == 'zpl':
+            action = self.env.ref("stock.label_lot_template").report_action(lot_id.id, config=False)
+            clean_action(action, self.env)
+            return action

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _, Command
+from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_compare, float_round, float_is_zero, format_datetime
 from odoo.tools.misc import OrderedSet, format_date, groupby as tools_groupby
@@ -1969,48 +1970,78 @@ class MrpProduction(models.Model):
                 'state': 'done',
             })
 
+        report_actions = self._get_autoprint_done_report_actions()
         if self.env.context.get('skip_redirection'):
+            if report_actions:
+                return {
+                    'type': 'ir.actions.client',
+                    'tag': 'do_multi_print',
+                    'params': {
+                        'reports': report_actions,
+                    }
+                }
             return True
-
+        another_action = False
         if not backorders:
             if self.env.context.get('from_workorder'):
-                return {
+                another_action = {
                     'type': 'ir.actions.act_window',
                     'res_model': 'mrp.production',
                     'views': [[self.env.ref('mrp.mrp_production_form_view').id, 'form']],
                     'res_id': self.id,
                     'target': 'main',
                 }
-            if self.user_has_groups('mrp.group_mrp_reception_report'):
+            elif self.user_has_groups('mrp.group_mrp_reception_report'):
                 mos_to_show = self.filtered(lambda mo: mo.picking_type_id.auto_show_reception_report)
                 lines = mos_to_show.move_finished_ids.filtered(lambda m: m.product_id.type == 'product' and m.state != 'cancel' and m.quantity_done and not m.move_dest_ids)
                 if lines:
                     if any(mo.show_allocation for mo in mos_to_show):
-                        action = mos_to_show.action_view_reception_report()
-                        return action
+                        another_action = mos_to_show.action_view_reception_report()
+            if report_actions:
+                return {
+                    'type': 'ir.actions.client',
+                    'tag': 'do_multi_print',
+                    'params': {
+                        'reports': report_actions,
+                        'anotherAction': another_action,
+                    }
+                }
+            if another_action:
+                return another_action
             return True
         context = self.env.context.copy()
         context = {k: v for k, v in context.items() if not k.startswith('default_')}
         for k, v in context.items():
             if k.startswith('skip_'):
                 context[k] = False
-        action = {
+        another_action = {
             'res_model': 'mrp.production',
             'type': 'ir.actions.act_window',
             'context': dict(context, mo_ids_to_backorder=None)
         }
         if len(backorders) == 1:
-            action.update({
+            another_action.update({
+                'views': [[False, 'form']],
                 'view_mode': 'form',
                 'res_id': backorders[0].id,
             })
         else:
-            action.update({
+            another_action.update({
                 'name': _("Backorder MO"),
                 'domain': [('id', 'in', backorders.ids)],
+                'views': [[False, 'list'], [False, 'form']],
                 'view_mode': 'tree,form',
             })
-        return action
+        if report_actions:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'do_multi_print',
+                'params': {
+                    'reports': report_actions,
+                    'anotherAction': another_action,
+                }
+            }
+        return another_action
 
     def pre_button_mark_done(self):
         for production in self:
@@ -2585,3 +2616,14 @@ class MrpProduction(models.Model):
         if missing_lot_id_products:
             error_msg = _('You need to supply Lot/Serial Number for products:') + missing_lot_id_products
             raise UserError(error_msg)
+
+    def _get_autoprint_done_report_actions(self):
+        """ Reports to auto-print when MO is marked as done
+        """
+        report_actions = []
+        productions_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_done_production_order)
+        if productions_to_print:
+            action = self.env.ref("mrp.action_report_production_order").report_action(productions_to_print.ids, config=False)
+            clean_action(action, self.env)
+            report_actions.append(action)
+        return report_actions

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2638,4 +2638,18 @@ class MrpProduction(models.Model):
                 action = self.env.ref("mrp.label_manufacture_template").report_action(labels_to_print.ids, config=False)
                 clean_action(action, self.env)
                 report_actions.append(action)
+        if self.user_has_groups('mrp.group_mrp_reception_report'):
+            reception_labels_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_mrp_reception_report_labels and p.picking_type_id.code == 'mrp_operation')
+            if reception_labels_to_print:
+                moves_to_print = reception_labels_to_print.move_finished_ids.move_dest_ids
+                if moves_to_print:
+                    # needs to be string to support python + js calls to report
+                    quantities = ','.join(str(qty) for qty in moves_to_print.mapped(lambda m: math.ceil(m.product_uom_qty)))
+                    data = {
+                        'docids': moves_to_print.ids,
+                        'quantity': quantities,
+                    }
+                    action = self.env.ref('stock.label_picking').report_action(moves_to_print, data=data, config=False)
+                    clean_action(action, self.env)
+                    report_actions.append(action)
         return report_actions

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2652,4 +2652,18 @@ class MrpProduction(models.Model):
                     action = self.env.ref('stock.label_picking').report_action(moves_to_print, data=data, config=False)
                     clean_action(action, self.env)
                     report_actions.append(action)
+        if self.user_has_groups('stock.group_production_lot'):
+            productions_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_done_mrp_lot and p.move_finished_ids.move_line_ids.lot_id)
+            productions_by_print_formats = productions_to_print.grouped(lambda p: p.picking_type_id.done_mrp_lot_label_to_print)
+            for print_format in productions_to_print.picking_type_id.mapped('done_mrp_lot_label_to_print'):
+                lots_to_print = productions_by_print_formats.get(print_format)
+                lots_to_print = lots_to_print.move_finished_ids.move_line_ids.mapped('lot_id')
+                if print_format == 'pdf':
+                    action = self.env.ref("stock.action_report_lot_label").report_action(lots_to_print.ids, config=False)
+                    clean_action(action, self.env)
+                    report_actions.append(action)
+                elif print_format == 'zpl':
+                    action = self.env.ref("stock.label_lot_template").report_action(lots_to_print.ids, config=False)
+                    clean_action(action, self.env)
+                    report_actions.append(action)
         return report_actions

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2641,6 +2641,16 @@ class MrpProduction(models.Model):
                 clean_action(action, self.env)
                 report_actions.append(action)
         if self.user_has_groups('mrp.group_mrp_reception_report'):
+            reception_reports_to_print = self.filtered(
+                lambda p: p.picking_type_id.auto_print_mrp_reception_report
+                          and p.picking_type_id.code == 'mrp_operation'
+                          and p.move_finished_ids.move_dest_ids
+            )
+            if reception_reports_to_print:
+                action = self.env.ref('stock.stock_reception_report_action').report_action(reception_reports_to_print, config=False)
+                action['context'] = dict({'default_production_ids': reception_reports_to_print.ids}, **self.env.context)
+                clean_action(action, self.env)
+                report_actions.append(action)
             reception_labels_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_mrp_reception_report_labels and p.picking_type_id.code == 'mrp_operation')
             if reception_labels_to_print:
                 moves_to_print = reception_labels_to_print.move_finished_ids.move_dest_ids

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -44,6 +44,12 @@ class StockPickingType(models.Model):
     auto_print_mrp_reception_report_labels = fields.Boolean(
         "Auto Print Allocation Report Labels",
         help="If this checkbox is ticked, Odoo will automatically print the allocation report labels of a MO when it is done.")
+    auto_print_generated_mrp_lot = fields.Boolean(
+        "Auto Print Generated Lot/SN Label",
+        help='Automatically print the lot/SN label when the "Create a new serial/lot number" button is used.')
+    generated_mrp_lot_label_to_print = fields.Selection(
+        [('pdf', 'PDF'), ('zpl', 'ZPL')],
+        "Generated Lot/SN Label to Print", default='pdf')
 
     @api.depends('code')
     def _compute_use_create_lots(self):

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -35,6 +35,9 @@ class StockPickingType(models.Model):
     mrp_product_label_to_print = fields.Selection(
         [('pdf', 'PDF'), ('zpl', 'ZPL')],
         "Product Label to Print", default='pdf')
+    auto_print_mrp_reception_report_labels = fields.Boolean(
+        "Auto Print Allocation Report Labels",
+        help="If this checkbox is ticked, Odoo will automatically print the allocation report labels of a MO when it is done.")
 
     @api.depends('code')
     def _compute_use_create_lots(self):

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -29,6 +29,12 @@ class StockPickingType(models.Model):
     auto_print_done_production_order = fields.Boolean(
         "Auto Print Done Production Order",
         help="If this checkbox is ticked, Odoo will automatically print the production order of a MO when it is done.")
+    auto_print_done_mrp_product_labels = fields.Boolean(
+        "Auto Print Produced Product Labels",
+        help="If this checkbox is ticked, Odoo will automatically print the product labels of a MO when it is done.")
+    mrp_product_label_to_print = fields.Selection(
+        [('pdf', 'PDF'), ('zpl', 'ZPL')],
+        "Product Label to Print", default='pdf')
 
     @api.depends('code')
     def _compute_use_create_lots(self):

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -35,6 +35,12 @@ class StockPickingType(models.Model):
     mrp_product_label_to_print = fields.Selection(
         [('pdf', 'PDF'), ('zpl', 'ZPL')],
         "Product Label to Print", default='pdf')
+    auto_print_done_mrp_lot = fields.Boolean(
+        "Auto Print Produced Lot Label",
+        help="If this checkbox is ticked, Odoo will automatically print the lot/SN label of a MO when it is done.")
+    done_mrp_lot_label_to_print = fields.Selection(
+        [('pdf', 'PDF'), ('zpl', 'ZPL')],
+        "Lot/SN Label to Print", default='pdf')
     auto_print_mrp_reception_report_labels = fields.Boolean(
         "Auto Print Allocation Report Labels",
         help="If this checkbox is ticked, Odoo will automatically print the allocation report labels of a MO when it is done.")

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -26,6 +26,10 @@ class StockPickingType(models.Model):
         help="Allow automatic consumption of tracked components that are reserved",
     )
 
+    auto_print_done_production_order = fields.Boolean(
+        "Auto Print Done Production Order",
+        help="If this checkbox is ticked, Odoo will automatically print the production order of a MO when it is done.")
+
     @api.depends('code')
     def _compute_use_create_lots(self):
         for picking_type in self:

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -41,6 +41,9 @@ class StockPickingType(models.Model):
     done_mrp_lot_label_to_print = fields.Selection(
         [('pdf', 'PDF'), ('zpl', 'ZPL')],
         "Lot/SN Label to Print", default='pdf')
+    auto_print_mrp_reception_report = fields.Boolean(
+        "Auto Print Allocation Report",
+        help="If this checkbox is ticked, Odoo will automatically print the allocation report of a MO when it is done and has assigned moves.")
     auto_print_mrp_reception_report_labels = fields.Boolean(
         "Auto Print Allocation Report Labels",
         help="If this checkbox is ticked, Odoo will automatically print the allocation report labels of a MO when it is done.")

--- a/addons/mrp/report/report_stock_reception.xml
+++ b/addons/mrp/report/report_stock_reception.xml
@@ -4,6 +4,5 @@
         <field name="name">MRP Reception Report</field>
         <field name="tag">reception_report</field>
         <field name="res_model">report.stock.report_reception</field>
-        <field name="context">{'default_production_ids': active_ids}</field>
     </record>
 </odoo>

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -143,6 +143,12 @@
                     <group>
                         <group string="Print when done">
                             <field name="auto_print_done_production_order" string="Production Order"/>
+                            <label for="auto_print_done_mrp_product_labels" string="Product Labels"/>
+                            <div class="o_row">
+                                <field name="auto_print_done_mrp_product_labels" string="Product Labels"/>
+                                <label for="mrp_product_label_to_print" string="Print labels as:" invisible="not auto_print_done_mrp_product_labels" class="fw-bold"/>
+                                <field name="mrp_product_label_to_print" invisible="not auto_print_done_mrp_product_labels"/>
+                            </div>
                         </group>
                         <group string="">
                             <div colspan="2">

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -149,6 +149,7 @@
                                 <label for="mrp_product_label_to_print" string="Print labels as:" invisible="not auto_print_done_mrp_product_labels" class="fw-bold"/>
                                 <field name="mrp_product_label_to_print" invisible="not auto_print_done_mrp_product_labels"/>
                             </div>
+                            <field name="auto_print_mrp_reception_report_labels" string="Allocation Report Labels" groups="mrp.group_mrp_reception_report"/>
                         </group>
                         <group string="">
                             <div colspan="2">

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -155,6 +155,7 @@
                                 <label for="done_mrp_lot_label_to_print" string="Print labels as:" invisible="not auto_print_done_mrp_lot" class="fw-bold"/>
                                 <field name="done_mrp_lot_label_to_print" invisible="not auto_print_done_mrp_lot"/>
                             </div>
+                            <field name="auto_print_mrp_reception_report" string="Allocation Report" groups="mrp.group_mrp_reception_report"/>
                             <field name="auto_print_mrp_reception_report_labels" string="Allocation Report Labels" groups="mrp.group_mrp_reception_report"/>
                         </group>
                         <group string="">

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -149,6 +149,12 @@
                                 <label for="mrp_product_label_to_print" string="Print labels as:" invisible="not auto_print_done_mrp_product_labels" class="fw-bold"/>
                                 <field name="mrp_product_label_to_print" invisible="not auto_print_done_mrp_product_labels"/>
                             </div>
+                            <label for="auto_print_done_mrp_lot" string="Lot/SN Labels" groups="stock.group_production_lot"/>
+                            <div class="o_row" groups="stock.group_production_lot">
+                                <field name="auto_print_done_mrp_lot" string="Lot/SN Labels"/>
+                                <label for="done_mrp_lot_label_to_print" string="Print labels as:" invisible="not auto_print_done_mrp_lot" class="fw-bold"/>
+                                <field name="done_mrp_lot_label_to_print" invisible="not auto_print_done_mrp_lot"/>
+                            </div>
                             <field name="auto_print_mrp_reception_report_labels" string="Allocation Report Labels" groups="mrp.group_mrp_reception_report"/>
                         </group>
                         <group string="">

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -138,6 +138,26 @@
             <field name="auto_show_reception_report" position="after">
                 <field name="auto_show_reception_report" invisible="code != 'mrp_operation'" groups="mrp.group_mrp_reception_report"/>
             </field>
+            <xpath expr="//page[@name='hardware']" position="after">
+                <page name="mrp_hardware" string="Hardware" invisible="code != 'mrp_operation'">
+                    <group>
+                        <group string="Print when done">
+                            <field name="auto_print_done_production_order" string="Production Order"/>
+                        </group>
+                        <group string="">
+                            <div colspan="2">
+                                Odoo opens a PDF preview by default. If you want to print instantly,
+                                install the IoT App on a computer that is on the same local network as the
+                                barcode operator and configure the routing of the reports.
+                                <a href="https://www.odoo.com/documentation/master/applications/productivity/iot/devices/printer.html"
+                                    target="_blank" class="fa fa-arrow-right">
+                                    Documentation
+                                </a>
+                            </div>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
         </field>
     </record>
 

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -168,6 +168,14 @@
                                 </a>
                             </div>
                         </group>
+                        <group string='Print when "Create new Lot/SN"' groups="stock.group_production_lot">
+                            <label for="auto_print_generated_mrp_lot" string="Lot/SN Label"/>
+                            <div class="o_row">
+                                <field name="auto_print_generated_mrp_lot" string="Lot/SN Label"/>
+                                <label for="generated_mrp_lot_label_to_print" string="Print labels as:" invisible="not auto_print_generated_mrp_lot" class="fw-bold"/>
+                                <field name="generated_mrp_lot_label_to_print" invisible="not auto_print_generated_mrp_lot"/>
+                            </div>
+                        </group>
                     </group>
                 </page>
             </xpath>

--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -61,20 +61,34 @@
                     <div class="o_label_name">
                         <strong t-field="product.display_name"/>
                     </div>
-                    <t t-if="price_included">
-                        <div class="o_label_left_column">
-                            <span class="text-nowrap" t-field="product.default_code"/>
-                        </div>
-                        <div class="o_label_price_medium text-end">
-                            <strong t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
-                                t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
-                        </div>
-                    </t>
-                    <t t-else="">
-                        <div class="o_label_left_column o_label_full_with">
-                            <span class="text-nowrap" t-field="product.default_code"/>
-                        </div>
-                    </t>
+                    <div class="o_label_left_column">
+                        <span class="text-nowrap" t-field="product.default_code"/>
+                    </div>
+                    <div class="o_label_price_medium text-end">
+                        <strong t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                            t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
+                    </div>
+                    <div class= "text-center o_label_small_barcode">
+                        <t t-if="barcode">
+                            <div t-out="barcode" style="padding:0" t-options="{'widget': 'barcode', 'symbology': 'auto', 'img_style': barcode_size}"/>
+                            <span class="text-center" t-out="barcode"/>
+                        </t>
+                    </div>
+                </div>
+            </td>
+        </template>
+
+        <template id="report_simple_label4x12_no_price">
+            <t t-set="barcode_size" t-value="'width:33mm;height:4mm'"/>
+            <t t-set="table_style" t-value="'width:43mm;height:19mm;' + table_style"/>
+            <td t-att-style="make_invisible and 'visibility:hidden;'" >
+                <div class="o_label_full o_label_small_text" t-att-style="table_style">
+                    <div class="o_label_name">
+                        <strong t-field="product.display_name"/>
+                    </div>
+                    <div class="o_label_left_column o_label_full_with">
+                        <span class="text-nowrap" t-field="product.default_code"/>
+                    </div>
                     <div class= "text-center o_label_small_barcode">
                         <t t-if="barcode">
                             <div t-out="barcode" style="padding:0" t-options="{'widget': 'barcode', 'symbology': 'auto', 'img_style': barcode_size}"/>
@@ -120,15 +134,15 @@
                 <t t-if="columns and rows">
                     <t t-if="columns == 2 and rows == 7">
                         <t t-set="padding_page" t-value="'padding: 14mm 3mm'"/>
-                        <t t-set="report_to_call" t-value="'product.report_simple_label2x7'"/>
+                        <t t-set="report_to_call" t-value="'2x7'"/>
                     </t>
                     <t t-if="columns == 4 and rows == 7">
                         <t t-set="padding_page" t-value="'padding: 14mm 3mm'"/>
-                        <t t-set="report_to_call" t-value="'product.report_simple_label4x7'"/>
+                        <t t-set="report_to_call" t-value="'4x7'"/>
                     </t>
                     <t t-if="columns == 4 and rows == 12">
                         <t t-set="padding_page" t-value="'padding: 20mm 8mm'"/>
-                        <t t-set="report_to_call" t-value="'product.report_simple_label4x12'"/>
+                        <t t-set="report_to_call" t-value="'4x12'"/>
                     </t>
                     <t t-foreach="range(page_numbers)" t-as="page">
                         <div class="o_label_sheet" t-att-style="padding_page">
@@ -156,7 +170,21 @@
                                                 <t t-set="make_invisible" t-value="True"/>
                                             </t>
                                             <t t-set="table_style" t-value="'border: 1px solid %s;' % (product.env.user.company_id.primary_color or 'black')"/>
-                                            <t t-call="{{report_to_call}}"/>
+                                            <!-- IMPORTANT: explictly call templates in place of {{template}} otherwise studio won't load report correctly -->
+                                            <t t-if="report_to_call == '2x7'">
+                                                <t t-call="product.report_simple_label2x7"/>
+                                            </t>
+                                            <t t-elif="report_to_call == '4x7'">
+                                                <t t-call="product.report_simple_label4x7"/>
+                                            </t>
+                                            <t t-elif="report_to_call == '4x12'">
+                                                <t t-if="price_included">
+                                                    <t t-call="product.report_simple_label4x12"/>
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-call="product.report_simple_label4x12_no_price"/>
+                                                </t>
+                                            </t>
                                         </t>
                                     </tr>
                                 </t>

--- a/addons/product/report/product_reports.xml
+++ b/addons/product/report/product_reports.xml
@@ -15,12 +15,45 @@
             <field name="disable_shrinking" eval="True"/>
             <field name="dpi">96</field>
         </record>
-        <record id="report_product_template_label" model="ir.actions.report">
-            <field name="name">Product Label (PDF)</field>
+        <record id="report_product_template_label_2x7" model="ir.actions.report">
+            <field name="name">Product Label 2x7 (PDF)</field>
             <field name="model">product.template</field>
             <field name="report_type">qweb-pdf</field>
-            <field name="report_name">product.report_producttemplatelabel</field>
-            <field name="report_file">product.report_producttemplatelabel</field>
+            <field name="report_name">product.report_producttemplatelabel2x7</field>
+            <field name="report_file">product.report_producttemplatelabel2x7</field>
+            <field name="paperformat_id" ref="product.paperformat_label_sheet"/>
+            <field name="print_report_name">'Products Labels - %s' % (object.name)</field>
+            <field name="binding_model_id" eval="False"/>
+            <field name="binding_type">report</field>
+        </record>
+        <record id="report_product_template_label_4x7" model="ir.actions.report">
+            <field name="name">Product Label 4x7 (PDF)</field>
+            <field name="model">product.template</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">product.report_producttemplatelabel4x7</field>
+            <field name="report_file">product.report_producttemplatelabel4x7</field>
+            <field name="paperformat_id" ref="product.paperformat_label_sheet"/>
+            <field name="print_report_name">'Products Labels - %s' % (object.name)</field>
+            <field name="binding_model_id" eval="False"/>
+            <field name="binding_type">report</field>
+        </record>
+        <record id="report_product_template_label_4x12" model="ir.actions.report">
+            <field name="name">Product Label 4x12 (PDF)</field>
+            <field name="model">product.template</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">product.report_producttemplatelabel4x12</field>
+            <field name="report_file">product.report_producttemplatelabel4x12</field>
+            <field name="paperformat_id" ref="product.paperformat_label_sheet"/>
+            <field name="print_report_name">'Products Labels - %s' % (object.name)</field>
+            <field name="binding_model_id" eval="False"/>
+            <field name="binding_type">report</field>
+        </record>
+        <record id="report_product_template_label_4x12_noprice" model="ir.actions.report">
+            <field name="name">Product Label 4x12 No Price (PDF)</field>
+            <field name="model">product.template</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">product.report_producttemplatelabel4x12noprice</field>
+            <field name="report_file">product.report_producttemplatelabel4x12noprice</field>
             <field name="paperformat_id" ref="product.paperformat_label_sheet"/>
             <field name="print_report_name">'Products Labels - %s' % (object.name)</field>
             <field name="binding_model_id" eval="False"/>

--- a/addons/product/report/product_template_templates.xml
+++ b/addons/product/report/product_template_templates.xml
@@ -1,11 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<template id="report_producttemplatelabel">
+
+<!-- IMPORTANT: explictly include col/row otherwise studio won't load report correctly -->
+<template id="report_producttemplatelabel2x7">
     <t t-call="web.basic_layout">
         <div class="page">
-            <t t-call="product.report_productlabel">
-                <t t-set="products" t-value="products"/>
-            </t>
+            <t t-set="columns" t-value="2"/>
+            <t t-set="rows" t-value="7"/>
+            <t t-call="product.report_productlabel"/>
+        </div>
+    </t>
+</template>
+
+<template id="report_producttemplatelabel4x7">
+    <t t-call="web.basic_layout">
+        <div class="page">
+            <t t-set="columns" t-value="4"/>
+            <t t-set="rows" t-value="7"/>
+            <t t-call="product.report_productlabel"/>
+        </div>
+    </t>
+</template>
+
+<template id="report_producttemplatelabel4x12">
+    <t t-call="web.basic_layout">
+        <div class="page">
+            <t t-set="columns" t-value="4"/>
+            <t t-set="rows" t-value="12"/>
+            <t t-set="price_included" t-value="True"/>
+            <t t-call="product.report_productlabel"/>
+        </div>
+    </t>
+</template>
+
+<template id="report_producttemplatelabel4x12noprice">
+    <t t-call="web.basic_layout">
+        <div class="page">
+            <t t-set="columns" t-value="4"/>
+            <t t-set="rows" t-value="12"/>
+            <t t-set="price_included" t-value="False"/>
+            <t t-call="product.report_productlabel"/>
         </div>
     </t>
 </template>
@@ -13,9 +47,7 @@
 <template id="report_producttemplatelabel_dymo">
     <t t-call="web.basic_layout">
         <div class="page">
-            <t t-call="product.report_productlabel_dymo">
-                <t t-set="products" t-value="products"/>
-            </t>
+            <t t-call="product.report_productlabel_dymo"/>
         </div>
     </t>
 </template>

--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -29,8 +29,8 @@ class ProductLabelLayout(models.TransientModel):
         for wizard in self:
             if 'x' in wizard.print_format:
                 columns, rows = wizard.print_format.split('x')[:2]
-                wizard.columns = int(columns)
-                wizard.rows = int(rows)
+                wizard.columns = columns.isdigit() and int(columns) or 1
+                wizard.rows = rows.isdigit() and int(rows) or 1
             else:
                 wizard.columns, wizard.rows = 1, 1
 
@@ -42,7 +42,9 @@ class ProductLabelLayout(models.TransientModel):
         if self.print_format == 'dymo':
             xml_id = 'product.report_product_template_label_dymo'
         elif 'x' in self.print_format:
-            xml_id = 'product.report_product_template_label'
+            xml_id = 'product.report_product_template_label_%sx%s' % (self.columns, self.rows)
+            if 'xprice' not in self.print_format:
+                xml_id += '_noprice'
         else:
             xml_id = ''
 

--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -72,6 +72,6 @@ class ProductLabelLayout(models.TransientModel):
         xml_id, data = self._prepare_report_data()
         if not xml_id:
             raise UserError(_('Unable to find report template for %s format', self.print_format))
-        report_action = self.env.ref(xml_id).report_action(None, data=data)
+        report_action = self.env.ref(xml_id).report_action(None, data=data, config=False)
         report_action.update({'close_on_report_download': True})
         return report_action

--- a/addons/stock/models/__init__.py
+++ b/addons/stock/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import barcode
+from . import ir_actions_report
 from . import product_strategy
 from . import res_company
 from . import res_partner

--- a/addons/stock/models/ir_actions_report.py
+++ b/addons/stock/models/ir_actions_report.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = 'ir.actions.report'
+
+    def _get_rendering_context(self, report, docids, data):
+        data = super()._get_rendering_context(report, docids, data)
+        if report.report_name == 'stock.report_reception_report_label' and not docids:
+            docids = data['docids']
+            docs = self.env[report.model].browse(docids)
+            data.update({
+                'doc_ids': docids,
+                'docs': docs,
+            })
+        return data

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -89,6 +89,27 @@ class PickingType(models.Model):
     auto_print_delivery_slip = fields.Boolean(
         "Auto Print Delivery Slip",
         help="If this checkbox is ticked, Odoo will automatically print the delivery slip of a picking when it is validated.")
+
+    auto_print_product_labels = fields.Boolean(
+        "Auto Print Product Labels",
+        help="If this checkbox is ticked, Odoo will automatically print the product labels of a picking when it is validated.")
+    product_label_format = fields.Selection([
+        ('dymo', 'Dymo'),
+        ('2x7xprice', '2 x 7 with price'),
+        ('4x7xprice', '4 x 7 with price'),
+        ('4x12', '4 x 12'),
+        ('4x12xprice', '4 x 12 with price'),
+        ('zpl', 'ZPL Labels'),
+        ('zplxprice', 'ZPL Labels with price')], string="Product Label Format to auto-print", default='2x7xprice')
+    auto_print_lot_labels = fields.Boolean(
+        "Auto Print Lot/SN Labels",
+        help="If this checkbox is ticked, Odoo will automatically print the lot/SN labels of a picking when it is validated.")
+    lot_label_format = fields.Selection([
+        ('4x12_lots', '4 x 12 - One per lot/SN'),
+        ('4x12_units', '4 x 12 - One per unit'),
+        ('zpl_lots', 'ZPL Labels - One per lot/SN'),
+        ('zpl_units', 'ZPL Labels - One per unit')],
+        string="Lot Label Format to auto-print", default='4x12_lots')
     auto_print_reception_report_labels = fields.Boolean(
         "Auto Print Reception Report Labels",
         help="If this checkbox is ticked, Odoo will automatically print the reception report labels of a picking when it is validated.")
@@ -1740,6 +1761,34 @@ class Picking(models.Model):
                         'quantity': quantities,
                     }
                     action = self.env.ref('stock.label_picking').report_action(moves_to_print, data=data, config=False)
+                    clean_action(action, self.env)
+                    report_actions.append(action)
+        pickings_print_product_label = self.filtered(lambda p: p.picking_type_id.auto_print_product_labels)
+        pickings_by_print_formats = pickings_print_product_label.grouped(lambda p: p.picking_type_id.product_label_format)
+        for print_format in pickings_print_product_label.picking_type_id.mapped("product_label_format"):
+            pickings = pickings_by_print_formats.get(print_format)
+            wizard = self.env['product.label.layout'].create({
+                'product_ids': pickings.move_ids.product_id.ids,
+                'move_ids': pickings.move_ids.ids,
+                'picking_quantity': 'picking',
+                'print_format': pickings.picking_type_id.product_label_format,
+            })
+            action = wizard.process()
+            if action:
+                clean_action(action, self.env)
+                report_actions.append(action)
+        if self.user_has_groups('stock.group_production_lot'):
+            pickings_print_lot_label = self.filtered(lambda p: p.picking_type_id.auto_print_lot_labels and p.move_line_ids.lot_id)
+            pickings_by_print_formats = pickings_print_lot_label.grouped(lambda p: p.picking_type_id.lot_label_format)
+            for print_format in pickings_print_lot_label.picking_type_id.mapped("lot_label_format"):
+                pickings = pickings_by_print_formats.get(print_format)
+                wizard = self.env['lot.label.layout'].create({
+                    'picking_ids': pickings.ids,
+                    'label_quantity': 'lots' if '_lots' in print_format else 'units',
+                    'print_format': '4x12' if '4x12' in print_format else 'zpl',
+                })
+                action = wizard.process()
+                if action:
                     clean_action(action, self.env)
                     report_actions.append(action)
         return report_actions

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -89,6 +89,9 @@ class PickingType(models.Model):
     auto_print_delivery_slip = fields.Boolean(
         "Auto Print Delivery Slip",
         help="If this checkbox is ticked, Odoo will automatically print the delivery slip of a picking when it is validated.")
+    auto_print_return_slip = fields.Boolean(
+        "Auto Print Return Slip",
+        help="If this checkbox is ticked, Odoo will automatically print the return slip of a picking when it is validated.")
 
     auto_print_product_labels = fields.Boolean(
         "Auto Print Product Labels",
@@ -1746,6 +1749,11 @@ class Picking(models.Model):
         pickings_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_delivery_slip)
         if pickings_to_print:
             action = self.env.ref("stock.action_report_delivery").report_action(pickings_to_print.ids, config=False)
+            clean_action(action, self.env)
+            report_actions.append(action)
+        pickings_print_return_slip = self.filtered(lambda p: p.picking_type_id.auto_print_return_slip)
+        if pickings_print_return_slip:
+            action = self.env.ref("stock.return_label_report").report_action(pickings_print_return_slip.ids, config=False)
             clean_action(action, self.env)
             report_actions.append(action)
 

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -10,6 +10,7 @@ from markupsafe import escape
 
 from odoo import SUPERUSER_ID, _, api, fields, models
 from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
+from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, format_datetime, format_date, groupby
@@ -84,6 +85,9 @@ class PickingType(models.Model):
     auto_show_reception_report = fields.Boolean(
         "Show Reception Report at Validation",
         help="If this checkbox is ticked, Odoo will automatically show the reception report (if there are moves to allocate to) when validating.")
+    auto_print_delivery_slip = fields.Boolean(
+        "Auto Print Delivery Slip",
+        help="If this checkbox is ticked, Odoo will automatically print the delivery slip of a picking when it is validated.")
 
     count_picking_draft = fields.Integer(compute='_compute_picking_count')
     count_picking_ready = fields.Integer(compute='_compute_picking_count')
@@ -1143,7 +1147,8 @@ class Picking(models.Model):
         pickings_to_backorder = self - pickings_not_to_backorder
         pickings_not_to_backorder.with_context(cancel_backorder=True)._action_done()
         pickings_to_backorder.with_context(cancel_backorder=False)._action_done()
-
+        report_actions = self._get_autoprint_report_actions()
+        another_action = False
         if self.user_has_groups('stock.group_reception_report'):
             pickings_show_report = self.filtered(lambda p: p.picking_type_id.auto_show_reception_report)
             lines = pickings_show_report.move_ids.filtered(lambda m: m.product_id.type == 'product' and m.state != 'cancel' and m.quantity_done and not m.move_dest_ids)
@@ -1159,7 +1164,18 @@ class Picking(models.Model):
                         ('product_id', 'in', lines.product_id.ids)], limit=1):
                     action = pickings_show_report.action_view_reception_report()
                     action['context'] = {'default_picking_ids': pickings_show_report.ids}
-                    return action
+                    if not report_actions:
+                        return action
+                    another_action = action
+        if report_actions:
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'do_multi_print',
+                'params': {
+                    'reports': report_actions,
+                    'anotherAction': another_action,
+                }
+            }
         return True
 
     def action_set_quantities_to_reservation(self):
@@ -1683,3 +1699,12 @@ class Picking(models.Model):
 
     def _get_report_lang(self):
         return self.move_ids and self.move_ids[0].partner_id.lang or self.partner_id.lang or self.env.lang
+
+    def _get_autoprint_report_actions(self):
+        report_actions = []
+        pickings_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_delivery_slip)
+        if pickings_to_print:
+            action = self.env.ref("stock.action_report_delivery").report_action(pickings_to_print.ids, config=False)
+            clean_action(action, self.env)
+            report_actions.append(action)
+        return report_actions

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -113,6 +113,9 @@ class PickingType(models.Model):
         ('zpl_lots', 'ZPL Labels - One per lot/SN'),
         ('zpl_units', 'ZPL Labels - One per unit')],
         string="Lot Label Format to auto-print", default='4x12_lots')
+    auto_print_reception_report = fields.Boolean(
+        "Auto Print Reception Report",
+        help="If this checkbox is ticked, Odoo will automatically print the reception report of a picking when it is validated and has assigned moves.")
     auto_print_reception_report_labels = fields.Boolean(
         "Auto Print Reception Report Labels",
         help="If this checkbox is ticked, Odoo will automatically print the reception report labels of a picking when it is validated.")
@@ -1761,6 +1764,15 @@ class Picking(models.Model):
             report_actions.append(action)
 
         if self.user_has_groups('stock.group_reception_report'):
+            reception_reports_to_print = self.filtered(
+                lambda p: p.picking_type_id.auto_print_reception_report
+                          and p.picking_type_id.code != 'outgoing'
+                          and p.move_ids.move_dest_ids
+            )
+            if reception_reports_to_print:
+                action = self.env.ref('stock.stock_reception_report_action').report_action(reception_reports_to_print, config=False)
+                clean_action(action, self.env)
+                report_actions.append(action)
             reception_labels_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_reception_report_labels and p.picking_type_id.code != 'outgoing')
             if reception_labels_to_print:
                 moves_to_print = reception_labels_to_print.move_ids.move_dest_ids

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -116,6 +116,9 @@ class PickingType(models.Model):
     auto_print_reception_report_labels = fields.Boolean(
         "Auto Print Reception Report Labels",
         help="If this checkbox is ticked, Odoo will automatically print the reception report labels of a picking when it is validated.")
+    auto_print_packages = fields.Boolean(
+        "Auto Print Packages",
+        help="If this checkbox is ticked, Odoo will automatically print the packages and their contents of a picking when it is validated.")
 
     auto_print_package_label = fields.Boolean(
         "Auto Print Package Label",
@@ -1799,4 +1802,10 @@ class Picking(models.Model):
                 if action:
                     clean_action(action, self.env)
                     report_actions.append(action)
+        if self.user_has_groups('stock.group_tracking_lot'):
+            pickings_print_packages = self.filtered(lambda p: p.picking_type_id.auto_print_packages and p.move_line_ids.result_package_id)
+            if pickings_print_packages:
+                action = self.env.ref("stock.action_report_picking_packages").report_action(pickings_print_packages.ids, config=False)
+                clean_action(action, self.env)
+                report_actions.append(action)
         return report_actions

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import math
 import time
 from ast import literal_eval
 from datetime import date, timedelta
@@ -88,6 +89,9 @@ class PickingType(models.Model):
     auto_print_delivery_slip = fields.Boolean(
         "Auto Print Delivery Slip",
         help="If this checkbox is ticked, Odoo will automatically print the delivery slip of a picking when it is validated.")
+    auto_print_reception_report_labels = fields.Boolean(
+        "Auto Print Reception Report Labels",
+        help="If this checkbox is ticked, Odoo will automatically print the reception report labels of a picking when it is validated.")
 
     auto_print_package_label = fields.Boolean(
         "Auto Print Package Label",
@@ -1723,4 +1727,19 @@ class Picking(models.Model):
             action = self.env.ref("stock.action_report_delivery").report_action(pickings_to_print.ids, config=False)
             clean_action(action, self.env)
             report_actions.append(action)
+
+        if self.user_has_groups('stock.group_reception_report'):
+            reception_labels_to_print = self.filtered(lambda p: p.picking_type_id.auto_print_reception_report_labels and p.picking_type_id.code != 'outgoing')
+            if reception_labels_to_print:
+                moves_to_print = reception_labels_to_print.move_ids.move_dest_ids
+                if moves_to_print:
+                    # needs to be string to support python + js calls to report
+                    quantities = ','.join(str(qty) for qty in moves_to_print.mapped(lambda m: math.ceil(m.product_uom_qty)))
+                    data = {
+                        'docids': moves_to_print.ids,
+                        'quantity': quantities,
+                    }
+                    action = self.env.ref('stock.label_picking').report_action(moves_to_print, data=data, config=False)
+                    clean_action(action, self.env)
+                    report_actions.append(action)
         return report_actions

--- a/addons/stock/report/report_stock_reception.xml
+++ b/addons/stock/report/report_stock_reception.xml
@@ -30,7 +30,7 @@
     <record id="stock_reception_report_action" model="ir.actions.report">
         <field name="name">Reception Report</field>
         <field name="model">stock.picking</field>
-        <field name="report_type">qweb-html</field>
+        <field name="report_type">qweb-pdf</field>
         <field name="report_name">stock.report_reception</field>
     </record>
 

--- a/addons/stock/static/src/client_actions/multi_print.js
+++ b/addons/stock/static/src/client_actions/multi_print.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { sprintf } from "@web/core/utils/strings";
+
+async function doMultiPrint(env, action) {
+    for (const report of action.params.reports) {
+        if (report.type != "ir.actions.report") {
+            env.services.notification.add(_t("Incorrect type of action submitted as a report, skipping action"), {
+                title: _t("Report Printing Error"),
+            });
+            continue
+        } else if (report.report_type === "qweb-html") {
+            env.services.notification.add(
+                sprintf(
+                    _t("HTML reports cannot be auto-printed, skipping report: %s"),
+                            report.name)
+                , {
+                title: _t("Report Printing Error"),
+            });
+            continue
+        }
+        // WARNING: potential issue if pdf generation fails, then action_service defaults
+        // to HTML and rest of the action chain will break w/potentially never resolving promise
+        await env.services.action.doAction({ type: "ir.actions.report", ...report });
+    }
+    if (action.params.anotherAction) {
+        return env.services.action.doAction(action.params.anotherAction);
+    } else if (action.params.on_close) {
+        // handle special cases such as barcode
+        action.params.on_close()
+    } else {
+        return env.services.action.doAction("reload_context");
+    }
+}
+
+registry.category("actions").add("do_multi_print", doMultiPrint);

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -128,6 +128,7 @@
                             <group name="auto_print">
                                 <group string="Print on Validation">
                                     <field name="auto_print_delivery_slip" string="Delivery Slip"/>
+                                    <field name="auto_print_return_slip" string="Return Slip"/>
                                     <label for="auto_print_product_labels" string="Product Labels"/>
                                     <div class="o_row">
                                         <field name="auto_print_product_labels" string="Product Labels"/>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -128,6 +128,18 @@
                             <group name="auto_print">
                                 <group string="Print on Validation">
                                     <field name="auto_print_delivery_slip" string="Delivery Slip"/>
+                                    <label for="auto_print_product_labels" string="Product Labels"/>
+                                    <div class="o_row">
+                                        <field name="auto_print_product_labels" string="Product Labels"/>
+                                        <label for="product_label_format" string="Print label as:" invisible="not auto_print_product_labels" class="fw-bold"/>
+                                        <field name="product_label_format" invisible="not auto_print_product_labels"/>
+                                    </div>
+                                    <label for="auto_print_lot_labels" string="Lot/SN Labels" groups="stock.group_production_lot"/>
+                                    <div class="o_row" groups="stock.group_production_lot">
+                                        <field name="auto_print_lot_labels" string="Lot/SN Labels"/>
+                                        <label for="lot_label_format" string="Print label as:" invisible="not auto_print_lot_labels" class="fw-bold"/>
+                                        <field name="lot_label_format" invisible="not auto_print_lot_labels"/>
+                                    </div>
                                     <field name="auto_print_reception_report_labels" string="Reception Report Labels" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
                                 </group>
                                 <group string="">

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -128,6 +128,7 @@
                             <group name="auto_print">
                                 <group string="Print on Validation">
                                     <field name="auto_print_delivery_slip" string="Delivery Slip"/>
+                                    <field name="auto_print_reception_report_labels" string="Reception Report Labels" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
                                 </group>
                                 <group string="">
                                     <div colspan="2">

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -142,6 +142,7 @@
                                         <field name="lot_label_format" invisible="not auto_print_lot_labels"/>
                                     </div>
                                     <field name="auto_print_reception_report_labels" string="Reception Report Labels" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
+                                    <field name="auto_print_packages" string="Package Content" groups="stock.group_tracking_lot"/>
                                 </group>
                                 <group string="">
                                     <div colspan="2">

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -141,6 +141,7 @@
                                         <label for="lot_label_format" string="Print label as:" invisible="not auto_print_lot_labels" class="fw-bold"/>
                                         <field name="lot_label_format" invisible="not auto_print_lot_labels"/>
                                     </div>
+                                    <field name="auto_print_reception_report" string="Reception Report" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
                                     <field name="auto_print_reception_report_labels" string="Reception Report Labels" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
                                     <field name="auto_print_packages" string="Package Content" groups="stock.group_tracking_lot"/>
                                 </group>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -78,49 +78,71 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <label for="name"/>
                     <h1><field name="name" placeholder="e.g. Receptions"/></h1>
-                    <group name="first">
-                        <group>
-                            <field name="code"/>
-                            <field name="active" invisible="1"/>
-                            <field name="company_id" invisible="1"/>
-                            <field name="hide_reservation_method" invisible="1"/>
-                            <field name="show_picking_type" invisible="1"/>
-                            <field name="sequence_id" groups="base.group_no_one"/>
-                            <field name="sequence_code"/>
-                            <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
-                            <field name="reservation_method" invisible="hide_reservation_method" widget="radio"/>
-                            <label for="reservation_days_before" string="Reserve before scheduled date" invisible="code == 'incoming' or reservation_method != 'by_date'"/>
-                            <div class="o_row" invisible="code == 'incoming' or reservation_method != 'by_date'">
-                                <span><field name="reservation_days_before" style="width: 23px;"/> days before/</span>
-                                <span><field name="reservation_days_before_priority" style="width: 23px;"/> days before when starred</span>
-                            </div>
-                            <field name="auto_show_reception_report" invisible="code not in ['incoming', 'internal']" groups="stock.group_reception_report"/>
-                        </group>
-                        <group>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
-                            <field invisible="code not in ['incoming', 'outgoing', 'internal']" name="return_picking_type_id" string="Returns Type"/>
-                            <field name="default_location_return_id" invisible="code not in ['incoming', 'outgoing', 'internal']" groups="stock.group_stock_multi_locations"/>
-                            <field name="create_backorder"/>
-                            <field name="show_operations" invisible="not show_picking_type"/>
-                            <field name="show_reserved" invisible="code != 'incoming'"/>
-                        </group>
-                    </group>
-                    <group name="second">
-                        <group invisible="code not in ['incoming', 'outgoing', 'internal']" string="Lots/Serial Numbers" groups="stock.group_production_lot" name="stock_picking_type_lot">
-                            <field name="use_create_lots" string="Create New"/>
-                            <field name="use_existing_lots" string="Use Existing ones"/>
-                        </group>
-                        <group invisible="code not in ['incoming', 'outgoing', 'internal']" string="Packages" groups="stock.group_tracking_lot">
-                            <field name="show_entire_packs"/>
-                        </group>
-                        <!-- As this group will be hidden without multi_loccation, you will not be able to create a
-                            picking type with the code 'Internal', which make sense, but as the field 'code' on picking
-                            types can't be partially hidden, you can still select the code internal in the form view -->
-                        <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
-                            <field name="default_location_src_id" options="{'no_create': True}" required="code in ('internal', 'outgoing')"/>
-                            <field name="default_location_dest_id" options="{'no_create': True}" required="code in ('internal', 'incoming')"/>
-                        </group>
-                    </group>
+                    <notebook>
+                        <page name="general" string="General">
+                            <group name="first">
+                                <group>
+                                    <field name="code"/>
+                                    <field name="active" invisible="1"/>
+                                    <field name="company_id" invisible="1"/>
+                                    <field name="hide_reservation_method" invisible="1"/>
+                                    <field name="show_picking_type" invisible="1"/>
+                                    <field name="sequence_id" groups="base.group_no_one"/>
+                                    <field name="sequence_code"/>
+                                    <field name="warehouse_id" groups="stock.group_stock_multi_warehouses" force_save="1"/>
+                                    <field name="reservation_method" invisible="hide_reservation_method" widget="radio"/>
+                                    <label for="reservation_days_before" string="Reserve before scheduled date" invisible="code == 'incoming' or reservation_method != 'by_date'"/>
+                                    <div class="o_row" invisible="code == 'incoming' or reservation_method != 'by_date'">
+                                        <span><field name="reservation_days_before" style="width: 23px;"/> days before/</span>
+                                        <span><field name="reservation_days_before_priority" style="width: 23px;"/> days before when starred</span>
+                                    </div>
+                                    <field name="auto_show_reception_report" invisible="code not in ['incoming', 'internal']" groups="stock.group_reception_report"/>
+                                </group>
+                                <group>
+                                    <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                                    <field invisible="code not in ['incoming', 'outgoing', 'internal']" name="return_picking_type_id" string="Returns Type"/>
+                                    <field name="default_location_return_id" invisible="code not in ['incoming', 'outgoing', 'internal']" groups="stock.group_stock_multi_locations"/>
+                                    <field name="create_backorder"/>
+                                    <field name="show_operations" invisible="not show_picking_type"/>
+                                    <field name="show_reserved" invisible="code != 'incoming'"/>
+                                </group>
+                            </group>
+                            <group name="second">
+                                <group invisible="code not in ['incoming', 'outgoing', 'internal']" string="Lots/Serial Numbers" groups="stock.group_production_lot" name="stock_picking_type_lot">
+                                    <field name="use_create_lots" string="Create New"/>
+                                    <field name="use_existing_lots" string="Use Existing ones"/>
+                                </group>
+                                <group invisible="code not in ['incoming', 'outgoing', 'internal']" string="Packages" groups="stock.group_tracking_lot">
+                                    <field name="show_entire_packs"/>
+                                </group>
+                                <!-- As this group will be hidden without multi_loccation, you will not be able to create a
+                                    picking type with the code 'Internal', which make sense, but as the field 'code' on picking
+                                    types can't be partially hidden, you can still select the code internal in the form view -->
+                                <group string="Locations" groups="stock.group_stock_multi_locations" name="locations">
+                                    <field name="default_location_src_id" options="{'no_create': True}" required="code in ('internal', 'outgoing')"/>
+                                    <field name="default_location_dest_id" options="{'no_create': True}" required="code in ('internal', 'incoming')"/>
+                                </group>
+                            </group>
+                        </page>
+                        <page name="hardware" string="Hardware" invisible="code not in ['incoming', 'outgoing', 'internal']" >
+                            <group name="auto_print">
+                                <group string="Print on Validation">
+                                    <field name="auto_print_delivery_slip" string="Delivery Slip"/>
+                                </group>
+                                <group string="">
+                                    <div colspan="2">
+                                        Odoo opens a PDF preview by default. If you (Enterprise users only) want to print instantly,
+                                        install the IoT App on a computer that is on the same local network as the
+                                        barcode operator and configure the routing of the reports.
+                                        <a href="https://www.odoo.com/documentation/master/applications/productivity/iot/devices/printer.html"
+                                           target="_blank" class="fa fa-arrow-right">
+                                            Documentation
+                                        </a>
+                                    </div>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -140,6 +140,14 @@
                                         </a>
                                     </div>
                                 </group>
+                                <group string='Print on "Put in Pack"' groups="stock.group_tracking_lot">
+                                    <label for="auto_print_package_label" string="Package Label"/>
+                                    <div class="o_row">
+                                        <field name="auto_print_package_label" string="Package Label"/>
+                                        <label for="package_label_to_print" string="Print label as:" invisible="not auto_print_package_label" class="fw-bold"/>
+                                        <field name="package_label_to_print" invisible="not auto_print_package_label"/>
+                                    </div>
+                                </group>
                             </group>
                         </page>
                     </notebook>

--- a/addons/stock/wizard/stock_lot_label_layout.py
+++ b/addons/stock/wizard/stock_lot_label_layout.py
@@ -37,6 +37,6 @@ class ProductLabelLayout(models.TransientModel):
             docids = []
             for lot_id, qty in quantity_by_lot.items():
                 docids.append([lot_id] * qty)
-        report_action = self.env.ref(xml_id).report_action(docids)
+        report_action = self.env.ref(xml_id).report_action(docids, config=False)
         report_action.update({'close_on_report_download': True})
         return report_action

--- a/addons/stock_delivery/models/delivery_carrier.py
+++ b/addons/stock_delivery/models/delivery_carrier.py
@@ -55,7 +55,13 @@ class DeliveryCarrier(models.Model):
             )
 
     def get_return_label_prefix(self):
-        return 'ReturnLabel-%s' % self.delivery_type
+        return 'LabelReturn-%s' % self.delivery_type
+
+    def _get_delivery_label_prefix(self):
+        return 'LabelShipping-%s' % self.delivery_type
+
+    def _get_delivery_doc_prefix(self):
+        return 'ShippingDoc-%s' % self.delivery_type
 
     def get_tracking_link(self, picking):
         ''' Ask the tracking link to the service provider

--- a/addons/stock_delivery/wizard/choose_delivery_package.py
+++ b/addons/stock_delivery/wizard/choose_delivery_package.py
@@ -63,3 +63,4 @@ class ChooseDeliveryPackage(models.TransientModel):
             delivery_package.package_type_id = self.delivery_package_type_id
         if self.shipping_weight:
             delivery_package.shipping_weight = self.shipping_weight
+        return self.picking_id._post_put_in_pack_hook(delivery_package)

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -267,7 +267,8 @@ class StockPickingBatch(models.Model):
             if move_line_ids:
                 res = move_line_ids.picking_id[0]._pre_put_in_pack_hook(move_line_ids)
                 if not res:
-                    res = move_line_ids.picking_id[0]._put_in_pack(move_line_ids, False)
+                    package = move_line_ids.picking_id[0]._put_in_pack(move_line_ids, False)
+                    return move_line_ids.picking_id[0]._post_put_in_pack_hook(package)
                 return res
             else:
                 raise UserError(_("Please add 'Done' quantities to the batch picking to create a new pack."))


### PR DESCRIPTION
This PR handles a number of stock/mrp related printing improvements:
- allow users to select certain reports to be auto-printed at validation of a picking or a manufacturing order as well as when "Put in Pack" is used in a picking and the "Create Serial Number" button is clicked within an mo (in differing use cases). Each report was added in separate commits in case individual reports are decided to no longer be allowed to auto-print in the future (and also avoid a giant commit for all the reports at the same time)
- product label templates have been split into separate reports to allow for easier user customization (i.e. via studio)

It also handles some other related-ish improvements/fixes:
- unify shipping doc names: before they were inconsistent across shipping connectors, so now there is a method that should be called by shipping connectors to determine their pdf filename prefixes
- reception report correctly split moves when assigning (to prevent incorrect `reservation_dates` in moves)
- avoid asking for document layout configuration when printing product labels (it doesn't use the layout template)
- avoid singleton access when validating 2 MOs with different operation types


Additional detail is in each commit
Task: 3046178
ENT PR: odoo/enterprise#43362
Upgrade PR: odoo/upgrade#5298

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
