### PR TITLE
[FIX] base: solve error on loading demo data

### DIFF
--- a/odoo/addons/base/models/ir_demo.py
+++ b/odoo/addons/base/models/ir_demo.py
@@ -13,7 +13,7 @@ class IrDemo(models.TransientModel):
 
     @assert_log_admin_access
     def install_demo(self):
-        force_demo(self.env)
+        force_demo(self.sudo().env)
         return {
             'type': 'ir.actions.act_url',
             'target': 'self',


### PR DESCRIPTION
When we try to to load demo data with some apps already installed it shows some access rights error

Steps to reproduce the error :
1-start a db without demo data
2-install invoicing
3-load demo data
4-you will get an error

The origin of the problem is that the user loading the data doesn't really have all the access and writing rights.

opw-3377382