### PR TITLE
[IMP] purchase: added discount field in Vendor Pricelist

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -67,6 +67,10 @@ class SupplierInfo(models.Model):
     delay = fields.Integer(
         'Delivery Lead Time', default=1, required=True,
         help="Lead time in days between the confirmation of the purchase order and the receipt of the products in your warehouse. Used by the scheduler for automatic computation of the purchase order planning.")
+    discount = fields.Float(
+        string="Discount (%)",
+        digits='Discount',
+        readonly=False)
 
     @api.onchange('product_tmpl_id')
     def _onchange_product_tmpl_id(self):

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -32,6 +32,7 @@
                             </div>
                             <label for="date_start" string="Validity"/>
                             <div class="o_row"><field name="date_start" class="oe_inline"/> to <field name="date_end" class="oe_inline"/></div>
+                            <field name="discount"/>
                             <field name="company_id" options="{'no_create': True}"/>
                         </group>
                     </group>
@@ -117,6 +118,7 @@
                 <field name="min_qty" optional="hide"/>
                 <field name="product_uom" groups="uom.group_uom" optional="hide"/>
                 <field name="price" string="Price"/>
+                <field name="discount" optional="hide"/>
                 <field name="currency_id" groups="base.group_multi_currency"/>
                 <field name="delay" optional="hide"/>
             </tree>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -257,6 +257,7 @@
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>
                                     <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" invisible="not id"/>
                                     <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use','=','purchase'), ('company_id', '=', parent.company_id), ('country_id', '=', parent.tax_country_id)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show"/>
+                                    <field name="discount" string="Disc.%" readonly="qty_invoiced != 0" optional="hide"/>
                                     <field name="price_subtotal" string="Tax excl."/>
                                     <field name="price_total"
                                            string="Tax incl."


### PR DESCRIPTION
In this commit
==============

- Added the discount fields to the vendor pricelist and PO line models, making them optional and hidden.
- Implemented automatic filling of the discount field on the PO line when the unit price is sourced from the vendor pricelist.
- Implemented a mechanism to automatically populate the discount field on the PO line when the unit price is fetched from the vendor pricelist.
- Modified the pricing logic to ensure the discount is applied to the tax-excluded price.
- PO confirmation process to check if a pricelist already exists for the vendor. If not, a new pricelist line is created, including the discount if it is present.

task - 3380306
