### PR TITLE
[FIX] hr_holidays: Properly make 'My Time Off' action buttons invisible

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -516,13 +516,16 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//button[@name='action_approve']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="states"/>
+                <attribute name="attrs">{'invisible': 1}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_validate']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="states"/>
+                <attribute name="attrs">{'invisible': 1}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_refuse']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="states"/>
+                <attribute name="attrs">{'invisible': 1}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Since the action buttons are not field nodes, the 'invisible' attribute
doesn't do anything. The only way to make them invisible is to have an
'invisible' key in attrs/modifiers.
    
The 'states' attribute was removed, since ir_ui_view overwrites the
'invisible' item in the modifiers dict if 'states' exists in the node.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
