### PR TITLE
[FIX] discuss: channel name overflow

### DIFF
--- a/addons/mail/static/src/discuss/core/web/channel_selector.xml
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.xml
@@ -12,13 +12,14 @@
             t-on-click="(ev) => markEventHandled(ev, 'channelSelector.onClickInput')"
             t-on-keydown="onKeydownInput"
             type="text"
+            maxlength="100"
         />
     </div>
     <NavigableList class="'o-discuss-ChannelSelector-list z-index-1'" t-props="navigableListProps"/>
 </t>
 
 <t t-name="discuss.ChannelSelector.channel" owl="1">
-    <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
+    <strong class="px-2 py-1 align-self-center flex-shrink-1 text-break">
         <t t-if="option.channelId === '__create__'">
             Create: #
         </t>


### PR DESCRIPTION
Before this commit:
The channel name used to overflow in the channel suggestion section and also there was also no limit on the lenght of how long the name of the channel can be.

After this commit:
The name will not overflow in the channnel suggestion section and the user will also have a certain limit on the length of channel name:

Task id: 3366608