### PR TITLE
[IMP] payment_adyen: replace API URLs with an account-specific URL prefix

### DIFF
--- a/addons/payment_adyen/controllers/main.py
+++ b/addons/payment_adyen/controllers/main.py
@@ -59,10 +59,7 @@ class AdyenController(http.Controller):
             'channel': 'Web',
         }
         response_content = provider_sudo._adyen_make_request(
-            url_field_name='adyen_checkout_api_url',
-            endpoint='/paymentMethods',
-            payload=data,
-            method='POST'
+            endpoint='/paymentMethods', payload=data, method='POST'
         )
         _logger.info("paymentMethods request response:\n%s", pprint.pformat(response_content))
         return response_content
@@ -139,10 +136,7 @@ class AdyenController(http.Controller):
 
         # Make the payment request to Adyen
         response_content = provider_sudo._adyen_make_request(
-            url_field_name='adyen_checkout_api_url',
-            endpoint='/payments',
-            payload=data,
-            method='POST'
+            endpoint='/payments', payload=data, method='POST'
         )
 
         # Handle the payment request response
@@ -171,10 +165,7 @@ class AdyenController(http.Controller):
         # Make the payment details request to Adyen
         provider_sudo = request.env['payment.provider'].browse(provider_id).sudo()
         response_content = provider_sudo._adyen_make_request(
-            url_field_name='adyen_checkout_api_url',
-            endpoint='/payments/details',
-            payload=payment_details,
-            method='POST'
+            endpoint='/payments/details', payload=payment_details, method='POST'
         )
 
         # Handle the payment details request response

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -96,10 +96,7 @@ class PaymentTransaction(models.Model):
         # Make the payment request to Adyen
         try:
             response_content = self.provider_id._adyen_make_request(
-                url_field_name='adyen_checkout_api_url',
-                endpoint='/payments',
-                payload=data,
-                method='POST',
+                endpoint='/payments', payload=data, method='POST'
             )
         except ValidationError as e:
             if self.operation == 'offline':
@@ -143,7 +140,6 @@ class PaymentTransaction(models.Model):
             'reference': refund_tx.reference,
         }
         response_content = refund_tx.provider_id._adyen_make_request(
-            url_field_name='adyen_checkout_api_url',
             endpoint='/payments/{}/refunds',
             endpoint_param=self.provider_reference,
             payload=data,
@@ -183,7 +179,6 @@ class PaymentTransaction(models.Model):
             'reference': self.reference,
         }
         response_content = self.provider_id._adyen_make_request(
-            url_field_name='adyen_checkout_api_url',
             endpoint='/payments/{}/captures',
             endpoint_param=self.provider_reference,
             payload=data,
@@ -219,7 +214,6 @@ class PaymentTransaction(models.Model):
             'reference': self.reference,
         }
         response_content = self.provider_id._adyen_make_request(
-            url_field_name='adyen_checkout_api_url',
             endpoint='/payments/{}/cancels',
             endpoint_param=self.provider_reference,
             payload=data,

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -14,8 +14,7 @@ class AdyenCommon(PaymentCommon):
             'adyen_api_key': 'dummy',
             'adyen_client_key': 'dummy',
             'adyen_hmac_key': '12345678',
-            'adyen_checkout_api_url': 'https://this.is.an.url',
-            'adyen_recurring_api_url': 'https://this.is.an.url',
+            'adyen_api_url_prefix': 'prefix',
         })
 
         # Override default values

--- a/addons/payment_adyen/views/payment_provider_views.xml
+++ b/addons/payment_adyen/views/payment_provider_views.xml
@@ -12,8 +12,7 @@
                     <field name="adyen_api_key" required="code == 'adyen' and state != 'disabled'" password="True"/>
                     <field name="adyen_client_key" required="code == 'adyen' and state != 'disabled'"/>
                     <field name="adyen_hmac_key" required="code == 'adyen' and state != 'disabled'" password="True"/>
-                    <field name="adyen_checkout_api_url" required="code == 'adyen' and state != 'disabled'"/>
-                    <field name="adyen_recurring_api_url" required="code == 'adyen' and state != 'disabled'"/>
+                    <field name="adyen_api_url_prefix" required="code == 'adyen' and state != 'disabled'"/>
                 </group>
             </group>
             <group name="provider_config" position='before'>


### PR DESCRIPTION
Before this commit, users were required to compute the API URLs, which is
specific to each Adyen account, themselves. After this commit, users
will be able to copy their account prefix from Adyen to automatically
generate the API URLs.

task-3338126

See also:
- https://github.com/odoo/upgrade/pull/4876
