### PR TITLE
[IMP] product,website_sale: improve image-attribute display type

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -29,6 +29,7 @@ class ProductAttribute(models.Model):
         selection=[
             ('radio', 'Radio'),
             ('pills', 'Pills'),
+            ('pills_with_images', 'Pills with Images'),
             ('select', 'Select'),
             ('color', 'Color'),
         ],

--- a/addons/product/models/product_attribute_value.py
+++ b/addons/product/models/product_attribute_value.py
@@ -10,6 +10,7 @@ class ProductAttributeValue(models.Model):
     _name = 'product.attribute.value'
     # if you change this _order, keep it in sync with the method
     # `_sort_key_variant` in `product.template'
+    _inherit = ['image.mixin']
     _order = 'attribute_id, sequence, id'
     _description = "Attribute Value"
 

--- a/addons/product/views/product_attribute_views.xml
+++ b/addons/product/views/product_attribute_views.xml
@@ -45,6 +45,7 @@
                                 <field name="display_type" invisible="1"/>
                                 <field name="is_custom" groups="product.group_product_variant"/>
                                 <field name="html_color" attrs="{'column_invisible': [('parent.display_type', '!=', 'color')]}" widget="color"/>
+                                <field name="image_1920" widget='image' class="oe_avatar text-start float-none" options="{'preview_image': 'image_128'}" attrs="{'column_invisible': [('parent.display_type', 'not in', ['color', 'pills_with_images'])]}"/>
                             </tree>
                         </field>
                     </page>

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -552,7 +552,7 @@ class WebsiteSale(http.Controller):
         """
         if (
             not request.env.user.has_group('website.group_website_restricted_editor')
-            or image_res_model not in ['product.product', 'product.template', 'product.image']
+            or image_res_model not in ['product.product', 'product.template', 'product.image', 'product.attribute.value']
         ):
             raise NotFound()
 
@@ -561,6 +561,8 @@ class WebsiteSale(http.Controller):
             request.env['product.product'].browse(image_res_id).write({'image_1920': False})
         elif image_res_model == 'product.template':
             request.env['product.template'].browse(image_res_id).write({'image_1920': False})
+        elif image_res_model == 'product.attribute.value':
+            request.env['product.attribute.value'].browse(image_res_id).write({'image_1920': False})
         else:
             request.env['product.image'].browse(image_res_id).unlink()
 

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -380,7 +380,7 @@ var VariantMixin = {
             combinationData.parent_exclusions = parentExclusions;
         }
         $parent
-            .find('option, input, label, .o_variant_pills')
+            .find('option, input, label, .o_variant_pills, .o_variant_img_pills')
             .removeClass('css_not_available')
             .attr('title', function () { return $(this).data('value_name') || ''; })
             .data('excluded-by', '');
@@ -501,7 +501,7 @@ var VariantMixin = {
             .find('option[value=' + attributeValueId + '], input[value=' + attributeValueId + ']');
         $input.addClass('css_not_available');
         $input.closest('label').addClass('css_not_available');
-        $input.closest('.o_variant_pills').addClass('css_not_available');
+        $input.closest('.o_variant_pills, .o_variant_img_pills').addClass('css_not_available');
 
         if (excludedBy && attributeNames) {
             var $target = $input.is('option') ? $input : $input.closest('label').add($input);

--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -956,6 +956,7 @@ options.registry.ReplaceMedia.include({
     async willStart() {
         const parent = this.$target.parent();
         this.isProductPageImage = this.$target.closest('.o_wsale_product_images').length > 0;
+        this.isProductAttributeImage = this.$target.closest('.o_wsale_product_attribute').length > 0;
         // Product Page images may be the product's image or a record of `product.image`
         this.recordModel = parent.data('oe-model');
         this.recordId = parent.data('oe-id');
@@ -991,7 +992,10 @@ options.registry.ReplaceMedia.include({
      * @override
      */
     async _computeWidgetVisibility(widgetName, params) {
-        if (['media_wsale_resequence', 'media_wsale_remove'].includes(widgetName)) {
+        if(['media_wsale_remove'].includes(widgetName)) {
+            return this.isProductPageImage || this.isProductAttributeImage;
+        }
+        if (['media_wsale_resequence'].includes(widgetName)) {
             // Only include these if we are inside of the product's page images
             return this.isProductPageImage;
         }

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -170,7 +170,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
                         $toSelect.prop('selected', true);
                     }
                 });
-                this._changeAttribute(['.css_attribute_color', '.o_variant_pills']);
+                this._changeAttribute(['.css_attribute_color', '.o_variant_pills', '.o_variant_img_pills']);
             }
         }
     },

--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -197,6 +197,21 @@ label.css_attribute_color.css_not_available {
             background-color: map-get($grays, '200');
         }
     }
+
+    .o_variant_img_pills {
+        min-width: 110px;
+        min-height: 127px;
+        cursor: default;
+
+        &.btn.active {
+            background-color: map-get($theme-colors, 'primary');
+        }
+        &:not(.active) {
+            color: map-get($grays, '600');
+            background-color: $white;
+            border: 1px solid map-get($grays, '600');
+        }
+    }
 }
 
 .o_product_configurator {

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -220,6 +220,7 @@
             <we-select string="Display Type" data-no-preview="true">
                 <we-button data-set-display-type="radio">Radio</we-button>
                 <we-button data-set-display-type="pills">Pills</we-button>
+                <we-button data-set-display-type="pills_with_images">Pills With Images</we-button>
                 <we-button data-set-display-type="select">Select</we-button>
                 <we-button data-set-display-type="color">Color</we-button>
             </we-select>

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -64,29 +64,34 @@
                         </ul>
                     </t>
 
-                    <t t-if="ptal.attribute_id.display_type == 'pills'">
-                        <ul t-att-data-attribute_id="ptal.attribute_id.id"
-                            t-attf-class="btn-group-toggle list-inline list-unstyled o_wsale_product_attribute #{'d-none' if single_and_custom else ''}"
+                    <t t-if="ptal.attribute_id.display_type in ['pills','pills_with_images']">
+                        <t t-set="is_image_pill" t-value="ptal.attribute_id.display_type == 'pills_with_images'"/>
+                        <ul t-if="not single_and_custom"
+                            t-att-data-attribute_id="ptal.attribute_id.id"
+                            t-attf-class="btn-group-toggle list-inline list-unstyled o_wsale_product_attribute #{'d-flex flex-wrap' if is_image_pill else ''}"
                             data-bs-toggle="buttons">
                             <t t-foreach="ptal.product_template_value_ids._only_active()" t-as="ptav">
-                                <li t-attf-class="o_variant_pills btn btn-primary mb-1 list-inline-item js_attribute_value #{'active' if ptav in combination else ''}">
-                                    <input type="radio"
-                                        t-attf-class="js_variant_change #{ptal.attribute_id.create_variant}"
-                                        t-att-checked="ptav in combination"
-                                        t-att-name="'ptal-%s' % ptal.id"
-                                        t-att-value="ptav.id"
-                                        t-att-data-value_id="ptav.id"
-                                        t-att-id="ptav.id"
-                                        t-att-data-value_name="ptav.name"
-                                        t-att-data-attribute_name="ptav.attribute_id.name"
-                                        t-att-data-is_custom="ptav.is_custom"
-                                        t-att-data-is_single_and_custom="single_and_custom"
-                                        t-att-autocomplete="off"/>
-                                    <div class="radio_input_value o_variant_pills_input_value">
-                                        <span t-field="ptav.name"/>
-                                        <t t-call="website_sale.badge_extra_price"/>
-                                    </div>
-                                </li>
+                                <label>
+                                    <li t-attf-class="#{'o_variant_img_pills me-2 d-flex flex-column' if is_image_pill else 'o_variant_pills'} btn btn-primary mb-1 list-inline-item js_attribute_value #{'active' if ptav in combination else ''}">
+                                        <div t-if="is_image_pill and not ptav.is_custom" t-field="ptav.product_attribute_value_id.image_1920" t-options="{'widget': 'image', 'class': 'o_image_64_contain'}"/>
+                                        <input type="radio"
+                                            t-attf-class="#{'d-none' if is_image_pill else ''} js_variant_change #{ptal.attribute_id.create_variant}"
+                                            t-att-checked="ptav in combination"
+                                            t-att-name="'ptal-%s' % ptal.id"
+                                            t-att-value="ptav.id"
+                                            t-att-data-value_id="ptav.id"
+                                            t-att-id="ptav.id"
+                                            t-att-data-value_name="ptav.name"
+                                            t-att-data-attribute_name="ptav.attribute_id.name"
+                                            t-att-data-is_custom="ptav.is_custom"
+                                            t-att-data-is_single_and_custom="single_and_custom"
+                                            t-att-autocomplete="off"/>
+                                        <div class="radio_input_value o_variant_pills_input_value m-auto">
+                                            <span t-field="ptav.name" t-attf-class="#{'d-block' if is_image_pill else ''}"/>
+                                            <t t-call="website_sale.badge_extra_price"/>
+                                        </div>
+                                    </li>
+                                </label>
                             </t>
                         </ul>
                     </t>
@@ -94,9 +99,12 @@
                     <t t-if="ptal.attribute_id.display_type == 'color'">
                         <ul t-att-data-attribute_id="ptal.attribute_id.id" t-attf-class="list-inline o_wsale_product_attribute #{'d-none' if single_and_custom else ''}">
                             <li t-foreach="ptal.product_template_value_ids._only_active()" t-as="ptav" class="list-inline-item me-1">
-                                <label t-attf-style="background-color:#{ptav.html_color or ptav.product_attribute_value_id.name if not ptav.is_custom else ''}"
-                                    t-attf-class="css_attribute_color #{'active' if ptav in combination else ''} #{'custom_value' if ptav.is_custom else ''} #{'transparent' if (not ptav.is_custom and not ptav.html_color) else ''}">
-                                    <input type="radio"
+                                <t t-if="ptav.product_attribute_value_id.image_1920" t-set="img_url" t-value="website.image_url(ptav.product_attribute_value_id, 'image_1920')"/>
+                                <t t-if="img_url" t-set="img_style" t-value="'background:url('+img_url+'); background-size:cover;'"/>
+                                <t t-set="color_style" t-value="'background:'+str(ptav.html_color or ptav.product_attribute_value_id.name if not ptav.is_custom else '')"/>
+                                <label t-attf-style="#{img_style if ptav.product_attribute_value_id.image_1920 else color_style}"
+                                        t-attf-class="css_attribute_color #{'active' if ptav in combination else ''} #{'custom_value' if ptav.is_custom else ''} #{'transparent' if (not ptav.is_custom and not ptav.html_color) else ''}">
+                                      <input type="radio"
                                         t-attf-class="js_variant_change  #{ptal.attribute_id.create_variant}"
                                         t-att-checked="ptav in combination"
                                         t-att-name="'ptal-%s' % ptal.id"


### PR DESCRIPTION
With this commit,

1. A new variant display type = "Pills with images" has been added. Now, users can have the option to select the display type as "Pills with images" if they want to add an image along with the attribute.

2. Image options for the color variant have been implemented. Users can now add images to represent pattern colors such as "leopard" instead of solely selecting a solid color.

task-3381738

1. User can have a new option to choose "Pills with image".
![display_type_option](https://github.com/odoo/odoo/assets/125337508/77a16b4e-d9b8-4b0e-9d7c-c43524dca5ce)

2. User can add the image for the variant.
![color_pattern](https://github.com/odoo/odoo/assets/125337508/bdd1f672-c96d-438d-994c-b220a2b6542c)
![variant_image](https://github.com/odoo/odoo/assets/125337508/ad7798a7-662b-43a9-98d1-89f34c914ec2)

3. This is how it looks in the end.
![how_it_display](https://github.com/odoo/odoo/assets/125337508/2c10d170-7181-4f54-9713-576b54f03d25)
