### PR TITLE
[IMP] mass_mailing: do not load images on add sidebar and commitChanges

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -535,6 +535,7 @@ export class MassMailingHtmlField extends HtmlField {
         for (const img of $container.find("img")) {
             const $img = $(img);
             const src = $img.attr("src");
+            $img.removeAttr('loading');
 
             let m = src.match(/^\/web\/image\/\w+\.s_default_image_(?:theme_[a-z]+_)?(.+)$/);
             if (!m) {

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -141,6 +141,7 @@ export class MassMailingHtmlField extends HtmlField {
             const clonedBody = clonedHtmlNode.querySelector('body');
             const clonedIframeTarget = clonedHtmlNode.querySelector('#iframe_target');
             clonedBody.replaceChildren(clonedIframeTarget);
+            clonedBody.querySelector('.iframe-utils-zone').remove();
             clonedHtmlNode.querySelectorAll('script').forEach(script => script.remove()); // Remove scripts.
             iframe.srcdoc = clonedHtmlNode.outerHTML;
             const iframePromise = new Promise((resolve) => {

--- a/addons/mass_mailing/static/src/js/snippets.editor.js
+++ b/addons/mass_mailing/static/src/js/snippets.editor.js
@@ -32,11 +32,26 @@ export const MassMailingSnippetsMenu = snippetsEditor.SnippetsMenu.extend({
             this.$editable = this.options.wysiwyg.getEditable();
         });
     },
+    /**
+     * @override
+     */
+    callPostSnippetDrop: async function ($target) {
+        $target.find('img[loading=lazy]').removeAttr('loading');
+        return this._super(...arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * @override
+     */
+    _computeSnippetTemplates: function (html) {
+        const $html = $(`<div>${html}</div>`);
+        $html.find('img').attr('loading', 'lazy');
+        return this._super($html.html().trim());
+    },
     /**
      * @override
      */


### PR DESCRIPTION
Images in mass_mailing are not lazy loaded, which is deliberate for the mailing itself and its conversion, but when we load the sidebar we add the HTML to all the snippets and hide it so if these images are not lazy loaded, they all get loaded along with the sidebar, which is slow and unnecessary.

Additionally, failing to remove the sidebar from the conversion iframe made these images load again when committing changes.

This loads the images only once we add them to the mailing, which is when we remove the lazy loading attribute.

task-3323894

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
