### PR TITLE
Master knowledge return of the collaborative abd

### DIFF
--- a/addons/web_editor/models/ir_websocket.py
+++ b/addons/web_editor/models/ir_websocket.py
@@ -23,7 +23,7 @@ class IrWebsocket(models.AbstractModel):
                         res_id = int(match[3])
 
                         # Verify access to the edition channel.
-                        if not self.env.user._is_internal():
+                        if self.env.user._is_public():
                             raise AccessDenied()
 
                         document = self.env[model_name].browse([res_id])

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1158,6 +1158,7 @@ export class OdooEditor extends EventTarget {
         this._handleCommandHint();
         this.multiselectionRefresh();
         this.observerActive();
+        this.dispatchEvent(new Event('historyResetFromSteps'));
     }
     historyGetMissingSteps({fromStepId, toStepId}) {
         const fromIndex = this._historySteps.findIndex(x => x.id === fromStepId);
@@ -1652,6 +1653,7 @@ export class OdooEditor extends EventTarget {
         this.historyResetLatestComputedSelection();
         this._handleCommandHint();
         this.multiselectionRefresh();
+        this.dispatchEvent(new Event('historyExternalSteps'));
     }
 
     // Multi selection

--- a/addons/web_editor/static/src/js/wysiwyg/PeerToPeer.js
+++ b/addons/web_editor/static/src/js/wysiwyg/PeerToPeer.js
@@ -173,8 +173,8 @@ export class PeerToPeer {
     }
 
     stop() {
-        this._stopped = true;
         this.closeAllConnections();
+        this._stopped = true;
     }
 
     getConnectedClientIds() {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -147,8 +147,7 @@ const Wysiwyg = Widget.extend({
         let editorCollaborationOptions;
         if (
             options.collaborationChannel &&
-            // Hack: check if mail module is installed.
-            this.getSession()['notification_type']
+            this._hasICEServers()
         ) {
             editorCollaborationOptions = this.setupCollaboration(options.collaborationChannel);
             if (this.options.collaborativeTrigger === 'start') {
@@ -2715,7 +2714,10 @@ const Wysiwyg = Widget.extend({
     _bindOnBlur() {
         this.$editable.on('blur', this._onBlur);
     },
-
+    _hasICEServers() {
+        // Hack: check if mail module is installed.
+        return !!this.getSession()['notification_type'];
+    },
 });
 Wysiwyg.activeCollaborationChannelNames = new Set();
 Wysiwyg.activeWysiwygs = new Set();


### PR DESCRIPTION
Enable the collaborative mode in Knowledge and allow portal users
to use it.

In Knowledge, there is a custom `KnowledgeHtmlField` which adds a menu
placeholder if the `HtmlField` value is empty. It evaluates if it is empty after
each `historyStep`.

This commit introduces a new `historyExternalSteps` event so that the
`KnowledgeHtmlField` is able to properly hide/show that menu even after a
collaborator made the value empty.

Encapsulate the `mail` ICE servers availability check in an overridable
function, since the hack does not work in a portal context, but Knowledge portal
users should be allowed to use the collaborative feature. Knowledge will
override the session check by always returning true, since mail is a dependency
of Knowledge and is therefore always installed with it.

Allow access to the edition channel for portal users.

task-3378266
