### PR TITLE
[FIX] website_sale: handle invalid literal issue for category in product page

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -612,7 +612,10 @@ class WebsiteSale(http.Controller):
         ProductCategory = request.env['product.public.category']
 
         if category:
-            category = ProductCategory.browse(int(category)).exists()
+            try:
+                category = ProductCategory.browse(int(category)).exists()
+            except ValueError as e:
+                raise ValidationError(_("Invalid value error")) from e
 
         attrib_list = request.httprequest.args.getlist('attrib')
         attrib_values = [[int(x) for x in v.split("-")] for v in attrib_list if v]


### PR DESCRIPTION
When a user search product on a website and click on it. After that modify the URL  like '/shop/warranty-30?category=string', instead of the '/shop/warranty-30?category=1'.  in that case, the trace back will be generated.

Steps to produce an issue:
- Install the website_sale module.
- Go to the Website > Shop, search for a product, and then click on it.
- Now change the URL  eg.  '//shop/warranty-30?category=any string. After that, a traceback will be generated.

Error: invalid literal for int() with base 10: 'aze'

If applied, this commit will solve the issue of the invalid literal for integer, when the user enters the URL like '/shop/warranty-30?category=string', instead of the '/shop/warranty-30?category=1'.

Sentry  Traceback:
```ValueError: invalid literal for int() with base 10: '8#attr=43'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 453, in product
    return request.render("website_sale.product", self._prepare_product_values(product, category, search, **kwargs))
  File "addons/website_sale_product_configurator/controllers/main.py", line 42, in _prepare_product_values
    values = super(WebsiteSale, self)._prepare_product_values(product, category, search, **kwargs)
  File "addons/website_sale/controllers/main.py", line 617, in _prepare_product_values
    category = ProductCategory.browse(int(category)).exists()
```

Sentry-4084912758
