### PR TITLE
[FIX] sale_{timesheet,project}: avoid recompute SOL when allow_billable is changed

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -672,7 +672,7 @@ class ProjectTask(models.Model):
     def SELF_READABLE_FIELDS(self):
         return super().SELF_READABLE_FIELDS | {'allow_billable', 'sale_order_id', 'sale_line_id', 'display_sale_order_button'}
 
-    @api.depends('sale_line_id', 'project_id', 'partner_id.commercial_partner_id', 'allow_billable')
+    @api.depends('sale_line_id', 'project_id', 'partner_id.commercial_partner_id')
     def _compute_sale_order_id(self):
         for task in self:
             if not task.allow_billable:
@@ -695,7 +695,7 @@ class ProjectTask(models.Model):
         (self - billable_task).partner_id = False
         super(ProjectTask, billable_task)._compute_partner_id()
 
-    @api.depends('partner_id.commercial_partner_id', 'sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'milestone_id.sale_line_id', 'allow_billable')
+    @api.depends('partner_id.commercial_partner_id', 'sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'milestone_id.sale_line_id')
     def _compute_sale_line(self):
         for task in self:
             if not task.allow_billable:

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -66,7 +66,7 @@ class AccountAnalyticLine(models.Model):
                 else:
                     timesheet.timesheet_invoice_type = 'other_costs'
 
-    @api.depends('task_id.sale_line_id', 'project_id.sale_line_id', 'employee_id', 'project_id.allow_billable')
+    @api.depends('task_id.sale_line_id', 'project_id.sale_line_id', 'employee_id')
     def _compute_so_line(self):
         for timesheet in self.filtered(lambda t: not t.is_so_line_edited and t._is_not_billed()):  # Get only the timesheets are not yet invoiced
             timesheet.so_line = timesheet.project_id.allow_billable and timesheet._timesheet_determine_sale_line()

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -568,7 +568,7 @@ class ProjectTask(models.Model):
         for task in self:
             task.analytic_account_active = task.analytic_account_active or task.so_analytic_account_id.active
 
-    @api.depends('partner_id.commercial_partner_id', 'sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
+    @api.depends('partner_id.commercial_partner_id', 'sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id')
     def _compute_sale_line(self):
         super()._compute_sale_line()
         for task in self:

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -176,3 +176,18 @@ class TestProject(TestCommonSaleTimesheet):
         })
 
         self.assertEqual(self.project_global.analytic_account_balance, expected_analytic_account_balance)
+
+    def test_allow_billable_in_project_change(self):
+        projects = self.so.project_ids
+        self.assertEqual(len(projects), 2)
+        projects.allow_billable = False
+        self.assertFalse(projects.partner_id)
+        self.assertFalse(projects.sale_line_id)
+        self.assertFalse(projects.tasks.partner_id)
+        self.assertFalse(projects.tasks.sale_line_id)
+
+        projects.allow_billable = True
+        self.assertFalse(projects.partner_id)
+        self.assertFalse(projects.sale_line_id)
+        self.assertFalse(projects.tasks.partner_id)
+        self.assertFalse(projects.tasks.sale_line_id)


### PR DESCRIPTION
Before this commit, since #111335, the partner is removed and not visible when allow_billable is set to False. It means when the user set `allow_billable` on a project, the partner will be always empty and so it is not really needed to recompute it since with no partner set, no SOL could be found.

This commit removes `allow_billable` in the dependencies to avoid triggering the compute of SOL field in task and timesheet model
 when the `allow_billable` is changed in the project linked.
