### PR TITLE
[IMP] stock: improve the pivot view for better visualization of stock variation

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -194,6 +194,17 @@
         </field>
     </record>
 
+    <record id="view_stock_move_line_pivot" model="ir.ui.view">
+        <field name="name">stock.move.line.pivot</field>
+        <field name="model">stock.move.line</field>
+        <field name="arch" type="xml">
+            <pivot string="Moves History">
+                <field name="product_category_name" type="col"/>
+                <field name="date" interval="month" type="row"/>
+            </pivot>
+        </field>
+    </record>
+
     <record id="action_revert_inventory_adjustment" model="ir.actions.server">
         <field name="name">Revert Inventory Adjustment</field>
         <field name="model_id" ref="stock.model_stock_move_line"/>
@@ -209,7 +220,7 @@
             <field name="res_model">stock.move.line</field>
             <field name="view_mode">tree,kanban,pivot,form</field>
             <field name="view_id" ref="view_move_line_tree"/>
-            <field name="context">{'search_default_done': 1, 'create': 0}</field>
+            <field name="context">{'search_default_done': 1, 'create': 0, 'pivot_measures': ['qty_done', '__count__']}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     There's no product move yet

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -6,9 +6,9 @@
             <field name="model">stock.move</field>
             <field name="arch" type="xml">
                 <pivot string="Stock Moves Analysis" sample="1">
-                    <field name="product_id" type="row"/>
                     <field name="location_dest_id" groups="stock.group_stock_multi_locations" type="row"/>
-                    <field name="product_uom_qty" type="measure"/>
+                    <field name="picking_type_id" type="col"/>
+                    <field name="date" interval="month" type="row"/>
                 </pivot>
             </field>
         </record>
@@ -389,6 +389,7 @@
                     <filter string="Date" name="today" date="date" help="Scheduled or processing date"/>
                     <group expand="0" string="Group By">
                         <filter string="Product" name="by_product" domain="[]"  context="{'group_by': 'product_id'}"/>
+                        <filter string="Operation Type" name="groupby_picking_type_id" domain="[]"  context="{'group_by': 'picking_type_id'}"/>
                         <filter string="Picking" name="groupby_picking_id" domain="[]"  context="{'group_by': 'picking_id'}"/>
                         <filter string="Source Location" name="groupby_location_id" domain="[]" context="{'group_by': 'location_id'}" groups="stock.group_stock_multi_locations"/>
                         <filter string="Destination Location" name="groupby_dest_location_id" domain="[]" context="{'group_by': 'location_dest_id'}" groups="stock.group_stock_multi_locations"/>
@@ -401,11 +402,13 @@
         </record>
 
         <record id="stock_move_action" model="ir.actions.act_window">
-            <field name="name">Stock Moves</field>
+            <field name="name">Move Analysis</field>
             <field name="res_model">stock.move</field>
             <field name="view_id" ref="view_move_tree"/>
             <field name="search_view_id" ref="view_move_search"/>
-            <field name="context">{'search_default_done': 1}</field>
+            <field name="context">{'search_default_done': 1,
+                'pivot_measures': ['quantity_done', '__count__'],
+                }</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 No stock move found
@@ -418,7 +421,7 @@
         </record>
 
         <record model="ir.actions.act_window.view" id="action_stock_move_tree_all">
-            <field name="sequence" eval="1"/>
+            <field name="sequence" eval="3"/>
             <field name="view_mode">tree</field>
             <field name="view_id" ref="view_move_tree"/>
             <field name="act_window_id" ref="stock_move_action"/>
@@ -432,7 +435,7 @@
         </record>
 
         <record model="ir.actions.act_window.view" id="action_stock_move_pivot_all">
-            <field name="sequence" eval="3"/>
+            <field name="sequence" eval="1"/>
             <field name="view_mode">pivot</field>
             <field name="view_id" ref="view_move_pivot"/>
             <field name="act_window_id" ref="stock_move_action"/>
@@ -479,6 +482,6 @@
             </field>
         </record>
 
-    <menuitem action="stock_move_action" id="stock_move_menu" parent="stock.menu_warehouse_report" sequence="230" groups="base.group_no_one"/>
+    <menuitem action="stock_move_action" id="stock_move_menu" name="Move Analysis" parent="stock.menu_warehouse_report" sequence="230"/>
 
 </odoo>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -151,7 +151,7 @@
         </field>
     </record>
 
-    <menuitem id="menu_valuation" name="Valuation" parent="stock.menu_warehouse_report" sequence="250" action="stock_valuation_layer_action" groups="base.group_no_one"/>
+    <menuitem id="menu_valuation" name="Valuation" parent="stock.menu_warehouse_report" sequence="250" action="stock_valuation_layer_action"/>
 
     <record id="stock_valuation_layer_picking" model="ir.ui.view">
         <field name="name">stock.valuation.layer.picking</field>


### PR DESCRIPTION
- Menu stock move renamed into 'moves analysis'
- the `moves analysis` menu presents an open default pivot view with predefined filters and group by that facilitate the visualization of stock variations based on quantity
- Add some default filters too in the moves history pivot view

