### PR TITLE
[FIX] web, hr_holidays: Check the attrs of the calendar for popover rendering

### DIFF
--- a/addons/hr_holidays/static/src/js/time_off_calendar.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar.js
@@ -20,8 +20,8 @@ odoo.define('hr_holidays.dashboard.view_custo', function(require) {
         init: function (parent, eventInfo) {
             this._super.apply(this, arguments);
             const state = this.event.extendedProps.record.state;
-            this.canDelete = state && ['validate', 'refuse'].indexOf(state) === -1;
-            this.canEdit = state !== undefined;
+            this.canDelete = this.canDelete && state && ['validate', 'refuse'].indexOf(state) === -1;
+            this.canEdit = this.canEdit && state !== undefined;
             this.displayFields = [];
 
             if (this.modelName === "hr.leave.report.calendar") {

--- a/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
+++ b/addons/hr_holidays/static/src/js/time_off_calendar_employee.js
@@ -21,8 +21,8 @@ odoo.define('hr_holidays.employee.dashboard.views', function(require) {
         init: function (parent, eventInfo) {
             this._super.apply(this, arguments);
             const state = this.event.extendedProps.record.state;
-            this.canDelete = state && ['validate', 'refuse'].indexOf(state) === -1;
-            this.canEdit = state !== undefined;
+            this.canDelete = this.canDelete && state && ['validate', 'refuse'].indexOf(state) === -1;
+            this.canEdit = this.canEdit && state !== undefined;
             this.displayFields = [];
 
             if (this.modelName === "hr.leave.report.calendar") {

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_popover.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_popover.js
@@ -30,7 +30,8 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
         this.fields = eventInfo.fields;
         this.event = eventInfo.event;
         this.modelName = eventInfo.modelName;
-        this._canDelete = eventInfo.canDelete;
+        this.canDelete = eventInfo.canDelete;
+        this.canEdit = eventInfo.canEdit;
         this.popoverFields = eventInfo.popoverFields;
     },
     /**
@@ -77,7 +78,7 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
      * @return {boolean}
      */
     isEventDeletable() {
-        return this._canDelete;;
+        return this.canDelete;
     },
     /**
      * @return {boolean}
@@ -89,7 +90,7 @@ var CalendarPopover = Widget.extend(WidgetAdapterMixin, StandaloneFieldManagerMi
      * @return {boolean}
      */
     isEventEditable() {
-        return true;
+        return this.canEdit;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_renderer.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_renderer.js
@@ -208,6 +208,7 @@ return AbstractRenderer.extend({
         this.hideDate = params.hideDate;
         this.hideTime = params.hideTime;
         this.canDelete = params.canDelete;
+        this.canEdit = params.canEdit;
         this.canCreate = params.canCreate;
         this.scalesInfo = params.scalesInfo;
         this._isInDOM = false;
@@ -849,6 +850,7 @@ return AbstractRenderer.extend({
             event: eventData,
             modelName: this.model,
             canDelete: this.canDelete,
+            canEdit: this.canEdit,
             popoverFields: this.popoverFields,
         };
 

--- a/addons/web/static/src/legacy/js/views/calendar/calendar_view.js
+++ b/addons/web/static/src/legacy/js/views/calendar/calendar_view.js
@@ -187,6 +187,7 @@ var CalendarView = AbstractView.extend({
         this.rendererParams.hideDate = utils.toBoolElse(attrs.hide_date || '', false);
         this.rendererParams.hideTime = utils.toBoolElse(attrs.hide_time || '', false);
         this.rendererParams.canDelete = this.controllerParams.activeActions.delete;
+        this.rendererParams.canEdit = this.controllerParams.activeActions.edit;
         this.rendererParams.canCreate = this.controllerParams.activeActions.create;
         this.rendererParams.scalesInfo = scalesInfo;
 


### PR DESCRIPTION
Before this fix, the edit and delete attributes on the calendar view would be ignored on the popover events. Now it takes into account explicitly set attributes before rendering.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
