### PR TITLE
[IMP] timeoff: improve reports ux 

### DIFF
--- a/addons/hr_holidays/report/hr_leave_reports.xml
+++ b/addons/hr_holidays/report/hr_leave_reports.xml
@@ -11,17 +11,14 @@
                 <filter domain="[('state','in',('confirm','validate1'))]" string="To Approve" name="approve"/>
                 <filter string="Approved Requests" domain="[('state', '=', 'validate')]" name="validated"/>
                 <separator/>
-                <filter name="active_types" string="Active Types" domain="[('holiday_status_id.active', '=', True)]" help="Filters only on requests that belong to an time off type that is 'active' (active field is True)"/>
+                <filter string="Time off" domain="[('leave_type', '=', 'request')]" name="leave_type_timeoff"/>
+                <filter string="Allocations" domain="[('leave_type', '=', 'allocation')]" name="leave_type_allocations"/>
                 <separator/>
                 <filter string="My Department" name="department" domain="[('department_id.manager_id.user_id', '=', uid)]" help="My Department"/>
-                <separator/>
-                <filter string="Active Employee" name="active_employee" domain="[('active_employee','=',True)]"/>
                 <separator/>
                 <filter name="year" date="date_from" default_period="this_year" string="Current Year"/>
                 <separator/>
                 <filter string="My Requests" name="my_leaves" domain="[('employee_id.user_id', '=', uid)]"/>
-                <filter string="Archived" name="archived" domain="[('active', '=', False)]"/>
-                <separator/>
                 <field name="department_id" operator="child_of"/>
                 <field name="holiday_status_id"/>
                 <group expand="0" string="Group By">
@@ -39,17 +36,26 @@
         <field name="name">report.hr.holidays.report.leave_all.tree</field>
         <field name="model">hr.leave.report</field>
         <field name="arch" type="xml">
-            <tree create="0" edit="0" delete="0">
-                <button name="action_open_record" type="object" icon="fa-external-link" title="Open" />
-                <field name="employee_id" decoration-muted="not active_employee"/>
+            <tree create="0" edit="0" delete="0" action="action_open_record" type="object">
+                <field name="employee_id"/>
                 <field name="number_of_days" string="Number of Days" sum="Remaining Days"/>
                 <field name="leave_type"/>
                 <field name="date_from"/>
                 <field name="date_to"/>
                 <field name="state"/>
                 <field name="name"/>
-                <field name="active_employee" column_invisible="True"/>
             </tree>
+        </field>
+    </record>
+
+    <record id="hr_leave_report_graph" model="ir.ui.view">
+        <field name="name">report.hr.holidays.report.leave_all.graph</field>
+        <field name="model">hr.leave.report</field>
+        <field name="arch" type="xml">
+            <graph string="Time off Summary" sample="1">
+                <field name="employee_id"/>
+                <field name="number_of_days" string="Duration (Days)" type="measure"/>
+            </graph>
         </field>
     </record>
 
@@ -57,59 +63,24 @@
         <field name="name">report.hr.holidays.report.leave_all.pivot</field>
         <field name="model">hr.leave.report</field>
         <field name="arch" type="xml">
-            <pivot>
-                <field name="employee_id" decoration-muted="not active_employee"/>
+            <pivot string="Time off Summary" sample="1">
+                <field name="employee_id"/>
                 <field name="number_of_days" type="measure"/>
-                <field name="leave_type"/>
-                <field name="date_from"/>
-                <field name="date_to"/>
-                <field name="state"/>
-                <field name="name"/>
-                <field name="active_employee" invisible="1"/>
             </pivot>
         </field>
     </record>
 
-    <record id="hr_leave_report_view_form" model="ir.ui.view">
-        <field name="name">hr.leave.report.view.form</field>
-        <field name="model">hr.leave.report</field>
-        <field name="arch" type="xml">
-            <form>
-                <sheet>
-                    <group>
-                        <group>
-                            <field name="employee_id"/>
-                            <field name="name"/>
-                            <field name="allocation_id" invisible="not allocation_id"/>
-                            <field name="leave_id" invisible="not leave_id"/>
-                            <field name="leave_type" />
-                            <field name="category_id"/>
-                            <field name="state"/>
-                            <field name="date_from"/>
-                            <field name="date_to"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
-                        </group>
-                        <group>
-                            <field name="active_employee"/>
-                            <field name="number_of_days"/>
-                            <field name="department_id"/>
-                            <field name="holiday_status_id"/>
-                            <field name="holiday_type"/>
-                        </group>
-                    </group>
-                </sheet>
-            </form>
-        </field>
-    </record>
-
-    <record id="act_hr_employee_holiday_request" model="ir.actions.server">
-        <field name="name">Time off Analysis</field>
-        <field name="model_id" ref="hr_holidays.model_hr_leave_report"/>
-        <field name="binding_model_id" ref="hr.model_hr_employee"/>
-        <field name="state">code</field>
-        <field name="groups_id" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
-        <field name="code">
-        action = model.action_time_off_analysis()
+    <record id="act_hr_employee_holiday_type" model="ir.actions.act_window">
+        <field name="name">Time Off Analysis</field>
+        <field name="res_model">hr.leave.report</field>
+        <field name="view_mode">graph,tree,pivot</field>
+        <field name="search_view_id" ref="view_hr_holidays_filter_report"/>
+        <field name="domain">[('holiday_type','=','employee')]</field>
+        <field name="context">{'search_default_group_type': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No data yet!
+            </p>
         </field>
     </record>
 

--- a/addons/hr_holidays/views/hr_holidays_views.xml
+++ b/addons/hr_holidays/views/hr_holidays_views.xml
@@ -79,7 +79,7 @@
         id="menu_hr_holidays_summary_all"
         name="by Type"
         parent="menu_hr_holidays_report"
-        action="act_hr_employee_holiday_request"
+        action="act_hr_employee_holiday_type"
         sequence="3"/>
 
     <menuitem

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -55,7 +55,7 @@
                 <separator/>
                 <filter string="Active Employee" name="active_employee" domain="[('active_employee','=',True)]"/>
                 <separator/>
-                <filter name="filter_date_from" date="date_from"/>
+                <filter name="filter_date_from" date="date_from" default_period="this_year" string="Current Year"/>
                 <separator/>
                 <filter name="active_time_off" string="Active"
                     domain="[('holiday_status_id.active', '=', True)]" help="Active Time Off"/>
@@ -772,11 +772,41 @@
         </field>
     </record>
 
+    <record id="view_holiday_list" model="ir.ui.view">
+        <field name="name">hr.holidays.report_list</field>
+        <field name="model">hr.leave</field>
+        <field name="priority">20</field>
+        <field name="arch" type="xml">
+            <tree string="Time Off Summary" sample="1">
+                <field name="employee_id"/>
+                <field name="number_of_days" string="Number of Days" type="measure"/>
+                <field name="date_from"/>
+                <field name="date_to"/>
+                <field name="state"/>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="hr_leave_report_search_view" model="ir.ui.view">
+        <field name="name">he.leave.report.search.view</field>
+        <field name="inherit_id" ref="view_hr_holidays_filter"/>
+        <field name="mode">primary</field>
+        <field name="model">hr.leave</field>
+        <field name="arch" type="xml">
+            <filter name="active_employee" position="replace"/>
+            <filter name="archive" position="replace"/>
+            <filter name="active_time_off" position="replace"/>
+        </field>
+    </record>
+
     <record id="action_hr_available_holidays_report" model="ir.actions.act_window">
         <field name="name">Time Off Analysis</field>
         <field name="res_model">hr.leave</field>
-        <field name="view_mode">graph,pivot,calendar,form</field>
-        <field name="context">{'search_default_year': 1, 'search_default_active_employee': 2, 'search_default_group_employee': 1, 'search_default_group_type': 1}</field>
+        <field name="view_mode">tree,graph,pivot,calendar,form</field>
+        <field name="search_view_id" ref="hr_leave_report_search_view"/>
+        <field name="context">{'search_default_filter_date_from': 1, 'search_default_group_employee': 1, 'search_default_group_type': 1}</field>
+        <field name="domain">[('active', '=', True), ('active_employee','=',True)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No data yet!
@@ -784,8 +814,15 @@
         </field>
     </record>
 
+    <record id="action_window_leave_list" model="ir.actions.act_window.view">
+        <field name="sequence" eval="5"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_holiday_list"/>
+        <field name="act_window_id" ref="action_hr_available_holidays_report"/>
+    </record>
+
     <record id="action_window_leave_graph" model="ir.actions.act_window.view">
-        <field name="sequence" eval="1"/>
+        <field name="sequence" eval="10"/>
         <field name="view_mode">graph</field>
         <field name="view_id" ref="view_holiday_graph"/>
         <field name="act_window_id" ref="action_hr_available_holidays_report"/>


### PR DESCRIPTION
Before this PR if we go to the Time off and go to reporting in that select the to employee  there are graph , calendar, pivot views and there are two default filter active employee , Employee > Type .

And After that when we go to  to type there are list, pivot view  and by default there are 4 filter to the list view of the to type and in list view there is button.

Improvements :

To Employee :
Add the List view and make it default.
And make Current year by  default.

To Type :
Add the graph view and make it default.
Made changes in the filter add Time off Allocations in that filter. Remove that button and use action method to the record.

task-3389174
