### PR TITLE
[FIX] base: restrict deactivation and deletion of Sign up login view

### DIFF
--- a/addons/auth_signup/i18n/auth_signup.pot
+++ b/addons/auth_signup/i18n/auth_signup.pot
@@ -675,6 +675,18 @@ msgid "Welcome to ${object.company_id.name}!"
 msgstr ""
 
 #. module: auth_signup
+#: code:addons/auth_signup/models/ir_ui_view.py:0
+#, python-format
+msgid "You cannot deactivate the Sign up login view."
+msgstr ""
+
+#. module: auth_signup
+#: code:addons/auth_signup/models/ir_ui_view.py:0
+#, python-format
+msgid "You cannot delete the Sign up login view."
+msgstr ""
+
+#. module: auth_signup
 #: code:addons/auth_signup/models/res_users.py:0
 #, python-format
 msgid "You cannot perform this action on an archived user."

--- a/addons/auth_signup/models/__init__.py
+++ b/addons/auth_signup/models/__init__.py
@@ -2,5 +2,6 @@
 
 from . import res_config_settings
 from . import ir_http
+from . import ir_ui_view
 from . import res_partner
 from . import res_users

--- a/addons/auth_signup/models/ir_ui_view.py
+++ b/addons/auth_signup/models/ir_ui_view.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+class View(models.Model):
+    _inherit = 'ir.ui.view'
+
+    @api.constrains('active')
+    def _check_auth_signup_view(self):
+        if self.filtered(lambda v: v.xml_id == 'auth_signup.signup' and not v.active):
+            raise UserError(_("You cannot deactivate the Sign up login view."))
+
+    def unlink(self):
+        if self.filtered(lambda v: v.xml_id == 'auth_signup.signup'):
+            raise UserError(_("You cannot delete the Sign up login view."))
+        return super().unlink()


### PR DESCRIPTION
When user deactivate or delete 'auth_signup.signup' view and tries to access it, the traceback will be generated.

To reproduce the issue:

- Install 'website' module
- Go to Settings > Technical > User Interface > Views
- Deactivate or delete 'auth_signup.signup' view
- Go to website configuration settings and select 'Free sign up'
- Go to signup page

Traceback in sentry -
```
KeyError: ('ir.ui.view', <function View._get_view_id at 0x7fdd61ea5fc0>, 8, False, 'auth_signup.signup', (3,))
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: View 'auth_signup.signup' in website 3 not found
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 192, in _dispatch
    result.flatten()
  File "odoo/http.py", line 1241, in flatten
    self.response.append(self.render())
  File "odoo/http.py", line 1233, in render
    return request.env["ir.ui.view"]._render_template(self.template, self.qcontext)
  File "addons/website/models/ir_ui_view.py", line 434, in _render_template
    view = self._get(template).sudo()
  File "odoo/addons/base/models/ir_ui_view.py", line 2059, in _get
    return self.browse(self._get_view_id(view_ref))
  File "<decorator-gen-279>", line 2, in _get_view_id
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "addons/website/models/ir_ui_view.py", line 387, in _get_view_id
    raise ValueError('View %r in website %r not found' % (xml_id, self._context['website_id']))
```

sentry-4282368596