### PR TITLE
[IMP] website_slides: allow multiple correct answers

### DIFF
--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_embed_detection
 from . import test_gamification_karma
 from . import test_security
 from . import test_slide_channel
+from . import test_slide_question
 from . import test_slide_resource
 from . import test_slide_slide
 from . import test_statistics

--- a/addons/website_slides/tests/test_slide_question.py
+++ b/addons/website_slides/tests/test_slide_question.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
+
+from odoo.addons.website_slides.tests import common as slides_common
+from odoo.tests.common import users
+
+class TestSlideQuestionManagement(slides_common.SlidesCase):
+
+    @users('user_officer')
+    def test_compute_answers_validation_error(self):
+        channel = self.env['slide.channel'].create({
+            'name': 'Test compute answers channel',
+            'slide_ids': [Command.create({
+                'name': "Test compute answers validation error slide",
+                'slide_category': 'quiz',
+                'question_ids': [Command.create({
+                    'question': 'Will test compute answers validation error pass?',
+                    'answer_ids': [
+                        Command.create({
+                            'text_value': 'An incorrect answer',
+                        }),
+                        Command.create({
+                            'is_correct': True,
+                            'text_value': 'A correct answer',
+                        })
+                    ]
+                })]
+            })]
+        })
+
+        question = channel.slide_ids[0].question_ids[0]
+        self.assertFalse(question.answers_validation_error)
+
+        for val in (False, True):
+            question.answer_ids[0].is_correct = val
+            question.answer_ids[1].is_correct = val
+            self.assertTrue(question.answers_validation_error)

--- a/addons/website_slides/views/slide_question_views.xml
+++ b/addons/website_slides/views/slide_question_views.xml
@@ -5,6 +5,12 @@
         <field name="model">slide.question</field>
         <field name="arch" type="xml">
             <form string="Quiz">
+                <div invisible="answers_validation_error == ''">
+                    <div class="alert alert-info my-1 mx-2" role="alert" aria-label="Validation error">
+                        <i class="fa fa-info-circle" aria-hidden="true"/>
+                        <field name="answers_validation_error" class="ms-2" readonly="1"/>
+                    </div>
+                </div>
                 <sheet>
                     <label for="question" string="Question Name"/>
                     <h1>


### PR DESCRIPTION
Purpose
=======
Currently the user interface let you specify several correct answers per quiz question. But when you save the course, you get a notification error. As those are simple quizzes, it might be interesting to simply allow multiple answers.

Specifications
==============
Allow questions with multiple correct answers.
Indicate to the quiz participant when a question has several correct answers.

Task-3366803

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
