### PR TITLE
[FIX] l10n_ke: Renamed Tax Groups Labels for Kenya

### DIFF
--- a/addons/l10n_ke/data/template/account.tax.group-ke.csv
+++ b/addons/l10n_ke/data/template/account.tax.group-ke.csv
@@ -1,5 +1,5 @@
 "id","name","country_id","tax_receivable_account_id","tax_payable_account_id"
-"tax_group_16","TVA 16%","base.ke","ke1110","ke2200"
-"tax_group_8","TVA 8%","base.ke","ke1110","ke2200"
-"tax_group_0","TVA 0%","base.ke","ke1110","ke2200"
+"tax_group_16","VAT 16%","base.ke","ke1110","ke2200"
+"tax_group_8","VAT 8%","base.ke","ke1110","ke2200"
+"tax_group_0","VAT 0%","base.ke","ke1110","ke2200"
 "tax_group_withholding","Withholding Tax","base.ke","ke1110","ke2200"


### PR DESCRIPTION
Prior to this, tax groups in Kenya where labeled "TVA"

The labels are changed for a version containing "VAT" instead

task-3391884

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
