### PR TITLE
[IMP] l10n_de: add delivery date on invoice

### DIFF
--- a/addons/l10n_de/models/__init__.py
+++ b/addons/l10n_de/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move
 from . import datev
 from . import chart_template
 from . import ir_actions_report

--- a/addons/l10n_de/models/account_move.py
+++ b/addons/l10n_de/models/account_move.py
@@ -1,0 +1,26 @@
+from odoo import models, api
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.depends('invoice_date')
+    def _compute_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_delivery_date()
+        for move in self:
+            if move.invoice_date and move.country_code == 'DE' and not move.delivery_date:
+                move.delivery_date = move.invoice_date
+
+    @api.depends('country_code', 'move_type')
+    def _compute_show_delivery_date(self):
+        # EXTENDS 'account'
+        super()._compute_show_delivery_date()
+        for move in self:
+            if move.country_code == 'DE':
+                move.show_delivery_date = move.is_sale_document()
+
+    def _post(self, soft=True):
+        for move in self:
+            if move.country_code == 'DE' and move.is_sale_document() and not move.delivery_date:
+                move.delivery_date = move.invoice_date
+        return super()._post(soft)

--- a/addons/l10n_din5008/models/account_move.py
+++ b/addons/l10n_din5008/models/account_move.py
@@ -18,6 +18,8 @@ class AccountMove(models.Model):
                 data.append((_("Invoice Date"), format_date(self.env, record.invoice_date)))
             if record.invoice_date_due:
                 data.append((_("Due Date"), format_date(self.env, record.invoice_date_due)))
+            if record.delivery_date:
+                data.append((_("Delivery Date"), format_date(self.env, record.delivery_date)))
             if record.invoice_origin:
                 data.append((_("Source"), record.invoice_origin))
             if record.ref:

--- a/addons/l10n_din5008/models/base_document_layout.py
+++ b/addons/l10n_din5008/models/base_document_layout.py
@@ -44,6 +44,7 @@ class BaseDocumentLayout(models.TransientModel):
             (_("Invoice No."), 'INV/2021/12345'),
             (_("Invoice Date"), format_date(self.env, fields.Date.today())),
             (_("Due Date"), format_date(self.env, fields.Date.add(fields.Date.today(), days=7))),
+            (_("Delivery Date"), format_date(self.env, fields.Date.add(fields.Date.today(), days=7))),
             (_("Reference"), 'SO/2021/45678'),
         ]
 


### PR DESCRIPTION
Delivery dates on invoices are a legal requirement on germany. It needs to be
displayed on the header of the form view and will be displayed on the printed
invoices.

Task-id: 3383318