### PR TITLE
[IMP] generic: make missing translatable terms translatable

### DIFF
--- a/addons/barcodes/models/barcode_events_mixin.py
+++ b/addons/barcodes/models/barcode_events_mixin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields, api
+from odoo import models, fields, api, _
 
 class BarcodeEventsMixin(models.AbstractModel):
     """ Mixin class for objects reacting when a barcode is scanned in their form views
@@ -22,4 +22,4 @@ class BarcodeEventsMixin(models.AbstractModel):
             return self.on_barcode_scanned(barcode)
 
     def on_barcode_scanned(self, barcode):
-        raise NotImplementedError("In order to use barcodes.barcode_events_mixin, method on_barcode_scanned must be implemented")
+        raise NotImplementedError(_("In order to use barcodes.barcode_events_mixin, method on_barcode_scanned must be implemented"))

--- a/addons/hr_fleet/models/employee.py
+++ b/addons/hr_fleet/models/employee.py
@@ -24,7 +24,7 @@ class Employee(models.Model):
             "views": [[self.env.ref("hr_fleet.fleet_vehicle_assignation_log_employee_view_list").id, "tree"], [False, "form"]],
             "domain": [("driver_employee_id", "in", self.ids)],
             "context": dict(self._context, default_driver_id=self.user_id.partner_id.id, default_driver_employee_id=self.id),
-            "name": "History Employee Cars",
+            "name": _("History Employee Cars"),
         }
 
     def _compute_employee_cars_count(self):

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -167,7 +167,7 @@ Do not hesitate to contact your manager or the human resource department.""")
             "res_model": "sms.composer",
             "view_mode": 'form',
             "context": context,
-            "name": "Send SMS Text Message",
+            "name": _("Send SMS Text Message"),
             "target": "new",
         }
 

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -5297,6 +5297,13 @@ msgid "VAT Untaxed"
 msgstr ""
 
 #. module: l10n_ar
+#. odoo-python
+#: code:addons/l10n_ar/models/account_chart_template.py:0
+#, python-format
+msgid "Ventas Preimpreso"
+msgstr ""
+
+#. module: l10n_ar
 #: model:account.account,name:l10n_ar.3_base_venta_de_mercaderia
 #: model:account.account,name:l10n_ar.4_base_venta_de_mercaderia
 #: model:account.account,name:l10n_ar.5_base_venta_de_mercaderia

--- a/addons/l10n_ar/models/account_chart_template.py
+++ b/addons/l10n_ar/models/account_chart_template.py
@@ -23,7 +23,7 @@ class AccountChartTemplate(models.Model):
             for vals in res:
                 if vals['type'] == 'sale':
                     vals.update({
-                        "name": "Ventas Preimpreso",
+                        "name": _("Ventas Preimpreso"),
                         "code": "0001",
                         "l10n_ar_afip_pos_number": 1,
                         "l10n_ar_afip_pos_partner_id": company.partner_id.id,

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -172,7 +172,7 @@ class LoyaltyReward(models.Model):
 
     def _search_reward_product_ids(self, operator, value):
         if operator not in ('=', '!=', 'in'):
-            raise NotImplementedError("Unsupported search operator")
+            raise NotImplementedError(_("Unsupported search operator"))
         return [
             '&', ('reward_type', '=', 'product'),
             '|', ('reward_product_id', operator, value),

--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -232,11 +232,11 @@ class PhoneMixin(models.AbstractModel):
         can_access = self.env['phone.blacklist'].check_access_rights('write', raise_exception=False)
         if can_access:
             return {
-                'name': 'Are you sure you want to unblacklist this Phone Number?',
+                'name': _('Are you sure you want to unblacklist this Phone Number?'),
                 'type': 'ir.actions.act_window',
                 'view_mode': 'form',
                 'res_model': 'phone.blacklist.remove',
                 'target': 'new',
             }
         else:
-            raise AccessError("You do not have the access right to unblacklist phone numbers. Please contact your administrator.")
+            raise AccessError(_("You do not have the access right to unblacklist phone numbers. Please contact your administrator."))

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -3,7 +3,7 @@
 
 import time
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class ProductProduct(models.Model):
@@ -60,7 +60,7 @@ class ProductProduct(models.Model):
             field_no_aggr, _sep, agg = field.partition(':')
             if field_no_aggr in fields_list:
                 if agg and agg != 'sum':
-                    raise NotImplementedError('Aggregate functions other than \':sum\' are not allowed.')
+                    raise NotImplementedError(_('Aggregate functions other than \':sum\' are not allowed.'))
                 return field_no_aggr
             return field
         fields = {truncate_aggr(field) for field in fields}

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -2627,7 +2627,7 @@ class Task(models.Model):
                 if project._check_project_sharing_access():
                     url = f"/my/projects/{self.parent_id.project_id.id}?task_id={self.parent_id.id}"
                 return {
-                    "name": "Portal Parent Task",
+                    "name": _("Portal Parent Task"),
                     "type": "ir.actions.act_url",
                     "url": url,
                 }
@@ -2668,7 +2668,7 @@ class Task(models.Model):
                 action['res_id'] = subtasks.id
             return action
         return {
-            'name': 'Portal Sub-tasks',
+            'name': _('Portal Sub-tasks'),
             'type': 'ir.actions.act_url',
             'url': f'/my/projects/{self.project_id.id}/task/{self.id}/subtasks' if len(subtasks) > 1 else subtasks.get_portal_url(query_string='project_sharing=1'),
         }

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -729,7 +729,7 @@ class ProjectTask(models.Model):
         if not self.display_sale_order_button:
             return {}
         return {
-            "name": "Portal Sale Order",
+            "name": _("Portal Sale Order"),
             "type": "ir.actions.act_url",
             "url": self.sale_order_id.access_url,
         }

--- a/addons/website_event/models/website_visitor.py
+++ b/addons/website_event/models/website_visitor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.osv import expression
 
 
@@ -69,7 +69,7 @@ class WebsiteVisitor(models.Model):
         'in', [1, 2])] should return visitors having a registration on events 1, 2 as
         well as their children for notification purpose. """
         if operator == "not in":
-            raise NotImplementedError("Unsupported 'Not In' operation on visitors registrations")
+            raise NotImplementedError(_("Unsupported 'Not In' operation on visitors registrations"))
 
         all_registrations = self.env['event.registration'].sudo().search([
             ('event_id', operator, operand)

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -340,7 +340,7 @@ class Track(models.Model):
 
     def _search_wishlist_visitor_ids(self, operator, operand):
         if operator == "not in":
-            raise NotImplementedError("Unsupported 'Not In' operation on track wishlist visitors")
+            raise NotImplementedError(_("Unsupported 'Not In' operation on track wishlist visitors"))
 
         track_visitors = self.env['event.track.visitor'].sudo().search([
             ('visitor_id', operator, operand),

--- a/addons/website_event_track/models/website_visitor.py
+++ b/addons/website_event_track/models/website_visitor.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.osv import expression
 
 
@@ -38,7 +38,7 @@ class WebsiteVisitor(models.Model):
         """ Search visitors with terms on wishlisted tracks. E.g. [('event_track_wishlisted_ids',
         'in', [1, 2])] should return visitors having wishlisted tracks 1, 2. """
         if operator == "not in":
-            raise NotImplementedError("Unsupported 'Not In' operation on track wishlist visitors")
+            raise NotImplementedError(_("Unsupported 'Not In' operation on track wishlist visitors"))
 
         track_visitors = self.env['event.track.visitor'].sudo().search([
             ('track_id', operator, operand),


### PR DESCRIPTION
In this commit, we have addressed a crucial issue related to translation. We discovered that certain key
terms in our application were not properly marked for translation, resulting in a lack of support for different languages. To rectify this, we have implemented the necessary changes to make these terms translatable. By doing so, we have successfully resolved the language compatibility problem and improved the overall internationalization of our application. This commit ensures that all terms, previously overlooked or untranslatable, are now fully accessible for translation, enhancing the localization experience for our users across the globe.

task:3358438