### PR TITLE
[IMP] mail: remove redundant index from mail_message

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -254,8 +254,6 @@ class Message(models.Model):
 
     def init(self):
         self._cr.execute("""SELECT indexname FROM pg_indexes WHERE indexname = 'mail_message_model_res_id_idx'""")
-        if not self._cr.fetchone():
-            self._cr.execute("""CREATE INDEX mail_message_model_res_id_idx ON mail_message (model, res_id)""")
         self._cr.execute("""CREATE INDEX IF NOT EXISTS mail_message_model_res_id_id_idx ON mail_message (model, res_id, id)""")
 
     @api.model


### PR DESCRIPTION
This index is obsolete since https://github.com/odoo/odoo/pull/83476 witch add a more complete index to the table.

See https://github.com/odoo/upgrade/pull/4920

task-3380989