### PR TITLE
[IMP] account: default taxes for multi-company product creation

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -866,17 +866,13 @@ class AccountMoveLine(models.Model):
         company_domain = self.env['account.tax']._check_company_domain(self.move_id.company_id)
         if self.move_id.is_sale_document(include_receipts=True):
             # Out invoice.
-            if self.product_id.taxes_id:
-                tax_ids = self.product_id.taxes_id.filtered_domain(company_domain)
-            else:
-                tax_ids = self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'sale')
+            filtered_taxes_id = self.product_id.taxes_id.filtered_domain(company_domain)
+            tax_ids = filtered_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'sale')
 
         elif self.move_id.is_purchase_document(include_receipts=True):
             # In invoice.
-            if self.product_id.supplier_taxes_id:
-                tax_ids = self.product_id.supplier_taxes_id.filtered_domain(company_domain)
-            else:
-                tax_ids = self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'purchase')
+            filtered_supplier_taxes_id = self.product_id.supplier_taxes_id.filtered_domain(company_domain)
+            tax_ids = filtered_supplier_taxes_id or self.account_id.tax_ids.filtered(lambda tax: tax.type_tax_use == 'purchase')
 
         else:
             tax_ids = self.account_id.tax_ids

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -381,6 +381,8 @@ class AccountTax(models.Model):
                 name += ' (%s)' % type_tax_use.get(record.type_tax_use)
             if record.tax_scope:
                 name += ' (%s)' % tax_scope.get(record.tax_scope)
+            if len(self.env.companies) > 1 and self.env.context.get('params', {}).get('model') == 'product.template':
+                name += ' (%s)' % record.company_id.display_name
             record.display_name = name
 
     @api.onchange('amount')

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -42,3 +42,4 @@ from . import test_multivat
 from . import test_account_partner
 from . import test_setup_wizard
 from . import test_structured_reference
+from . import test_product

--- a/addons/account/tests/test_product.py
+++ b/addons/account/tests/test_product.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestProduct(AccountTestInvoicingCommon):
+
+    def test_multi_company_product_tax(self):
+        """ Ensure default taxes are set for all companies on products with no company set. """
+        product_without_company = self.env['product.template'].with_context(allowed_company_ids=self.env.company.ids).create({
+            'name': 'Product Without a Company',
+        })
+        product_with_company = self.env['product.template'].with_context(allowed_company_ids=self.env.company.ids).create({
+            'name': 'Product With a Company',
+            'company_id': self.company_data['company'].id,
+        })
+        companies = self.env['res.company'].sudo().search([])
+        # Product should have all the default taxes of the other companies.
+        self.assertRecordValues(product_without_company.sudo(), [{
+            'taxes_id': companies.account_sale_tax_id.ids,
+            'supplier_taxes_id': companies.account_purchase_tax_id.ids,
+        }])
+        # Product should have only the default tax of the company it belongs to.
+        self.assertRecordValues(product_with_company.sudo(), [{
+            'taxes_id': self.company_data['company'].account_sale_tax_id.ids,
+            'supplier_taxes_id': self.company_data['company'].account_purchase_tax_id.ids,
+        }])

--- a/addons/membership/models/partner.py
+++ b/addons/membership/models/partner.py
@@ -110,7 +110,16 @@ class Partner(models.Model):
                 'move_type': 'out_invoice',
                 'partner_id': partner.id,
                 'invoice_line_ids': [
-                    (0, None, {'product_id': product.id, 'quantity': 1, 'price_unit': amount, 'tax_ids': [(6, 0, product.taxes_id.ids)]})
+                    (
+                        0,
+                        None,
+                        {
+                            'product_id': product.id,
+                            'quantity': 1,
+                            'price_unit': amount,
+                            'tax_ids': [(6, 0, product.taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(self.env.company)).ids)]
+                        }
+                     )
                 ]
             })
 

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -486,7 +486,7 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
 
         def create_order_line(product, quantity, discount=0.0):
             price_unit = self.pricelist._get_product_price(product, quantity)
-            tax_ids = fiscal_position.map_tax(product.taxes_id)
+            tax_ids = fiscal_position.map_tax(product.taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(self.env.company)))
             price_unit_after_discount = price_unit * (1 - discount / 100.0)
             tax_values = (
                 tax_ids.compute_all(price_unit_after_discount, self.currency, quantity)

--- a/addons/project_sale_expense/tests/test_project_profitability.py
+++ b/addons/project_sale_expense/tests/test_project_profitability.py
@@ -81,7 +81,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
         )
         self.assertDictEqual(
             expense_profitability['costs'],
-            {'id': 'expenses', 'sequence': expense_sequence, 'billed': -280.0 - expense_foreign.untaxed_amount * 0.2, 'to_bill': 0.0},
+            {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-280.0 - expense_foreign.untaxed_amount * 0.2), 'to_bill': 0.0},
         )
 
         expense_sheet.action_sheet_move_create()
@@ -109,7 +109,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
         )
         self.assertDictEqual(
             expense_profitability['costs'],
-            {'id': 'expenses', 'sequence': expense_sequence, 'billed': -280.0 - expense_foreign.untaxed_amount * 0.2, 'to_bill': 0.0},
+            {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-280.0 - expense_foreign.untaxed_amount * 0.2), 'to_bill': 0.0},
         )
 
         self.assertDictEqual(
@@ -135,7 +135,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
         )
         self.assertDictEqual(
             expense_profitability['costs'],
-            {'id': 'expenses', 'sequence': expense_sequence, 'billed': -280.0 - expense_foreign.untaxed_amount * 0.2, 'to_bill': 0.0},
+            {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-280.0 - expense_foreign.untaxed_amount * 0.2), 'to_bill': 0.0},
         )
 
         self.assertDictEqual(
@@ -183,7 +183,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
         )
         self.assertDictEqual(
             expense_profitability['costs'],
-            {'id': 'expenses', 'sequence': expense_sequence, 'billed': -280.0 - expense_foreign.untaxed_amount * 0.2, 'to_bill': 0.0},
+            {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-280.0 - expense_foreign.untaxed_amount * 0.2), 'to_bill': 0.0},
         )
 
         expense_sheet._do_refuse('Test Cancel Expense')
@@ -194,7 +194,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
         )
         self.assertDictEqual(
             expense_profitability.get('costs', {}),
-            {'id': 'expenses', 'sequence': expense_sequence, 'billed': -expense_foreign.untaxed_amount * 0.2, 'to_bill': 0.0},
+            {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-expense_foreign.untaxed_amount * 0.2), 'to_bill': 0.0},
         )
 
         invoice = self.env['sale.advance.payment.inv'].with_context({
@@ -227,7 +227,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
         )
         self.assertDictEqual(
             expense_profitability['costs'],
-            {'id': 'expenses', 'sequence': expense_sequence, 'billed': -expense_foreign.untaxed_amount * 0.2, 'to_bill': 0.0},
+            {'id': 'expenses', 'sequence': expense_sequence, 'billed': expense.currency_id.round(-expense_foreign.untaxed_amount * 0.2), 'to_bill': 0.0},
         )
 
         expense_sheet_foreign._do_refuse('Test Cancel Expense')

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -316,6 +316,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
             'amount': 33.3333,
             'company_id': self.company_data['company'].id,
             'cash_basis_transition_account_id': cash_basis_transfer_account.id,
+            'type_tax_use': 'purchase',
             'tax_exigibility': 'on_payment',
             'invoice_repartition_line_ids': [
                 (0, 0, {


### PR DESCRIPTION
Before:
When a new product was created in a multi-company setting, if the company field is empty, the product is available for all companies. The default sale and purchase tax of the company was set on the product. The problem is that only the default taxes of the currently  active company was set on the product, so viewing  the product in other companies showed an empty field for the tax.

Now:
When creating a new product with the company field empty, the default taxes of the other companies are set on the product as well.

task-3375286

Enterprise PR: odoo/enterprise/pull/45075