### PR TITLE
[IMP] hr_contract: rename 'Advantage' to 'Benefit'

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -236,7 +236,7 @@
                                             <div class="mb-3" name="wage_period_label">/ month</div>
                                         </div>
                                     </group>
-                                    <group name="yearly_advantages"/>
+                                    <group name="yearly_benefits"/>
                                 </group>
                             </page>
                             <page string="Contract Details" name="other" groups="hr_contract.group_hr_contract_manager">


### PR DESCRIPTION
In this commit, I have made changes from 'Advantage' to 'Benefit' because I made modifications in the 'hr_contract_module'. This group is being utilized in 'hr_contract', so I updated the file accordingly.

task-3374616