### PR TITLE
[FIX] hr: update the value of bank_account_id to false when removing partner_id

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -356,12 +356,15 @@ class HrEmployeePrivate(models.Model):
 
     def write(self, vals):
         if 'address_home_id' in vals:
-            account_id = vals.get('bank_account_id') or self.bank_account_id.id
-            if account_id:
-                self.env['res.partner.bank'].browse(account_id).partner_id = vals['address_home_id']
-            self.message_unsubscribe(self.address_home_id.ids)
-            if vals['address_home_id']:
-                self._message_subscribe([vals['address_home_id']])
+            if not vals['address_home_id']:
+                vals.update({'bank_account_id': False})
+            else:
+                account_id = vals.get('bank_account_id') or self.bank_account_id.id
+                if account_id:
+                    self.env['res.partner.bank'].browse(account_id).partner_id = vals['address_home_id']
+                self.message_unsubscribe(self.address_home_id.ids)
+                if vals['address_home_id']:
+                    self._message_subscribe([vals['address_home_id']])
         if 'user_id' in vals:
             # Update the profile pictures with user, except if provided 
             vals.update(self._sync_user(self.env['res.users'].browse(vals['user_id']),


### PR DESCRIPTION
An error occurs by the following steps:
- Install hr_contract, contacts and account modules.
- Go to the contacts > Configuration > Bank Accounts.
- Create a new bank account add account number and select the account holder.
- Save the record.
- Go to Employees > Create new employee >Provide any name.
- Go to private information page of the employee.
- In the `address_home_id` field select partner who is our account holder.
- Now bank account number field is visible > select the bank account number.
- Save the record.
- Return to the `address_home_id` field and remove the previously selected partner.
- Attempt to save the record, which results in an error.

see the Stack Trace: 
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5379, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: res.partner()
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/hr_contract/models/hr_employee.py", line 98, in write
    res = super().write(vals)
  File "addons/hr/models/hr_employee.py", line 392, in write
    bank_account.partner_id = vals['address_home_id']
  File "odoo/fields.py", line 1320, in __set__
    records.write({self.name: write_value})
  File "addons/account/models/res_partner_bank.py", line 298, in write
    account.partner_id._message_log(body=msg, tracking_value_ids=tracking_value_ids)
  File "addons/mail/models/mail_thread.py", line 2593, in _message_log
    self.ensure_one()
  File "odoo/models.py", line 5382, in ensure_one
    raise ValueError("Expected singleton: %s" % self)

```

sentry - 4284660846
