### PR TITLE
[FIX] website_slides_survey: Consider the group while inheriting view

### DIFF
--- a/addons/website_slides_survey/views/slide_channel_views.xml
+++ b/addons/website_slides_survey/views/slide_channel_views.xml
@@ -5,10 +5,19 @@
         <field name="model">slide.channel</field>
         <field name="inherit_id" ref="website_slides.view_slide_channel_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//span[@name='members_completed_count_label']" position="replace">
-                <field  name="nbr_certification" invisible="1"/>
-                <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '>', 0)]}">Finished</span>
-                <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '=', 0)]}">Certified</span>
+            <xpath expr="//button[@name='action_redirect_to_completed_members']" position="replace">
+                <button name="action_redirect_to_completed_members"
+                    type="object"
+                    icon="fa-trophy"
+                    class="oe_stat_button"
+                    groups="website_slides.group_website_slides_officer">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_value"><field name="members_completed_count" nolabel="1"/></span>
+                        <field  name="nbr_certification" invisible="1"/>
+                        <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '>', 0)]}">Finished</span>
+                        <span class="o_stat_text" attrs="{'invisible': [('nbr_certification', '=', 0)]}">Certified</span>
+                    </div>
+                </button>
             </xpath>
             <xpath expr="//field[@name='slide_category']" position="after">
                 <field name="survey_id"/>


### PR DESCRIPTION
`website_slides_survey.slide_channel_view_form` was inheriting the view `website_slides.view_slide_channel_form` and replacing a button that has a group on it. This results in a client crash when opening the eLearning app if you don't have the proper permission to see the button from the parent view

via post-migration feedback
