### PR TITLE
[FIX] website_slides: fix quiz success message popup

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz_finish.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz_finish.js
@@ -19,18 +19,16 @@ var SlideQuizFinishModal = Dialog.extend({
         this.quiz = options.quiz;
         this.hasNext = options.hasNext;
         this.userId = options.userId;
-        options = Object.assign({
-            size: 'medium',
-            dialogClass: 'd-flex p-0',
-            technical: false,
-            renderHeader: false,
-            renderFooter: false
-        }, options || {});
         this._super.apply(this, arguments);
+        this.size = "medium";
+        this.dialogClass = "d-flex p-0";
+        this.technical = false;
+        this.renderHeader = false;
+        this.renderFooter = false;
         this.opened(function () {
             self._animateProgressBar();
             self._animateText();
-        })
+        });
     },
 
     start: function() {


### PR DESCRIPTION
Purpose
=======
The modal indicating quiz success no longer looks as expected.

Specifications
==============
Restore the modal's original appearance

Task-3370713

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
