### PR TITLE
[FIX] website_sale: change website currency to expected currency

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -126,7 +126,10 @@ class Website(models.Model):
     @api.depends('all_pricelist_ids', 'pricelist_id', 'company_id')
     def _compute_currency_id(self):
         for website in self:
-            website.currency_id = website.pricelist_id.currency_id or website.company_id.currency_id
+            if website.pricelist_id.currency_id.active:
+                website.currency_id = website.pricelist_id.currency_id or website.company_id.currency_id
+            else:
+                website.currency_id = website.company_id.currency_id
 
     def _compute_enabled_delivery(self):
         for website in self:


### PR DESCRIPTION
Versions:
---------
- saas-16.2+

Steps to reproduce:
-------------------
1. Go to the companies and change the country to another country
2. The currency should be updated automatically
3. Deactivate other currencies from the invoicing configuration
4. Make sure only one currency is activated as mentioned in the company.
5. Go to the website and the product are in the previous currency

Issue:
------
After changing the country and deactivate the previous currency, the prices of the products in e-commerce are using the currency related to the previously selected country

Cause:
------
The website currency is computed based on the pricelist currency, but the respective currency is not even active, and since we only have one currency active we can not change it manually through pricelist interface

Solution:
---------
Before assigning the website currency, verify if the pricelist currency is active, if it is not the website currency should be assigned based on the company currency.

OPW-3380391