### PR TITLE
[IMP] Stock: Add yearly order for stock replenishment info wizard sales history

### DIFF
--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -22,6 +22,12 @@ class Company(models.Model):
         domain="[('model', '=', 'stock.picking')]",
         default=_default_confirmation_mail_template,
         help="Email sent to the customer once the order is done.")
+    stock_replenishment_info_periods = fields.Selection([
+        ('month', 'Monthly'),
+        ('year', 'Yearly'),
+    ], string='Stock Replenishment Info Periods',
+        default='year',
+        help="The stock replenishment info can be either ordered yearly or monthly")
     annual_inventory_month = fields.Selection([
         ('1', 'January'),
         ('2', 'February'),

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -47,6 +47,8 @@ class ResConfigSettings(models.TransientModel):
     annual_inventory_day = fields.Integer(related='company_id.annual_inventory_day', readonly=False)
     group_stock_reception_report = fields.Boolean("Reception Report", implied_group='stock.group_reception_report')
     group_stock_auto_reception_report = fields.Boolean("Show Reception Report at Validation", implied_group='stock.group_auto_reception_report')
+    stock_replenishment_info_periods = fields.Selection(related='company_id.stock_replenishment_info_periods', readonly=False)
+
 
     @api.onchange('group_stock_multi_locations')
     def _onchange_group_stock_multi_locations(self):

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -106,6 +106,17 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-12 col-lg-6 o_setting_box" id="stock.replenishment_info_period">
+                                <div class="o_setting_right_pane">
+                                    <label for="stock_replenishment_info_periods" string="Replenishment info period"/>
+                                    <div class="text-muted">
+                                        Modify the way stocks are grouped in the stock replenishment info wizard.
+                                    </div>
+                                    <div class="content-group">
+                                        <field name="stock_replenishment_info_periods" class="o_light_label" widget="selection"/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         <h2>Barcode</h2>
                         <div class="row mt16 o_settings_container" name="barcode_setting_container">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The stock replenishment info wizard contains a sale history ordered by months only: (up to 3 months)
![Screenshot from 2023-07-04 17-00-23](https://github.com/odoo/odoo/assets/48206917/742ed001-ddd0-4deb-bfaf-b23db201b7f0)


After the merge, the stock replenishment info wizard sale history can now be ordered by years based on a res config setting: (up to 2 years)
![Screenshot from 2023-07-04 16-43-54](https://github.com/odoo/odoo/assets/48206917/a1886ec3-43e8-40ff-b46e-29511f97bec7)

