### PR TITLE
[IMP] account: auto post valid invoices

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -234,6 +234,18 @@
                                     </div>
                                 </div>
                             </t>
+                            <t t-if="dashboard.number_auto_post_issue > 0">
+                                <div class="row">
+                                    <div class="col overflow-hidden text-start">
+                                        <a type="object" name="open_action" context="{'search_default_unposted': True, 'search_default_auto_post_issue': True}">
+                                            <span title="Entries that could not be auto posted"><t t-out="dashboard.number_auto_post_issue"/> Entries auto posted issues</span>
+                                        </a>
+                                    </div>
+                                    <div class="col-auto text-end">
+                                        <span><t t-out="dashboard.auto_post_issue_balance"/></span>
+                                    </div>
+                                </div>
+                            </t>
                         </div>
                     </t>
 
@@ -354,6 +366,19 @@
                                     </div>
                                     <div class="col-auto text-end">
                                         <span><t t-out="dashboard.to_check_balance"/></span>
+                                    </div>
+                                </div>
+                            </t>
+                            <t t-if="dashboard.number_auto_post_issue > 0">
+                                <div class="row">
+                                    <div class="col overflow-hidden text-start">
+                                        <a type="object" name="open_action" context="{'search_default_auto_post_issue': True}">
+                                            <span t-if="journal_type == 'sale'" title="Invoices that could not be auto posted"><t t-out="dashboard.number_auto_post_issue"/> Invoices auto posted issues</span>
+                                            <span t-if="journal_type == 'purchase'" title="Bills that could not be auto posted"><t t-out="dashboard.number_auto_post_issue"/> Bills auto posted issues</span>
+                                        </a>
+                                    </div>
+                                    <div class="col-auto text-end">
+                                        <span><t t-out="dashboard.auto_post_issue_balance"/></span>
                                     </div>
                                 </div>
                             </t>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1283,6 +1283,7 @@
                     <filter string="Reversed" name="reversed" domain="[('payment_state', '=', 'reversed')]"/>
                     <separator/>
                     <filter string="To Check" name="to_check" domain="[('to_check', '=', True)]"/>
+                    <filter invisible="1" string="Auto Post Issue" name="auto_post_issue" domain="[('auto_post_issue', '=', True)]"/>
                     <separator/>
                     <filter string="Sales" name="sales" domain="[('journal_id.type', '=', 'sale')]" context="{'default_journal_type': 'sale'}"/>
                     <filter string="Purchases" name="purchases" domain="[('journal_id.type', '=', 'purchase')]" context="{'default_journal_type': 'purchase'}"/>
@@ -1326,6 +1327,7 @@
                     <filter name="cancel" string="Cancelled" domain="[('state', '=', 'cancel')]"/>
                     <separator/>
                     <filter string="To Check" name="to_check" domain="[('to_check', '=', True)]"/>
+                    <filter invisible="1" string="Auto Post Issue" name="auto_post_issue" domain="[('auto_post_issue', '=', True)]"/>
                     <separator/>
                     <!-- not_paid & partial -->
                     <filter name="open" string="Unpaid" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial'))]"/>


### PR DESCRIPTION
Previously, when account moves were set to auto post, and the cron was triggered to post them, if a single invoice triggered a user error, none of them were posted (User error might be missing required field to post, archived journal, inactive currency, ...). This commit enables to post all valid invoices. The invoices that could not be posted are now visible on the accounting dashboard on their respective journal card, and a note is written on the chatter of the problematic invoices.

task-3244310




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
