### PR TITLE
[FIX] point_of_sale: fallback to company's stock output account

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -127,7 +127,7 @@ class StockPicking(models.Model):
                 for line in rec.pos_order_id.lines:
                     if line.product_id.type != 'product':
                         continue
-                    out = line.product_id.categ_id.property_stock_account_output_categ_id
+                    out = line.product_id.categ_id.property_stock_account_output_categ_id or rec.company_id.property_stock_account_output_categ_id
                     exp = line.product_id._get_product_accounts()['expense']
                     cost_per_account[(out, exp)] += line.total_cost
                 move_vals = []


### PR DESCRIPTION
Before this commit, the `property_stock_account_output_categ_id` field
on the product category could be empty which was causing issues.
Solution is to add a fallback to the company's
`property_stock_account_output_categ_id`.

opw-3386941

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
