### PR TITLE
[IMP] fleet: Improve vehicle creation + general UX

### DIFF
--- a/addons/fleet/data/fleet_data.xml
+++ b/addons/fleet/data/fleet_data.xml
@@ -13,6 +13,14 @@
             <field eval="False" name="doall" />
         </record>
 
+        <record id="fleet_vehicle_action_configure_properties_field" model="ir.actions.client">
+            <field name="name">Add Properties</field>
+            <field name="res_model">fleet.vehicle</field>
+            <field name="tag">action_configure_properties_field</field>
+            <field name="binding_model_id" ref="fleet.model_fleet_vehicle"/>
+            <field name="binding_view_types">form</field>
+        </record>
+
         <record id="fleet_vehicle_state_new_request" model="fleet.vehicle.state">
             <field name="name">New Request</field>
             <field name="sequence">4</field>

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -25,7 +25,7 @@ class FleetVehicle(models.Model):
     _rec_names_search = ['name', 'driver_id.name']
 
     def _get_default_state(self):
-        state = self.env.ref('fleet.fleet_vehicle_state_registered', raise_if_not_found=False)
+        state = self.env.ref('fleet.fleet_vehicle_state_new_request', raise_if_not_found=False)
         return state if state and state.id else False
 
     name = fields.Char(compute="_compute_vehicle_name", store=True)
@@ -118,6 +118,7 @@ class FleetVehicle(models.Model):
         ('overdue', 'Overdue'),
         ('today', 'Today'),
     ], compute='_compute_service_activity')
+    vehicle_properties = fields.Properties('Properties', definition='model_id.vehicle_properties_definition', copy=True)
 
     @api.depends('log_services')
     def _compute_service_activity(self):

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -44,6 +44,7 @@ class FleetVehicleModel(models.Model):
     horsepower = fields.Integer()
     horsepower_tax = fields.Float('Horsepower Taxation')
     electric_assistance = fields.Boolean(default=False)
+    vehicle_properties_definition = fields.PropertiesDefinition('Vehicle Properties')
 
     @api.model
     def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -37,7 +37,7 @@
                     </group>
                     <group string="Vehicle" col="2">
                         <group col="1">
-                            <field name="vehicle_id" readonly="1"/>
+                            <field name="vehicle_id"/>
                         </group>
                         <group col="2">
                             <field name="purchaser_id" widget="many2one_avatar"/>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -111,6 +111,10 @@
                             <field name="location"/>
                         </group>
                     </group>
+                    <div class="d-flex">
+                        <field name="vehicle_properties" nolabel="1" columns="2"
+                            hideKanbanOption="1" hideAddButton="1"/>
+                    </div>
                     <notebook>
                         <page string="Tax Info">
                             <group>
@@ -197,6 +201,7 @@
                 <field name="contract_renewal_due_soon" invisible="1"/>
                 <field name="contract_renewal_overdue" invisible="1"/>
                 <field name="contract_renewal_total" invisible="1"/>
+                <field name="vehicle_properties"/>
                 <field name="contract_state" widget="badge" decoration-info="contract_state == 'open'"
                     decoration-danger="contract_state == 'expired'" optional="hide"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>
@@ -221,6 +226,7 @@
                 <field name="tag_ids"/>
                 <field string="Status" name="state_id"/>
                 <field string="Current Driver" name="driver_id"/>
+                <field string="Properties" name="vehicle_properties"/>
                 <filter string="Available" name="available"
                     domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '|', '&amp;', ('plan_to_change_car', '=', True), ('vehicle_type', '=', 'car'), '&amp;', ('plan_to_change_bike', '=', True), ('vehicle_type', '=', 'bike')]"/>
                 <filter string="Bikes" name="bikes" domain="[('vehicle_type', '=', 'bike')]"/>


### PR DESCRIPTION
Purpose
=======

When you create a vehicle, there is no sense in adding it to the "registered column", you always start at the first stage. And this is also very subjective to create a contract for one year. Why ? In addition, the contract is empty, excepted for the date.

Specification
=============

- When you create a vehicle, his stage is : New Request

- On the contract form view, make the vehicle's field editable, the driver is always related to the vehicle.

- Allow to add property fields on vehicle and model 

TaskID: 3349871
