### PR TITLE
[IMP] *: Editing currencies display symbol for better differentiation

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -268,7 +268,7 @@ class AccountTestInvoicingCommon(TransactionCase):
         default_values = default_values or {}
         foreign_currency = cls.env['res.currency'].create({
             'name': 'Gold Coin',
-            'symbol': '☺',
+            'curr_symbol': '☺',
             'rounding': 0.001,
             'position': 'after',
             'currency_unit_label': 'Gold',

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -17,13 +17,13 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
         # We need a third currency as you could have a company's currency != journal's currency !=
         cls.currency_data_2 = cls.setup_multi_currency_data(default_values={
             'name': 'Dark Chocolate Coin',
-            'symbol': '🍫',
+            'curr_symbol': '🍫',
             'currency_unit_label': 'Dark Choco',
             'currency_subunit_label': 'Dark Cacao Powder',
         }, rate2016=6.0, rate2017=4.0)
         cls.currency_data_3 = cls.setup_multi_currency_data(default_values={
             'name': 'Black Chocolate Coin',
-            'symbol': '🍫',
+            'curr_symbol': '🍫',
             'currency_unit_label': 'Black Choco',
             'currency_subunit_label': 'Black Cacao Powder',
         }, rate2016=12.0, rate2017=8.0)

--- a/addons/account/tests/test_account_move_payments_widget.py
+++ b/addons/account/tests/test_account_move_payments_widget.py
@@ -16,7 +16,7 @@ class TestAccountMovePaymentsWidget(AccountTestInvoicingCommon):
 
         cls.currency_data_2 = cls.setup_multi_currency_data(default_values={
             'name': 'Stars',
-            'symbol': '☆',
+            'curr_symbol': '☆',
             'currency_unit_label': 'Stars',
             'currency_subunit_label': 'Little Stars',
         }, rate2016=6.0, rate2017=4.0)

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -36,7 +36,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
 
         cls.currency_data_2 = cls.setup_multi_currency_data(default_values={
             'name': 'Diamond',
-            'symbol': '💎',
+            'curr_symbol': '💎',
             'currency_unit_label': 'Diamond',
             'currency_subunit_label': 'Carbon',
         }, rate2016=6.0, rate2017=4.0)
@@ -367,7 +367,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         currency_1 = self.currency_data['currency']
         currency_2 = self.setup_multi_currency_data({
             'name': 'Bretonnian Ecu',
-            'symbol': '👑',
+            'curr_symbol': '👑',
             'currency_unit_label': 'Ecu',
             'currency_subunit_label': 'Bretonnian Denier',
         })['currency']
@@ -1862,7 +1862,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         comp_curr = self.company_data['currency']
         foreign_curr = self.env['res.currency'].create({
             'name': "Sushi",
-            'symbol': '🍣',
+            'curr_symbol': '🍣',
             'rounding': 0.01,
             'rate_ids': [
                 Command.create({'name': '2019-09-24', 'rate': 0.050800000000}),
@@ -2163,7 +2163,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         comp_curr = self.company_data['currency']
         foreign_curr = self.env['res.currency'].create({
             'name': "Sushi",
-            'symbol': '🍣',
+            'curr_symbol': '🍣',
             'rounding': 0.01,
             'rate_ids': [
                 Command.create({'name': '2019-09-24', 'rate': 0.050800000000}),
@@ -2541,7 +2541,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         rate = 1/1.5289
         currency = self.setup_multi_currency_data(default_values={
             'name': 'XXX',
-            'symbol': 'XXX',
+            'curr_symbol': 'XXX',
             'currency_unit_label': 'XX',
             'currency_subunit_label': 'X',
             'rounding': 0.01,
@@ -3250,7 +3250,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.env.company.tax_exigibility = True
         currency_id = self.setup_multi_currency_data(default_values={
             'name': 'bitcoin',
-            'symbol': 'bc',
+            'curr_symbol': 'bc',
             'currency_unit_label': 'Bitcoin',
             'currency_subunit_label': 'Tiny bitcoin',
         }, rate2016=0.5, rate2017=0.66666666666666)['currency'].id
@@ -3333,7 +3333,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.env.company.tax_exigibility = True
         currency_id = self.setup_multi_currency_data(default_values={
             'name': 'bitcoin',
-            'symbol': 'bc',
+            'curr_symbol': 'bc',
             'currency_unit_label': 'Bitcoin',
             'currency_subunit_label': 'Tiny bitcoin',
             'rounding': 0.01,
@@ -3527,7 +3527,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         self.env.company.tax_exigibility = True
         rates_data = self.setup_multi_currency_data(default_values={
             'name': 'Playmock',
-            'symbol': '🦌',
+            'curr_symbol': '🦌',
             'rounding': 0.01,
             'currency_unit_label': 'Playmock',
             'currency_subunit_label': 'Cent',

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -14,7 +14,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         cls.currency_data_3 = cls.setup_multi_currency_data({
             'name': "Umbrella",
-            'symbol': '☂',
+            'curr_symbol': '☂',
             'currency_unit_label': "Umbrella",
             'currency_subunit_label': "Broken Umbrella",
         }, rate2017=0.01)

--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -24,17 +24,17 @@ class TestTransferWizard(AccountTestInvoicingCommon):
         # Create test currencies
         cls.test_currency_1 = cls.env['res.currency'].create({
             'name': "PMK",
-            'symbol':'P',
+            'curr_symbol':'P',
         })
 
         cls.test_currency_2 = cls.env['res.currency'].create({
             'name': "toto",
-            'symbol':'To',
+            'curr_symbol':'To',
         })
 
         cls.test_currency_3 = cls.env['res.currency'].create({
             'name': "titi",
-            'symbol':'Ti',
+            'curr_symbol':'Ti',
         })
 
         # Create test rates

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1077,7 +1077,7 @@ class Import(models.TransientModel):
             if float_regex.search(split_value[0]) is not None:
                 currency_index = 1
             # Check that currency exists
-            currency = self.env['res.currency'].search([('symbol', '=', split_value[currency_index].strip())])
+            currency = self.env['res.currency'].search(['|', ('symbol', '=', split_value[currency_index].strip()), ('symbol', '=', split_value[currency_index].strip())])
             if len(currency):
                 return split_value[(currency_index + 1) % 2] if not negative else '-' + split_value[(currency_index + 1) % 2]
             # Otherwise it is not a float with a currency symbol

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -461,7 +461,7 @@ class TestExpenses(TestExpenseCommon):
         # pylint: disable=bad-whitespace
         foreign_currency = self.env['res.currency'].create({
             'name': 'Exposure',
-            'symbol': ' ',
+            'curr_symbol': ' ',
             'rounding': 0.01,
             'position': 'after',
             'currency_unit_label': 'Nothing',

--- a/addons/hr_expense/tests/test_expenses_mail_import.py
+++ b/addons/hr_expense/tests/test_expenses_mail_import.py
@@ -97,9 +97,9 @@ class TestExpensesMailImport(TestExpenseCommon):
 
         # subject having other currency then company currency, it should ignore other currency then company currency
         assertParsedValues(
-            "foo bar %s1406.91 royal giant" % self.currency_data['currency'].symbol,
+            "foo bar %s1406.91 royal giant" % self.currency_data['currency'].curr_symbol,
             self.company_data['currency'],
-            "foo bar %s royal giant" % self.currency_data['currency'].symbol,
+            "foo bar %s royal giant" % self.currency_data['currency'].curr_symbol,
             1406.91,
             self.env['product.product'],
         )
@@ -117,7 +117,7 @@ class TestExpensesMailImport(TestExpenseCommon):
 
         # subject having other currency then company currency, it should accept other currency because multi currency is activated
         assertParsedValues(
-            "product_a %s2510.90 chhota bheem" % self.currency_data['currency'].symbol,
+            "product_a %s2510.90 chhota bheem" % self.currency_data['currency'].curr_symbol,
             self.company_data['currency'] + self.currency_data['currency'],
             "chhota bheem",
             2510.90,

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -448,7 +448,7 @@ class TestBomPriceSubcontracting(TestBomPriceCommon):
         """Test calculation of bom cost with subcontracting and supplier in different currency."""
         currency_a = self.env['res.currency'].create({
             'name': 'ZEN',
-            'symbol': 'Z',
+            'curr_symbol': 'Z',
             'rounding': 0.01,
             'currency_unit_label': 'Zenny',
             'rate_ids': [(0, 0, {

--- a/addons/product/tests/test_product_pricelist.py
+++ b/addons/product/tests/test_product_pricelist.py
@@ -61,7 +61,7 @@ class TestProductPricelist(ProductCommon):
 
         cls.new_currency = cls.env['res.currency'].create({
             'name': 'Wonderful Currency',
-            'symbol': ':)',
+            'curr_symbol': ':)',
             'rate_ids': [Command.create({'rate': 10, 'name': time.strftime('%Y-%m-%d')})],
         })
 

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -306,7 +306,7 @@ class TestPurchase(AccountTestInvoicingCommon):
         })
         currency = self.env['res.currency'].create({
             'name': 'Dark Chocolate Coin',
-            'symbol': '🍫',
+            'curr_symbol': '🍫',
             'rounding': 0.001,
             'position': 'after',
             'currency_unit_label': 'Dark Choco',

--- a/addons/purchase_stock/tests/test_fifo_price.py
+++ b/addons/purchase_stock/tests/test_fifo_price.py
@@ -139,7 +139,7 @@ class TestFifoPrice(ValuationReconciliationTestCommon):
         # We will temporarily change the currency rate on the sixth of June to have the same results all year
         NewUSD = self.env['res.currency'].create({
             'name': 'new_usd',
-            'symbol': '$²',
+            'curr_symbol': '$²',
             'rate_ids': [(0, 0, {'rate': 1.2834, 'name': time.strftime('%Y-%m-%d')})],
         })
 

--- a/addons/sale/tests/test_sale_product_attribute_value_config.py
+++ b/addons/sale/tests/test_sale_product_attribute_value_config.py
@@ -55,13 +55,13 @@ class TestSaleProductAttributeValueCommon(TestProductAttributeValueCommon):
             })
 
     @classmethod
-    def _get_or_create_currency(cls, name, symbol):
+    def _get_or_create_currency(cls, name, curr_symbol):
         """Get or create a currency based on name. This makes the test
         non-reliant on demo data."""
         currency = cls.env['res.currency'].search([('name', '=', name)])
         return currency or currency.create({
             'name': name,
-            'symbol': symbol,
+            'curr_symbol': curr_symbol,
         })
 
 

--- a/addons/spreadsheet/tests/test_currency.py
+++ b/addons/spreadsheet/tests/test_currency.py
@@ -8,12 +8,12 @@ class TestCurrencyRates(TransactionCase):
             [
                 {
                     "name": "MC1",
-                    "symbol": ":D",
+                    "curr_symbol": ":D",
                     "rounding": 0.001,
                 },
                 {
                     "name": "MC2",
-                    "symbol": "§",
+                    "curr_symbol": "§",
                 },
             ]
         )

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3838,7 +3838,7 @@ class TestStockValuation(TransactionCase):
         # Creates two new currencies.
         currency_1 = self.env['res.currency'].create({
             'name': 'UNF',
-            'symbol': 'U',
+            'curr_symbol': 'U',
             'rounding': 0.01,
             'currency_unit_label': 'Unifranc',
             'rate': 1,
@@ -3846,7 +3846,7 @@ class TestStockValuation(TransactionCase):
         })
         currency_2 = self.env['res.currency'].create({
             'name': 'DBL',
-            'symbol': 'DD',
+            'curr_symbol': 'DD',
             'rounding': 0.01,
             'currency_unit_label': 'Doublard',
             'rate': 2,

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -315,7 +315,7 @@ class TestStockValuationStandard(TestStockValuationCommon):
     def test_currency_precision_and_standard_svl_value(self):
         currency = self.env['res.currency'].create({
             'name': 'Odoo',
-            'symbol': 'O',
+            'curr_symbol': 'O',
             'rounding': 1,
         })
         new_company = self.env['res.company'].create({
@@ -789,7 +789,7 @@ class TestStockValuationFIFO(TestStockValuationCommon):
     def test_currency_precision_and_fifo_svl_value(self):
         currency = self.env['res.currency'].create({
             'name': 'Odoo',
-            'symbol': 'O',
+            'curr_symbol': 'O',
             'rounding': 1,
         })
         new_company = self.env['res.company'].create({

--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -350,7 +350,7 @@ class TestGroupedExport(XlsxCreatorCase):
     def test_float_representation(self):
         currency = self.env['res.currency'].create({
             'name': "bottlecap",
-            'symbol': "b",
+            'curr_symbol': "b",
             'rounding': 0.001,
             'decimal_places': 3,
         })

--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -7,5 +7,18 @@ export const currencies = session.currencies || {};
 delete session.currencies;
 
 export function getCurrency(id) {
-    return currencies[id];
+    if (id && ((currencies && currencies[id]) || (currencies.currencies && currencies.currencies[id]))) {
+        return currencies[id]? currencies[id]:
+        currencies.currencies[id]? currencies.currencies[id]: false;
+    }
+    return false;
 }
+
+export function getCurrencySymbol(id) {
+    if (id && ((currencies && currencies[id]) || (currencies.currencies && currencies.currencies[id]))) {
+        return currencies[id]? currencies[id].symbol:
+        currencies.currencies[id]? currencies.currencies[id].symbol: false;
+    }
+    return false;
+}
+

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -9,7 +9,7 @@ import { isBinarySize } from "@web/core/utils/binary";
 import { humanNumber, insertThousandsSep } from "@web/core/utils/numbers";
 
 import { markup } from "@odoo/owl";
-import { getCurrency } from "@web/core/currency";
+import { getCurrency, getCurrencySymbol } from "@web/core/currency";
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -298,11 +298,11 @@ export function formatMonetary(value, options = {}) {
     } else {
         formattedValue = formatFloat(value, { digits });
     }
-
+    let symbol = currency.symbol? currency.symbol: getCurrencySymbol(currencyId);
     if (!currency || options.noSymbol) {
         return formattedValue;
     }
-    const formatted = [currency.symbol, formattedValue];
+    const formatted = [symbol, formattedValue];
     if (currency.position === "after") {
         formatted.reverse();
     }

--- a/addons/web/static/src/views/fields/monetary/monetary_field.js
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.js
@@ -55,7 +55,7 @@ export class MonetaryField extends Component {
     }
 
     get currencySymbol() {
-        return this.currency ? this.currency.symbol : "";
+        return this.currency? this.currency.symbol: "";
     }
 
     get currencyDigits() {

--- a/addons/web/static/tests/views/fields/monetary_field_tests.js
+++ b/addons/web/static/tests/views/fields/monetary_field_tests.js
@@ -622,6 +622,13 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
+        // assert.strictEqual(
+        //     Object.entries(target.querySelectorAll(".o_field_many2one_selection li")),
+        //     "CUSTOM",
+        //     "CUSTOM TEST"
+        // );
+        
+
         // replace bottom with new helpers when they exist
         await click(target, ".o_field_many2one_selection input");
         const euroM2OListItem = Array.from(

--- a/addons/website_event_sale/tests/common.py
+++ b/addons/website_event_sale/tests/common.py
@@ -16,7 +16,7 @@ class TestWebsiteEventSaleCommon(TransactionCase):
         cls.currency_test = cls.env['res.currency'].create({
             'name': 'eventX',
             'rounding': 0.01,
-            'symbol': 'EX',
+            'curr_symbol': 'EX',
         })
         cls.partner = cls.env['res.partner'].create({'name': 'test'})
         cls.env['res.currency.rate'].search([]).unlink()

--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -5,7 +5,7 @@
         <record id="USD" model="res.currency">
             <field name="name">USD</field>
             <field name="full_name">United States dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -16,7 +16,7 @@
         <record id="VEF" model="res.currency">
             <field name="name">VEF</field>
             <field name="full_name">Venezuelan bolívar fuerte</field>
-            <field name="symbol">Bs.F</field>
+            <field name="curr_symbol">Bs.F</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Bolivar</field>
@@ -26,7 +26,7 @@
         <record id="CAD" model="res.currency">
             <field name="name">CAD</field>
             <field name="full_name">Canadian dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -36,7 +36,7 @@
         <record id="CHF" model="res.currency">
             <field name="name">CHF</field>
             <field name="full_name">Swiss franc</field>
-            <field name="symbol">CHF</field>
+            <field name="curr_symbol">CHF</field>
             <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
@@ -47,7 +47,7 @@
         <record id="BRL" model="res.currency">
             <field name="name">BRL</field>
             <field name="full_name">Brazilian real</field>
-            <field name="symbol">R$</field>
+            <field name="curr_symbol">R$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -58,7 +58,7 @@
         <record id="CNY" model="res.currency">
             <field name="name">CNY</field>
             <field name="full_name">Chinese yuan</field>
-            <field name="symbol">¥</field>
+            <field name="curr_symbol">¥</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Yuan</field>
@@ -69,7 +69,7 @@
         <record id="COP" model="res.currency">
             <field name="name">COP</field>
             <field name="full_name">Colombian peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -80,7 +80,7 @@
         <record id="CZK" model="res.currency">
             <field name="name">CZK</field>
             <field name="full_name">Czech koruna</field>
-            <field name="symbol">Kč</field>
+            <field name="curr_symbol">Kč</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Koruna</field>
@@ -90,7 +90,7 @@
         <record id="DKK" model="res.currency">
             <field name="name">DKK</field>
             <field name="full_name">Danish krone</field>
-            <field name="symbol">kr</field>
+            <field name="curr_symbol">kr</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -101,7 +101,7 @@
         <record id="HUF" model="res.currency">
             <field name="name">HUF</field>
             <field name="full_name">Hungarian forint</field>
-            <field name="symbol">Ft</field>
+            <field name="curr_symbol">Ft</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Forint</field>
@@ -111,7 +111,7 @@
         <record id="IDR" model="res.currency">
             <field name="name">IDR</field>
             <field name="full_name">Indonesian rupiah</field>
-            <field name="symbol">Rp</field>
+            <field name="curr_symbol">Rp</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -122,7 +122,7 @@
         <record id="LVL" model="res.currency">
             <field name="name">LVL</field>
             <field name="full_name">Latvian lats</field>
-            <field name="symbol">Ls</field>
+            <field name="curr_symbol">Ls</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Lats</field>
@@ -132,7 +132,7 @@
         <record id="NOK" model="res.currency">
             <field name="name">NOK</field>
             <field name="full_name">Norwegian krone</field>
-            <field name="symbol">kr</field>
+            <field name="curr_symbol">kr</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -143,7 +143,7 @@
         <record id="XPF" model="res.currency">
             <field name="name">XPF</field>
             <field name="full_name">CFP franc</field>
-            <field name="symbol">XPF</field>
+            <field name="curr_symbol">XPF</field>
             <field name="rounding">1.00</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -153,7 +153,7 @@
         <record id="PAB" model="res.currency">
             <field name="name">PAB</field>
             <field name="full_name">Panamanian balboa</field>
-            <field name="symbol">B/.</field>
+            <field name="curr_symbol">B/.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Balboa</field>
@@ -163,7 +163,7 @@
         <record id="PLN" model="res.currency">
             <field name="name">PLN</field>
             <field name="full_name">Polish złoty</field>
-            <field name="symbol">zł</field>
+            <field name="curr_symbol">zł</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Zloty</field>
@@ -173,7 +173,7 @@
         <record id="SEK" model="res.currency">
             <field name="name">SEK</field>
             <field name="full_name">Swedish krona</field>
-            <field name="symbol">kr</field>
+            <field name="curr_symbol">kr</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Krona</field>
@@ -183,7 +183,7 @@
         <record id="ARS" model="res.currency">
             <field name="name">ARS</field>
             <field name="full_name">Argentine peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -194,7 +194,7 @@
         <record id="INR" model="res.currency">
             <field name="name">INR</field>
             <field name="full_name">Indian rupee</field>
-            <field name="symbol">₹</field>
+            <field name="curr_symbol">₹</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -205,7 +205,7 @@
         <record id="AUD" model="res.currency">
             <field name="name">AUD</field>
             <field name="full_name">Australian dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
@@ -216,7 +216,7 @@
         <record id="UAH" model="res.currency">
             <field name="name">UAH</field>
             <field name="full_name">Ukraine Hryvnia</field>
-            <field name="symbol">₴</field>
+            <field name="curr_symbol">₴</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Hryvnia</field>
@@ -226,7 +226,7 @@
         <record id="VND" model="res.currency">
             <field name="name">VND</field>
             <field name="full_name">Vietnamese đồng</field>
-            <field name="symbol">₫</field>
+            <field name="curr_symbol">₫</field>
             <field name="rounding">1.00</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dong</field>
@@ -236,7 +236,7 @@
         <record id="HKD" model="res.currency">
             <field name="name">HKD</field>
             <field name="full_name">Hong Kong dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
@@ -247,7 +247,7 @@
         <record id="JPY" model="res.currency">
             <field name="name">JPY</field>
             <field name="full_name">Japanese yen</field>
-            <field name="symbol">¥</field>
+            <field name="curr_symbol">¥</field>
             <field name="rounding">1.00</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -258,7 +258,7 @@
         <record id="BGN" model="res.currency">
             <field name="name">BGN</field>
             <field name="full_name">Bulgarian lev</field>
-            <field name="symbol">лв</field>
+            <field name="curr_symbol">лв</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Lev</field>
@@ -268,7 +268,7 @@
         <record id="LTL" model="res.currency">
             <field name="name">LTL</field>
             <field name="full_name">Lithuanian litas</field>
-            <field name="symbol">Lt</field>
+            <field name="curr_symbol">Lt</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Litas</field>
@@ -278,7 +278,7 @@
         <record id="RON" model="res.currency">
             <field name="name">RON</field>
             <field name="full_name">Romanian leu</field>
-            <field name="symbol">lei</field>
+            <field name="curr_symbol">lei</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Leu</field>
@@ -288,7 +288,7 @@
         <record id="HRK" model="res.currency">
             <field name="name">HRK</field>
             <field name="full_name">Croatian kuna</field>
-            <field name="symbol">kn</field>
+            <field name="curr_symbol">kn</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kuna</field>
@@ -298,7 +298,7 @@
         <record id="RUB" model="res.currency">
             <field name="name">RUB</field>
             <field name="full_name">Russian ruble</field>
-            <field name="symbol">руб</field>
+            <field name="curr_symbol">руб</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Ruble</field>
@@ -308,7 +308,7 @@
         <record id="TRY" model="res.currency">
             <field name="name">TRY</field>
             <field name="full_name">Turkish lira</field>
-            <field name="symbol">₺</field>
+            <field name="curr_symbol">₺</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Lira</field>
@@ -318,7 +318,7 @@
         <record id="KRW" model="res.currency">
             <field name="name">KRW</field>
             <field name="full_name">South Korean won</field>
-            <field name="symbol">₩</field>
+            <field name="curr_symbol">₩</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -329,7 +329,7 @@
         <record id="MXN" model="res.currency">
             <field name="name">MXN</field>
             <field name="full_name">Mexican peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -340,7 +340,7 @@
         <record id="MYR" model="res.currency">
             <field name="name">MYR</field>
             <field name="full_name">Malaysian ringgit</field>
-            <field name="symbol">RM</field>
+            <field name="curr_symbol">RM</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -351,7 +351,7 @@
         <record id="NZD" model="res.currency">
             <field name="name">NZD</field>
             <field name="full_name">New Zealand dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
@@ -362,7 +362,7 @@
         <record id="PHP" model="res.currency">
             <field name="name">PHP</field>
             <field name="full_name">Philippine peso</field>
-            <field name="symbol">₱</field>
+            <field name="curr_symbol">₱</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Peso</field>
@@ -372,7 +372,7 @@
         <record id="SGD" model="res.currency">
             <field name="name">SGD</field>
             <field name="full_name">Singapore dollar</field>
-            <field name="symbol">S$</field>
+            <field name="curr_symbol">S$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -383,7 +383,7 @@
         <record id="ZAR" model="res.currency">
             <field name="name">ZAR</field>
             <field name="full_name">South African rand</field>
-            <field name="symbol">R</field>
+            <field name="curr_symbol">R</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -395,7 +395,7 @@
             <field name="name">CRC</field>
             <field name="full_name">Costa Rican colón</field>
             <field name="rounding">0.01</field>
-            <field name="symbol">₡</field>
+            <field name="curr_symbol">₡</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Colon</field>
@@ -405,7 +405,7 @@
         <record id="MUR" model="res.currency">
             <field name="name">MUR</field>
             <field name="full_name">Mauritian rupee</field>
-            <field name="symbol">Rs</field>
+            <field name="curr_symbol">Rs</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
@@ -415,7 +415,7 @@
         <record id="XOF" model="res.currency">
             <field name="name">XOF</field>
             <field name="full_name">CFA franc BCEAO</field>
-            <field name="symbol">CFA</field>
+            <field name="curr_symbol">CFA</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -425,7 +425,7 @@
         <record id="XAF" model="res.currency">
             <field name="name">XAF</field>
             <field name="full_name">CFA franc BEAC</field>
-            <field name="symbol">FCFA</field>
+            <field name="curr_symbol">FCFA</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -435,7 +435,7 @@
         <record id="UGX" model="res.currency">
             <field name="name">UGX</field>
             <field name="full_name">Ugandan shilling</field>
-            <field name="symbol">USh</field>
+            <field name="curr_symbol">USh</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shilling</field>
@@ -445,7 +445,7 @@
         <record id="HNL" model="res.currency">
             <field name="name">HNL</field>
             <field name="full_name">Honduran lempira</field>
-            <field name="symbol">L</field>
+            <field name="curr_symbol">L</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -456,7 +456,7 @@
         <record id="CLP" model="res.currency">
             <field name="name">CLP</field>
             <field name="full_name">Chilean peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -467,7 +467,7 @@
         <record id="UYU" model="res.currency">
             <field name="name">UYU</field>
             <field name="full_name">Uruguayan peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Peso</field>
@@ -477,7 +477,7 @@
         <record id="AFN" model="res.currency">
             <field name="name">AFN</field>
             <field name="full_name">Afghan afghani</field>
-            <field name="symbol">Afs</field>
+            <field name="curr_symbol">Afs</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Afghani</field>
@@ -487,7 +487,7 @@
         <record id="AOA" model="res.currency">
             <field name="name">AOA</field>
             <field name="full_name">Angolan kwanza</field>
-            <field name="symbol">Kz</field>
+            <field name="curr_symbol">Kz</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kwanza</field>
@@ -497,7 +497,7 @@
         <record id="XCD" model="res.currency">
             <field name="name">XCD</field>
             <field name="full_name">East Caribbean dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -507,7 +507,7 @@
         <record id="AMD" model="res.currency">
             <field name="name">AMD</field>
             <field name="full_name">Armenian dram</field>
-            <field name="symbol">դր.</field>
+            <field name="curr_symbol">դր.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dram</field>
@@ -517,7 +517,7 @@
         <record id="AWG" model="res.currency">
             <field name="name">AWG</field>
             <field name="full_name">Aruban florin</field>
-            <field name="symbol">Afl.</field>
+            <field name="curr_symbol">Afl.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Guilder</field>
@@ -527,7 +527,7 @@
         <record id="AZN" model="res.currency">
             <field name="name">AZN</field>
             <field name="full_name">Azerbaijani manat</field>
-            <field name="symbol">m</field>
+            <field name="curr_symbol">m</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Manat</field>
@@ -537,7 +537,7 @@
         <record id="BSD" model="res.currency">
             <field name="name">BSD</field>
             <field name="full_name">Bahamian dollar</field>
-            <field name="symbol">B$</field>
+            <field name="curr_symbol">B$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -547,7 +547,7 @@
         <record id="BHD" model="res.currency">
             <field name="name">BHD</field>
             <field name="full_name">Bahraini dinar</field>
-            <field name="symbol">BD</field>
+            <field name="curr_symbol">BD</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -557,7 +557,7 @@
         <record id="BDT" model="res.currency">
             <field name="name">BDT</field>
             <field name="full_name">Bangladeshi taka</field>
-            <field name="symbol">৳</field>
+            <field name="curr_symbol">৳</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Taka</field>
@@ -567,7 +567,7 @@
         <record id="BBD" model="res.currency">
             <field name="name">BBD</field>
             <field name="full_name">Barbados dollar</field>
-            <field name="symbol">Bds$</field>
+            <field name="curr_symbol">Bds$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -577,7 +577,7 @@
         <record id="BYR" model="res.currency">
             <field name="name">BYR</field>
             <field name="full_name">Belarusian ruble</field>
-            <field name="symbol">BR</field>
+            <field name="curr_symbol">BR</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Ruble BYR</field>
@@ -587,7 +587,7 @@
         <record id="BYN" model="res.currency">
             <field name="name">BYN</field>
             <field name="full_name">Belarusian ruble</field>
-            <field name="symbol">Br</field>
+            <field name="curr_symbol">Br</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rubles</field>
@@ -597,7 +597,7 @@
         <record id="BZD" model="res.currency">
             <field name="name">BZD</field>
             <field name="full_name">Belize dollar</field>
-            <field name="symbol">BZ$</field>
+            <field name="curr_symbol">BZ$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -607,7 +607,7 @@
         <record id="BMD" model="res.currency">
             <field name="name">BMD</field>
             <field name="full_name">Bermudian dollar</field>
-            <field name="symbol">BD$</field>
+            <field name="curr_symbol">BD$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -617,7 +617,7 @@
         <record id="BTN" model="res.currency">
             <field name="name">BTN</field>
             <field name="full_name">Bhutanese ngultrum</field>
-            <field name="symbol">Nu.</field>
+            <field name="curr_symbol">Nu.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Ngultrum</field>
@@ -627,7 +627,7 @@
         <record id="BOB" model="res.currency">
             <field name="name">BOB</field>
             <field name="full_name">Boliviano</field>
-            <field name="symbol">Bs.</field>
+            <field name="curr_symbol">Bs.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Boliviano</field>
@@ -637,7 +637,7 @@
         <record id="BAM" model="res.currency">
             <field name="name">BAM</field>
             <field name="full_name">Bosnia and Herzegovina convertible mark</field>
-            <field name="symbol">KM</field>
+            <field name="curr_symbol">KM</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Mark</field>
@@ -647,7 +647,7 @@
         <record id="BWP" model="res.currency">
             <field name="name">BWP</field>
             <field name="full_name">Botswana pula</field>
-            <field name="symbol">P</field>
+            <field name="curr_symbol">P</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pula</field>
@@ -657,7 +657,7 @@
         <record id="BIF" model="res.currency">
             <field name="name">BIF</field>
             <field name="full_name">Burundian franc</field>
-            <field name="symbol">FBu</field>
+            <field name="curr_symbol">FBu</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -667,7 +667,7 @@
         <record id="KHR" model="res.currency">
             <field name="name">KHR</field>
             <field name="full_name">Cambodian riel</field>
-            <field name="symbol">៛</field>
+            <field name="curr_symbol">៛</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Riel</field>
@@ -677,7 +677,7 @@
         <record id="KYD" model="res.currency">
             <field name="name">KYD</field>
             <field name="full_name">Cayman Islands dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -687,7 +687,7 @@
         <record id="KMF" model="res.currency">
             <field name="name">KMF</field>
             <field name="full_name">Comorian franc</field>
-            <field name="symbol">CF</field>
+            <field name="curr_symbol">CF</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -697,7 +697,7 @@
         <record id="CDF" model="res.currency">
             <field name="name">CDF</field>
             <field name="full_name">Congolese franc</field>
-            <field name="symbol">Fr</field>
+            <field name="curr_symbol">Fr</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -707,7 +707,7 @@
         <record id="CUP" model="res.currency">
             <field name="name">CUP</field>
             <field name="full_name">Cuban peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Peso</field>
@@ -717,7 +717,7 @@
         <record id="ANG" model="res.currency">
             <field name="name">ANG</field>
             <field name="full_name">Netherlands Antillean guilder</field>
-            <field name="symbol">ƒ</field>
+            <field name="curr_symbol">ƒ</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Guilder</field>
@@ -728,7 +728,7 @@
         <record id="DJF" model="res.currency">
             <field name="name">DJF</field>
             <field name="full_name">Djiboutian franc</field>
-            <field name="symbol">Fdj</field>
+            <field name="curr_symbol">Fdj</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -738,7 +738,7 @@
         <record id="DOP" model="res.currency">
             <field name="name">DOP</field>
             <field name="full_name">Dominican peso</field>
-            <field name="symbol">RD$</field>
+            <field name="curr_symbol">RD$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pesos</field>
@@ -749,7 +749,7 @@
         <record id="EGP" model="res.currency">
             <field name="name">EGP</field>
             <field name="full_name">Egyptian pound</field>
-            <field name="symbol">LE</field>
+            <field name="curr_symbol">LE</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pound</field>
@@ -759,7 +759,7 @@
         <record id="SVC" model="res.currency">
             <field name="name">SVC</field>
             <field name="full_name">Salvadoran Colon</field>
-            <field name="symbol">¢</field>
+            <field name="curr_symbol">¢</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Colones</field>
@@ -769,7 +769,7 @@
         <record id="ERN" model="res.currency">
             <field name="name">ERN</field>
             <field name="full_name">Eritrean nakfa</field>
-            <field name="symbol">Nfk</field>
+            <field name="curr_symbol">Nfk</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Nakfa</field>
@@ -779,7 +779,7 @@
         <record id="ETB" model="res.currency">
             <field name="name">ETB</field>
             <field name="full_name">Ethiopian birr</field>
-            <field name="symbol">Br</field>
+            <field name="curr_symbol">Br</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Birr</field>
@@ -789,7 +789,7 @@
         <record id="FKP" model="res.currency">
             <field name="name">FKP</field>
             <field name="full_name">Falkland Islands pound</field>
-            <field name="symbol">£</field>
+            <field name="curr_symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pound</field>
@@ -799,7 +799,7 @@
         <record id="FJD" model="res.currency">
             <field name="name">FJD</field>
             <field name="full_name">Fiji dollar</field>
-            <field name="symbol">FJ$</field>
+            <field name="curr_symbol">FJ$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -809,7 +809,7 @@
         <record id="GEL" model="res.currency">
             <field name="name">GEL</field>
             <field name="full_name">Georgian lari</field>
-            <field name="symbol">ლ</field>
+            <field name="curr_symbol">ლ</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Lari</field>
@@ -819,7 +819,7 @@
         <record id="GIP" model="res.currency">
             <field name="name">GIP</field>
             <field name="full_name">Gibraltar pound</field>
-            <field name="symbol">£</field>
+            <field name="curr_symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pound</field>
@@ -829,7 +829,7 @@
         <record id="GNF" model="res.currency">
             <field name="name">GNF</field>
             <field name="full_name">Guinean franc</field>
-            <field name="symbol">FG</field>
+            <field name="curr_symbol">FG</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -839,7 +839,7 @@
         <record id="GYD" model="res.currency">
             <field name="name">GYD</field>
             <field name="full_name">Guyanese dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -849,7 +849,7 @@
         <record id="HTG" model="res.currency">
             <field name="name">HTG</field>
             <field name="full_name">Haitian gourde</field>
-            <field name="symbol">G</field>
+            <field name="curr_symbol">G</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Gourde</field>
@@ -859,7 +859,7 @@
         <record id="ISK" model="res.currency">
             <field name="name">ISK</field>
             <field name="full_name">Icelandic króna</field>
-            <field name="symbol">kr</field>
+            <field name="curr_symbol">kr</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Krona</field>
@@ -869,7 +869,7 @@
         <record id="IRR" model="res.currency">
             <field name="name">IRR</field>
             <field name="full_name">Iranian rial</field>
-            <field name="symbol">﷼</field>
+            <field name="curr_symbol">﷼</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -879,7 +879,7 @@
         <record id="IQD" model="res.currency">
             <field name="name">IQD</field>
             <field name="full_name">Iraqi dinar</field>
-            <field name="symbol"> ع.د</field>
+            <field name="curr_symbol"> ع.د</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -889,7 +889,7 @@
         <record id="ILS" model="res.currency">
             <field name="name">ILS</field>
             <field name="full_name">Israeli new shekel</field>
-            <field name="symbol">₪</field>
+            <field name="curr_symbol">₪</field>
             <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
@@ -900,7 +900,7 @@
         <record id="JMD" model="res.currency">
             <field name="name">JMD</field>
             <field name="full_name">Jamaican dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -910,7 +910,7 @@
         <record id="JOD" model="res.currency">
             <field name="name">JOD</field>
             <field name="full_name">Jordanian dinar</field>
-            <field name="symbol"> د.ا </field>
+            <field name="curr_symbol"> د.ا </field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -920,7 +920,7 @@
         <record id="KZT" model="res.currency">
             <field name="name">KZT</field>
             <field name="full_name">Kazakhstani tenge</field>
-            <field name="symbol">₸</field>
+            <field name="curr_symbol">₸</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Tenge</field>
@@ -930,7 +930,7 @@
         <record id="KES" model="res.currency">
             <field name="name">KES</field>
             <field name="full_name">Kenyan shilling</field>
-            <field name="symbol">KSh</field>
+            <field name="curr_symbol">KSh</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shilling</field>
@@ -940,7 +940,7 @@
         <record id="KWD" model="res.currency">
             <field name="name">KWD</field>
             <field name="full_name">Kuwaiti dinar</field>
-            <field name="symbol"> د.ك </field>
+            <field name="curr_symbol"> د.ك </field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -950,7 +950,7 @@
         <record id="KGS" model="res.currency">
             <field name="name">KGS</field>
             <field name="full_name">Kyrgyzstani som</field>
-            <field name="symbol">лв</field>
+            <field name="curr_symbol">лв</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Som</field>
@@ -960,7 +960,7 @@
         <record id="LAK" model="res.currency">
             <field name="name">LAK</field>
             <field name="full_name">Lao kip</field>
-            <field name="symbol">₭</field>
+            <field name="curr_symbol">₭</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kip</field>
@@ -970,7 +970,7 @@
         <record id="LBP" model="res.currency">
             <field name="name">LBP</field>
             <field name="full_name">Lebanese pound</field>
-            <field name="symbol">ل.ل</field>
+            <field name="curr_symbol">ل.ل</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pound</field>
@@ -980,7 +980,7 @@
         <record id="LSL" model="res.currency">
             <field name="name">LSL</field>
             <field name="full_name">Lesotho loti</field>
-            <field name="symbol">M</field>
+            <field name="curr_symbol">M</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Loti</field>
@@ -990,7 +990,7 @@
         <record id="LRD" model="res.currency">
             <field name="name">LRD</field>
             <field name="full_name">Liberian dollar</field>
-            <field name="symbol">L$</field>
+            <field name="curr_symbol">L$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1000,7 +1000,7 @@
         <record id="LYD" model="res.currency">
             <field name="name">LYD</field>
             <field name="full_name">Libyan dinar</field>
-            <field name="symbol"> ل.د </field>
+            <field name="curr_symbol"> ل.د </field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -1010,7 +1010,7 @@
         <record id="MOP" model="res.currency">
             <field name="name">MOP</field>
             <field name="full_name">Macanese pataca</field>
-            <field name="symbol">MOP$</field>
+            <field name="curr_symbol">MOP$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pataca</field>
@@ -1020,7 +1020,7 @@
         <record id="MKD" model="res.currency">
             <field name="name">MKD</field>
             <field name="full_name">Macedonian denar</field>
-            <field name="symbol">ден</field>
+            <field name="curr_symbol">ден</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Denar</field>
@@ -1030,7 +1030,7 @@
         <record id="MGA" model="res.currency">
             <field name="name">MGA</field>
             <field name="full_name">Malagasy ariary</field>
-            <field name="symbol">Ar</field>
+            <field name="curr_symbol">Ar</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Ariary</field>
@@ -1040,7 +1040,7 @@
         <record id="MWK" model="res.currency">
             <field name="name">MWK</field>
             <field name="full_name">Malawian kwacha</field>
-            <field name="symbol">MK</field>
+            <field name="curr_symbol">MK</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kwacha</field>
@@ -1050,7 +1050,7 @@
         <record id="MVR" model="res.currency">
             <field name="name">MVR</field>
             <field name="full_name">Maldivian rufiyaa</field>
-            <field name="symbol">.ރ</field>
+            <field name="curr_symbol">.ރ</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rufiyaa</field>
@@ -1060,7 +1060,7 @@
         <record id="MRO" model="res.currency">
             <field name="name">MRO</field>
             <field name="full_name">Mauritanian ouguiya (old)</field>
-            <field name="symbol">UM</field>
+            <field name="curr_symbol">UM</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Ouguiya</field>
@@ -1070,7 +1070,7 @@
         <record id="MRU" model="res.currency">
             <field name="name">MRU</field>
             <field name="full_name">Mauritanian ouguiya</field>
-            <field name="symbol">UM</field>
+            <field name="curr_symbol">UM</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Ouguiya</field>
@@ -1080,7 +1080,7 @@
         <record id="MDL" model="res.currency">
             <field name="name">MDL</field>
             <field name="full_name">Moldovan leu</field>
-            <field name="symbol">L</field>
+            <field name="curr_symbol">L</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Leu</field>
@@ -1090,7 +1090,7 @@
         <record id="MNT" model="res.currency">
             <field name="name">MNT</field>
             <field name="full_name">Mongolian tögrög</field>
-            <field name="symbol">₮</field>
+            <field name="curr_symbol">₮</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Tugrik</field>
@@ -1100,7 +1100,7 @@
         <record id="MAD" model="res.currency">
             <field name="name">MAD</field>
             <field name="full_name">Moroccan dirham</field>
-            <field name="symbol">DH</field>
+            <field name="curr_symbol">DH</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dirham</field>
@@ -1110,7 +1110,7 @@
         <record id="BND" model="res.currency">
             <field name="name">BND</field>
             <field name="full_name">Brunei dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1120,7 +1120,7 @@
         <record id="DZD" model="res.currency">
             <field name="name">DZD</field>
             <field name="full_name">Algerian dinar</field>
-            <field name="symbol">DA</field>
+            <field name="curr_symbol">DA</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -1130,7 +1130,7 @@
         <record id="GHS" model="res.currency">
             <field name="name">GHS</field>
             <field name="full_name">Ghanaian cedi</field>
-            <field name="symbol">GH¢</field>
+            <field name="curr_symbol">GH¢</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Cedi</field>
@@ -1140,7 +1140,7 @@
         <record id="GMD" model="res.currency">
             <field name="name">GMD</field>
             <field name="full_name">Gambian dalasi</field>
-            <field name="symbol">D</field>
+            <field name="curr_symbol">D</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dalasi</field>
@@ -1150,7 +1150,7 @@
         <record id="MZN" model="res.currency">
             <field name="name">MZN</field>
             <field name="full_name">Mozambican metical</field>
-            <field name="symbol">MT</field>
+            <field name="curr_symbol">MT</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Metical</field>
@@ -1160,7 +1160,7 @@
         <record id="MMK" model="res.currency">
             <field name="name">MMK</field>
             <field name="full_name">Myanmar kyat</field>
-            <field name="symbol">K</field>
+            <field name="curr_symbol">K</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kyat</field>
@@ -1170,7 +1170,7 @@
         <record id="NAD" model="res.currency">
             <field name="name">NAD</field>
             <field name="full_name">Namibian dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1180,7 +1180,7 @@
         <record id="NPR" model="res.currency">
             <field name="name">NPR</field>
             <field name="full_name">Nepalese rupee</field>
-            <field name="symbol">₨</field>
+            <field name="curr_symbol">₨</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
@@ -1190,7 +1190,7 @@
         <record id="ALL" model="res.currency">
             <field name="name">ALL</field>
             <field name="full_name">Albanian lek</field>
-            <field name="symbol">L</field>
+            <field name="curr_symbol">L</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Lek</field>
@@ -1200,7 +1200,7 @@
         <record id="NIO" model="res.currency">
             <field name="name">NIO</field>
             <field name="full_name">Nicaraguan córdoba</field>
-            <field name="symbol">C$</field>
+            <field name="curr_symbol">C$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Cordoba</field>
@@ -1210,7 +1210,7 @@
         <record id="NGN" model="res.currency">
             <field name="name">NGN</field>
             <field name="full_name">Nigerian naira</field>
-            <field name="symbol">₦</field>
+            <field name="curr_symbol">₦</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Naira</field>
@@ -1220,7 +1220,7 @@
         <record id="KPW" model="res.currency">
             <field name="name">KPW</field>
             <field name="full_name">North Korean won</field>
-            <field name="symbol">₩</field>
+            <field name="curr_symbol">₩</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Won</field>
@@ -1230,7 +1230,7 @@
         <record id="ZWL" model="res.currency">
             <field name="name">ZWL</field>
             <field name="full_name">Zimbabwean dollar</field>
-            <field name="symbol">Z$</field>
+            <field name="curr_symbol">Z$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1240,7 +1240,7 @@
         <record id="ZMW" model="res.currency">
             <field name="name">ZMW</field>
             <field name="full_name">Zambian kwacha</field>
-            <field name="symbol">ZK</field>
+            <field name="curr_symbol">ZK</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kwacha</field>
@@ -1250,7 +1250,7 @@
         <record id="YER" model="res.currency">
             <field name="name">YER</field>
             <field name="full_name">Yemeni rial</field>
-            <field name="symbol">﷼</field>
+            <field name="curr_symbol">﷼</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rial</field>
@@ -1260,7 +1260,7 @@
         <record id="EUR" model="res.currency">
             <field name="name">EUR</field>
             <field name="full_name">Euro</field>
-            <field name="symbol">€</field>
+            <field name="curr_symbol">€</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Euros</field>
@@ -1270,7 +1270,7 @@
         <record id="VUV" model="res.currency">
             <field name="name">VUV</field>
             <field name="full_name">Vanuatu vatu</field>
-            <field name="symbol">VT</field>
+            <field name="curr_symbol">VT</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Vatu</field>
@@ -1279,7 +1279,7 @@
         <record id="UZS" model="res.currency">
             <field name="name">UZS</field>
             <field name="full_name">Uzbekistan som</field>
-            <field name="symbol">лв</field>
+            <field name="curr_symbol">лв</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Som</field>
@@ -1289,7 +1289,7 @@
         <record id="AED" model="res.currency">
             <field name="name">AED</field>
             <field name="full_name">United Arab Emirates dirham</field>
-            <field name="symbol">د.إ</field>
+            <field name="curr_symbol">د.إ</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dirham</field>
@@ -1299,7 +1299,7 @@
         <record id="TMT" model="res.currency">
             <field name="name">TMT</field>
             <field name="full_name">Turkmenistan manat</field>
-            <field name="symbol">T</field>
+            <field name="curr_symbol">T</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Manat</field>
@@ -1309,7 +1309,7 @@
         <record id="TND" model="res.currency">
             <field name="name">TND</field>
             <field name="full_name">Tunisian dinar</field>
-            <field name="symbol">DT</field>
+            <field name="curr_symbol">DT</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -1319,7 +1319,7 @@
         <record id="TTD" model="res.currency">
             <field name="name">TTD</field>
             <field name="full_name">Trinidad and Tobago dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1329,7 +1329,7 @@
         <record id="TOP" model="res.currency">
             <field name="name">TOP</field>
             <field name="full_name">Tongan paʻanga</field>
-            <field name="symbol">T$</field>
+            <field name="curr_symbol">T$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Paanga</field>
@@ -1339,7 +1339,7 @@
         <record id="THB" model="res.currency">
             <field name="name">THB</field>
             <field name="full_name">Thai baht</field>
-            <field name="symbol">฿</field>
+            <field name="curr_symbol">฿</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Baht</field>
@@ -1349,7 +1349,7 @@
         <record id="TZS" model="res.currency">
             <field name="name">TZS</field>
             <field name="full_name">Tanzanian shilling</field>
-            <field name="symbol">TSh</field>
+            <field name="curr_symbol">TSh</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shilling</field>
@@ -1359,7 +1359,7 @@
         <record id="TJS" model="res.currency">
             <field name="name">TJS</field>
             <field name="full_name">Tajikistani somoni</field>
-            <field name="symbol">TJS</field>
+            <field name="curr_symbol">TJS</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Somoni</field>
@@ -1369,7 +1369,7 @@
         <record id="TWD" model="res.currency">
             <field name="name">TWD</field>
             <field name="full_name">New Taiwan dollar</field>
-            <field name="symbol">NT$</field>
+            <field name="curr_symbol">NT$</field>
             <field name="rounding">1.00</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1379,7 +1379,7 @@
         <record id="SYP" model="res.currency">
             <field name="name">SYP</field>
             <field name="full_name">Syrian pound</field>
-            <field name="symbol">£</field>
+            <field name="curr_symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pound</field>
@@ -1389,7 +1389,7 @@
         <record id="SZL" model="res.currency">
             <field name="name">SZL</field>
             <field name="full_name">Swazi lilangeni</field>
-            <field name="symbol">E</field>
+            <field name="curr_symbol">E</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Lilangeni</field>
@@ -1399,7 +1399,7 @@
         <record id="SRD" model="res.currency">
             <field name="name">SRD</field>
             <field name="full_name">Surinamese dollar</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1409,7 +1409,7 @@
         <record id="SDG" model="res.currency">
             <field name="name">SDG</field>
             <field name="full_name">Sudanese pound</field>
-            <field name="symbol">ج.س.</field>
+            <field name="curr_symbol">ج.س.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
         </record>
@@ -1417,7 +1417,7 @@
         <record id="LKR" model="res.currency">
             <field name="name">LKR</field>
             <field name="full_name">Sri Lankan rupee</field>
-            <field name="symbol">Rs</field>
+            <field name="curr_symbol">Rs</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
@@ -1427,7 +1427,7 @@
         <record id="SSP" model="res.currency">
             <field name="name">SSP</field>
             <field name="full_name">South Sudanese pound</field>
-            <field name="symbol">£</field>
+            <field name="curr_symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pounds</field>
@@ -1437,7 +1437,7 @@
         <record id="GBP" model="res.currency">
             <field name="name">GBP</field>
             <field name="full_name">Pound sterling</field>
-            <field name="symbol">£</field>
+            <field name="curr_symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
@@ -1448,7 +1448,7 @@
         <record id="SOS" model="res.currency">
             <field name="name">SOS</field>
             <field name="full_name">Somali shilling</field>
-            <field name="symbol">Sh.</field>
+            <field name="curr_symbol">Sh.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shillings</field>
@@ -1458,7 +1458,7 @@
         <record id="SBD" model="res.currency">
             <field name="name">SBD</field>
             <field name="full_name">Solomon Islands dollar</field>
-            <field name="symbol">SI$</field>
+            <field name="curr_symbol">SI$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
@@ -1468,7 +1468,7 @@
         <record id="SLL" model="res.currency">
             <field name="name">SLL</field>
             <field name="full_name">Sierra Leonean leone</field>
-            <field name="symbol">Le</field>
+            <field name="curr_symbol">Le</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Leone</field>
@@ -1488,7 +1488,7 @@
         <record id="SCR" model="res.currency">
             <field name="name">SCR</field>
             <field name="full_name">Seychellois rupee</field>
-            <field name="symbol">SR</field>
+            <field name="curr_symbol">SR</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
@@ -1498,7 +1498,7 @@
         <record id="RSD" model="res.currency">
             <field name="name">RSD</field>
             <field name="full_name">Serbian dinar</field>
-            <field name="symbol">din.</field>
+            <field name="curr_symbol">din.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dinar</field>
@@ -1508,7 +1508,7 @@
         <record id="SAR" model="res.currency">
             <field name="name">SAR</field>
             <field name="full_name">Saudi riyal</field>
-            <field name="symbol">SR</field>
+            <field name="curr_symbol">SR</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Riyal</field>
@@ -1518,7 +1518,7 @@
         <record id="STD" model="res.currency">
             <field name="name">STD</field>
             <field name="full_name">São Tomé and Príncipe dobra</field>
-            <field name="symbol">Db</field>
+            <field name="curr_symbol">Db</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dobra</field>
@@ -1528,7 +1528,7 @@
         <record id="WST" model="res.currency">
             <field name="name">WST</field>
             <field name="full_name">Samoan tālā</field>
-            <field name="symbol">WS$</field>
+            <field name="curr_symbol">WS$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Tala</field>
@@ -1538,7 +1538,7 @@
         <record id="SHP" model="res.currency">
             <field name="name">SHP</field>
             <field name="full_name">Saint Helena pound</field>
-            <field name="symbol">£</field>
+            <field name="curr_symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pound</field>
@@ -1548,7 +1548,7 @@
         <record id="RWF" model="res.currency">
             <field name="name">RWF</field>
             <field name="full_name">Rwandan franc</field>
-            <field name="symbol">RF</field>
+            <field name="curr_symbol">RF</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Franc</field>
@@ -1558,7 +1558,7 @@
         <record id="QAR" model="res.currency">
             <field name="name">QAR</field>
             <field name="full_name">Qatari riyal</field>
-            <field name="symbol">QR</field>
+            <field name="curr_symbol">QR</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rial</field>
@@ -1568,7 +1568,7 @@
         <record id="PEN" model="res.currency">
             <field name="name">PEN</field>
             <field name="full_name">Peruvian sol</field>
-            <field name="symbol">S/</field>
+            <field name="curr_symbol">S/</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -1579,7 +1579,7 @@
         <record id="PYG" model="res.currency">
             <field name="name">PYG</field>
             <field name="full_name">Paraguayan guaraní</field>
-            <field name="symbol">₲</field>
+            <field name="curr_symbol">₲</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Guarani</field>
@@ -1589,7 +1589,7 @@
         <record id="PGK" model="res.currency">
             <field name="name">PGK</field>
             <field name="full_name">Papua New Guinean kina</field>
-            <field name="symbol">K</field>
+            <field name="curr_symbol">K</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Kina</field>
@@ -1599,7 +1599,7 @@
         <record id="PKR" model="res.currency">
             <field name="name">PKR</field>
             <field name="full_name">Pakistani rupee</field>
-            <field name="symbol">Rs.</field>
+            <field name="curr_symbol">Rs.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
@@ -1609,7 +1609,7 @@
         <record id="OMR" model="res.currency">
             <field name="name">OMR</field>
             <field name="full_name">Omani rial</field>
-            <field name="symbol">ر.ع.</field>
+            <field name="curr_symbol">ر.ع.</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rial</field>
@@ -1619,7 +1619,7 @@
         <record id="CVE" model="res.currency">
             <field name="name">CVE</field>
             <field name="full_name">Cape Verdean escudo</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Escudo</field>
@@ -1629,7 +1629,7 @@
         <record id="COU" model="res.currency">
             <field name="name">COU</field>
             <field name="full_name">Unidad de Valor Real</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -1640,7 +1640,7 @@
         <record id="CLF" model="res.currency">
             <field name="name">CLF</field>
             <field name="full_name">Unidad de Fomento</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.0001</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
@@ -1651,7 +1651,7 @@
         <record id="CUC" model="res.currency">
             <field name="name">CUC</field>
             <field name="full_name">Cuban convertible peso</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Cuban convertible peso</field>
@@ -1660,7 +1660,7 @@
         <record id="GTQ" model="res.currency">
             <field name="name">GTQ</field>
             <field name="full_name">Guatemalan Quetzal</field>
-            <field name="symbol">Q</field>
+            <field name="curr_symbol">Q</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Quetzales</field>
@@ -1670,7 +1670,7 @@
         <record id="VES" model="res.currency">
             <field name="name">VES</field>
             <field name="full_name">Venezuelan bolívar soberano</field>
-            <field name="symbol">Bs</field>
+            <field name="curr_symbol">Bs</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
         </record>
@@ -1678,7 +1678,7 @@
         <record id="UYW" model="res.currency">
             <field name="name">UYW</field>
             <field name="full_name">Unidad previsional</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">0.0001</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">peso</field>
@@ -1688,7 +1688,7 @@
         <record id="UYI" model="res.currency">
             <field name="name">UYI</field>
             <field name="full_name">Uruguay Peso en Unidades Indexadas</field>
-            <field name="symbol">$</field>
+            <field name="curr_symbol">$</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Peso</field>
@@ -1698,7 +1698,7 @@
         <record id="STN" model="res.currency">
             <field name="name">STN</field>
             <field name="full_name">São Tomé and Príncipe dobra</field>
-            <field name="symbol">Db</field>
+            <field name="curr_symbol">Db</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dobra</field>

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -580,7 +580,7 @@ class TestExpression(SavepointCaseWithUserDemo):
         ])
 
         # create a currency and a currency rate
-        currency = Currency.create({'name': 'ZZZ', 'symbol': 'ZZZ', 'rounding': 1.0})
+        currency = Currency.create({'name': 'ZZZ', 'curr_symbol': 'ZZZ', 'rounding': 1.0})
         currency_rate = CurrencyRate.create({'name': '2010-01-01', 'currency_id': currency.id, 'rate': 1.0})
         non_currency_id = currency_rate.id + 1000
         default_currency = Currency.browse(1)

--- a/odoo/addons/base/tests/test_res_currency.py
+++ b/odoo/addons/base/tests/test_res_currency.py
@@ -21,3 +21,76 @@ class TestResConfig(TransactionCase):
                 node_inverse_company_rate = tree.xpath('//field[@name="inverse_company_rate"]')[0]
                 self.assertEqual(node_company_rate.get('string'), f'Unit per {expected_currency}')
                 self.assertEqual(node_inverse_company_rate.get('string'), f'{expected_currency} per Unit')
+
+class TestDisplaySymbol(TransactionCase):
+    def test_symbol_adaptation(self):
+        """Testing that the displaid symbol of the currencies adapts itself to the following rules:
+        If a single currency with a said curr_symbol is active, its symbol is its curr_symbol
+        If a second currency is activated with the same curr_symbol, both currencies have their symbol changed for their name (ISO)
+        If a third or more currencies with the same curr_symbol are activated, their symbol is changed for their name (ISO)
+        When deactivating a currency resulting in two or more currencies with the same curr_symbol remaining, only the currency
+                that is deactivated has its symbol reversed to its original symbol (curr_symbol).
+        When deactivating one of the two last active currencies sharing the same curr_symbol, both their symbol are
+                reversed to their original symbol (curr_symbol).
+        """
+        def test_activate_second_dollar(self, USD, CAD):
+            """Testing that when a second currency with '$' as curr_symbol is activated, both the newly activated currency
+            and the original one (USD is activated by default after the setup) have their symbol changed
+            from their curr_symbol to their ISO code"""
+            self.assertTrue(USD.symbol == "$")
+            self.assertTrue(CAD.symbol == "$")
+
+            self.assertFalse(CAD.active)
+            CAD.write({'active': 'True'})
+            self.assertTrue(CAD.active)
+
+            self.assertTrue(USD.symbol == "USD")
+            self.assertTrue(CAD.symbol == "CAD")
+
+        def test_activate_third_dollar(self, USD, CAD, AUD):
+            """Testing that when a third currency with '$' as curr_symbol is activated, both the newly activated currency
+            and the two others have their ISO code as symbol"""
+            self.assertTrue(USD.symbol == "USD")
+            self.assertTrue(CAD.symbol == "CAD")
+
+            AUD.write({'active': True})
+            self.assertTrue(AUD.active)
+
+            self.assertTrue(USD.symbol == "USD")
+            self.assertTrue(CAD.symbol == "CAD")
+            self.assertTrue(AUD.symbol == "AUD")
+
+        def test_deactivate_third_dollar(self, USD, CAD, AUD):
+            """Testing that when the third currency sharing the same curr_symbol is deactivated, only that one has its
+            symbol reversed to its original symbol"""
+            self.assertTrue(USD.symbol == "USD")
+            self.assertTrue(CAD.symbol == "CAD")
+            self.assertTrue(AUD.symbol == "AUD")
+
+            AUD.write({'active': False})
+            self.assertFalse(AUD.active)
+
+            self.assertTrue(USD.symbol == "USD")
+            self.assertTrue(CAD.symbol == "CAD")
+            self.assertTrue(AUD.symbol == "$")
+
+        def test_deactivate_second_dollar(self, USD, CAD):
+            """Testing that when one of two last active currencies sharing the same curr_symbol is deactivated, both those
+            currencies have their symbol reversed to their original symbol"""
+            self.assertTrue(USD.symbol == "USD")
+            self.assertTrue(CAD.symbol == "CAD")
+
+            CAD.write({'active': False})
+            self.assertFalse(CAD.active)
+
+            self.assertTrue(USD.symbol == "$")
+            self.assertTrue(CAD.symbol == "$")
+
+        USD = self.env['res.currency'].search([('name', '=', 'USD')])
+        CAD = self.env['res.currency'].sudo().search([('name', '=', 'CAD'), ('active', '=', False)])
+        AUD = self.env['res.currency'].sudo().search([('name', '=', 'AUD'), ('active', '=', False)])
+
+        test_activate_second_dollar(self, USD, CAD)
+        test_activate_third_dollar(self, USD, CAD, AUD)
+        test_deactivate_third_dollar(self, USD, CAD, AUD)
+        test_deactivate_second_dollar(self, USD, CAD)

--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -85,7 +85,8 @@
             <field name="arch" type="xml">
                 <tree string="Currencies" decoration-muted="(not active)">
                     <field name="name"/>
-                    <field name="symbol"/>
+                    <field name="curr_symbol" string="Symbol"/>
+                    <field name="symbol" string="Displayed as"/>
                     <field name="full_name" string="Name" optional="show"/>
                     <field name="date" string="Last Update"/>
                     <field name="rate" digits="[12,6]"/>
@@ -160,7 +161,8 @@
                             </group>
 
                             <group string="Display">
-                                <field name="symbol"/>
+                                <field name="curr_symbol" string="Symbol"/>
+                                <field name="symbol" string="Displayed as"/>
                                 <field name="position"/>
                             </group>
                         </group>

--- a/odoo/addons/test_converter/tests/test_html.py
+++ b/odoo/addons/test_converter/tests/test_html.py
@@ -108,7 +108,7 @@ class TestCurrencyExport(TestExport):
     def setUp(self):
         super(TestCurrencyExport, self).setUp()
         self.Currency = self.env['res.currency']
-        self.base = self.create(self.Currency, name="Source", symbol=u'source')
+        self.base = self.create(self.Currency, name="Source", curr_symbol='source')
 
     def create(self, model, **values):
         return model.create(values)
@@ -122,7 +122,7 @@ class TestCurrencyExport(TestExport):
         return converter.record_to_html(obj, 'value', options)
 
     def test_currency_post(self):
-        currency = self.create(self.Currency, name="Test", symbol=u"test")
+        currency = self.create(self.Currency, name="Test", curr_symbol="test")
         obj = self.create(self.Model, value=-0.12)
 
         converted = self.convert(obj, dest=currency)
@@ -135,7 +135,7 @@ class TestCurrencyExport(TestExport):
 
     def test_currency_pre(self):
         currency = self.create(
-            self.Currency, name="Test", symbol=u"test", position='before')
+            self.Currency, name="Test", curr_symbol="test", position='before')
         obj = self.create(self.Model, value=0.12)
 
         converted = self.convert(obj, dest=currency)
@@ -150,7 +150,7 @@ class TestCurrencyExport(TestExport):
     def test_currency_precision(self):
         """ Precision should be the currency's, not the float field's
         """
-        currency = self.create(self.Currency, name="Test", symbol=u"test",)
+        currency = self.create(self.Currency, name="Test", curr_symbol="test")
         obj = self.create(self.Model, value=0.1234567)
 
         converted = self.convert(obj, dest=currency)


### PR DESCRIPTION
*: account, base, base_import, hr_expense, mrp_subcontracting_account,
product, purchase, purchase_stock, sale, spreadsheet, stock_account,
test_xlsx_export, web, website_event_sale

Description of the issue/feature this PR addresses:

Prior to this, when multiple currencies with the same symbol where to appear
in a same document or be sent from a country to another with the same currency
symbol, the only information the recipient had was
the currency symbol leading to lack of clarity.

Desired behavior after PR is merged:

This implementation makes it now automatic that when multiple currencies with
the same symbol are active, it is their ISO code instead of their symbol
that is used to display them. This way, there is no room for misinterpretation.

Whenever a currency is activated, this code checks whether or not another
currency with the same symbol is already active. If it is the case, the ISO
code replaces the symbol of the newly activated currency. Also, when a currency
is deactivated, this code checks whether or not a single currency with the same
symbol is still active. If it is the case, it puts the symbol of that currency
back to its original state. If not, it means that there are still multiple
currencies with that symbol active in which case their symbol should
not change. In both cases, the symbol of the currencies which is being 
deactivated is reversed to its original value, the currency's symbol.

The features interacts with three fields. Each of them is on the res.currency
model. The field "name" which is used to hold the currency's ISO code. No
change has been made to that field. The field "curr_symbol" which is new and 
takes the field "symbol" previous role which was to hold the currency's symbol.
And the field "symbol" which is now a computed field which value will depend
on the number of active currencies with the same symbol as the one
the computation is happening on.

Adding this improvement, the differentiation between currencies with a similar
symbol is now way clearer.

task-3360250