### PR TITLE
[FIX] purchase_stock: Stock valuation layer without account_move_id

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -44,7 +44,7 @@ class StockMove(models.Model):
             receipt_value = 0
             if move_layer:
                 receipt_value += sum(move_layer.mapped(lambda l: l.currency_id._convert(
-                    l.value, order.currency_id, order.company_id, l.create_date, round=False)))
+                    l.value, order.currency_id, order.company_id, l.account_move_id.date or fields.Date.context_today(self), round=False)))
             if invoiced_layer:
                 receipt_value += sum(invoiced_layer.mapped(lambda l: l.currency_id._convert(
                     l.value, order.currency_id, order.company_id, l.create_date, round=False)))


### PR DESCRIPTION
When using inventory valuation in FIFO manual, stock valuation layers can be made without account_move_id. This breaks the currency conversion in _get_price_unit, which expects a date. This fix defaults the date to today in those cases.

Also fixes TestStockValuationWithCOA.test_invoice_on_ordered_qty_with_backorder_and_different_currency_manual

See opw-3382065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
