### PR TITLE
[FIX] l10n_eu_oss: Create OSS account with correct tags

### DIFF
--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -115,6 +115,7 @@ class Company(models.Model):
                 'code': new_code,
                 'account_type': sales_tax_accounts[0].account_type,
                 'company_id': self.id,
+                'tag_ids': [Command.link(tag.id) for tag in sales_tax_accounts[0].tag_ids]
                 })
             self.env['ir.model.data'].create({
                 'name': f'oss_tax_account_company_{self.id}',


### PR DESCRIPTION
Bugfix. When installing l10n_eu_oss with l10n_de_skr03, an OSS account '17010 Unsatzsteuer 19% OSS' is created. However, this account has no account tags set on it, so it gets left out from the Balance Sheet report. (Note that in Germany, due to there being two CoAs, the Balance Sheet report still works using account tags.)

The solution: when creating the OSS account, re-use the account tags of the account we are copying.