### PR TITLE
[FIX] web_editor: handle float_time edition

### DIFF
--- a/addons/web_editor/models/ir_qweb.py
+++ b/addons/web_editor/models/ir_qweb.py
@@ -32,6 +32,7 @@ import odoo.modules
 from odoo import api, models, fields
 from odoo.tools import ustr, posix_to_ldml, pycompat
 from odoo.tools import html_escape as escape
+from odoo.tools.float_utils import float_round
 from odoo.tools.misc import get_lang, babel_locale_parse
 from odoo.addons.base.models import ir_qweb
 
@@ -188,6 +189,19 @@ class Float(models.AbstractModel):
         value = element.text_content().strip()
         return float(value.replace(lang.thousands_sep or '', '')
                           .replace(lang.decimal_point, '.'))
+
+
+class FloatTimeConverter(models.AbstractModel):
+    _name = 'ir.qweb.field.float_time'
+    _description = 'Qweb Field Float Time'
+    _inherit = 'ir.qweb.field.float_time'
+
+    @api.model
+    def from_html(self, model, field, element):
+        if ':' in element.text_content():
+            hours, minutes = map(int, element.text_content().split(':'))
+            return float_round((hours + (minutes / 60)), 2)
+        return float(element.text_content())
 
 
 class ManyToOne(models.AbstractModel):

--- a/addons/web_editor/models/test_models.py
+++ b/addons/web_editor/models/test_models.py
@@ -14,6 +14,7 @@ class ConverterTest(models.Model):
     char = fields.Char()
     integer = fields.Integer()
     float = fields.Float()
+    float_time = fields.Char()
     numeric = fields.Float(digits=(16, 2))
     many2one = fields.Many2one('web_editor.converter.test.sub')
     binary = fields.Binary(attachment=False)


### PR DESCRIPTION
When the user tries to change the value of the `completion_time` field of the `slide.slide` model from the website the traceback will be generated.

Steps to reproduce:
1. Install the `eLearning` module.
2. Go to the website and click on the courses menu.
3. Open the course which has channel type `document`. i.e: `Trees, Wood and Gardens`
4. Click on the `Edit` button.
5. Change the value of the `completion_time` field and save it.

Traceback in sentry : 
```
ValueError: could not convert string to float: '00:00'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/website/models/ir_ui_view.py", line 485, in save
    super(View, self).save(value, xpath=xpath)
  File "addons/web_editor/models/ir_ui_view.py", line 175, in save
    self.save_embedded_field(arch_section)
  File "addons/web_editor/models/ir_ui_view.py", line 55, in save_embedded_field
    Model.browse(int(el.get('data-oe-id'))).write({field: value})
  File "addons/website_slides/models/slide_slide.py", line 642, in write
    res = super(Slide, self).write(values)
  File "addons/mail/models/mail_thread.py", line 312, in write
    result = super(MailThread, self).write(values)
  File "addons/website/models/mixins.py", line 220, in write
    return super(WebsitePublishedMixin, self).write(values)
  File "odoo/models.py", line 4009, in write
    field.write(self, value)
  File "odoo/fields.py", line 1124, in write
    cache_value = self.convert_to_cache(value, records)
  File "odoo/fields.py", line 1542, in convert_to_cache
    value = float(value or 0.0)
```

when the user tries to change the value of `completion_time` field from the website and save it at that time the value of `completion_time` gets the string type and it is not converted to float. so, that the error is occurring.

This commit will solve the above issue by handling float_time edition format.

Sentry-4288785196