### PR TITLE
[FIX] website_sale_digital: handle non-integer type attachment_id 

### DIFF
--- a/addons/website_sale_digital/controllers/main.py
+++ b/addons/website_sale_digital/controllers/main.py
@@ -70,8 +70,10 @@ class WebsiteSaleDigital(CustomerPortal):
     @http.route([
         '/my/download',
     ], type='http', auth='public')
-    def download_attachment(self, attachment_id):
+    def download_attachment(self, attachment_id=False):
         # Check if this is a valid attachment id
+        if not attachment_id or not attachment_id.isnumeric():
+            return redirect(self.orders_page)
         attachment = request.env['ir.attachment'].sudo().search_read(
             [('id', '=', int(attachment_id))],
             ["name", "datas", "mimetype", "res_model", "res_id", "type", "url"]


### PR DESCRIPTION
This issue arises when a user cannot add value to the `attachment_id` when
entering the manual URL.In this case traceback will be generated.

steps to produce :
- Install the website_sale_digital module.
- Go to website > Enter the wrong URL without the value of `attachment_id`.
- For e.g. `my/download?attachment_id` > Press the enter error will generated.

see the traceback: 
```
ValueError: invalid literal for int() with base 10: ''
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale_digital/controllers/main.py", line 50, in download_attachment
    attachment = request.env['ir.attachment'].sudo().browse(int(attachment_id)).exists()
```

After this commit, the problem of a non-integer type for `attachment_id` will be resolved by redirecting the user to the Sales Orders page.

We added `attachment_id=False` because users get an error when attempting to 
visit `my/download` URL, which was caused by the missing argument attachment_id.

sentry-4286948781

