### PR TITLE
[FIX] core: fix colon equal for python 3.7

### DIFF
--- a/addons/website/models/ir_model.py
+++ b/addons/website/models/ir_model.py
@@ -42,6 +42,7 @@ class BaseModel(models.AbstractModel):
 
     def _get_base_lang(self):
         """ Returns the default language of the website as the base language if the record is bound to it """
-        if website := ir_http.get_request_website():
+        website = ir_http.get_request_website()
+        if website:
             return website.default_lang_id.code
         return super()._get_base_lang()

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -488,6 +488,6 @@ class View(models.Model):
     def _get_base_lang(self):
         """ Returns the default language of the website as the base language if the record is bound to it """
         self.ensure_one()
-        if website := self.website_id:
-            return website.default_lang_id.code
+        if self.website_id:
+            return self.website_id.default_lang_id.code
         return super()._get_base_lang()

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1707,7 +1707,8 @@ class _String(Field):
             return False
         if callable(self.translate) and record.env.context.get('edit_translations'):
             terms = self.get_trans_terms(value)
-            if (base_lang := record._get_base_lang()) != (record.env.lang or 'en_US'):
+            base_lang = record._get_base_lang()
+            if base_lang != (record.env.lang or 'en_US'):
                 base_value = record.with_context(edit_translations=None, lang=base_lang)[self.name]
                 base_terms = self.get_trans_terms(base_value)
                 term_to_state = {term: "translated" if base_term != term else "to_translate" for term, base_term in zip(terms, base_terms)}


### PR DESCRIPTION
In the fix
https://github.com/odoo/odoo/commit/e4a38e0fe94ab74146eec3b75f5aef7783729fc6 := which is not supported by python3.7 is used
this fix removes the := operator

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
