### PR TITLE
[FIX] website: close navbar dropdown on page click

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -449,25 +449,6 @@ weSnippetEditor.SnippetEditor.include({
 // Edit mode customizations of public widgets.
 
 publicWidget.registry.hoverableDropdown.include({
-    /**
-     * @override
-     */
-    start() {
-        if (this.editableMode) {
-            this._onPageClick = this._onPageClick.bind(this);
-            this.el.closest('#wrapwrap').addEventListener('click', this._onPageClick, {capture: true});
-        }
-        return this._super.apply(this, arguments);
-    },
-    /**
-     * @override
-     */
-    destroy() {
-        if (this.editableMode) {
-            this.el.closest('#wrapwrap').removeEventListener('click', this._onPageClick, {capture: true});
-        }
-        return this._super.apply(this, arguments);
-    },
 
     //--------------------------------------------------------------------------
     // Private
@@ -476,6 +457,7 @@ publicWidget.registry.hoverableDropdown.include({
     /**
      * Hides all opened dropdowns.
      *
+     * TODO: Remove in master.
      * @private
      */
     _hideDropdowns() {
@@ -492,6 +474,7 @@ publicWidget.registry.hoverableDropdown.include({
      * Called when the page is clicked anywhere.
      * Closes the shown dropdown if the click is outside of it.
      *
+     * TODO: Remove in master.
      * @private
      * @param {Event} ev
      */

--- a/addons/website/static/src/js/editor/wysiwyg.js
+++ b/addons/website/static/src/js/editor/wysiwyg.js
@@ -69,6 +69,8 @@ Wysiwyg.include({
      * @override
      */
     start: async function () {
+        // Bind the _onPageClick handler to click event: to close the dropdown if clicked outside.
+        this.el.addEventListener("click", this._onPageClick.bind(this), { capture: true });
         this.options.toolbarHandler = $('#web_editor-top-edit');
 
         // Dropdown menu initialization: handle dropdown openings by hand
@@ -195,6 +197,7 @@ Wysiwyg.include({
      */
     destroy: function () {
         this._restoreMegaMenus();
+        this.el.removeEventListener("click", this._onPageClick.bind(this), { capture: true });
         this._super.apply(this, arguments);
     },
 
@@ -334,6 +337,36 @@ Wysiwyg.include({
         megaMenuEl.classList.add('o_no_parent_editor');
         this.odooEditor.observerActive("toggleMegaMenu");
         return this.snippetsMenu.activateSnippet($(megaMenuEl));
+    },
+    /**
+     * Hides all opened dropdowns.
+     *
+     * @private
+     */
+    _hideDropdowns() {
+        for (const toggleEl of this.el.querySelectorAll(
+            ".o_mega_menu_toggle, #top_menu_container .dropdown-toggle"
+        )) {
+            $(toggleEl).dropdown("hide");
+        }
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Called when the page is clicked anywhere.
+     * Closes the shown dropdown if the click is outside of it.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onPageClick(ev) {
+        if (ev.target.closest(".dropdown.show")) {
+            return;
+        }
+        this._hideDropdowns();
     },
 });
 


### PR DESCRIPTION
Issue:
In edit mode, the "on click" dropdown remains open even after clicking outside of the dropdown.

With this pull request [1], we manually handle the dropdown to keep it open when clicking a dropdown item, but it prevents the dropdown from closing when clicking outside of the menu.

Before this commit, we only handled the on-page click event for the HoverableDropdown [2], but not for the clickable dropdown. To maintain the same behavior for both clickable and hoverable dropdowns, this commit binds the onPageClick event once we entered in edit mode.

[1]: https://github.com/odoo/odoo/commit/fe67b34f1a03d838df82a1307cf6467f994a8f3b
[2]: https://github.com/odoo/odoo/commit/455e03c743d6f1db70fab4e82b2fdbc963bc22ef

task-3370847
