### PR TITLE
Saas 16.2 fix default tax repartition type aboo

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -20,9 +20,6 @@ class IrActionsReport(models.Model):
             return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
 
         invoices = self.env['account.move'].browse(res_ids)
-        if any(not x.is_purchase_document(include_receipts=True) for x in invoices):
-            raise UserError(_("You can only print the original document for purchase documents."))
-
         original_attachments = invoices.message_main_attachment_id
         if not original_attachments:
             raise UserError(_("No original purchase document could be found for any of the selected purchase documents."))

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1712,15 +1712,30 @@ class MrpProduction(models.Model):
 
             move = moves and moves.pop(0)
             move_qty_to_reserve = move.product_qty
+
+            for index, (quantity, move_line, ml_vals) in enumerate(ml_by_move):
+                taken_qty = min(quantity, move_qty_to_reserve)
+                taken_qty_uom = min(product_uom._compute_quantity(taken_qty, move_line.product_uom_id), move_line.qty_done)
+                if float_is_zero(taken_qty_uom, precision_rounding=move_line.product_uom_id.rounding):
+                    continue
+                move_line.with_context(bypass_reservation_update=True).reserved_uom_qty = taken_qty_uom
+                move_qty_to_reserve -= taken_qty_uom
+                ml_by_move[index] = (quantity - taken_qty_uom, move_line, ml_vals)
+
+                if float_compare(move_qty_to_reserve, 0, precision_rounding=move.product_uom.rounding) <= 0:
+                    assigned_moves.add(move.id)
+                    move = moves and moves.pop(0)
+                    move_qty_to_reserve = move and move.product_qty or 0
+
             for quantity, move_line, ml_vals in ml_by_move:
                 while float_compare(quantity, 0, precision_rounding=product_uom.rounding) > 0 and move:
                     # Do not create `stock.move.line` if there is no initial demand on `stock.move`
                     taken_qty = min(move_qty_to_reserve, quantity)
                     taken_qty_uom = product_uom._compute_quantity(taken_qty, move_line.product_uom_id)
                     if move == initial_move:
-                        move_line.with_context(bypass_reservation_update=True).reserved_uom_qty = taken_qty_uom
+                        move_line.with_context(bypass_reservation_update=True).reserved_uom_qty += taken_qty_uom
                         if set_consumed_qty:
-                            move_line.qty_done = taken_qty_uom
+                            move_line.qty_done += taken_qty_uom
                     elif not float_is_zero(taken_qty_uom, precision_rounding=move_line.product_uom_id.rounding):
                         new_ml_vals = dict(
                             ml_vals,

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -225,6 +225,55 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, lot_id=lot_final), nb_product_todo, f'You should have the {nb_product_todo} final product in stock')
         self.assertEqual(len(production.procurement_group_id.mrp_production_ids), nb_product_todo)
 
+    def test_tracking_backorder_series_lot_2(self):
+        """
+        Create a MO with component tracked by lots. Produce a part of the demand
+        by using some specific lots (not the ones suggested by the onchange).
+        The components' reservation of the backorder should consider which lots
+        have been consumed in the initial MO
+        """
+        production, _, _, p1, p2 = self.generate_mo(tracking_base_2='lot')
+        lot1, lot2 = self.env['stock.lot'].create([{
+            'name': f'lot_consumed_{i}',
+            'product_id': p2.id,
+            'company_id': self.env.company.id,
+        } for i in range(2)])
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 20)
+        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 3, lot_id=lot1)
+        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 2, lot_id=lot2)
+
+        production.action_assign()
+
+        production_form = Form(production)
+        production_form.qty_producing = 3
+
+        details_operation_form = Form(production.move_raw_ids.filtered(lambda m: m.product_id == p1), view=self.env.ref('stock.view_stock_move_operations'))
+        with details_operation_form.move_line_ids.edit(0) as ml:
+            ml.qty_done = 4 * 3
+        details_operation_form.save()
+
+        # Consume 1 Product from lot1 and 2 from lot 2
+        p2_smls = production.move_raw_ids.filtered(lambda m: m.product_id == p2).move_line_ids
+        self.assertEqual(len(p2_smls), 2, 'One for each lot')
+        details_operation_form = Form(production.move_raw_ids.filtered(lambda m: m.product_id == p2), view=self.env.ref('stock.view_stock_move_operations'))
+        with details_operation_form.move_line_ids.edit(0) as ml:
+            ml.qty_done = 1
+            ml.lot_id = lot1
+        with details_operation_form.move_line_ids.edit(1) as ml:
+            ml.qty_done = 2
+            ml.lot_id = lot2
+        details_operation_form.save()
+
+        production = production_form.save()
+        action = production.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+
+        p2_bo_mls = production.procurement_group_id.mrp_production_ids[-1].move_raw_ids.filtered(lambda m: m.product_id == p2).move_line_ids
+        self.assertEqual(len(p2_bo_mls), 1)
+        self.assertEqual(p2_bo_mls.lot_id, lot1)
+        self.assertEqual(p2_bo_mls.reserved_qty, 2)
+
     def test_tracking_backorder_series_serial_1(self):
         """ Create a MO of 4 tracked products (serial) with pbm_sam.
         all component is tracked by serial

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -732,9 +732,6 @@ class PosOrder(models.Model):
                         'display_type': 'rounding',
                     })
 
-                total_amount_currency += amount_currency
-                total_balance += balance
-
         # Stock.
         if self.company_id.anglo_saxon_accounting and self.picking_ids.ids:
             stock_moves = self.env['stock.move'].sudo().search([
@@ -762,15 +759,26 @@ class PosOrder(models.Model):
                     'balance': -balance,
                 })
 
-        # Payment terms.
-        pos_receivable_account = self.company_id.account_default_pos_receivable_account_id
-        aml_vals_list_per_nature['payment_terms'].append({
-            'name': f"{pos_receivable_account.code} {pos_receivable_account.code}",
-            'account_id': pos_receivable_account.id,
-            'currency_id': self.currency_id.id,
-            'amount_currency': -total_amount_currency,
-            'balance': -total_balance,
-        })
+        for payment_id in self.payment_ids:
+            is_split_transaction = payment_id.payment_method_id.split_transactions
+            if is_split_transaction:
+                reversed_move_receivable_account_id = self.partner_id.property_account_receivable_id
+            else:
+                reversed_move_receivable_account_id = payment_id.payment_method_id.receivable_account_id or self.company_id.account_default_pos_receivable_account_id
+
+            aml_vals_entry_found = [aml_entry for aml_entry in aml_vals_list_per_nature['payment_terms'] if aml_entry['account_id'] == reversed_move_receivable_account_id.id]
+            if aml_vals_entry_found and not is_split_transaction:
+                aml_vals_entry_found[0]['amount_currency'] += self.session_id._amount_converter(payment_id.amount, self.date_order, False)
+                aml_vals_entry_found[0]['balance'] += payment_id.amount
+            else:
+                aml_vals_list_per_nature['payment_terms'].append({
+                    'partner_id': self.partner_id.id if is_split_transaction else False,
+                    'name': f"{reversed_move_receivable_account_id.code} {reversed_move_receivable_account_id.code}",
+                    'account_id': reversed_move_receivable_account_id.id,
+                    'currency_id': self.currency_id.id,
+                    'amount_currency': self.session_id._amount_converter(payment_id.amount, self.date_order, False),
+                    'balance': payment_id.amount,
+                })
 
         return aml_vals_list_per_nature
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1525,3 +1525,79 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         credit_notes = self.env['account.move'].search([('move_type', '=', 'out_refund')], order='id desc', limit=1)
         self.assertEqual(credit_notes.ref, "Reversal of: "+invoices.name)
         self.assertEqual(credit_notes.reversed_entry_id.id, invoices.id)
+
+    def test_invoicing_after_closing_session(self):
+        """ Test that an invoice can be created after the session is closed """
+        #create customer account payment method
+        self.customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+
+        self.product1 = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+        #add customer account payment method to pos config
+        self.pos_config.write({
+            'payment_method_ids': [(4, self.customer_account_payment_method.id, 0)],
+        })
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+
+        # create pos order
+        order = self.PosOrder.create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': self.partner1.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.product1.id,
+                'price_unit': 6,
+                'discount': 0,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': 6,
+                'price_subtotal_incl': 6,
+            })],
+            'pricelist_id': self.pos_config.pricelist_id.id,
+            'amount_paid': 6.0,
+            'amount_total': 6.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+            })
+
+        #pay for the order with customer account
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.PosMakePayment.with_context(**payment_context).create({
+            'amount': 2.0,
+            'payment_method_id': self.cash_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.PosMakePayment.with_context(**payment_context).create({
+            'amount': 4.0,
+            'payment_method_id': self.customer_account_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+
+        # close session
+        current_session.action_pos_session_closing_control()
+
+        # create invoice
+        order.action_pos_order_invoice()
+        #get journal entry that does the reverse payment, it the ref must contains Reversal
+        reverse_payment = self.env['account.move'].search([('ref', 'ilike', "Reversal")])
+        original_payment = self.env['account.move'].search([('ref', '=', current_session.display_name)])
+        original_customer_payment_entry = original_payment.line_ids.filtered(lambda l: l.account_id.account_type == 'asset_receivable')
+        reverser_customer_payment_entry = reverse_payment.line_ids.filtered(lambda l: l.account_id.account_type == 'asset_receivable')
+        #check that both use the same account
+        self.assertEqual(len(reverser_customer_payment_entry), 2)
+        self.assertEqual(reverser_customer_payment_entry[0].balance, -2.0)
+        self.assertEqual(reverser_customer_payment_entry[1].balance, -4.0)
+        self.assertEqual(original_customer_payment_entry.account_id.id, reverser_customer_payment_entry.account_id.id)
+        self.assertEqual(reverser_customer_payment_entry.partner_id, original_customer_payment_entry.partner_id)

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1396,7 +1396,7 @@ class Task(models.Model):
                 stage = self.env['project.task.type'].sudo().search([('user_id', '=', user_id.id)], limit=1)
                 # In the case no stages have been found, we create the default stages for the user
                 if not stage:
-                    stages = self.env['project.task.type'].sudo().with_context(lang=user_id.partner_id.lang, default_project_id=False).create(
+                    stages = self.env['project.task.type'].sudo().with_context(lang=user_id.partner_id.lang, default_project_ids=False).create(
                         self.with_context(lang=user_id.partner_id.lang)._get_default_personal_stage_create_vals(user_id.id)
                     )
                     stage = stages[0]

--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1295,6 +1295,7 @@
                             widget="many2many_avatar_user"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>
+                        <field name="description" invisible="1"/>
                     </group>
                 </form>
             </field>

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -6,7 +6,7 @@ from ast import literal_eval
 from odoo import api, fields, models, _
 from odoo.addons.phone_validation.tools import phone_validation
 from odoo.exceptions import UserError
-from odoo.tools import html2plaintext
+from odoo.tools import html2plaintext, plaintext2html
 
 
 class SendSMS(models.TransientModel):
@@ -329,7 +329,7 @@ class SendSMS(models.TransientModel):
     def _prepare_log_body_values(self, sms_records_values):
         result = {}
         for record_id, sms_values in sms_records_values.items():
-            result[record_id] = html2plaintext(sms_values['body'])
+            result[record_id] = plaintext2html(html2plaintext(sms_values['body']))
         return result
 
     def _prepare_mass_log_values(self, records, sms_records_values):

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -48,7 +48,7 @@ registry.category("web_tour.tours").add('configurator_translation', {
     // Features screen
     {
         content: "select confidentialité",
-        trigger: '.card:contains(confidentialité)',
+        trigger: '.card:contains(Parseltongue_privacy)',
     }, {
         content: "Click on build my website",
         trigger: 'button.btn-primary',
@@ -62,16 +62,10 @@ registry.category("web_tour.tours").add('configurator_translation', {
         timeout: 30000,
     }, {
         // Check the content of the save button to make sure the website is in
-        // French. (The editor should be in the website's default language,
-        // which should be french in this test.)
-        // Also note that sometimes the translation is being changed on
-        // Transifex from "Sauvegarder" to "Sauver" or the other way around.
-        // TODO: Strengthen this tour by creating a new fake language and some
-        //       translations for the checked terms. See what's done in `Sign`
-        //       `test_translate_sign_instructions` tour with the `Parseltongue`
-        //       language.
+        // Parseltongue. (The editor should be in the website's default language,
+        // which should be parseltongue in this test.)
         content: "exit edit mode",
-        trigger: '.o_we_website_top_actions button.btn-primary:contains("Sauvegarder"), .o_we_website_top_actions button.btn-primary:contains("Sauver")',
+        trigger: '.o_we_website_top_actions button.btn-primary:contains("Save_Parseltongue")',
     }, {
          content: "wait for editor to be closed",
          trigger: 'iframe body:not(.editor_enable)',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- When specifying a tax repartition, 'of tax' was used as default.
- Several 'base' line could be added.

Desired behavior after PR is merged:

- Change the default repartition to 'base'.
- Only one 'base' can be added to the tax distributions.

How is the issue fixed:

- Modification of the defaut value in the field definition.
- Onchange functions in the accountTax class check in the repartition_line_ids if a 'base' line already exists:
   - if yes, set all subsequent lines to 'tax' distribution.
   - if no, use the default 'base' distribution value.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
