### PR TITLE
[IMP] event: add a lang field on event.

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -23,7 +23,7 @@
     </t>
 </div></field>
             <field name="report_template_ids" eval="[(4, ref('event.action_report_event_registration_foldable_badge'))]"/>
-            <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="lang">{{ object.event_id.lang or object.partner_id.lang }}</field>
             <field name="auto_delete" eval="True"/>
         </record>
 
@@ -257,7 +257,7 @@
 </table>
             </field>
             <field name="report_template_ids" eval="[(4, ref('event.action_report_event_registration_full_page_ticket'))]"/>
-            <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="lang">{{ object.event_id.lang or object.partner_id.lang }}</field>
         </record>
 
         <record id="event_reminder" model="mail.template">
@@ -477,7 +477,7 @@
 </td></tr>
 </table>
             </field>
-            <field name="lang">{{ object.partner_id.lang }}</field>
+            <field name="lang">{{ object.event_id.lang or object.partner_id.lang }}</field>
         </record>
 
     </data>

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -113,6 +113,10 @@ class EventEvent(models.Model):
     def _default_event_mail_ids(self):
         return self.env['event.type']._default_event_mail_type_ids()
 
+    @api.model
+    def _lang_get(self):
+        return self.env['res.lang'].get_installed()
+
     name = fields.Char(string='Event', translate=True, required=True)
     note = fields.Html(string='Note', store=True, compute="_compute_note", readonly=False)
     description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, default=_default_description)
@@ -217,6 +221,8 @@ class EventEvent(models.Model):
         compute_sudo=True)
     country_id = fields.Many2one(
         'res.country', 'Country', related='address_id.country_id', readonly=False, store=True)
+    lang = fields.Selection(_lang_get, string='Language',
+        help="All the communication emails sent to attendees will be translated in this language.")
     # ticket reports
     ticket_instructions = fields.Html('Ticket Instructions', translate=True,
         compute='_compute_ticket_instructions', store=True, readonly=False,

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -45,6 +45,7 @@
                             <field name="date_begin" string="Date" widget="daterange" options="{'end_date_field': 'date_end'}" />
                             <field name="date_end" invisible="1" />
                             <field name="date_tz"/>
+                            <field name="lang"/>
                             <field name="event_type_id" string="Template"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>
                         </group>


### PR DESCRIPTION
In order to allow all communication to be sent in
a chosen language, a lang_id field is added on the event.event model. If set (amongst the installed languages) this language will be used to translate email templates instead of the partner's one (which is still the default one)

The field is added on the event form view.

Task-3357099


