### PR TITLE
[FIX] account: prevent deletion of account invoice reports template

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -13601,6 +13601,14 @@ msgid ""
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/ir_actions_report.py:0
+#, python-format
+msgid ""
+"You can't delete the account invoice report; remove it from the print menu "
+"instead."
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_bank_statement.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import models, api, _
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import UserError
 
 from odoo.tools import float_compare
@@ -57,3 +58,15 @@ class IrActionsReport(models.Model):
         data = data and dict(data) or {}
         data.update({'float_compare': float_compare})
         return super()._get_rendering_context(docids=docids, data=data)
+
+    def unlink(self):
+        invoice_reports = [
+            'account.account_invoices',
+            'account.account_invoices_without_payment'
+        ]
+        if self.filtered(lambda v: v.xml_id in invoice_reports) \
+           and not self._context.get(MODULE_UNINSTALL_FLAG):
+            raise UserError(
+                _("You can't delete the account invoice report; remove it from the print menu instead.")
+            )
+        return super().unlink()


### PR DESCRIPTION
When user delete 'account.report_invoice_with_payments record' report and
clicks on "preview" the invoice trace-back will appear.

Steps to reproduce:
1. Install the Invoicing module.
2. Go to settings > Technical > reports or go to views.
3. Delete the account.report_invoice_with_payments record.
4. Go to the invoice app.
5. Open any one invoice and click on the preview button.

Traceback in sentry : 
```
KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7f46d2c597e0>, 'account.account_invoices')
  File "odoo/tools/cache.py", line 91, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: External ID not found in the system: account.account_invoices
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/account/controllers/portal.py", line 121, in portal_my_invoice_detail
    return self._show_report(model=invoice_sudo, report_type=report_type, report_ref='account.account_invoices', download=download)
  File "addons/portal/controllers/portal.py", line 491, in _show_report
    report = getattr(ReportAction, method_name)(report_ref, list(model.ids), data={'report_type': report_type})[0]
  File "addons/account/models/ir_actions_report.py", line 53, in _render_qweb_pdf
    if self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice'):
  File "odoo/addons/base/models/ir_actions_report.py", line 522, in _get_report
    report = self.env.ref(report_ref)
  File "odoo/api.py", line 566, in ref
    res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
  File "odoo/addons/base/models/ir_model.py", line 2013, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-40>", line 2, in _xmlid_lookup
  File "odoo/tools/cache.py", line 96, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 2006, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
```

This commit solves the above issue by preventing the deletion of
the account invoice reports, which are used for invoice preview.

sentry-4287666629