### PR TITLE
[FIX] stock_picking_batch : select allowed users batch transfers

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -18,7 +18,8 @@ class StockPickingBatch(models.Model):
     user_id = fields.Many2one(
         'res.users', string='Responsible', tracking=True, check_company=True,
         readonly=True, states={'draft': [('readonly', False)], 'in_progress': [('readonly', False)]},
-        help='Person responsible for this batch transfer')
+        help='Person responsible for this batch transfer',
+        domain=lambda self: "[('groups_id', '=', {})]".format(self.env.ref("stock.group_stock_user").id))
     company_id = fields.Many2one(
         'res.company', string="Company", required=True, readonly=True,
         index=True, default=lambda self: self.env.company)


### PR DESCRIPTION
When you create a new batch transfer you can select any user even portal users as responsible.

Steps to reproduce the error :
1-create a new contact
2-install inventory and activate batch transfers
3-create a new batch transfer and select the new user

The origin of the problem is there is no domain on the user_id field.

opw-3359742
