### PR TITLE
[IMP] l10n_in_edi: hsn compliance value to be stored at Invoice Level

### DIFF
--- a/addons/l10n_in/models/account.py
+++ b/addons/l10n_in/models/account.py
@@ -9,6 +9,8 @@ from odoo import tools
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
+    l10n_in_hsn_code = fields.Char(related='product_id.l10n_in_hsn_code', depends=["product_id"], store=True, readonly=False)
+
     def init(self):
         tools.create_index(self._cr, 'account_move_line_move_product_index', self._table, ['move_id', 'product_id'])
 

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -35,6 +35,9 @@
                        invisible="move_type not in ('out_invoice', 'out_refund') or country_code != 'IN' or move_type == 'entry'"
                        readonly="state != 'draft'"/>
             </xpath>
+            <xpath expr="//notebook/page[@name='invoice_tab']//field[@name='invoice_line_ids']/tree//field[@name='account_id']" position="after">
+                <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -18,7 +18,7 @@
 
         <xpath expr="//t[@name='account_invoice_line_accountable']/td[1]" position="after">
             <td t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
-              <span t-if="line.product_id.l10n_in_hsn_code" t-field="line.product_id.l10n_in_hsn_code"></span>
+              <span t-if="line.l10n_in_hsn_code" t-field="line.l10n_in_hsn_code"></span>
             </td>
         </xpath>
 

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -98,7 +98,7 @@ class AccountEdiFormat(models.Model):
                 error_message.append(_(
                     """Set an appropriate GST tax on line "%s" (if it's zero rated or nil rated then select it also)""", line.product_id.name))
             if line.product_id:
-                hsn_code = self._l10n_in_edi_extract_digits(line.product_id.l10n_in_hsn_code)
+                hsn_code = self._l10n_in_edi_extract_digits(line.l10n_in_hsn_code)
                 if not hsn_code:
                     error_message.append(_("HSN code is not set in product %s", line.product_id.name))
                 elif not re.match("^[0-9]+$", hsn_code):
@@ -352,7 +352,7 @@ class AccountEdiFormat(models.Model):
             "SlNo": str(index),
             "PrdDesc": line.name.replace("\n", ""),
             "IsServc": line.product_id.type == "service" and "Y" or "N",
-            "HsnCd": self._l10n_in_edi_extract_digits(line.product_id.l10n_in_hsn_code),
+            "HsnCd": self._l10n_in_edi_extract_digits(line.l10n_in_hsn_code),
             "Qty": self._l10n_in_round_value(quantity or 0.0, 3),
             "Unit": line.product_uom_id.l10n_in_code and line.product_uom_id.l10n_in_code.split("-")[0] or "OTH",
             # Unit price in company currency and tax excluded so its different then price_unit

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -111,7 +111,7 @@ class AccountEdiFormat(models.Model):
         for line in move.invoice_line_ids.filtered(lambda line: not (line.display_type in ('line_section', 'line_note', 'rounding') or line.product_id.type == "service")):
             goods_line_is_available = True
             if line.product_id:
-                hsn_code = self._l10n_in_edi_extract_digits(line.product_id.l10n_in_hsn_code)
+                hsn_code = self._l10n_in_edi_extract_digits(line.l10n_in_hsn_code)
                 if not hsn_code:
                     error_message.append(_("HSN code is not set in product %s", line.product_id.name))
                 elif not re.match("^[0-9]+$", hsn_code):
@@ -472,7 +472,7 @@ class AccountEdiFormat(models.Model):
         tax_details_by_code = self._get_l10n_in_tax_details_by_line_code(line_tax_details.get("tax_details", {}))
         line_details = {
             "productName": line.product_id.name,
-            "hsnCode": extract_digits(line.product_id.l10n_in_hsn_code),
+            "hsnCode": extract_digits(line.l10n_in_hsn_code),
             "productDesc": line.name,
             "quantity": line.quantity,
             "qtyUnit": line.product_id.uom_id.l10n_in_code and line.product_id.uom_id.l10n_in_code.split("-")[0] or "OTH",


### PR DESCRIPTION
Before this commit
==================
HSN Codes are mapped to Product and same Carried to the various reporting level.

After this commit
=================
HSN Codes are stored at invoice level and displayed in invoice lines

Related upgrade PR: https://github.com/odoo/upgrade/pull/5418

task- 3410236