### PR TITLE
[FIX] web, hr_holidays: formView overflowing in modal

### DIFF
--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -1,7 +1,5 @@
 .o_hr_leave_form {
-    .o_form_sheet {
-        overflow: hidden;
-    }
+
     .o_hr_leave_content {
         .o_group {
             margin: 0;
@@ -20,9 +18,7 @@
         .o_hr_leave_subtitle {
             font-size: 1.2rem;
         }
-        .o_hr_leave_column {
-            padding: 16px;
-        }
+
         .col_right {
             background-color: map-get($grays, '200');
             padding-top: 28px;

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -241,7 +241,7 @@
                 <field name="tz_mismatch" invisible="1"/>
                 <field name="holiday_type" invisible="1"/>
                 <field name="leave_type_request_unit" invisible="1"/>
-                <div class="o_hr_leave_content row my-n4">
+                <div class="o_hr_leave_content row">
                     <div class="o_hr_leave_column col_left col-md-6 col-12">
                         <div name="title" class="o_hr_leave_title" invisible="1">
                             <field name="employee_id" readonly="1" force_save="1" invisible="1"/>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -237,9 +237,10 @@
 
     // Sheet BG
     .o_form_sheet_bg {
+        --formView-sheetBg-padding-top:  #{map-get($spacers, 2)};
         --formView-sheetBg-padding-x: #{map-get($spacers, 3)};
 
-        padding-top: map-get($spacers, 2);
+        padding-top: var(--formView-sheetBg-padding-top);;
         padding-left: var(--formView-sheetBg-padding-x);
         padding-right: var(--formView-sheetBg-padding-x);
         width: 100%;
@@ -981,20 +982,22 @@
     .o_form_view {
         min-height: auto;
 
-        --formView-sheetBg-padding-top: #{map-get($spacers, 2)};
-        --formView-sheetBg-padding-x: #{$modal-inner-padding};
+        .o_form_sheet_bg {
+            --formView-sheetBg-padding-top: 0;
+            --formView-sheetBg-padding-x: 0;
+        }
     }
 
     .o_form_sheet {
         --formView-sheet-margin-x: 0;
-        --formView-sheet-padding-y: #{map-get($spacers, 2)};
-        --formView-sheet-padding-y-md: #{map-get($spacers, 2)};
-        --formView-sheet-padding-y-lg: #{map-get($spacers, 2)};
-        --formView-sheet-padding-y-xxl: #{map-get($spacers, 2)};
-        --formView-sheet-padding-x: 0;
-        --formView-sheet-padding-x-md: 0;
-        --formView-sheet-padding-x-lg: 0;
-        --formView-sheet-padding-x-xxl: 0;
+        --formView-sheet-padding-y: #{map-get($spacers, 3)};
+        --formView-sheet-padding-y-md: #{map-get($spacers, 3)};
+        --formView-sheet-padding-y-lg: #{map-get($spacers, 3)};
+        --formView-sheet-padding-y-xxl: #{map-get($spacers, 3)};
+        --formView-sheet-padding-x: #{map-get($spacers, 3)};
+        --formView-sheet-padding-x-md: #{map-get($spacers, 3)};;
+        --formView-sheet-padding-x-lg: #{map-get($spacers, 3)};;
+        --formView-sheet-padding-x-xxl: #{map-get($spacers, 3)};;
         --formView-sheet-border-radius: 0;
         --formView-sheet-border-width: 0;
         --formView-sheet-border-width-md: 0;
@@ -1005,8 +1008,8 @@
     }
 
     .o_notebook {
-        --notebook-margin-x: calc(var(--formView-sheetBg-padding-x) * -1);
-        --notebook-padding-x: var(--formView-sheetBg-padding-x);
+        --notebook-margin-x: calc(var(--formView-sheet-padding-x) * -1);
+        --notebook-padding-x: var(--formView-sheet-padding-x);
     }
 
     &.o_onboarding_payment_provider_wizard .o_form_renderer {

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -57,6 +57,10 @@
     }
 }
 
+.modal .ribbon {
+    --Ribbon-gap-right: 0;
+}
+
 // after ribbon widget there can be field widgets or oe_title which may
 // have widgets on right end, add margin-right so ribbon not overlap on it
 .ribbon {


### PR DESCRIPTION
The formView inside the modal in the Time Off module was overflowing. A negative margin was applied in a previous fix for the ribbons which  shouldn't have been applied in https://github.com/odoo/odoo/commit/80098df3dddd65295988221477aea8a5dba7bc5c#diff-19c67c01eceaf5d8061dde85b4e8989c4d6c94ff71c80d336e5132d989a16c17L244

Removing this and also removing the `overflow: hidden;` on the `.form-sheet` and the  padding on `.hr_leave_column` fixes the issue.

![Screenshot 2023-07-05 at 12 13 57](https://github.com/odoo/odoo/assets/19491443/fe06e424-324d-446a-ae78-042da427c687)

Another issue arose while fixing this:

![Screenshot 2023-07-06 at 11 25 40](https://github.com/odoo/odoo/assets/19491443/12c8f673-426b-4c8a-aa09-301baf88fc94)

Ribbons on formViews within the modal have a space around them because  of the padding on `.o_form_sheet_bg`.
Switching the padding from `.o_form_sheet_bg` to ` .o_form_sheet` when inside a modal fixes this for all formviews within modals that may have a ribbon.

As for the button you can see in the screenshot, the issue existed before milk and should be done in a separate PR.

task-3414251
part of task-3326263


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
