### PR TITLE
[IMP] point_of_sale: remove is Simple Line

### DIFF
--- a/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_gcc_pos/static/src/xml/OrderReceipt.xml
@@ -96,18 +96,6 @@
     </t>
 
     <t t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension" owl="1">
-        <xpath expr="//t[@t-if='isSimple(line)']/div/span[hasclass('price_display')]" position="attributes">
-            <attribute name="t-if">!receipt.is_gcc_country</attribute>
-        </xpath>
-        <xpath expr="//t[@t-if='isSimple(line)']/WrappedProductNameLines" position="after">
-            <div class="responsive-price" t-if="receipt.is_gcc_country">
-                <div class="pos-receipt-left-padding" style="display: inline-flex;">
-                    <div t-translation="off">Taxes / الضرائب</div>:<span t-esc="env.utils.formatCurrency(line.tax, false)" style="margin-left: 5px"/>
-                </div>
-                <span t-esc="env.utils.formatCurrency(line.price_display, false)" class="price_display pos-receipt-right-align"/>
-            </div>
-        </xpath>
-
         <xpath expr="//t[@t-esc='line.unit_name']/.." position="attributes">
             <attribute name="t-if">!receipt.is_gcc_country</attribute>
         </xpath>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.js
@@ -34,12 +34,4 @@ export class OrderReceipt extends Component {
     get shippingDate() {
         return this.receiptEnv.shippingDate;
     }
-    isSimple(line) {
-        return (
-            line.discount === 0 &&
-            line.is_in_unit &&
-            line.quantity === 1 &&
-            !(line.display_discount_policy == "without_discount" && line.price < line.price_lst)
-        );
-    }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.xml
@@ -178,48 +178,39 @@
     </t>
     <t t-name="point_of_sale.OrderLinesReceipt" owl="1">
         <t t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
-            <t t-if="isSimple(line)">
-                <div class="responsive-price">
-                    <t t-esc="line.product_name_wrapped[0]" />
-                    <span t-esc="env.utils.formatCurrency(line.price_display, false)" class="price_display pos-receipt-right-align"/>
-                </div>
-                <WrappedProductNameLines line="line" />
-            </t>
-            <t t-else="">
-                <div t-esc="line.product_name_wrapped[0]" />
-                <WrappedProductNameLines line="line" />
-                <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
-                    <div class="pos-receipt-left-padding">
-                        <t t-esc="env.utils.formatCurrency(line.price_lst, false)" />
-                        ->
-                        <t t-esc="env.utils.formatCurrency(line.price, false)" />
-                    </div>
-                </t>
-                <t t-elif="line.discount !== 0">
-                    <div class="pos-receipt-left-padding">
-                        <t t-if="pos.config.iface_tax_included === 'total'">
-                            <t t-esc="env.utils.formatCurrency(line.price_with_tax_before_discount, false)"/>
-                        </t>
-                        <t t-else="">
-                            <t t-esc="env.utils.formatCurrency(line.price, false)"/>
-                        </t>
-                    </div>
-                </t>
-                <t t-if="line.discount !== 0">
-                    <div class="pos-receipt-left-padding">
-                        Discount: <t t-esc="line.discount" />%
-                    </div>
-                </t>
+            <div t-esc="line.product_name_wrapped[0]" />
+            <WrappedProductNameLines line="line" />
+            <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
                 <div class="pos-receipt-left-padding">
-                    <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
-                    <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
-                    x
-                    <t t-esc="env.utils.formatCurrency(line.price_display_one)" />
-                    <span class="price_display pos-receipt-right-align">
-                        <t t-esc="env.utils.formatCurrency(line.price_display, false)" />
-                    </span>
+                    <t t-esc="env.utils.formatCurrency(line.price_lst, false)" />
+                    ->
+                    <t t-esc="env.utils.formatCurrency(line.price, false)" />
                 </div>
             </t>
+            <t t-elif="line.discount !== 0">
+                <div class="pos-receipt-left-padding">
+                    <t t-if="pos.config.iface_tax_included === 'total'">
+                        <t t-esc="env.utils.formatCurrency(line.price_with_tax_before_discount, false)"/>
+                    </t>
+                    <t t-else="">
+                        <t t-esc="env.utils.formatCurrency(line.price, false)"/>
+                    </t>
+                </div>
+            </t>
+            <t t-if="line.discount !== 0">
+                <div class="pos-receipt-left-padding">
+                    Discount: <t t-esc="line.discount" />%
+                </div>
+            </t>
+            <div class="pos-receipt-left-padding">
+                <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
+                <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+                x
+                <t t-esc="env.utils.formatCurrency(line.price_display_one)" />
+                <span class="price_display pos-receipt-right-align">
+                    <t t-esc="env.utils.formatCurrency(line.price_display, false)" />
+                </span>
+            </div>
             <t t-if="line.customer_note">
                 <div class="pos-receipt-left-padding pos-receipt-customer-note">
                     <t t-esc="line.customer_note"/>


### PR DESCRIPTION
This commit remove the way we display the price on the same line as the product name. It was only used in few cases and most of the time the price was display on another line because we have to add information. So now, we just use only one generic case that can handle all of them.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
