### PR TITLE
[FIX] web: add markup for wkhtmltopdf error messages

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1142,7 +1142,7 @@ function makeActionManager(env) {
             const state = await wkhtmltopdfStateProm;
             // display a notification according to wkhtmltopdf's state
             if (state in WKHTMLTOPDF_MESSAGES) {
-                env.services.notification.add(WKHTMLTOPDF_MESSAGES[state], {
+                env.services.notification.add(markup(WKHTMLTOPDF_MESSAGES[state]), {
                     sticky: true,
                     title: env._t("Report"),
                 });


### PR DESCRIPTION
before this commit, the sticky error messages shown was not properly formatted.

after this commit, the html message will be properly formatted and displayed to user.

Before:
![Screenshot from 2023-07-06 15-08-43](https://github.com/odoo/odoo/assets/27989791/56497bc6-dd90-4398-9990-b43f5de08cb7)

After:

![Screenshot from 2023-07-06 15-07-57](https://github.com/odoo/odoo/assets/27989791/30ab7ceb-addf-47c5-870e-ae1461b0db3e)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
