### PR TITLE
[IMP] core: allow sentry_ignored for on routes level

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -713,7 +713,12 @@ def route(route=None, **routing):
             if params_ko:
                 _logger.warning("%s called ignoring args %s", fname, params_ko)
 
-            result = endpoint(self, *args, **params_ok)
+            try:
+                result = endpoint(self, *args, **params_ok)
+            except Exception as exc:
+                if routing.get('sentry_ignored'):
+                    exc.sentry_ignored = True
+                raise
             if routing['type'] == 'http':  # _generate_routing_rules() ensures type is set
                 return Response.load(result)
             return result


### PR DESCRIPTION
This commit is part of a strategic cleaning of the codebase. The final goal is to manage crashes via Sentry, i.e. by aggregating tracebacks from server logs and hence to fix the issues even before the customer reports it.

As a part of this strategy, we need to clean server logs that are not supposed to be fixed. For example, custom changes in Studio that break inheritance and generate traceback [1].

This commit introduce new feature that allows ignoring some route completely. Without such a feature the cleaning patches might look too complicated [2].

[1]: https://online.sentry.io/issues/4049274369/
[2]: https://github.com/odoo/enterprise/pull/42259

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
