### PR TITLE
[IMP] hr_expense: Fill payment_mode

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -783,7 +783,7 @@
                                         'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header',
                                         'default_company_id': company_id,
                                         'default_employee_id': employee_id,
-                                        'default_payment_mode': payment_mode,
+                                        'default_payment_mode': payment_mode or 'own_account',
                                     }"
                                     attrs="{'readonly': [('is_editable', '=', False)]}"
                                     force_save="1">


### PR DESCRIPTION
When creating a new expense sheet the payment_mode is empty by default. When
adding a new expense to it, the payment mode of the expense itself should be
filled with 'own_account' but if the payment mode of the expense sheet
 is set, the payment_mode of the expense related will be the same as the expense
  sheet.

Task: 3382023

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
