### PR TITLE
[FIX] sale: translating invoice general terms

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -326,7 +326,9 @@ class SaleOrder(models.Model):
             order = order.with_company(order.company_id)
             if order.terms_type == 'html' and self.env.company.invoice_terms_html:
                 baseurl = html_keep_url(order._get_note_url() + '/terms')
+                context = {'lang': order.partner_id.lang or order.env.user.lang}
                 order.note = _('Terms & Conditions: %s', baseurl)
+                del context
             elif not is_html_empty(self.env.company.invoice_terms):
                 order.note = order.with_context(lang=order.partner_id.lang).env.company.invoice_terms
 


### PR DESCRIPTION
Versions:
---------
- 16.0+

Steps to reproduce:
-------------------
1. Go to sales
2. Create a new SO and select a customer with a different language
3. Click on “send by email”
4. In the SO template pdf, the term “conditions and terms” is not translated to the customer's language

Issue:
------
In the SO template pdf, the term “conditions and terms” is not translated to the customer's language.

Cause:
------
This respective field is computed on _compute_note and it is being translated using the current user language instead of the customer language.

Solution:
---------
Change the context ‘lang’ to the customer language before translating the term

OPW-3389739