### PR TITLE
[FIX] project: grant access to sub-tasks with no project_id

### DIFF
--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -146,7 +146,7 @@
         <field name="name">Project: See private tasks</field>
         <field name="model_id" ref="project.model_project_task"/>
         <field name="domain_force">[
-            ('project_id.privacy_visibility', '!=', 'followers'),
+            '|', ('project_id', '=', False), ('project_id.privacy_visibility', '!=', 'followers'),
             '|', '|', ('project_id', '!=', False),
                       ('parent_id', '!=', False),
                  ('user_ids', 'in', user.id),


### PR DESCRIPTION
Some changes on the model project.task resulted in subtasks with no project_id set to be only visible to their assignee(s).

Steps
=====
- Install module project
- Create a project accessible to all internal users
- Add a task to this project
- Add a subtask linked to this first task, assigned to the current user and with no project_id set
- Login as another project user

Issue
=====
The subtask record is invisible (and inaccessible).

Cause
=====
Two factors resulted in this unwanted behavior:
- The ir rule "Project: See private tasks" has issue with its domain, i.e. the leaf `('project_id.privacy_visibility', '!=', 'followers')` is not verified for records with no project_id set.
- Before https://github.com/odoo/odoo/pull/115546 it wasn't noticeable as a project_id was automatically attributed to subtasks.

Fix
===
A check on project_id is simply added in the problematic record rule.

task-3414801