### PR TITLE
[FIX] mail: hide unfollow button if mail delivery fail

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -531,6 +531,8 @@ class MailMail(models.Model):
                     batch = self.browse(batch_ids)
                     batch.write({'state': 'exception', 'failure_reason': exc})
                     batch._postprocess_sent_message(success_pids=[], failure_type="mail_smtp")
+                    for mail in self:
+                        mail.body_html = re.sub(_UNFOLLOW_REGEX, '', str(mail.body_html))
             else:
                 self.browse(batch_ids)._send(
                     auto_commit=auto_commit,


### PR DESCRIPTION
When the user clicks the email's Unfollow button, an error traceback will show up.

Step reproduce :
 - Install the Discuss, Sales
 - Open Sale Order> Click on the Send by Email Button > Send.
    (Send record Delivery Failed due to SMTP config, not set up)
  - Open Settings > Techincal >Email > Emails.
  -  Open Email record. > See UnFollow Button in the Body Of Email Template.
    (Footer of Body or Right side of Powered by Odoo )
   -  Click the Unfollow Button.
 
Traceback:-
```
TypeError: MailController.mail_action_unfollow() missing 4 required positional arguments: 'model', 'res_id', 'pid', and 'token'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
```
Error:
TypeError :-MailController.mail_action_unfollow() missing 4 required positional
            arguments: 'model', 'res_id', 'pid', and 'token'

While Clicking on unfollow Button, at that times argument data is not prepared due to that data preparing in real-time so for that we should do the  SMTP Config for getting the value of that function argument.

sentry-3965574308

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
