### PR TITLE
[IMP] account: No currency creation from account.move form

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -874,12 +874,15 @@
                                           attrs="{'invisible': [('move_type', '=', 'entry')]}"> in </span>
                                     <field name="currency_id"
                                            groups="base.group_multi_currency"
-                                           attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('move_type', '=', 'entry')]}"/>
+                                           attrs="{'readonly': [('state', '!=', 'draft')], 'invisible': [('move_type', '=', 'entry')]}"
+                                           options="{'no_create': True}"
+                                           context="{'search_default_active': 1, 'search_default_inactive': 1}"/>
                                 </div>
 
                                 <field name="currency_id"
                                        attrs="{'readonly': [('state', '!=', 'draft')]}"
-                                       groups="!account.group_account_readonly,base.group_multi_currency"/>
+                                       groups="!account.group_account_readonly,base.group_multi_currency"
+                                       options="{'no_create': True}"/>
 
                             </group>
                         </group>


### PR DESCRIPTION
Prior to this, when searching for a currency in an invoice or journal entry,
"create" and "create and edit" options would show up to propose the creation
of the currency to the user although the currency already exists but is
inactive by default. This could lead to currency duplicates.

This implementation makes it now impossible to create a currency when
searching in a currency field and forces the user to go through the
settings to activate the currency he wants. In addition, we show the
inactive currencies as well in all journal entries that aren't
a miscellaneous operation.

task-3383375



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
