### PR TITLE
[FIX] l10n_in_edi*: fixed documentation link in settings

### DIFF
--- a/addons/l10n_in_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                             <t class="o_form_label">Setup E-invoice</t>
                             <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
                             <div class="text-muted">
-                                Check the <a href="https://www.odoo.com/documentation/15.0/applications/finance/accounting/fiscal_localizations/localizations/india.html">documentation</a> to get credentials
+                                Check the <a href="https://www.odoo.com/documentation/15.0/applications/finance/fiscal_localizations/india.html">documentation</a> to get credentials
                             </div>
                             <div class="content-group">
                                 <div class="mt16 row">

--- a/addons/l10n_in_edi_ewaybill/views/res_config_settings_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/res_config_settings_views.xml
@@ -13,7 +13,7 @@
                             <t class="o_form_label">Setup E-Waybill</t>
                             <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
                             <div class="text-muted">
-                                Check the <a href="https://www.odoo.com/documentation/15.0/applications/finance/accounting/fiscal_localizations/localizations/india.html">documentation</a> to get credentials
+                                Check the <a href="https://www.odoo.com/documentation/15.0/applications/finance/fiscal_localizations/india.html">documentation</a> to get credentials
                             </div>
                             <div class="content-group">
                                 <div class="mt16 row">


### PR DESCRIPTION
l10n_in_edi:

Before this commit : In Accounting settings the documentation link no longer works.

After this commit : In Accounting settings the documentation link is updated.

l10n_id_edi_ewaybill:

Before this commit : In Accounting settings the documentation link no longer works.

After this commit : In Accounting settings the documentation link is updated.

task-3247082

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
