### PR TITLE
[FIX] pos_sale: fix runbot error 23084

### DIFF
--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -93,6 +93,6 @@ ProductScreen.check.totalAmountIs(40);
 ProductScreen.do.clickPayButton();
 PaymentScreen.do.clickPaymentMethod('Bank');
 PaymentScreen.do.clickValidate();
-Chrome.do.clickTicketButton();
+ReceiptScreen.check.isShown();
 
 Tour.register('PosSettleOrderRealTime', { test: true, url: '/pos/ui' }, getSteps());


### PR DESCRIPTION
After validation of the order, receipt screen will be shown. However, the next step was clicking the "Orders" button which can cause race condition. The pos UI can sometimes show the receipt screen without being followed the Orders screen. Since the test doesn't depend on clicking the Orders button, we can remove it and replace it with a more expected result, which is showing the receipt screen.

Runbot Error: 23084
