### PR TITLE
[IMP] sale: Hide downpayment product from user.

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -69,6 +69,7 @@ This module contains all the common features of Sales Management and eCommerce.
             'sale/static/src/js/sale_progressbar_field.js',
             'sale/static/src/js/tours/sale.js',
             'sale/static/src/js/product_discount_field.js',
+            'sale/static/src/js/many2one_barcode_sale_product_field.js',
             'sale/static/src/js/sale_product_field.js',
             'sale/static/src/js/product_catalog/**/*',
             'sale/static/src/xml/**/*',

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -897,7 +897,9 @@ class SaleOrderLine(models.Model):
     @api.depends('product_id', 'state', 'qty_invoiced', 'qty_delivered')
     def _compute_product_updatable(self):
         for line in self:
-            if line.state == 'cancel':
+            if line.is_downpayment:
+                line.product_updatable = False
+            elif line.state == 'cancel':
                 line.product_updatable = False
             elif line.state == 'sale' and (
                 line.order_id.locked

--- a/addons/sale/static/src/js/many2one_barcode_sale_product_field.js
+++ b/addons/sale/static/src/js/many2one_barcode_sale_product_field.js
@@ -1,0 +1,18 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { many2OneBarcodeField, Many2OneBarcodeField } from "@web/views/fields/many2one_barcode/many2one_barcode_field";
+
+export class Many2OneBarcodeFieldSaleProduct extends Many2OneBarcodeField {}
+
+export const many2OneBarcodeFieldSaleProduct = {
+    ...many2OneBarcodeField,
+    component: Many2OneBarcodeField,
+    extractProps(fieldInfo, dynamicInfo) {
+        const props = many2OneBarcodeField.extractProps(...arguments);
+        props.canOpen = dynamicInfo.context?.is_downpayment !== true && props.canOpen;
+        return props;
+    },
+};
+
+registry.category("fields").add("many2one_barcode_sale_product", many2OneBarcodeFieldSaleProduct);

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -39,9 +39,10 @@ export class SaleOrderLineProductField extends Many2OneField {
         // product form should be accessible if the widget field is readonly
         // or if the line cannot be edited (e.g. locked SO)
         return (
-            this.props.readonlyField ||
-            (this.props.record.model.root.activeFields.order_line &&
-                this.props.record.model.root._isReadonly("order_line"))
+                ! this.props.record.data.is_downpayment && ( this.props.readonlyField || (
+                this.props.record.model.root.activeFields.order_line &&
+                this.props.record.model.root._isReadonly("order_line")
+            ))
         );
     }
     get hasExternalButton() {

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -53,6 +53,14 @@
                     <field string="Sale Orders" name="sale_order_count" widget="statinfo"/>
                 </button>
             </xpath>
+            <xpath expr="//field[@name='invoice_line_ids']/tree" position="inside">
+                <field name="is_downpayment" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="attributes">
+                <attribute name="context">{'is_downpayment': is_downpayment}</attribute>
+                <attribute name="widget">many2one_barcode_sale_product</attribute>
+                <attribute name="attrs">{'readonly': [('is_downpayment', '=', True)]}</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -35,11 +35,6 @@ class ResConfigSettings(models.TransientModel):
              "and not after the delivery.",
         config_parameter='sale.automatic_invoice',
     )
-    deposit_default_product_id = fields.Many2one(
-        related='company_id.sale_down_payment_product_id',
-        readonly=False,
-        # previously config_parameter='sale.default_deposit_product_id',
-    )
 
     invoice_mail_template_id = fields.Many2one(
         comodel_name='mail.template',

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -154,13 +154,6 @@
                                 <field name="invoice_mail_template_id" class="oe_inline" options="{'no_create': True}"/>
                             </div>
                         </setting>
-                        <setting id="down_payments"
-                            string="Down Payments"
-                            help="Product used for down payments"
-                            documentation="/applications/sales/sales/invoicing/down_payment.html"
-                            company_dependent="1">
-                            <field name="deposit_default_product_id" context="{'default_detailed_type': 'service'}"/>
-                        </setting>
                     </block>
                     <block title="Connectors" id="connectors_setting_container">
                         <setting id="amazon_connector" documentation="/applications/sales/sales/amazon_connector/setup.html" help="Import Amazon orders and sync deliveries">

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -69,11 +69,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
         string="Income Account",
         domain=[('deprecated', '=', False)],
         help="Account used for deposits")
-    deposit_taxes_id = fields.Many2many(
-        comodel_name='account.tax',
-        string="Customer Taxes",
-        domain=[('type_tax_use', '=', 'sale')],
-        help="Taxes used for deposits")
 
     # UI
     display_draft_invoice_warning = fields.Boolean(compute="_compute_display_draft_invoice_warning")

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -195,6 +195,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 self.company_id.sale_down_payment_product_id = self.env['product.product'].create(
                     self._prepare_down_payment_product_values()
                 )
+                self.company_id.sale_down_payment_product_id.product_tmpl_id.active = False  # hide down payment product from user
                 self._compute_product_id()
 
             # Create down payment section if necessary
@@ -245,7 +246,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
             'invoice_policy': 'order',
             'company_id': self.company_id.id,
             'property_account_income_id': self.deposit_account_id.id,
-            'taxes_id': [Command.set(self.deposit_taxes_id.ids)],
+            'taxes_id': False,
+            'active': False,  # hide down payment product from user
         }
 
     def _prepare_down_payment_section_values(self, order):

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -49,9 +49,6 @@
                         options="{'no_create': True}"
                         attrs="{'invisible': [('product_id', '!=', False)]}"
                         groups="account.group_account_manager"/>
-                    <field name="deposit_taxes_id"
-                        widget="many2many_tags"
-                        attrs="{'invisible': [('product_id', '!=', False)]}"/>
                 </group>
                 <group attrs="{'invisible': [('has_down_payments', '=', False)]}">
                     <field name="amount_invoiced"/>


### PR DESCRIPTION
In the settings, the Downpayments Products setting for Sales/Invoicing has become obsolete.
This commit removes the DownPayment Product from the Invoicing Settings. And hide the DownPayment Product from the user by archiving it and make it unclickable in SO's and invoices.

See: https://github.com/odoo/upgrade/pull/4914

Task: 3422811