### PR TITLE
[ADD] analytic_account: Add a constraint on analytic account naming.

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -125,6 +125,15 @@ class AccountAnalyticAccount(models.Model):
                 name = f'{name} - {analytic.partner_id.commercial_partner_id.name}'
             analytic.display_name = name
 
+    @api.constrains('name')
+    def _check_unique_name_in_plan(self):
+        for account in self:
+            account_ids = account.plan_id.account_ids.ids
+            account_ids.remove(account.id)
+            analytic_accounts = self.env['account.analytic.account'].browse(account_ids)
+            if account.name in [a['name'] for a in analytic_accounts]:
+                raise UserError("Another entry with the same name already exists in the same plan.")
+
     def copy_data(self, default=None):
         default = dict(default or {})
         default.setdefault('name', _("%s (copy)", self.name))

--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -132,7 +132,7 @@ class AccountAnalyticAccount(models.Model):
             account_ids.remove(account.id)
             analytic_accounts = self.env['account.analytic.account'].browse(account_ids)
             if account.name in [a['name'] for a in analytic_accounts]:
-                raise UserError("Another entry with the same name already exists in the same plan.")
+                raise UserError(_("Another entry with the same name already exists in the same plan."))
 
     def copy_data(self, default=None):
         default = dict(default or {})

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -791,11 +791,18 @@ class Project(models.Model):
     @api.model
     def _create_analytic_account_from_values(self, values):
         company = self.env['res.company'].browse(values.get('company_id')) if values.get('company_id') else self.env.company
+        
+        plan = company.analytic_plan_id
+        account_ids = plan.account_ids.ids
+        analytic_account_names = [a['name'] for a in self.env['account.analytic.account'].browse(account_ids)]
+        default_str = 'Unknown Analytic Account'
+        default_ctr = analytic_account_names.count(default_str)
+
         analytic_account = self.env['account.analytic.account'].create({
-            'name': values.get('name', _('Unknown Analytic Account')),
+            'name': values.get('name', _(f"{default_str}_{default_ctr + 1}")),
             'company_id': company.id,
             'partner_id': values.get('partner_id'),
-            'plan_id': company.analytic_plan_id.id,
+            'plan_id': plan.id,
         })
         return analytic_account
 


### PR DESCRIPTION
Before it is added

Two analytic accounts in the same analytic plan could have the same name.

What does it do

Add a constraint on the name so that two analytic account in the same analytic plan cannot have the same name.

How does it work

Using api.constraint decorator, read the analytic account names in the same analytic plan. Then, compare the names to the one the user wants to set. Raise an error if on matches.

task-3414535

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
