### PR TITLE
[IMP] sale_timesheet: make timesheet revenues accurate for prepaid

### DIFF
--- a/addons/sale_timesheet/report/timesheets_analysis_report.py
+++ b/addons/sale_timesheet/report/timesheets_analysis_report.py
@@ -36,13 +36,22 @@ class TimesheetsAnalysisReport(models.Model):
             A.so_line AS so_line,
             A.timesheet_invoice_type AS timesheet_invoice_type,
             A.timesheet_invoice_id AS timesheet_invoice_id,
-            CASE WHEN A.order_id IS NULL THEN 0 ELSE A.unit_amount * SOL.price_unit * sol_product_uom.factor / a_product_uom.factor END AS timesheet_revenues,
+            CASE
+                WHEN A.order_id IS NULL OR T.service_type in ('manual', 'milestones')
+                THEN 0
+                WHEN T.invoice_policy = 'order' AND SOL.qty_delivered != 0
+                THEN (SOL.price_total / SOL.qty_delivered) * A.unit_amount
+                ELSE A.unit_amount * SOL.price_unit * sol_product_uom.factor / a_product_uom.factor
+            END AS timesheet_revenues,
             CASE WHEN A.order_id IS NULL THEN 0 ELSE A.unit_amount END AS billable_time
         """
 
     @api.model
     def _from(self):
         return super()._from() + """
-        LEFT JOIN sale_order_line SOL ON A.so_line = SOL.id
-        LEFT JOIN uom_uom sol_product_uom ON sol_product_uom.id=SOL.product_uom
-        INNER JOIN uom_uom a_product_uom ON a_product_uom.id=A.product_uom_id"""
+            LEFT JOIN sale_order_line SOL ON A.so_line = SOL.id
+            LEFT JOIN uom_uom sol_product_uom ON sol_product_uom.id = SOL.product_uom
+            INNER JOIN uom_uom a_product_uom ON a_product_uom.id = A.product_uom_id
+            LEFT JOIN product_product P ON P.id = SOL.product_id
+            LEFT JOIN product_template T ON T.id = P.product_tmpl_id
+        """


### PR DESCRIPTION
...services

In the reporting of Timesheets, "timesheet revenues" represent `sol.price_unit * sum(timesheets.unit_amount)`.
While this calculation is correct for SOLs with a service invoiced on delivered quantities, it doesn't reflect the truth when the product is prepaid/fixed price (ordered quantities).

With this commit, the "timesheet revenues" related to the latter type of services will be equal to
`sol.price_total / sol.qty_delivered * sum(timesheets.unit_amount)`. Where we determine the revenue per unit, and apply it to the total duration of timesheets.

Example:
Say a SOL with a service of type "prepaid/fixed price", an ordered quantity of 4, and a price per unit of 3.00€. The total price is 12.00€ no matter how much has been delivered. Say users A and B, having respectively timesheeted 2h and 1h, so the delivered quantity of the SOL is 3.
We'll note "timesheet revenue of user X" "TR(X)".

Before this commit:
`TR(A) = 3.00€/h * 2h = 6.00€`
`TR(B) = 3.00€/h * 1h = 3.00€`
`TR(A) + TR(B) = 6.00€ + 3.00€ = 9.00€`
The total timesheet revenues is 9.00€ where it should be 12.00€.

Now:
`TR(A) = 12.00€ / 3h * 2h = 8.00€`
`TR(B) = 12.00€ / 3h * 1h = 4.00€`
`TR(A) + TR(B) = 8.00€ + 4.00€ = 12.00€`
The total timesheet revenues corresponds to the SOL's total price.

task-3368808




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
