### PR TITLE
[FIX] mass_mailing: discard button remains

### DIFF
--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -6533,6 +6533,8 @@ QUnit.module("Views", (hooks) => {
         await editInput(target, ".o_field_widget[name=foo] input", "1234");
         await clickDiscard(target);
         assert.containsNone(target, ".modal");
+        def.resolve();
+        await nextTick();
         assert.strictEqual(
             target.querySelector('.o_field_widget[name="foo"] input').value,
             "blip",
@@ -6540,8 +6542,6 @@ QUnit.module("Views", (hooks) => {
         );
 
         // complete the onchange
-        def.resolve();
-        await nextTick();
         assert.strictEqual(
             target.querySelector('.o_field_widget[name="foo"] input').value,
             "blip",

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2384,13 +2384,13 @@ const Wysiwyg = Widget.extend({
             this._shouldDelayBlur = false;
         }
     },
-    _onBlur: function () {
+    _onBlur: function (action) {
         if (this._shouldDelayBlur) {
             this._pendingBlur = true;
         } else {
             // todo: to remove when removing the legacy field_html
             this.trigger_up('wysiwyg_blur');
-            this.options.onWysiwygBlur && this.options.onWysiwygBlur();
+            this.options.onWysiwygBlur && this.options.onWysiwygBlur(action);
         }
     },
     _onScroll: function(ev) {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -195,7 +195,19 @@ Wysiwyg.include({
         if (!this.options.inIframe) {
             this._super.apply(this, arguments);
         } else {
-            this.$iframe[0].contentWindow.addEventListener('blur', this._onBlur);
+            let action = undefined; 
+            // Extract both the status button and addEvent Listner on both of them 
+            // so the action ['Save' OR 'Discard'] can be passed on to _onBlur of wysiwyg
+
+            const actionButtons = Array.from(document.querySelectorAll('.o_form_button_save, .o_form_button_cancel'));
+            actionButtons.forEach(btn => {
+                btn.addEventListener('mousedown', (ev) => {
+                    action = ev.currentTarget.dataset.tooltip;
+                });
+            });
+            this.$iframe[0].contentWindow.addEventListener('blur', () => {
+                this._onBlur(action);
+            });
         }
     },
 


### PR DESCRIPTION
Before this commit:

After making some changes in mass_mailing when discard button is clicked, this discard reappears.

After this commit:

Now, after making changes when we click on discard button, the button disappears

task-3324903