### PR TITLE
[FIX] website: ensure proper display of options in different mode switches

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -180,7 +180,7 @@ options.registry.gallery = options.Class.extend({
 
         _.each(imgs, function (img, index) {
             var $img = $(img);
-            var $col = $('<div/>', {class: colClass});
+            var $col = $('<div/>', {class: 'o_snippet_not_selectable ' + colClass});
             $col.append($img).appendTo($row);
             if ((index + 1) % columns === 0) {
                 $row = $('<div/>', {class: 'row s_nb_column_fixed'});
@@ -281,7 +281,9 @@ options.registry.gallery = options.Class.extend({
             if (img.width >= img.height * 2 || img.width > 600) {
                 wrapClass = 'col-lg-6';
             }
-            var $wrap = $('<div/>', {class: wrapClass}).append(imgHolderEls[index]);
+            var $wrap = $("<div/>", { class: "o_snippet_not_selectable " + wrapClass }).append(
+                imgHolderEls[index]
+            );
             $row.append($wrap);
         });
     },


### PR DESCRIPTION
Steps to reproduce:

 1. Drop an Images Wall snippet
 2. Select an image
 3. Switch Mode from Masonry to Grid or Float => option blocks displayed
 4. Again select an image
 5. Switch Mode from Float or Grid to any mode => empty option blocks are displayed

This commit enhances the selectability of elements when switching modes in the Images Wall snippet. Previously, when transitioning from Grid or Float mode to masonry mode, the option blocks were displayed as empty because the element was not selectable. However, when switching from Masonry to Grid or Float mode, the option blocks were not empty because the element was selectable.
To address this inconsistency, the commit introduces the addition of `o_snippet_not_selectable`, making the element selectable during mode changes.

task-3374831
