### PR TITLE
[FIX] base_import: restore selection of nested fields

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -187,8 +187,11 @@ export class ImportAction extends Component {
     // Fields
     //--------------------------------------------------------------------------
 
-    onFieldChanged(column, fieldId) {
-        const selection = this.model.fields.find((f) => f.id === fieldId);
+    onFieldChanged(column, fieldPath) {
+        let selection;
+        for (const group of Object.values(column.fields)) {
+            selection = selection || group.find(f => f.fieldPath === fieldPath);
+        }
         this.model.setColumnField(column, selection);
     }
 

--- a/addons/base_import/static/src/import_data_content/import_data_content.js
+++ b/addons/base_import/static/src/import_data_content/import_data_content.js
@@ -46,7 +46,7 @@ export class ImportDataContent extends Component {
     makeChoices(fields) {
         return fields.map((field) => ({
             label: field.label,
-            value: field.id,
+            value: field.fieldPath,
         }));
     }
 

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -60,9 +60,9 @@
                             </td>
                             <td>
                                 <SelectMenu
-                                    value="column.fieldInfo and column.fieldInfo.id"
+                                    value="column.fieldInfo and column.fieldInfo.fieldPath"
                                     groups="getGroups(column)"
-                                    onSelect="(fieldId) => this.props.onFieldChanged(column, fieldId)"
+                                    onSelect="fieldPath => this.props.onFieldChanged(column, fieldPath)"
                                     searchPlaceholder="searchPlaceholder"
                                     togglerClass="column.fieldInfo ? 'ps-1' : ''"
                                 >


### PR DESCRIPTION
Selecting a nested field (ie a field on a relational field) no longer works since the introduction of [commit 1]. This commit aimed to resolve some issues regarding the usage of objects as values in the `SelectMenu` component but made the assumptions that any importable field can be represented by its name and can be found on the model being imported. Both of these do not hold in the case of nested fields however (multiple nested fields on different models can have the same name).

Instead of using the field name, the `fieldPath` can be used to represent the `SelectMenu` choices in unique fashion.

opw-3390220

[commit 1]: https://github.com/odoo/odoo/commit/22cc9660ed3b87d3a03d437cb87925ba8b587bfa