### PR TITLE
[FIX] purchase_stock: trigger compute_qty when POL qty changes

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -89,7 +89,7 @@ class Orderpoint(models.Model):
     vendor_id = fields.Many2one(related='supplier_id.partner_id', string="Vendor", store=True)
     purchase_visibility_days = fields.Float(default=0.0, help="Visibility Days applied on the purchase routes.")
 
-    @api.depends('product_id.purchase_order_line_ids', 'product_id.purchase_order_line_ids.state')
+    @api.depends('product_id.purchase_order_line_ids.product_uom_qty', 'product_id.purchase_order_line_ids.state')
     def _compute_qty(self):
         """ Extend to add more depends values """
         return super()._compute_qty()


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “P1”
- Create reordering rule (Mini 2 and Maximum 5)
- Add a vendor
- Run the scheduler
- The RFQ will be generated for 5 qty of “P1”
- Create a SO of Product A for 10 units.

- 10 units will be updated in the PO. (Now PO has 15 quantities)
- Add another product in the sale order “P2”.

**Problem:**
The Pol with the product “P1”  will be again updated with 10 quantities and total quantities of 25.

When creating a SO with a quantity of 10, the `qty_to_order` field is
computed and set to a demand of 10. So, the PO is updated. However,
the `compute_qty` function in the `stock.warehouse.orderpoint` model
is not triggered because it’s depends on the lines in the PO
(adding or removing a line is required for it to be triggered).
Since this computation is not triggered, the `qty_to_forecast`
field is not updated:

https://github.com/odoo/odoo/blob/72444f13ee7f71178733883e9022b27a5b7a0049/addons/stock/models/stock_orderpoint.py#L97

As a result, the `qty_to_order` field is also not updated and remains
at 10 instead of becoming 0:

https://github.com/odoo/odoo/blob/87d33596d11cf2e287b4c10736d49d782bf6d6f0/addons/stock/models/stock_orderpoint.py#L271-L272

https://github.com/odoo/odoo/blob/8462f6c9a09076b5d7a937c66b236404905172a8/addons/stock/models/stock_orderpoint.py#L508

opw-3342879
opw-3324064
