### PR TITLE
[FIX] web_editor: remove unwanted styles and tags

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -152,7 +152,6 @@ export const CLIPBOARD_WHITELISTS = {
     ],
     attributes: ['class', 'href', 'src', 'target'],
     styledTags: ['SPAN', 'B', 'STRONG', 'I', 'S', 'U', 'FONT'],
-    styles: ['text-decoration', 'font-weight', 'background-color', 'color', 'font-style', 'text-decoration-line', 'font-size']
 };
 
 function defaultOptions(defaultObject, object) {
@@ -2330,7 +2329,8 @@ export class OdooEditor extends EventTarget {
      * @param {Node} node
      */
     _cleanForPaste(node) {
-        if (!this._isWhitelisted(node) || this._isBlacklisted(node)) {
+        if (!this._isWhitelisted(node) || this._isBlacklisted(node) ||
+            node.id && node.id.startsWith('docs-internal-guid') || node.nodeName === 'P' && node.parentNode.nodeName === 'LI') {
             if (!node.matches || node.matches(CLIPBOARD_BLACKLISTS.remove.join(','))) {
                 node.remove();
             } else {
@@ -2385,14 +2385,8 @@ export class OdooEditor extends EventTarget {
             for (const attribute of [...node.attributes]) {
                 // Keep allowed styles on nodes with allowed tags.
                 if (CLIPBOARD_WHITELISTS.styledTags.includes(node.nodeName) && attribute.name === 'style') {
-                    const spanInlineStyles = attribute.value.split(';').map(x => x.trim());
-                    const allowedSpanInlineStyles = spanInlineStyles.filter(rawStyle => {
-                        return CLIPBOARD_WHITELISTS.styles.includes(rawStyle.split(':')[0].trim());
-                    });
                     node.removeAttribute(attribute.name);
-                    if (allowedSpanInlineStyles.length > 0) {
-                        node.setAttribute(attribute.name, allowedSpanInlineStyles.join(';'));
-                    } else if (['SPAN', 'FONT'].includes(node.tagName)) {
+                    if (['SPAN', 'FONT'].includes(node.tagName)) {
                         for (const unwrappedNode of unwrapContents(node)) {
                             this._cleanForPaste(unwrappedNode);
                         }
@@ -2428,12 +2422,11 @@ export class OdooEditor extends EventTarget {
                 okClass instanceof RegExp ? okClass.test(item) : okClass === item,
             );
         } else {
-            const allowedSpanStyles = CLIPBOARD_WHITELISTS.styles.map(s => `span[style*="${s}"]`);
             return (
                 item.nodeType === Node.TEXT_NODE ||
                 (
                     item.matches &&
-                    item.matches([...CLIPBOARD_WHITELISTS.nodes, ...allowedSpanStyles].join(','))
+                    item.matches([...CLIPBOARD_WHITELISTS.nodes].join(','))
                 )
             );
         }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -96,7 +96,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, 'a<span style="text-decoration: underline">bc</span>d');
                     },
-                    contentAfter: '<p>123a<span style="text-decoration: underline">bc</span>d[]</p>',
+                    contentAfter: '<p>123abcd[]</p>',
                 });
             });
         });
@@ -519,7 +519,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>1<b style="font-weight: bolder">23</b>&nbsp;4[]abcd</p>',
+                    contentAfter: '<p>1<b>23</b>&nbsp;4[]abcd</p>',
                 });
             });
             it('should paste a text in a p', async () => {
@@ -528,7 +528,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>ab1<b style="font-weight: bolder">23</b>&nbsp;4[]cd</p>',
+                    contentAfter: '<p>ab1<b>23</b>&nbsp;4[]cd</p>',
                 });
             });
             it('should paste a text in a span', async () => {
@@ -537,7 +537,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>a<span>b1<b style="font-weight: bolder">23</b>&nbsp;4[]c</span>d</p>',
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]c</span>d</p>',
                 });
             });
         });
@@ -548,7 +548,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>a1<b style="font-weight: bolder">23</b>&nbsp;4[]d</p>',
+                    contentAfter: '<p>a1<b>23</b>&nbsp;4[]d</p>',
                 });
             });
             it('should paste a text in a span', async () => {
@@ -557,7 +557,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>a<span>b1<b style="font-weight: bolder">23</b>&nbsp;4[]e</span>f</p>',
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]e</span>f</p>',
                 });
             });
             it('should paste a text when selection across two span', async () => {
@@ -566,14 +566,14 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>a<span>b1<b style="font-weight: bolder">23</b>&nbsp;4[]e</span>f</p>',
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]e</span>f</p>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<span>b[c</span>- -<span>d]e</span>f</p>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<p>a<span>b1<b style="font-weight: bolder">23</b>&nbsp;4[]e</span>f</p>',
+                    contentAfter: '<p>a<span>b1<b>23</b>&nbsp;4[]e</span>f</p>',
                 });
             });
             it('should paste a text when selection across two p', async () => {
@@ -582,14 +582,14 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>a<p>b1<b style="font-weight: bolder">23</b>&nbsp;4[]e</p>f</div>',
+                    contentAfter: '<div>a<p>b1<b>23</b>&nbsp;4[]e</p>f</div>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<div>a<p>b[c</p>- -<p>d]e</p>f</div>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>a<p>b1<b style="font-weight: bolder">23</b>&nbsp;4[]e</p>f</div>',
+                    contentAfter: '<div>a<p>b1<b>23</b>&nbsp;4[]e</p>f</div>',
                 });
             });
             it('should paste a text when selection leave a span', async () => {
@@ -598,14 +598,14 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>ab<span>c1<b style="font-weight: bolder">23</b>&nbsp;4[]</span>f</div>',
+                    contentAfter: '<div>ab<span>c1<b>23</b>&nbsp;4[]</span>f</div>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<div>a[b<span>c]d</span>ef</div>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>a1<b style="font-weight: bolder">23</b>&nbsp;4[]<span>d</span>ef</div>',
+                    contentAfter: '<div>a1<b>23</b>&nbsp;4[]<span>d</span>ef</div>',
                 });
             });
             it('should paste a text when selection across two element', async () => {
@@ -614,21 +614,21 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>1a<p>b1<b style="font-weight: bolder">23</b>&nbsp;4[]<span>e</span>f</p></div>',
+                    contentAfter: '<div>1a<p>b1<b>23</b>&nbsp;4[]<span>e</span>f</p></div>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<div>2a<span>b[c</span><p>d]e</p>f</div>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>2a<span>b1<b style="font-weight: bolder">23</b>&nbsp;4[]</span>e<br>f</div>',
+                    contentAfter: '<div>2a<span>b1<b>23</b>&nbsp;4[]</span>e<br>f</div>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<div>3a<p>b[c</p><p>d]e</p>f</div>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>3a<p>b1<b style="font-weight: bolder">23</b>&nbsp;4[]e</p>f</div>',
+                    contentAfter: '<div>3a<p>b1<b>23</b>&nbsp;4[]e</p>f</div>',
                 });
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/htmlTables.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/htmlTables.test.js
@@ -221,25 +221,25 @@ describe('Paste HTML tables', () => {
             
             
             <tbody><tr>
-                <td class=""><span style="color: rgb(73, 80, 87);font-size: 10pt;font-style: italic"><span class="" style="color: #495057;font-size: 10.0pt;font-weight: 400;font-style: italic;text-decoration: none">Italic
-                        then also </span><span class="" style="color: #495057;font-size: 10.0pt;font-weight: 700;font-style: italic;text-decoration: none">BOLD</span></span></td>
-                <td class=""><span style="color: rgb(73, 80, 87);font-size: 10pt;font-style: italic"><s>Italic strike</s></span></td>
+                <td class="">Italic
+                        then also BOLD</td>
+                <td class=""><s>Italic strike</s></td>
             </tr>
             <tr>
-                <td class=""><span style="color: rgb(73, 80, 87);font-size: 10pt;font-weight: 700"><span class="" style="color: #495057;font-size: 10.0pt;font-weight: 700;font-style: normal;text-decoration: none">Just bold </span><span class="" style="color: #495057;font-size: 10.0pt;font-weight: 400;font-style: italic;text-decoration: none">Just Italic</span></span></td>
-                <td class=""><span style="color: rgb(73, 80, 87);font-size: 10pt;font-weight: 700;text-decoration: underline">Bold underline</span></td>
+                <td class="">Just bold Just Italic</td>
+                <td class="">Bold underline</td>
             </tr>
             <tr>
-                <td class=""><span style="color: red;font-size: 10pt">Color text</span></td>
-                <td class=""><span style="color: red;font-size: 10pt;text-decoration: underline"><s>Color strike and underline</s></span></td>
+                <td class="">Color text</td>
+                <td class=""><s>Color strike and underline</s></td>
             </tr>
             <tr>
-                <td class=""><span style="color: rgb(73, 80, 87);font-size: 10pt">Color background</span></td>
-                <td class=""><span style="color: red;font-size: 10pt">Color text on color background</span></td>
+                <td class="">Color background</td>
+                <td class="">Color text on color background</td>
             </tr>
             <tr>
-                <td class=""><span style="font-size: 14pt">14pt MONO TEXT
-                </span></td>
+                <td class="">14pt MONO TEXT
+                </td>
             </tr>
         </tbody></table><p>
     
@@ -328,33 +328,33 @@ describe('Paste HTML tables', () => {
         
         <tbody>
             <tr>
-                <td><span style="font-weight: normal;font-style: italic;color: rgb(73, 80, 87)">
-                    <span style="font-size:10pt;font-style:italic;color:#495057">Italic then also
-                    </span><span style="font-size:10pt;font-weight:bold;font-style:italic;color:#495057">BOLD</span>
-                </span></td>
-                <td><span style="font-style: italic;text-decoration: line-through;color: rgb(73, 80, 87)">Italic strike</span></td>
+                <td>
+                    Italic then also
+                    BOLD
+                </td>
+                <td>Italic strike</td>
             </tr>
             <tr>
-                <td><span style="font-weight: bold;color: rgb(73, 80, 87)">
-                    <span style="font-size:10pt;font-weight:bold;font-style:normal;color:#495057">Just
-                        Bold </span><span style="font-size:10pt;font-style:italic;color:#495057">Just
-                        Italic</span>
-                </span></td>
-                <td><span style="font-weight: bold;text-decoration: underline;color: rgb(73, 80, 87)">Bold underline</span></td>
+                <td>
+                    Just
+                        Bold Just
+                        Italic
+                </td>
+                <td>Bold underline</td>
             </tr>
             <tr>
-                <td><span style="color: rgb(255, 0, 0)">Color text</span></td>
-                <td><span style="text-decoration: underline line-through;color: rgb(255, 0, 0)">Color
-                    strike and underline</span></td>
+                <td>Color text</td>
+                <td>Color
+                    strike and underline</td>
             </tr>
             <tr>
-                <td><span style="font-weight: normal;color: rgb(73, 80, 87)">Color background
-                </span></td>
-                <td><span style="color: rgb(255, 0, 0)">Color
-                    text on color background</span></td>
+                <td>Color background
+                </td>
+                <td>Color
+                    text on color background</td>
             </tr>
             <tr>
-                <td><span style="font-size: 14pt;font-weight: normal">14pt MONO TEXT</span></td>
+                <td>14pt MONO TEXT</td>
             </tr>
         </tbody>
     </table><p>
@@ -471,21 +471,21 @@ describe('Paste HTML tables', () => {
         </tr>
         <tr>
             <td>
-                <font style="color: rgb(255, 0, 0)">Color text</font>
+                Color text
             </td>
             <td><u><s>
-                        <font style="color: rgb(255, 0, 0)">Color strike and underline</font>
+                        Color strike and underline
                     </s></u></td>
         </tr>
         <tr>
             <td>Color background</td>
             <td>
-                <font style="color: rgb(255, 0, 0)">Color text on color background</font>
+                Color text on color background
             </td>
         </tr>
         <tr>
             <td>
-                <font style="font-size: 14pt">14pt MONO TEXT</font>
+                14pt MONO TEXT
             </td>
         </tr>
     </tbody></table><p>


### PR DESCRIPTION
Current behavior before PR:

When pasting text from Google Docs, it often includes additional tags such as `<b>` and `<P>`, along with unwanted styles.

Desired behavior after PR is merged:

When pasting text from google Docs, those extra tags and styles are now removed.

task-3378093




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
