### PR TITLE
[FIX] loyalty_delivery: Add dependency sale_loyalty

### DIFF
--- a/addons/loyalty_delivery/__manifest__.py
+++ b/addons/loyalty_delivery/__manifest__.py
@@ -5,7 +5,7 @@
     'summary': "Add a free shipping option to your rewards",
     'category': 'Sales',
     'version': '1.0',
-    'depends': ['loyalty', 'delivery'],
+    'depends': ['delivery', 'sale_loyalty'],
     'data': [
         'data/loyalty_delivery_data.xml',
         'views/loyalty_reward_views.xml',


### PR DESCRIPTION
The field "coupon_id" in the "sale.order.line" is introduced by the "sale_loyalty" module.
As the "loyalty_delivery" module relies on this field, it is crucial to establish the correct dependency.

1. Install `sale` and `loyalty`
2. Uninstall `sale_loyalty`
3. Install `loyalty_delivery`


While accessing Website - Shop - Add to Cart - Process Checkout.

```python
Traceback (most recent call last):
  File "/home/odoo/src/odoo/16.0/odoo/http.py", line 1584, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/16.0/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/src/odoo/16.0/odoo/http.py", line 1611, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/16.0/odoo/http.py", line 1725, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/16.0/addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo/src/odoo/16.0/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/16.0/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/16.0/addons/website_sale_delivery/controllers/main.py", line 24, in shop_payment
    order._check_carrier_quotation(force_carrier_id=carrier_id, keep_carrier=keep_carrier)
  File "/home/odoo/src/odoo/16.0/addons/website_sale_delivery/models/sale_order.py", line 54, in _check_carrier_quotation
    res = carrier.rate_shipment(self)
  File "/home/odoo/src/odoo/16.0/addons/delivery/models/delivery_carrier.py", line 198, in rate_shipment
    amount_without_delivery = order._compute_amount_total_without_delivery()
  File "/home/odoo/src/odoo/16.0/addons/loyalty_delivery/models/sale_order.py", line 12, in _compute_amount_total_without_delivery
    lines = self.order_line.filtered(lambda l: l.coupon_id)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 5397, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 5397, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/src/odoo/16.0/addons/loyalty_delivery/models/sale_order.py", line 12, in <lambda>
    lines = self.order_line.filtered(lambda l: l.coupon_id)
AttributeError: 'sale.order.line' object has no attribute 'coupon_id'
```
Description of the issue/feature this PR addresses:

The field "coupon_id" in the "sale.order.line" is introduced by the "sale_loyalty" module 
(source: https://github.com/odoo/odoo/blob/d0ae3018f9999116c3837b7702e3514af815a6c5/addons/sale_loyalty/models/sale_order_line.py#L11). 
As the "loyalty_delivery" module (source: https://github.com/odoo/odoo/blob/d0ae3018f9999116c3837b7702e3514af815a6c5/addons/loyalty_delivery/models/sale_order.py#L12) relies on this field, it is crucial to establish the correct dependency. 

Current behavior before PR:


Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
