### PR TITLE
[IMP] mrp: update BOM - adapt MO multi step behaviour

### DIFF
--- a/addons/mrp/data/mail_templates.xml
+++ b/addons/mrp/data/mail_templates.xml
@@ -7,23 +7,42 @@
             Manual actions may be needed.
             <div class="mt16">
                 <p>Exception(s):</p>
-                <ul t-foreach="order_exceptions.items()" t-as="order_exception">
-                    <li>
-                        <t t-set="move_raw_id" t-value="order_exception[0]"/>
-                        <t t-set="exception" t-value="order_exception[1]"/>
-                        <t t-set="order" t-value="exception[0]"/>
-                        <t t-set="new_qty" t-value="exception[1][0]"/>
-                        <t t-set="old_qty" t-value="exception[1][1]"/>
+                <t t-if="has_multiple_products">
+                    <ul>
+                        <li>
                             <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="production_order.id"><t t-esc="production_order.name"/></a>:
-                            <t t-esc="new_qty"/> <t t-esc="move_raw_id.product_uom.name"/> of <t t-esc="move_raw_id.product_id.name"/>
-                            <t t-if="cancel">
-                                cancelled
-                            </t>
-                            <t t-if="not cancel">
-                                ordered instead of <t t-esc="old_qty"/> <t t-esc="move_raw_id.product_uom.name"/>
-                            </t>
-                      </li>
-                </ul>
+                            <ul t-foreach="order_exceptions.items()" t-as="order_exception">
+                                <li>
+                                    <t t-set="move_raw_id" t-value="order_exception[0]"/>
+                                    <t t-set="exception" t-value="order_exception[1]"/>
+                                    <t t-set="new_qty" t-value="exception[1][0]"/>
+                                    <t t-set="old_qty" t-value="exception[1][1]"/>
+                                    <t t-esc="new_qty"/> <t t-esc="move_raw_id.product_uom.name"/> of <t t-esc="move_raw_id.product_id.name"/>
+                                    ordered instead of <t t-esc="old_qty"/> <t t-esc="move_raw_id.product_uom.name"/>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </t>
+                <t t-else="">
+                    <ul t-foreach="order_exceptions.items()" t-as="order_exception">
+                        <li>
+                            <t t-set="move_raw_id" t-value="order_exception[0]"/>
+                            <t t-set="exception" t-value="order_exception[1]"/>
+                            <t t-set="order" t-value="exception[0]"/>
+                            <t t-set="new_qty" t-value="exception[1][0]"/>
+                            <t t-set="old_qty" t-value="exception[1][1]"/>
+                                <a href="#" data-oe-model="mrp.production" t-att-data-oe-id="production_order.id"><t t-esc="production_order.name"/></a>:
+                                <t t-esc="new_qty"/> <t t-esc="move_raw_id.product_uom.name"/> of <t t-esc="move_raw_id.product_id.name"/>
+                                <t t-if="cancel">
+                                    cancelled
+                                </t>
+                                <t t-if="not cancel">
+                                    ordered instead of <t t-esc="old_qty"/> <t t-esc="move_raw_id.product_uom.name"/>
+                                </t>
+                          </li>
+                    </ul>
+                </t>
             </div>
             <div class="mt16" t-if="not cancel and impacted_pickings">
                 <p>Impacted Transfer(s):</p>


### PR DESCRIPTION
Before commit:
==================
In MO if a line is deleted or line has its to consume quantity reduced so in transfers user does not get any kind of warning or exception, same case in the child MO (MTO use case) when it exists if line is deleted or line has its to consume quantity reduced.

After commit:
================
Exception is created when a line is deleted or line has its to consume quantity reduced and when child MO (MTO use case) when it exists.

task: 3283010