### PR TITLE
[IMP] point_of_sale: partner editor, use t-model for fields

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerDetailsEdit.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PartnerListScreen/PartnerDetailsEdit.xml
@@ -13,37 +13,36 @@
                 </t>
                 <input type="file" class="image-uploader" t-on-change="uploadImage" />
             </div>
-            <input class="detail partner-name" name="name" t-att-value="props.partner.name or ''"
-                   placeholder="Name" t-on-change="captureChange" />
+            <input class="detail partner-name" name="name" t-model="changes.name" placeholder="Name" t-on-change="captureChange" />
             <div class="partner-details-box clearfix">
                 <div class="partner-details-left">
                     <div class="partner-detail">
                         <span class="label">Street</span>
                         <input class="detail" name="street"
-                               t-on-change="captureChange" t-att-value="props.partner.street || ''"
+                               t-model="changes.street"
+                               t-on-change="captureChange"
                                placeholder="Street" />
                     </div>
                     <div class="partner-detail">
                         <span class="label">City</span>
                         <input class="detail" name="city"
-                               t-on-change="captureChange" t-att-value="props.partner.city || ''"
+                               t-model="changes.city"
+                               t-on-change="captureChange"
                                placeholder="City" />
                     </div>
                     <div class="partner-detail">
                         <span class="label">Postcode</span>
                         <input class="detail" name="zip"
-                               t-on-change="captureChange" t-att-value="props.partner.zip || ''"
+                               t-model="changes.zip"
+                               t-on-change="captureChange"
                                placeholder="ZIP" />
                     </div>
-                    <div class="partner-detail">
+                    <div class="partner-detail" t-if="env.pos.states.some((state) => state.country_id[0] == changes.country_id)">
                         <span class="label">State</span>
-                        <select class="detail" name="state_id"
-                                t-on-change="captureChange">
+                        <select class="detail" name="state_id" t-model="changes.state_id" t-on-change="captureChange">
                             <option value="">None</option>
                             <t t-foreach="env.pos.states" t-as="state" t-key="state.id">
-                                <option t-if="props.partner.country_id[0] == state.country_id[0]"
-                                        t-att-value="state.id"
-                                        t-att-selected="props.partner.state_id ? ((state.id === props.partner.state_id[0]) ? true : undefined) : undefined">
+                                <option t-if="changes.country_id == state.country_id[0]" t-att-value="state.id">
                                     <t t-esc="state.name" />
                                 </option>
                             </t>
@@ -51,12 +50,10 @@
                     </div>
                     <div class="partner-detail">
                         <span class="label">Country</span>
-                        <select class="detail" name="country_id"
-                                t-on-change="captureChange">
+                        <select class="detail" name="country_id" t-model="changes.country_id" t-on-change="captureChange">
                             <option value="">None</option>
                             <t t-foreach="env.pos.countries" t-as="country" t-key="country.id">
-                                <option t-att-value="country.id"
-                                        t-att-selected="props.partner.country_id ? ((country.id === props.partner.country_id[0]) ? true : undefined) : undefined">
+                                <option t-att-value="country.id">
                                     <t t-esc="country.name" />
                                 </option>
                             </t>
@@ -66,11 +63,9 @@
                 <div class="partner-details-right">
                     <div class="partner-detail">
                         <span class="label">Language</span>
-                        <select class="detail" name="lang"
-                                t-on-change="captureChange">
+                        <select class="detail" name="lang" t-model="changes.lang" t-on-change="captureChange">
                             <t t-foreach="env.pos.langs" t-as="lang" t-key="lang.id">
-                                <option t-att-value="lang.code"
-                                        t-att-selected="props.partner.lang ? ((lang.code === props.partner.lang) ? true : undefined) : lang.code === env.pos.user.lang? true : undefined">
+                                <option t-att-value="lang.code">
                                     <t t-esc="lang.name" />
                                 </option>
                             </t>
@@ -78,40 +73,30 @@
                     </div>
                     <div class="partner-detail">
                         <span class="label">Email</span>
-                        <input class="detail" name="email" type="email"
-                               t-on-change="captureChange"
-                               t-att-value="props.partner.email || ''" />
+                        <input class="detail" name="email" type="email" t-model="changes.email" t-on-change="captureChange" />
                     </div>
                     <div class="partner-detail">
                         <span class="label">Phone</span>
-                        <input class="detail" name="phone" type="tel"
-                               t-on-change="captureChange"
-                               t-att-value="props.partner.phone || ''" />
+                        <input class="detail" name="phone" type="tel" t-model="changes.phone" t-on-change="captureChange" />
                     </div>
                     <div class="partner-detail">
                         <span class="label">Mobile</span>
-                        <input class="detail" name="mobile" type="tel"
-                               t-on-change="captureChange"
-                               t-att-value="props.partner.mobile || ''" />
+                        <input class="detail" name="mobile" type="tel" t-model="changes.mobile" t-on-change="captureChange" />
                     </div>
                     <div class="partner-detail">
                         <span class="label">Barcode</span>
-                        <input class="detail barcode" name="barcode" t-on-change="captureChange"
-                               t-att-value="props.partner.barcode || ''" />
+                        <input class="detail barcode" name="barcode" t-model="changes.barcode" t-on-change="captureChange" />
                     </div>
                     <div class="partner-detail">
                         <span class="label">Tax ID</span>
-                        <input class="detail vat" name="vat" t-on-change="captureChange"
-                               t-att-value="props.partner.vat || ''" />
+                        <input class="detail vat" name="vat" t-model="changes.vat" t-on-change="captureChange" />
                     </div>
                     <div t-if="env.pos.pricelists.length gt 1" class="partner-detail">
                         <span class="label">Pricelist</span>
-                        <select class="detail" name="property_product_pricelist"
-                                t-on-change="captureChange">
+                        <select class="detail" name="property_product_pricelist" t-on-change="captureChange" t-model="changes.property_product_pricelist">
                             <t t-foreach="env.pos.pricelists" t-as="pricelist"
                                t-key="pricelist.id">
-                                <option t-att-value="pricelist.id"
-                                        t-att-selected="props.partner.property_product_pricelist ? (pricelist.id === props.partner.property_product_pricelist[0] ? true : undefined) : pricelist.id === env.pos.default_pricelist.id ? true : undefined">
+                                <option t-att-value="pricelist.id">
                                     <t t-esc="pricelist.display_name" />
                                 </option>
                             </t>


### PR DESCRIPTION
At the moment, the partner editor in pos does not use the owl reactivity system, using instead an onchange function on each input and manually keeping track of state.

This approach is overcomplicated and leads to bugs.

The necessity of this task first appeared because of one such bug, namely: the state input options not changing in order to reflect the selected country.

Instead of finding a patch for this problem, we decided in this PR to replace the old logic, making use of useState and t-model.

Backport of https://github.com/odoo/odoo/pull/126021
TaskId: 3419122