### PR TITLE
[FIX] hr_holidays: Fix domain in _get_number_of_days

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -728,7 +728,8 @@ class HolidaysRequest(models.Model):
         if employee_id:
             employee = self.env['hr.employee'].browse(employee_id)
             # We force the company in the domain as we are more than likely in a compute_sudo
-            domain = [('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
+            domain = [('time_type', '=', 'leave'),
+                      ('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
             result = employee._get_work_days_data_batch(date_from, date_to, domain=domain)[employee.id]
             if self.request_unit_half and result['hours'] > 0:
                 result['days'] = 0.5


### PR DESCRIPTION
The domain was forced to fix multi-company rules, but now is missing domain checking whether the resource.calendar.leave is of "leave" type. This is set if the domain is None but since the domain is overridden, it needs to be set explicitly



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
