### PR TITLE
[IMP] various: UI/UX improvements

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -15,7 +15,7 @@
                                 type="action" class="oe_stat_button" icon="fa-line-chart">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">
-                                    Registration statistics
+                                    Registration
                                 </span>
                             </div>
                         </button>
@@ -117,7 +117,6 @@
         <field name="model">event.event</field>
         <field name="arch" type="xml">
             <tree string="Events"
-                decoration-danger="(seats_max and seats_max&lt;seats_reserved)"
                 multi_edit="1"
                 sample="1">
                 <field name="name"/>

--- a/addons/mass_mailing/models/utm_campaign.py
+++ b/addons/mass_mailing/models/utm_campaign.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo.tools.float_utils import float_round
 
 
 class UtmCampaign(models.Model):
@@ -37,10 +38,10 @@ class UtmCampaign(models.Model):
         help="Selection to determine the winner mailing that will be sent.")
 
     # stat fields
-    received_ratio = fields.Integer(compute="_compute_statistics", string='Received Ratio')
-    opened_ratio = fields.Integer(compute="_compute_statistics", string='Opened Ratio')
-    replied_ratio = fields.Integer(compute="_compute_statistics", string='Replied Ratio')
-    bounced_ratio = fields.Integer(compute="_compute_statistics", string='Bounced Ratio')
+    received_ratio = fields.Float(compute="_compute_statistics", string='Received Ratio')
+    opened_ratio = fields.Float(compute="_compute_statistics", string='Opened Ratio')
+    replied_ratio = fields.Float(compute="_compute_statistics", string='Replied Ratio')
+    bounced_ratio = fields.Float(compute="_compute_statistics", string='Bounced Ratio')
 
     @api.depends('ab_testing_winner_mailing_id')
     def _compute_ab_testing_completed(self):
@@ -110,10 +111,10 @@ class UtmCampaign(models.Model):
                 total = (stats['expected'] - stats['cancel']) or 1
                 delivered = stats['sent'] - stats['bounce']
                 vals = {
-                    'received_ratio': 100.0 * delivered / total,
-                    'opened_ratio': 100.0 * stats['open'] / total,
-                    'replied_ratio': 100.0 * stats['reply'] / total,
-                    'bounced_ratio': 100.0 * stats['bounce'] / total
+                    'received_ratio': float_round(100.0 * delivered / total, precision_digits=2),
+                    'opened_ratio': float_round(100.0 * stats['open'] / total, precision_digits=2),
+                    'replied_ratio': float_round(100.0 * stats['reply'] / total, precision_digits=2),
+                    'bounced_ratio': float_round(100.0 * stats['bounce'] / total, precision_digits=2)
                 }
 
             campaign.update(vals)

--- a/addons/mass_mailing/tests/test_mailing_ab_testing.py
+++ b/addons/mass_mailing/tests/test_mailing_ab_testing.py
@@ -50,7 +50,7 @@ class TestMailingABTesting(MassMailCommon):
         self.ab_testing_mailing_2.mailing_trace_ids[:15].set_opened()
         self.ab_testing_mailing_ids.invalidate_recordset()
 
-        self.assertEqual(self.ab_testing_mailing_1.opened_ratio, 66)
+        self.assertEqual(self.ab_testing_mailing_1.opened_ratio, 66.67)
         self.assertEqual(self.ab_testing_mailing_2.opened_ratio, 50)
 
         with self.mock_mail_gateway():
@@ -82,7 +82,7 @@ class TestMailingABTesting(MassMailCommon):
         self.ab_testing_mailing_2.mailing_trace_ids[:15].set_opened()
         self.ab_testing_mailing_ids.invalidate_recordset()
 
-        self.assertEqual(self.ab_testing_mailing_1.opened_ratio, 66)
+        self.assertEqual(self.ab_testing_mailing_1.opened_ratio, 66.67)
         self.assertEqual(self.ab_testing_mailing_2.opened_ratio, 50)
 
         with self.mock_mail_gateway():
@@ -165,7 +165,7 @@ class TestMailingABTesting(MassMailCommon):
         self.ab_testing_mailing_2.mailing_trace_ids[:15].set_opened()
         self.ab_testing_mailing_ids.invalidate_recordset()
 
-        self.assertEqual(self.ab_testing_mailing_1.opened_ratio, 66)
+        self.assertEqual(self.ab_testing_mailing_1.opened_ratio, 66.67)
         self.assertEqual(self.ab_testing_mailing_2.opened_ratio, 50)
 
         with self.mock_mail_gateway():

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -130,20 +130,19 @@
                     </div>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
-                            <button name="action_view_delivered"
-                                id="button_view_delivered"
-                                type="object"
-                                context="{'search_default_filter_delivered': True}"
-                                invisible="state in ('draft', 'test')"
-                                class="oe_stat_button">
-                                <field name="received_ratio" string="Received" widget="percentpie"/>
-                            </button>
                             <button name="action_view_opened"
                                 type="object"
                                 context="{'search_default_filter_opened': True}"
                                 invisible="state in ('draft', 'test')"
                                 class="oe_stat_button">
                                 <field name="opened_ratio" string="Opened" widget="percentpie"/>
+                            </button>
+                            <button name="action_view_replied"
+                                type="object"
+                                context="{'search_default_filter_replied': True}"
+                                invisible="state in ('draft', 'test')"
+                                class="oe_stat_button">
+                                <field name="replied_ratio" string="Replied" widget="percentpie"/>
                             </button>
                             <button name="action_view_clicked"
                                 type="object"
@@ -152,12 +151,13 @@
                                 class="oe_stat_button">
                                 <field name="clicks_ratio" string="Clicked" widget="percentpie"/>
                             </button>
-                            <button name="action_view_replied"
+                            <button name="action_view_delivered"
+                                id="button_view_delivered"
                                 type="object"
-                                context="{'search_default_filter_replied': True}"
+                                context="{'search_default_filter_delivered': True}"
                                 invisible="state in ('draft', 'test')"
                                 class="oe_stat_button">
-                                <field name="replied_ratio" string="Replied" widget="percentpie"/>
+                                <field name="received_ratio" string="Received" widget="percentpie"/>
                             </button>
                             <button name="action_view_bounced"
                                 type="object"
@@ -413,12 +413,14 @@
                     <xpath expr="//div[hasclass('alert-info')]/div[hasclass('o_mails_in_queue')]/strong" position="move"/>
                 </xpath>
                 <xpath expr="//div[hasclass('alert-info')]/div[hasclass('o_mails_in_queue')]" position="replace"/>
-                <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <xpath expr="//button[@name='action_view_opened']" position="before">
                     <button name="action_view_traces_sent"
                         invisible="state in ('draft', 'test')"
                         type="object" class="oe_stat_button" icon="fa-paper-plane">
                         <field name="sent" widget="statinfo" string="Sent"/>
                     </button>
+                </xpath>
+                <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                     <button name="action_view_traces_canceled"
                         invisible="state in ('draft', 'test')"
                         type="object" class="oe_stat_button" icon="fa-paper-plane-o">

--- a/addons/mass_mailing/views/snippets/s_cover.xml
+++ b/addons/mass_mailing/views/snippets/s_cover.xml
@@ -5,8 +5,9 @@
             <div class="container">
                 <div class="row">
                     <div class="col-lg-12 oe_img_bg  pt56 pb48" style="background-image: url('/web/image/mass_mailing.s_cover_default_image');">
-                        <h1 style="text-align: center;"><font style="font-size: 62px; font-weight: bold;">Catchy Headline</font></h1>
-                        <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
+                        <div class="o_we_bg_filter bg-black-50"/>
+                        <h1 class="text-white" style="text-align: center;"><font style="font-size: 62px; font-weight: bold;">Catchy Headline</font></h1>
+                        <p class="lead text-white" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
                     </div>
                 </div>
             </div>

--- a/addons/mass_mailing_crm/models/mailing_mailing.py
+++ b/addons/mass_mailing_crm/models/mailing_mailing.py
@@ -42,7 +42,7 @@ class MassMailing(models.Model):
             'name': _("Leads Analysis"),
             'res_model': 'crm.lead',
             'type': 'ir.actions.act_window',
-            'view_mode': 'graph,pivot,tree,form',
+            'view_mode': 'tree,pivot,graph,form',
         }
 
     def _prepare_statistics_email_values(self):

--- a/addons/mass_mailing_sale/models/mailing_mailing.py
+++ b/addons/mass_mailing_sale/models/mailing_mailing.py
@@ -53,7 +53,7 @@ class MassMailing(models.Model):
             'name': _("Sales Analysis"),
             'res_model': 'sale.report',
             'type': 'ir.actions.act_window',
-            'view_mode': 'graph,pivot,tree,form',
+            'view_mode': 'tree,pivot,graph,form',
         }
 
     def action_redirect_to_invoiced(self):
@@ -79,7 +79,7 @@ class MassMailing(models.Model):
             'name': _("Invoices Analysis"),
             'res_model': 'account.invoice.report',
             'type': 'ir.actions.act_window',
-            'view_mode': 'graph,pivot,tree,form',
+            'view_mode': 'tree,pivot,graph,form',
         }
 
     def _prepare_statistics_email_values(self):

--- a/addons/test_mass_mailing/tests/test_mailing_statistics.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics.py
@@ -69,7 +69,7 @@ class TestMailingStatistics(TestMassMailCommon):
         kpi_values = body_html.xpath('//table[@data-field="mail"]//*[hasclass("kpi_value")]/text()')
         self.assertEqual(
             [t.strip().strip('%') for t in kpi_values],
-            ['100', str(mailing.opened_ratio), str(mailing.replied_ratio)]
+            ['100.0', str(mailing.opened_ratio), str(mailing.replied_ratio)]
         )
         # test body content: clicks (a bit hackish but hey we are in stable)
         kpi_click_values = body_html.xpath('//table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')

--- a/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
@@ -63,7 +63,7 @@ class TestMailingStatistics(TestMassSMSCommon):
         kpi_values = body_html.xpath('//table[@data-field="sms"]//*[hasclass("kpi_value")]/text()')
         self.assertEqual(
             [t.strip().strip('%') for t in kpi_values],
-            ['100', str(mailing.opened_ratio), str(mailing.replied_ratio)]
+            ['100.0', str(float(mailing.opened_ratio)), str(float(mailing.replied_ratio))]
         )
         # test body content: clicks (a bit hackish but hey we are in stable)
         kpi_click_values = body_html.xpath('//table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')

--- a/addons/web/static/src/views/kanban/kanban_header.js
+++ b/addons/web/static/src/views/kanban/kanban_header.js
@@ -152,6 +152,7 @@ export class KanbanHeader extends Component {
     archiveGroup() {
         this.dialog.add(ConfirmationDialog, {
             body: _t("Are you sure that you want to archive all the records from this column?"),
+            confirmLabel: _t("Archive All"),
             confirm: async () => {
                 await this.group.list.archive();
                 this.props.progressBarState?.updateCounts(this.group);

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2174,7 +2174,7 @@ export class Wysiwyg extends Component {
     }
     _getBannerCommand(title, alertClass, iconClass, description, priority) {
         return {
-            category: _t('Banner'),
+            category: _t('Banners'),
             name: title,
             priority: priority,
             description: description,
@@ -2241,10 +2241,10 @@ export class Wysiwyg extends Component {
         const editorOptions = this.options;
         const categories = [{ name: _t('Banners'), priority: 65 },];
         const commands = [
-            this._getBannerCommand(_t('Banner Info'), 'info', 'fa-info-circle', _t('Insert an info banner section'), 24),
-            this._getBannerCommand(_t('Banner Success'), 'success', 'fa-check-circle', _t('Insert a success banner section'), 23),
-            this._getBannerCommand(_t('Banner Warning'), 'warning', 'fa-exclamation-triangle', _t('Insert a warning banner section'), 22),
-            this._getBannerCommand(_t('Banner Danger'), 'danger', 'fa-exclamation-circle', _t('Insert a danger banner section'), 21),
+            this._getBannerCommand(_t('Banner Info'), 'info', 'fa-info-circle', _t('Insert an info banner'), 24),
+            this._getBannerCommand(_t('Banner Success'), 'success', 'fa-check-circle', _t('Insert a success banner'), 23),
+            this._getBannerCommand(_t('Banner Warning'), 'warning', 'fa-exclamation-triangle', _t('Insert a warning banner'), 22),
+            this._getBannerCommand(_t('Banner Danger'), 'danger', 'fa-exclamation-circle', _t('Insert a danger banner'), 21),
             {
                 category: _t('Structure'),
                 name: _t('Quote'),

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -17,7 +17,8 @@
 
     <!-- Link Dialog (allows to choose a style and content for a link on the page) -->
     <div t-name="web_editor.LinkDialog">
-        <Dialog size="'xl'">
+        <t t-set="title">Insert a Link / Button</t>
+        <Dialog size="'xl'" title="title">
             <div  class="o_link_dialog">
                 <div class="row" t-ref="linkComponentWrapper">
                     <form class="col-lg-8">
@@ -100,7 +101,7 @@
                     </div>
                 </div>
                 <t t-set-slot="footer">
-                    <button class="btn btn-primary" t-on-click="this.onSave">Save</button>
+                    <button class="btn btn-primary" t-on-click="this.onSave">Insert</button>
                     <button class="btn btn-secondary" t-on-click="this.props.close">Discard</button>
                 </t>
             </div>


### PR DESCRIPTION
-> Remove the decorator from event list view as user do not get why there records
    are coloured.

-> Ensure that the clicks % and reply KPI are always shown with 2 decimal places
    in forms, list views, and other relevant areas.

-> Change the order of the mailing stat button.

-> Change the ui of the cover block by adding the dark filter and the white
   color for text by default so that text are readable with other images also.

-> Change the order of the view that opens through the action button which shows
    the business document created. put the list view first and graph at last.

-> Change the title and the name of the confirm button of the /button modal.

-> Change the name of the confirm button of /link modal.

-> Change the name of the confirm button of the confirmation dialog which opens
    while archiving the record.

Task-3204554