### PR TITLE
[FIX] web: CP: clipped breadcrumb

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -88,7 +88,7 @@
                 </button>
             </t>
             <t t-else="">
-                <ol class="breadcrumb flex-nowrap text-nowrap small lh-1">
+                <ol class="breadcrumb flex-nowrap text-nowrap small lh-sm">
                     <li t-if="collapsedBreadcrumbs.length" class="breadcrumb-item d-inline-flex min-w-0">
                         <Dropdown togglerClass="'btn btn-light btn-sm p-0'">
                             <t t-set-slot="toggler">


### PR DESCRIPTION
Prior to this commit, the breadcrumb was clipped on Firefox. This was due to the combination of a too small line-height and the text-truncate.

This commit fixes this issue.

task-3420828
Part of task-3326263

The issue : https://www.awesomescreenshot.com/image/40989484?key=52da1f8dce0093ac54549dfb74b134d8

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
