### PR TITLE
[IMP] mail: move shortcut search view to mail module

### DIFF
--- a/addons/mail/views/mail_shortcode_views.xml
+++ b/addons/mail/views/mail_shortcode_views.xml
@@ -3,10 +3,22 @@
     <data>
 
         <!-- mail.shortcode -->
+        <record id="mail_shortcode_view_search" model="ir.ui.view">
+            <field name="name">mail.shortcode.search</field>
+            <field name="model">mail.shortcode</field>
+            <field name="arch" type="xml">
+                <search string="Canned Responses Search">
+                    <field name="source"/>
+                    <field name="substitution"/>
+                </search>
+            </field>
+        </record>
+
         <record id="mail_shortcode_action" model="ir.actions.act_window">
             <field name="name">Chat Shortcode</field>
             <field name="res_model">mail.shortcode</field>
             <field name="view_mode">tree,form</field>
+            <field name="search_view_id" ref="mail_shortcode_view_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 Define a new chat shortcode


### PR DESCRIPTION
Before this commit the `mail.shortcut` search view was only available when installing `website_livechat_helpdesk`. This search view focuses on classical `mail.shortcut` field and could be used accross the different modules that use this view.

enterprise: https://github.com/odoo/enterprise/pull/43940
