### PR TITLE
[IMP] web: allow lang to be overriden by url query params

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -62,12 +62,16 @@ class Home(http.Controller):
             return request.redirect('/web/login?error=access')
 
     @http.route('/web/webclient/load_menus/<string:unique>', type='http', auth='user', methods=['GET'])
-    def web_load_menus(self, unique):
+    def web_load_menus(self, unique, lang=None):
         """
         Loads the menus for the webclient
         :param unique: this parameters is not used, but mandatory: it is used by the HTTP stack to make a unique request
+        :param lang: language in which the menus should be loaded (only works if language is installed)
         :return: the menus (including the images in Base64)
         """
+        if lang:
+            request.update_context(lang=lang)
+
         menus = request.env["ir.ui.menu"].load_web_menus(request.session.debug)
         body = json.dumps(menus, default=ustr)
         response = request.make_response(body, [

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -253,12 +253,18 @@
                 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
                 <meta name="theme-color" content="#71639e"/>
                 <script type="text/javascript">
-                    odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
-                    odoo.reloadMenus = () => fetch(`/web/webclient/load_menus/${odoo.__session_info__.cache_hashes.load_menus}`).then(res => res.json());
-                    odoo.loadMenusPromise = odoo.reloadMenus();
                     // Block to avoid leaking variables in the script scope
                     {
+                        odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
                         const { user_context,  cache_hashes } = odoo.__session_info__;
+                        const lang = new URLSearchParams(document.location.search).get("lang");
+                        let menuURL = `/web/webclient/load_menus/${cache_hashes.load_menus}`;
+                        if (lang) {
+                            user_context.lang = lang;
+                            menuURL += `?lang=${lang}`
+                        }
+                        odoo.reloadMenus = () => fetch(menuURL).then(res => res.json());
+                        odoo.loadMenusPromise = odoo.reloadMenus();
                         // Prefetch translations to speedup webclient. This is done in JS because link rel="prefetch"
                         // is not yet supported on safari.
                         fetch(`/web/webclient/translations/${cache_hashes.translations}?lang=${user_context.lang}`);


### PR DESCRIPTION
With this commit, it is possible to load the web client in a language different than the user by using the `lang=` query string in the url: For example, `/web?lang=en_us`

This is useful when we need to quickly check something, without changing the current user settings. Note that it will only work if the url lang has been installed on the database.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
