### PR TITLE
[FIX] discuss: allow message id to be pinned messages

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -707,7 +707,7 @@ class Channel(models.Model):
         """
         self.ensure_one()
         message_to_update = self.env['mail.message'].search([
-            ['id', '=', message_id],
+            ['id', '=', int(message_id)],
             ['model', '=', 'discuss.channel'],
             ['res_id', '=', self.id],
             ['pinned_at', '=' if pinned else '!=', False]


### PR DESCRIPTION
Somehow 'message_id' holds the floating values, so while we are going to pin the message will generate the traceback.

Error: InvalidTextRepresentation: invalid input syntax for type integer: 16.01
LINE 1: ...s_partner_id = 3) WHERE ((((mail_message.id = '16.01')

Traceback:
```
InvalidTextRepresentation: invalid input syntax for type integer: "16.01"
LINE 1: ...s_partner_id = 3) WHERE (((("mail_message"."id" = '16.01') A...
                                                             ^

  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/mail/models/discuss/discuss_channel.py", line 709, in set_message_pin
    message_to_update = self.env['mail.message'].search([
  File "odoo/models.py", line 1566, in search
    return self.search_fetch(domain, [], offset=offset, limit=limit, order=order)
  File "odoo/models.py", line 1589, in search_fetch
    query = self._search(domain, offset=offset, limit=limit, order=order or self._order)
  File "addons/mail/models/mail_message.py", line 313, in _search
    self.env.cr.execute(query_str, params)
  File "odoo/sql_db.py", line 319, in execute
    res = self._obj.execute(query, params) 
```

Therefore, if we convert message_id into an integer it will prevent the traceback. if message_id has float values.

sentry-4307398197
