### PR TITLE
[FIX] web: ace_field: fix the code selection problem

### DIFF
--- a/addons/web/static/src/views/fields/ace/ace_field.js
+++ b/addons/web/static/src/views/fields/ace/ace_field.js
@@ -46,20 +46,22 @@ export class AceField extends Component {
     }
 
     handleChange(newValue) {
-        this.state.value = newValue;
-        this.debouncedCommit();
+        this.debouncedCommit(newValue);
     }
 
     updateCodeEditor({ record, mode, readonly }) {
-        this.state.value = formatText(record.data[this.props.name]);
+        const modelValue = formatText(record.data[this.props.name]);
+        if (modelValue !== this.internalValue) {
+            this.state.value = modelValue;
+        }
         this.state.mode = mode === "xml" ? "qweb" : mode;
         this.state.readonly = readonly;
     }
 
-    commitChanges() {
+    commitChanges(value) {
         if (!this.props.readonly) {
-            const value = this.state.value;
             if (this.props.record.data[this.props.name] !== value) {
+                this.internalValue = value;
                 return this.props.record.update({ [this.props.name]: value });
             }
         }


### PR DESCRIPTION
Steps to reproduce:
-------------------

- Go to an automated actions
- Modify the "Action To Do" field to "Execute Python Code"
- In the Python code field, type something very fast

Expected Behaviour:
-------------------
The ace field editor contains the typed code.

Actual Behaviour:
-----------------
![chrome-capture-2023-6-11](https://github.com/odoo/odoo/assets/109217759/b0f5b96c-6de6-467b-81f9-3f35f0fa2c55)

The ace library select all the code.

The reason behind the actual behaviour is that the `ace_field` does an update to the model whenever the field is changed. When the model take the new value into account, it changes the props of `ace_field` which passes this props to the `CodeEditor`. The problem is that the user could in this little window time type more character. Resulting in the `CodeEditor` receiving an older code and setting the older code in the ace library (which reset the cursor and select the text).

The fix consists of propaging the code props from the model only if it comes from an `onChange`.
This commit also remove the useless re-rendering whenever the user type something in the code editor.

