### PR TITLE
[FIX] core: removed trailing space from order by element

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4813,7 +4813,7 @@ class BaseModel(metaclass=MetaModel):
                         qualifield_name = "COALESCE(%s, false)" % qualifield_name
                     elif field.type == 'properties' and property_name:
                         qualifield_name = f"({qualifield_name} -> '{property_name}')"
-                    order_by_elements.append(f"{qualifield_name} {order_direction} {order_nulls}")
+                    order_by_elements.append(f"{qualifield_name} {order_direction} {order_nulls}".strip())
                 else:
                     _logger.warning("Model %r cannot be sorted on field %r (not a column)", self._name, order_field)
                     continue  # ignore non-readable or "non-joinable" fields


### PR DESCRIPTION
issue has been generated during upgrading database. when we have `order_nulls` contain empty value
and we are comparing orignal database product's  `on hand` qty with upgraded database product's `on hand`.
Before upgrade in order by was getting this
`mrp_bom__product_id__product_tmpl_id"."priority" DESC` and after upgrade will get this
`mrp_bom__product_id__product_tmpl_id"."priority" DESC ` so there is trailing space at the end of element.
which create difference between
original and after upgrade on hand qty.

```
>>> m = 'mrp_bom__product_id__product_tmpl_id.priority DESC'
>>> m.rpartition(" ")
('mrp_bom__product_id__product_tmpl_id.priority', ' ', 'DESC')
>>> z = 'mrp_bom__product_id__product_tmpl_id.priority DESC '
>>> z.rpartition(" ")
('mrp_bom__product_id__product_tmpl_id.priority DESC', ' ', '')
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
