### PR TITLE
[IMP] website, web_editor, *: track records saved from website builder

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -296,27 +296,38 @@ class Web_Editor(http.Controller):
         """ Removes a web-based image attachment if it is used by no view (template)
 
         Returns a dict mapping attachments which would not be removed (if any)
-        mapped to the views preventing their removal
+        mapped to a dict about what prevents their removal containing:
+        - matches: list of records that reference the attachment
+        - accessModels: list of names of models that contain records that reference the attachment
+            but cannot be accessed by the user
         """
         self._clean_context()
         Attachment = attachments_to_remove = request.env['ir.attachment']
-        Views = request.env['ir.ui.view']
 
         # views blocking removal of the attachment
         removal_blocked_by = {}
 
         for attachment in Attachment.browse(ids):
-            # in-document URLs are html-escaped, a straight search will not
-            # find them
-            url = tools.html_escape(attachment.local_url)
-            views = Views.search([
-                "|",
-                ('arch_db', 'like', '"%s"' % url),
-                ('arch_db', 'like', "'%s'" % url)
-            ])
-
-            if views:
-                removal_blocked_by[attachment.id] = views.read(['name'])
+            referrers = None if kwargs.get('force') else attachment._is_used_in_html_field()
+            if referrers:
+                matches = []
+                unique_url = set()
+                for items in referrers['matches']:
+                    fields = ['name', 'website_url'] if 'website_url' in items._fields else ['name']
+                    records = items.read(fields)
+                    if 'website_url' not in items._fields:
+                        # Fallback to backend url
+                        for record in records:
+                            record['website_url'] = f'/web#model={items._name}&id={record["id"]}'
+                    for record in records:
+                        if record['website_url'] in unique_url:
+                            continue
+                        unique_url.add(record['website_url'])
+                        matches.append(record)
+                removal_blocked_by[attachment.id] = {
+                    'matches': matches,
+                    'accessModels': [{'name': request.env[model_name]._description} for model_name in referrers['sudo_models']],
+                }
             else:
                 attachments_to_remove += attachment
         if attachments_to_remove:

--- a/addons/web_editor/models/__init__.py
+++ b/addons/web_editor/models/__init__.py
@@ -11,5 +11,6 @@ from . import models
 from . import html_field_history_mixin
 
 from . import assets
+from . import edited
 
 from . import test_models

--- a/addons/web_editor/models/__init__.py
+++ b/addons/web_editor/models/__init__.py
@@ -6,6 +6,7 @@ from . import ir_qweb
 from . import ir_qweb_fields
 from . import ir_ui_view
 from . import ir_http
+from . import ir_module_module
 from . import ir_websocket
 from . import models
 from . import html_field_history_mixin

--- a/addons/web_editor/models/edited.py
+++ b/addons/web_editor/models/edited.py
@@ -1,0 +1,103 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from psycopg2.sql import SQL, Placeholder
+
+from odoo import models, fields, api, tools
+from odoo.osv.expression import AND, OR
+
+
+# Avoid the need to find whether a record already exists before inserting.
+INSERT_SQL = SQL("""
+    INSERT INTO web_editor_edited (res_model, res_field, res_id)
+    VALUES ({res_model}, {res_field}, {res_id})
+    ON CONFLICT DO NOTHING
+""").format(
+    res_model=Placeholder('res_model'),
+    res_field=Placeholder('res_field'),
+    res_id=Placeholder('res_id'),
+)
+
+class EditedModel(models.Model):
+    # This model is technical only - its records can only be accessed via sudo.
+
+    _name = 'web_editor.edited'
+    _description = "Website Edited Records"
+    _log_access = False
+
+    res_model = fields.Char('Model')
+    res_field = fields.Char('Field')
+    res_id = fields.Integer('Record Id')
+
+    def init(self):
+        # Ensure there is at most one active variant for each combination.
+        query = """
+            CREATE UNIQUE INDEX IF NOT EXISTS web_editor_edited_unique_index
+            ON %s (res_model, res_field, res_id)
+        """
+        self.env.cr.execute(query % self._table)
+
+    @api.model
+    def _get_base_edited_html_fields(self):
+        return [('ir.ui.view', 'arch_db', [('type', '=', 'qweb')])]
+
+    @api.model
+    def _get_edited_html_fields(self):
+        """ Returns the list of fields that were tracked as edited.
+
+            :return: list of (model name, field name, domain) tuples
+        """
+        all_edited = self.sudo().read_group(
+            [], ['res_ids:array_agg(res_id)'],
+            groupby=['res_model', 'res_field'], lazy=False,
+        )
+        result = self._get_base_edited_html_fields()
+        result.extend([
+            (edited['res_model'], edited['res_field'], [('id', 'in', edited['res_ids'])])
+            for edited in all_edited
+        ])
+        return result
+
+    @api.model
+    def _track(self, res_model, res_field, res_id):
+        # Only track HTML fields
+        if self.env[res_model]._fields[res_field].type != 'html':
+            return
+        self.env.cr.execute(INSERT_SQL, {
+            'res_model': res_model,
+            'res_field': res_field,
+            'res_id': res_id,
+        })
+
+    @api.model
+    def _find_in_field(self, html_escaped_likes, model_name, field_name, base_domain):
+        """ Returns models where the "likes" appear inside HTML fields or True
+            if it appears inside non-accessible records.
+
+            :param html_escaped_likes: array of string to include as values of
+                domain 'like'. Values must be HTML escaped.
+            :param model_name: name of the model
+            :param field_name: name of the field
+            :param base_domain: list of records to check (or all if unspecified)
+
+            :return: matching records or True if matches are found in sudo or
+                None if not found
+        """
+        if model_name not in self.env:
+            # Do not fail if table was not cleaned after removing a module.
+            return None
+        matches = self.env[model_name]
+        if field_name not in matches._fields:
+            # Do not fail if table was not cleaned after removing a module.
+            return None
+        if matches._fields[field_name].type == 'binary':
+            # Do not check binary fields with "like".
+            return None
+        likes = [[(field_name, 'like', like)] for like in html_escaped_likes]
+        domain = AND([base_domain, OR(likes)])
+        if matches.check_access_rights('read', raise_exception=False):
+            matches = matches.with_context(active_test=False).search(domain)
+            if matches:
+                return matches
+        sudo_matches = self.env[model_name].sudo().with_context(active_test=False).search(domain, limit=1)
+        if sudo_matches:
+            return True

--- a/addons/web_editor/models/ir_attachment.py
+++ b/addons/web_editor/models/ir_attachment.py
@@ -84,3 +84,13 @@ class IrAttachment(models.Model):
         - Non admin user uploading an unsplash image (bypass binary/url check)
         """
         return False
+
+    def _is_used_in_html_field(self):
+        """Returns a model where this attachment is used, or a dict with model names or False."""
+        self.ensure_one()
+        # Keep significant part of attachment url
+        url = self.local_url
+        is_default_local_url = url.startswith(f'/web/image/{self.id}?')
+        if is_default_local_url:
+            url = f'/web/image/{self.id}' if self.image_src else f'/web/content/{self.id}'
+        return self.env['web_editor.edited']._find_url(url, is_default_local_url)

--- a/addons/web_editor/models/ir_module_module.py
+++ b/addons/web_editor/models/ir_module_module.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrModuleModule(models.Model):
+    _name = "ir.module.module"
+    _description = 'Module'
+    _inherit = _name
+
+    def module_uninstall(self):
+        result = super().module_uninstall()
+        self.env['web_editor.edited']._clean()
+        return result

--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -76,6 +76,7 @@ class IrUiView(models.Model):
                     record.with_context(lang=self.get_default_lang_code()).write({field: value})
                 else:
                     record.write({field: value})
+                self.env['web_editor.edited']._track(Model._name, field, int(el.get('data-oe-id')))
 
                 if callable(Model._fields[field].translate):
                     self._copy_custom_snippet_translations(record, field)

--- a/addons/web_editor/security/ir.model.access.csv
+++ b/addons/web_editor/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_web_editor_converter_test,access_web_editor_converter_test,model_web_editor_converter_test,base.group_system,1,1,1,1
 access_web_editor_converter_test_sub,access_web_editor_converter_test_sub,model_web_editor_converter_test_sub,base.group_system,1,1,1,1
+access_web_editor_edited,access_web_editor_edited,model_web_editor_edited,base.group_user,0,0,0,0

--- a/addons/website/models/__init__.py
+++ b/addons/website/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import assets
 from . import base_partner_merge
+from . import edited
 from . import ir_actions_server
 from . import ir_asset
 from . import ir_attachment

--- a/addons/website/models/edited.py
+++ b/addons/website/models/edited.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class Edited(models.AbstractModel):
+    _inherit = 'web_editor.edited'
+
+    @api.model
+    def _get_base_edited_html_fields(self):
+        result = super()._get_base_edited_html_fields()
+        result.extend([
+            ('website', 'custom_code_head', []),
+            ('website', 'custom_code_footer', []),
+            ('website', 'robots_txt', []),
+            ('website.menu', 'mega_menu_content', []),
+            ('theme.website.menu', 'mega_menu_content', []),
+        ])
+        return result

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1001,9 +1001,9 @@ class Website(models.Model):
 
         # Search the URL in every relevant field
         html_fields_attributes = self._get_html_fields_attributes() + [
-            ('website.menu', 'website_menu', 'url', False),
+            ('website.menu', 'website_menu', 'url', False, []),
         ]
-        for model, _table, column, _translate in html_fields_attributes:
+        for model, _table, column, _translate, base_domain in html_fields_attributes:
             Model = self.env[model]
             if not Model.check_access_rights('read', raise_exception=False):
                 continue
@@ -1012,6 +1012,7 @@ class Website(models.Model):
             domains = []
             for url, website_domain in search_criteria:
                 domains.append(AND([
+                    base_domain,
                     [(column, 'ilike', url)],
                     website_domain if hasattr(Model, 'website_id') else [],
                 ]))
@@ -1473,25 +1474,14 @@ class Website(models.Model):
         )
 
     def _get_html_fields_attributes(self):
-        html_fields = [('ir.ui.view', 'ir_ui_view', 'arch_db', True)]
+        field_specs = self.env['web_editor.edited']._get_edited_html_fields()
+        html_fields = []
         cr = self.env.cr
-        cr.execute("""
-            SELECT f.model,
-                   f.name,
-                   f.translate
-              FROM ir_model_fields f
-              JOIN ir_model m
-                ON m.id = f.model_id
-             WHERE f.ttype = 'html'
-               AND f.store = true
-               AND m.transient = false
-               AND f.model NOT LIKE 'ir.actions%%'
-               AND f.model NOT IN %s
-        """, ([self._get_html_fields_attributes_blacklist()]))
-        for model, name, translate in cr.fetchall():
+        for model, name, domain in field_specs:
             table = self.env[model]._table
+            translate = self.env[model]._fields[name].translate
             if tools.table_exists(cr, table) and tools.column_exists(cr, table, name):
-                html_fields.append((model, table, name, translate))
+                html_fields.append((model, table, name, translate, domain))
         return html_fields
 
     def _is_snippet_used(self, snippet_module, snippet_id, asset_version, asset_type, html_fields_attributes):
@@ -1508,13 +1498,22 @@ class Website(models.Model):
             return True
 
         # As well as every snippet dropped in html fields
+
+        def domain_where_clause(_model, domain):
+            if not domain:
+                return ''
+            query = self.env[_model]._where_calc(domain, active_test=False)
+            _, where_clause, query_params = query.get_sql()
+            return self.env.cr.mogrify(' WHERE ' + where_clause, query_params).decode()
+
         self.env.cr.execute(sql.SQL(" UNION ").join(
-            sql.SQL("SELECT regexp_matches({}{}, {}, 'g') FROM {}").format(
+            sql.SQL("SELECT regexp_matches({}{}, {}, 'g') FROM {}{}").format(
                 sql.Identifier(column),
                 sql.SQL("->>'en_US'" if translate else ''),
                 sql.Placeholder('snippet_regex'),
-                sql.Identifier(table)
-            ) for _model, table, column, translate in html_fields_attributes
+                sql.Identifier(table),
+                sql.SQL(domain_where_clause(_model, domain)),
+            ) for _model, table, column, translate, domain in html_fields_attributes
         ), {'snippet_regex': f'<([^>]*data-snippet="{snippet_id}"[^>]*)>'})
 
         snippet_occurences = [r[0][0] for r in self.env.cr.fetchall()]


### PR DESCRIPTION
*: website_blog, website_event_booth_exhibitor,
    website_event_booth_sale_exhibitor, website_event_exhibitor,
    website_event_track, website_forum, website_hr_recruitment,
    website_livechat, website_partner, website_sale,
    website_sale_stock, website_slides

This PR introduces a new model that tracks which records HTML
fields were edited from the website builder.
This mechanism enriches `_get_html_fields_attributes` by adding a
domain in each field specification limiting the search to the tracked
records only.

Website-only HTML fields are registered to website_edited so
that they do not need to be tracked per individual record.

The deletion of used attachments from the media dialog is prevented
since [1]. It is possible that it worked at the time, but that it
stopped working in [2] when the routes for attachments have been
updated.
Also, it only checked for the presence of attachments in views,
ignoring other HTML fields.

This PR fixes the existing mechanism and also limits the search on
views to QWeb views, and adds the check across other HTML fields.
This commit also detects non-image attachments which are obtained
through the `/web/content/...` route.
It also adapts the link within the warning so that the website page of
the blocking object is reached if there is one, otherwise it falls back
onto the backend page of the object.

Steps to reproduce:
- Drop a Text - Image block on a website page/a product page.
- Upload an attachment in that block.
- Save.
- Edit another page.
- In the media dialog, delete the uploaded attachment.

=> Attachment is deleted and page contains a missing image/document.

[1]: e78a3b1
[2]: 6baf611