### PR TITLE
[IMP] project, sale_(project, timesheet): display helper

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.xml
@@ -3,7 +3,7 @@
 
     <t t-name="project.ProjectRightSidePanelSection" owl="1">
         <div class="o_rightpanel_section py-0" t-att-name="props.name" t-if="props.show">
-            <div class="o_rightpanel_header d-flex align-items-center justify-content-between py-2 bg-100" t-att-class="props.headerClassName" t-if="props.header">
+            <div class="o_rightpanel_header d-flex align-items-center justify-content-between py-2 bg-100 border-bottom" t-att-class="props.headerClassName" t-if="props.header">
                 <div class="o_rightpanel_title d-flex flex-row-reverse align-items-center" t-if="props.slots.title">
                     <h3 class="m-0 lh-lg"><t t-slot="title"/></h3>
                 </div>

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -58,11 +58,8 @@ export class ProjectRightSidePanel extends Component {
     }
 
     get showProjectProfitability() {
-        return !!this.state.data.profitability_items
-            && (
-                this.state.data.profitability_items.revenues.data.length > 0
-                || this.state.data.profitability_items.costs.data.length > 0
-            );
+        const { costs, revenues } = this.state.data.profitability_items;
+        return costs.data.length || revenues.data.length;
     }
 
     formatFloat(value) {

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -37,18 +37,22 @@
             </ProjectRightSidePanelSection>
             <ProjectRightSidePanelSection
                 name="'profitability'"
-                show="showProjectProfitability"
-                dataClassName="'pb-3 border-bottom o_rightpanel_full_width'"
+                show="!!this.state.data.profitability_items"
+                dataClassName="'py-3'"
             >
                 <t t-set-slot="title" owl="1">
                     Profitability
                 </t>
                 <ProjectProfitability
+                    t-if="showProjectProfitability"
                     data="state.data.profitability_items"
                     labels="state.data.profitability_labels"
                     formatMonetary="formatMonetary.bind(this)"
                     onClick="(params) => this.onProjectActionClick(params)"
                 />
+                <span t-else="" class="text-muted fst-italic">
+                    Track project costs, revenues, and margin by setting the analytic account associated with the project on relevant documents.
+                </span>
             </ProjectRightSidePanelSection>
             <ProjectRightSidePanelSection
                 name="'milestones'"

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -339,7 +339,7 @@ class Project(models.Model):
         panel_data = super().get_panel_data()
         return {
             **panel_data,
-            'sale_items': self._get_sale_items(),
+            'sale_items': self._get_sale_items() if self.allow_billable else {},
         }
 
     def get_sale_items_data(self, domain=None, offset=0, limit=None, with_action=True):

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -5,13 +5,16 @@
         <xpath expr="//ProjectRightSidePanelSection[@name=&quot;'profitability'&quot;]" position="before">
             <ProjectRightSidePanelSection
                 name="'sales'"
-                show="state.data.sale_items and state.data.sale_items.total &gt; 0"
-                dataClassName="'o_rightpanel_full_width'"
+                show="!!state.data.sale_items?.data"
+                dataClassName="'py-3'"
             >
                 <t t-set-slot="title" owl="1">
                     Sales
                 </t>
-                <table class="table table-sm table-striped table-hover mb-0">
+                <span t-if="!state.data.sale_items.data.length" class="text-muted fst-italic">
+                    Track what you sold, delivered, and invoiced.
+                </span>
+                <table t-else="" class="table table-sm table-striped table-hover mb-0">
                     <thead class="bg-100">
                         <tr>
                             <th>Sales Order Items</th>


### PR DESCRIPTION
In this commit, we show a helper message in case there are no records to show under those sections (milestone, profitability, sales section) in project right side panel. This change was made in order to provide a better user experience for users who are viewing the project's right-side panel and there are no records to show.

task-3293012

