### PR TITLE
[FIX] partner_autocomplete: change logger type to warning

### DIFF
--- a/addons/partner_autocomplete/models/iap_autocomplete_api.py
+++ b/addons/partner_autocomplete/models/iap_autocomplete_api.py
@@ -42,7 +42,7 @@ class IapAutocompleteEnrichAPI(models.AbstractModel):
         except exceptions.ValidationError:
             return False, 'Insufficient Credit'
         except (ConnectionError, HTTPError, exceptions.AccessError, exceptions.UserError) as exception:
-            _logger.error('Autocomplete API error: %s', str(exception))
+            _logger.warning('Autocomplete API error: %s', str(exception))
             return False, str(exception)
         except iap_tools.InsufficientCreditError as exception:
             _logger.warning('Insufficient Credits for Autocomplete Service: %s', str(exception))


### PR DESCRIPTION
An error occurs while attempting to connect the IAP server,
The problem seems like the IAP server was down, This error is generated and
subsequently caught by a sentry.

See the error:
`Autocomplete API error: The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was https://partner-autocomplete.odoo.com/iap/partner_autocomplete/enrich`

To handle this issue, we have changed the logger `error` to `warning`.

sentry-3930839889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
