### PR TITLE
[FIX] base: exclude populate

### DIFF
--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -18,6 +18,7 @@ DEFAULT_EXCLUDE = [
     "static/tests/**/*",
     "migrations/**/*",
     "upgrades/**/*",
+    "populate/**/*",
 ]
 
 STANDARD_MODULES = ['web', 'web_enterprise', 'theme_common', 'base']


### PR DESCRIPTION
excludes populate files while running cloc

### Issue:
Some custom modules require using populate for performance testing. And do not require to be maintained in the future

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
