### PR TITLE
[FIX] hr_skills: fix resume end date wrong selection

### DIFF
--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -47,8 +47,8 @@
                             <field name="display_type" required="1"/>
                         </group>
                         <group>
-                            <field name="date_start" required="True"/>
-                            <field name="date_end"/>
+                            <field name="date_start" string="Duration" widget="daterange" options="{'end_date_field': 'date_end'}"/>
+                            <field name="date_end" invisible="1"/>
                         </group>
                     </group>
                     <field name="description" placeholder="Description"/>

--- a/addons/hr_skills_slides/views/hr_templates.xml
+++ b/addons/hr_skills_slides/views/hr_templates.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="hr_skills.resume_line_view_form"/>
         <field eval="20" name="priority"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='line_type_id']" position="after">
+            <xpath expr="//field[@name='display_type']" position="after">
                 <field name="channel_id"
                     readonly="0"
                     invisible="display_type != 'course'"/>

--- a/addons/hr_skills_survey/views/hr_templates.xml
+++ b/addons/hr_skills_survey/views/hr_templates.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="hr_skills.resume_line_view_form"/>
         <field eval="20" name="priority"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='line_type_id']" position="after">
+            <xpath expr="//field[@name='display_type']" position="after">
                 <field name="survey_id"
                     domain="[('certification', '=', True)]"
                     readonly="0"


### PR DESCRIPTION
before this commit, in resume we are able to put end date less than start date
which is not possible in real life.
inside form view add daterange widget to start date field so user not able to
select end date less than start date.

task-3397726

