### PR TITLE
[IMP] analytic_plan: don't allow user to choose a parent's plan which create a recursion

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -22,7 +22,7 @@ class AccountAnalyticPlan(models.Model):
         string="Parent",
         ondelete='cascade',
         check_company=True,
-        domain="[('id', '!=', id)]",
+        domain="['!', ('id', 'child_of', id)]",
     )
     parent_path = fields.Char(
         index='btree',


### PR DESCRIPTION
Problem
---------

When you have an analytics plans which is the parent of another one, you should not be able to choose the child plan as parent of this one.

A user has the possibility to do it; when he saves, we he gets the error: Recursion Detected.

Objective
---------

Don't show the child plans of an analytics plan to avoid the user to choose something that raises the error.

Solution
---------

Update the domain of the field `parent_id` to exclude the analytic plans that are the children of the current plan.

task-3414188

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
