### PR TITLE
[IMP] sale: option to generate single/multiple invoice from so

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -80,6 +80,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
     # UI
     display_draft_invoice_warning = fields.Boolean(compute="_compute_display_draft_invoice_warning")
     display_invoice_amount_warning = fields.Boolean(compute="_compute_display_invoice_amount_warning")
+    consolidated_billing = fields.Boolean(
+        string="Consolidated Billing", default=True,
+        help="Create one invoice for all orders related to same customer and same invoicing address"
+    )
 
     #=== COMPUTE METHODS ===#
 
@@ -191,7 +195,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def _create_invoices(self, sale_orders):
         self.ensure_one()
         if self.advance_payment_method == 'delivered':
-            return sale_orders._create_invoices(final=self.deduct_down_payments)
+            return sale_orders._create_invoices(final=self.deduct_down_payments, grouped=not self.consolidated_billing)
         else:
             self.sale_order_ids.ensure_one()
             self = self.with_company(self.company_id)

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -17,6 +17,7 @@
                 <group>
                     <field name="sale_order_ids" invisible="1"/>
                     <field name="count" attrs="{'invisible': [('count', '=', 1)]}"/>
+                    <field name="consolidated_billing" attrs="{'invisible': [('count', '=', 1)]}"/>
                     <field name="advance_payment_method" class="oe_inline"
                         widget="radio"
                         attrs="{'invisible': [('count', '&gt;', 1)]}"/>


### PR DESCRIPTION
before this commit, if there is multiple sale order for a customer, and if we try to create new invoices for this orders from the tree view, it creates one invoices for all the orders.

there will be cases, where we have to create separate invoices for each orders.

after this commit, a boolean will be introduced in the wizard, by which user can decide one invoice or multiple invoice by grouping sale order.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
