### PR TITLE
[FIX] website: adopt duplicate view of website menu

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1062,7 +1062,7 @@ class Website(models.Model):
             else:
                 domain = [('key', '=', view_id)]
                 order = View._order
-            views = View.with_context(active_test=False).search(domain, order=order)
+            views = View.with_context(active_test=False).search(domain, order=order, limit=1)
             if views:
                 view = views.filter_duplicate()
             else:


### PR DESCRIPTION
If the user creates a duplicate view of the website menu and then user tries to edit that menu so the traceback will appear.

To reproduce the issue:
- Install the website Module
- Open Setting > Technical > User Interface > Views
- Open one view of the website Menu(Home Menu)
- Create a duplicate view of that Menu
- Open the website > Click on Edit Button. Traceback will appear.

Traceback: -
```
ValueError: too many values to unpack (expected 1)
  File "odoo/models.py", line 5379, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: ir.ui.view(2224, 2225)
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/main.py", line 646, in get_switchable_related_views
    views = request.env["ir.ui.view"].get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
  File "addons/website/models/ir_ui_view.py", line 275, in get_related_views
    return super(View, self).get_related_views(key, bundles=bundles)
  File "addons/web_editor/models/ir_ui_view.py", line 277, in get_related_views
    views = View._views_get(key, bundles=bundles)
  File "addons/web_editor/models/ir_ui_view.py", line 243, in _views_get
    node = etree.fromstring(view.arch)
  File "odoo/fields.py", line 1151, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5382, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

The user tries to edit the website menu after creating a duplicate view. we should do the user can easily access duplicate views of the website Menu,

sentry-3954574360
