### PR TITLE
[FIX] stock: disable the duplicate action from warehouse

### DIFF
--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -5,7 +5,7 @@
             <field name="name">stock.warehouse</field>
             <field name="model">stock.warehouse</field>
             <field name="arch" type="xml">
-                <form string="Warehouse">
+                <form string="Warehouse" duplicate="false">
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button name="action_view_all_routes"


### PR DESCRIPTION
When a user tries to duplicate the "Warehose" record from the action menu, in that case, it generates the traceback in the terminal.

Steps to produce an issue:
- Install stock module
- Inventory > Configuration > Warehouse Management > Warehouses
- Select a record and try to duplicate it.

Error:  UniqueViolation: duplicate key value violates unique constraint "stock_warehouse_warehouse_code_uniq"
DETAIL:  Key (code, company_id)=(WH, 1) already exists.

When users try to duplicate "Warehouse(s)" records from the action menu after that, it generates this traceback in the terminal. So,hide a duplicate action from the warehouse form view.

Sentry Traceback:
```UniqueViolation: duplicate key value violates unique constraint "stock_warehouse_warehouse_code_uniq"
DETAIL:  Key (code, company_id)=(WH, 1) already exists.

  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 451, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "odoo/models.py", line 4651, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "odoo/models.py", line 4573, in _load_records_create
    return self.create(values)
  File "<decorator-gen-210>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "addons/stock/models/stock_warehouse.py", line 127, in create
    warehouses = super().create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4207, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4410, in _create
    cr.execute(
  File "odoo/sql_db.py", line 312, in execute
    res = self._obj.execute(query, params)
ParseError: while parsing /home/odoo/src/odoo/saas-16.3/addons/stock/data/stock_data.xml:83, somewhere inside
<record id="warehouse0" model="stock.warehouse">
            <field name="partner_id" ref="base.main_partner"/>
            <field name="code">WH</field>
        </record>
  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

Sentry-4280171275
