### PR TITLE
[FIX] base: prevent quick create of new field using studio

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -471,6 +471,7 @@ class IrModelFields(models.Model):
     _description = "Fields"
     _order = "name"
     _rec_name = 'field_description'
+    _view_options = {'no_create': True}
 
     name = fields.Char(string='Field Name', default='x_', required=True, index=True)
     complete_name = fields.Char(index=True)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1290,6 +1290,15 @@ actual arch.
                     for arch, _view in self._get_x2many_missing_view_archs(field, node, node_info):
                         node.append(arch)
 
+                if (
+                    field.relational
+                    and not node.get('options')
+                ):
+                    model = self.env[field.comodel_name]
+                    options = model._view_options
+                    if options:
+                        node.set('options', str(options))
+
                 for child in node:
                     if child.tag in ('form', 'tree', 'graph', 'kanban', 'calendar'):
                         node_info['children'] = []
@@ -2315,6 +2324,7 @@ class Model(models.AbstractModel):
     _inherit = 'base'
 
     _date_name = 'date'         #: field to use for default calendar view
+    _view_options = {}
 
     def _get_access_action(self, access_uid=None, force_website=False):
         """ Return an action to open the document. This method is meant to be


### PR DESCRIPTION
This error occurs when a user tries to create `quick create` a field. 
steps to produce:
- Enable developer mode > Install the web_studio module.
- Go to Settings > Technical > Fields Selection.
- Create a new record > Open Studio > Drag and drop new many2one field
- Select the `fields` in Relation > Click on confirm and close the studio.
- Attempt to quick create a field for the new many2one field
- Error will be generated.

see the traceback:
```
AssertionError: missing model name for {'field_description': 'Loan'}
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 1662, in name_create
    record = self.create({self._rec_name: name})
  File "<decorator-gen-319>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "home/odoo/src/enterprise/saas-16.3/web_studio/models/studio_mixin.py", line 19, in create
    res = super(StudioMixin, self).create(vals)
  File "<decorator-gen-32>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/ir_model.py", line 909, in create
    assert vals.get('model'), f"missing model name for {vals}"
```

I handle this issue by adding `no_create: True` on `ir.model.fields` model. after that, it will not give the option of quick create a field for `ir.model.fields` model records.

Inspired by the following PR : https://github.com/odoo/odoo/pull/124870

sentry-4280377855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
