### PR TITLE
[FIX] mail: enforce chatter background color

### DIFF
--- a/addons/mail/static/src/web/chatter.scss
+++ b/addons/mail/static/src/web/chatter.scss
@@ -1,7 +1,10 @@
-.o-mail-Chatter .o-mail-Message-body [summary~="o_mail_notification"] {
-    display: none;
-}
+.o-mail-Chatter{
+    background-color: $o-webclient-background-color;
 
+    .o-mail-Message-body [summary~="o_mail_notification"] {
+        display: none;
+    }
+}
 .o-chatter-disabled .o-mail-Message-actions {
     display: none;
 }
@@ -12,7 +15,6 @@
 
 .o-mail-Chatter-top {
     z-index: $o-mail-NavigableList-zIndex - 2;
-    background-color: $o-webclient-background-color;
 
     &.shadow-sm {
         background-image: linear-gradient(90deg, transparent, $o-view-background-color, transparent);


### PR DESCRIPTION
Before this PR, chatter background was transparent, in most case it's not an issue, but in Documents app the background is different and the chatter isn't readable anymore.
This PR enforce the background color to be the same has the webclient background.

![image](https://github.com/odoo/odoo/assets/1810149/116b4da0-5471-47c4-b9d9-874be18c2dc7)
