### PR TITLE
[FIX] mass_mailing:  handle sms testing with empty record

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -582,6 +582,8 @@ class MassMailing(models.Model):
         return False
 
     def action_test(self):
+        if not self:
+            return
         self.ensure_one()
         ctx = dict(self.env.context, default_mass_mailing_id=self.id, dialog_size='medium')
         return {


### PR DESCRIPTION
When testing empty records in sms marketing it generates traceback.

Step to Reproduce:
   1. Install the SMS Marketing module.
   2. Install Studio
   3. Go to SMS Marketing. Create new
   4. Change the property of the fields, Title, Mailing Lists, and SMS Body to make it unrequired.
   5. Again create a new record.
   6. Click on the Test button
   7. Then click on the DISCARD CHANGES Button.

Traceback: 
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5384, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: mailing.mailing()
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/mass_mailing_sms/models/mailing_mailing.py", line 129, in action_test
    return super(Mailing, self).action_test()
  File "addons/mass_mailing/models/mailing.py", line 600, in action_test
    self.ensure_one()
  File "odoo/models.py", line 5387, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

Therefore, to prevent an empty record set add a condition.

sentry-4309438646