### PR TITLE
[IMP] crm: replace meeting count by date for lead stat btn

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -29,11 +29,10 @@
                             <button name="action_schedule_meeting" type="object"
                                 class="oe_stat_button" icon="fa-calendar"
                                 context="{'partner_id': partner_id}"
-                                invisible="type == 'lead'">
+                                invisible="not id or type == 'lead'">
                                 <div class="o_stat_info">
-                                    <field name="calendar_event_count" class="o_stat_value"/>
-                                    <span class="o_stat_text" invisible="calendar_event_count &lt; 2"> Meetings</span>
-                                    <span class="o_stat_text" invisible="calendar_event_count &gt; 1"> Meeting</span>
+                                    <span class="o_stat_text"><field name="meeting_display_label"/></span>
+                                    <field name="meeting_display_date" class="o_stat_value" invisible="not meeting_display_date"/>
                                 </div>
                             </button>
                             <button name="action_show_potential_duplicates" type="object"


### PR DESCRIPTION
Instead of having a count field for meetings linked to a crm.lead, show a date instead:
- If there is a next meeting, its date
- Otherwise, show last meeting date
- If no meeting, show no date and display "No Meetings"

This commit removes the field "calendar_event_count" that has no use anymore. A test using the count field is adapted.

UPG PR https://github.com/odoo/upgrade/pull/4935

Task-3418397

