### PR TITLE
[FIX] base_import: selected encoding differs from original encoding of file

### DIFF
--- a/addons/base_import/i18n/base_import.pot
+++ b/addons/base_import/i18n/base_import.pot
@@ -1115,6 +1115,14 @@ msgid "You must configure at least one field to import"
 msgstr ""
 
 #. module: base_import
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
+msgid ""
+"Your CSV file is unable to decode in %s encoding. Please try another "
+"encoding option."
+msgstr ""
+
+#. module: base_import
 #. openerp-web
 #: code:addons/base_import/static/src/legacy/xml/base_import.xml:0
 #, python-format


### PR DESCRIPTION
Currently, When the user imports a bank statement CSV file of encoding other than 'utf-16' and in formatting options, the user selects 'utf-16' encoding and tries to import then an error occurs.

To reproduce the issue:
1. Install Accounting module.
2. Import a bank statement CSV file of encoding other than 'utf-16'.
3. In Formatting options select 'utf-16' Encoding.
4. Click on the Import or Test button.
5. The error will occur in the backend and an odoo server error with CSV data will occur at the frontend.

See this traceback: 
```
UnicodeDecodeError: 'utf-16-le' codec can't decode byte 0x0a in position 460: truncated data
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/enterprise/saas-16.3/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py", line 128, in execute_import
    return super(AccountBankStmtImportCSV, self).execute_import(fields, columns, options, dryrun=dryrun)
  File "addons/base_import/models/base_import.py", line 1307, in execute_import
    input_file_data, import_fields = self._convert_import_data(fields, options)
  File "addons/base_import/models/base_import.py", line 1048, in _convert_import_data
    _file_length, rows_to_import = self._read_file(options)
  File "addons/base_import/models/base_import.py", line 366, in _read_file
    raise e
  File "addons/base_import/models/base_import.py", line 364, in _read_file
    return getattr(self, '_read_' + file_extension)(options)
  File "addons/base_import/models/base_import.py", line 472, in _read_csv
    csv_data = csv_data.decode(encoding).encode('utf-8')
```

To solve this issue an ImportValidationError has been raised when the csv_data is unable to decode in selected encoding.

sentry-4187434651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
