### PR TITLE
 [CLA] twio.tech CLA - Backport to saas-15.2

### DIFF
--- a/doc/cla/corporate/twio_tech.md
+++ b/doc/cla/corporate/twio_tech.md
@@ -1,0 +1,15 @@
+Switzerland, 2023-04-11
+
+twio.tech AG agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Sandro Faeh hello@twio.tech https://github.com/twio-tech
+
+List of contributors:
+
+Dawn Hwang hwangh95@gmail.com https://github.com/hwangh95


### PR DESCRIPTION
Through #126800, the CLA was manually backported to 15.0, but forwardport was disabled, making it be unavailable on saas-15.2. This will manually backport the CLA to saas-15.2 to prevent a build fail in #128275 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
