### PR TITLE
[FIX] product,sale: put product price when applying Quotation Template

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -363,7 +363,7 @@ class PricelistItem(models.Model):
         product.ensure_one()
         uom.ensure_one()
 
-        currency = currency or self.currency_id
+        currency = currency or self.currency_id or self.env.company.currency_id
         currency.ensure_one()
 
         # Pricelist specific values are specified according to product UoM

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -431,7 +431,7 @@ class SaleOrderLine(models.Model):
             # manually edited
             if line.qty_invoiced > 0:
                 continue
-            if not line.product_uom or not line.product_id or not line.order_id.pricelist_id:
+            if not line.product_uom or not line.product_id:
                 line.price_unit = 0.0
             else:
                 price = line.with_company(line.company_id)._get_display_price()


### PR DESCRIPTION
__Current behavior before PR:__
When setting a Quotation Template on a new quotation without customer, product in the order lines are set to a price of 0.

__Description of the fix:__
As it was done [in this commit](https://github.com/odoo/odoo/commit/83c52575d0ce3d7deb1737c622c6ce366db8c31b#diff-5a563f36ffd028b0d8510c6d1339b097a5067a2247cc35c0f9bdd1fd0b5a0b05), a price is set even when there is no pricelist. The currency of the company is used in that case.

opw-3340506