### PR TITLE
[IMP] project: improve project updates

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -73,14 +73,29 @@
                 </tfoot>
             </table>
         </div>
-        <div class="o_rightpanel_subsection">
+        <div class="o_rightpanel_subsection" t-if="revenues.data.length &amp;&amp; costs.data.length">
             <table class="table table-sm table-borderless w-100 mb-0">
                 <thead>
-                    <tr>
+                    <tr class="align-top">
                         <th>Margin</th>
-                        <th class="text-end" t-att-class="margin.invoiced_billed &lt; 0 ? 'text-danger' : 'text-success'"><t t-esc="props.formatMonetary(margin.invoiced_billed)"/></th>
-                        <th class="text-end" t-att-class="margin.to_invoice_to_bill &lt; 0 ? 'text-danger' : 'text-success'"><t t-esc="props.formatMonetary(margin.to_invoice_to_bill)"/></th>
-                        <th class="text-end" t-att-class="margin.total &lt; 0 ? 'text-danger' : 'text-success'"><t t-esc="props.formatMonetary(margin.total)"/></th>
+                        <th class="text-end" t-att-class="margin.invoiced_billed &lt; 0 ? 'text-danger' : 'text-success'">
+                            <t t-esc="props.formatMonetary(margin.invoiced_billed)"/><br/>
+                            <t t-if="costs.total.billed != 0">
+                                <t t-esc="margin.invoiced_billed > 0 ? '+' : ''"/><t t-esc="(margin.invoiced_billed / (-costs.total.billed) * 100).toFixed(0)"/>%
+                            </t>
+                        </th>
+                        <th class="text-end" t-att-class="margin.to_invoice_to_bill &lt; 0 ? 'text-danger' : 'text-success'">
+                            <t t-esc="props.formatMonetary(margin.to_invoice_to_bill)"/><br/>
+                            <t t-if="costs.total.to_bill != 0">
+                                <t t-esc="margin.to_invoice_to_bill > 0 ? '+' : ''"/><t t-esc="(margin.to_invoice_to_bill / (-costs.total.to_bill) * 100).toFixed(0)"/>%
+                            </t>
+                        </th>
+                        <th class="text-end" t-att-class="margin.total &lt; 0 ? 'text-danger' : 'text-success'">
+                            <t t-esc="props.formatMonetary(margin.total)"/><br/>
+                            <t t-if="(costs.total.billed + costs.total.to_bill) != 0">
+                                <t t-esc="margin.total > 0 ? '+' : ''"/><t t-esc="(margin.total / (-costs.total.billed - costs.total.to_bill) * 100).toFixed(0)"/>%
+                            </t>
+                        </th>
                     </tr>
                 </thead>
             </table>


### PR DESCRIPTION
1. Purpose: be consistent with the information indicated in the description of the form view + add a way for users to analyze the margin of their project is relative terms
- updates right-side panel > display the margin % under the margin
- apply the same color code and visibility conditions as for the margin

2. Purpose: currently, SOLs and associated revenues are only taken into account in the project updates right-side panel when it is set either on the project, its tasks or its timesheets. This was designed this way to manage the use-case where the AA of the project would be linked to multiple projects. We wanted to avoid duplicate information.However, in practice, it seems that the current behavior is confusing and is generating a lot of questions from customers (according to our colleagues at the support and the PS). IMO, the use-case where an AA would be shared with multiple projects is not very common and we should privilege the basic use-case.In addition, even if we have duplicate information in case of a shared AA, it is still possible to have the detail per project from the accounting app by setting a corresponding analytic distribution.
- SOLs and associated revenues should be taken into account in the project updates right-side panel regardless if the SOLs are set on the projects, its tasks or timesheets, or not

task-3330274