### PR TITLE
[FIX] web_editor: Change the base for o_editable search in the MediaDialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1359,7 +1359,12 @@ const Wysiwyg = Widget.extend({
         // selection when the modal is closed.
         const restoreSelection = preserveCursor(this.odooEditor.document);
 
-        const $editable = $(OdooEditorLib.closestElement(range.startContainer, '.o_editable') || this.odooEditor.editable);
+        const $target = $(params.node || range.startContainer);
+        const $closestBrandedEditable = $target.closest(
+            '.o_editable:data(oe-model):data(oe-id),.o_editable:data(oe-media-domain)'
+        );
+        const $editable = $($closestBrandedEditable[0] || this.odooEditor.editable);
+
         const model = $editable.data('oe-model');
         const field = $editable.data('oe-field');
         const type = $editable.data('oe-type');


### PR DESCRIPTION
Previously, we relied on document.getSelection() to perform the search for o_editable. This approach worked fine for the website's wysiwyg, as it operates within its own iframe and has its own document property and selection. However, in the mass_mailling module, both the wysiwyg and snippet_option share the same iframe and document.

Consequently, when the replace button is clicked in mass_mailling, the wysiwyg starts searching for o_editable from the button's location and fails to find the root o_editable element within the wysiwyg.

To address this issue, we have modified the search process to be based on the param.node when opening the MediaDialog.

opw-3340212

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
