### PR TITLE
[IMP] base: test exporting of translation files

### DIFF
--- a/addons/hr_attendance/static/src/client_action/kiosk_confirm/kiosk_confirm.xml
+++ b/addons/hr_attendance/static/src/client_action/kiosk_confirm/kiosk_confirm.xml
@@ -1,5 +1,3 @@
-
-
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -186,60 +186,59 @@
     <t t-name="point_of_sale.OrderLinesReceipt">
         <div id="receipt-orderline" t-foreach="receiptData.receipt.orderlines" t-as="line" t-key="line.id" t-att-class="{'border-start border-3 ps-1': line.isPartOfCombo }">
             <div t-esc="line.product_name_wrapped[0]" />
-                <span>
-                    <t t-foreach="line.product_name_wrapped.slice(1)" t-as="wrapped_line" t-key="wrapped_line_index">
-                        <t t-esc="wrapped_line"/>
-                    </t>
-                </span>
-                <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
-                    <div class="pos-receipt-left-padding">
-                        <t t-esc="env.utils.formatCurrency(line.price_lst, false)" />
-                        ->
-                        <t t-esc="env.utils.formatCurrency(line.price, false)" />
-                    </div>
+            <span>
+                <t t-foreach="line.product_name_wrapped.slice(1)" t-as="wrapped_line" t-key="wrapped_line_index">
+                    <t t-esc="wrapped_line"/>
                 </t>
-                <t t-elif="line.discount !== 0">
-                    <div class="pos-receipt-left-padding">
-                        <t t-if="pos.config.iface_tax_included === 'total'">
-                            <t t-esc="env.utils.formatCurrency(line.price_with_tax_before_discount, false)"/>
-                        </t>
-                        <t t-else="">
-                            <t t-esc="env.utils.formatCurrency(line.unitDisplayPriceBeforeDiscount, false)"/>
-                        </t>
-                    </div>
-                </t>
-                <t t-if="line.discount !== 0">
-                    <div class="pos-receipt-left-padding">
-                        Discount: <t t-esc="line.discount" />%
-                    </div>
-                </t>
+            </span>
+            <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
                 <div class="pos-receipt-left-padding">
-                    <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
-                    <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
-                    x
-                    <t t-esc="env.utils.formatCurrency(line.price_display_one)" />
-                    <div class="price_display pos-receipt-right-align">
-                        <span t-esc="env.utils.formatCurrency(line.price_display, false)" />
-                        <span class="tax-letter" />
-                    </div>
+                    <t t-esc="env.utils.formatCurrency(line.price_lst, false)" />
+                    ->
+                    <t t-esc="env.utils.formatCurrency(line.price, false)" />
                 </div>
-                <t t-if="line.customer_note">
-                    <div class="pos-receipt-left-padding pos-receipt-customer-note">
-                        <t t-esc="line.customer_note"/>
-                    </div>
-                </t>
-                <t t-if="line.pack_lot_lines">
-                    <div class="pos-receipt-left-padding">
-                        <ul>
-                            <t t-foreach="line.pack_lot_lines" t-as="lot" t-key="lot.cid">
-                                <li>
-                                    SN <t t-esc="lot.lot_name"/>
-                                </li>
-                            </t>
-                        </ul>
-                    </div>
-                </t>
+            </t>
+            <t t-elif="line.discount !== 0">
+                <div class="pos-receipt-left-padding">
+                    <t t-if="pos.config.iface_tax_included === 'total'">
+                        <t t-esc="env.utils.formatCurrency(line.price_with_tax_before_discount, false)"/>
+                    </t>
+                    <t t-else="">
+                        <t t-esc="env.utils.formatCurrency(line.unitDisplayPriceBeforeDiscount, false)"/>
+                    </t>
+                </div>
+            </t>
+            <t t-if="line.discount !== 0">
+                <div class="pos-receipt-left-padding">
+                    Discount: <t t-esc="line.discount" />%
+                </div>
+            </t>
+            <div class="pos-receipt-left-padding">
+                <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
+                <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+                x
+                <t t-esc="env.utils.formatCurrency(line.price_display_one)" />
+                <div class="price_display pos-receipt-right-align">
+                    <span t-esc="env.utils.formatCurrency(line.price_display, false)" />
+                    <span class="tax-letter" />
+                </div>
             </div>
+            <t t-if="line.customer_note">
+                <div class="pos-receipt-left-padding pos-receipt-customer-note">
+                    <t t-esc="line.customer_note"/>
+                </div>
+            </t>
+            <t t-if="line.pack_lot_lines">
+                <div class="pos-receipt-left-padding">
+                    <ul>
+                        <t t-foreach="line.pack_lot_lines" t-as="lot" t-key="lot.cid">
+                            <li>
+                                SN <t t-esc="lot.lot_name"/>
+                            </li>
+                        </t>
+                    </ul>
+                </div>
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/kiosk/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/kiosk/components/attribute_selection/attribute_selection.xml
@@ -8,7 +8,7 @@
                 </t>
                 <t t-else="">
                     <h1>Your resume</h1>
-                </div>
+                </t>
             </div>
             <div t-if="!state.showResume" class="attribute-selection-content align-items-center justify-content-start">
                 <div class="row row-cols-3 g-3">

--- a/addons/website_event/static/src/snippets/s_searchbar/000.xml
+++ b/addons/website_event/static/src/snippets/s_searchbar/000.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<template xml:space="preserve">
+<templates xml:space="preserve">
 
     <t t-inherit="website.s_searchbar.autocomplete" t-inherit-mode="extension">
         <xpath expr="//div[@class='o_search_result_item_detail px-3']" position="inside">

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -64,7 +64,7 @@ class DiscussChannel(models.Model):
             message = _("""%s started a conversation with %s.
                         The chat request has been canceled.""") % (name, operator or _('an operator'))
         else:
-            message = _('Visitor %s left the conversation.', f"#{self.livechat_visitor_id.id}" if self.livechat_visitor_id else '')
+            message = _('Visitor %s left the conversation.') % (f"#{self.livechat_visitor_id.id}" if self.livechat_visitor_id else '')
 
         return message
 

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -10,7 +10,7 @@ import io
 
 from odoo.exceptions import UserError
 from odoo.tools import sql
-from odoo.tools.translate import quote, unquote, xml_translate, html_translate, TranslationImporter
+from odoo.tools.translate import quote, unquote, xml_translate, html_translate, TranslationImporter, TranslationModuleReader
 from odoo.tests.common import TransactionCase, BaseCase, new_test_user, tagged
 
 _stats_logger = logging.getLogger('odoo.tests.stats')
@@ -343,6 +343,15 @@ class TestLanguageInstall(TransactionCase):
         self.assertEqual(len(loaded), 1)
         self.assertEqual(loaded[0][1], ['fr_FR'])
         self.assertEqual(loaded[0][2], True)
+
+
+@tagged('post_install', '-at_install')
+class TestTranslationExport(TransactionCase):
+
+    def test_export_translatable_resources(self):
+        """Read files of installed modules and export translatable terms"""
+        with self.assertNoLogs('odoo.tools.translate', "ERROR"):
+            TranslationModuleReader(self.env.cr)
 
 
 class TestTranslation(TransactionCase):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1112,6 +1112,7 @@ class TranslationModuleReader:
                             value_en = record[field_name] or ''
                             value_lang = record.with_context(lang=self._lang)[field_name] or ''
                         except Exception:
+                            _logger.exception("Failed to extract terms from %s", name)
                             continue
                         trans_type = 'model_terms' if callable(field.translate) else 'model'
                         for term_en, term_langs in field.get_translation_dictionary(value_en, {self._lang: value_lang}).items():


### PR DESCRIPTION
Static qweb files are not tested for syntax errors.
This commits adds a hacky way to do this job: we test exporting of translation files.

Inspired by the following PRs, that were made as a response for errors caught by sentry

* https://github.com/odoo/enterprise/pull/43975
* https://github.com/odoo/odoo/pull/128221
