### PR TITLE
[FIX] translate: don't access non-existing self.lang when error handling

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1256,7 +1256,7 @@ class TranslationImporter:
             reader = TranslationFileReader(fileobj, fileformat=fileformat)
             self._load(reader, lang, xmlids)
         except IOError:
-            iso_lang = get_iso_codes(self.lang)
+            iso_lang = get_iso_codes(lang)
             filename = '[lang: %s][format: %s]' % (iso_lang or 'new', fileformat)
             _logger.exception("couldn't read translation file %s", filename)
 


### PR DESCRIPTION
Loading an invalid PO file [1] makes polib.py raise an IOError. This is caught by TranslationImporter's load. A small typo introduced in 727ef9e0a2ca93089b472eb1313117fee8dc876d made the exception handler error:
```
  File "/odoo/addons/base/models/ir_module.py", line 964, in _update_translations
    self.env['ir.module.module']._load_module_terms(mod_names, filter_lang, overwrite)
  File "/odoo/addons/base/models/ir_module.py", line 1074, in _load_module_terms
    translation_importer.load_file(trans_file, lang)
  File "/odoo/tools/translate.py", line 1238, in load_file
    self.load(fileobj, fileformat, lang, xmlids=xmlids)
  File "/odoo/tools/translate.py", line 1259, in load
    iso_lang = get_iso_codes(self.lang)
AttributeError: 'TranslationImporter' object has no attribute 'lang'
```
[1] e.g. instead of a 'msgid' line followed by a 'msgstr' line have two 'msgid' lines