### PR TITLE
[IMP] base_import_module: show only zip file to select

### DIFF
--- a/addons/base_import_module/views/base_import_module_view.xml
+++ b/addons/base_import_module/views/base_import_module_view.xml
@@ -11,7 +11,7 @@
                     <p class="alert alert-warning" role="alert">Note: you can only import data modules (.xml files and static assets)</p>
                     <group states="init" col="4">
                         <label for="module_file" string="Select module package to import (.zip file):" colspan="4"/>
-                        <field name="module_file" colspan="4"/>
+                        <field name="module_file" colspan="4" options="{'accepted_file_extensions': '.zip'}"/>
 
                         <field name="force"/>
                     </group>


### PR DESCRIPTION
before this commit, in the import module wizard the end user can select any type of file in the upload file field and clicking import it will say only zip format is supported.

after this commit, on clicking upload files, only
zip files will be shown to the end user to select, which will make easy to select the files from
directory

Related EE: https://github.com/odoo/enterprise/pull/44089

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
