### PR TITLE
[FIX] website: remove reCaptcha token from email on form submit

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -182,7 +182,7 @@ class WebsiteForm(http.Controller):
                     custom_fields.append((_('email'), field_value))
 
             # If it's a custom field
-            elif field_name != 'context':
+            elif field_name not in ['context', 'recaptcha_token_response']:
                 custom_fields.append((field_name, field_value))
 
         data['custom'] = "\n".join([u"%s : %s" % v for v in custom_fields])


### PR DESCRIPTION
When submitting a form that sends an email, the `recaptcha_token_response`
is sent along the other fields, making the email received less readable.
This commit removes it from the custom fields once the form has been
treated, so that it does not show in the email.

opw-3392206