### PR TITLE
[IMP] stock: improvements

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -682,7 +682,7 @@ class StockPicking(models.Model):
     weight_bulk = fields.Float(
         'Bulk Weight', compute='_compute_bulk_weight', help="Total weight of products which are not in a package.")
     shipping_weight = fields.Float(
-        "Weight for Shipping", compute='_compute_shipping_weight', readonly=False,
+        "Weight for Shipping", compute='_compute_shipping_weight', readonly=False, store=True,
         help="Total weight of packages and products not in a package. "
         "Packages with no shipping weight specified will default to their products' total weight. "
         "This is the weight used to compute the cost of the shipping.")
@@ -721,6 +721,7 @@ class StockPicking(models.Model):
         string='Date Category', store=False,
         search='_search_date_category', readonly=True
     )
+    partner_country_id = fields.Many2one('res.country', related='partner_id.country_id')
 
     _name_uniq = models.Constraint(
         'unique(name, company_id)',

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -574,7 +574,7 @@
                 </filter>
                 <filter name="real_stock_negative" position="after">
                     <searchpanel>
-                        <field name="categ_id" icon="fa-filter" string="Category" select="multi"/>
+                        <field name="categ_id" icon="fa-filter" string="Category" enable_counters="1"/>
                     </searchpanel>
                 </filter>
             </field>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -38,7 +38,7 @@
         <field name="priority">25</field>
         <field name="arch" type="xml">
             <list string="Move Lines" create="0" default_order="date" action="action_open_reference" type="object">
-                <field name="scheduled_date" optional="hide"/>
+                <field name="scheduled_date"/>
                 <field name="picking_id"/>
                 <field name="picking_partner_id"/>
                 <field name="product_id"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -387,6 +387,7 @@
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Scheduled Date" name="expected_date" domain="[]" context="{'group_by': 'scheduled_date'}"/>
                         <filter string="Source Document" name="origin" domain="[]" context="{'group_by': 'origin'}"/>
+                        <filter string="Destination Country" name="partner_country" context="{'group_by': 'partner_country_id'}"/>
                         <filter string="Operation Type" name="picking_type" domain="[]" context="{'group_by': 'picking_type_id'}"/>
                         <filter string="Properties" name="group_by_picking_properties" context="{'group_by': 'picking_properties'}"/>
                     </group>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -60,8 +60,8 @@
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                 <field name="quantity" string="Quantity" optional="show" sum="Total Moved Quantity"/>
                 <field name="remaining_qty" type="measure" optional="hide" sum="Total Remaining Quantity"/>
-                <field name="unit_cost" optional="hide"/>
                 <field name="uom_id" widget="many2one_uom" groups="uom.group_uom" optional="hide"/>
+                <field name="unit_cost" optional="hide"/>
                 <field name="currency_id" column_invisible="True" />
                 <field name="value" sum="Total Value" optional="show"/>
                 <field name="description" optional="hide"/>

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -259,6 +259,12 @@ class StockPickingBatch(models.Model):
                     picking.batch_id.id,
                     picking.batch_id.name))
 
+        if empty_waiting_pickings:
+            self.message_post(body=_(
+                "%s was removed from the batch, no quantity processed",
+                Markup(', ').join([picking._get_html_link() for picking in empty_waiting_pickings])
+            ))
+
         return pickings.with_context(**context).button_validate()
 
     def action_assign(self):


### PR DESCRIPTION
With this commit
================
#### Inventory Overview
- The date field is now visible for the operations list view.

#### Stock Report
- Implemented a hierarchical structure for the category search panel, allowing
  or more organized and structured categorization of items.

#### Pickings
- In the list view of each transfer, we have the capability to group the items
  based on the destination Country.

#### Inventory Adjustments
- It is now possible to group the items based on product category.

#### Shipping Weight
- The Shipping Weight field was editable in the transfer, but upon refresh or
  reopening, it reverted to its previous value. This issue is now resolved by
  setting the field as store=True.

#### Stock Valuation Report
- Relocated Unit of Measure after the quanity column

#### Batch Pickings
- When a picking is automatically removed during validation, the details of
  the removal will be logged in the chatter. Additionally, the removed
  picking will be reserved once again.



Task - [3346198](https://www.odoo.com/odoo/my-tasks/3346198)