### PR TITLE
[FIX] website: made scrollbar visible on right aligned scrollbar

### DIFF
--- a/addons/website/static/src/js/content/adapt_content.js
+++ b/addons/website/static/src/js/content/adapt_content.js
@@ -16,4 +16,16 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    // Special case for Safari browser: padding on wrapwrap is added by the
+    // layout option (boxed, etc), but it also receives a border on top of
+    // it to simulate an addition of padding. That padding is added with
+    // the "sidebar" header template to combine both options/effects.
+    // Sadly, the border hack is not working on safari, the menu is somehow
+    // broken and its content is not visible.
+    // This class will be used in scss to instead add the border size to the
+    // padding directly on Safari when "sidebar" menu is enabled.
+    if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+        document.querySelector("#wrapwrap").classList.add("o_safari_browser");
+    }
 });

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1136,16 +1136,28 @@ header {
             // - The website layout template when different than 'full'
             // We need to combine both using `calc`. The `border` solution does
             // not work on Safari.
-            $padding-size: o-website-value('sidebar-width');
-            @if o-website-value('layout') != 'full' {
-                $padding-size: calc(#{$grid-gutter-width} * 2 + #{$padding-size});
+            // Hack: padding is also used by layout option (boxed, etc), need to
+            // combine both options/effects...
+            &:not(.o_safari_browser) {
+                @if $-hamburger-right {
+                    border-right: o-website-value("sidebar-width") solid transparent;
+                } @else {
+                    border-left: o-website-value("sidebar-width") solid transparent;
+                }
             }
-            @if $-hamburger-right {
-                padding-right: $padding-size;
-            } @else {
-                padding-left: $padding-size;
+            // ... but don't use it on Safari, it doesn't work, the menu is
+            // somehow broken and not visible.
+            &.o_safari_browser {
+                $padding-size: o-website-value("sidebar-width");
+                @if o-website-value("layout") != "full" {
+                    $padding-size: calc(#{$grid-gutter-width} * 2 + #{$padding-size});
+                }
+                @if $-hamburger-right {
+                    padding-right: $padding-size;
+                } @else {
+                    padding-left: $padding-size;
+                }
             }
-
             > header {
                 @if $-hamburger-right {
                     @include o-position-absolute(0, 0, 0, auto);


### PR DESCRIPTION
In this fw-PR [[1]], which were fixed the issue of invisibility of the navbar in Safari by writing the browser-specific CSS. During fw-port, in saas-16.1 we refactored the CSS to achieve consistency across all browsers which cause the invisibility of the scrollbar in Chrome.

1. Scrollbar takes place between padding & border ( in the box model ). So in Safari with the border solution, the scrollbar takes place at the end while in Chrome with the padding solution scrollbar takes place before the navbar.
2. The scrollbar was visible in Safari & not in Chrome because Safari doesn't reserve the extra space for the scrollbar in DOM as Chrome.

It was not actually hidden behind the menu but it was placed outside the right-side window. ( as per point 1).

To handle that, reverting the solution which has browser-specific CSS.
Also, introduced a missing scrollbar for a navbar.

[1]: https://github.com/odoo/odoo/pull/107616

Behaviour before this PR : 

1] Chrome:
![image](https://github.com/odoo/odoo/assets/125337508/d9eb30f8-96d9-4d30-804e-02ce4def0440)


Behaviour after this PR : 

1] Safari:
<img width="1440" alt="scrollbar_in_safari" src="https://github.com/odoo/odoo/assets/125337508/2cd87ac3-3552-457e-bdb7-4cd90f2e3865">

2] Chrome:
![Menu_SccrollBar](https://github.com/odoo/odoo/assets/125337508/027b8343-f496-4f95-8702-9f599e041532)


task-3366354