### PR TITLE
[FIX] mail: fix crash Activity view

### DIFF
--- a/addons/mail/static/src/web/activity/activity_cell.js
+++ b/addons/mail/static/src/web/activity/activity_cell.js
@@ -34,7 +34,7 @@ export class ActivityCell extends Component {
                 month: "short",
             });
         } else {
-            return date.toLocaleDateString({
+            return date.toLocaleString({
                 day: "numeric",
                 month: "short",
                 year: "numeric",


### PR DESCRIPTION
__Current behavior before PR:__
An owl error is thrown when trying to access the Activity view if there
is a record from which the activity with the closest deadline is not in
the current year.

The code is calling `toLocaleDateString` on a `DateTime` object. However
this method belongs to the JS `Date` class.

__Description of the fix:__
Use the luxon method `toLocaleString`

__Example of steps to reproduce the issue:__
1. In a contact form, click on `Activities` (top right of the chatter)
2. Set **Due date** to a date before current year
3. Go to contact list
4. Click on Activity view (top right)
↳ Traceback:
`Caused by: TypeError: date.toLocaleDateString is not a function`

opw-3421367
opw-3423316
opw-3425008