### PR TITLE
[FIX] account: inconsistency in invoice report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -168,7 +168,6 @@
                                 </t>
                             </tbody>
                         </table>
-                    </div>
                     <div id="right-elements" t-attf-class="#{'col-5' if report_type != 'html' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
                         <div id="total" class="clearfix row mb-2">
                             <div class="ms-auto">
@@ -211,6 +210,7 @@
                                 <small class="text-muted lh-sm"><span t-field="o.amount_total_words"/></small>
                             </p>
                         </div>
+                    </div>
                     </div>
                     <div id="payment_term">
                         <div class="justify-text">


### PR DESCRIPTION
Steps to reproduce:
1. Install l10n_din5008
2. Settings > document layout > din5008
3. create an invoice and print it
4. there is an offset between the tax table and the rest of the invoice

Issue:
during 3764914c8616bf59d299e6279cc6fc93321cdacb, the tax_totals table was put in a different div than invoice_line_table, while this might not cause issues in the default layout, it does once you introduce a layout that changes the width settings as the two elements now would behave differently.

Fix:
put them back under `<div class="page mb-4">`

opw-3414289
opw-3419139