### PR TITLE
[IMP] website_profile: specify reason for profile access denial

### DIFF
--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo><data>
-    <!--Private profile-->
-    <template id="private_profile" inherit_id="website_profile.private_profile">
-        <xpath expr="//div[@id='private_profile_return_link_container']" position="inside">
+    <!--Access Denied - Profile Page-->
+    <template id="profile_access_denied" inherit_id="website_profile.profile_access_denied">
+        <xpath expr="//div[@id='profile_access_denied_return_link_container']" position="inside">
             <t t-if="request.params.get('forum_id')">
                 <a t-attf-href="/forum/#{request.params.get('forum_id')}" class="btn btn-primary">Return to the forum</a>
             </t>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -508,12 +508,12 @@
         <h6 t-else="" t-field="badge.name" class="d-inline my-0"/>
     </template>
 
-    <!--Private profile-->
-    <template id="private_profile" name="Private Profile Page">
+    <!--Access Denied - Profile Page-->
+    <template id="profile_access_denied" name="Access Denied - Profile Page">
         <t t-call="website.layout">
             <div class="container mb32 mt48">
-                <h1 class="mt32">This profile is private!</h1>
-                <div id="private_profile_return_link_container">
+                <h1 class="mt32" t-out="denial_reason"/>
+                <div id="profile_access_denied_return_link_container">
                     <p><a t-attf-href="/">Return to the website.</a></p>
                 </div>
             </div>

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <odoo><data>
-    <!--Private profile-->
-    <template id="private_profile" inherit_id="website_profile.private_profile">
-        <xpath expr="//div[@id='private_profile_return_link_container']" position="inside">
+    <!--Access Denied - Profile Page-->
+    <template id="profile_access_denied" inherit_id="website_profile.profile_access_denied">
+        <xpath expr="//div[@id='profile_access_denied_return_link_container']" position="inside">
             <t t-if="request.params.get('channel_id')">
                 <p><a t-attf-href="/slides/course-#{request.params.get('channel_id')}">Return to the course.</a></p>
             </t>


### PR DESCRIPTION
Purpose
=======
Website profiles of users like Mitchell Admin, which are set as "public", are also rendered as "Private". In Fact, accessing public profiles require to be logged-in and to own a minimum level of karma. Users shall be aware of those rules.

Specifications
==============
On profile acces denial, give users the proper reason among these 3 cases:
- Need to be logged-in first.
- Not enough karma to view a public profile
- Private profile.

Note: the minimum level of karma required to access a public profile is now editable. See PR#123411

Task-3360050

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
