### PR TITLE
[FIX] web_editor: handle we-list trailing space

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2185,19 +2185,20 @@ const ListUserValueWidget = UserValueWidget.extend({
      * @private
      */
     _notifyCurrentState() {
+        const trimmed = (str) => str.trim().replace(/\s+/g, " ");
         const values = [...this.listTable.querySelectorAll('.o_we_list_record_name input')].map(el => {
-            const id = this.isCustom ? el.value : el.name;
+            const id = trimmed(this.isCustom ? el.value : el.name);
             return Object.assign({
                 id: /^-?[0-9]{1,15}$/.test(id) ? parseInt(id) : id,
-                name: el.value,
-                display_name: el.value,
+                name: trimmed(el.value),
+                display_name: trimmed(el.value),
             }, el.dataset);
         });
         if (this.hasDefault) {
             const checkboxes = [...this.listTable.querySelectorAll('we-button.o_we_checkbox_wrapper.active')];
             this.selected = checkboxes.map(el => {
                 const input = el.parentElement.previousSibling.firstChild;
-                const id = this.isCustom ? input.value : input.name;
+                const id = trimmed(this.isCustom ? input.value : input.name);
                 return /^-?[0-9]{1,15}$/.test(id) ? parseInt(id) : id;
             });
             values.forEach(v => {


### PR DESCRIPTION
**Reproduce issue:**

- Drop and drop a form snippet
- Set a field as a multiple checkbox
- Toggle on option 1
- Set a space at the end of option 1 so "option 1 "
- Blur the input

**Result:** You will find, Option 1 is no more selected.

The root cause of this issue appears to be the unexpected trimming of the HTML
input box. By default, HTML trims leading and trailing spaces, as well as
considers multiple inner spaces as a single space. Consequently, inconsistencies
arise between the input value, ID, and display name. This commit trims the value
from the initial to maintain consistency.

As a result, `option 1`, `option 1   `, `  option 1`, and `option     1` will
all be trimmed and considered the same.

task-3254884
