### PR TITLE
[FIX] web: quick create kanban column

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -2367,7 +2367,8 @@ export class DynamicGroupList extends DynamicList {
      * @returns {Promise<Group>}
      */
     async _createGroup(groupName, groupData = {}, isFolded = false) {
-        groupData = { ...groupData, name: groupName };
+        const fieldName = 'x_name' in this.activeFields ? 'x_name' : 'name';
+        groupData[fieldName] = groupName;
         const [id] = await this.model.orm.create(this.groupByField.relation, [groupData], {
             context: this.context,
         });

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -13563,4 +13563,26 @@ QUnit.module("Views", (hooks) => {
         );
         assert.notEqual(previousScrollTop, 0, "Should not have the scrollTop value at 0");
     });
+
+    QUnit.test("kanban quick create column", async function (assert) {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <field name="foo"/>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["product_id"],
+        });
+
+        await click(target, "button.o_kanban_add_column");
+        await editInput(target, ".input-group > input", "new_kanban_stage");
+        await click(target, ".o_kanban_add");
+        assert.containsOnce(target, ".o_column_title:contains('new_kanban_stage')");
+    });
 });


### PR DESCRIPTION
It is impossible to quickly create a stage for models created with Studio

Steps to reproduce:
1. Install Studio
2. Toggle Studio and create a new app with a new model
3. Select the "Pipeline stages" feature for the new model
4. Close Studio
5. Open the new app and try to create a new stage in the kanban view
6. An error is thrown

Solution:
Use the correct field 'name' or 'x_name' depending on the model fields

Problem:
The name of the field for studio models is not always 'name'

opw-3422676