### PR TITLE
[IMP] hr_recruitment: remove default responsible in applicant

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -249,7 +249,7 @@ class Applicant(models.Model):
     @api.depends('job_id')
     def _compute_user(self):
         for applicant in self:
-            applicant.user_id = applicant.job_id.user_id.id or self.env.uid
+            applicant.user_id = applicant.job_id.user_id.id
 
     @api.depends('partner_id', 'partner_id.email', 'partner_id.mobile', 'partner_id.phone')
     def _compute_partner_phone_email(self):


### PR DESCRIPTION
Steps:
 - install hr_recruitment app
 - Create a job Positions without Recruiter
 - Published job Positions
 - Got To website and apply
 - Open applicant
 - Public user is set in applicant responsible

Issue:
   public user is set if Recruiter is empty in job Position

Fix:
   In this commit we have removed the default current user as the responsible applicant.

task-3424017
