### PR TITLE
[FIX] website_sale: Get the right translation description in the cart

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -32,6 +32,18 @@ class SaleOrderLine(models.Model):
         for record in self:
             record.name_short = record.product_id.with_context(display_default_code=False).display_name
 
+    @api.depends('product_id')
+    def _compute_name(self):
+        for line in self:
+            if not line.product_id:
+                continue
+            if not line.order_partner_id.is_public:
+                line = line.with_context(lang=line.order_partner_id.lang)
+            else:
+                line = line.with_context(lang=self.env.lang)
+            name = line._get_sale_order_line_multiline_description_sale()
+            line.name = name
+
     #=== BUSINESS METHODS ===#
 
     def _get_sale_order_line_multiline_description_sale(self):


### PR DESCRIPTION
### Steps
- Add a different language
- Go to the website shop
- Change the language to the added one
- Add a product to the cart
- Go to the cart

### Issue
The description of the product is not translated.

opw-3389358