### PR TITLE
[FIX] web: don't save when no changes

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1326,6 +1326,17 @@ export class Record extends DataPoint {
      * @returns {Promise<boolean>}
      */
     async _save(options = { stayInEdition: false, noReload: false }) {
+        const changes = this.getChanges();
+        const keys = Object.keys(changes);
+        const hasChanges = this.isVirtual || keys.length;
+        const shouldReload = hasChanges ? !options.noReload : false;
+        const context = this.context;
+
+        if(!hasChanges){
+            // there are no changes => no save needed
+            return true;
+        }
+
         if (!this._checkValidity()) {
             const invalidFields = [...this._invalidFields].map((fieldName) => {
                 return `<li>${escape(this.fields[fieldName].string || fieldName)}</li>`;
@@ -1336,11 +1347,6 @@ export class Record extends DataPoint {
             });
             return false;
         }
-        const changes = this.getChanges();
-        const keys = Object.keys(changes);
-        const hasChanges = this.isVirtual || keys.length;
-        const shouldReload = hasChanges ? !options.noReload : false;
-        const context = this.context;
 
         if (this.isVirtual) {
             if (keys.length === 1 && keys[0] === "display_name") {


### PR DESCRIPTION
To Reproduce
=============
- enable multi step routes
- edit Receipts operation and uncheck the two options under Traceability
- create storable product with Traceability using lot/serial number
- make purchase of this product and receive it in your inventory
- under inventory/reports/Locations click on line of this product you will be stuck at that page even if you click discard

Problem
========
Clicking discard in 16+ switches the mode of the record to "readonly", which will trigger a save, on save fucntion we check if all fields are valid before doing anything, which will fail in this use-case as lot/serial number is required and we don't have one for this product.

Solution
========
in save function, if there are no changes made, we don't have to check the validity of fields

opw-3422259