### PR TITLE
[IMP] base: allowed format for import translation

### DIFF
--- a/odoo/addons/base/wizard/base_import_language_views.xml
+++ b/odoo/addons/base/wizard/base_import_language_views.xml
@@ -10,7 +10,7 @@
                     <group>
                         <field name="name" placeholder="e.g. English"/>
                         <field name="code" string="Code" placeholder="e.g. en_US"/>
-                        <field name="data" filename="filename"/>
+                        <field name="data" filename="filename" options="{'accepted_file_extensions': '.csv,.po'}"/>
                         <field name="filename" invisible="1"/>
                         <field name="overwrite" groups="base.group_no_one"/>
                     </group>


### PR DESCRIPTION
before this commit, in the import translation
wizard, if user try to import a file
currently it will show any file types to
upload even though supported formats are
csv and po

after this commit, if user try to import a
file only csv and po files will be shown


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
