### PR TITLE
[FIX] web: fix pager in formView's notebook-listView

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -537,7 +537,9 @@
                             --ListRenderer-margin-x: var(--notebook-margin-x);
                             --ListRenderer-table-padding-x: var(--notebook-padding-x);
 
-                            margin-top: -$o-horizontal-padding;
+                            &:first-child {
+                                margin-top: -$o-horizontal-padding;
+                            }
 
                             // use original padding-left for handle cell in editable list
                             tr > :first-child.o_handle_cell {


### PR DESCRIPTION
[FIX] web: fix pager in formView's notebook-listView

The negative `margin-top` of the listview inside the formView overlaps
the pager, cutting the bottom. By setting the `margin-top` only when 
the listView is the `:first-child`, the `margin-top` no longer exists
when a pager is in the view.
![image](https://github.com/odoo/odoo/assets/19491443/03a644c9-52da-4a85-950c-c96407c7b96f)


task-3430375
part of task-3326263


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
