### PR TITLE
[IMP] im_livechat, mail: add user from member list 

### DIFF
--- a/addons/im_livechat/static/src/core/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/channel_invitation_patch.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.discuss.ChannelInvitation" t-inherit-mode="extension">
+        <xpath expr="//*[@name='selectablePartnerDetail']" position="replace">
+            <t t-if="props.thread.type !== 'livechat' or !selectablePartner.lang_name">$0</t>
+            <div t-else="" class="d-flex flex-column flex-grow-1">
+                <t>$0</t>
+                <span class="mx-2 text-truncate text-start fs-6">
+                    <i class="fa fa-comment-o me-1" aria-label="Lang"/>
+                    <t t-esc="selectablePartner.lang_name"/>
+                </span>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/partner_compare.js
+++ b/addons/im_livechat/static/src/core/partner_compare.js
@@ -1,0 +1,23 @@
+/* @odoo-module */
+
+import { partnerCompareRegistry } from "@mail/core/common/partner_compare";
+
+partnerCompareRegistry.add(
+    "im_livechat.available",
+    (p1, p2, { thread }) => {
+        if (thread?.type === "livechat" && p1.is_available !== p2.is_available) {
+            return p1.is_available ? -1 : 1;
+        }
+    },
+    { sequence: 15 }
+);
+
+partnerCompareRegistry.add(
+    "im_livechat.invite-count",
+    (p1, p2, { thread }) => {
+        if (thread?.type === "livechat" && p1.invite_by_self_count !== p2.invite_by_self_count) {
+            return p2.invite_by_self_count - p1.invite_by_self_count;
+        }
+    },
+    { sequence: 20 }
+);

--- a/addons/im_livechat/static/tests/channel_invite_tests.js
+++ b/addons/im_livechat/static/tests/channel_invite_tests.js
@@ -32,3 +32,79 @@ QUnit.test("Can invite a partner to a livechat channel", async (assert) => {
     await click("button[title='Show Member List']");
     assert.containsOnce($, ".o-discuss-ChannelMember:contains(James)");
 });
+
+QUnit.test("Available operators come first", async (assert) => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].create({
+        name: "Harry",
+        im_status: "offline",
+        user_ids: [pyEnv["res.users"].create({ name: "Harry" })],
+    });
+    const ronId = pyEnv["res.partner"].create({
+        name: "Ron",
+        im_status: "online",
+        user_ids: [pyEnv["res.users"].create({ name: "Available operator" })],
+    });
+    pyEnv["im_livechat.channel"].create({
+        available_operator_ids: [Command.create({ partner_id: ronId })],
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #1",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.publicPartnerId }),
+        ],
+        channel_type: "livechat",
+    });
+
+    const { openDiscuss } = await start();
+    await openDiscuss(channelId);
+    await click("button[title='Add Users']");
+    const partnerSuggestions = document.querySelectorAll(".o-discuss-ChannelInvitation-selectable");
+    assert.ok(partnerSuggestions[0].textContent.includes("Ron"));
+    assert.ok(partnerSuggestions[1].textContent.includes("Harry"));
+});
+
+QUnit.test("Partners invited most frequently by the current user come first", async (assert) => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].create({
+        name: "John",
+        im_status: "offline",
+        user_ids: [pyEnv["res.users"].create({ name: "John" })],
+    });
+    pyEnv["res.partner"].create({
+        name: "Albert",
+        im_status: "offline",
+        user_ids: [pyEnv["res.users"].create({ name: "Albert" })],
+    });
+    pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #1",
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.publicPartnerId }),
+        ],
+        livechat_operator_id: pyEnv.currentPartnerId,
+    });
+    pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #2",
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.publicPartnerId }),
+        ],
+        livechat_operator_id: pyEnv.currentPartnerId,
+    });
+
+    const { openDiscuss } = await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussCategoryItem:contains(Visitor #1)");
+    await click("button[title='Add Users']");
+    await click(".o-discuss-ChannelInvitation-selectable:contains(John) input");
+    await click("button:contains(Invite)");
+    await click(".o-mail-DiscussCategoryItem:contains(Visitor #2)");
+    await click("button[title='Add Users']");
+    const partnerSuggestions = document.querySelectorAll(".o-discuss-ChannelInvitation-selectable");
+    assert.ok(partnerSuggestions[0].textContent.includes("John"));
+    assert.ok(partnerSuggestions[1].textContent.includes("Albert"));
+});

--- a/addons/mail/static/src/core/common/partner_compare.js
+++ b/addons/mail/static/src/core/common/partner_compare.js
@@ -23,7 +23,7 @@ partnerCompareRegistry.add(
             return 1;
         }
     },
-    { sequence: 10 }
+    { sequence: 35 }
 );
 
 partnerCompareRegistry.add(
@@ -41,7 +41,7 @@ partnerCompareRegistry.add(
             }
         }
     },
-    { sequence: 20 }
+    { sequence: 45 }
 );
 
 partnerCompareRegistry.add(
@@ -62,7 +62,7 @@ partnerCompareRegistry.add(
             return 1;
         }
     },
-    { sequence: 25 }
+    { sequence: 50 }
 );
 
 partnerCompareRegistry.add(
@@ -83,7 +83,7 @@ partnerCompareRegistry.add(
             return 1;
         }
     },
-    { sequence: 30 }
+    { sequence: 55 }
 );
 
 partnerCompareRegistry.add(
@@ -91,5 +91,5 @@ partnerCompareRegistry.add(
     (p1, p2) => {
         return p1.id - p2.id;
     },
-    { sequence: 50 }
+    { sequence: 75 }
 );

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -56,7 +56,7 @@ function transformAction(component, id, action) {
         /** Closes this action. */
         close() {
             if (this.toggle) {
-                component.threadActions.activeAction = null;
+                component.threadActions.activeAction = component.threadActions.actionStack.pop();
             }
             action.close?.(component, this);
         },
@@ -68,7 +68,7 @@ function transformAction(component, id, action) {
         },
         /** Props to pass to the component of this action. */
         get componentProps() {
-            return action.componentProps?.(this);
+            return action.componentProps?.(this, component);
         },
         /** Condition to display this action. */
         get condition() {
@@ -93,17 +93,34 @@ function transformAction(component, id, action) {
             const res = this.isActive && action.nameActive ? action.nameActive : action.name;
             return typeof res === "function" ? res(component) : res;
         },
-        /** Action to execute when this action is selected (on or off). */
-        onSelect() {
+        /**
+         * Action to execute when this action is selected (on or off).
+         *
+         * @param {object} [param0]
+         * @param {boolean} [param0.keepPrevious] Whether the previous action
+         * should be kept so that closing the current action goes back
+         * to the previous one.
+         * */
+        onSelect({ keepPrevious } = {}) {
             if (this.toggle && this.isActive) {
                 this.close();
             } else {
-                this.open();
+                this.open({ keepPrevious });
             }
         },
-        /** Opens this action. */
-        open() {
+        /**
+         * Opens this action.
+         *
+         * @param {object} [param0]
+         * @param {boolean} [param0.keepPrevious] Whether the previous action
+         * should be kept so that closing the current action goes back
+         * to the previous one.
+         * */
+        open({ keepPrevious } = {}) {
             if (this.toggle) {
+                if (component.threadActions.activeAction && keepPrevious) {
+                    component.threadActions.actionStack.push(component.threadActions.activeAction);
+                }
                 component.threadActions.activeAction = this;
             }
             action.open?.(component, this);
@@ -142,6 +159,7 @@ export function useThreadActions() {
                 .filter((action) => action.condition)
                 .sort((a1, a2) => a1.sequence - a2.sequence);
         },
+        actionStack: [],
         activeAction: null,
     });
     return state;

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -53,12 +53,9 @@ export class ChannelInvitation extends Component {
         const Partners = results["partners"];
         const selectablePartners = [];
         for (const selectablePartner of Partners) {
-            const partnerId = selectablePartner.id;
-            const name = selectablePartner.name;
             const newPartner = this.personaService.insert({
-                id: partnerId,
-                name: name,
                 type: "partner",
+                ...selectablePartner,
             });
             selectablePartners.push(newPartner);
         }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -16,7 +16,9 @@
                                         <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle bg-view mt-n1 ms-n1'"/>
                                     </div>
                                 </div>
-                                <span class="flex-grow-1 mx-2 text-truncate text-start fs-6" t-esc="selectablePartner.name"/>
+                                <t name="selectablePartnerDetail">
+                                    <span class="flex-grow-1 mx-2 text-truncate text-start fs-6" t-esc="selectablePartner.name"/>
+                                </t>
                                 <input class="form-check-input flex-shrink-0" type="checkbox" t-att-checked="state.selectedPartners.includes(selectablePartner) ? 'checked' : undefined"/>
                             </div>
                         </t>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -11,7 +11,7 @@ import { useService } from "@web/core/utils/hooks";
 
 export class ChannelMemberList extends Component {
     static components = { ImStatus, ActionPanel };
-    static props = ["thread", "className?"];
+    static props = ["thread", "openChannelInvitePanel", "className?"];
     static template = "discuss.ChannelMemberList";
 
     setup() {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,6 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList" owl="1">
         <ActionPanel title="title">
+            <button t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-secondary m-3 mt-0">Invite a User</button>
             <t t-if="props.thread.onlineMembers.length > 0">
                 <h6 class="mx-3 text-700">
                     Online -

--- a/addons/mail/static/src/discuss/core/common/partner_compare.js
+++ b/addons/mail/static/src/discuss/core/common/partner_compare.js
@@ -22,7 +22,7 @@ partnerCompareRegistry.add(
             return 1;
         }
     },
-    { sequence: 0 }
+    { sequence: 25 }
 );
 
 partnerCompareRegistry.add(
@@ -39,5 +39,5 @@ partnerCompareRegistry.add(
             }
         }
     },
-    { sequence: 15 }
+    { sequence: 40 }
 );

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -55,6 +55,15 @@ threadActionsRegistry
                 (!component.props.chatWindow || component.props.chatWindow.isOpen)
             );
         },
+        componentProps(action, component) {
+            return {
+                openChannelInvitePanel({ keepPrevious } = {}) {
+                    component.threadActions.actions
+                        .find(({ id }) => id === "add-users")
+                        ?.open({ keepPrevious });
+                },
+            };
+        },
         panelOuterClass: "o-discuss-ChannelMemberList",
         icon: "fa fa-fw fa-users",
         iconLarge: "fa fa-fw fa-lg fa-users",

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -282,6 +282,7 @@ patch(MockServer.prototype, "mail/models/discuss_channel", {
                 this.pyEnv["discuss.channel.member"].create({
                     channel_id: channel.id,
                     partner_id: partner.id,
+                    create_uid: this.pyEnv.currentUserId,
                 })
             );
         }


### PR DESCRIPTION
This PR focuses on partner invitations for livechat channels:
- Add "invite a user" button to the member list
- Sort partners by availibility (partner is a livechat operator
and connected) then most invited users (by the current partner)
- Display partner lang of suggested partners

part of task-3332872


![chrome-capture-2023-6-19](https://github.com/odoo/odoo/assets/48757558/c542752d-1026-4bea-8636-d4bb12ecab11)
