### PR TITLE
[IMP] calendar: improve calendar recurrence in event

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -569,6 +569,9 @@ class Meeting(models.Model):
         update_recurrence = recurrence_update_setting in ('all_events', 'future_events') and len(self) == 1
         break_recurrence = values.get('recurrency') is False
 
+        if any(vals in self._get_recurrent_fields() for vals in values) and not (update_recurrence or values.get('recurrency')):
+            raise UserError(_('Unable to save the recurrence with "This Event"'))
+
         update_alarms = False
         update_time = False
         self._set_videocall_location([values])

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -334,7 +334,7 @@ class RecurrenceRule(models.Model):
     def _detach_events(self, events):
         events.write({
             'recurrence_id': False,
-            'recurrency': False,
+            'recurrency': True,
         })
         return events
 

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -4,6 +4,7 @@
 import pytz
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
+from odoo.exceptions import UserError
 
 from odoo.tests.common import TransactionCase, Form
 from freezegun import freeze_time
@@ -375,6 +376,36 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
         events = recurrence.calendar_event_ids
         self.assertEqual(events[0].start_date, date(2019, 10, 22), "The first event has the initial start date")
         self.assertEqual(events[1].start_date, date(2019, 10, 29), "The start date of the second event is one week later")
+
+    def test_recurrency_with_this_event(self):
+        """
+        1) Create an event with a recurrence set on it
+        2) Try updating the event with a different recurrence without specifying 'recurrence_update'
+        3) Update the recurrence of one of the events, this time using the 'recurrence_update' as future_events
+        4) Finally, check that the updated event correctly reflects the recurrence
+        """
+        event = self.env['calendar.event'].create({
+            'name': "Test Event",
+            'allday': False,
+            'rrule': u'FREQ=DAILY;INTERVAL=1;COUNT=10',
+            'recurrency': True,
+            'start': datetime(2023, 7, 28, 1, 0),
+            'stop': datetime(2023, 7, 29, 18, 0),
+            })
+        events = self.env['calendar.recurrence'].search([('base_event_id', '=', event.id)]).calendar_event_ids
+        self.assertEqual(len(events), 10, "It should have 10 events in the recurrence")
+
+        # Update the recurrence without without specifying 'recurrence_update'
+        with self.assertRaises(UserError):
+            event.write({'rrule': u'FREQ=DAILY;INTERVAL=2;COUNT=5'})
+        # Update the recurrence of the earlier event
+        events[5].write({
+            'recurrence_update': 'future_events',
+            'count': 2,
+        })
+        updated_events = self.env['calendar.recurrence'].search([('base_event_id', '=', events[5].id)]).calendar_event_ids
+        self.assertEqual(len(updated_events), 2, "It should have 2 events in the recurrence")
+        self.assertTrue(updated_events[1].recurrency, "It should have recurrency in the updated events")
 
 class TestUpdateRecurrentEvents(TestRecurrentEvents):
 


### PR DESCRIPTION
Before this commit, if you had a recurring event and tried to change any recurrence-related fields while selecting the
'This Event' option from the header, the changes you made would not be applied. The desired behavior is that when we changed the recurrence of an event, we intend to modify both the current event and the following events or all events.

In this commit, a UserError is now thrown to notify that changing the recurrence of an event is not allowed when
the 'This Event' option is selected.



Task-3425216


