### PR TITLE
[FIX] base_import: handle invalid input error while importing

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -21,7 +21,7 @@ import requests
 from PIL import Image
 
 from odoo import api, fields, models
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.tools.translate import _
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools import config, DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, pycompat
@@ -925,7 +925,10 @@ class Import(models.TransientModel):
         name_create_enabled_fields = options.pop('name_create_enabled_fields', {})
         import_limit = options.pop('limit', None)
         model = self.env[self.res_model].with_context(import_file=True, name_create_enabled_fields=name_create_enabled_fields, _import_limit=import_limit)
-        import_result = model.load(import_fields, data)
+        try:
+            import_result = model.load(import_fields, data)
+        except Exception as e:
+            raise UserError(str(e))
         _logger.info('done')
 
         # If transaction aborted, RELEASE SAVEPOINT is going to raise


### PR DESCRIPTION
Currently, When the user imports a record in 'marketing.trace' and assigns a string value to 'mailing_trace_ids' field an error is generated.

To reproduce the issue:
1. Install the Marketing Automation module.
2. Go to Reporting > Traces > Import records.
3. Import a file and in 'mailing_trace_ids' column add string values.
4. Click on the Import or Test button.
5. The error will be generated.

See this traceback:
```
InvalidTextRepresentation: invalid input syntax for type integer: "666mike1981@gmail.com"
LINE 1: ...ROM "mailing_trace" WHERE ("mailing_trace"."id" = '666mike19...
                                                             ^

  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/base_import/models/base_import.py", line 1328, in execute_import
    import_result = model.load(import_fields, merged_data)
  File "odoo/models.py", line 1236, in load
    for id, xid, record, info in converted:
  File "odoo/models.py", line 1398, in _convert_records
    converted = convert(record, functools.partial(_log, extras, stream.index))
  File "odoo/addons/base/models/ir_fields.py", line 118, in fn
    converted[field], ws = converters[field](value)
  File "odoo/addons/base/models/ir_fields.py", line 641, in _str_to_one2many
    id, _, w2 = self.db_id_for(model, field, subfield, record[subfield])
  File "odoo/addons/base/models/ir_fields.py", line 462, in db_id_for
    ids = RelatedModel.name_search(name=value, operator='=')
  File "odoo/models.py", line 1694, in name_search
    return self.browse(ids).sudo().name_get()
  File "odoo/models.py", line 5345, in browse
    if not ids:
  File "odoo/tools/query.py", line 256, in __bool__
    return bool(self.get_result_ids())
  File "odoo/tools/query.py", line 219, in get_result_ids
    self._cr.execute(query_str, params)
  File "odoo/sql_db.py", line 312, in execute
    res = self._obj.execute(query, params)
```

To solve this issue an UserError has been raised when there will be invalid value in import fields.

sentry-4286675903

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
