### PR TITLE
[FIX] point_of_sale: make `get_taxed_lst_price` return a number

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2590,8 +2590,7 @@ exports.Orderline = Backbone.Model.extend({
             var product_taxes = this.get_taxes_after_fp(taxes_ids);
             return this.compute_all(product_taxes, lst_price, 1, this.pos.currency.rounding).total_included;
         }
-        var digits = this.pos.dp['Product Price'];
-        return lst_price.toFixed(digits)
+        return lst_price;
     },
     get_price_without_tax: function(){
         return this.get_all_prices().priceWithoutTax;


### PR DESCRIPTION
Before this commit, `toFixed` was called on `lst_price` in `get_taxed_lst_price`, causing it to return a string instead of a number, which caused issues with `formatCurrency` as it expects a number.

opw-3415062


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
