### PR TITLE
[FIX] base_import: check the field in model while importing file

### DIFF
--- a/addons/base_import/i18n/base_import.pot
+++ b/addons/base_import/i18n/base_import.pot
@@ -290,6 +290,13 @@ msgid "Field Name"
 msgstr ""
 
 #. module: base_import
+#. odoo-python
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
+msgid "Field {%s} not present in the model"
+msgstr ""
+
+#. module: base_import
 #: model:ir.model.fields,field_description:base_import.field_base_import_import__file
 msgid "File"
 msgstr ""

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -25,6 +25,7 @@ from odoo import api, fields, models
 from odoo.tools.translate import _
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools import config, DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, pycompat
+from odoo.exceptions import UserError
 
 FIELDS_RECURSION_LIMIT = 3
 ERROR_PREVIEW_BYTES = 200
@@ -1500,8 +1501,11 @@ class Import(models.TransientModel):
             field_path = field_string.split('/')
             target_field = field_path[-1]
             target_model = self.env[fallback_values[field_string]['field_model']]
+            target_field_data = target_model.fields_get([target_field])
 
-            selection_values = [value.lower() for (key, value) in target_model.fields_get([target_field])[target_field]['selection']]
+            if not target_field_data:
+                raise UserError(_('Field {%s} not present in the model', target_field))
+            selection_values = [value.lower() for (key, value) in target_field_data[target_field]['selection']]
             fallback_values[field_string]['selection_values'] = selection_values
 
         # check fallback values


### PR DESCRIPTION
When the user imports a file in 'products' and if the file contain a field that is not present in the model, the 'target_field' will get an empty dictionary. The error will be generated.


see:-
```
KeyError: 'detailed_type'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/base_import/models/base_import.py", line 1318, in execute_import
    merged_data = self._handle_fallback_values(import_fields, merged_data, options['fallback_values'])
  File "addons/base_import/models/base_import.py", line 1504, in _handle_fallback_values
    selection_values = [value.lower() for (key, value) in target_model.fields_get([target_field])[target_field]['selection']]
```


sentry-4310024163