### PR TITLE
[FIX] website: the nested translation data shouldn’t have div element

### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -254,7 +254,7 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
 
         // Apply data-oe-readonly on nested data.
         $(this.websiteService.pageDocument).find(savableSelector)
-            .filter(':has(' + savableSelector + ')')
+            .filter(':has(' + savableSelector + ')' + ':not(div)')
             .attr('data-oe-readonly', true);
 
         const styleEl = document.createElement('style');


### PR DESCRIPTION
Reproduction:
1. Install Event, Sales, Website, and add new language French for example
2. Login as Admin, go to shop, and go to a product page
3. In the full description of the product, add a contact me section,save
4. Change the website language to French, click the Translate button
5. Scroll down to the contact me part and click on the end of the button text to modify it
6. Input anything, the new text is out of the button

Fix: In the translator component, the nested data is selected and applied with data-oe-readonly attribut. However, the nested data selection also includes the div container elements which are not related to translation. The data-oe-readonly attribute will influence the contenteditable switch in OdooEditor for link button when editing the button text by clicking

opw-3109750
task-3135864


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
