### PR TITLE
[FIX] payment_mercado_pago: handle unauthorized payment attempt

### DIFF
--- a/addons/payment_mercado_pago/i18n/payment_mercado_pago.pot
+++ b/addons/payment_mercado_pago/i18n/payment_mercado_pago.pot
@@ -1,0 +1,109 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* payment_mercado_pago
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-07-25 12:21+0000\n"
+"PO-Revision-Date: 2023-07-25 12:21+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: payment_mercado_pago
+#: model_terms:ir.ui.view,arch_db:payment_mercado_pago.payment_provider_form
+msgid "Access Token"
+msgstr ""
+
+#. module: payment_mercado_pago
+#: model:ir.model.fields,field_description:payment_mercado_pago.field_payment_provider__code
+msgid "Code"
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_provider.py:0
+#, python-format
+msgid "Could not establish the connection to the API."
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_provider.py:0
+#, python-format
+msgid "Invalid JSON format"
+msgstr ""
+
+#. module: payment_mercado_pago
+#: model:ir.model.fields.selection,name:payment_mercado_pago.selection__payment_provider__code__mercado_pago
+msgid "Mercado Pago"
+msgstr ""
+
+#. module: payment_mercado_pago
+#: model:ir.model.fields,field_description:payment_mercado_pago.field_payment_provider__mercado_pago_access_token
+msgid "Mercado Pago Access Token"
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_transaction.py:0
+#, python-format
+msgid "No transaction found matching reference %s."
+msgstr ""
+
+#. module: payment_mercado_pago
+#: model:ir.model,name:payment_mercado_pago.model_payment_provider
+msgid "Payment Provider"
+msgstr ""
+
+#. module: payment_mercado_pago
+#: model:ir.model,name:payment_mercado_pago.model_payment_transaction
+msgid "Payment Transaction"
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_transaction.py:0
+#, python-format
+msgid "Received data with invalid status: %s"
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_transaction.py:0
+#, python-format
+msgid "Received data with missing payment id."
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_transaction.py:0
+#, python-format
+msgid "Received data with missing reference."
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_transaction.py:0
+#, python-format
+msgid "Received data with missing status."
+msgstr ""
+
+#. module: payment_mercado_pago
+#. odoo-python
+#: code:addons/payment_mercado_pago/models/payment_provider.py:0
+#, python-format
+msgid ""
+"The communication with the API failed. Mercado Pago gave us the following "
+"information: '%s' (code %s)"
+msgstr ""
+
+#. module: payment_mercado_pago
+#: model:ir.model.fields,help:payment_mercado_pago.field_payment_provider__code
+msgid "The technical code of this payment provider."
+msgstr ""

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
 import logging
 import pprint
 
@@ -79,4 +80,6 @@ class Paymentprovider(models.Model):
             raise ValidationError(
                 "Mercado Pago: " + _("Could not establish the connection to the API.")
             )
+        except json.decoder.JSONDecodeError:
+            raise ValidationError(_('Invalid JSON format'))
         return response.json()


### PR DESCRIPTION
The user attempts to make a payment using the 'Mercado Pago' Payment Provider when they are not allowed to access or authorized to make a payment at that time response does not convert into JSON. And JSONDecode error will be generated, There is another chance to trackback occurs due to Server-side issues.

Traceback on sentry:

```
HTTPError: 403 Client Error: Forbidden for url: https://api.mercadopago.com/checkout/preferences
  File "addons/payment_mercado_pago/models/payment_provider.py", line 63, in _mercado_pago_make_request
    response.raise_for_status()
  File "requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 1812, in shop_payment_transaction
    return tx_sudo._get_processing_values()
  File "addons/payment/models/payment_transaction.py", line 481, in _get_processing_values
    rendering_values = self._get_specific_rendering_values(processing_values)
  File "addons/payment_mercado_pago/models/payment_transaction.py", line 40, in _get_specific_rendering_values
    api_url = self.provider_id._mercado_pago_make_request(
  File "addons/payment_mercado_pago/models/payment_provider.py", line 68, in _mercado_pago_make_request
    response_content = response.json()
  File "requests/models.py", line 900, in json
    return complexjson.loads(self.text, **kwargs)
  File "__init__.py", line 525, in loads
    return _default_decoder.decode(s)
  File "simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
```

To handle this situation, the code has been updated to ensure that if the response is not appropriate then raise validation error.

sentry-4214916971

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
