### PR TITLE
[FIX] spreadsheet: fix crash in sortZone

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
@@ -37268,6 +37268,7 @@ day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} ) ${_lt("A
             const sortedIndexOfSortTypeCells = sortCells(sortingCells, sortDirection, Boolean(options.emptyCellAsZero));
             const sortedIndex = sortedIndexOfSortTypeCells.map((x) => x.index);
             const [width, height] = [cells.length, cells[0].length];
+            const cellUpdates = [];
             for (let c = 0; c < width; c++) {
                 for (let r = 0; r < height; r++) {
                     let cell = cells[c][sortedIndex[r]];
@@ -37294,9 +37295,10 @@ day_count_convention (number, default=${DEFAULT_DAY_COUNT_CONVENTION} ) ${_lt("A
                         newCellValues.format = cell.format;
                         newCellValues.value = cell.evaluated.value;
                     }
-                    this.dispatch("UPDATE_CELL", newCellValues);
+                    cellUpdates.push(newCellValues);
                 }
             }
+            cellUpdates.forEach(value => this.dispatch("UPDATE_CELL", value));
         }
         /**
          * Return the distances between main merge cells in the zone.


### PR DESCRIPTION
**Current behavior before PR:**
When sorting the cells (in `sortZone` method), it is editing the cells directly inside the loop. When it dispatches the "UPDATE_CELL" command, if the content of the cell is empty, it will remove the corresponding `cellId` from the `SheetPlugin.cellPosition` array. Therefore, it won't be able to retrieve the position of the cell in a future iteration of the loop to retrieve its value (with `this.getters.getCellPosition`)

**Example of steps to reproduce the issue:**

1. Go to the `Dashboards` app
2. Configuration > Dashboards
3. Click on Sales for instance (e.g. Sales app must be installed)
4. Then click on Edit to open the spreadsheet
5. Insert a new sheet
6. Put this formula in one cell (the second argument must be the ID of a sale order that doesn't exist)
(e.g. `=ODOO.LIST(1,300,"name")`)
7. Click on the column header and create a filter
8. Sort the column

↳ Traceback: `Error: asking for a cell position that doesn't exist`

[VIDEO to reproduce](https://watch.screencastify.com/v/l6GODXQhWqpoASsnp3KA)

**Description of the fix:**
Store the cell updates in an array to apply them all at once at the end.

opw-3422772
