### PR TITLE
[FIX] website_event : fix date filtering

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -397,9 +397,9 @@ class WebsiteEventController(http.Controller):
         domain = request.website.website_domain()
         if country_code:
             country = request.env['res.country'].search([('code', '=', country_code)], limit=1)
-            events = Event.search(domain + ['|', ('address_id', '=', None), ('country_id.code', '=', country_code), ('date_begin', '>=', '%s 00:00:00' % fields.Date.today())], order="date_begin")
+            events = Event.search(domain + ['|', ('address_id', '=', None), ('country_id.code', '=', country_code), ('date_end', '>=', '%s 00:00:00' % fields.Date.today())], order="date_begin")
         if not events:
-            events = Event.search(domain + [('date_begin', '>=', '%s 00:00:00' % fields.Date.today())], order="date_begin")
+            events = Event.search(domain + [('date_end', '>=', '%s 00:00:00' % fields.Date.today())], order="date_begin")
         for event in events:
             if country_code and event.country_id.code == country_code:
                 result['country'] = country


### PR DESCRIPTION
before this commit:
 - The filtering was done using the begining date so if the date was in the past the event was not showing even if the event is still running

after the commit:
 - The check is done on the end date so the events are all show unless the end date is in the past.

Description of the issue/feature this PR addresses: opw-3339339




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
