### PR TITLE
[FIX] account: calculate early discount if invoice has it in batch payment

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3271,6 +3271,7 @@ class AccountMove(models.Model):
         }
 
         res_per_invoice = {}
+        aml = False
         for aml_values in aml_values_list:
             aml = aml_values['aml']
             invoice = aml.move_id
@@ -3291,7 +3292,7 @@ class AccountMove(models.Model):
                     # Track the balance to handle the exchange difference.
                     open_balance -= vals['balance']
 
-        exchange_diff_sign = aml.company_currency_id.compare_amounts(open_balance, 0.0)
+        exchange_diff_sign = aml and aml.company_currency_id.compare_amounts(open_balance, 0.0)
         if exchange_diff_sign != 0.0:
 
             if exchange_diff_sign > 0.0:


### PR DESCRIPTION
While registering payments in batches, if one invoice payment term has an early
discount and another does not have an early discount, it generates a traceback.

Steps to Reproduce:

   1. Install "Invoicing".
   2. Create two invoices with different customers.
   3. Open the first invoice, select the 'payment term' that does not
      have an early discount, and confirm it.
   4. Open the second invoice, select the 'payment term' that has an
      early discount, and confirm it.
   5. From the list view select those two invoices and click on
      the 'Register Payment' Button.
   6. Then click on the wizard 'Create Payment' button.

Traceback:
 ```
UnboundLocalError: local variable 'aml' referenced before assignment
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/account/wizard/account_payment_register.py", line 920, in action_create_payments
    payments = self._create_payments()
  File "addons/account/wizard/account_payment_register.py", line 909, in _create_payments
    'create_vals': self._create_payment_vals_from_batch(batch_result),
  File "home/odoo/src/enterprise/saas-16.3/account_sepa/models/account_payment_register.py", line 24, in _create_payment_vals_from_batch
    return super()._create_payment_vals_from_batch(batch_result)
  File "addons/account/wizard/account_payment_register.py", line 760, in _create_payment_vals_from_batch
    ._get_invoice_counterpart_amls_for_early_payment_discount(epd_aml_values_list, open_balance)
  File "addons/account/models/account_move.py", line 3235, in _get_invoice_counterpart_amls_for_early_payment_discount
    exchange_diff_sign = aml.company_currency_id.compare_amounts(open_balance, 0.0)
```

This commit solves the above issue by calculating an early discount
if the related invoice payment term has an early discount.

sentery-4315297841

