### PR TITLE
[FIX] point_of_sale: raise not_found for invalid url

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -33,8 +33,10 @@ class PosController(http.Controller):
                 ('user_id', '=', request.session.uid),
                 ('rescue', '=', False)
                 ]
-        if config_id:
+        if config_id and config_id.isnumeric():
             domain = AND([domain,[('config_id', '=', int(config_id))]])
+        else:
+            return request.not_found()
         pos_session = request.env['pos.session'].sudo().search(domain, limit=1)
 
         # The same POS session can be opened by a different user => search without restricting to


### PR DESCRIPTION
When the user tries to enter a URL like pos/ui?config_id=abc instead of pos/ui?config_id=1, the traceback appears.

Steps to produce:
1. install  PoS module > open session.
2. change the URL with pos/ui?config_id=abc and the traceback will be generated 
Error: ValueError: invalid literal for int() with base 10: 'string'

```
ValueError: invalid literal for int() with base 10: '1https://one-fab-outlet.odoo.com/pos/ui?config_id=1'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/point_of_sale/controllers/main.py", line 40, in pos_web
    domain = AND([domain,[('config_id', '=', int(config_id))]])
```

see:
https://github.com/odoo/odoo/blob/0a854e59867461d1c159a5ef16c57052765b730d/addons/point_of_sale/controllers/main.py#L36-L37 In the above use case when trying to convert a config_id into type int(), if the value is not numeric it will lead to the above traceback. So, this commit raises not_found() error instead of valueerror.




sentry-4317550539






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
