### PR TITLE
[IMP] web,mail: Discuss app commands in command palette

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -581,7 +581,7 @@ class Channel(models.Model):
         # Last interest and is_pinned are updated for a chat when posting a message.
         # So a notification is needed to update UI, and it should come before the
         # notification of the message itself to ensure the channel automatically opens.
-        if self.is_chat or self.channel_type == 'group':
+        if self.is_chat or self.channel_type in ['channel', 'group']:
             for member in self.channel_member_ids.filtered('partner_id'):
                 bus_notifications.insert(0, [member.partner_id, 'discuss.channel/last_interest_dt_changed', {
                     'id': self.id,
@@ -614,7 +614,7 @@ class Channel(models.Model):
 
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, *, message_type='notification', **kwargs):
-        self.filtered(lambda channel: channel.is_chat or channel.channel_type == 'group').mapped('channel_member_ids').sudo().write({
+        self.filtered(lambda channel: channel.is_chat or channel.channel_type in ['channel', 'group']).mapped('channel_member_ids').sudo().write({
             'is_pinned': True,
             'last_interest_dt': fields.Datetime.now(),
         })

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -121,6 +121,7 @@ export class Store {
             canAdd: true,
             serverStateKey: "is_discuss_sidebar_category_channel_open",
             addTitle: _t("Add or join a channel"),
+            addHotkey: "c",
             threads: [], // list of ids
         },
         chats: {
@@ -132,6 +133,7 @@ export class Store {
             canAdd: true,
             serverStateKey: "is_discuss_sidebar_category_chat_open",
             addTitle: _t("Start a conversation"),
+            addHotkey: "d",
             threads: [], // list of ids
         },
         // mailboxes in sidebar

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -482,7 +482,14 @@ export class ThreadService {
         }
     }
 
-    async getChat({ userId, partnerId }) {
+    /**
+     * Search and fetch for a partner with a given user or partner id.
+     * @param {Object} param0
+     * @param {number} param0.userId
+     * @param {number} param0.partnerId
+     * @returns {Promise<import { Persona } from "@mail/core/common/persona_model";> | undefined}
+     */
+    async getPartner({ userId, partnerId }) {
         if (userId) {
             let user = this.store.users[userId];
             if (!user) {
@@ -528,13 +535,35 @@ export class ThreadService {
                 }
                 partner.user = { id: userId };
             }
+            return partner;
         }
+    }
 
-        let chat = Object.values(this.store.threads).find(
-            (thread) => thread.type === "chat" && thread.chatPartnerId === partnerId
+    /**
+     * @param {import { Persona } from "@mail/core/common/persona_model";} partner
+     * @returns {Thread | undefined}
+     */
+    searchChat(partner) {
+        if (!partner) {
+            return;
+        }
+        return Object.values(this.store.threads).find(
+            (thread) => thread.type === "chat" && thread.chatPartnerId === partner.id
         );
+    }
+
+    /**
+     * Search and fetch for a partner with a given user or partner id.
+     * @param {Object} param0
+     * @param {number} param0.userId
+     * @param {number} param0.partnerId
+     * @returns {Promise<Thread | undefined>}
+     */
+    async getChat({ userId, partnerId }) {
+        const partner = await this.getPartner({ userId, partnerId });
+        let chat = this.searchChat(partner);
         if (!chat || !chat.is_pinned) {
-            chat = await this.joinChat(partnerId);
+            chat = await this.joinChat(partnerId || partner?.id);
         }
         if (!chat) {
             this.notificationService.add(

--- a/addons/mail/static/src/core/web/command_category.js
+++ b/addons/mail/static/src/core/web/command_category.js
@@ -1,0 +1,10 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+const commandCategoryRegistry = registry.category("command_categories");
+
+commandCategoryRegistry
+    .add("discuss_mentioned", { namespace: "@", name: _t("Mentions") }, { sequence: 10 })
+    .add("discuss_recent", { namespace: "#", name: _t("Recent") }, { sequence: 10 });

--- a/addons/mail/static/src/core/web/command_palette.xml
+++ b/addons/mail/static/src/core/web/command_palette.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.DiscussCommand" owl="1">
+        <div class="o_command_default d-flex align-items-center px-4 py-2">
+            <img class="rounded me-2" t-if="props.imgUrl" t-att-src="props.imgUrl"  style="width: 25px; height: 25px"/>
+            <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
+            <span class="pe-1 text-ellipsis fw-bold">
+                <t t-slot="name" />
+            </span>
+            <span t-if="props.persona and props.persona.email" t-out="'- ' + props.persona.email"/>
+            <span class="flex-grow-1"/>
+            <div t-if="props.counter > 0">
+                <span t-attf-class="badge rounded-pill o-discuss-badge ms-3 me-1 fw-bold" t-esc="props.counter"/>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -255,6 +255,25 @@ patch(ThreadService.prototype, {
         }
         this.chatWindowService.notifyState(chatWindow);
     },
+    getRecentChannels() {
+        return Object.values(this.store.threads)
+            .filter((thread) => thread.model === "discuss.channel")
+            .sort((a, b) => {
+                if (!a.lastInterestDateTime && !b.lastInterestDateTime) {
+                    return 0;
+                }
+                if (a.lastInterestDateTime && !b.lastInterestDateTime) {
+                    return -1;
+                }
+                if (!a.lastInterestDateTime && b.lastInterestDateTime) {
+                    return 1;
+                }
+                return b.lastInterestDateTime.ts - a.lastInterestDateTime.ts;
+            });
+    },
+    getNeedactionChannels() {
+        return this.getRecentChannels().filter((channel) => this.getCounter(channel) > 0);
+    },
 });
 
 patch(threadService, {

--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_start_meeting.xml
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_start_meeting.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarStartMeeting">
         <div class="d-flex justify-content-center">
-            <button class="btn btn-primary rounded" t-on-click="onClickStartMeeting">Start a meeting</button>
+            <button class="btn btn-primary rounded" t-on-click="onClickStartMeeting" data-hotkey="m">Start a meeting</button>
         </div>
         <hr class="w-100 opacity-0"/>
     </t>

--- a/addons/mail/static/src/discuss/core/web/command_palette.js
+++ b/addons/mail/static/src/discuss/core/web/command_palette.js
@@ -2,13 +2,21 @@
 
 import { cleanTerm } from "@mail/utils/common/format";
 
-import { Component, xml } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { url } from "@web/core/utils/urls";
+import { imageCacheKey } from "@web/views/fields/image/image_field";
+import { ImStatus } from "@mail/core/common/im_status";
 
 const commandSetupRegistry = registry.category("command_setup");
 const commandProviderRegistry = registry.category("command_provider");
+
+class DiscussCommand extends Component {
+    static components = { ImStatus };
+    static template = "mail.DiscussCommand";
+}
 
 // -----------------------------------------------------------------------------
 // add @ namespace + provider
@@ -20,14 +28,6 @@ commandSetupRegistry.add("@", {
     placeholder: _t("Search for a user..."),
 });
 
-class DialogCommand extends Component {}
-DialogCommand.template = xml`
-    <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2 cursor-pointer">
-        <t t-slot="name"/>
-        <span t-if="props.email" t-out="props.email"/>
-    </div>
-`;
-
 commandProviderRegistry.add("mail.partner", {
     namespace: "@",
     /**
@@ -37,19 +37,61 @@ commandProviderRegistry.add("mail.partner", {
         const messaging = env.services["mail.messaging"];
         const threadService = env.services["mail.thread"];
         const suggestionService = env.services["mail.suggestion"];
-        const results = await messaging.searchPartners(options.searchValue);
-        return suggestionService
-            .sortPartnerSuggestions(results, options.searchValue)
-            .map(function (partner) {
-                return {
-                    Component: DialogCommand,
+        const commands = [];
+        const mentionedChannels = threadService.getNeedactionChannels();
+        // We don't want to display the same channel twice in the command palette.
+        const displayedPartnerIds = new Set();
+        if (!options.searchValue) {
+            mentionedChannels.slice(0, 3).map((channel) => {
+                if (channel.type === "chat") {
+                    displayedPartnerIds.add(channel.chatPartnerId);
+                }
+                commands.push({
+                    Component: DiscussCommand,
+                    async action() {
+                        switch (channel.type) {
+                            case "chat":
+                                threadService.openChat({ partnerId: channel.chatPartnerId });
+                                break;
+                            case "group":
+                                threadService.open(channel);
+                                break;
+                            case "channel": {
+                                await threadService.joinChannel(channel.id, channel.name);
+                                threadService.open(channel);
+                            }
+                        }
+                    },
+                    name: channel.displayName,
+                    category: "discuss_mentioned",
+                    props: {
+                        imgUrl: channel.imgUrl,
+                        persona: channel.type === "chat" ? channel.correspondent : undefined,
+                        counter: threadService.getCounter(channel),
+                    },
+                });
+            });
+        }
+        const searchResults = await messaging.searchPartners(options.searchValue);
+        suggestionService
+            .sortPartnerSuggestions(searchResults, options.searchValue)
+            .filter((partner) => !displayedPartnerIds.has(partner.id))
+            .map((partner) => {
+                const chat = threadService.searchChat(partner);
+                commands.push({
+                    Component: DiscussCommand,
                     action() {
                         threadService.openChat({ partnerId: partner.id });
                     },
                     name: partner.name,
-                    props: { email: partner.email },
-                };
+                    props: {
+                        imgUrl: threadService.avatarUrl(partner),
+                        persona: partner,
+                        counter: chat ? threadService.getCounter(chat) : undefined,
+                    },
+                });
             });
+        return commands;
     },
 });
 
@@ -72,6 +114,31 @@ commandProviderRegistry.add("discuss.channel", {
     async provide(env, options) {
         const messaging = env.services["mail.messaging"];
         const threadService = env.services["mail.thread"];
+        const commands = [];
+        const recentChannels = threadService.getRecentChannels();
+        // We don't want to display the same thread twice in the command palette.
+        const shownChannels = new Set();
+        if (!options.searchValue) {
+            recentChannels
+                .filter((channel) => ["channel", "group"].includes(channel.type))
+                .slice(0, 3)
+                .map((channel) => {
+                    shownChannels.add(channel.id);
+                    commands.push({
+                        Component: DiscussCommand,
+                        async action() {
+                            await threadService.joinChannel(channel.id, channel.name);
+                            threadService.open(channel);
+                        },
+                        name: channel.displayName,
+                        category: "discuss_recent",
+                        props: {
+                            imgUrl: channel.imgUrl,
+                            counter: threadService.getCounter(channel),
+                        },
+                    });
+                });
+        }
         const domain = [
             ["channel_type", "=", "channel"],
             ["name", "ilike", cleanTerm(options.searchValue)],
@@ -79,17 +146,48 @@ commandProviderRegistry.add("discuss.channel", {
         const channelsData = await messaging.orm.searchRead(
             "discuss.channel",
             domain,
-            ["channel_type", "name"],
+            ["channel_type", "name", "avatar_128"],
             { limit: 10 }
         );
-        return channelsData.map((data) => ({
-            async action() {
-                const channel = await threadService.joinChannel(data.id, data.name);
-                threadService.open(channel);
-            },
-            // todo: handle displayname in a way (seems like "group" channels
-            // do not have a name
-            name: data.name,
-        }));
+        channelsData
+            .filter((data) => !shownChannels.has(data.id))
+            .map((data) => {
+                commands.push({
+                    Component: DiscussCommand,
+                    async action() {
+                        const channel = await threadService.joinChannel(data.id, data.name);
+                        threadService.open(channel);
+                    },
+                    name: data.name,
+                    props: {
+                        imgUrl: url("/web/image", {
+                            model: "discuss.channel",
+                            field: "avatar_128",
+                            id: data.id,
+                            unique: imageCacheKey(data.avatar_128),
+                        }),
+                    },
+                });
+            });
+        const groups = recentChannels.filter(
+            (channel) =>
+                !shownChannels.has(channel.id) &&
+                channel.type === "group" &&
+                cleanTerm(channel.displayName).includes(cleanTerm(options.searchValue))
+        );
+        groups.map((channel) => {
+            commands.push({
+                Component: DiscussCommand,
+                async action() {
+                    threadService.open(channel);
+                },
+                name: channel.displayName,
+                props: {
+                    imgUrl: channel.imgUrl,
+                    counter: threadService.getCounter(channel),
+                },
+            });
+        });
+        return commands;
     },
 });

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -20,7 +20,7 @@
             <div class="flex-grow-1"/>
             <div class="d-flex me-3">
                 <i t-if="category.canView" t-attf-class="fa fa-cog {{ hover_class }}" title="View or join channels" t-on-click="() => this.openCategory(category)" role="img"/>
-                <i t-if="category.canAdd and category.isOpen" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"/>
+                <i t-if="category.canAdd and category.isOpen" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"  t-att-data-hotkey="category.addHotkey"/>
             </div>
             <div t-if="!category.isOpen and threadService.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill me-3 o-discuss-badge fw-bold">
                 <t t-esc="threadService.getDiscussSidebarCategoryCounter(category.id)"/>

--- a/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { afterNextRender, click, start, startServer } from "@mail/../tests/helpers/test_utils";
+import { Command } from "@mail/../tests/helpers/command";
 
 import { commandService } from "@web/core/commands/command_service";
 import { registry } from "@web/core/registry";
@@ -13,7 +14,11 @@ const commandSetupRegistry = registry.category("command_setup");
 QUnit.module("command palette", {
     async beforeEach() {
         serviceRegistry.add("command", commandService);
-        registry.category("command_categories").add("default", { label: "default" });
+        registry
+            .category("command_categories")
+            .add("default", { label: "default" })
+            .add("discuss_mentioned", { namespace: "@", name: "Mentions" }, { sequence: 10 })
+            .add("discuss_recent", { namespace: "#", name: "Recent" }, { sequence: 10 });
     },
 });
 
@@ -45,3 +50,67 @@ QUnit.test("open the chatWindow of a channel from the command palette", async (a
     assert.containsOnce($, ".o-mail-ChatWindow");
     assert.containsOnce($, ".o-mail-ChatWindow-name:contains(general)");
 });
+
+QUnit.test("Channel mentions in the command palette of Discuss app with @", async (assert) => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Mario" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "group",
+    });
+    const messageId = pyEnv["mail.message"].create({
+        author_id: partnerId,
+        model: "discuss.channel",
+        res_id: channelId,
+        body: "@Mitchell Admin",
+        needaction: true,
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_type: "inbox",
+        res_partner_id: pyEnv.currentPartnerId,
+    });
+    const { advanceTime } = await start({ hasTimeControl: true });
+    triggerHotkey("control+k");
+    await nextTick();
+    await editSearchBar("@");
+    await afterNextRender(() => advanceTime(commandSetupRegistry.get("@").debounceDelay));
+    assert.containsOnce($, ".o_command_palette:contains('Mentions')");
+    assert.containsOnce(
+        $(".o_command_category:contains('Mentions')"),
+        ".o_command:contains('Mitchell Admin and Mario')"
+    );
+    assert.containsOnce(
+        $(".o_command_category:not(:contains('Mentions'))"),
+        ".o_command:contains('Mario')"
+    );
+    assert.containsOnce(
+        $(".o_command_category:not(:contains('Mentions'))"),
+        ".o_command:contains('Mitchell Admin')"
+    );
+    assert.containsOnce($, ".o_command.focused:contains('Mitchell Admin and Mario')");
+
+    await click(".o_command.focused");
+    assert.containsOnce($, ".o-mail-ChatWindow:contains('Mitchell Admin and Mario')");
+});
+
+QUnit.test(
+    "Max 3 most recent channels in command palette of Discuss app with #",
+    async (assert) => {
+        const pyEnv = await startServer();
+        pyEnv["discuss.channel"].create({ name: "channel_1" });
+        pyEnv["discuss.channel"].create({ name: "channel_2" });
+        pyEnv["discuss.channel"].create({ name: "channel_3" });
+        pyEnv["discuss.channel"].create({ name: "channel_4" });
+        const { advanceTime } = await start({ hasTimeControl: true });
+        triggerHotkey("control+k");
+        await nextTick();
+        await editSearchBar("#");
+        await afterNextRender(() => advanceTime(commandSetupRegistry.get("#").debounceDelay));
+        assert.containsOnce($, ".o_command_palette:contains('Recent')");
+        assert.containsN($(".o_command_category:contains('Recent')"), ".o_command", 3);
+    }
+);

--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -153,6 +153,7 @@ export class CommandPalette extends Component {
             if (commands.length) {
                 categories.push({
                     commands,
+                    name: this.categoryNames[category],
                     keyId: category,
                 });
             }
@@ -191,6 +192,7 @@ export class CommandPalette extends Component {
      */
     async setCommands(namespace, options = {}) {
         this.categoryKeys = ["default"];
+        this.categoryNames = {};
         const proms = this.providersByNamespace[namespace].map((provider) => {
             const { provide } = provider;
             const result = provide(this.env, options);
@@ -205,6 +207,7 @@ export class CommandPalette extends Component {
             if (namespaceConfig.categories) {
                 let commandsSorted = [];
                 this.categoryKeys = namespaceConfig.categories;
+                this.categoryNames = namespaceConfig.categoryNames || {};
                 if (!this.categoryKeys.includes("default")) {
                     this.categoryKeys.push("default");
                 }

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -16,6 +16,7 @@
           <div t-if="!state.commands.length" class="o_command_palette_listbox_empty px-4 py-3 fst-italic" t-out="state.emptyMessage"/>
           <t t-if="!isFuzzySearch" t-foreach="commandsByCategory" t-as="category" t-key="category.keyId">
             <div class="o_command_category px-0">
+              <span t-if="category.name" class="text-truncate text-uppercase fw-bold fs-6 px-3" t-out="category.name"/>
               <t t-foreach="category.commands" t-as="command" t-key="command.keyId">
                 <t t-set="commandIndex" t-value="state.commands.indexOf(command)"/>
                 <div t-attf-id="o_command_{{commandIndex}}" class="o_command"

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -90,14 +90,17 @@ export const commandService = {
                 if (!configByNamespace[namespace]) {
                     configByNamespace[namespace] = {
                         categories: [],
+                        categoryNames: {},
                     };
                 }
             }
 
             for (const [category, el] of commandCategoryRegistry.getEntries()) {
                 const namespace = el.namespace || "default";
+                const name = el.name;
                 if (namespace in configByNamespace) {
                     configByNamespace[namespace].categories.push(category);
+                    configByNamespace[namespace].categoryNames[category] = name;
                 }
             }
 


### PR DESCRIPTION
This commit adds some discuss-related options in the command
palette.

- hotkeys to add channel (C) & chat (D), and start a meeting (M);
- namespaces `@` or `#` show mentionned and recent conversations
  in Discuss app when search is empty;

Items show optional badge with needaction counter.

Mentions/Recent categories are only visible when there are no
search term. Indeed, `@term` searches for users while `#channel`
searches for channels, so these categories are meant to quickly
jump to recent and important conversations. When typing some
search terms, the fuzzy search has precedence over mentions/recent
criteria.

task-3330218

Before:
![image](https://github.com/odoo/odoo/assets/26395662/6f60c363-d286-4551-bb55-17ada999e136)
![image](https://github.com/odoo/odoo/assets/26395662/d68ce1a6-94c5-42fe-8126-15fe2e2fb046)

After: 
![image](https://github.com/odoo/odoo/assets/26395662/e134a446-0ba1-4655-a332-ba46276afe51)
![image](https://github.com/odoo/odoo/assets/26395662/f78b4d81-a4b1-4cf0-a6c4-722a83b862e3)
![image](https://github.com/odoo/odoo/assets/26395662/42d92e71-2a91-4fa0-b70f-a33c914a2fcc)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
