### PR TITLE
[REF/IMP] pivot table functions

### DIFF
--- a/addons/spreadsheet/static/src/list/list_functions.js
+++ b/addons/spreadsheet/static/src/list/list_functions.js
@@ -17,7 +17,7 @@ function assertListsExists(listId, getters) {
     }
 }
 
-functionRegistry.add("ODOO.LIST", {
+const ODOO_LIST = {
     description: _t("Get the value from a list."),
     args: [
         arg("list_id (string)", _t("ID of the list.")),
@@ -58,9 +58,9 @@ functionRegistry.add("ODOO.LIST", {
         }
     },
     returns: ["NUMBER", "STRING"],
-});
+};
 
-functionRegistry.add("ODOO.LIST.HEADER", {
+const ODOO_LIST_HEADER = {
     description: _t("Get the header of a list."),
     args: [
         arg("list_id (string)", _t("ID of the list.")),
@@ -74,4 +74,7 @@ functionRegistry.add("ODOO.LIST.HEADER", {
         return this.getters.getListHeaderValue(id, field);
     },
     returns: ["NUMBER", "STRING"],
-});
+};
+
+functionRegistry.add("ODOO.LIST", ODOO_LIST);
+functionRegistry.add("ODOO.LIST.HEADER", ODOO_LIST_HEADER);

--- a/addons/spreadsheet/static/src/pivot/pivot_functions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_functions.js
@@ -37,118 +37,126 @@ function assertDomainLength(domain) {
     }
 }
 
+const ODOO_FILTER_VALUE = {
+    description: _t("Return the current value of a spreadsheet filter."),
+    args: [arg("filter_name (string)", _t("The label of the filter whose value to return."))],
+    category: "Odoo",
+    compute: function (filterName) {
+        return this.getters.getFilterDisplayValue(filterName);
+    },
+    returns: ["STRING"],
+};
+
+const ODOO_PIVOT = {
+    description: _t("Get the value from a pivot."),
+    args: [
+        arg("pivot_id (string)", _t("ID of the pivot.")),
+        arg("measure_name (string)", _t("Name of the measure.")),
+        arg("domain_field_name (string,optional,repeating)", _t("Field name.")),
+        arg("domain_value (string,optional,repeating)", _t("Value.")),
+    ],
+    compute: function (pivotId, measureName, ...domain) {
+        pivotId = toString(pivotId);
+        const measure = toString(measureName);
+        const args = domain.map(toString);
+        assertPivotsExists(pivotId, this.getters);
+        assertMeasureExist(pivotId, measure, this.getters);
+        assertDomainLength(args);
+        return this.getters.getPivotCellValue(pivotId, measure, args);
+    },
+    category: "Odoo",
+    computeFormat: function (pivotId, measureName, ...domain) {
+        pivotId = toString(pivotId.value);
+        const measure = toString(measureName.value);
+        const field = this.getters.getPivotDataSource(pivotId).getReportMeasures()[measure];
+        if (!field) {
+            return undefined;
+        }
+        switch (field.type) {
+            case "integer":
+                return "0";
+            case "float":
+                return "#,##0.00";
+            case "monetary":
+                return this.getters.getCompanyCurrencyFormat() || "#,##0.00";
+            default:
+                return undefined;
+        }
+    },
+    returns: ["NUMBER", "STRING"],
+};
+
+const ODOO_PIVOT_HEADER = {
+    description: _t("Get the header of a pivot."),
+    args: [
+        arg("pivot_id (string)", _t("ID of the pivot.")),
+        arg("domain_field_name (string,optional,repeating)", _t("Field name.")),
+        arg("domain_value (string,optional,repeating)", _t("Value.")),
+    ],
+    category: "Odoo",
+    compute: function (pivotId, ...domain) {
+        pivotId = toString(pivotId);
+        const args = domain.map(toString);
+        assertPivotsExists(pivotId, this.getters);
+        assertDomainLength(args);
+        return this.getters.getDisplayedPivotHeaderValue(pivotId, args, this.locale);
+    },
+    computeFormat: function (pivotId, ...domain) {
+        pivotId = toString(pivotId.value);
+        const pivot = this.getters.getPivotDataSource(pivotId);
+        const len = domain.length;
+        if (!len) {
+            return undefined;
+        }
+        const fieldName = toString(domain[len - 2].value);
+        const value = toString(domain[len - 1].value);
+        if (fieldName === "measure" || value === "false") {
+            return undefined;
+        }
+        const { aggregateOperator, field } = pivot.parseGroupField(fieldName);
+        switch (field.type) {
+            case "integer":
+                return "0";
+            case "float":
+            case "monetary":
+                return "#,##0.00";
+            case "date":
+            case "datetime":
+                switch (aggregateOperator) {
+                    case "day":
+                        return this.locale.dateFormat;
+                    case "month":
+                        return "mmmm yyyy";
+                    case "year":
+                        return "0";
+                    case "week":
+                    case "quarter":
+                        return undefined;
+                }
+                break;
+            default:
+                return undefined;
+        }
+    },
+    returns: ["NUMBER", "STRING"],
+};
+
+const ODOO_PIVOT_POSITION = {
+    description: _t("Get the absolute ID of an element in the pivot"),
+    args: [
+        arg("pivot_id (string)", _t("ID of the pivot.")),
+        arg("field_name (string)", _t("Name of the field.")),
+        arg("position (number)", _t("Position in the pivot")),
+    ],
+    compute: function () {
+        throw new Error(_t(`[[FUNCTION_NAME]] cannot be called from the spreadsheet.`));
+    },
+    returns: ["STRING"],
+    hidden: true,
+};
+
 functionRegistry
-    .add("ODOO.FILTER.VALUE", {
-        description: _t("Return the current value of a spreadsheet filter."),
-        args: [arg("filter_name (string)", _t("The label of the filter whose value to return."))],
-        category: "Odoo",
-        compute: function (filterName) {
-            return this.getters.getFilterDisplayValue(filterName);
-        },
-        returns: ["STRING"],
-    })
-    .add("ODOO.PIVOT", {
-        description: _t("Get the value from a pivot."),
-        args: [
-            arg("pivot_id (string)", _t("ID of the pivot.")),
-            arg("measure_name (string)", _t("Name of the measure.")),
-            arg("domain_field_name (string,optional,repeating)", _t("Field name.")),
-            arg("domain_value (string,optional,repeating)", _t("Value.")),
-        ],
-        compute: function (pivotId, measureName, ...domain) {
-            pivotId = toString(pivotId);
-            const measure = toString(measureName);
-            const args = domain.map(toString);
-            assertPivotsExists(pivotId, this.getters);
-            assertMeasureExist(pivotId, measure, this.getters);
-            assertDomainLength(args);
-            return this.getters.getPivotCellValue(pivotId, measure, args);
-        },
-        category: "Odoo",
-        computeFormat: function (pivotId, measureName, ...domain) {
-            pivotId = toString(pivotId.value);
-            const measure = toString(measureName.value);
-            const field = this.getters.getPivotDataSource(pivotId).getReportMeasures()[measure];
-            if (!field) {
-                return undefined;
-            }
-            switch (field.type) {
-                case "integer":
-                    return "0";
-                case "float":
-                    return "#,##0.00";
-                case "monetary":
-                    return this.getters.getCompanyCurrencyFormat() || "#,##0.00";
-                default:
-                    return undefined;
-            }
-        },
-        returns: ["NUMBER", "STRING"],
-    })
-    .add("ODOO.PIVOT.HEADER", {
-        description: _t("Get the header of a pivot."),
-        args: [
-            arg("pivot_id (string)", _t("ID of the pivot.")),
-            arg("domain_field_name (string,optional,repeating)", _t("Field name.")),
-            arg("domain_value (string,optional,repeating)", _t("Value.")),
-        ],
-        category: "Odoo",
-        compute: function (pivotId, ...domain) {
-            pivotId = toString(pivotId);
-            const args = domain.map(toString);
-            assertPivotsExists(pivotId, this.getters);
-            assertDomainLength(args);
-            return this.getters.getDisplayedPivotHeaderValue(pivotId, args, this.locale);
-        },
-        computeFormat: function (pivotId, ...domain) {
-            pivotId = toString(pivotId.value);
-            const pivot = this.getters.getPivotDataSource(pivotId);
-            const len = domain.length;
-            if (!len) {
-                return undefined;
-            }
-            const fieldName = toString(domain[len - 2].value);
-            const value = toString(domain[len - 1].value);
-            if (fieldName === "measure" || value === "false") {
-                return undefined;
-            }
-            const { aggregateOperator, field } = pivot.parseGroupField(fieldName);
-            switch (field.type) {
-                case "integer":
-                    return "0";
-                case "float":
-                case "monetary":
-                    return "#,##0.00";
-                case "date":
-                case "datetime":
-                    switch (aggregateOperator) {
-                        case "day":
-                            return this.locale.dateFormat;
-                        case "month":
-                            return "mmmm yyyy";
-                        case "year":
-                            return "0";
-                        case "week":
-                        case "quarter":
-                            return undefined;
-                    }
-                    break;
-                default:
-                    return undefined;
-            }
-        },
-        returns: ["NUMBER", "STRING"],
-    })
-    .add("ODOO.PIVOT.POSITION", {
-        description: _t("Get the absolute ID of an element in the pivot"),
-        args: [
-            arg("pivot_id (string)", _t("ID of the pivot.")),
-            arg("field_name (string)", _t("Name of the field.")),
-            arg("position (number)", _t("Position in the pivot")),
-        ],
-        compute: function () {
-            throw new Error(_t(`[[FUNCTION_NAME]] cannot be called from the spreadsheet.`));
-        },
-        returns: ["STRING"],
-        hidden: true,
-    });
+    .add("ODOO.FILTER.VALUE", ODOO_FILTER_VALUE)
+    .add("ODOO.PIVOT", ODOO_PIVOT)
+    .add("ODOO.PIVOT.HEADER", ODOO_PIVOT_HEADER)
+    .add("ODOO.PIVOT.POSITION", ODOO_PIVOT_POSITION);


### PR DESCRIPTION
## [REF] spreadsheet: define function in constants

Ths commit change the pivot/list function to defined them in a constant,
and add this constant in the function registry, rather than define the
function directly in the registry.

This allow for re-using the functions code and call it from other
functions.

## [REF] spreadsheet: refactor insert pivot methods

The goal here is to simplify the code of the insertion of a pivot in the
pivot core plugin. Now the domain/style for each cell of the pivot is computed
in the `SpreadsheetPivotTable` class, which simplify a lot the plugin.

## [IMP] speadsheet: add Pivot table function

Add an ODOO.PIVOT.TABLE function that is an array formula that returns the
whole pivot. This is needed for example to compute an average in a dashboard,
because standard pivot formula won't update with new values.

Task: [3318865](https://www.odoo.com/web#id=3318865&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
