### PR TITLE
[IMP] web: improve selection with SHIFT in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -734,7 +734,7 @@ export class ListRenderer extends Component {
     }
 
     shouldReverseHeader(column) {
-        return this.isNumericColumn(column) && (!this.isRTL);
+        return this.isNumericColumn(column) && !this.isRTL;
     }
 
     isSortable(column) {
@@ -1086,10 +1086,7 @@ export class ListRenderer extends Component {
         switch (direction) {
             case "up": {
                 let futureRow = row.previousElementSibling;
-                futureRow =
-                    futureRow ||
-                    (row.parentElement.previousElementSibling &&
-                        row.parentElement.previousElementSibling.lastElementChild);
+                futureRow = futureRow || row.parentElement.previousElementSibling?.lastElementChild;
 
                 if (futureRow) {
                     const addCell = [...futureRow.children].find((c) =>
@@ -1109,10 +1106,7 @@ export class ListRenderer extends Component {
             }
             case "down": {
                 let futureRow = row.nextElementSibling;
-                futureRow =
-                    futureRow ||
-                    (row.parentElement.nextElementSibling &&
-                        row.parentElement.nextElementSibling.firstElementChild);
+                futureRow = futureRow || row.parentElement.nextElementSibling?.firstElementChild;
                 if (futureRow) {
                     const addCell = [...futureRow.children].find((c) =>
                         c.classList.contains("o_group_field_row_add")
@@ -1234,6 +1228,12 @@ export class ListRenderer extends Component {
 
     expandCheckboxes(record, direction) {
         const { records } = this.props.list;
+        if (!record && direction === "down") {
+            const defaultRecord = records[0];
+            this.shiftKeyedRecord = defaultRecord;
+            defaultRecord.toggleSelection(true);
+            return true;
+        }
         const recordIndex = records.indexOf(record);
         const shiftKeyedRecordIndex = records.indexOf(this.shiftKeyedRecord);
         let nextRecord;
@@ -1256,7 +1256,8 @@ export class ListRenderer extends Component {
         }
 
         if (isExpanding) {
-            nextRecord.toggleSelection(this.shiftKeyedRecord.selected);
+            record.toggleSelection(true);
+            nextRecord.toggleSelection(true);
         } else {
             record.toggleSelection(false);
         }
@@ -1753,7 +1754,7 @@ export class ListRenderer extends Component {
         }
     }
 
-    toggleRecordSelection(record) {
+    toggleRecordSelection(record, ev) {
         if (!this.canSelectRecord) {
             return;
         }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -455,6 +455,79 @@ QUnit.module("Views", (hooks) => {
         }
     });
 
+    QUnit.test(
+        "multiple interactions to change the range of checked boxes",
+        async function (assert) {
+            for (let i = 0; i < 5; i++) {
+                serverData.models.foo.records.push({ id: 5 + i, bar: true, foo: "foo" + i });
+            }
+
+            await makeView({
+                type: "list",
+                resModel: "foo",
+                serverData,
+                arch: '<tree><field name="foo"/><field name="int_field"/></tree>',
+            });
+
+            await triggerHotkey("ArrowDown");
+            const firstCheckbox = target.querySelector(
+                ".o_data_row:nth-child(1) .o_list_record_selector input"
+            );
+            assert.notEqual(
+                document.activeElement,
+                firstCheckbox,
+                "first checkbox should not be focused initially"
+            );
+
+            await triggerEvent(document.activeElement, null, "keydown", {
+                key: "Shift",
+                shiftKey: true,
+            });
+            await triggerHotkey("shift+ArrowDown");
+            assert.strictEqual(
+                document.activeElement,
+                firstCheckbox,
+                "first checkbox is now focused"
+            );
+            triggerHotkey("shift+ArrowDown");
+            triggerHotkey("shift+ArrowDown");
+            triggerHotkey("shift+ArrowDown");
+            triggerHotkey("shift+ArrowUp");
+            triggerHotkey("ArrowDown");
+            triggerHotkey("ArrowDown");
+            triggerHotkey("shift+ArrowDown");
+
+            await click(
+                target.querySelector(".o_data_row:nth-child(8) .o_list_record_selector .o-checkbox")
+            );
+            await triggerEvent(document.activeElement, null, "keydown", {
+                key: "Shift",
+                shiftKey: true,
+            });
+            await triggerHotkey("shift+ArrowDown");
+
+            const expectedCheckedRows = [1, 2, 3, 5, 6, 8, 9];
+
+            for (let i = 1; i < 10; i++) {
+                if (expectedCheckedRows.includes(i)) {
+                    assert.ok(
+                        target.querySelector(
+                            `.o_data_row:nth-child(${i}) .o_list_record_selector input`
+                        ).checked,
+                        `row ${i} checked`
+                    );
+                } else {
+                    assert.notOk(
+                        target.querySelector(
+                            `.o_data_row:nth-child(${i}) .o_list_record_selector input`
+                        ).checked,
+                        `row ${i} unchecked`
+                    );
+                }
+            }
+        }
+    );
+
     QUnit.test("list with class and style attributes", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
This commit improves the selection of records in list view using the SHIFT and arrow keys. In task 2039894, it has been made possible to select a range of records using the keyboard, but the experience was confusing. So, the latest task aims to improve the situation regarding selection with keyboard and navigation.

A test has been added to verify the behavior when selecting multiple rows, using multiple ways of interaction (SHIFT + arrow, click, navigate and select).

task-3418715