### PR TITLE
[FIX] web: dynamic placeholder traceback in firefox

### DIFF
--- a/addons/web/static/lib/owl/owl.js
+++ b/addons/web/static/lib/owl/owl.js
@@ -2876,6 +2876,10 @@
     function validateBaseType(key, value, type) {
         if (typeof type === "function") {
             if (typeof value === "object") {
+                // Validate against the correct HTMLElement class with respect to iframes.
+                if (type === HTMLElement && value.ownerDocument && value.ownerDocument.defaultView) {
+                    type = value.ownerDocument.defaultView.HTMLElement;
+                }
                 if (!(value instanceof type)) {
                     return `'${key}' is not a ${describeType(type)}`;
                 }


### PR DESCRIPTION
**Current behavior before PR:**

In Firefox, when the developer mode was enabled and an attempt was made to create a dynamic placeholder, it would result in a traceback being generated.

**Desired behavior after PR is merged:**

Now, when the developer mode is enabled in Firefox and an attempt is made to create a dynamic placeholder, a dynamic placeholder popover will now open instead of encountering a traceback.

task-3415762