### PR TITLE
[IMP] calendar: get instant feedback on meeting

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -96,7 +96,8 @@ class Attendee(models.Model):
         """ Hook to be able to override the invitation email sending process.
          Notably inside appointment to use a different mail template from the appointment type. """
         self._send_mail_to_attendees(
-            self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False)
+            self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False),
+            force_send=True,
         )
 
     def _send_mail_to_attendees(self, mail_template, force_send=False):
@@ -104,6 +105,8 @@ class Attendee(models.Model):
             :param mail_template: a mail.template record
             :param force_send: if set to True, the mail(s) will be sent immediately (instead of the next queue processing)
         """
+        if force_send:
+            force_send_limit = int(self.env['ir.config_parameter'].sudo().get_param('mail.mail_force_send_limit', 100))
         if isinstance(mail_template, str):
             raise ValueError('Template should be a template record, not an XML ID anymore.')
         if self.env['ir.config_parameter'].sudo().get_param('calendar.block_mail') or self._context.get("no_mail_to_attendees"):
@@ -115,6 +118,7 @@ class Attendee(models.Model):
         # get ics file for all meetings
         ics_files = self.mapped('event_id')._get_ics_file()
 
+        mail_messages = self.env['mail.message']
         for attendee in self:
             if attendee.email and attendee._should_notify_attendee():
                 event_id = attendee.event_id.id
@@ -143,7 +147,7 @@ class Attendee(models.Model):
                     'subject',
                     attendee.ids,
                     compute_lang=True)[attendee.id]
-                attendee.event_id.with_context(no_document=True).sudo().message_notify(
+                mail_messages |= attendee.event_id.with_context(no_document=True).sudo().message_notify(
                     email_from=attendee.event_id.user_id.email_formatted or self.env.user.email_formatted,
                     author_id=attendee.event_id.user_id.partner_id.id or self.env.user.partner_id.id,
                     body=body,
@@ -151,8 +155,11 @@ class Attendee(models.Model):
                     partner_ids=attendee.partner_id.ids,
                     email_layout_xmlid='mail.mail_notification_light',
                     attachment_ids=attachment_ids,
-                    force_send=force_send,
+                    force_send=False,
                 )
+        # batch sending at the end
+        if force_send and len(self) < force_send_limit:
+            mail_messages.sudo().mail_ids.send_after_commit()
 
     def _should_notify_attendee(self):
         """ Utility method that determines if the attendee should be notified.

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -890,10 +890,9 @@ class Meeting(models.Model):
     def action_sendmail(self):
         email = self.env.user.email
         if email:
-            for meeting in self:
-                meeting.attendee_ids._send_mail_to_attendees(
-                    self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False)
-                )
+            self.attendee_ids._send_mail_to_attendees(
+                self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False),
+            )
         return True
 
     def action_open_composer(self):
@@ -969,6 +968,10 @@ class Meeting(models.Model):
     # ------------------------------------------------------------
     # MAILING
     # ------------------------------------------------------------
+
+    def _skip_send_mail_status_update(self):
+        """Overridable getter to identify whether to send invitation/cancelation emails."""
+        return False
 
     def _get_attendee_emails(self):
         """ Get comma-separated attendee email addresses. """

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -703,7 +703,8 @@ class Meeting(models.Model):
         if 'partner_ids' in values:
             # we send to all partners and not only the new ones
             (current_attendees - previous_attendees)._send_mail_to_attendees(
-                self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False)
+                self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False),
+                force_send=True,
             )
         if not self.env.context.get('is_calendar_event_new') and 'start' in values:
             start_date = fields.Datetime.to_datetime(values.get('start'))
@@ -712,7 +713,8 @@ class Meeting(models.Model):
                 (current_attendees & previous_attendees).with_context(
                     calendar_template_ignore_recurrence=not update_recurrence
                 )._send_mail_to_attendees(
-                    self.env.ref('calendar.calendar_template_meeting_changedate', raise_if_not_found=False)
+                    self.env.ref('calendar.calendar_template_meeting_changedate', raise_if_not_found=False),
+                    force_send=True,
                 )
 
         return True

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -253,10 +253,6 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'res_id': cls.activity_type_1.id,
         })
 
-    def setUp(self):
-        super(TestCrmCommon, self).setUp()
-        self.flush_tracking()
-
     @classmethod
     def _activate_multi_company(cls):
         cls.company_2 = cls.env['res.company'].create({

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -107,6 +107,13 @@ class Meeting(models.Model):
                 raise ValidationError(_("The following event can only be updated by the organizer "
                                         "according to the event permissions set on Google Calendar."))
 
+    def _skip_send_mail_status_update(self):
+        """If a google calendar is not syncing with the user, don't send a mail."""
+        user_id = self._get_event_user()
+        if user_id.is_google_calendar_synced() and user_id.res_users_settings_id._is_google_calendar_valid():
+            return True
+        return super()._skip_send_mail_status_update()
+
     def _get_sync_domain(self):
         # in case of full sync, limit to a range of 1y in past and 1y in the future by default
         ICP = self.env['ir.config_parameter'].sudo()

--- a/addons/google_calendar/models/calendar_attendee.py
+++ b/addons/google_calendar/models/calendar_attendee.py
@@ -3,21 +3,11 @@
 
 from odoo import models
 
-from odoo.addons.google_calendar.models.google_sync import google_calendar_token
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
 
 class Attendee(models.Model):
     _name = 'calendar.attendee'
     _inherit = 'calendar.attendee'
-
-    def _send_mail_to_attendees(self, mail_template, force_send=False):
-        """ Override
-        If not synced with Google, let Odoo in charge of sending emails
-        Otherwise, nothing to do: Google will send them
-        """
-        with google_calendar_token(self.env.user.sudo()) as token:
-            if not token:
-                super()._send_mail_to_attendees(mail_template, force_send)
 
     def do_tentative(self):
         # Synchronize event after state change

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from unittest.mock import MagicMock, patch
+from collections import defaultdict
+from datetime import datetime
+from unittest.mock import patch
 
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
 from odoo.addons.google_account.models.google_service import GoogleService
 from odoo.addons.google_calendar.models.res_users import User
-from odoo.addons.google_calendar.models.google_sync import GoogleSync
+from odoo.addons.google_calendar.models.google_sync import google_calendar_token, GoogleSync
 from odoo.tests.common import HttpCase, new_test_user
 from freezegun import freeze_time
 from contextlib import contextmanager
 
 
 def patch_api(func):
-    @patch.object(GoogleSync, '_google_insert', MagicMock(spec=GoogleSync._google_insert))
-    @patch.object(GoogleSync, '_google_delete', MagicMock(spec=GoogleSync._google_delete))
-    @patch.object(GoogleSync, '_google_patch', MagicMock(spec=GoogleSync._google_patch))
     def patched(self, *args, **kwargs):
-        return func(self, *args, **kwargs)
+        with self.mock_google_sync():
+            return func(self, *args, **kwargs)
     return patched
 
 @patch.object(User, '_get_google_calendar_token', lambda user: 'dummy-token')
@@ -41,47 +41,90 @@ class TestSyncGoogle(HttpCase):
                 patch.object(self.env.cr, 'now', lambda: mock_dt):
             yield
 
+    @contextmanager
+    def mock_google_sync(self, user_id=None):
+        self._gsync_deleted_ids = []
+        self._gsync_insert_values = []
+        self._gsync_patch_values = defaultdict(list)
+
+        # as these are normally post-commit hooks, we don't change any state here
+        def _mock_delete(model, service, google_id, **kwargs):
+            with google_calendar_token(user_id or model.env.user.sudo()) as token:
+                if token:
+                    self._gsync_deleted_ids.append(google_id)
+
+        def _mock_insert(model, service, values, **kwargs):
+            if not values:
+                return
+            with google_calendar_token(user_id or model.env.user.sudo()) as token:
+                if token:
+                    self._gsync_insert_values.append((values, kwargs))
+
+        def _mock_patch(model, service, google_id, values, **kwargs):
+            with google_calendar_token(user_id or model.env.user.sudo()) as token:
+                if token:
+                    self._gsync_patch_values[google_id].append((values, kwargs))
+
+        with self.env.cr.savepoint(), \
+             patch.object(GoogleSync, '_google_insert', autospec=True, wraps=GoogleSync, side_effect=_mock_insert), \
+             patch.object(GoogleSync, '_google_delete', autospec=True, wraps=GoogleSync, side_effect=_mock_delete), \
+             patch.object(GoogleSync, '_google_patch', autospec=True, wraps=GoogleSync, side_effect=_mock_patch):
+            yield
+
+    @contextmanager
+    def mock_google_service(self):
+        self._gservice_request_uris = []
+
+        def _mock_do_request(model, uri, *args, **kwargs):
+            self._gservice_request_uris.append(uri)
+            return (200, {}, datetime.now())
+
+        with patch.object(GoogleService, '_do_request', autospec=True, wraps=GoogleService, side_effect=_mock_do_request):
+            yield
+
     def assertGoogleEventDeleted(self, google_id):
-        GoogleSync._google_delete.assert_called()
-        args, dummy = GoogleSync._google_delete.call_args
-        self.assertEqual(args[1], google_id, "Event should have been deleted")
+        self.assertIn(google_id, self._gsync_deleted_ids, "Event should have been deleted")
 
     def assertGoogleEventNotDeleted(self):
-        GoogleSync._google_delete.assert_not_called()
+        self.assertFalse(self._gsync_deleted_ids)
 
     def assertGoogleEventInserted(self, values, timeout=None):
-        expected_args = (values,)
-        expected_kwargs = {'timeout': timeout} if timeout else {}
-        GoogleSync._google_insert.assert_called_once()
-        args, kwargs = GoogleSync._google_insert.call_args
-        args[1:][0].pop('conferenceData', None)
-        self.assertEqual(args[1:], expected_args) # skip Google service arg
-        self.assertEqual(kwargs, expected_kwargs)
+        self.assertEqual(len(self._gsync_insert_values), 1)
+        matching = []
+        for insert_values, insert_kwargs in self._gsync_insert_values:
+            if all(insert_values.get(key, False) == value for key, value in values.items()):
+                matching.append((insert_values, insert_kwargs))
+        self.assertGreaterEqual(len(matching), 1, 'There must be at least 1 matching insert.')
+        insert_values, insert_kwargs = matching[0]
+        self.assertDictEqual(insert_kwargs, {'timeout': timeout} if timeout else {})
 
     def assertGoogleEventNotInserted(self):
-        GoogleSync._google_insert.assert_not_called()
+        self.assertFalse(self._gsync_insert_values)
 
     def assertGoogleEventPatched(self, google_id, values, timeout=None):
-        expected_args = (google_id, values)
-        expected_kwargs = {'timeout': timeout} if timeout else {}
-        GoogleSync._google_patch.assert_called_once()
-        args, kwargs = GoogleSync._google_patch.call_args
-        self.assertEqual(args[1:], expected_args) # skip Google service arg
-        self.assertEqual(kwargs, expected_kwargs)
+        patch_values_all = self._gsync_patch_values.get(google_id)
+        self.assertTrue(patch_values_all)
+        matching = []
+        for patch_values, patch_kwargs in patch_values_all:
+            if all(patch_values.get(key, False) == values[key] for key in values):
+                matching.append((patch_values, patch_kwargs))
+        self.assertGreaterEqual(len(matching), 1, 'There must be at least 1 matching patch.')
+        patch_values, patch_kwargs = matching[0]
+        self.assertDictEqual(patch_kwargs, {'timeout': timeout} if timeout else {})
 
     def assertGoogleEventNotPatched(self):
-        GoogleSync._google_patch.assert_not_called()
+        self.assertFalse(self._gsync_patch_values)
 
     def assertGoogleAPINotCalled(self):
         self.assertGoogleEventNotPatched()
         self.assertGoogleEventNotInserted()
         self.assertGoogleEventNotDeleted()
 
-    def assertGoogleEventSendUpdates(self, mock_do_request, expected_value):
-        mock_do_request.assert_called_once()
-        args, _ = mock_do_request.call_args
-        val = "sendUpdates=%s" % expected_value
-        self.assertTrue(val in args[0], "The URL should contain %s" % val)
+    def assertGoogleEventSendUpdates(self, expected_value):
+        self.assertEqual(len(self._gservice_request_uris), 1)
+        uri = self._gservice_request_uris[0]
+        uri_parameter = "sendUpdates=%s" % expected_value
+        self.assertIn(uri_parameter, uri, "The URL should contain %s" % uri_parameter)
 
     def call_post_commit_hooks(self):
         """
@@ -92,8 +135,3 @@ class TestSyncGoogle(HttpCase):
         while funcs:
             func = funcs.popleft()
             func()
-
-    def assertGoogleEventHasNoConferenceData(self):
-        GoogleSync._google_insert.assert_called_once()
-        args, _ = GoogleSync._google_insert.call_args
-        self.assertFalse(args[1].get('conferenceData', False))

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -7,11 +7,14 @@ from datetime import datetime, date, timedelta
 from dateutil.relativedelta import relativedelta
 from odoo.tests.common import new_test_user
 from odoo.exceptions import ValidationError
+from odoo.addons.google_calendar.models.res_users import User
 from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle, patch_api
 from odoo.addons.google_calendar.utils.google_calendar import GoogleEvent, GoogleCalendarService
 from odoo import Command, tools
 from unittest.mock import patch
 
+
+@patch.object(User, '_get_google_calendar_token', lambda user: 'dummy-token')
 class TestSyncGoogle2Odoo(TestSyncGoogle):
 
     def setUp(self):

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -3,16 +3,19 @@
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo.addons.google_calendar.utils.google_event import GoogleEvent
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
-from odoo.addons.google_account.models.google_service import GoogleService
 from odoo.addons.google_calendar.models.res_users import User
 from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle, patch_api
+from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo import tools
+
+from .test_token_access import TestTokenAccess
 
 @tagged('odoo2google')
 @patch.object(User, '_get_google_calendar_token', lambda user: 'dummy-token')
@@ -601,34 +604,32 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'transparency': 'opaque',
         }, timeout=3)
 
-    @patch.object(GoogleService, '_do_request')
-    def test_send_update_do_request(self, mock_do_request):
+    def test_send_update_do_request(self):
         self.env.cr.postcommit.clear()
-        event = self.env['calendar.event'].create({
-            'name': "Event",
-            'allday': True,
-            'start': datetime(2020, 1, 15),
-            'stop': datetime(2020, 1, 15),
-            'need_sync': False,
-        })
-        mock_do_request.return_value = (200, GoogleEvent([event._google_values()]), datetime.now())
-        event.with_context(send_updates=True)._sync_odoo2google(self.google_service)
-        self.call_post_commit_hooks()
-        self.assertGoogleEventSendUpdates(mock_do_request, 'all')
+        with self.mock_google_service():
+            event = self.env['calendar.event'].create({
+                'name': "Event",
+                'allday': True,
+                'start': datetime(2020, 1, 15),
+                'stop': datetime(2020, 1, 15),
+                'need_sync': False,
+            })
+            event.with_context(send_updates=True)._sync_odoo2google(self.google_service)
+            self.call_post_commit_hooks()
+        self.assertGoogleEventSendUpdates('all')
 
-    @patch.object(GoogleService, '_do_request')
-    def test_not_send_update_do_request(self, mock_do_request):
-        event = self.env['calendar.event'].create({
-            'name': "Event",
-            'allday': True,
-            'start': datetime(2020, 1, 15),
-            'stop': datetime(2020, 1, 15),
-            'need_sync': False,
-        })
-        mock_do_request.return_value = (200, GoogleEvent([event._google_values()]), datetime.now())
-        event.with_context(send_updates=False)._sync_odoo2google(self.google_service)
-        self.call_post_commit_hooks()
-        self.assertGoogleEventSendUpdates(mock_do_request, 'none')
+    def test_not_send_update_do_request(self):
+        with self.mock_google_service():
+            event = self.env['calendar.event'].create({
+                'name': "Event",
+                'allday': True,
+                'start': datetime(2020, 1, 15),
+                'stop': datetime(2020, 1, 15),
+                'need_sync': False,
+            })
+            event.with_context(send_updates=False)._sync_odoo2google(self.google_service)
+            self.call_post_commit_hooks()
+        self.assertGoogleEventSendUpdates('none')
 
     @patch_api
     def test_recurrence_delete_single_events(self):
@@ -780,7 +781,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'location' : 'Event Location'
         })
         event._sync_odoo2google(self.google_service)
-        self.assertGoogleEventHasNoConferenceData()
+        self.assertGoogleEventInserted({'conferenceData': False})
 
     @patch_api
     def test_event_available_privacy(self):
@@ -833,3 +834,47 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
             'transparency': 'opaque',
         })
+
+
+@tagged('odoo2google')
+class TestSyncOdoo2GoogleMail(TestTokenAccess, TestSyncGoogle, MailCommon):
+
+    @patch.object(User, '_get_google_calendar_token', lambda user: user.google_calendar_token)
+    @freeze_time("2020-01-01")
+    def test_event_creation_for_user(self):
+        organizer1 = self.users[0]
+        organizer2 = self.users[1]
+        user_root = self.env.ref('base.user_root')
+        organizer1.google_calendar_token = 'abc'
+        organizer2.google_calendar_token = False
+        event_values = {
+            'name': "Event",
+            'start': datetime(2020, 1, 15, 8, 0),
+            'stop': datetime(2020, 1, 15, 18, 0),
+        }
+        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
+        for create_user, organizer, responsible, expect_mail, is_public in [
+            (user_root, organizer1, organizer1, False, True), (user_root, None, user_root, True, True),
+                (organizer1, None, organizer1, False, False), (organizer1, organizer2, organizer1, False, True)]:
+            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
+                with self.mock_mail_gateway(), self.mock_google_sync(user_id=responsible):
+                    self.env['calendar.event'].with_user(create_user).create({
+                        **event_values,
+                        'partner_ids': [(4, partner.id)],
+                        'user_id': organizer.id if organizer else False,
+                    })
+                if not expect_mail:
+                    self.assertNotSentEmail()
+                    self.assertGoogleEventInserted({
+                        'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'needsAction'}],
+                        'id': False,
+                        'start': {'dateTime': '2020-01-15T08:00:00+00:00', 'date': None},
+                        'end': {'dateTime': '2020-01-15T18:00:00+00:00', 'date': None},
+                        'guestsCanModify': is_public,
+                        'organizer': {'email': organizer.email, 'self': False} if organizer else False,
+                        'summary': 'Event',
+                        'reminders': {'useDefault': False, 'overrides': []},
+                    }, timeout=3)
+                else:
+                    self.assertGoogleEventNotInserted()
+                    self.assertMailMail(partner, 'sent', author=user_root.partner_id)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -25,7 +25,7 @@ from werkzeug import urls
 from xmlrpc import client as xmlrpclib
 from markupsafe import Markup, escape
 
-from odoo import _, api, exceptions, fields, models, tools, registry, SUPERUSER_ID, Command
+from odoo import _, api, exceptions, fields, models, tools, Command
 from odoo.addons.mail.tools.web_push import push_to_end_point, DeviceUnreachableError
 from odoo.exceptions import MissingError, AccessError
 from odoo.osv import expression
@@ -3309,16 +3309,7 @@ class MailThread(models.AbstractModel):
             # unless asked specifically, send emails after the transaction to
             # avoid side effects due to emails being sent while the transaction fails
             if not test_mode and send_after_commit:
-                email_ids = emails.ids
-                dbname = self.env.cr.dbname
-                _context = self._context
-
-                @self.env.cr.postcommit.add
-                def send_notifications():
-                    db_registry = registry(dbname)
-                    with db_registry.cursor() as cr:
-                        env = api.Environment(cr, SUPERUSER_ID, _context)
-                        env['mail.mail'].browse(email_ids).send()
+                emails.send_after_commit()
             else:
                 emails.send()
 

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -70,6 +70,13 @@ class Meeting(models.Model):
         outlook_connected = self.env.user._get_microsoft_calendar_token()
         return outlook_connected and self.env.user.sudo().microsoft_synchronization_stopped is False
 
+    def _skip_send_mail_status_update(self):
+        """If microsoft calendar is not syncing, don't send a mail."""
+        user_id = self._get_event_user_m()
+        if self.with_user(user_id)._check_microsoft_sync_status() and user_id._get_microsoft_sync_status() == "sync_active":
+            return True
+        return super()._skip_send_mail_status_update()
+
     @api.model_create_multi
     def create(self, vals_list):
         notify_context = self.env.context.get('dont_notify', False)

--- a/addons/microsoft_calendar/models/calendar_attendee.py
+++ b/addons/microsoft_calendar/models/calendar_attendee.py
@@ -1,24 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
 
-from odoo.addons.microsoft_calendar.models.microsoft_sync import microsoft_calendar_token
-from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
+from odoo import models
 
 
 class Attendee(models.Model):
     _name = 'calendar.attendee'
     _inherit = 'calendar.attendee'
-
-    def _send_mail_to_attendees(self, mail_template, force_send=False):
-        """ Override the super method
-        If not synced with Microsoft Outlook, let Odoo in charge of sending emails
-        Otherwise, Microsoft Outlook will send them
-        """
-        with microsoft_calendar_token(self.env.user.sudo()) as token:
-            if not token:
-                super()._send_mail_to_attendees(mail_template, force_send)
 
     def do_tentative(self):
         # Synchronize event after state change

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 
 from odoo import Command
 
+from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
 from odoo.addons.microsoft_calendar.models.res_users import User
@@ -503,3 +504,56 @@ class TestCreateEvents(TestCommon):
         default_privacy_odoo_event = self.env['calendar.event'].search([('microsoft_id', '=', 200)])
         self.assertFalse(undefined_privacy_odoo_event.privacy, "Event with undefined privacy must have False value in privacy field.")
         self.assertFalse(default_privacy_odoo_event.privacy, "Event with custom privacy must have False value in privacy field.")
+
+
+class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.users = cls.env['res.users'].create({
+            'name': f'user{n}',
+            'login': f'user{n}',
+            'email': f'user{n}@odoo.com',
+            'microsoft_calendar_rtoken': f'abc{n}',
+            'microsoft_calendar_token': f'abc{n}',
+            'microsoft_calendar_token_validity': datetime(9999, 12, 31),
+            'res_users_settings_ids': [(0, 0, {
+                'microsoft_synchronization_stopped': False,
+                'microsoft_calendar_sync_token': f'{n}_sync_token',
+            })]
+        } for n in range(1, 3)).user_ids
+
+    @freeze_time("2020-01-01")
+    @patch.object(User, '_get_microsoft_calendar_token', lambda user: user.microsoft_calendar_token)
+    def test_event_creation_for_user(self):
+        """Check that either emails or synchronization happens correctly when creating an event for another user."""
+        user_root = self.env.ref('base.user_root')
+        self.assertFalse(user_root.microsoft_calendar_token)
+        partner = self.env['res.partner'].create({'name': 'Jean-Luc', 'email': 'jean-luc@opoo.com'})
+        event_values = {
+            'name': 'Event',
+            'need_sync_m': True,
+            'start': datetime(2020, 1, 15, 8, 0),
+            'stop': datetime(2020, 1, 15, 18, 0),
+        }
+        for create_user, organizer, expect_mail in [
+            (user_root, self.users[0], True), (user_root, None, True),
+                (self.users[0], None, False), (self.users[0], self.users[1], False)]:
+            with self.subTest(create_uid=create_user.name if create_user else None, user_id=organizer.name if organizer else None):
+                with self.mock_mail_gateway(), patch.object(MicrosoftCalendarService, 'insert') as mock_insert:
+                    mock_insert.return_value = ('1', '1')
+                    self.env['calendar.event'].with_user(create_user).create({
+                        **event_values,
+                        'partner_ids': [(4, organizer.partner_id.id), (4, partner.id)] if organizer else [(4, partner.id)],
+                        'user_id': organizer.id if organizer else False,
+                    })
+                    self.env.cr.postcommit.run()
+                if not expect_mail:
+                    self.assertNotSentEmail()
+                    mock_insert.assert_called_once()
+                    self.assert_dict_equal(mock_insert.call_args[0][0]['organizer'], {
+                        'emailAddress': {'address': organizer.email if organizer else '', 'name': organizer.name if organizer else ''}
+                    })
+                else:
+                    mock_insert.assert_not_called()
+                    self.assertMailMail(partner, 'sent', author=(organizer or create_user).partner_id)


### PR DESCRIPTION
Prior to this, when creating a meeting, confirmations/invitations would be added to the mail queue instead of being force sent.

This resulted in slow feedback in cases where the event was created by one of the attendees rather than by a user.

To remedy this, we add a low treshold of 20 where
confirmation/invitation emails will be sent immediately.

The choice of 20 is made because sending 20 emails can be done synchronously in a reasonable amount of time and we expect most events created by the attendees through some automated means to only include a handful of attendees.

task-3193021
