### PR TITLE
[FIX] account: statement in bank reconciliation in list view

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -280,10 +280,10 @@ class AccountBankStatement(models.Model):
                 order='internal_index desc',
             )
         # single line edit
-        elif context_st_line_id and len(active_ids) <= 1:
+        elif context_st_line_id and active_ids and len(active_ids) <= 1:
             lines = self.env['account.bank.statement.line'].browse(context_st_line_id)
         # multi edit
-        elif context_st_line_id and len(active_ids) > 1:
+        elif context_st_line_id and active_ids and len(active_ids) > 1:
             lines = self.env['account.bank.statement.line'].browse(active_ids).sorted()
             if len(lines.journal_id) > 1:
                 raise UserError(_("A statement should only contain lines from the same journal."))


### PR DESCRIPTION
When user tries to add statement in bank reconciliation in list view,
a traceback will appear.

Steps to reproduce the issue:
- Go to Accounting > Dashboard > Bank
- Switch to list view of bank reconciliation.
- Create statement in any record of bank reconciliation > 'Create and edit'.

Traceback:
```
KeyError: <NewId 0x7f0541d5b6d0>
  File "odoo/api.py", line 959, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'account.bank.statement(<NewId 0x7f0541d5b6d0>,).first_line_index'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 966, in get
    raise CacheMiss(record, field)
KeyError: <NewId 0x7f0541d5b6d0>
  File "odoo/api.py", line 959, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'account.bank.statement(<NewId 0x7f0541d5b6d0>,).line_ids'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 966, in get
    raise CacheMiss(record, field)
TypeError: object of type 'NoneType' has no len()
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6711, in onchange
    snapshot1 = Snapshot(record, nametree)
  File "odoo/models.py", line 6485, in __init__
    self.fetch(name)
  File "odoo/models.py", line 6495, in fetch
    self[name] = record[name]
  File "odoo/models.py", line 6131, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1155, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1365, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1338, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4491, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "addons/account/models/account_bank_statement.py", line 116, in _compute_balance_start
    for stmt in self.sorted(lambda x: x.first_line_index or '0'):
  File "odoo/models.py", line 5816, in sorted
    return self.browse(item.id for item in sorted(self, key=key, reverse=reverse))
  File "addons/account/models/account_bank_statement.py", line 116, in <lambda>
    for stmt in self.sorted(lambda x: x.first_line_index or '0'):
  File "odoo/fields.py", line 1209, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4491, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "addons/account/models/account_bank_statement.py", line 110, in _compute_date_index
    sorted_lines = stmt.line_ids.sorted('internal_index')
  File "odoo/fields.py", line 4321, in __get__
    return super().__get__(records, owner)
  File "odoo/fields.py", line 2805, in __get__
    return super().__get__(records, owner)
  File "odoo/fields.py", line 1242, in __get__
    defaults = record.default_get([self.name])
  File "addons/account/models/account_bank_statement.py", line 283, in default_get
    elif context_st_line_id and len(active_ids) <= 1:
```

https://github.com/odoo/odoo/blob/e83b2de36761a093799464e289e81d4787296ff9/addons/account/models/account_bank_statement.py#L283 Here, when 'active_ids' is None and it tries to calculate len(active_ids),
So it will lead to above traceback.

sentry-4305119691

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
