### PR TITLE
[FIX] stock: remove "base.main_partner" from stock.warehouse XML data

### DIFF
--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -77,7 +77,6 @@
 
         <!-- Resource: stock.warehouse -->
         <record id="warehouse0" model="stock.warehouse">
-            <field name="partner_id" ref="base.main_partner"/>
             <field name="code">WH</field>
         </record>
 


### PR DESCRIPTION
When a user deletes a "Contact" of the company i.e., the main company from the "Contacts" list. After that, try to install the "stock" module, then a traceback will be generated.

Steps to produce (Without demo data database):
- Install a "contacts" module and activate the developer mode.
- Settings > User & Companies > Companies
- Click on the developer icon and  Edit View : Form"  and search a "partner_id" field and modifies the read-only attribute as readonly="0".
- Change to the "Contact" field value as "Administrator" or create a new Contact and set it.
- Go to the "Contacts" menu and search the "Your Company" record and delete it.
- Go to "Apps" and search for a "stock" module and try to install it. 
- After that, a traceback will be generated.

When the user deletes a "Your Company" record, i.e., the main company of the contact record, from the contact list after that "stock" module installation time, traceback will be generated. But, In the stock.warehouse," the object " partner_id" field is not required, and this field value will set the default current company of contact, i.e., partner_id, so there is no need to set a partner_id from the xml data.

for code reference.,
https://github.com/odoo/odoo/blob/16.0/addons/stock/models/stock_warehouse.py#L42

Sentry Traceback:
```
UserError: Sociétés incompatibles sur les enregistrements :
- 'Super Fast, Super clean' appartient à la société False et 'Projects' (project_ids: 'S00001 - Intervention HOME') appartient à une autre société.
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 451, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "odoo/models.py", line 4651, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "odoo/models.py", line 4573, in _load_records_create
    return self.create(values)
  File "<decorator-gen-209>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "addons/stock/models/stock_warehouse.py", line 145, in create
    self._update_partner_data(vals['partner_id'], vals.get('company_id'))
  File "addons/stock/models/stock_warehouse.py", line 314, in _update_partner_data
    self.env['res.partner'].browse(partner_id).write({'property_stock_customer': transit_loc, 'property_stock_supplier': transit_loc})
  File "addons/base_vat/models/res_partner.py", line 730, in write
    return super(ResPartner, self).write(values)
  File "home/odoo/src/enterprise/saas-16.3/sign/models/res_partner.py", line 36, in write
    res = super(ResPartner, self).write(vals)
  File "addons/snailmail/models/res_partner.py", line 26, in write
    return super(ResPartner, self).write(vals)
  File "addons/partner_autocomplete/models/res_partner.py", line 179, in write
    res = super(ResPartner, self).write(values)
  File "addons/base_geolocalize/models/res_partner.py", line 22, in write
    return super().write(vals)
  File "odoo/addons/base/models/res_partner.py", line 687, in write
    result = result and super(Partner, self).write(vals)
  File "addons/mail/models/mail_activity_mixin.py", line 241, in write
    return super(MailActivityMixin, self).write(vals)
  File "addons/mail/models/mail_thread.py", line 312, in write
    result = super(MailThread, self).write(values)
  File "addons/website/models/mixins.py", line 220, in write
    return super(WebsitePublishedMixin, self).write(values)
  File "odoo/models.py", line 4057, in write
    self._check_company()
  File "odoo/models.py", line 3692, in _check_company
    raise UserError("\n".join(lines))
ParseError: while parsing /home/odoo/src/odoo/saas-16.3/addons/stock/data/stock_data.xml:83, somewhere inside
<record id="warehouse0" model="stock.warehouse">
            <field name="partner_id" ref="base.main_partner"/>
            <field name="code">WH</field>
        </record>
  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

Sentry-4295498089, 4370319268