### PR TITLE
[IMP] mail: add guest to context when available

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -11,7 +11,7 @@ from odoo.tools import consteq
 class AttachmentController(http.Controller):
     @http.route("/mail/attachment/upload", methods=["POST"], type="http", auth="public")
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
-        env = request.env["ir.attachment"]._get_upload_env(request, thread_model, thread_id)
+        env = request.env["ir.attachment"]._get_upload_env(thread_model, thread_id)
         vals = {
             "name": ufile.filename,
             "raw": ufile.read(),
@@ -49,7 +49,7 @@ class AttachmentController(http.Controller):
     @http.route("/mail/attachment/delete", methods=["POST"], type="json", auth="public")
     def mail_attachment_delete(self, attachment_id, access_token=None):
         attachment_sudo = request.env["ir.attachment"].browse(int(attachment_id)).sudo().exists()
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         message_sudo = guest.env["mail.message"].sudo().search([("attachment_ids", "in", attachment_sudo.ids)], limit=1)
         if not attachment_sudo:
             target = request.env.user.partner_id

--- a/addons/mail/controllers/discuss/binary.py
+++ b/addons/mail/controllers/discuss/binary.py
@@ -14,9 +14,7 @@ class BinaryController(http.Controller):
         auth="public",
     )
     def discuss_channel_partner_avatar_128(self, channel_id, partner_id, **kwargs):
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request(
-            request=request, channel_id=channel_id
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context(channel_id=channel_id)
         partner_sudo = channel_member_sudo.env["res.partner"].browse(partner_id).exists()
         placeholder = partner_sudo._avatar_get_placeholder_path()
         domain = [("channel_id", "=", channel_id), ("partner_id", "=", partner_id)]
@@ -38,9 +36,7 @@ class BinaryController(http.Controller):
         "/discuss/channel/<int:channel_id>/guest/<int:guest_id>/avatar_128", methods=["GET"], type="http", auth="public"
     )
     def discuss_channel_guest_avatar_128(self, channel_id, guest_id, **kwargs):
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request(
-            request=request, channel_id=channel_id
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context(channel_id=channel_id)
         guest_sudo = channel_member_sudo.env["mail.guest"].browse(guest_id).exists()
         placeholder = guest_sudo._avatar_get_placeholder_path()
         domain = [("channel_id", "=", channel_id), ("guest_id", "=", guest_id)]
@@ -62,9 +58,7 @@ class BinaryController(http.Controller):
         "/discuss/channel/<int:channel_id>/attachment/<int:attachment_id>", methods=["GET"], type="http", auth="public"
     )
     def discuss_channel_attachment(self, channel_id, attachment_id, download=None, **kwargs):
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=int(channel_id)
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(channel_id=int(channel_id))
         domain = [
             ("id", "=", int(attachment_id)),
             ("res_id", "=", int(channel_id)),
@@ -82,9 +76,7 @@ class BinaryController(http.Controller):
         auth="public",
     )
     def discuss_channel_avatar_128(self, channel_id, **kwargs):
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=channel_id
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(channel_id=channel_id)
         domain = [("id", "=", channel_id)]
         channel_sudo = channel_member_sudo.env["discuss.channel"].search(domain, limit=1)
         if not channel_sudo:
@@ -105,9 +97,7 @@ class BinaryController(http.Controller):
         auth="public",
     )
     def fetch_image(self, channel_id, attachment_id, width=0, height=0, **kwargs):
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=channel_id
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(channel_id=channel_id)
         domain = [
             ("id", "=", attachment_id),
             ("res_id", "=", channel_id),

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -18,7 +18,7 @@ class RtcController(http.Controller):
             - list target_session_ids: list of the ids of the sessions that should receive the content
             - string content: the content to send to the other sessions
         """
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         notifications_by_session = defaultdict(list)
         for sender_session_id, target_session_ids, content in peer_notifications:
             session_sudo = guest.env["discuss.channel.rtc.session"].sudo().browse(int(sender_session_id)).exists()
@@ -40,7 +40,7 @@ class RtcController(http.Controller):
         :param dict values: write dict for the fields to update
         """
         if request.env.user._is_public():
-            guest = request.env["mail.guest"]._get_guest_from_request(request)
+            guest = request.env["mail.guest"]._get_guest_from_context()
             if guest:
                 session = guest.env["discuss.channel.rtc.session"].sudo().browse(int(session_id)).exists()
                 if session and session.guest_id == guest:
@@ -56,9 +56,7 @@ class RtcController(http.Controller):
         """Joins the RTC call of a channel if the user is a member of that channel
         :param int channel_id: id of the channel to join
         """
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=int(channel_id)
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(channel_id=int(channel_id))
         return channel_member_sudo._rtc_join_call(check_rtc_session_ids=check_rtc_session_ids)
 
     @http.route("/mail/rtc/channel/leave_call", methods=["POST"], type="json", auth="public")
@@ -66,9 +64,7 @@ class RtcController(http.Controller):
         """Disconnects the current user from a rtc call and clears any invitation sent to that user on this channel
         :param int channel_id: id of the channel from which to disconnect
         """
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=int(channel_id)
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(channel_id=int(channel_id))
         return channel_member_sudo._rtc_leave_call()
 
     @http.route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="json", auth="public")
@@ -77,9 +73,7 @@ class RtcController(http.Controller):
         :param member_ids: members whose invitation is to cancel
         :type member_ids: list(int) or None
         """
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=int(channel_id)
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(channel_id=int(channel_id))
         return channel_member_sudo.channel_id._rtc_cancel_invitations(member_ids=member_ids)
 
     @http.route("/mail/rtc/audio_worklet_processor", methods=["GET"], type="http", auth="public")
@@ -98,9 +92,7 @@ class RtcController(http.Controller):
 
     @http.route("/discuss/channel/ping", methods=["POST"], type="json", auth="public")
     def channel_ping(self, channel_id, rtc_session_id=None, check_rtc_session_ids=None):
-        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(
-            request=request, channel_id=int(channel_id)
-        )
+        channel_member_sudo = request.env["discuss.channel.member"]._get_as_sudo_from_context(channel_id=int(channel_id))
         if rtc_session_id:
             domain = [
                 ("id", "=", int(rtc_session_id)),

--- a/addons/mail/controllers/guest.py
+++ b/addons/mail/controllers/guest.py
@@ -9,7 +9,7 @@ from odoo.http import request
 class GuestController(http.Controller):
     @http.route("/mail/guest/update_name", methods=["POST"], type="json", auth="public")
     def mail_guest_update_name(self, guest_id, name):
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         guest_to_rename_sudo = guest.env["mail.guest"].browse(guest_id).sudo().exists()
         if not guest_to_rename_sudo:
             raise NotFound()

--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -9,7 +9,7 @@ class LinkPreviewController(http.Controller):
     def mail_link_preview(self, message_id, clear=None):
         if not request.env["mail.link.preview"]._is_link_preview_enabled():
             return
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         message = guest.env["mail.message"].search([("id", "=", int(message_id))])
         if not message:
             return
@@ -21,7 +21,7 @@ class LinkPreviewController(http.Controller):
 
     @http.route("/mail/link_preview/delete", methods=["POST"], type="json", auth="public")
     def mail_link_preview_delete(self, link_preview_id):
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         link_preview_sudo = guest.env["mail.link.preview"].sudo().search([("id", "=", int(link_preview_id))])
         if not link_preview_sudo:
             return

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -9,7 +9,7 @@ from odoo.http import request
 class MessageReactionController(http.Controller):
     @http.route("/mail/message/reaction", methods=["POST"], type="json", auth="public")
     def mail_message_add_reaction(self, message_id, content, action):
-        guest_sudo = request.env["mail.guest"]._get_guest_from_request(request).sudo()
+        guest_sudo = request.env["mail.guest"]._get_guest_from_context().sudo()
         message_sudo = guest_sudo.env["mail.message"].browse(int(message_id)).exists()
         if not message_sudo._validate_access_for_current_persona("write"):
             raise NotFound()

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -71,7 +71,7 @@ class ThreadController(http.Controller):
 
     @http.route("/mail/message/post", methods=["POST"], type="json", auth="public")
     def mail_message_post(self, thread_model, thread_id, post_data, context=None):
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         guest.env["ir.attachment"].browse(post_data.get("attachment_ids", []))._check_attachments_access(
             post_data.get("attachment_tokens")
         )
@@ -91,7 +91,7 @@ class ThreadController(http.Controller):
                 'last_used': datetime.now(),
                 'ids': canned_response_ids,
             })
-        thread = request.env[thread_model]._get_from_request_or_raise(request, int(thread_id))
+        thread = request.env[thread_model]._get_from_context_or_raise(int(thread_id))
         if "body" in post_data:
             post_data["body"] = Markup(post_data["body"])  # contains HTML such as @mentions
         new_partners = []
@@ -110,7 +110,7 @@ class ThreadController(http.Controller):
 
     @http.route("/mail/message/update_content", methods=["POST"], type="json", auth="public")
     def mail_message_update_content(self, message_id, body, attachment_ids, attachment_tokens=None, partner_ids=None):
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         guest.env["ir.attachment"].browse(attachment_ids)._check_attachments_access(attachment_tokens)
         message_sudo = guest.env["mail.message"].browse(message_id).sudo().exists()
         if not message_sudo.is_current_user_or_guest_author and not guest.env.user._is_admin():

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -11,7 +11,7 @@ class WebclientController(http.Controller):
     def mail_init_messaging(self):
         if not request.env.user.sudo()._is_public():
             return request.env.user.sudo(request.env.user.has_group("base.group_portal"))._init_messaging()
-        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        guest = request.env["mail.guest"]._get_guest_from_context()
         if guest:
             return guest.sudo()._init_messaging()
         raise NotFound()

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -293,11 +293,11 @@ class Channel(models.Model):
             self._cr.execute('CREATE INDEX discuss_channel_member_seen_message_id_idx ON discuss_channel_member (channel_id,partner_id,seen_message_id)')
 
     @api.model
-    def _get_from_request_or_raise(self, request, thread_id):
+    def _get_from_context_or_raise(self, thread_id):
         """Overridden because guests and (portal) users need sudo to post on channels. This ensures they are actually
         members before granting them access, as well as properly setting up the guest context on the resulting thread
         if applicable."""
-        return self.env["discuss.channel.member"]._get_as_sudo_from_request_or_raise(request, thread_id).channel_id
+        return self.env["discuss.channel.member"]._get_as_sudo_from_context_or_raise(thread_id).channel_id
 
     # ------------------------------------------------------------
     # MEMBERS MANAGEMENT

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -16,14 +16,14 @@ class IrAttachment(models.Model):
         return super()._bus_notification_target()
 
     @api.model
-    def _get_upload_env(self, request, thread_model, thread_id):
+    def _get_upload_env(self, thread_model, thread_id):
         """Overriden to allow guests and (portal) users to upload attachments to channels they have
         access to. The base method returns the env of the current request, which is not sudo and
         relies on access rights. Guests or (portal) users need sudo to upload attachments."""
         if thread_model == "discuss.channel":
             return (
-                request.env["discuss.channel.member"]
-                ._get_as_sudo_from_request_or_raise(request=request, channel_id=int(thread_id))
+                self.env["discuss.channel.member"]
+                ._get_as_sudo_from_context_or_raise(channel_id=int(thread_id))
                 .env
             )
-        return super()._get_upload_env(request, thread_model, thread_id)
+        return super()._get_upload_env(thread_model, thread_id)

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -49,7 +49,7 @@ class MailGuest(models.Model):
         """Returns the current guest record from the context, if applicable."""
         guest = self.env.context.get('guest')
         if isinstance(guest, self.pool['mail.guest']):
-            return guest
+            return guest.with_context(guest=guest)
         return self.env['mail.guest']
 
     def _get_guest_from_request(self, request):

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -90,5 +90,5 @@ class IrAttachment(models.Model):
         ]
 
     @api.model
-    def _get_upload_env(self, request, thread_model, thread_id):
+    def _get_upload_env(self, thread_model, thread_id):
         return request.env

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -25,3 +25,11 @@ class IrHttp(models.AbstractModel):
                 'user_context': user_context,
             })
         return result
+
+    @classmethod
+    def _pre_dispatch(cls, rule, args):
+        """Overriden to add the guest to the context if any."""
+        super()._pre_dispatch(rule, args)
+        guest = request.env["mail.guest"]._get_guest_from_request(request)
+        if guest:
+            request.update_context(guest=guest)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -452,7 +452,7 @@ class MailThread(models.AbstractModel):
             raise exceptions.UserError(_("Only messages type comment can have their content updated"))
 
     @api.model
-    def _get_from_request_or_raise(self, request, thread_id):
+    def _get_from_context_or_raise(self, thread_id):
         return self.browse(thread_id).exists()
 
     # ------------------------------------------------------------


### PR DESCRIPTION
This PR prepares the ground for the one introducing guests
for livechat visitors. Since our SameSite cookie policy
is Lax, the cookie won't be send on unsafe cross site
requests thus another mechanism will be introduced to
retrieve the guest.

This PR abstracts the way the guest is retrieved in order
to ease this transition as much as possible by overriding
the `ir_http._pre_dispatch` method in order to inject the
guest in the context if any.

part of task-3332628