### PR TITLE
[FIX] l10n_mx: vat number is missing in default layouts

### DIFF
--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -47,6 +47,7 @@ With this module you will have:
         "views/res_bank_view.xml",
         "views/res_config_settings_views.xml",
         "views/account_views.xml",
+        "views/report_templates.xml",
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_mx/views/report_templates.xml
+++ b/addons/l10n_mx/views/report_templates.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="l10n_mx_external_layout_standard" inherit_id="web.external_layout_standard">
+        <div t-field="company.partner_id" position="attributes">
+            <attribute t-if="company.country_id.code == 'MX'" name="t-options">{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": true}</attribute>
+        </div>
+    </template>
+
+    <template id="l10n_mx_external_layout_background" inherit_id="web.external_layout_background">
+        <span t-field="company.partner_id" position="attributes">
+            <attribute t-if="company.country_id.code == 'MX'" name="t-options">{"widget": "contact", "fields": ["address", "vat"], "no_marker": true}</attribute>
+        </span>
+    </template>
+
+    <template id="l10n_mx_external_layout_boxed" inherit_id="web.external_layout_boxed">
+        <span t-field="company.partner_id" position="attributes">
+            <attribute t-if="company.country_id.code == 'MX'" name="t-options">{"widget": "contact", "fields": ["address", "name", "vat"], "no_marker": true}</attribute>
+        </span>
+    </template>
+</odoo>


### PR DESCRIPTION
Steps to reproduce:
1. Install l10n_mx
2. issue an invoice or look into the default document layouts
3. in the light and background layouts, the vat number (RFC) is missing

Issue:
the vat number is mandatory in the document layouts right below the address. this is not the case now [1]

[1] https://www.sat.gob.mx/articulo/99662/articulo-29-a#:~:text=I.%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%20The,that%20issues%20it

Fix:
inherit the templates and add `vat` to the contact widget fields

opw-3425847