### PR TITLE
[FIX] website_forum: description field missing required attribute

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -191,6 +191,10 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
         let $textarea = $form.find('textarea[name=content]');
         // It's not really in the textarea that the user write at first
         const fillableTextAreaEl = $form[0].querySelector(".o_wysiwyg_textarea_wrapper");
+        const buttonWithSpan = fillableTextAreaEl.querySelector('button span');
+        if (buttonWithSpan && buttonWithSpan.textContent) {
+            fillableTextAreaEl.querySelector('button span').textContent = '';
+        }
         const isTextAreaFilled = fillableTextAreaEl &&
             (fillableTextAreaEl.innerText.trim() || fillableTextAreaEl.querySelector("img"));
 


### PR DESCRIPTION
before this commit, opening forum in mobile view and trying to post a new post, the description field is no more required.

* open forum in mobile or mobile view
* create a new post
* enter title and keep description untouched
* hit post your question, the question will get saved without description

after this commit, the description field will be required and on clicking post your question red border around the description field will be shown indicating it is required

Related to changes introduced to web editor in:  https://github.com/odoo/odoo/commit/7c1c6ecc52f05a9fa20365a80ffdd092cf4cd4f7



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
