### PR TITLE
[IMP] http_routing: improve window title

### DIFF
--- a/addons/http_routing/views/http_routing_template.xml
+++ b/addons/http_routing/views/http_routing_template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="http_error">
+    <template id="http_error" name="HTTP Error">
         <t t-call="web.frontend_layout">
             <div id="wrap">
                 <div class="oe_structure">


### PR DESCRIPTION
before this commit, the window title is
shown as http_error,error_message and
http_error_debug

after this commit, clean window title will
be shown to end user

before this commit:
![WhatsApp Image 2023-07-19 at 10 28 12 PM](https://github.com/odoo/odoo/assets/99093808/4e323ad0-d8b5-423d-b19a-a3302adc45c2)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
