### PR TITLE
[FIX] mail: handle assertion error when email_from field is not set

### DIFF
--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -35,7 +35,7 @@
                                 context="{'default_composition_mode':'comment', 'default_parent_id': mail_message_id_int}" states='received,sent,exception,cancel'/>
                         </div>
                         <group>
-                            <field name="email_from"/>
+                            <field name="email_from" required="1"/>
                             <field name="email_to"/>
                             <field name="recipient_ids" widget="many2many_tags"
                                 domain="[('active', '=', True)]"/>


### PR DESCRIPTION
Currently, When the user is creating a mail and keeps the email_from field empty and then clicks on 'Send Now' button an error is generated at the backend.

To reproduce the issue:
1. Turn on the developer mode.
2. Install Discuss module.
3. Configure an valid outgoing mail server.
4. Go to Settings > Technical > Email > create a new mail.
5. Keep the email_from field empty and save manually.
6. Then click on 'Send Now' button an error will be generated at the backend.

See this error:
```
AssertionError: You must either provide a sender address explicitly or configure using the combination of `mail.catchall.domain` and `mail.default.from` ICPs, in the server configuration file or with the --email-from startup parameter.
  File "addons/mail/models/mail_mail.py", line 599, in _send
    msg = IrMailServer.build_email(
  File "odoo/addons/base/models/ir_mail_server.py", line 479, in build_email
    assert email_from, "You must either provide a sender address explicitly or configure "\
```

The error occurs from
https://github.com/odoo/odoo/blob/3ab351eb4faf356edb1ab24aee24dca6eba1f430/odoo/addons/base/models/ir_mail_server.py#L468-L471
To solve this issue the `email_from` field is marked as required from XML side.

sentry-4152987936

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
