### PR TITLE
[IMP] pos_self_order: alignment of qr menu button in settings

### DIFF
--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -8,13 +8,13 @@
             <setting id="iface_orderline_notes" position="after">
                 <setting string="QR Code Menu" help="Allow customers to see the menu from their phone">
                     <field name="pos_self_order_view_mode"/>
-                    <div class="content-group d-flex gap-5" attrs="{'invisible': [('pos_self_order_view_mode','=',False)]}">
+                    <div class="content-group d-flex" attrs="{'invisible': [('pos_self_order_view_mode','=',False)]}">
                         <div class="d-flex flex-column align-items-start w-50">
                             <button class="btn-link p-0" icon="oi-arrow-right" name="pos_self_order.custom_link_action" type="action" string="Configure Buttons"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="generate_qr_codes_page" type="object" string="Generate QR Codes"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="preview_self_order_app" type="object" string="Preview"/>
                         </div>
-                        <div class="d-flex flex-column align-items-start">
+                        <div class="d-flex flex-column align-items-start w-50">
                             <div class="d-flex flex-column align-items-start">
                                 <field name="pos_self_order_image_name" invisible ="1"/>
                                 <label for="pos_self_order_image" string="Set Background Image"/>


### PR DESCRIPTION
before this commit, in the pos settings when the qr code menu is activated, the buttons Generate QR Codes, Configure Buttons, Preview is not aligned properly

after this commit, the button will be aligned properly in the settings.

Before:

![Screenshot from 2023-07-20 10-17-46](https://github.com/odoo/odoo/assets/27989791/f05415fe-c207-4e0b-b8ea-fc6e7182ee6e)

After:
![Screenshot from 2023-07-20 10-25-02](https://github.com/odoo/odoo/assets/27989791/7355eb48-9137-4838-a8ea-032bedb9ebae)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
