### PR TITLE
[FIX] hr: check records from create user server action

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -437,7 +437,8 @@
             <field name="groups_id" eval="[(4, ref('base.group_erp_manager'))]"/>
             <field name="state">code</field>
             <field name="code">
-                action = records.action_create_user()
+                if records:
+                    action = records.action_create_user()
             </field>
         </record>
 


### PR DESCRIPTION
When a user tries to create a user from an employee who is not yet created, the error will be raised like the 'NoneType' object has no attribute 'with_context' while evaluating
'action = records.with_context(allow_create_employee=False).action_create_user()'

Steps to Produce:
- Employees > Open any employee.
- Make the `name` field as unrequired from Studio or Edit form view.
- Now click on the 'New' button to create an Employee.
- From actions, click on 'Create User' before filling any fields.
- Discard changes > Error.

Before calling the action with records that are not yet created, it is essential to check if the records exist or not.

Traceback:
```
AttributeError: 'NoneType' object has no attribute 'with_context'
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(149,)", line 1, in <module>
ValueError: <class 'AttributeError'>: "'NoneType' object has no attribute 'with_context'" while evaluating
'action = records.with_context(allow_create_employee=False).action_create_user()'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/action.py", line 46, in run
    result = action.run()
  File "odoo/addons/base/models/ir_actions.py", line 702, in run
    res = runner(run_self, eval_context=eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 559, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```


Sentry-4326429856