### PR TITLE
[FIX] iot: Worldline Driver payment stuck fix

### DIFF
--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreenPaymentLines.xml
@@ -12,14 +12,14 @@
                                  <t t-esc="line.payment_method.name" />
                              </div>
                             <div class="payment-amount">
-                                <t t-if="line and line.payment_status and ['done', 'waitingCard', 'waiting', 'reversing', 'reversed'].includes(line.payment_status)">
+                                <t t-if="line and line.payment_status and ['done', 'waitingCard', 'waitingForCard', 'waiting', 'reversing', 'reversed'].includes(line.payment_status)">
                                         <t t-esc="env.pos.format_currency_no_symbol(line.get_amount())" />
                                 </t>
                                 <t t-else="">
                                         <t t-esc="formatLineAmount(line)" />
                                 </t>
                             </div>
-                            <t t-if="!line.payment_status or !['done', 'reversed'].includes(line.payment_status)">
+                            <t t-if="!line.payment_status or !['done', 'reversed', 'waiting', 'waitingCancel', 'waitingCard'].includes(line.payment_status)">
                                 <div class="delete-button"
                                     t-on-click="trigger('delete-payment-line', { cid: line.cid })"
                                     aria-label="Delete" title="Delete">


### PR DESCRIPTION
Before, when the cashier would rapidly press on "Send" followed by "Cancel" in a loop it was possible to get stuck with a payment line which would be impossible to delete or have no payment line but with Worldline terminal asking for a payment which would never get saved in Odoo.

This PR fixes both issues

Related PRs:
[15.0 Enterprise](https://github.com/odoo/enterprise/pull/44377)
[16.0 Odoo](https://github.com/odoo/odoo/pull/128920)
[16.0 Enterprise](https://github.com/odoo/enterprise/pull/44191)

[task 3390547](https://www.odoo.com/web#id=3390547&cids=1&menu_id=4720&action=333&active_id=1428&model=project.task&view_type=form)