### PR TITLE
[FIX] website: ensure images wall component doesn't accept text input

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -117,6 +117,7 @@ options.registry.gallery = options.Class.extend({
                         alt: attachments[i].description || '',
                         'data-name': _t('Image'),
                         style: $images.length > 0 ? $images[0].style.cssText : '',
+                        contenteditable: 'true',
                     }).appendTo($container);
                 }
                 if (attachments.length > 0) {

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -13,6 +13,7 @@
 
 <template id="s_images_wall" name="Images Wall">
     <section class="s_image_gallery o_spc-small o_masonry pt24 pb24"
+             contenteditable="false"
              data-vcss="001"
              data-columns="3" style="height: 500px; overflow: hidden;">
         <div class="container">


### PR DESCRIPTION
Steps to reproduce:
 1. Go to the website
 2. Drag Images wall snippet
 3. Add Images
 4. Click on an image
 5. Write some text => text in between images.

Before this commit, when we select an image on an images wall snippet 
and try to add some text to the snippet, it gets added between the 
images.

This commit ensures that the images in the images wall and snippet are
made non-editable by setting the `contenteditable` attribute for the
image and snippet.

task-3380599
