### PR TITLE
[IMP] website_forum: improve filters in forum

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -334,7 +334,7 @@ class WebsiteForum(WebsiteProfile):
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/ask_for_close', type='http', auth="user", methods=['POST'], website=True)
     def question_ask_for_close(self, forum, question, **post):
-        reasons = request.env['forum.post.reason'].search([('reason_type', '=', 'basic')])
+        reasons = request.env['forum.post.reason'].search([])
 
         values = self._prepare_user_values(**post)
         values.update({
@@ -366,12 +366,13 @@ class WebsiteForum(WebsiteProfile):
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/delete', type='http', auth="user", methods=['POST'], website=True)
     def question_delete(self, forum, question, **kwarg):
-        question.active = False
+        question.state = 'deleted'
         return request.redirect("/forum/%s" % slug(forum))
 
     @http.route('/forum/<model("forum.forum"):forum>/question/<model("forum.post"):question>/undelete', type='http', auth="user", methods=['POST'], website=True)
     def question_undelete(self, forum, question, **kwarg):
-        question.active = True
+        question.state = 'closed'
+        question.closed_reason_id = False
         return request.redirect("/forum/%s/%s" % (slug(forum), slug(question)))
 
     # Post
@@ -548,7 +549,7 @@ class WebsiteForum(WebsiteProfile):
             raise werkzeug.exceptions.NotFound()
 
         Post = request.env['forum.post']
-        domain = [('forum_id', '=', forum.id), ('state', '=', 'offensive'), ('active', '=', False)]
+        domain = [('forum_id', '=', forum.id), ('state', '=', 'offensive')]
         offensive_posts_ids = Post.search(domain, order='write_date DESC')
 
         values = self._prepare_user_values(forum=forum)

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -329,11 +329,9 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
             if (data.error) {
                 const message = data.error === 'anonymous_user'
                     ? _t("Sorry you must be logged to flag a post")
-                    : data.error === 'post_already_flagged'
-                        ? _t("This post is already flagged")
-                        : data.error === 'post_non_flaggable'
-                            ? _t("This post can not be flagged")
-                            : data.error;
+                    : data.error === 'post_non_flaggable'
+                        ? _t("This post can not be flagged")
+                        : data.error;
                 this._displayAccessDeniedNotification(message);
             } else if (data.success) {
                 const child = elem.firstElementChild;
@@ -349,11 +347,12 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     }
                     $(elem).nextAll('.flag_validator').removeClass('d-none');
                 } else if (data.success === 'post_flagged_non_moderator') {
-                    const forumAnswer = elem.closest('.forum_answer');
-                    elem.innerText = _t(' Flagged');
-                    elem.prepend(child);
-                    forumAnswer.fadeIn(1000);
-                    forumAnswer.slideUp(1000);
+                    this.displayNotification({
+                        message: _t("Moderators will be notified about this post."),
+                        title: _t("The post has been successfully flagged"),
+                        sticky: false,
+                        type: "info",
+                    });
                 }
             }
         });

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -42,10 +42,9 @@
                     <h3 t-attf-class="col-lg-10 mb-0" t-out="question.name"/>
                     <div class="col d-flex justify-content-end align-items-center">
                         <i t-if="question.state == 'close'" class="fa fa-lock ms-2 fs-4" title="Closed" data-bs-toggle="tooltip" data-bs-placement="top"/>
-                        <span t-elif="not question.active" class="badge bg-danger">
-                            <t t-if="question.state!='offensive'">Deleted</t>
-                            <t t-if="question.state=='offensive'">Offensive</t>
-                            <t t-if="question.state=='offensive' and question.closed_reason_id">
+                        <span t-elif="question.state == 'deleted'" class="badge bg-danger">Deleted</span>
+                        <span t-elif="question.state == 'offensive'" class="badge bg-danger">Offensive
+                            <t t-if="question.closed_reason_id">
                                 <t t-out="question.closed_reason_id.name.capitalize()"/>
                             </t>
                         </span>
@@ -119,6 +118,8 @@
                             <t t-if="filters == 'solved'">Solved</t>
                             <t t-elif="filters == 'unsolved'">Unsolved</t>
                             <t t-elif="filters == 'unanswered'">Unanswered</t>
+                            <t t-elif="filters == 'offensive'">Offensive</t>
+                            <t t-elif="filters == 'deleted'">Deleted</t>
                         </t>
                     </a>
                     <div class="dropdown-menu" role="menu">
@@ -153,6 +154,32 @@
                             <a t-attf-href="?#{ keep_query('search', 'sorting', 'my', filters='unanswered') }"
                                 class="dropdown-item">Unanswered
                             </a>
+                            <t t-if="user.karma>=forum.karma_moderate">
+                                <div class="dropdown-divider"/>
+                                <a t-attf-href="/forum/#{ slug(forum) }/validation_queue"
+                                    class="dropdown-item">To Validate
+                                </a>
+                                <a t-attf-href="/forum/#{ slug(forum) }/flagged_queue"
+                                    class="dropdown-item">Flagged
+                                </a>
+                                <a t-attf-href="/forum/#{ slug(forum) }/closed_posts"
+                                    class="dropdown-item">Closed
+                                </a>
+                            </t>
+                            <div class="dropdown-divider"/>
+                            <t t-if="user.karma>=forum.karma_moderate">
+                                <a t-attf-href="?#{ keep_query('search', 'sorting', 'my', filters='offensive') }"
+                                    class="dropdown-item">Offensive
+                                </a>
+                                <a t-attf-href="?#{ keep_query('search', 'sorting', 'my', filters='deleted') }"
+                                    class="dropdown-item">Deleted
+                                </a>
+                            </t>
+                            <t>
+                                <a t-if="my=='mine' and forum.karma_moderate>=user.karma" t-attf-href="?#{ keep_query('search', 'sorting', 'my', filters='hidden') }"
+                                    class="dropdown-item">Hidden
+                                </a>
+                            </t>
                         </t>
                     </div>
                 </div>

--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -18,7 +18,8 @@
         <div class="alert bg-light text-muted" t-if="not offensive">
             If you close this post, it will be hidden for most users. Only
             users having a high karma can see closed posts to moderate
-            them.
+            them. If you close the post with offensive reason, it will not show up
+            for moderators in "Closed" queue.
         </div>
         <div class="alert bg-light text-muted" t-if="offensive">
             If you mark this post as offensive, it will be hidden for most users. Only
@@ -36,7 +37,9 @@
                 <label class="form-label col-lg-2" for="reason"><t t-if="offensive">Offensive</t><t t-if="not offensive">Closing</t> Reason:</label>
                 <select class="form-select form-select col" name="reason_id">
                     <t t-foreach="reasons or []" t-as="reason">
-                        <option t-att-value="reason.id" t-att-selected="reason.id == question.closed_reason_id.id"><t t-out="reason.name"/></option>
+                        <option t-att-value="reason.id" t-att-selected="reason.id == question.closed_reason_id.id">
+                        <t t-out="reason.name"/> <t t-if="reason.reason_type=='offensive'"> - <t t-out="reason.reason_type"/></t>
+                        </option>
                     </t>
                 </select>
             </div>
@@ -206,7 +209,7 @@
                                 <t t-set="classes" t-value="'btn-outline-primary flex-grow-1'"/>
                             </t>
                             <t t-if="queue_type == 'close'" t-call="website_forum.link_button">
-                                <t t-set="url" t-valuef="#{ post_url }/delete"/>
+                                <t t-set="url" t-valuef="/forum/#{ slug(forum) }/question/#{ slug(question) }/delete"/>
                                 <t t-set="label">Delete</t>
                                 <t t-set="icon" t-value="'fa fa-trash'"/>
                                 <t t-set="karma" t-value="question.karma_unlink if not question.can_unlink else 0"/>

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -16,7 +16,12 @@
                 aria-label="You're following this post"
                 data-bs-toggle="tooltip"
                 class="fa fa-bell"/>
-            <a t-attf-href="/forum/#{slug(question.forum_id)}/#{slug(question)}#{ ('/#answer-%s' % answer.id) if answer else '' }"
+            <small t-if="question.state == 'close'"
+                title="This post is closed"
+                aria-label="This post is closed"
+                data-bs-toggle="tooltip"
+                class="fa fa-lock"/>
+            <a t-attf-href="/forum/#{slug(question.forum_id)}/#{slug(question)}#{answer and ('/#answer-%s' % answer.id)}"
                 t-attf-title="Read: #{question.name}"
                 t-attf-class="stretched-link text-body #{_link_classes}">
                 <span t-out="question.name" t-if="question.name"/>
@@ -148,7 +153,8 @@
         <div>
             <button type="submit" t-attf-class="o_wforum_submit_post #{ 'oe_social_share_call ' if forum.allow_share else '' }btn btn-primary my-3 #{ 'karma_required' if not question.can_answer else ''}"
                     t-att-data-karma="question.forum_id.karma_answer"
-                    data-social-target-type="answer" data-hashtags="#answer">Post Answer</button>
+                    data-social-target-type="answer" data-hashtags="#answer">
+                    Post Answer</button>
             <a href="#"
                class="o_wforum_discard_btn btn btn-link"
                data-bs-toggle="collapse"
@@ -212,7 +218,7 @@
                 <h5 >You have a pending post</h5>
                 <span>Please wait for a moderator to validate your previous post to be allowed to reply to questions.</span>
             </div>
-            <div t-attf-class="alert alert-danger #{'d-none ' if question.state != 'flagged' else ''}text-center" >
+            <div t-if="user.karma > forum.karma_flag" t-attf-class="alert alert-danger #{question.state != 'flagged' and 'd-none '}text-center" >
                 <h5>This question has been flagged</h5>
                 <span t-if="question.can_moderate">As a moderator, you can either validate or reject this answer.</span>
                 <t t-call="website_forum.link_button">
@@ -234,11 +240,18 @@
                     on <span t-field="question.closed_date"/>
                 <div t-if="user.karma > question.karma_close" class="mt-3 text-center">
                     <t t-call="website_forum.link_button">
-                        <t t-set="url" t-value="'/forum/' + slug(forum) + '/question/' + slug(question) + '/reopen'"/>
+                        <t t-set="url" t-valuef="/forum/#{ slug(forum) }/question/#{ slug(question) }/reopen"/>
                         <t t-set="label">Reopen</t>
                         <t t-set="icon" t-value="'fa-folder-open'"/>
                         <t t-set="karma" t-value="question.karma_close if not question.can_close else 0"/>
                         <t t-set="classes" t-value="'btn-info'"/>
+                    </t>
+                    <t t-if="user.karma > question.karma_unlink" t-call="website_forum.link_button">
+                        <t t-set="url" t-valuef="/forum/#{ slug(forum) }/question/#{ slug(question) }/delete"/>
+                        <t t-set="label">Delete</t>
+                        <t t-set="icon" t-value="'fa-trash'"/>
+                        <t t-set="karma" t-value="not question.can_close and question.karma_close or 0"/>
+                        <t t-set="classes" t-value="'btn-danger'"/>
                     </t>
                 </div>
             </div>
@@ -270,7 +283,7 @@
                         <i class="fa fa-reply me-1"/>Answer
                     </a>
                 </div>
-                <t t-if="question.state != 'close' and question.active != False and question.can_answer and forum">
+                <t t-if="question.active != False and question.can_answer and forum">
                     <div id="post_reply" class="answer_collapse position-fixed d-flex flex-column start-0 end-0 bottom-0 w-100 w-lg-50 shadow mx-auto px-3 bg-body"
                          t-if="forum and not forum.has_pending_post and (not question.uid_has_answered or question.forum_id.mode == 'discussions')">
                         <div t-call="website_forum.post_answer" class="container my-3"/>
@@ -298,6 +311,7 @@
 
     <div t-attf-class="o_wforum_#{post_type} row g-0 mb-2 rounded
                        #{ 'o_wforum_answer_correct my-2 mx-n3 mx-lg-n2 mx-xl-n3 py-3 px-3 px-lg-2 px-xl-3' if post_id == answer and post_id.is_correct else '' }"
+        t-if="_question_creator != _answer_creator or request.env.user.karma > post_id.karma_close"
         t-att-data-type="post_type"
         t-att-data-last-activity="post_id.create_date"
         t-att-data-last-update="post_id.write_date"
@@ -463,7 +477,7 @@
             <t t-set="karma" t-value="post_id.karma_edit if not post_id.can_edit else 0"/>
         </t>
         <t t-if="post_id == question">
-            <t t-if="post_id.state != 'close'" t-call="website_forum.link_button">
+            <t t-if="post_id.state != 'close' and request.env.user.karma > post_id.karma_close" t-call="website_forum.link_button">
                 <t t-set="url" t-value="'/forum/' + slug(forum) +'/question/' + slug(post_id) + '/ask_for_close'"/>
                 <t t-set="label">Close</t>
                 <t t-set="inDropdown" t-value="True"/>
@@ -485,7 +499,7 @@
                 <t t-set="karma" t-value="post_id.forum_id.karma_moderate if not post_id.can_moderate else 0"/>
             </t>
         </t>
-        <t t-if="post_id.active" t-call="website_forum.link_button">
+        <t t-if="post_id.active and post_id.state == 'close' and request.env.user.karma > post_id.karma_unlink" t-call="website_forum.link_button">
             <t t-set="url" t-value="'/forum/' + slug(forum) +'/question/' + slug(post_id) + '/delete'"/>
             <t t-set="label">Delete</t>
             <t t-set="inDropdown" t-value="True"/>

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -114,7 +114,6 @@
             <field name="active" column_invisible="True"/>
             <field name="name"/>
             <field name="website_url"/>
-
             <field name="forum_id" optional="show"/>
             <field name="views" string="# Views" sum="Total Views" optional="hide"/>
             <field name="child_count" string="# Answers" sum="Total Answers" optional="hide"/>


### PR DESCRIPTION
This commit improves filters in forum so that moderator can see all non-deleted posts on main page, use filters to move to flagged, closed or pending post lists, and reopen them through filters if need arises.

task-3349373





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
