### PR TITLE
[FIX] project: include web_editor.assets_wysiwyg in project.webclient

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -132,6 +132,8 @@
             'web/static/lib/py.js/lib/py_extras.js',
             'web/static/lib/jquery.ba-bbq/jquery.ba-bbq.js',
 
+            ('include', 'web_editor.assets_wysiwyg'),
+
             'web/static/src/legacy/scss/fields.scss',
             'web/static/src/legacy/scss/views.scss',
 


### PR DESCRIPTION
Since #118966, the `web_editor.assets_wysiwyg` assets are not lazy loaded anymore and therefore need to be included in `project.webclient`.

task-3434068

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
