### PR TITLE
[FIX] im_livechat : translate terms with user language

### DIFF
--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -789,6 +789,13 @@ msgid "Header Background Color"
 msgstr ""
 
 #. module: im_livechat
+#. odoo-python
+#: code:addons/im_livechat/models/im_livechat_channel.py:0
+#, python-format
+msgid "Hello, how may I help you?"
+msgstr ""
+
+#. module: im_livechat
 #: model:ir.model.fields.selection,name:im_livechat.selection__im_livechat_channel_rule__action__hide_button
 msgid "Hide"
 msgstr ""

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -265,9 +265,9 @@ class ImLivechatChannel(models.Model):
             'button_background_color': self.button_background_color,
             'title_color': self.title_color,
             'button_text_color': self.button_text_color,
-            'button_text': self.button_text,
-            'input_placeholder': self.input_placeholder,
-            'default_message': self.default_message,
+            'button_text': _(self.button_text),
+            'input_placeholder': _(self.input_placeholder),
+            'default_message': _(self.default_message),
             "channel_name": self.name,
             "channel_id": self.id,
         }


### PR DESCRIPTION
Issue :
When you open the chat as a public user with another lanuage the welcome message and the button_text are not translated.

Steps to reproduce the error :
1-install website and live chat
2-install french language
3-open another tab in incognito mode and change the language to fr 4-click on the live chat icon you will see the message in en

Problem :
The terms aren't being translated from the backend so they just stay in english

Solution :
I added the terms in the .pot file and used `_`  function to translate them when we use them.

The problem is already solved in saas-16.2

opw-3425344