### PR TITLE
[FIX] mail: fix activity view for future activities

### DIFF
--- a/addons/mail/static/src/web/activity/activity_cell.js
+++ b/addons/mail/static/src/web/activity/activity_cell.js
@@ -34,7 +34,7 @@ export class ActivityCell extends Component {
                 month: "short",
             });
         } else {
-            return date.toLocaleDateString({
+            return date.toLocaleString({
                 day: "numeric",
                 month: "short",
                 year: "numeric",


### PR DESCRIPTION
When the activity_cell.js module was moved over to luxon instead of using JS built in Date object, it accessed `date.toLocaleDateString` which is a function that exists within the normal JS Date type but not within the Luxon DateTime object.

Steps to reproduce:
1) Create an activity scheduled for next year
2) Try to open activity view

opw-3422854
