### PR TITLE
[FIX] base: prevent quick create of new field using studio

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -888,7 +888,8 @@ class IrModelFields(models.Model):
         for vals in vals_list:
             if 'model_id' in vals:
                 vals['model'] = IrModel.browse(vals['model_id']).model
-            assert vals.get('model'), f"missing model name for {vals}"
+            if not vals.get('model'):
+                raise UserError(f"Missing model name for {vals}")
             models.add(vals['model'])
 
         # for self._get_ids() in _update_selection()


### PR DESCRIPTION
This error occurs when a user tries to create `quick create` a field. steps to produce:
- Enable developer mode > Install the web_studio module.
- Go to Settings > Technical > Fields Selection.
- Create a new record > Open Studio > Drag and drop new many2one field
- Select the `fields` in Relation > Click on confirm and close the studio.
- Attempt to quick create a field for the new many2one field
- Error will be generated.

see the traceback:
```
AssertionError: missing model name for {'field_description': 'Loan'}
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 1662, in name_create
    record = self.create({self._rec_name: name})
  File "<decorator-gen-319>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "home/odoo/src/enterprise/saas-16.3/web_studio/models/studio_mixin.py", line 19, in create
    res = super(StudioMixin, self).create(vals)
  File "<decorator-gen-32>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/ir_model.py", line 909, in create
    assert vals.get('model'), f"missing model name for {vals}"
```

I handle this issue by adding usererror instead of using an assert statement.

sentry-4280377855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
