### PR TITLE
[IMP] web_tour, *: remove default click trigger on final tour step

### DIFF
--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -124,5 +124,6 @@ registry.category("web_tour.tours").add('account_tax_group', {
     {
         content: "Check tax value is reset",
         trigger: '.o_tax_group_amount_value:contains("120")',
+        isCheck: true,
     },
 ]});

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -56,7 +56,8 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
     }
 }, {
     content: "check that user cannot invite themself.",
-    trigger: "body.CannotInviteYourself"
+    trigger: "body.CannotInviteYourself",
+    isCheck: true,
 }]});
 
 registry.category("web_tour.tours").add('totp_admin_invite', {
@@ -71,4 +72,5 @@ registry.category("web_tour.tours").add('totp_admin_invite', {
 }, {
     content: "check that demo user can be invited to use 2FA.",
     trigger: "button:contains(Invite to use 2FA)",
+    isCheck: true,
 }]});

--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -67,6 +67,7 @@
         {
             trigger: '.o_event_title:contains("TEST EVENT")',
             content: 'Check the event title',
+            isCheck: true,
         },
     ]});
 
@@ -119,6 +120,7 @@
         {
             content: 'Wait declined status',
             trigger: '.o_attendee_status_declined',
+            isCheck: true,
         },
     ]});
     
@@ -149,5 +151,6 @@
         {
             content: 'Wait declined status',
             trigger: '.o_attendee_status_declined',
+            isCheck: true,
         },
     ]});

--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -51,5 +51,6 @@
             run: 'click',
         },{
             trigger: '.o_kanban_renderer',
+            isCheck: true,
         }
     ]});

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -84,5 +84,6 @@
             trigger: ".o_menu_brand",
             extra_trigger: ".o_reward_rainbow",
             content: "last rainbowman appears",
+            isCheck: true,
         }
     ]});

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -82,6 +82,12 @@ registry.category("web_tour.tours").add('hr_holidays_tour', {
     {
         trigger: 'button[name="action_approve"]',
         content: _t("Let's approve it"),
-        position: 'bottom'
+        position: 'bottom',
+    },
+    {
+        trigger: `tr.o_data_row:first:not(:has(button[name="action_approve"]))`,
+        content: "Verify leave is approved",
+        auto: true,
+        isCheck: true,
     }
 ]});

--- a/addons/im_livechat/static/tests/tours/im_livechat_channel_creation_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_channel_creation_tour.js
@@ -9,6 +9,7 @@ const requestChatSteps = [
     },
     {
         trigger: ".o-mail-ChatWindow",
+        isCheck: true,
     },
 ];
 
@@ -37,6 +38,7 @@ registry.category("web_tour.tours").add("im_livechat_request_chat_and_send_messa
         },
         {
             trigger: ".o-mail-Message:contains('Hello, I need help')",
+            isCheck: true,
         },
     ],
 });

--- a/addons/mail/static/src/discuss/core/web/discuss_tour.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_tour.js
@@ -88,5 +88,10 @@ registry.category("web_tour.tours").add("mail_tour", {
             ),
             position: "bottom",
         },
+        {
+            trigger: ".o-discuss-ChannelSelector",
+            auto: true,
+            isCheck: true,
+        }
     ],
 });

--- a/addons/mail/static/tests/tours/mail_chatter_activity_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_chatter_activity_test_tour.js
@@ -30,6 +30,7 @@ registry.category("web_tour.tours").add("mail_activity_schedule_from_chatter", {
         },
         {
             trigger: ".o-mail-Message:contains('Play Mario Kart')",
+            isCheck: true,
         },
     ],
 });

--- a/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_full_composer_test_tour.js
@@ -104,6 +104,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_full_compo
         {
             content: "Check message contains the attachment",
             trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("text.txt")',
+            isCheck: true,
         },
     ],
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -34,6 +34,11 @@ class Do {
                 trigger: ".pos-rightheader .floor-button",
                 mobile: true,
             },
+            {
+                content: "Check the product page",
+                trigger: ".product-list-container .product-list",
+                isCheck: true,
+            },
         ];
     }
 
@@ -358,6 +363,10 @@ class Check {
             content: "go back to the products",
             trigger: ".pos-rightheader .floor-button",
             mobile: true,
+        }, {
+            content: "Check the product page",
+            trigger: ".product-list-container .product-list",
+            isCheck: true,
         });
         return res;
     }
@@ -407,6 +416,11 @@ class Check {
                 trigger: ".pos-rightheader .floor-button",
                 mobile: true,
             },
+            {
+                content: "Check the product page",
+                trigger: ".product-list-container .product-list",
+                isCheck: true,
+            }
         ];
     }
     modeIsActive(mode) {

--- a/addons/portal/static/tests/tours/portal.js
+++ b/addons/portal/static/tests/tours/portal.js
@@ -12,7 +12,8 @@ registry.category("web_tour.tours").add('portal_load_homepage', {
         },
         {
             content: "Load my account details",
-            trigger: 'input[value="Joel Willis"]'
+            trigger: 'input[value="Joel Willis"]',
+            isCheck: true,
         }
     ]
 });

--- a/addons/pos_self_order/static/tests/tours/self_order_after_meal_cart_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_after_meal_cart_tour.js
@@ -101,5 +101,6 @@ registry.category("web_tour.tours").add("self_order_after_meal_cart_tour", {
         PosSelf.check.isPrimaryBtn("My Orders"),
         PosSelf.action.clickPrimaryBtn("My Orders"),
         PosSelf.action.clickBack(),
+        PosSelf.check.isPrimaryBtn("View Menu"),
     ],
 });

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -73,4 +73,5 @@ registry.category("web_tour.tours").add('burndown_chart_tour', {
 }, {
     content: 'The comparison menu is not rendered',
     trigger: ':not(:has(.o_comparison_menu))',
+    isCheck: true,
 }]});

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -88,6 +88,10 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
 }, {
     trigger: 'iframe button.o_switch_view.o_list',
     content: 'Go to the list view',
+}, {
+    trigger: 'iframe .o_list_view',
+    content: 'Check the list view',
+    isCheck: true,
 }];
 
 registry.category("web_tour.tours").add('project_sharing_tour', {

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -22,7 +22,11 @@ function openProjectUpdateAndReturnToTasks(view, viewClass) {
             trigger: '.o_back_button',
             content: 'Go back to the task view : ' + view,
             // extra_trigger: '.o_list_view', // FIXME: [XBO] uncomment it when the sample data will be displayed after discarding the creation of a project update record.
-        },
+        }, {
+            trigger: `.${viewClass}`,
+            content: 'Check the task view : ' + view,
+            isCheck: true,
+        }
     ];
 }
 

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -17,5 +17,6 @@
     },
     {
         trigger: 'iframe .o_report_stock_rule',
+        isCheck: true,
     },
     ]});

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -98,6 +98,7 @@ var lastSteps = [{
     }
 }, {
     trigger: 'h1.tour_success',
+    isCheck: true,
 }];
 
 registry.category("web_tour.tours").add('test_certification_failure', {

--- a/addons/survey/static/tests/tours/certification_success.js
+++ b/addons/survey/static/tests/tours/certification_success.js
@@ -92,5 +92,6 @@ registry.category("web_tour.tours").add('test_certification_success', {
     }, {
         content: "test passed",
         trigger: 'div:contains("Congratulations, you have passed the test!")',
+        isCheck: true,
     }
 ]});

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -63,5 +63,6 @@ registry.category("web_tour.tours").add('test_survey', {
     {
         content: 'Thank you',
         trigger: 'h1:contains("Thank you!")',
+        isCheck: true,
     }
 ]});

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -67,6 +67,7 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
     {
         content: 'Thank you',
         trigger: 'h1:contains("Thank you!")',
+        isCheck: true,
     }
 
 ]});

--- a/addons/survey/static/tests/tours/survey_prefill.js
+++ b/addons/survey/static/tests/tours/survey_prefill.js
@@ -146,6 +146,7 @@ registry.category("web_tour.tours").add('test_survey_prefill', {
             $('.o_survey_title').addClass('tour_success_2');
         }
     }, {
-        trigger: '.o_survey_title.tour_success_2'
+        trigger: '.o_survey_title.tour_success_2',
+        isCheck: true,
     }
 ]});

--- a/addons/web_tour/static/src/tour_service/tour_compilers.js
+++ b/addons/web_tour/static/src/tour_service/tour_compilers.js
@@ -354,7 +354,11 @@ export function compileStepAuto(stepIndex, step, options) {
                     const m = step.run.match(/^([a-zA-Z0-9_]+) *(?:\(? *(.+?) *\)?)?$/);
                     actionHelper[m[1]](m[2]);
                 } else if (!step.isCheck) {
-                    actionHelper.auto();
+                    if (stepIndex === tour.steps.length - 1) {
+                        console.warn('Tour %s: ignoring action (auto) of last step', tour.name);
+                    } else {
+                        actionHelper.auto();
+                    }
                 }
 
                 return result;

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -81,5 +81,6 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_display_on_click", {
         in_modal: false,
         extra_trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
         trigger: "iframe .s_popup .modal[id='Win-%2420'].show",
+        isCheck: true,
     },
 ]);

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -57,4 +57,5 @@ wTourUtils.registerWebsitePreviewTour("snippet_version", {
     content: "s_share is outdated",
     extra_trigger: 'we-customizeblock-options:contains(Share) .snippet-option-VersionControl > we-alert',
     trigger: 'iframe body',
+    isCheck: true,
 }]);

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -492,6 +492,7 @@
             content: 'Verify that the recipient email has been saved',
             // We have to this that way because the input type = hidden.
             trigger: 'iframe form:has(input[name="email_to"][value="test@test.test"])',
+            isCheck: true,
         },
     ]);
 

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -148,7 +148,8 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
     },
     {
         content:  "Check form is submitted without errors",
-        trigger:  "#wrap:has(h1:contains('Thank You!'))"
+        trigger:  "#wrap:has(h1:contains('Thank You!'))",
+        isCheck: true,
     }
 ]});
 
@@ -182,6 +183,7 @@ registry.category("web_tour.tours").add("website_form_editor_tour_results", {
         content:  "Check mail.mail records have been created",
         trigger:  "#website_form_editor_success_test_tour_mail_mail",
         allowInvisible: true,
+        isCheck: true,
     }
 ]});
 registry.category("web_tour.tours").add('website_form_contactus_submit', {
@@ -205,5 +207,6 @@ registry.category("web_tour.tours").add('website_form_contactus_submit', {
     {
         content: 'Check form is submitted without errors',
         trigger: '#wrap:has(h1:contains("Thank You!"))',
+        isCheck: true,
     },
 ]});

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -87,5 +87,9 @@
         extra_trigger: "iframe body:not(.editor_enable)",
         position: "bottom",
         content: Markup(_t("<b>Publish your blog post</b> to make it visible to your visitors.")),
-    },
+    }, {
+        trigger: '.o_menu_systray_item a:contains("Published")',
+        auto: true,
+        isCheck: true,
+    }
 ]);

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -22,6 +22,7 @@
     {
         content: "Ensure form model has changed and page reload is done after save",
         trigger: "iframe section.s_website_form form[data-model_name='crm.lead']",
+        isCheck: true,
     }]);
 
     registry.category("web_tour.tours").add('website_crm_tour', {
@@ -56,7 +57,8 @@
         trigger: ".s_website_form_send"
     }, {
         content: "Check we were redirected to the success page",
-        trigger: "#wrap:has(h1:contains('Thank You!'))"
+        trigger: "#wrap:has(h1:contains('Thank You!'))",
+        isCheck: true,
     }]});
 
     registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_tour', {
@@ -75,7 +77,8 @@
         trigger: ".s_website_form_send"
     }, {
         content: "Check we were redirected to the success page",
-        trigger: "#wrap:has(h1:contains('Thank You!'))"
+        trigger: "#wrap:has(h1:contains('Thank You!'))",
+        isCheck: true,
     }]});
 
     export default {};

--- a/addons/website_event/static/tests/tours/tickets_questions.js
+++ b/addons/website_event/static/tests/tours/tickets_questions.js
@@ -52,5 +52,5 @@ registry.category("web_tour.tours").add('test_tickets_questions', {
     // The tour stops too early and the registration fails if we don't wait the confirmation.
     content: 'Wait for confirmation',
     trigger: '.o_wereg_confirmed, .oe_cart',
-    auto: true
+    isCheck: true,
 }]});

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -53,4 +53,5 @@
         trigger: ".o_website_edit_in_backend > a",
         content: _t("Click here to customize your event further."),
         position: "bottom",
+        isCheck: true,
     }]);

--- a/addons/website_event/static/tests/tours/website_event_pages_seo.js
+++ b/addons/website_event/static/tests/tours/website_event_pages_seo.js
@@ -29,5 +29,6 @@ registry.category("web_tour.tours").add('website_event_pages_seo', {
         content: "Check that the page title is adapted, inside and outside the iframe",
         trigger: 'html:has(title:containsExactText(Hello, world!))',
         extra_trigger: 'iframe html:has(title:containsExactText(Hello, world!))',
+        isCheck: true,
     },
 ]});

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -60,4 +60,9 @@
         trigger: ".o_wforum_validate_toggler[data-karma]:first",
         content: _t("Click here to accept this answer."),
         position: "right",
+    }, {
+        content: "Check edit button is there",
+        trigger: "a:contains('Edit your answer')",
+        auto: true,
+        isCheck: true,
     }]);

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -32,6 +32,7 @@
         }, {
             content: "Check the form is submitted without errors",
             trigger: "#jobs_thankyou h1:contains('Congratulations')",
+            isCheck: true,
         }];
     }
 

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -50,6 +50,7 @@ export const start = [
         content: "Is your message correctly sent ?",
         trigger: "body.no_duplicated_message",
         shadow_dom: false,
+        isCheck: true,
     },
 ];
 
@@ -79,6 +80,7 @@ export const feedback = [
     {
         content: "Thanks for your feedback",
         trigger: "p:contains('Thank you for your feedback')",
+        isCheck: true,
     },
 ];
 
@@ -118,6 +120,7 @@ export const close = [
         content: "Is the Test succeded ?",
         trigger: "body.tour_success",
         shadow_dom: false,
+        isCheck: true,
     },
 ];
 

--- a/addons/website_livechat/static/tests/tours/website_livechat_request.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_request.js
@@ -39,6 +39,7 @@ const chatRequest = [
         content: "Is your message correctly sent ?",
         shadow_dom: false,
         trigger: "body.no_duplicated_message",
+        isCheck: true,
     },
 ];
 

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -57,6 +57,7 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
             content:
                 "Livechat button is present since the old livechat session was linked to the public user, not the current user.",
             trigger: ".o-livechat-LivechatButton",
+            isCheck: true,
         },
     ],
 });
@@ -98,6 +99,7 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
             content:
                 "Livechat button is present since the old livechat session was linked to the logged user, not the public one.",
             trigger: ".o-livechat-LivechatButton",
+            isCheck: true,
         },
     ],
 });

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -75,5 +75,6 @@ wTourUtils.registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
     {
         content: 'Check that the link style is correct',
         trigger: 'iframe .s_newsletter_block .js_subscribed_btn.btn.btn-custom.flat:not(.btn-success)',
+        isCheck: true,
     },
 ]);

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -158,6 +158,7 @@ function payWithTransfer(redirect=false) {
             content: "Last step",
             trigger: '.oe_website_sale_tx_status:contains("Please use the following transfer details")',
             timeout: 30000,
+            isCheck: true,
         }]
     } else {
         return [

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -366,4 +366,9 @@
         content: "Pay Now",
         extra_trigger: '#payment_method label:contains("Wire Transfer") input:checked,#payment_method:not(:has("input:radio:visible"))',
         trigger: 'button[name="o_payment_submit_button"]:visible',
+    },
+    {
+        content: "Check payment status confirmation window",
+        trigger: ".oe_website_sale_tx_status[data-order-tracking-info]",
+        isCheck: true,
     }]});

--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -62,6 +62,7 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
         {
             content: "Check that quantity is 1",
             trigger: ".js_quantity[value='1']",
+            isCheck: true,
         },
     ]
 });

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -30,5 +30,6 @@ registry.category("web_tour.tours").add('tour_shop_dynamic_variants', {
     {
         content: "check the variant is in the cart",
         trigger: 'td.td-product_name:contains(Dynamic Product (Dynamic Value 2))',
+        isCheck: true,
     },
 ]});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -17,4 +17,8 @@ wTourUtils.registerWebsitePreviewTour("shop_editor", {
     trigger: "iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
     extra_trigger: "iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
     content: "Click on the pricelist again.",
+}, {
+    trigger: "iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
+    content: "Check pricelist dropdown opened",
+    isCheck: true,
 }]);

--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -73,5 +73,6 @@ registry.category("web_tour.tours").add('shop_mail', {
     {
         content: "wait mail to be sent, and go see it",
         trigger: '.o-mail-Message-body:contains("Your"):contains("order")',
+        isCheck: true,
     },
 ]});

--- a/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
+++ b/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
@@ -40,6 +40,7 @@ registry.category("web_tour.tours").add('onsite_payment_tour', {
         {
             content: 'Assert pay on site is NOT an option',
             trigger: 'body:not(:contains("Test Payment Provider"))',
+            isCheck: true,
         },
     ]
 });

--- a/addons/website_sale_product_configurator/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale_product_configurator/static/tests/tours/website_sale_variants_modal_window.js
@@ -60,5 +60,6 @@
         {
             content: "Check never custom variant",
             trigger: 'td.td-product_name:contains(Never attribute size custom: Yes never custom: TEST)',
+            isCheck: true,
         }
     ]});

--- a/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
+++ b/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
@@ -19,6 +19,7 @@ registry.category("web_tour.tours").add('website_sale_stock_reorder_from_portal'
         {
             content: "Check that there is one product that does not have enough stock",
             trigger: "#o_wsale_reorder_body div.text-warning:contains('You ask for 2.0 Units but only 1.0 are available.')",
+            isCheck: true,
         },
     ]
 });

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_stock_notification.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_stock_notification.js
@@ -26,6 +26,7 @@ registry.category("web_tour.tours").add('back_in_stock_notification_product', {
         {
             content: "Success Message",
             trigger: '#stock_notification_success_message',
+            isCheck: true,
         },
     ],
 });

--- a/addons/website_sale_stock_wishlist/static/tests/tours/website_sale_stock_wishlist_stock_notification.js
+++ b/addons/website_sale_stock_wishlist/static/tests/tours/website_sale_stock_wishlist_stock_notification.js
@@ -22,6 +22,7 @@ registry.category("web_tour.tours").add('stock_notification_wishlist', {
         {
             content: "Success Message",
             trigger: '#stock_notification_success_message',
+            isCheck: true,
         },
     ],
 });

--- a/addons/website_slides/static/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/tests/tours/slides_tour_tools.js
@@ -161,6 +161,11 @@ const addImageToSection = (sectionName, pageName, backend) => {
 {
     content: 'eLearning: back to course',
     trigger: `${prefix}.o_wslides_fs_sidebar_header a:contains("Déboulonnate")`,
+},
+{
+    content: 'eLearning: check course page',
+    trigger: `${prefix}.o_wslides_course_main`,
+    isCheck: true,
 }];
 };
 
@@ -214,6 +219,10 @@ const addPdfToSection = function (sectionName, pageName, backend) {
 }, {
     content: 'eLearning: back to course',
     trigger: `${prefix}.o_wslides_fs_sidebar_header a:contains("Déboulonnate")`,
+}, {
+    content: 'eLearning: check course page',
+    trigger: `${prefix}.o_wslides_course_main`,
+    isCheck: true,
 }];
 };
 

--- a/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
+++ b/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
@@ -19,6 +19,7 @@ function checkLoginColumn(translation) {
         }, {
             content: `Login column should be ${translation}`,
             trigger: `[data-name="login"] span:contains("${translation}")`,
+            isCheck: true,
         }
     ]
 }


### PR DESCRIPTION
When we haven't provided a custom action, the tour step runs the default
action. In the final step of the tour, when there is no `run` or
`isCheck` provided, we don't want to execute the default action as it
can lead to a race condition.

With this commit [1], from saas-16.3 we have refactored the web_tour to
OWL. During the refactoring, it lost the condition initially introduced
by PR[2] that handles the final step of tours.

So this PR,
1. Restored the missing condition.
2. Replaced the simple `console.log()` with a warning, because it's easy
   to miss the log compared to a warning.
3. Rsolve the warnings raised by the last tour steps

[1]: https://github.com/odoo/odoo/commit/3a798039d6f200f8e28448ddb6a2d3c46654a203
[2]: https://github.com/odoo/odoo/commit/9733f6e1ab31abf780a5ad671f700fac883b63ee

task-3429500

PR Enterprise: https://github.com/odoo/enterprise/pull/46683