### PR TITLE
[FIX] fields: check custom field while reading record

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1385,8 +1385,10 @@ class Field(MetaField('DummyField', (object,), {})):
         try:
             with records.env.protecting(fields, records):
                 records._compute_field_value(self)
-        except Exception:
+        except Exception as e:
             for field in fields:
+                if field.name.startswith('x_'):
+                    e.sentry_ignored = True
                 if field.store:
                     env.add_to_compute(field, records)
             raise


### PR DESCRIPTION
Currently, if any user creates a custom field in any model and tries to access more than one record with that custom field. The error will be generated.



see:-
```
KeyError: 16
  File "odoo/api.py", line 959, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'sale.order.line(16,).x_price_below_cost'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 966, in get
    raise CacheMiss(record, field)
ValueError: too many values to unpack (expected 1)
  File "odoo/models.py", line 5384, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: sale.order.line(16, 17)
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  ?, line 1, in <module>
  File "odoo/fields.py", line 1151, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5387, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: <class 'ValueError'>: "Expected singleton: sale.order.line(16, 17)" while evaluating
"self['x_price_below_cost'] = (self.margin < 0)"
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 3177, in read
    return self._read_format(fnames=fields, load=load)
  File "odoo/models.py", line 3369, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "odoo/models.py", line 6131, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1209, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4491, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 102, in determine
    return needle(records, *args)
  File "odoo/addons/base/models/ir_model.py", line 38, in <lambda>
    func = lambda self: safe_eval(text, SAFE_EVAL_BASE, {'self': self}, mode="exec")
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```


sentry-4327791442