### PR TITLE
[FIX] base_setup: enable auto install

### DIFF
--- a/addons/base_setup/__manifest__.py
+++ b/addons/base_setup/__manifest__.py
@@ -17,6 +17,7 @@ Shows you a list of applications features to install from.
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
         ],
+    'auto_install': True,
     'installable': True,
 
     'license': 'LGPL-3',


### PR DESCRIPTION
before this commit, on creating a new db, the general settings menu is not accessible for end users without installing any app.

for eg, if user need to activate the developer mode, no option without installing an app.

after this commit, on a fresh db base_setup module will automatically installed on creating a new db, and general settings menu will be accessible.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
