### PR TITLE
[IMP] sale: add product in sale report tree

### DIFF
--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -32,6 +32,7 @@
                 <field name="date" widget="date"/>
                 <field name="order_reference" optional="show"/>
                 <field name="partner_id" optional="hide"/>
+                <field name="product_id" string="Product" optional="show"/>
                 <field name="user_id" optional="show" widget="many2one_avatar_user"/>
                 <field name="team_id" optional="show"/>
                 <field name="company_id" optional="show" groups="base.group_multi_company"/>


### PR DESCRIPTION
before this commit, in the sale.report tree
view, the product field was not added.

* sales -> reporting -> switch to pivot
* click on any row to open the tree

after this commit, the product field will
be added in the sale.report tree view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
