### PR TITLE
[IMP] account: remove unused function

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -610,9 +610,6 @@ class account_journal(models.Model):
             'context': self._get_move_action_context(),
         }
 
-    def create_cash_statement(self):
-        raise UserError(_('Please install Accounting for this feature'))
-
     def action_create_vendor_bill(self):
         """ This function is called by the "Import" button of Vendor Bills,
         visible on dashboard if no bill has been created yet.


### PR DESCRIPTION
before this commit, the create_cash_statement function defined in the journal model is not called from any where.

left over in:  https://github.com/odoo/odoo/commit/9299f81f19a87d6e6eb9ee19a79d96d3fb1050b2

after this commit, the function will be removed from code.

Related EE: https://github.com/odoo/enterprise/pull/44453


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
