### PR TITLE
[IMP] project: share private project

### DIFF
--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -16,8 +16,7 @@
                 </p>
                 <field name="res_model" invisible="1"/>
                 <field name="res_id" invisible="1"/>
-                <field name="display_access_mode" invisible="1" />
-                <p class="alert alert-warning" attrs="{'invisible': [('access_warning', '=', '')]}" role="alert"><field name="access_warning"/></p>
+                <field name="display_access_mode" invisible="1"/>
                 <group>
                     <field options="{'horizontal': true}" name="access_mode" widget="radio" attrs="{'invisible': [('display_access_mode', '=', False)]}" class="mb-4"/>
                     <field name="share_link" widget="CopyClipboardChar" options="{'string': 'Copy Link'}" attrs="{'invisible': [('access_mode', '=', 'edit')]}" string="Link" class="mb-4"/>
@@ -29,7 +28,7 @@
                 </group>
                 <field name="note" placeholder="Add a note" nolabel="1"/>
                 <footer>
-                    <button string="Send" name="action_share_record" attrs="{'invisible': [('access_warning', '!=', '')]}" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Send" name="action_share_record" type="object" class="btn-primary" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>
@@ -52,14 +51,13 @@
         </field>
     </record>
 
-    <record id="project_share_wizard_action" model="ir.actions.act_window">
+    <record id="project_share_wizard_action" model="ir.actions.server">
         <field name="name">Share Project</field>
-        <field name="res_model">project.share.wizard</field>
+        <field name="model_id" ref="project.model_project_project"></field>
         <field name="binding_model_id" ref="model_project_project"/>
-        <field name="view_mode">form</field>
-        <field name="context">{'dialog_size': 'medium'}</field>
-        <field name="target">new</field>
-        <field name="context">{'dialog_size': 'medium'}</field>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_share_project()</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
**Prior to this commit:**
When the project to be shared is private, the 'Share Project' wizard opens and a warning appears saying private projects can't be shared.

**Post this commit:**
The warning appears as a toast notification as there is no need of opening a wizard when the project can't be shared.

**Task:** 3432287