### PR TITLE
[FIX] web_editor: synchronise fields with oe_unremovable

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1426,6 +1426,19 @@ export class OdooEditor extends EventTarget {
         }
     }
     /**
+     * Ensure that a callback is called without triggering a rollback.
+     *
+     * If a rollback was set before the callback, do not reset it.
+     */
+    withoutRollback(callback) {
+        const priorRollback = this._toRollback;
+        callback();
+        this.observerFlush();
+        if (!priorRollback) {
+            this._toRollback = false;
+        }
+    }
+    /**
      * Place the selection on the last known selection position from the history
      * steps.
      *

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1296,21 +1296,23 @@ export class Wysiwyg extends Component {
                         $nodes.addClass('o_editable_date_field_format_changed');
                     }
                     const html = $node.html();
-                    for (const node of $nodes) {
-                        if (node.classList.contains('o_translation_without_style')) {
-                            // For generated elements such as the navigation
-                            // labels of website's table of content, only the
-                            // text of the referenced translation must be used.
-                            const text = $node.text();
-                            if (node.innerText !== text) {
-                                node.innerText = text;
+                    this.odooEditor.withoutRollback(() => {
+                        for (const node of $nodes) {
+                            if (node.classList.contains('o_translation_without_style')) {
+                                // For generated elements such as the navigation
+                                // labels of website's table of content, only the
+                                // text of the referenced translation must be used.
+                                const text = $node.text();
+                                if (node.innerText !== text) {
+                                    node.innerText = text;
+                                }
+                                continue;
                             }
-                            continue;
+                            if (node.innerHTML !== html) {
+                                node.innerHTML = html;
+                            }
                         }
-                        if (node.innerHTML !== html) {
-                            node.innerHTML = html;
-                        }
-                    }
+                    });
                     this._observeOdooFieldChanges();
                 });
                 observer.observe(field, observerOptions);


### PR DESCRIPTION
When the mechanism that synchronise odoo fields contained an unremovable, even though no unremovable got removed, the Odoo editor would rollback as the syncing mechanism would set innerHTML to the synced nodes, which would remove the unremovable. To prevent the rollback in that kind of circumstance, this commit introduce a new method on the OdooEditor `withoutRollback`.

task-3436834


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
