### PR TITLE
[IMP] survey: add scoring after each page

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -651,6 +651,41 @@ class SurveyQuestion(models.Model):
             'right_inputs_count': len(user_input_lines.filtered(lambda line: line.answer_is_correct).mapped('user_input_id'))
         }
 
+    # ------------------------------------------------------------
+    # OTHERS
+    # ------------------------------------------------------------
+
+    def _get_correct_answers(self):
+        """ Return a dictionary linking the scorable question ids to their correct answers.
+        The questions without correct answers are not considered.
+        """
+        correct_answers = {}
+
+        # Simple and multiple choice
+        choices_questions = self.filtered(lambda q: q.question_type in ['simple_choice', 'multiple_choice'])
+        if choices_questions:
+            suggested_answers_data = self.env['survey.question.answer'].search_read(
+                [('question_id', 'in', choices_questions.ids), ('is_correct', '=', True)],
+                ['question_id', 'id'],
+                load='', # prevent computing display_names
+            )
+            for data in suggested_answers_data:
+                if not data.get('id'):
+                    continue
+                correct_answers.setdefault(data['question_id'], []).append(data['id'])
+
+        # Numerical box, date, datetime
+        for question in self - choices_questions:
+            if question.question_type not in ['numerical_box', 'date', 'datetime']:
+                continue
+            answer = question[f'answer_{question.question_type}']
+            if question.question_type == 'date':
+                answer = tools.format_date(self.env, answer)
+            elif question.question_type == 'datetime':
+                answer = tools.format_datetime(self.env, answer, tz='UTC', dt_format=False)
+            correct_answers[question.id] = answer
+
+        return correct_answers
 
 class SurveyQuestionAnswer(models.Model):
     """ A preconfigured answer for a question. This model stores values used

--- a/addons/survey/tests/__init__.py
+++ b/addons/survey/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from . import common
 from . import test_survey
+from . import test_survey_controller
 from . import test_survey_flow
 from . import test_survey_flow_with_conditions
 from . import test_certification_flow

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import datetime
 import re
 
 from collections import Counter
@@ -248,6 +249,40 @@ class SurveyCase(common.TransactionCase):
                 kwargs['labels'] = [{'value': 'MChoice0'}, {'value': 'MChoice1'}]
             elif question_type == 'simple_choice':
                 kwargs['labels'] = [{'value': 'SChoice0'}, {'value': 'SChoice1'}]
+            elif question_type == 'matrix':
+                kwargs['labels'] = [{'value': 'Column0'}, {'value': 'Column1'}]
+                kwargs['labels_2'] = [{'value': 'Row0'}, {'value': 'Row1'}]
+            all_questions |= self._add_question(self.page_0, 'Q0', question_type, **kwargs)
+
+        return all_questions
+
+    def _create_one_question_per_type_with_scoring(self):
+        all_questions = self.env['survey.question']
+        for (question_type, dummy) in self.env['survey.question']._fields['question_type'].selection:
+            kwargs = {}
+            kwargs['question_type'] = question_type
+            if question_type == 'numerical_box':
+                kwargs['answer_score'] = 1
+                kwargs['answer_numerical_box'] = 5
+            elif question_type == 'date':
+                kwargs['answer_score'] = 2
+                kwargs['answer_date'] = datetime.date(2023, 10, 16)
+            elif question_type == 'datetime':
+                kwargs['answer_score'] = 3
+                kwargs['answer_datetime'] = datetime.datetime(2023, 11, 17, 8, 0, 0)
+            elif question_type == 'multiple_choice':
+                kwargs['answer_score'] = 4
+                kwargs['labels'] = [
+                    {'value': 'MChoice0', 'is_correct': True},
+                    {'value': 'MChoice1', 'is_correct': True},
+                    {'value': 'MChoice2'}
+                ]
+            elif question_type == 'simple_choice':
+                kwargs['answer_score'] = 5
+                kwargs['labels'] = [
+                    {'value': 'SChoice0', 'is_correct': True},
+                    {'value': 'SChoice1'}
+                ]
             elif question_type == 'matrix':
                 kwargs['labels'] = [{'value': 'Column0'}, {'value': 'Column1'}]
                 kwargs['labels_2'] = [{'value': 'Row0'}, {'value': 'Row1'}]

--- a/addons/survey/tests/test_survey_controller.py
+++ b/addons/survey/tests/test_survey_controller.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.addons.survey.tests import common
+from odoo.tests.common import HttpCase
+
+
+class TestSurveyController(common.TestSurveyCommon, HttpCase):
+
+    def test_submit_route_scoring_after_page(self):
+        """ Check that the submit route for a scoring after page survey is returning the
+        accurate correct answers depending on the survey layout and the active page questions.
+        The correct answers of the inactive conditional questions shouldn't be returned.
+        """
+        survey = self.env['survey.survey'].create({
+            'title': 'How much do you know about words?',
+            'scoring_type': 'scoring_with_answers_after_page',
+        })
+        (
+            a_q1_partial, a_q1_correct, a_q1_incorrect,
+            a_q2_incorrect, a_q2_correct,
+            a_q3_correct, a_q3_incorrect
+        ) = self.env['survey.question.answer'].create([
+            {'value': 'A thing full of letters.', 'answer_score': 1.0},
+            {'value': 'A unit of language, [...], carrying a meaning.', 'answer_score': 4.0, 'is_correct': True},
+            {'value': 'A thing related to space', 'answer_score': -4.0},
+            {'value': 'Yes', 'answer_score': -0.5},
+            {'value': 'No', 'answer_score': 0.5, 'is_correct': True},
+            {'value': 'Yes', 'answer_score': 0.5, 'is_correct': True},
+            {'value': 'No', 'answer_score': 0.2},
+        ])
+        q1, q2, q3 = self.env['survey.question'].create([{
+            'survey_id': survey.id,
+            'title': 'What is a word?',
+            'sequence': 2,
+            'question_type': 'simple_choice',
+            'suggested_answer_ids': [Command.set((a_q1_partial | a_q1_correct | a_q1_incorrect).ids)],
+            'constr_mandatory': False,
+        }, {
+            'survey_id': survey.id,
+            'title': 'Are you sure?',
+            'sequence': 3,
+            'question_type': 'simple_choice',
+            'suggested_answer_ids': [Command.set((a_q2_incorrect | a_q2_correct).ids)],
+            'triggering_answer_ids': [Command.set((a_q1_partial | a_q1_incorrect).ids)],
+            'constr_mandatory': False,
+        }, {
+            'survey_id': survey.id,
+            'title': 'Are you sure?',
+            'sequence': 5,
+            'question_type': 'simple_choice',
+            'suggested_answer_ids': [Command.set((a_q3_correct | a_q3_incorrect).ids)],
+            'triggering_answer_ids': [Command.set([a_q1_correct.id])],
+            'constr_mandatory': False,
+        }])
+        pages = [
+            {'is_page': True, 'question_type': False, 'sequence': 1, 'title': 'Page 0', 'survey_id': survey.id},
+            {'is_page': True, 'question_type': False, 'sequence': 4, 'title': 'Page 1', 'survey_id': survey.id},
+        ]
+
+        q1_correct_answer = {str(q1.id): [a_q1_correct.id]}
+        cases = [
+            ('page_per_question', [], q1_correct_answer),
+            ('page_per_question', a_q1_correct, q1_correct_answer),
+            ('page_per_question', a_q1_incorrect, q1_correct_answer),
+            ('one_page', [], q1_correct_answer), # skipping gives answers for active questions (q2 and q3 conditional questions are inactive)
+            ('one_page', a_q1_correct, {**q1_correct_answer, str(q3.id): [a_q3_correct.id]}),
+            ('one_page', a_q1_partial, {**q1_correct_answer, str(q2.id): [a_q2_correct.id]}),
+            # page0 contains q1 and q2, page1 contains q3
+            ('page_per_section', [], q1_correct_answer),
+            ('page_per_section', a_q1_correct, q1_correct_answer), # no correct answers for q3 because q3 is not on the same page as q1
+            ('page_per_section', a_q1_partial, {**q1_correct_answer, str(q2.id): [a_q2_correct.id]}),
+        ]
+
+        for case_index, (layout, answer_q1, expected_correct_answers) in enumerate(cases):
+            with self.subTest(case_index=case_index, layout=layout):
+                survey.questions_layout = layout
+                if layout == 'page_per_section':
+                    page0, _ = self.env['survey.question'].create(pages)
+
+                response = self._access_start(survey)
+                user_input = self.env['survey.user_input'].search([('access_token', '=', response.url.split('/')[-1])])
+                answer_token = user_input.access_token
+
+                r = self._access_page(survey, answer_token)
+                self.assertResponse(r, 200)
+                csrf_token = self._find_csrf_token(response.text)
+
+                r = self._access_begin(survey, answer_token)
+                self.assertResponse(r, 200)
+
+                post_data = {'csrf_token': csrf_token, 'token': answer_token}
+                post_data[q1.id] = answer_q1.id if answer_q1 else answer_q1
+                if layout == 'page_per_question':
+                    post_data['question_id'] = q1.id
+                elif layout == 'page_per_section':
+                    post_data['page_id'] = page0.id
+
+                # Submit answers and check the submit route is returning the accurate correct answers
+                response = self._access_submit(survey, answer_token, post_data)
+                self.assertResponse(response, 200)
+                self.assertEqual(response.json()['result'][0], expected_correct_answers)
+
+                user_input.invalidate_recordset() # TDE note: necessary as lots of sudo in controllers messing with cache

--- a/addons/survey/tests/test_survey_ui_session.py
+++ b/addons/survey/tests/test_survey_ui_session.py
@@ -189,31 +189,31 @@ class TestUiSession(HttpCase):
         # create a few answers beforehand to avoid having to back and forth too
         # many times between the tours and the python test
 
-        attendee_1.save_lines(nickname_question, 'xxxTheBestxxx')
-        attendee_2.save_lines(nickname_question, 'azerty')
-        attendee_3.save_lines(nickname_question, 'nicktalope')
+        attendee_1._save_lines(nickname_question, 'xxxTheBestxxx')
+        attendee_2._save_lines(nickname_question, 'azerty')
+        attendee_3._save_lines(nickname_question, 'nicktalope')
         self.assertEqual('xxxTheBestxxx', attendee_1.nickname)
         self.assertEqual('azerty', attendee_2.nickname)
         self.assertEqual('nicktalope', attendee_3.nickname)
 
-        attendee_1.save_lines(text_question, 'Attendee 1 is the best')
-        attendee_2.save_lines(text_question, 'Attendee 2 rulez')
-        attendee_3.save_lines(text_question, 'Attendee 3 will crush you')
-        attendee_1.save_lines(date_question, '2010-10-10')
-        attendee_2.save_lines(date_question, '2011-11-11')
-        attendee_2.save_lines(datetime_question, '2010-10-10 10:00:00')
-        attendee_3.save_lines(datetime_question, '2011-11-11 15:55:55')
-        attendee_1.save_lines(simple_choice_question, simple_choice_answer_1.id)
-        attendee_2.save_lines(simple_choice_question, simple_choice_answer_1.id)
-        attendee_3.save_lines(simple_choice_question, simple_choice_answer_2.id)
-        attendee_1.save_lines(scored_choice_question, scored_choice_answer_1.id)
-        attendee_2.save_lines(scored_choice_question, scored_choice_answer_2.id)
-        attendee_3.save_lines(scored_choice_question, scored_choice_answer_3.id)
-        attendee_1.save_lines(timed_scored_choice_question,
+        attendee_1._save_lines(text_question, 'Attendee 1 is the best')
+        attendee_2._save_lines(text_question, 'Attendee 2 rulez')
+        attendee_3._save_lines(text_question, 'Attendee 3 will crush you')
+        attendee_1._save_lines(date_question, '2010-10-10')
+        attendee_2._save_lines(date_question, '2011-11-11')
+        attendee_2._save_lines(datetime_question, '2010-10-10 10:00:00')
+        attendee_3._save_lines(datetime_question, '2011-11-11 15:55:55')
+        attendee_1._save_lines(simple_choice_question, simple_choice_answer_1.id)
+        attendee_2._save_lines(simple_choice_question, simple_choice_answer_1.id)
+        attendee_3._save_lines(simple_choice_question, simple_choice_answer_2.id)
+        attendee_1._save_lines(scored_choice_question, scored_choice_answer_1.id)
+        attendee_2._save_lines(scored_choice_question, scored_choice_answer_2.id)
+        attendee_3._save_lines(scored_choice_question, scored_choice_answer_3.id)
+        attendee_1._save_lines(timed_scored_choice_question,
             [timed_scored_choice_answer_1.id, timed_scored_choice_answer_3.id])
-        attendee_2.save_lines(timed_scored_choice_question,
+        attendee_2._save_lines(timed_scored_choice_question,
             [timed_scored_choice_answer_1.id, timed_scored_choice_answer_2.id])
-        attendee_3.save_lines(timed_scored_choice_question,
+        attendee_3._save_lines(timed_scored_choice_question,
             [timed_scored_choice_answer_2.id])
 
         with patch('odoo.addons.survey.models.survey_survey.Survey.action_open_session_manager', action_open_session_manager_mock):

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -103,6 +103,7 @@
                     if survey.background_image_url else False"/>
         <form role="form" method="post" t-att-name="survey.id"
                 class="d-flex flex-grow-1 align-items-center"
+                t-att-data-scoring-type="survey.scoring_type"
                 t-att-data-answer-token="answer.access_token"
                 t-att-data-survey-token="survey.access_token"
                 t-att-data-users-can-go-back="survey.users_can_go_back and not answer.is_session_answer"
@@ -191,6 +192,7 @@
             </t>
 
             <div class="text-center mt16 mb256">
+                <button id="next_page" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} d-none">Next</button>
                 <button type="submit" value="finish" class="btn btn-secondary disabled">Submit</button>
                     <span class="fw-bold text-muted ms-2 d-none d-md-inline">
                         <span id="enter-tooltip">or press Enter</span>
@@ -211,6 +213,7 @@
                 <div class="col-12 text-center mt16">
                     <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else 'next_skipped'
                         if answer.survey_first_submitted and skipped_questions.page_id and page in skipped_questions.page_id else 'next'"/>
+                    <button id="next_page" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} d-none">Next</button>
                     <button type="submit" t-att-value="submit_value" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} disabled">
                         <t t-if="submit_value == 'finish'">Submit</t>
                         <t t-elif="submit_value == 'next_skipped'">Next Skipped</t>
@@ -250,6 +253,7 @@
                     <div class="col-12 text-center mt16">
                         <t t-set="submit_value" t-value="'finish' if survey_last or answer.is_session_answer else
                             'next_skipped' if answer.survey_first_submitted and skipped_questions and question in skipped_questions else 'next'"/>
+                        <button id="next_page" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} d-none">Next</button>
                         <button type="submit" t-att-value="submit_value" t-attf-class="btn #{'btn-secondary' if survey_last else 'btn-primary'} disabled">
                             <t t-if="submit_value == 'finish'">Submit</t>
                             <t t-elif="submit_value == 'next_skipped'">Next Skipped</t>
@@ -377,16 +381,18 @@
     </template>
 
     <template id="question_numerical_box" name="Question: numerical box">
-        <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent text-dark rounded-0 p-0"
-               t-att-name="question.id" t-att-placeholder="question.question_placeholder"
-               t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
-               t-att-data-question-type="question.question_type"
-               t-att-data-validation-float-min="question.validation_min_float_value if question.validation_required else False"
-               t-att-data-validation-float-max="question.validation_max_float_value if question.validation_required else False"/>
+        <div class="o_survey_answer_wrapper p-1 rounded">
+            <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent text-dark rounded-0 p-0"
+                t-att-name="question.id" t-att-placeholder="question.question_placeholder"
+                t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
+                t-att-data-question-type="question.question_type"
+                t-att-data-validation-float-min="question.validation_min_float_value if question.validation_required else False"
+                t-att-data-validation-float-max="question.validation_max_float_value if question.validation_required else False"/>
+        </div>
     </template>
 
     <template id="question_date" name="Question: date box">
-        <div class="input-group o_survey_form_date">
+        <div class="input-group o_survey_form_date o_survey_answer_wrapper p-1 rounded">
             <input type="text" class="form-control datetimepicker-input o_survey_question_date bg-transparent text-dark rounded-0 p-0"
                    t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                    t-att-value="format_date(answer_lines[0].value_date) if answer_lines else None"
@@ -399,7 +405,7 @@
     </template>
 
     <template id="question_datetime" name="Question: datetime box">
-        <div class="input-group o_survey_form_date">
+        <div class="input-group o_survey_form_date o_survey_answer_wrapper p-1 rounded">
             <input type="text" class="form-control datetimepicker-input o_survey_question_datetime bg-transparent text-dark rounded-0 p-0"
                    t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                    t-att-value="format_datetime(answer_lines[0].value_datetime) if answer_lines else None"
@@ -427,7 +433,7 @@
     <template id="question_simple_choice" name="Question: simple choice">
         <t t-set="answer_line" t-value="answer_lines.filtered(lambda line: line.suggested_answer_id)"/>
         <t t-set="comment_line" t-value="answer_lines.filtered(lambda line: line.value_char_box)"/>
-        <div class="row g-2 o_survey_form_choice"
+        <div class="row g-2 o_survey_answer_wrapper o_survey_form_choice"
              t-att-data-name="question.id"
              t-att-data-is-skipped-question="is_skipped_question or None"
              data-question-type="simple_choice_radio">
@@ -496,7 +502,7 @@
 
     <template id="question_multiple_choice" name="Question: multiple choice">
         <t t-set="comment_line" t-value="answer_lines.filtered(lambda line: line.value_char_box)"/>
-        <div class="row g-2 o_survey_form_choice o_survey_question_multiple_choice"
+        <div class="row g-2 o_survey_answer_wrapper o_survey_form_choice o_survey_question_multiple_choice"
              t-att-data-name="question.id"
              t-att-data-question-type="question.question_type">
             <t t-set="item_idx" t-value="0"/>


### PR DESCRIPTION
Purpose
=======
Add a scoring option displaying the correct
answers after each page when taking the survey.

Specifications
==============
When the user submits the page:
- highlight in green the correct answer(s)
- highlight in red the wrong answer(s)
When the correction is displayed, prevent
the user from changing their answers.

Handling all question types that can specify
a correct answer:
- Numerical box
- Date
- Datetime
- Simple choice
- Multiple choice

Task-3374998

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
