### PR TITLE
[FIX] payment_razorpay: error handling reference matching transaction not found

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -213,9 +213,11 @@ class PaymentTransaction(models.Model):
                 else:  # The refund was initiated for an unknown source transaction.
                     pass  # Don't do anything with the refund notification.
         if not tx:
-            raise ValidationError(
+            exc = ValidationError(
                 "Razorpay: " + _("No transaction found matching reference %s.", reference)
             )
+            exc.sentry_ignored = True
+            raise exc
 
         return tx
 


### PR DESCRIPTION
If user made payment with 'razorpay' and during transaction  it does not found 
any matching reference, the error will be generated.

See this traceback:

```
ValidationError: Razorpay: No transaction found matching reference #MGHT5GHCqncRyL.
  File "addons/payment_razorpay/controllers/main.py", line 68, in razorpay_webhook
    tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
  File "addons/payment_razorpay/models/payment_transaction.py", line 216, in _get_tx_from_notification_data
    raise ValidationError(
```

sentry-4329675060


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
