### PR TITLE
[FIX] base_import_module: ignore error while importing custom module

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -225,6 +225,7 @@ class IrModule(models.Model):
                             success.append(mod_name)
                     except Exception as e:
                         _logger.exception('Error while importing module')
+                        e.sentry_ignored = True
                         errors[mod_name] = exception_to_unicode(e)
         r = ["Successfully imported module '%s'" % mod for mod in success]
         for mod, error in errors.items():


### PR DESCRIPTION
This error occurs when the user imports a custom module. steps to produce:
- Install the `base_import_module` module.
- Navigate to the `Apps` menu and select `Import Module`.
- Choose a zip file of the custom `product_manufacturer` module.
- Click on `Import App`.
- Error will be generated.

see the traceack:
```
ParseError: while parsing /tmp/tmp4lf6xj7k/product_manufacturer/views/product_manufacturer_view.xml:3
Error while validating view near:

                    <button string="Print Labels" type="object" name="action_open_label_layout" attrs="{'invisible': [('detailed_type', '==', 'service')]}"/>
                </header>
                <sheet name="product_form">
                    <field name="product_variant_count" invisible="1"/>
                    <field name="is_kits" invisible="1"/>

Field "manufacturer_id" d...
  File "addons/base_import_module/models/ir_module.py", line 224, in import_zipfile
    if self._import_module(mod_name, path, force=force):
  File "addons/base_import_module/models/ir_module.py", line 101, in _import_module
    convert_xml_import(self.env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 561, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
To handle this issue, we have added the sentry_ignored.
```

sentry-4199413810

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
