### PR TITLE
[FIX] purchase: Fix broken _name_search function on purchase.bill.union

### DIFF
--- a/addons/purchase/report/purchase_bill.py
+++ b/addons/purchase/report/purchase_bill.py
@@ -60,5 +60,5 @@ class PurchaseBillUnion(models.Model):
         domain = []
         if name:
             domain = ['|', ('name', operator, name), ('reference', operator, name)]
-        purchase_bills_union_ids = self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)
-        return self.browse(purchase_bills_union_ids).name_get()
+
+        return self._search(expression.AND([domain, args]), limit=limit, access_rights_uid=name_get_uid)


### PR DESCRIPTION
The _name_search was returning the results of a name_get() instead of returning the results from self._search(). Now the autocomplete feature should be usable again




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
