### PR TITLE
[FIX] google_gmail:  disallow gmail account connection without username

### DIFF
--- a/addons/google_gmail/models/google_gmail_mixin.py
+++ b/addons/google_gmail/models/google_gmail_mixin.py
@@ -63,6 +63,8 @@ class GoogleGmailMixin(models.AbstractModel):
         We need him to save the form so the current mail server record exist in DB, and
         we can include the record ID in the URL.
         """
+        if not self:
+            return {}
         self.ensure_one()
 
         if not self.env.user.has_group('base.group_system'):


### PR DESCRIPTION
If a user selects `Gmail OAuth Authentication` while creating an Outgoing Mail Server and then clicks on `Connect your Gmail account` without entering a username,  the user will encounter a UserError. If the user then clicks on `Discard Changes` they will face a singleton error.

steps to produce:
- Install `mail`.
- In Settings check `Custom Email Servers` and enter any value in `Id `and `Secret` and save the settings.
- Now again in settings click on `Outgoing Mail Servers` to create a server.
- While creating a server  enter the name of the server, `Gmail OAuth Authentication` under `Authentication with`.
- In `Connection` page without entering a username click on `Connect your Gmail Account`.

Traceback:
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5379, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: ir.mail_server()
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/google_gmail/models/google_gmail_mixin.py", line 66, in open_google_gmail_uri
    self.ensure_one()
  File "odoo/models.py", line 5382, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

After applying this commit, users will not be able to connect to their Gmail account without entering a username while creating an Outgoing Server.

sentry-4292447088

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
