### PR TITLE
[IMP] point_of_sale: remove unused function

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -44,13 +44,6 @@ class AccountMove(models.Model):
 
         return lot_values
 
-    def _get_reconciled_vals(self, partial, amount, counterpart_line):
-        """Add pos_payment_name field in the reconciled vals to be able to show the payment method in the invoice."""
-        result = super()._get_reconciled_vals(partial, amount, counterpart_line)
-        if counterpart_line.move_id.sudo().pos_payment_ids:
-            pos_payment = counterpart_line.move_id.sudo().pos_payment_ids
-            result['pos_payment_name'] = pos_payment.payment_method_id.name
-        return result
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'


### PR DESCRIPTION
before this commit, in point_of_sale module there is a function _get_reconciled_vals, which is left over in this commit: https://github.com/odoo/odoo/commit/785d49f3f0a21720d8c929d597d4041918ab7f41

initially the function is inherited to bring the payment method name in the invoice report from the pos, but it is decided not to add it again to keep it same from accounting and point of sale.

Discussion: https://github.com/odoo/odoo/pull/125995#issuecomment-1643938775

after this commit, the unused function will be
removed from the code.

Issue: https://github.com/odoo/odoo/issues/125933




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
