### PR TITLE
[IMP] web: orm service: add "webRead" function

### DIFF
--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -148,7 +148,7 @@ export class ORM {
             return Promise.resolve([]);
         }
         return this.call(model, "read", [ids, ["display_name"]], kwargs).then(
-            (data) => data && data.map(({id, display_name}) => [id, display_name])
+            (data) => data && data.map(({ id, display_name }) => [id, display_name])
         );
     }
 
@@ -254,6 +254,19 @@ export class ORM {
             domain,
             fields,
         });
+    }
+
+    /**
+     * @param {string} model
+     * @param {number[]} ids
+     * @param {any} [kwargs={}]
+     * @param {Object} [kwargs.specification]
+     * @param {Object} [kwargs.context]
+     * @returns {Promise<any[]>}
+     */
+    webRead(model, ids, kwargs = {}) {
+        validatePrimitiveList("ids", "number", ids);
+        return this.call(model, "web_read", [ids], kwargs);
     }
 
     /**

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -650,15 +650,13 @@ export class Record extends DataPoint {
                     specification: { display_name: {} },
                 };
                 proms.push(
-                    this.model.orm
-                        .call(value.resModel, "web_read", [[id]], kwargs)
-                        .then((records) => {
-                            changes[fieldName] = {
-                                resModel: value.resModel,
-                                resId: id,
-                                displayName: records[0].display_name,
-                            };
-                        })
+                    this.model.orm.webRead(value.resModel, [id], kwargs).then((records) => {
+                        changes[fieldName] = {
+                            resModel: value.resModel,
+                            resId: id,
+                            displayName: records[0].display_name,
+                        };
+                    })
                 );
             } else {
                 changes[fieldName] = value;
@@ -709,7 +707,7 @@ export class Record extends DataPoint {
                     specification: { display_name: {} },
                 };
                 proms.push(
-                    this.model.orm.call(relation, "web_read", [[id]], kwargs).then((records) => {
+                    this.model.orm.webRead(relation, [id], kwargs).then((records) => {
                         changes[fieldName] = [records[0].id, records[0].display_name || ""];
                     })
                 );

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -537,7 +537,7 @@ export class RelationalModel extends Model {
                 context: { bin_size: true, ...context },
                 specification: fieldSpec,
             };
-            const records = await this.orm.call(resModel, "web_read", [resIds], kwargs);
+            const records = await this.orm.webRead(resModel, resIds, kwargs);
             if (!records.length) {
                 throw new FetchRecordError(resIds);
             }

--- a/addons/web/static/src/views/record.js
+++ b/addons/web/static/src/views/record.js
@@ -67,11 +67,9 @@ class _Record extends Component {
                                 specification: fieldSpec,
                             };
                             proms.push(
-                                this.orm
-                                    .call(resModel, "web_read", [resIds], kwargs)
-                                    .then((records) => {
-                                        values[fieldName] = records;
-                                    })
+                                this.orm.webRead(resModel, resIds, kwargs).then((records) => {
+                                    values[fieldName] = records;
+                                })
                             );
                         }
                     }
@@ -84,12 +82,7 @@ class _Record extends Component {
                             context: activeField.context || {},
                             specification: { display_name: {} },
                         };
-                        const records = await this.orm.call(
-                            resModel,
-                            "web_read",
-                            [[resId]],
-                            kwargs
-                        );
+                        const records = await this.orm.webRead(resModel, [resId], kwargs);
                         return records[0].display_name;
                     };
                     if (typeof values[fieldName] === "number") {

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -339,6 +339,32 @@ QUnit.test("searchCount method", async (assert) => {
     });
 });
 
+QUnit.test("webRead method", async (assert) => {
+    const [query, rpc] = makeFakeRPC();
+    serviceRegistry.add("rpc", rpc);
+    const env = await makeTestEnv();
+    const context = { abc: 3 };
+    await env.services.orm.webRead("sale.order", [2, 5], {
+        specification: { name: {}, amount: {} },
+        context,
+    });
+    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/web_read");
+    assert.deepEqual(query.params, {
+        args: [[2, 5]],
+        kwargs: {
+            specification: { name: {}, amount: {} },
+            context: {
+                abc: 3,
+                lang: "en",
+                tz: "taht",
+                uid: 7,
+            },
+        },
+        method: "web_read",
+        model: "sale.order",
+    });
+});
+
 QUnit.test("webSearchRead method", async (assert) => {
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);


### PR DESCRIPTION
This commit adds a shortcut in the orm service to call the new "web_read" python method and adapts the few calls to use it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
