### PR TITLE
[FIX] web: create kanban column groupBy x2many

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -259,8 +259,8 @@ export class DynamicGroupList extends DynamicList {
         return group.value;
     }
 
-    _getDPHandleField(group) {
-        return group[this.handleField];
+    _getDPFieldValue(group, handleField) {
+        return group[handleField];
     }
 
     async _load(offset, limit, orderBy, domain) {

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -270,7 +270,7 @@ export class DynamicList extends DataPoint {
         if (this.resModel === resModel && !this.canResequence()) {
             return originalList;
         }
-        const handleField = this.handleField;
+        const handleField = this.resModel === resModel ? this.handleField : DEFAULT_HANDLE_FIELD;
         const dataPoints = [...originalList];
         const order = this.orderBy.find((o) => o.name === handleField);
         const asc = !order || order.asc;
@@ -283,13 +283,13 @@ export class DynamicList extends DataPoint {
             toIndex = fromIndex > targetIndex ? targetIndex + 1 : targetIndex;
         }
 
-        const getSequence = (dp) => dp && this._getDPHandleField(dp, handleField);
+        const getSequence = (dp) => dp && this._getDPFieldValue(dp, handleField);
 
         // Determine which records/groups need to be modified
         const firstIndex = Math.min(fromIndex, toIndex);
         const lastIndex = Math.max(fromIndex, toIndex) + 1;
         let reorderAll = dataPoints.some(
-            (dp) => this._getDPHandleField(dp, handleField) === undefined
+            (dp) => this._getDPFieldValue(dp, handleField) === undefined
         );
         if (!reorderAll) {
             let lastSequence = (asc ? -1 : 1) * Infinity;

--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -140,8 +140,8 @@ export class DynamicRecordList extends DynamicList {
         return record.resId;
     }
 
-    _getDPHandleField(record) {
-        return record.data[this.handleField];
+    _getDPFieldValue(record, handleField) {
+        return record.data[handleField];
     }
 
     async _load(offset, limit, orderBy, domain) {


### PR DESCRIPTION
Before this commit, in a kanban view grouped on a x2m, when we created a new column, we had a crash.

Why did this happen?
When a column is created, a resequence is triggered on the columns in order to have the correct position. Currently, we always use the DynamicGroupList handle field, which is not correct because if we are grouped on an x2m we use another resModel, so we want to use the default handle field (sequence).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
