### PR TITLE
[FIX] tests: avoid registry reload during tests.

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -449,3 +449,4 @@ def adapt_version(version):
 
 
 current_test = None
+running_test = False

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -719,6 +719,7 @@ class TransactionCase(BaseCase):
                 with cls.registry.cursor() as cr:
                     cls.registry.setup_models(cr)
                     cls.registry.registry_invalidated = False
+                    cls.registry.registry_sequence = cls.registry_start_sequence
 
         cls.addClassCleanup(reset_changes)
         cls.addClassCleanup(cls.registry.clear_caches)


### PR DESCRIPTION
A common error is to have a registry being reloaded in the midle of a a test because of a `check_signaling` catching a `signal_change` from another test while not being in test_mode.

The main issue is that the `in_test_mode` is manual, by using an HttpCase or calling enter_test_mode in the test.

The proposed solution stores a flag to know for sure if a test is running or not.
The `threading.current_thread().testing` flag is not enough when doing a request.
The `module.current_test` is not enough for post_install.

This is a first quick step to avoid an existing bug during the nightly restarting all test because the registry is reloaded during the `test_invoice_report_without_invoice_date`, a test calling check_signaling when making a request while not being in test mode.

This flag is used instead of `self.in_test_mode():` for `signal_changes` and `check_signaling` to be sure to have the correct behaviour

This check is also added in registry.new, logging an error and returning the same registry. This could also be changed by checking if another registry exists for this database, and if the ready and loaded states are coherent, but this may have more impact than this check.

More cleanup can be done in master:
- Don't use test logic in registry.py but patch it in all cases
- Replace many check as config['test_enable'] or `in_test_mode` with this new flag.
- Consider removing enter_test_mode, threading.current_thread().testing, ...