### PR TITLE
[FIX] website_slides: prevent translatable content from breaking up

### DIFF
--- a/addons/website_slides/i18n/website_slides.pot
+++ b/addons/website_slides/i18n/website_slides.pot
@@ -126,14 +126,6 @@ msgid "(empty)"
 msgstr ""
 
 #. module: website_slides
-#. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#, python-format
-msgid ". This way, they will be secured."
-msgstr ""
-
-#. module: website_slides
 #: model:slide.slide,name:website_slides.slide_slide_demo_1_5
 msgid "3 Main Methodologies"
 msgstr ""
@@ -2886,16 +2878,20 @@ msgstr ""
 
 #. module: website_slides
 #. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
+#: code:addons/website_slides/static/src/js/slides_upload.js:0
 #, python-format
-msgid "First, upload your videos on Vimeo and mark them as"
+msgid ""
+"First, upload your videos on Vimeo and mark them as "
+"%(bold_left)sPrivate%(bold_right)s. This way, they will be secured."
 msgstr ""
 
 #. module: website_slides
 #. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
+#: code:addons/website_slides/static/src/js/slides_upload.js:0
 #, python-format
-msgid "First, upload your videos on YouTube and mark them as"
+msgid ""
+"First, upload your videos on YouTube and mark them as "
+"%(bold_left)sunlisted%(bold_right)s. This way, they will be secured."
 msgstr ""
 
 #. module: website_slides
@@ -3382,9 +3378,9 @@ msgstr ""
 
 #. module: website_slides
 #. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
+#: code:addons/website_slides/static/src/js/slides_upload.js:0
 #, python-format
-msgid "Install the"
+msgid "Install the %(module)s app."
 msgstr ""
 
 #. module: website_slides
@@ -4500,14 +4496,6 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:website_slides.lesson_card
 #: model_terms:ir.ui.view,arch_db:website_slides.view_slide_channel_form
 msgid "Preview"
-msgstr ""
-
-#. module: website_slides
-#. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#, python-format
-msgid "Private"
 msgstr ""
 
 #. module: website_slides
@@ -6241,10 +6229,23 @@ msgstr ""
 
 #. module: website_slides
 #. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
+#: code:addons/website_slides/static/src/js/slides_upload.js:0
 #, python-format
-msgid "What does"
+msgid ""
+"What does %(bold_left)sPrivate%(bold_right)s mean? The Vimeo “Private” "
+"privacy setting means it is a video which can be viewed only by the users "
+"with the link to it. Your video will never come up in the search results nor"
+" on your channel."
+msgstr ""
+
+#. module: website_slides
+#. odoo-javascript
+#: code:addons/website_slides/static/src/js/slides_upload.js:0
+#, python-format
+msgid ""
+"What does %(bold_left)sunlisted%(bold_right)s mean? The YouTube “unlisted” "
+"means it is a video which can be viewed only by the users with the link to "
+"it. Your video will never come up in the search results nor on your channel."
 msgstr ""
 
 #. module: website_slides
@@ -6656,13 +6657,6 @@ msgid "anyway"
 msgstr ""
 
 #. module: website_slides
-#. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#, python-format
-msgid "app."
-msgstr ""
-
-#. module: website_slides
 #: model_terms:ir.ui.view,arch_db:website_slides.course_nav
 msgid "breadcrumb"
 msgstr ""
@@ -6857,25 +6851,6 @@ msgstr ""
 
 #. module: website_slides
 #. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#, python-format
-msgid ""
-"mean? The Vimeo \"Private\" privacy setting means it is a video which can be viewed only by the users with the link to it.\n"
-"                                    Your video will never come up in the search results nor on your channel."
-msgstr ""
-
-#. module: website_slides
-#. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#, python-format
-msgid ""
-"means? The YouTube \"unlisted\" means it is a video which can be viewed only"
-" by the users with the link to it. Your video will never come up in the "
-"search results nor on your channel."
-msgstr ""
-
-#. module: website_slides
-#. odoo-javascript
 #: code:addons/website_slides/static/src/xml/slide_course_join.xml:0
 #: model_terms:ir.ui.view,arch_db:website_slides.course_join
 #, python-format
@@ -6964,14 +6939,6 @@ msgstr ""
 #. module: website_slides
 #: model_terms:ir.ui.view,arch_db:website_slides.course_join
 msgid "to unlock"
-msgstr ""
-
-#. module: website_slides
-#. odoo-javascript
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#: code:addons/website_slides/static/src/xml/website_slides_upload.xml:0
-#, python-format
-msgid "unlisted"
 msgstr ""
 
 #. module: website_slides

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -1,8 +1,9 @@
 /** @odoo-module **/
 
+import { markup } from '@odoo/owl';
 import { uniqueId } from '@web/core/utils/functions';
-import { sprintf } from '@web/core/utils/strings';
-import {_t, qweb as QWeb} from 'web.core';
+import { escape, sprintf } from '@web/core/utils/strings';
+import { _t, qweb as QWeb } from 'web.core';
 import Dialog from 'web.Dialog';
 import publicWidget from 'web.public.widget';
 import utils from 'web.utils';
@@ -75,6 +76,47 @@ var SlideUploadDialog = Dialog.extend({
             self._bindSelect2Dropdown();
             self._resetModalButton();
         });
+    },
+
+    _bold(text) {
+        return markup(
+            sprintf(escape(text), {
+                bold_left: "<span class='fw-bold'>",
+                bold_right: "</span>",
+            })
+        );
+    },
+
+    getInstallText(module) {
+        return sprintf(_t("Install the %(module)s app."), { module });
+    },
+
+    get PRIVATE_UPLOAD_TEXT() {
+        const translatedText = _t(
+            "First, upload your videos on Vimeo and mark them as %(bold_left)sPrivate%(bold_right)s. This way, they will be secured."
+        );
+        return this._bold(translatedText);
+    },
+
+    get UNLISTED_UPLOAD_TEXT() {
+        const translatedText = _t(
+            "First, upload your videos on YouTube and mark them as %(bold_left)sunlisted%(bold_right)s. This way, they will be secured."
+        );
+        return this._bold(translatedText);
+    },
+
+    get WHAT_PRIVATE_MEANS_TEXT() {
+        const translatedText = _t(
+            "What does %(bold_left)sPrivate%(bold_right)s mean? The Vimeo “Private” privacy setting means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel."
+        );
+        return this._bold(translatedText);
+    },
+
+    get WHAT_UNLISTED_MEANS_TEXT() {
+        const translatedText = _t(
+            "What does %(bold_left)sunlisted%(bold_right)s mean? The YouTube “unlisted” means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel."
+        );
+        return this._bold(translatedText);
     },
 
     //--------------------------------------------------------------------------

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -29,7 +29,7 @@
                 <a class="o_wslides_js_upload_install_button w-100 text-center mb-4 btn rounded border text-600 p-3"
                     href="#" t-att-title="module_info['name']"
                     t-att-data-module-id="module_info['id']">
-                    <i class="fa fa-trophy"></i> <t t-out="module_info['motivational']"/><span class="text-primary"> Install the <t t-out="module_info['name']"/> app.</span>
+                    <i class="fa fa-trophy"></i> <t t-out="module_info['motivational']"/><span class="text-primary" t-esc="widget.getInstallText(module_info.name)"/>
                 </a>
             </t>
         </t>
@@ -250,15 +250,14 @@
                             <div class="o_slide_tutorial p-3">
                                 <div class="h5">How to upload your videos?</div>
                                 <div class="h6">On YouTube</div>
-                                <div>First, upload your videos on YouTube and mark them as <strong>unlisted</strong>. This way, they will be secured.</div>
-                                <div>What does <strong>unlisted</strong> means? The YouTube "unlisted" means it is a video which can be viewed only by the users with the link to it. Your video will never come up in the search results nor on your channel.</div>
+                                <div t-out="widget.UNLISTED_UPLOAD_TEXT"/>
+                                <div t-out="widget.WHAT_UNLISTED_MEANS_TEXT"/>
                                 <div><a href="https://support.google.com/youtube/answer/157177" target="_blank" >Change video privacy settings</a></div>
                                 <br/>
                                 <div class="h6">On Vimeo</div>
                                 <div>
-                                    <span>First, upload your videos on Vimeo and mark them as <strong>Private</strong>. This way, they will be secured.</span><br/>
-                                    <span>What does <strong>Private</strong> mean? The Vimeo "Private" privacy setting means it is a video which can be viewed only by the users with the link to it.
-                                    Your video will never come up in the search results nor on your channel.</span><br/>
+                                    <span t-out="widget.PRIVATE_UPLOAD_TEXT"/><br/>
+                                    <span t-out="widget.WHAT_PRIVATE_MEANS_TEXT"/><br/>
                                     <span><a href="https://vimeo.zendesk.com/hc/en-us/articles/224819527-Changing-the-privacy-settings-of-your-videos" target="_blank" >Change video privacy settings</a></span><br/><br/>
                                     <span>The video link to input here can be obtained by using the 'share' button in the Vimeo interface.</span><br/>
                                     <span>It should look similar to</span>


### PR DESCRIPTION
Nesting tags in a text node will break up the translations exported from it. For example,
```xml
<span>Install the <t t-out="module_info['name']"/> app.</span>
```
will result in two different translations when exported: “Install the” and “app.”.

This is a problem for translators because it prevents them from reordering the sentence according to the syntax of the target language, not to mention the lack of context, which makes translation difficult or even impossible.

This commit fixes the problem by interpolating the tags later, rather than including them directly in the string, so that the translation is not broken.