### PR TITLE
[IMP] l10n_it, l10n_it_edi: Split Payment

### DIFF
--- a/addons/l10n_it/data/account.account.template.csv
+++ b/addons/l10n_it/data/account.account.template.csv
@@ -27,6 +27,7 @@ id,code,name,account_type,reconcile,chart_template_id:id,tag_ids:id
 1501,1501,Crediti v/clienti,asset_receivable,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
 1502,1502,Crediti commerciali diversi,asset_current,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
 1503,1503,Clienti c/spese anticipate,asset_current,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
+1504,1504,Crediti v/clienti per Split Payment,asset_current,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
 1505,1505,Cambiali attive,asset_current,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
 1506,1506,Cambiali allo sconto,asset_current,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
 1507,1507,Cambiali all'incasso,asset_current,TRUE,l10n_it_chart_template_generic,l10n_it.account_tag_C_ATT
@@ -75,6 +76,7 @@ id,code,name,account_type,reconcile,chart_template_id:id,tag_ids:id
 2602,2602,Debiti per ritenute da versare,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS
 2605,2605,Erario c/IVA,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS
 2606,2606,Debiti per imposte,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS
+2607,2607,Erario c/IVA Split Payment,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS
 2619,2619,Debiti per cauzioni,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS
 2620,2620,Personale c/retribuzioni,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS
 2621,2621,Personale c/liquidazioni,liability_current,FALSE,l10n_it_chart_template_generic,l10n_it.account_tag_D_PASS

--- a/addons/l10n_it/data/account.fiscal.position.template.csv
+++ b/addons/l10n_it/data/account.fiscal.position.template.csv
@@ -1,5 +1,6 @@
 "name","chart_template_id:id","id","sequence","auto_apply","vat_required","country_id:id","country_group_id:id","note"
 "Italia","l10n_it_chart_template_generic","it",1,1,1,base.it,,
-"Regime Extra comunitario","l10n_it_chart_template_generic","extra",4,1,,,,
 "Regime Intra comunitario privato","l10n_it_chart_template_generic","intra_private",2,1,,,base.europe,
 "Regime Intra comunitario","l10n_it_chart_template_generic","intra",3,1,1,,base.europe,"Fattura emessa ai sensi dell’art. 17, comma 2 del DPR 26/10/1972 n. 633, l’applicazione dell’IVA è a carico del destinatario."
+"Regime Extra comunitario","l10n_it_chart_template_generic","extra",4,1,,,,
+"Scissione dei Pagamenti","l10n_it_chart_template_generic","split_payment_fiscal_position",5,1,1,base.it,,,"Operazione soggetta a split payment – il cedente non incassa l’Iva ai sensi dell’ex art.17-ter del D.P.R. 633/1972, l’acquirente è obbligato al versamento all’Agenzia delle Entrate."

--- a/addons/l10n_it/data/account.tax.group.csv
+++ b/addons/l10n_it/data/account.tax.group.csv
@@ -9,3 +9,4 @@ tax_group_iva_20,IVA 20%,base.it,Imponibile
 tax_group_iva_22,IVA 22%,base.it,Imponibile
 tax_group_imp_esc_art_15,Imponibile Escluso Art.15,base.it,Imponibile
 tax_group_fuori,Fuori Campo IVA,base.it,Imponibile
+tax_group_split_payment,Scissione dei Pagamenti,base.it,Scissione dei Pagamenti Esclusa

--- a/addons/l10n_it/data/account_fiscal_position_tax_template_data.xml
+++ b/addons/l10n_it/data/account_fiscal_position_tax_template_data.xml
@@ -78,4 +78,11 @@
         <field name="tax_src_id"  ref="00as"/>
         <field name="tax_dest_id" ref="00rcs"/>
     </record>
+
+    <record id="afpttn_it_split_payment_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="split_payment_fiscal_position"/>
+        <field name="tax_src_id"  ref="22v"/>
+        <field name="tax_dest_id" ref="22vsp_group"/>
+    </record>
+
 </odoo>

--- a/addons/l10n_it/data/account_tax_report_data.xml
+++ b/addons/l10n_it/data/account_tax_report_data.xml
@@ -181,7 +181,7 @@
                         </field>
                     </record>
                     <record id="tax_report_line_vp11" model="account.report.line">
-                        <field name="name">VP11 - Credito d'imposta</field>
+                        <field name="name">VP11 - Credito d&quot;imposta</field>
                         <field name="code">VP11</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_vp11_tag" model="account.report.expression">
@@ -289,12 +289,535 @@
                     </record>
                 </field>
             </record>
+            <record id="tax_report_line_turnover" model="account.report.line">
+                <field name="name">Turnover</field>
+                <field name="code">VE</field>
+                <field name="children_ids">
+                    <record id="tax_report_line_turnover_section_1" model="account.report.line">
+                        <field name="name">Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in caso di superamento di 1/3</field>
+                        <field name="code">VE_section1</field>
+                        <field name="children_ids">
+                            <record id="tax_report_line_ve1" model="account.report.line">
+                                <field name="name">VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 2%</field>
+                                <field name="code">VE1</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve1_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve1</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve2" model="account.report.line">
+                                <field name="name">VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 4%</field>
+                                <field name="code">VE2</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve2_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve3" model="account.report.line">
+                                <field name="name">VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 6,4%</field>
+                                <field name="code">VE3</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve3_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve3</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve4" model="account.report.line">
+                                <field name="name">VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 7,3%</field>
+                                <field name="code">VE4</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve4_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve4</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve5" model="account.report.line">
+                                <field name="name">VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 7,5%</field>
+                                <field name="code">VE5</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve5_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve5</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve6" model="account.report.line">
+                                <field name="name">VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,3%</field>
+                                <field name="code">VE6</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve6_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve6</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve7" model="account.report.line">
+                                <field name="name">VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,5%</field>
+                                <field name="code">VE7</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve7_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve7</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve8" model="account.report.line">
+                                <field name="name">VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,8%</field>
+                                <field name="code">VE8</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve8_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve8</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve9" model="account.report.line">
+                                <field name="name">VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 9,5%</field>
+                                <field name="code">VE9</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve9_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve9</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve10" model="account.report.line">
+                                <field name="name">VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 10%</field>
+                                <field name="code">VE10</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve10_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve10</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve11" model="account.report.line">
+                                <field name="name">VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 12,3%</field>
+                                <field name="code">VE11</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve11_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve11</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_turnover_section_2" model="account.report.line">
+                        <field name="name">Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili commerciali e professional</field>
+                        <field name="code">VE_section2</field>
+                        <field name="children_ids">
+                            <record id="tax_report_line_ve20" model="account.report.line">
+                                <field name="name">VE20 - Operazioni imponibili aliquota 4%</field>
+                                <field name="code">VE20</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve20_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve20</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve21" model="account.report.line">
+                                <field name="name">VE21 - Operazioni imponibili aliquota 5%</field>
+                                <field name="code">VE21</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve21_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve21</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve22" model="account.report.line">
+                                <field name="name">VE22 - Operazioni imponibili aliquota 10%</field>
+                                <field name="code">VE22</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve22_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve22</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve23" model="account.report.line">
+                                <field name="name">VE23 - Operazioni imponibili aliquota 22%</field>
+                                <field name="code">VE23</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve23_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve23</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_turnover_section_3" model="account.report.line">
+                        <field name="name">Totale imponibile e imposta</field>
+                        <field name="code">VE_section3</field>
+                        <field name="children_ids">
+                            <record id="tax_report_line_ve24" model="account.report.line">
+                                <field name="name">VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23</field>
+                                <field name="code">VE24</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve24_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">
+                                            VE1.balance + VE2.balance + VE3.balance + VE4.balance + VE5.balance
+                                            + VE6.balance + VE7.balance + VE8.balance + VE9.balance + VE10.balance
+                                            + VE11.balance + VE20.balance + VE21.balance + VE22.balance + VE23.balance
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve25" model="account.report.line">
+                                <field name="name">VE25 - Variazioni e arrotondamenti (usare segno &#43;/&#8722;)</field>
+                                <field name="code">VE25</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve25_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve25</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve26" model="account.report.line">
+                                <field name="name">VE26 - Totale VE24 e VE25</field>
+                                <field name="code">VE26</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve26_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">
+                                            VE24.balance + VE25.balance
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_report_line_turnover_section_4" model="account.report.line">
+                        <field name="name">Altre operazioni</field>
+                        <field name="code">VE_section4</field>
+                        <field name="children_ids">
+                            <record id="tax_report_line_ve30" model="account.report.line">
+                                <field name="name">VE30 - Operazioni che concorrono alla formazione del plafond</field>
+                                <field name="code">VE30</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_ve30_I" model="account.report.line">
+                                        <field name="name">VE30_I - Totale</field>
+                                        <field name="code">VE30_I</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve30_i_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">aggregation</field>
+                                                <field name="formula">
+                                                    VE30_II.balance + VE30_III.balance + VE30_IV.balance + VE30_V.balance
+                                                </field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve30_ii" model="account.report.line">
+                                        <field name="name">VE30_II - Esportazioni</field>
+                                        <field name="code">VE30_II</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve30_ii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve30_ii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve30_iii" model="account.report.line">
+                                        <field name="name">VE30_III - Cessioni intracomunitarie</field>
+                                        <field name="code">VE30_III</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve30_iii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve30_iii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve30_iv" model="account.report.line">
+                                        <field name="name">VE30_IV - Cessioni verso San Marino</field>
+                                        <field name="code">VE30_IV</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve30_iv_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve30_iv</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve30_v" model="account.report.line">
+                                        <field name="name">VE30_V - Operazioni assimilate</field>
+                                        <field name="code">VE30_V</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve30_v_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve30_v</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve31" model="account.report.line">
+                                <field name="name">VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento</field>
+                                <field name="code">VE31</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve31_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve31</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve32" model="account.report.line">
+                                <field name="name">VE32 - Altre operazioni non imponibili</field>
+                                <field name="code">VE32</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve32_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve32</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve33" model="account.report.line">
+                                <field name="name">VE33 - Operazioni esenti (art.10</field>
+                                <field name="code">VE33</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve33_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve33</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve34" model="account.report.line">
+                                <field name="name">VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a 7-septies</field>
+                                <field name="code">VE34</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve34_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve34</field>
+                                    </record>
+                                </field>
+                            </record>
+
+                            <record id="tax_report_line_ve35" model="account.report.line">
+                                <field name="name">VE35 - Operazioni con applicazione del reverse charge interno</field>
+                                <field name="code">VE35</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_ve35_I" model="account.report.line">
+                                        <field name="name">VE35_I - Total</field>
+                                        <field name="code">VE35_I</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_i_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">aggregation</field>
+                                                <field name="formula">
+                                                    VE35_II.balance + VE35_III.balance + VE35_IV.balance
+                                                    + VE35_V.balance + VE35_VI.balance + VE35_VII.balance
+                                                    + VE35_VIII.balance + VE35_IX.balance
+                                                </field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_ii" model="account.report.line">
+                                        <field name="name">VE35_II - Cessioni di rottami e altri materiali di recupero</field>
+                                        <field name="code">VE35_II</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_ii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_ii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_iii" model="account.report.line">
+                                        <field name="name">VE35_III - Cessioni di oro e argento puro</field>
+                                        <field name="code">VE35_III</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_iii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_iii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_iv" model="account.report.line">
+                                        <field name="name">VE35_IV - Subappalto nel settore edile</field>
+                                        <field name="code">VE35_IV</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_iv_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_iv</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_v" model="account.report.line">
+                                        <field name="name">VE35_V - Cessioni di fabbricati strumentali</field>
+                                        <field name="code">VE35_V</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_v_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_v</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_vi" model="account.report.line">
+                                        <field name="name">VE35_VI - Cessioni di telefoni cellulari</field>
+                                        <field name="code">VE35_VI</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_vi_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_vi</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_vii" model="account.report.line">
+                                        <field name="name">VE35_VII - Cessioni di prodotti elettronici</field>
+                                        <field name="code">VE35_VII</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_vii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_vii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_viii" model="account.report.line">
+                                        <field name="name">VE35_VIII - Prestazioni comparto edile e settori connessi</field>
+                                        <field name="code">VE35_VIII</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_viii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_viii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve35_ix" model="account.report.line">
+                                        <field name="name">VE35_IX - Operazioni settore energetico</field>
+                                        <field name="code">VE35_IX</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve35_ix_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve35_ix</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve36" model="account.report.line">
+                                <field name="name">VE36 - Operazioni non soggette all&quot;imposta effettuate nei confronti dei terremotati</field>
+                                <field name="code">VE36</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve36_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve36</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve37" model="account.report.line">
+                                <field name="name">VE37 - Operazioni effettuate nell&quot;anno ma con imposta esigibile negli anni successivi</field>
+                                <field name="code">VE37</field>
+                                <field name="children_ids">
+                                    <record id="tax_report_line_ve37_I" model="account.report.line">
+                                        <field name="name">VE37_I - Total</field>
+                                        <field name="code">VE37_I</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve37_i_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve37_i</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_report_line_ve37_ii" model="account.report.line">
+                                        <field name="name">VE37_II - ex art. 32-bis, DL n. 83/2012</field>
+                                        <field name="code">VE37_II</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_report_line_ve37_ii_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">ve37_ii</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve38" model="account.report.line">
+                                <field name="name">VE38 - Operazioni nei confronti di soggetti di cui all&quot;art.17-ter</field>
+                                <field name="code">VE38</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve38_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve38</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve39" model="account.report.line">
+                                <field name="name">VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta esigibile nel 2022</field>
+                                <field name="code">VE39</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve39_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve39</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_report_line_ve40" model="account.report.line">
+                                <field name="name">VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni</field>
+                                <field name="code">VE40</field>
+                                <field name="expression_ids">
+                                    <record id="tax_report_line_ve40_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve40</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
             <record id="tax_report_line_reverse_charge_iva" model="account.report.line">
                 <field name="name">Reverse Charge</field>
                 <field name="code">VJ</field>
                 <field name="children_ids">
                     <record id="tax_report_line_vj1" model="account.report.line">
-                        <field name="name">VJ1 - Acquisti di beni dalla Città del Vaticano e da San Marino</field>
+                        <field name="name">VJ1 - Acquisti di beni dalla Citt&#225; del Vaticano e da San Marino</field>
                         <field name="code">VJ1</field>
                         <field name="expression_ids">
                             <record id="tax_report_line_vj1_tag" model="account.report.expression">

--- a/addons/l10n_it/data/account_tax_template.xml
+++ b/addons/l10n_it/data/account_tax_template.xml
@@ -1167,4 +1167,51 @@
             }),
         ]"/>
     </record>
+
+    <!-- Split Payment (Scissione dei pagamenti) ......................................................... -->
+
+    <record id="22vsp" model="account.tax.template">
+        <field name="description">22vsp</field>
+        <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
+        <field name="name">22% SPv neg.</field>
+        <field name="sequence">350</field>
+        <field name="amount">-22</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="tax_group_split_payment"/>
+        <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'plus_report_expression_ids': [ref('tax_report_line_vp2_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('1504'),
+                'plus_report_expression_ids': [ref('tax_report_line_ve38_tag')],
+            }),
+        ]"/>
+        <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+            (0,0, {
+                'repartition_type': 'base',
+                'minus_report_expression_ids': [ref('tax_report_line_vp2_tag')],
+            }),
+            (0,0, {
+                'repartition_type': 'tax',
+                'account_id': ref('1504'),
+                'minus_report_expression_ids': [ref('tax_report_line_ve38_tag')],
+            }),
+        ]"/>
+    </record>
+    <record id="22vsp_group" model="account.tax.template">
+        <field name="description">22vsp_group</field>
+        <field name="chart_template_id" ref="l10n_it_chart_template_generic"/>
+        <field name="name">22% SPv</field>
+        <field name="sequence">360</field>
+        <field name="amount">0</field>
+        <field name="amount_type">group</field>
+        <field name="type_tax_use">sale</field>
+        <field name="tax_group_id" ref="tax_group_split_payment"/>
+        <field name="children_tax_ids" eval="[(6, 0, [ref('22v'),ref('22vsp')])]"/>
+    </record>
+
 </odoo>

--- a/addons/l10n_it/models/account_chart_template.py
+++ b/addons/l10n_it/models/account_chart_template.py
@@ -10,6 +10,11 @@ class AccountChartTemplate(models.Model):
         """ Set tax calculation rounding method required in Italian localization
         Also to avoid rounding errors when sent with FatturaPA"""
         res = super()._load(company)
+        self = self.with_company(company)
         if company.account_fiscal_country_id.code == 'IT':
             company.write({'tax_calculation_rounding_method': 'round_globally'})
+            vat_split_payment_account = self.env['account.account'].search([('company_id', '=', company.id), ('code', 'like', '2607%')])
+            split_payment_tax_group = self.env.ref('l10n_it.tax_group_split_payment')
+            split_payment_tax_group.property_tax_receivable_account_id = vat_split_payment_account
+            split_payment_tax_group.property_tax_payable_account_id = vat_split_payment_account
         return res

--- a/addons/l10n_it_edi/__manifest__.py
+++ b/addons/l10n_it_edi/__manifest__.py
@@ -27,9 +27,9 @@ E-invoice implementation
         'data/ir_cron.xml',
         'views/res_config_settings_views.xml',
         'views/l10n_it_view.xml',
-        ],
+    ],
     'demo': [
-        'data/account_invoice_demo.xml',
+        'data/account_invoice_demo.xml'
     ],
     'post_init_hook': '_l10n_it_edi_post_init',
     'license': 'LGPL-3',

--- a/addons/l10n_it_edi/data/account_invoice_demo.xml
+++ b/addons/l10n_it_edi/data/account_invoice_demo.xml
@@ -28,24 +28,37 @@
             <field name="website">www.itexample.com</field>
         </record>
 
-    <record id="demo_l10n_it_edi_bank" model="res.partner.bank">
-        <field name="acc_type">iban</field>
-        <field name="acc_number">BE71096123456769</field>
-        <field name="bank_id" ref="base.bank_bnp"/>
-        <field name="partner_id" ref="l10n_it.partner_demo_company_it"/>
-        <field name="company_id" ref="l10n_it.demo_company_it"/>
-    </record>
+        <record id="demo_l10n_it_edi_bank" model="res.partner.bank">
+            <field name="acc_type">iban</field>
+            <field name="acc_number">BE71096123456769</field>
+            <field name="bank_id" ref="base.bank_bnp"/>
+            <field name="partner_id" ref="l10n_it.partner_demo_company_it"/>
+            <field name="company_id" ref="l10n_it.demo_company_it"/>
+        </record>
 
-    <record id="demo_l10n_it_edi_partner_a" model="res.partner">
-      <field name="name">Biscotti Oslenghi</field>
-      <field name="company_type">company</field>
-      <field name="country_id" ref="base.it"/>
-      <field name="street">1234 Strada del Caffè</field>
-      <field name="city">Milano</field>
-      <field name="zip">20100</field>
-      <field name="vat">IT06289781004</field>
-      <field name="l10n_it_codice_fiscale">06289781004</field>
-      <field name="l10n_it_pa_index">N8MIMM9</field>
-    </record>
+        <record id="demo_l10n_it_edi_partner_a" model="res.partner">
+            <field name="name">Biscotti Oslenghi</field>
+            <field name="company_type">company</field>
+            <field name="country_id" ref="base.it"/>
+            <field name="street">1234 Strada del Caffè</field>
+            <field name="city">Milano</field>
+            <field name="zip">20100</field>
+            <field name="vat">IT06289781004</field>
+            <field name="l10n_it_codice_fiscale">06289781004</field>
+            <field name="l10n_it_pa_index">N8MIMM9</field>
+        </record>
+
+        <record id="demo_l10n_it_edi_partner_pa" model="res.partner">
+            <field name="name">Agenzia Regionale Emergenza Urgenza</field>
+            <field name="company_type">company</field>
+            <field name="country_id" ref="base.it"/>
+            <field name="street">Via Alfredo Campanini 6</field>
+            <field name="city">Milano</field>
+            <field name="zip">20124</field>
+            <field name="vat">IT11513540960</field>
+            <field name="l10n_it_codice_fiscale">11513540960</field>
+            <field name="l10n_it_pa_index">SOOTJS</field>
+        </record>
+
     </data>
 </odoo>

--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -186,7 +186,7 @@
                         <ImponibileImporto t-esc="format_monetary(tax_line['base_amount'], currency)"/>
                         <Imposta t-esc="format_monetary(tax_line['tax_amount'], currency)"/>
                     </t>
-                    <EsigibilitaIVA t-if="not has_exoneration or kind_exoneration == 'N6'" t-esc="tax.l10n_it_vat_due_date"/>
+                    <EsigibilitaIVA t-esc="tax_line['exigibility_code']"/>
                     <RiferimentoNormativo t-if="tax.l10n_it_law_reference" t-esc="format_alphanumeric(tax.l10n_it_law_reference[:100])"/>
                 </DatiRiepilogo>
             </t>

--- a/addons/l10n_it_edi/models/account_chart_template.py
+++ b/addons/l10n_it_edi/models/account_chart_template.py
@@ -2,18 +2,35 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
+from odoo.http import request
 
 
 class AccountChartTemplate(models.Model):
     _inherit = 'account.chart.template'
 
-    def _load(self, company):
+    def try_loading(self, company=False, install_demo=True):
         """
             Override normal default taxes, which are the ones with lowest sequence.
         """
-        result = super()._load(company)
-        template = company.chart_template_id
-        if template == self.env.ref('l10n_it.l10n_it_chart_template_generic'):
+        if not company:
+            if request and hasattr(request, 'allowed_company_ids'):
+                company = self.env['res.company'].browse(request.allowed_company_ids[0])
+            else:
+                company = self.env.company
+        self_company = self.with_company(company)
+
+        install_demo_and_base_demo = install_demo and self.env.ref('base.module_account').demo
+        if install_demo_and_base_demo and not company.chart_template_id and not self_company.existing_accounting(company):
+            fattura_pa = self.env.ref('l10n_it_edi.edi_fatturaPA')
+            edi_identification = fattura_pa._get_proxy_identification(company)
+            self_company.env['account_edi_proxy_client.user']._register_proxy_user(company, fattura_pa, edi_identification)
+
+        super().try_loading(company, install_demo)
+
+        if company.chart_template_id == self.env.ref('l10n_it.l10n_it_chart_template_generic', raise_if_not_found=False):
             company.account_sale_tax_id = self.env.ref(f'l10n_it.{company.id}_22v')
             company.account_purchase_tax_id = self.env.ref(f'l10n_it.{company.id}_22am')
-        return result
+
+            if install_demo_and_base_demo:
+                pa_partner = self_company.env.ref('l10n_it_edi.demo_l10n_it_edi_partner_pa')
+                pa_partner.property_account_position_id = self.env.ref(f'l10n_it.{company.id}_split_payment_fiscal_position')

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -10,7 +10,6 @@
             <xpath expr="//page[@name='advanced_options']" position="inside">
                 <group attrs="{'invisible': [('country_code', '!=', 'IT')]}">
                     <group>
-                        <field name="l10n_it_vat_due_date"/>
                         <field name="l10n_it_has_exoneration"/>
                         <field name="l10n_it_kind_exoneration" attrs="{'invisible': [('l10n_it_has_exoneration', '=', False)]}"/>
                         <field name="l10n_it_law_reference"/>


### PR DESCRIPTION
Split Payment

originally from: odoo/https://github.com/odoo/odoo/pull/117989

When an italian company bills a PA business (for example they're selling cleaning services for a public building) the PA business will send the VAT to the Tax Agency themselves, while generally the VAT is collected and sent to the Tax Agency by the buyer (the PA business). This is done to avoid VAT fraud as the PA doesn't trust the business will actually pay the VAT, that's very common in Italy.

-  Split Payment `account.tax`es are Groups of Taxes whose children target VE38 tax grid
-  `account_tax`'s `l10n_it_vat_due_date` is no more, we base ourselves on the VE38 tax grid
-  The Group of Taxes includes normal VAT and a reversed VAT entry (both for sale and purchase)
-  New Split Payment tax group has been added to build the correct totals in the move form view
- `_l10n_it_get_tax_kind` returns the new split_payment tax kind
- `account.tax`es and `account.fiscal.position` has been added to change from VAT to VAT Split Payment automatically when you select a res.partner that features the fiscal position.
- The Fiscal Position also has the law-required note that has to be featured on invoices that use Split Payment
- A PA business demo partner is added to showcase the new fiscal position
- Some bugfix on the chart template and the demo data was added to: 
   1) ensure the Demo company has at least `demo` proxy user, otherwise the invoices cannot get posted
   2) when switching from `demo` to `test`, ALL the demo users get replaced by test ones.
   3) WIP: test what happens if I turn on the demo data when the proxy user is test or prod. 
       Should that turn all proxy users to demo?

Task link: https://www.odoo.com/web#id=2823645&model=project.task
task-2823645