### PR TITLE
[FIX] account: correct the indentation of local variable journal

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -224,20 +224,20 @@ class AccountChartTemplate(models.AbstractModel):
                         ('code', '=', journal_data['code']),
                         ('company_id', '=', company.id),
                     ])
-                # Try to match by journal name to avoid conflict in the unique constraint on the mail alias
-                if not journal and 'name' in journal_data and 'type' in journal_data:
-                    journal = self.env['account.journal'].with_context(active_test=False).search([
-                        ('type', '=', journal_data['type']),
-                        ('name', '=', journal_data['name']),
-                        ('company_id', '=', company.id),
-                    ], limit=1)
-                if journal:
-                    del data['account.journal'][xmlid]
-                    self.env['ir.model.data']._update_xmlids([{
-                        'xml_id': f"account.{company.id}_{xmlid}",
-                        'record': journal,
-                        'noupdate': True,
-                    }])
+                    # Try to match by journal name to avoid conflict in the unique constraint on the mail alias
+                    if not journal and 'name' in journal_data and 'type' in journal_data:
+                        journal = self.env['account.journal'].with_context(active_test=False).search([
+                            ('type', '=', journal_data['type']),
+                            ('name', '=', journal_data['name']),
+                            ('company_id', '=', company.id),
+                        ], limit=1)
+                    if journal:
+                        del data['account.journal'][xmlid]
+                        self.env['ir.model.data']._update_xmlids([{
+                            'xml_id': f"account.{company.id}_{xmlid}",
+                            'record': journal,
+                            'noupdate': True,
+                        }])
 
         account_group_count = self.env['account.group'].search_count([('company_id', '=', company.id)])
         if account_group_count:


### PR DESCRIPTION
When the user matches the ```journals``` by type and name then it gets errors like ```'local variable journal referenced before assignment'``` because the journal variable is defined inside the condition.

See-

https://github.com/odoo/odoo/blob/125979c72d96669df7f11052ab80cd69368cc767/addons/account/models/chart_template.py#L221-L240

Traceback-
``` 
UnboundLocalError: local variable 'journal' referenced before assignment
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/account/models/res_config_settings.py", line 176, in reload_template
    self.env['account.chart.template'].try_loading(self.company_id.chart_template, company=self.company_id)
  File "addons/account/models/chart_template.py", line 142, in try_loading
    return self._load(template_code, company, install_demo)
  File "addons/account/models/chart_template.py", line 183, in _load
    self._pre_reload_data(company, template_data, data)
  File "addons/account/models/chart_template.py", line 228, in _pre_reload_data
    if not journal and 'name' in journal_data and 'type' in journal_data:
```

By applying these changes will correct the right indentation for the journal variable.

Sentry-4332370741