### PR TITLE
[IMP] project_timesheet_holidays: set project and task of the time-off type's company

### DIFF
--- a/addons/project_timesheet_holidays/data/holiday_timesheets_demo.xml
+++ b/addons/project_timesheet_holidays/data/holiday_timesheets_demo.xml
@@ -4,7 +4,7 @@
         <function model="hr.leave" name="_remove_resource_leave">
             <value eval="[ref('hr_holidays.hr_holidays_sl'), ref('hr_holidays.hr_holidays_cl_qdp'), ref('hr_holidays.hr_holidays_sl_qdp')]"/>
         </function>
-        <function model="hr.leave" name="_timesheet_create_lines">
+        <function model="hr.leave" name="_validate_leave_request">
             <value eval="[ref('hr_holidays.hr_holidays_sl'), ref('hr_holidays.hr_holidays_cl_qdp'), ref('hr_holidays.hr_holidays_sl_qdp')]"/>
         </function>
         <function model="hr.leave" name="_create_resource_leave">

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -22,9 +22,8 @@ class TestTimesheetHolidaysCreate(common.TransactionCase):
             'requires_allocation': 'no'
         })
 
-        company = self.env.company
-        self.assertEqual(status.timesheet_project_id, company.internal_project_id, 'The default project linked to the status should be the same as the company')
-        self.assertEqual(status.timesheet_task_id, company.leave_timesheet_task_id, 'The default task linked to the status should be the same as the company')
+        self.assertEqual(status.timesheet_project_id, status.company_id.internal_project_id, 'The default project linked to the status should be the same as the company')
+        self.assertEqual(status.timesheet_task_id, status.company_id.leave_timesheet_task_id, 'The default task linked to the status should be the same as the company')
 
     def test_company_create(self):
         main_company = self.env.ref('base.main_company')


### PR DESCRIPTION
Before this PR, the project and task fields were not dependent on the company. The default project was set as the company if it existed; otherwise, it was retrieved from the environment, and the internal project was set as the default. The task was computed based on the project.

In this PR, the project will only be set to its internal project if the company exists. If the company is false or not specified, both project and task will be set to false.

task-3279188

