### PR TITLE
[IMP] account: view journal items impacting a bank (without transaction)

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -884,17 +884,6 @@ class AccountJournal(models.Model):
             account_ids.add(line.payment_account_id.id or self.company_id.account_journal_payment_credit_account_id.id)
         return self.env['account.account'].browse(account_ids)
 
-    # TODO move to `account_reports` in master
-    def _get_last_bank_statement(self, domain=None):
-        ''' Retrieve the last bank statement created using this journal.
-        :param domain:  An additional domain to be applied on the account.bank.statement model.
-        :return:        An account.bank.statement record or an empty recordset.
-        '''
-        self.ensure_one()
-        last_statement_domain = (domain or []) + [('journal_id', '=', self.id), ('statement_id', '!=', False)]
-        last_st_line = self.env['account.bank.statement.line'].search(last_statement_domain, order='date desc, id desc', limit=1)
-        return last_st_line.statement_id
-
     def _get_available_payment_method_lines(self, payment_type):
         """
         This getter is here to allow filtering the payment method lines if needed in other modules.

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -287,6 +287,14 @@
                                     <span><t t-out="dashboard.outstanding_pay_account_balance"/></span>
                                 </div>
                             </div>
+                            <div class="row" t-if="dashboard.nb_misc_operations > 0">
+                                <div id="dashboard_bank_cash_misc_total" class="col text-start">
+                                    <a type="object" name="open_bank_difference_action">Misc. Operations</a>
+                                </div>
+                                <div class="col-auto text-end">
+                                    <span><t t-out="dashboard.misc_operations_balance"/></span>
+                                </div>
+                            </div>
                         </div>
                     </t>
                     <t t-name="JournalBodySalePurchase" id="account.JournalBodySalePurchase">

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -342,6 +342,7 @@
                     <filter string="Non Trade Payable" domain="[('account_id.account_type', '=', 'liability_payable'), ('account_id.non_trade', '=', True)]" help="From Non Trade Receivable accounts" name="non_trade_payable" invisible="1"/>
                     <filter string="Non Trade Receivable" domain="[('account_id.account_type', '=', 'asset_receivable'), ('account_id.non_trade', '=', True)]" help="From Non Trade Receivable accounts" name="non_trade_receivable" invisible="1"/>
                     <filter string="P&amp;L Accounts" domain="[('account_id.internal_group', 'in', ('income', 'expense'))]" help="From P&amp;L accounts" name="pl_accounts"/>
+                    <filter string="No Bank Transaction" domain="[('statement_line_id', '=', False)]" name="no_st_line_id" invisible="1"/>
                     <separator/>
                     <filter string="Date" name="date" date="date"/>
                     <filter string="Invoice Date" name="invoice_date" date="invoice_date"/>


### PR DESCRIPTION
Since the bank reconciliation report was removed, users no longer have a view of the journal items that impact the bank account without having a related transaction (account.bank.statement.line) Since these cause a difference between the GL balance and the balance displayed on the journal dashboard, it is useful to display a link and the total of these journal items. Only lines dated after the fiscal closing date, or the last statement date are included.

Task-3431843