### PR TITLE
[IMP] account: Exclude Off Balance Accounts from Account Mapping

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -89,12 +89,12 @@
                         <page name="account_mapping" string="Account Mapping" groups="account.group_account_readonly">
                             <field name="account_ids" widget="one2many" nolabel="1">
                                 <tree string="Account Mapping" editable="bottom">
-                                    <field name="account_src_id" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
-                                    <field name="account_dest_id" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
+                                    <field name="account_src_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
+                                    <field name="account_dest_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
                                 </tree>
                                 <form string="Account Mapping">
-                                    <field name="account_src_id" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
-                                    <field name="account_dest_id" domain="['|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
+                                    <field name="account_src_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
+                                    <field name="account_dest_id" domain="['|', '|', ('company_id', '=', False), ('company_id', '=', parent.company_id), ('account_type', '!=', 'off_balance')]"/>
                                 </form>
                             </field>
                         </page>


### PR DESCRIPTION
Implemented domain exclusion to remove Off Balance Accounts from Account Mapping in Belgian. This decision was motivated by the rarity of use of these accounts by our target audience, and their potentially confusing placement at the top of the list due to their prefix '0'. Now, the Account on Product and Account to use instead fields will not display these seldom-used accounts, improving usability and efficiency.

Task-Id: 3431420



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
