### PR TITLE
[FIX] stock: prevent traceback when open view diagram without product

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -973,7 +973,7 @@ class ProductTemplate(models.Model):
             products = self.env['product.product'].browse(self.env.context['default_product_id'])
         if not products and self.env.context.get('default_product_tmpl_id'):
             products = self.env['product.template'].browse(self.env.context['default_product_tmpl_id']).product_variant_ids
-        if not self.user_has_groups('stock.group_stock_multi_warehouses') and len(products) == 1:
+        if not self.user_has_groups('stock.group_stock_multi_warehouses') and products and len(products) == 1:
             company = products.company_id or self.env.company
             warehouse = self.env['stock.warehouse'].search([('company_id', '=', company.id)], limit=1)
             return self.env.ref('stock.action_report_stock_rule').report_action(None, data={


### PR DESCRIPTION
This traceback raises when user tries to  click `View Diagram` button without product name.

To reproduce this issue:

1) Install `stock` and `web_studio`
2) Create a new `product` in `stock`
3) Make product name as not required through `web_studio` 
4) Click `View Diagram` in `inventory` without `product name`

Error:-
```
TypeError: object of type 'bool' has no len()
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(346,)", line 1, in <module>
  File "addons/stock/models/product.py", line 964, in action_open_routes_diagram
    if not self.user_has_groups('stock.group_stock_multi_warehouses') and len(products) == 1:
ValueError: <class 'TypeError'>: "object of type 'bool' has no len()" while evaluating
'action = model.action_open_routes_diagram()'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/action.py", line 46, in run
    result = action.run()
  File "odoo/addons/base/models/ir_actions.py", line 702, in run
    res = runner(run_self, eval_context=eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 559, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```

On `action_open_routes_diagram` method initially `product` value is given as `False`.  When user clicks on `View diagram` button without product name, both `if` conditions fails.

See:-

https://github.com/odoo/odoo/blob/5c28c6df0390daad9a2050a1baf31dd05605747a/addons/stock/models/product.py#L970-L985

When both `if` conditions fails `products` value will be `False` and `products` is used in `len()`, 
which leads to above traceback.

Sentry-4330802430
