### PR TITLE
[FIX] base: traceback when creating a user

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -158,7 +158,7 @@ class Company(models.Model):
     @api.depends('root_id')
     def _compute_color(self):
         for company in self:
-            company.color = company.root_id.partner_id.color or (company.root_id.id % 12)
+            company.color = company.root_id.partner_id.color or (company.root_id._origin.id % 12)
 
     def _inverse_color(self):
         for company in self:


### PR DESCRIPTION
The combination of the new basic model and this change dc4dcead6ed5e16eebdf7a9f79afea31b24ec33f made it so that creating a new user would fail with a traceback.

This commit fixes the issue by making sure that the company_id that is used withing the initial onchange is a integer, and not a new-id.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
