### PR TITLE
[FIX] account_peppol: fix migration key, sql constraints

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -13,7 +13,6 @@ _logger = logging.getLogger(__name__)
 class AccountEdiProxyClientUser(models.Model):
     _inherit = 'account_edi_proxy_client.user'
 
-    peppol_migration_key = fields.Char(string="Migration Key")
     peppol_verification_code = fields.Char(string='SMS verification code')
     proxy_type = fields.Selection(
         selection_add=[('peppol', 'PEPPOL')],
@@ -37,11 +36,8 @@ class AccountEdiProxyClientUser(models.Model):
                 self.company_id.write({
                     'account_peppol_proxy_state': 'not_registered',
                     'is_account_peppol_participant': False,
+                    'account_peppol_migration_key': False,
                 })
-                self.env['ir.config_parameter'].set_param(
-                    f'account_peppol.migration_key_{self.company_id.id}',
-                    False
-                )
                 # commit the above changes before raising below
                 if not tools.config['test_enable'] and not modules.module.current_test:
                     self.env.cr.commit()

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -37,16 +37,12 @@ PEPPOL_ENDPOINT_WARNING = {
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    # to be removed once the module is available
-    account_peppol_attachment_ids = fields.Many2many(
-        comodel_name='ir.attachment',
-        string='Peppol Identification Documents',
-    )
     account_peppol_contact_email = fields.Char(
         string='Primary contact email',
         compute='_compute_account_peppol_contact_email', store=True, readonly=False,
         help='Primary contact email for Peppol-related communication',
     )
+    account_peppol_migration_key = fields.Char(string="Migration Key")
     account_peppol_phone_number = fields.Char(
         string='Phone number (for validation)',
         help='You will receive a verification code to this phone number',

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -27,21 +27,10 @@ class ResConfigSettings(models.TransientModel):
         string="Warning",
         compute="_compute_account_peppol_endpoint_warning",
     )
-    # to be changed in master to be a related field on res_company
-    account_peppol_migration_key = fields.Char(
-        compute="_compute_account_peppol_migration_key",
-        inverse="_inverse_account_peppol_migration_key",
-        readonly=False,
-    )
+    account_peppol_migration_key = fields.Char(related='company_id.account_peppol_migration_key', readonly=False)
     account_peppol_phone_number = fields.Char(related='company_id.account_peppol_phone_number', readonly=False)
     account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state', readonly=False)
     account_peppol_purchase_journal_id = fields.Many2one(related='company_id.peppol_purchase_journal_id', readonly=False)
-    # to be removed once the module is available
-    account_peppol_attachment_ids = fields.Many2many(
-        comodel_name='ir.attachment',
-        string='Peppol Identification Documents',
-        related='company_id.account_peppol_attachment_ids', readonly=False,
-    )
     account_peppol_verification_code = fields.Char(related='account_peppol_edi_user.peppol_verification_code', readonly=False)
     is_account_peppol_eligible = fields.Boolean(
         string='PEPPOL eligible',
@@ -107,20 +96,6 @@ class ResConfigSettings(models.TransientModel):
             else:
                 config.account_peppol_endpoint_warning = _("The endpoint number might not be correct. "
                                                            "Please check if you entered the right identification number.")
-
-    @api.depends('company_id')
-    def _compute_account_peppol_migration_key(self):
-        for config in self:
-            config.account_peppol_migration_key = self.env['ir.config_parameter'].get_param(
-                f'account_peppol.migration_key_{config.company_id.id}'
-            )
-
-    def _inverse_account_peppol_migration_key(self):
-        for config in self:
-            self.env['ir.config_parameter'].set_param(
-                f'account_peppol.migration_key_{config.company_id.id}',
-                config.account_peppol_migration_key
-            )
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -172,7 +172,7 @@ class TestPeppolParticipant(TransactionCase):
             try:
                 settings.button_update_peppol_user_data()
             except UserError:
-                settings.execute()
+                settings = self.env['res.config.settings'].create({})
                 self.assertRecordValues(
                     settings, [{
                         'account_peppol_migration_key': False,

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -16,8 +16,6 @@ class AccountMoveSend(models.Model):
         help='Send the invoice via PEPPOL',
     )
     enable_peppol = fields.Boolean(compute='_compute_send_mail_extra_fields')
-    # to be removed once the module is fully available
-    peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state')
     # technical field needed for computing a warning text about the peppol configuration
     peppol_warning = fields.Char(
         string="Warning",


### PR DESCRIPTION
Currently, the migration key is stored through a workaround as a config parameter, because the behaviour needed to be changed in stable. Now, several things can be fixed:
- `account_peppol_migration_key` is now a field on `res.company`, not `account_edi_proxy_client.user`
- `account_peppol_attachment_ids` can be removed as the specs changed and it's no longer necessary
- `peppol_proxy_state` can be removed as it's no longer useful after `enable_peppol` was added
- SQL constraints need to be changed to only include active users. This allows users to deregister/migrate away from Peppol and then re-register later, with their previous edi user being archived



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
