### PR TITLE
[FIX] web: user_menu switch width

### DIFF
--- a/addons/web/static/src/core/checkbox/checkbox.scss
+++ b/addons/web/static/src/core/checkbox/checkbox.scss
@@ -1,3 +1,0 @@
-.o-checkbox {
-    width: fit-content;
-}

--- a/addons/web/static/src/core/checkbox/checkbox.xml
+++ b/addons/web/static/src/core/checkbox/checkbox.xml
@@ -6,7 +6,7 @@
         <input
             t-att-id="props.id or id"
             type="checkbox"
-            class="form-check-input"
+            class="form-check-input d-inline-block"
             t-att-disabled="props.disabled"
             t-att-checked="props.value"
             t-att-name="props.name"


### PR DESCRIPTION
=== ISSUE ===

Commit[1] introduced a change on the `width` property of the checkbox component.

It uses a `fit-content` width to avoid ticking a checkbox from far away. This causes a layout issue with the lightmode/darkmode switch which now overflows its label.

=== AFTER ===

We add a `w-auto` to that specific checkbox in order to preserve the diff introduced by commit[1] and fix the layout when needed.


commit[1]: 3cc9836400b89e09fe869b9d990ca678b0391f59

task-3439412
part of task-3326263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
