### PR TITLE
[FIX] mail: fix NotAllowedError from audio play in Firefox

### DIFF
--- a/addons/mail/static/src/core/out_of_focus_service.js
+++ b/addons/mail/static/src/core/out_of_focus_service.js
@@ -124,12 +124,10 @@ export class OutOfFocusService {
 
     async _playSound() {
         if (this.canPlayAudio && this.multiTab.isOnMainTab()) {
-            try {
-                await this.audio.play();
-            } catch {
+            return Promise.resolve(this.audio.play()).catch(() => {
                 // Ignore errors due to the user not having interracted
                 // with the page before playing the sound.
-            }
+            });
         }
     }
 

--- a/addons/mail/static/src/rtc/rtc_session_model.js
+++ b/addons/mail/static/src/rtc/rtc_session_model.js
@@ -90,12 +90,9 @@ export class RtcSession {
         if (!this.audioElement) {
             return;
         }
-        try {
-            await this.audioElement.play();
-            this.audioError = undefined;
-        } catch (error) {
-            this.audioError = error.name;
-        }
+        return Promise.resolve(this.audioElement.play())
+            .then(() => (this.audioError = undefined))
+            .catch((error) => (this.audioError = error));
     }
 
     async updateStats() {


### PR DESCRIPTION
Before this commit, when receiving a new message in a chat while the device is in sleep mode on Firefox, the browser could show the following traceback on waking up the device:

```
NotAllowedError: The play method is not allowed by the user agent
```

This happens because the page is reloaded, and autoplay is blocked by Firefox autoplay policies (which are different from Chrome and Webkit). When receiving a new message while device is sleeping, the odoo tab is not focused, so it attempts to play an audio alert. Since the autoplay is disabled, it shouldn't play the audio.

This commit fixes the issue by handling all `.play()` in the same way, with `Promise.resolve(audio.play()).catch(() => {})`, which is a pattern that should work for all problems in all conditions, whether autoplay is allowed or not.
