### PR TITLE
[FIX] mail: add activities in mail thread if model has activity_ids field

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -458,3 +458,9 @@ class MailActivityMixin(models.AbstractModel):
             return False
         self.activity_search(act_type_xmlids, user_id=user_id).unlink()
         return True
+
+    def _get_mail_thread_data(self, request_list):
+        res = super()._get_mail_thread_data(request_list)
+        if 'activities' in request_list:
+            res['activities'] = self.activity_ids.activity_format()
+        return res

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4172,8 +4172,6 @@ class MailThread(models.AbstractModel):
             res['hasWriteAccess'] = True
         except AccessError:
             pass
-        if 'activities' in request_list:
-            res['activities'] = self.activity_ids.activity_format()
         if 'attachments' in request_list:
             res['attachments'] = self._get_mail_thread_data_attachments()._attachment_format()
         if 'followers' in request_list:


### PR DESCRIPTION
When user call form mailing list contact and clicks on end call button traceback
will appear this is because mailing list contact not have activity_ids field.

Steps to reproduce the error:
- Install 'SMS Marketing' and 'Voip'
- Go to 'SMS Marketing' > Mailing Lists > Mailing Lists Contacts
- Open any record, add mobile number > call
- End the call

Traceback:
```
Traceback (most recent call last):
  File "/home/odoo/odoo/community/odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/odoo/community/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/odoo/community/odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/odoo/community/odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/odoo/community/addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(request.params)
  File "/home/odoo/odoo/community/odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, params_ok)
  File "/home/odoo/odoo/community/addons/mail/controllers/thread.py", line 14, in mail_thread_data
    return thread._get_mail_thread_data(request_list)
  File "/home/odoo/odoo/community/addons/mail/models/mail_thread.py", line 4148, in _get_mail_thread_data
    res['activities'] = self.activity_ids.activity_format()
AttributeError: 'mailing.contact' object has no attribute 'activity_ids'
```

sentry-4306579710
