### PR TITLE
[FIX] web: avoid monokai ace editors leaking memory in qunit suite

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -600,6 +600,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/lib/ace/mode-xml.js',
             'web/static/lib/ace/mode-js.js',
             'web/static/lib/ace/mode-qweb.js',
+            'web/static/lib/ace/theme-monokai.js',
             'web/static/lib/nearest/jquery.nearest.js',
             'web/static/lib/stacktracejs/stacktrace.js',
             'web/static/lib/Chart/Chart.js',


### PR DESCRIPTION
When attempting to instantiate an ace editor with a given theme, ace will first create the editor with the default theme (textmate) which is always loaded, and register a callback to be called after the non-default theme has been loaded. This callback holds a reference to the editor's renderer which can itself retain large objects such as an entire owl application. These callbacks are not cleared even if the corresponding editor is destroyed.

Because in tests, the theme "monokai" was not included and ace cannot load it on its own, all tests that attempt to create an ace editor with that theme will leak memory. This commit fixes the issue by adding theme-monokai to the qunit suite assets.

Enterprise: https://github.com/odoo/enterprise/pull/44594
