### PR TITLE
[FIX] stock,product_expiry: Add 'with_expiration' context to _get_ava…

### DIFF
--- a/addons/product_expiry/models/product_product.py
+++ b/addons/product_expiry/models/product_product.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class Product(models.Model):
@@ -18,6 +18,7 @@ class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     use_expiration_date = fields.Boolean(string='Use Expiration Date',
+        compute='_compute_use_expiration_date', readonly=False, store=True,
         help='When this box is ticked, you have the possibility to specify dates to manage'
         ' product expiration, on the product and on the corresponding lot/serial numbers')
     expiration_time = fields.Integer(string='Expiration Date',
@@ -33,3 +34,8 @@ class ProductTemplate(models.Model):
     alert_time = fields.Integer(string='Alert Date',
         help='Number of days before the Expiration Date after which an alert should be'
         ' raised on the lot/serial number. It will be computed on the lot/serial number.')
+
+    @api.depends('tracking')
+    def _compute_use_expiration_date(self):
+        for record in self:
+            record.use_expiration_date = record.use_expiration_date and record.tracking != 'none'

--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -76,3 +76,8 @@ class StockMove(models.Model):
         if self.product_id.use_expiration_date:
             return super(StockMove, self.with_context(with_expiration=self.date))._update_reserved_quantity(need, available_quantity, location_id, lot_id, package_id, owner_id, strict)
         return super()._update_reserved_quantity(need, available_quantity, location_id, lot_id, package_id, owner_id, strict)
+
+    def _get_available_quantity(self, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, allow_negative=False):
+        if self.product_id.use_expiration_date:
+            return super(StockMove, self.with_context(with_expiration=self.date))._get_available_quantity(location_id, lot_id, package_id, owner_id, strict, allow_negative)
+        return super()._get_available_quantity(location_id, lot_id, package_id, owner_id, strict, allow_negative)

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -707,7 +707,7 @@ class StockQuant(models.Model):
             domain = expression.AND([[('owner_id', '=', owner_id and owner_id.id or False)], domain])
             domain = expression.AND([[('location_id', '=', location_id.id)], domain])
         if self.env.context.get('with_expiration'):
-            domain = expression.AND([[('expiration_date', '>=', self.env.context['with_expiration'])], domain])
+            domain = expression.AND([['|', ('expiration_date', '>=', self.env.context['with_expiration']), ('expiration_date', '=', False)], domain])
         return domain
 
     def _gather(self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, qty=0):


### PR DESCRIPTION
…ilable_quantity

This commit fix 3 issues with the reservation with use_expiration_date set on the product:

1) -- Discrepancy of available_quantity --
StockMove._update_reserved_quantity() works along StockMove._get_available_quantity() If the with_expiration context is added to one and not the other, the available_quantity sent to the 'update' method will not be correct.

2) -- Can't reserve on imperishable quants --
On the Quant, if expiration_date is False, the reservation will not be possible. Changed the domain from `expiration_date >= date` to `expiration is False or expiration_date >= date`

3) -- Expiration Date on untracked products --
On the Product Template form, you can:
 - set tracking to 'lot'
 - activate 'Use Expiration Date'
 - set tracking to 'none'
Resulting in the configuration `tracking: 'none', use_expiration_date: True` which is not supported.

---

# How to Reproduce
 - Create a product P, tracked by lot, with use_expiration_date = True
 - Set quantity on hand to 10 (without lot)
 - Create a Sale Order for 1 unit of P: Confirm
 - On the Delivery, 'Check Availability' (if not done automatically) => The Transfer is marked as Ready (aka: at least 1 unit reserved), but nothing is reserved. => If you Unreserve, the product availability is shown as Available, and if your Reserve again, it is shown as 'Not Available'

 OPW-3434996

---

BEFORE:
https://watch.screencastify.com/v/MS5nZfVYHuHfB2GHuTD6
- State of picking not correct when it can't reserve
- Can't reserve even when expiration_date is not set

AFTER:
https://watch.screencastify.com/v/gIwvZTKPrfCU906FttAR
- The picking can reserve when expiration_date is not set
- The state is correct when the picking can't reserve

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
