### PR TITLE
[FIX] base_import_module: Change logger to warning

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -179,7 +179,7 @@ class IrModule(models.Model):
                         if self._import_module(mod_name, path, force=force):
                             success.append(mod_name)
                     except Exception as e:
-                        _logger.exception('Error while importing module')
+                        _logger.warning('Error while importing module')
                         errors[mod_name] = exception_to_unicode(e)
         r = ["Successfully imported module '%s'" % mod for mod in success]
         for mod, error in errors.items():


### PR DESCRIPTION
When a user imports a custom module that contains an error,
 an exception type logger is raised, but this is not blocking
since it is not an error in the codebase

sentry-4199413810