### PR TITLE
[IMP] point_of_sale: sub-template created and rendered in main component

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
+++ b/addons/l10n_fr_pos_cert/static/src/xml/OrderReceipt.xml
@@ -9,8 +9,8 @@
         </xpath>
     </t>
 
-    <t t-name="l10n_fr_pos_cert.OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension">
-        <xpath expr="//div[@t-foreach='receipt.orderlines']" position="inside">
+    <t t-name="l10n_fr_pos_cert.ReceiptOrderline" t-inherit="point_of_sale.ReceiptOrderline" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='line.pack_lot_lines']" position="after">
             <t t-if="receipt.l10n_fr_hash !== false and line.price_type === 'manual'">
                 <div class="pos-receipt-right-padding">
                     Old unit price:

--- a/addons/l10n_gcc_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -90,7 +90,7 @@
         </xpath>
     </t>
 
-    <t t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension">
+    <t t-inherit="point_of_sale.ReceiptOrderline" t-inherit-mode="extension">
         <xpath expr="//t[@t-esc='line.unit_name']/.." position="attributes">
             <attribute name="t-if">!receipt.is_gcc_country</attribute>
         </xpath>

--- a/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
@@ -17,8 +17,8 @@
         </xpath>
     </t>
 
-    <t t-name="l10n_in_pos.OrderLinesReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension">
-        <xpath expr="//div[@t-foreach='receipt.orderlines']" position="inside">
+    <t t-name="l10n_in_pos.ReceiptOrderline" t-inherit="point_of_sale.ReceiptOrderline" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='line.pack_lot_lines']" position="after">
             <t t-if="line.l10n_in_hsn_code and pos.company.country and pos.company.country.code == 'IN'">
                 <div class="pos-receipt-left-padding">
                     <span>HSN Code: </span>

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt.xml
@@ -44,7 +44,9 @@
             <!-- Orderlines -->
 
             <div class="orderlines">
-                <t t-call="point_of_sale.OrderLinesReceipt"/>
+                <div t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
+                    <t t-call="point_of_sale.ReceiptOrderline"/>
+                </div>
             </div>
 
             <!-- Subtotal -->
@@ -185,59 +187,57 @@
             </div>
         </div>
     </t>
-    <t t-name="point_of_sale.OrderLinesReceipt">
-        <div t-foreach="receipt.orderlines" t-as="line" t-key="line.id">
-            <div t-esc="line.product_name_wrapped[0]" />
-            <WrappedProductNameLines line="line" />
-            <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
-                <div class="pos-receipt-left-padding">
-                    <t t-esc="env.utils.formatCurrency(line.price_lst, false)" />
-                    ->
-                    <t t-esc="env.utils.formatCurrency(line.price, false)" />
-                </div>
-            </t>
-            <t t-elif="line.discount !== 0">
-                <div class="pos-receipt-left-padding">
-                    <t t-if="pos.config.iface_tax_included === 'total'">
-                        <t t-esc="env.utils.formatCurrency(line.price_with_tax_before_discount, false)"/>
-                    </t>
-                    <t t-else="">
-                        <t t-esc="env.utils.formatCurrency(line.price, false)"/>
-                    </t>
-                </div>
-            </t>
-            <t t-if="line.discount !== 0">
-                <div class="pos-receipt-left-padding">
-                    Discount: <t t-esc="line.discount" />%
-                </div>
-            </t>
+    <t t-name="point_of_sale.ReceiptOrderline">
+        <div t-esc="line.product_name_wrapped[0]" />
+        <WrappedProductNameLines line="line" />
+        <t t-if="line.display_discount_policy == 'without_discount' and line.price != line.price_lst">
             <div class="pos-receipt-left-padding">
-                <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
-                <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
-                x
-                <t t-esc="env.utils.formatCurrency(line.price_display_one)" />
-                <div class="price_display pos-receipt-right-align">
-                    <span t-esc="env.utils.formatCurrency(line.price_display, false)" />
-                    <span t-esc="getTaxLetter(...getOrderlineTaxes(line))" class="tax-letter" /> 
-                </div>
+                <t t-esc="env.utils.formatCurrency(line.price_lst, false)" />
+                ->
+                <t t-esc="env.utils.formatCurrency(line.price, false)" />
             </div>
-            <t t-if="line.customer_note">
-                <div class="pos-receipt-left-padding pos-receipt-customer-note">
-                    <t t-esc="line.customer_note"/>
-                </div>
-            </t>
-            <t t-if="line.pack_lot_lines">
-                <div class="pos-receipt-left-padding">
-                    <ul>
-                        <t t-foreach="line.pack_lot_lines" t-as="lot" t-key="lot.cid">
-                            <li>
-                                SN <t t-esc="lot.lot_name"/>
-                            </li>
-                        </t>
-                    </ul>
-                </div>
-            </t>
+        </t>
+        <t t-elif="line.discount !== 0">
+            <div class="pos-receipt-left-padding">
+                <t t-if="pos.config.iface_tax_included === 'total'">
+                    <t t-esc="env.utils.formatCurrency(line.price_with_tax_before_discount, false)"/>
+                </t>
+                <t t-else="">
+                    <t t-esc="env.utils.formatCurrency(line.price, false)"/>
+                </t>
+            </div>
+        </t>
+        <t t-if="line.discount !== 0">
+            <div class="pos-receipt-left-padding">
+                Discount: <t t-esc="line.discount" />%
+            </div>
+        </t>
+        <div class="pos-receipt-left-padding">
+            <t t-esc="Math.round(line.quantity * Math.pow(10, pos.dp['Product Unit of Measure'])) / Math.pow(10, pos.dp['Product Unit of Measure'])"/>
+            <t t-if="!line.is_in_unit" t-esc="line.unit_name" />
+            x
+            <t t-esc="env.utils.formatCurrency(line.price_display_one)" />
+            <div class="price_display pos-receipt-right-align">
+                <span t-esc="env.utils.formatCurrency(line.price_display, false)" />
+                <span t-esc="getTaxLetter(...getOrderlineTaxes(line))" class="tax-letter" />
+            </div>
         </div>
+        <t t-if="line.customer_note">
+            <div class="pos-receipt-left-padding pos-receipt-customer-note">
+                <t t-esc="line.customer_note"/>
+            </div>
+        </t>
+        <t t-if="line.pack_lot_lines">
+            <div class="pos-receipt-left-padding">
+                <ul>
+                    <t t-foreach="line.pack_lot_lines" t-as="lot" t-key="lot.cid">
+                        <li>
+                            SN <t t-esc="lot.lot_name"/>
+                        </li>
+                    </t>
+                </ul>
+            </div>
+        </t>
     </t>
 
 </templates>

--- a/addons/pos_sale/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_sale/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_sale.OrderReceipt" t-inherit="point_of_sale.OrderLinesReceipt" t-inherit-mode="extension">
-        <xpath expr="//t[@t-foreach]" position="inside">
+    <t t-name="pos_sale.ReceiptOrderline" t-inherit="point_of_sale.ReceiptOrderline" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='line.pack_lot_lines']" position="after">
             <div class="pos-receipt-left-padding" t-if="line.so_reference">From <t t-esc="line.so_reference"/></div>
             <div class="pos-receipt-left-padding" t-if="line.down_payment_details">
                 <table class="sale-order-info ms-2 text-truncate">


### PR DESCRIPTION
in this commit
==============
created a sub-template named "ReceiptOrderline" to hold the content of the t-foreach loop. This sub-template is then integrated into the main receipt component

task - 3436764