### PR TITLE
[FIX] base: check compatibility between context *_view_ref and the model where the get_view is called

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2592,7 +2592,9 @@ class Model(models.AbstractModel):
                     self._cr.execute(query, (module, view_ref))
                     view_ref_res = self._cr.fetchone()
                     if view_ref_res:
-                        view_id = view_ref_res[0]
+                        view = View.browse(view_ref_res[0])
+                        if view.model == self._name:
+                            view_id = view_ref_res[0]
                 else:
                     _logger.warning(
                         '%r requires a fully-qualified external id (got: %r for model %s). '


### PR DESCRIPTION
### Before this PR
If there is in the context a *_view_ref , if is called a get_view on a different model in the same env, the context is shared and passed to get_view. This results on getting a view that is of a different model and not compatible with the model where  are looking for views. 

### After this PR
If a *_view_ref is passed in the context, i check that the model of the ir_ui_view is the same of the model where i have called the get_views 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
