### PR TITLE
[IMP] web, mail: command palette improvements

### DIFF
--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -15,48 +15,49 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { browser } from "@web/core/browser/browser";
 import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 
-const WithUserChatter = (T) => class extends T {
-    setup() {
-        super.setup(...arguments);
-        this.openChat = useOpenChat(this.relation);
-        if (this.props.withCommand) {
-            useAssignUserCommand();
-        }
-        this.avatarCard = usePopover(AvatarCardPopover, {
-            closeOnHoverAway: true,
-        });
-        this.openTimeout = false;
-    }
-
-    onClickAvatar() {
-        const id = this.props.record.data[this.props.name][0] ?? false;
-        if (id !== false) {
-            this.openChat(id);
-        }
-    }
-
-    openCard(ev) {
-        if (this.env.isSmall || this.relation !== "res.users") {
-            return;
-        }
-        const target = ev.currentTarget;
-        if (!target.querySelector(":scope > img")) {
-            return;
-        }
-        this.openTimeout = browser.setTimeout(() => {
-            if (!this.avatarCard.isOpen) {
-                this.avatarCard.open(target, {
-                    id: this.props.record.data[this.props.name][0],
-                });
+const WithUserChatter = (T) =>
+    class extends T {
+        setup() {
+            super.setup(...arguments);
+            this.openChat = useOpenChat(this.relation);
+            if (this.props.withCommand) {
+                useAssignUserCommand();
             }
-        }, 350);
-    }
+            this.avatarCard = usePopover(AvatarCardPopover, {
+                closeOnHoverAway: true,
+            });
+            this.openTimeout = false;
+        }
 
-    clearTimeout() {
-        browser.clearTimeout(this.openTimeout);
-        delete this.openTimeout;
-    }
-};
+        onClickAvatar() {
+            const id = this.props.record.data[this.props.name][0] ?? false;
+            if (id !== false) {
+                this.openChat(id);
+            }
+        }
+
+        openCard(ev) {
+            if (this.env.isSmall || this.relation !== "res.users") {
+                return;
+            }
+            const target = ev.currentTarget;
+            if (!target.querySelector(":scope > img")) {
+                return;
+            }
+            this.openTimeout = browser.setTimeout(() => {
+                if (!this.avatarCard.isOpen) {
+                    this.avatarCard.open(target, {
+                        id: this.props.record.data[this.props.name][0],
+                    });
+                }
+            }, 350);
+        }
+
+        clearTimeout() {
+            browser.clearTimeout(this.openTimeout);
+            delete this.openTimeout;
+        }
+    };
 
 export class Many2OneAvatarUserField extends WithUserChatter(Many2OneAvatarField) {
     static template = "mail.Many2OneAvatarUserField";
@@ -76,7 +77,7 @@ export const many2OneAvatarUserField = {
         const props = many2OneAvatarField.extractProps(...arguments);
         props.context = fieldInfo.context;
         props.domain = dynamicInfo.domain;
-        props.withCommand = fieldInfo.viewType === "form";
+        props.withCommand = fieldInfo.viewType === "form" || fieldInfo.viewType === "list";
         return props;
     },
 };

--- a/addons/mail/static/tests/discuss_app/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss_app/sidebar_tests.js
@@ -799,7 +799,7 @@ QUnit.test("chat - states: open manually by clicking the title", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
-    await contains("button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
 });
 
 QUnit.test("chat - states: close should call update server data", async (assert) => {
@@ -870,7 +870,7 @@ QUnit.test("chat - states: close from the bus", async () => {
         },
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains("button", { count: 0, text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
 });
 
 QUnit.test("chat - states: open from the bus", async () => {
@@ -889,7 +889,7 @@ QUnit.test("chat - states: open from the bus", async () => {
         },
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains("button", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
 });
 
 QUnit.test(
@@ -900,18 +900,18 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss();
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-        await contains("button", { text: "Mitchell Admin" });
+        await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
 
-        await click("button", { text: "Mitchell Admin" });
+        await click(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
         await contains("button:contains(Mitchell Admin).o-active");
 
         await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-        await contains("button", { text: "Mitchell Admin" });
+        await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
 
         await click("button div", { text: "Inbox" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-        await contains("button", { count: 0, text: "Mitchell Admin" });
+        await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
     }
 );
 

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -215,6 +215,7 @@ async function start(param0 = {}) {
             uid: pyEnv.currentUserId,
         },
         uid: pyEnv.currentUserId,
+        name: pyEnv.currentUser?.name,
         partner_id: pyEnv.currentPartnerId,
     });
     if (browser.Notification && !browser.Notification.isPatched) {

--- a/addons/web/static/src/core/commands/command_category.js
+++ b/addons/web/static/src/core/commands/command_category.js
@@ -7,7 +7,7 @@ commandCategoryRegistry
     .add("app", {}, { sequence: 10 })
     .add("smart_action", {}, { sequence: 15 })
     .add("actions", {}, { sequence: 30 })
-    .add("navbar", {}, { sequence: 40 })
-    .add("view_switcher", {}, { sequence: 50 })
-    .add("default", {}, { sequence: 100 })
-    .add("debug", {}, { sequence: 110 });
+    .add("default", {}, { sequence: 50 })
+    .add("view_switcher", {}, { sequence: 100 })
+    .add("debug", {}, { sequence: 110 })
+    .add("disabled", {});

--- a/addons/web/static/src/core/commands/command_service.js
+++ b/addons/web/static/src/core/commands/command_service.js
@@ -170,8 +170,24 @@ export const commandService = {
             if (!command.name || !command.action || typeof command.action !== "function") {
                 throw new Error("A Command must have a name and an action function.");
             }
-
             const registration = Object.assign({}, command, options);
+            if (registration.identifier) {
+                const commandsArray = Array.from(registeredCommands.values());
+                const sameName = commandsArray.find((com) => com.name === registration.name);
+                if (sameName) {
+                    if (registration.identifier !== sameName.identifier) {
+                        registration.name += ` (${registration.identifier})`;
+                        sameName.name += ` (${sameName.identifier})`;
+                    }
+                } else {
+                    const sameFullName = commandsArray.find(
+                        (com) => com.name === registration.name + `(${registration.identifier})`
+                    );
+                    if (sameFullName) {
+                        registration.name += ` (${registration.identifier})`;
+                    }
+                }
+            }
             if (registration.hotkey) {
                 const action = async () => {
                     const commandService = env.services.command;

--- a/addons/web/static/src/core/commands/default_providers.js
+++ b/addons/web/static/src/core/commands/default_providers.js
@@ -47,8 +47,14 @@ commandProviderRegistry.add("command", {
                 return cmd;
             })
             .filter((command) => command.isAvailable === undefined || command.isAvailable());
-
-        return commands.map((command) => ({
+        // Filter out same category dupplicate commands
+        const uniqueCommands = commands.filter((obj, index) => {
+            return (
+                index ===
+                commands.findIndex((o) => obj.name === o.name && obj.category === o.category)
+            );
+        });
+        return uniqueCommands.map((command) => ({
             Component: command.hotkey ? HotkeyCommandItem : DefaultCommandItem,
             action: command.action,
             category: command.category,
@@ -72,6 +78,9 @@ commandProviderRegistry.add("data-hotkeys", {
         )) {
             const closest = el.closest("[data-command-category]");
             const category = closest ? closest.dataset.commandCategory : "default";
+            if (category === "disabled") {
+                continue;
+            }
 
             const description =
                 el.title ||

--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -174,7 +174,8 @@ export const hotkeyService = {
             // NB: except for ESC, which is always allowed as hotkey in editables.
             const targetIsEditable =
                 event.target instanceof HTMLElement &&
-                (/input|textarea/i.test(event.target.tagName) || event.target.isContentEditable);
+                (/input|textarea/i.test(event.target.tagName) || event.target.isContentEditable) &&
+                !event.target.matches("input[type=checkbox], input[type=radio]");
             const shouldProtectEditable =
                 targetIsEditable && !event.target.dataset.allowHotkeys && singleKey !== "escape";
 

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -336,6 +336,13 @@ export class StaticList extends DataPoint {
         });
     }
 
+    unlinkFrom(resId, serverData) {
+        return this.model.mutex.exec(async () => {
+            await this._applyCommands([[x2ManyCommands.UNLINK, resId, serverData]]);
+            await this._onUpdate();
+        });
+    }
+
     load({ limit, offset, orderBy } = {}) {
         return this.model.mutex.exec(async () => {
             if (this.editedRecord && !(await this.editedRecord.checkValidity())) {

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ControlPanel">
-        <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" t-ref="root">
+        <div class="o_control_panel d-flex flex-column gap-3 gap-lg-1 px-3 pt-2 pb-3" t-ref="root" data-command-category="actions">
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -33,7 +33,7 @@ export const many2ManyTagsAvatarField = {
     component: Many2ManyTagsAvatarField,
     extractProps({ viewType }, dynamicInfo) {
         const props = many2ManyTagsField.extractProps(...arguments);
-        props.withCommand = viewType === "form";
+        props.withCommand = viewType === "form" || viewType === "list";
         props.domain = dynamicInfo.domain;
         return props;
     },

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -574,7 +574,11 @@ export class ListController extends Component {
                 const dialogProps = {
                     confirm: () => resolve(true),
                     cancel: () => {
-                        this.model.root.leaveEditMode({ discard: true });
+                        if (this.model.root.editedRecord) {
+                            this.model.root.leaveEditMode({ discard: true });
+                        } else {
+                            editedRecord.discard();
+                        }
                         resolve(false);
                     },
                     isDomainSelected,

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -5,7 +5,7 @@
     <header class="o_navbar" t-ref="root">
       <nav
         class="o_main_navbar"
-        data-command-category="navbar"
+        data-command-category="disabled"
       >
         <!-- Apps Menu -->
         <t t-call="web.NavBar.AppsMenu">


### PR DESCRIPTION
This commit applies several modifications to the command palette:
- The list of menus for the current app is now hidden in the command palette
- The assign user commands of the palette are now available in list view when multi-edit is supported and a mechanism to avoid command duplication has been implemented so that if several fields use the same command, it will be displayed with an identifier in the palette and the commands won't overlap
- The "View switcher" command category is moved to second last position of the command categories

task-3235223