### PR TITLE
[FIX] l10n_sa_edi: download EDI document in invoice

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -457,7 +457,7 @@ class AccountEdiFormat(models.Model):
         doc = invoice.edi_document_ids.filtered(lambda d: d.edi_format_id.code == 'sa_zatca' and d.state == 'sent')
         if doc is not None and doc.attachment_id.datas:
             return {invoice: {'xml_file': doc.attachment_id.datas.decode()}}
-        return {invoice: {'xml_file': self._l10n_sa_generate_zatca_template(invoice)}}
+        return self._l10n_sa_generate_zatca_template(invoice).encode()
 
     def _get_move_applicability(self, move):
         # EXTENDS account_edi


### PR DESCRIPTION
When user create a new invoice and then process it, if server returns an
unexpected error and user download the EDI Document.
a traceback will appear.

Steps to reproduce the error:
- Install ```l10n_sa``` and ```l10n_sa_edi```
- Switch to SA Company.
- Create New Invoice > Select Customer who has parent company
  (ex. Azure Interior, Brandon Freeman) > Add Invoice Lines
- Confirm > Process now
- Go to EDI Documents > Download

Traceback:
```
KeyError: 1
  File "odoo/api.py", line 959, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'account.edi.document(1,).edi_content'
  File "odoo/fields.py", line 1158, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 966, in get
    raise CacheMiss(record, field)
TypeError: a bytes-like object is required, not 'dict'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/binary.py", line 75, in content_common
    stream = request.env['ir.binary']._get_stream_from(record, field, filename, filename_field, mimetype)
  File "odoo/addons/base/models/ir_binary.py", line 129, in _get_stream_from
    stream = self._record_to_stream(record, field_name)
  File "home/odoo/src/enterprise/saas-16.3/documents/models/ir_binary.py", line 13, in _record_to_stream
    return super()._record_to_stream(record, field_name)
  File "odoo/addons/base/models/ir_binary.py", line 80, in _record_to_stream
    return Stream.from_binary_field(record, field_name)
  File "odoo/http.py", line 526, in from_binary_field
    data_b64 = record[field_name]
  File "odoo/models.py", line 6131, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1209, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 2358, in compute_value
    super().compute_value(records)
  File "odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4491, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "addons/account_edi/models/account_edi_document.py", line 62, in _compute_edi_content
    res = base64.b64encode(move_applicability['edi_content'](move))
  File "base64.py", line 58, in b64encode
    encoded = binascii.b2a_base64(s, newline=False)
```

https://github.com/odoo/odoo/blob/08f2ed7a132b8df4cc6c1863b9cc1e75ab4ddf32/addons/account_edi/models/account_edi_document.py#L62 Here, when user download EDI Document,
it will get ```move_applicability['edi_content'](move)``` as dictionary.
So it will lead to above traceback.

sentry-4312719182

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
