### PR TITLE
[FIX] tests: better running test detection

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -516,7 +516,7 @@ class AccountMoveSend(models.Model):
         :return: True if commit is accepted, False otherwise.
         """
         self.ensure_one()
-        return not tools.config['test_enable'] and not modules.module.current_test
+        return not modules.loading.running_test
 
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # TO OVERRIDE

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -133,7 +133,7 @@ class ResConfigSettings(models.TransientModel):
         # the client side is rolled back and the edi user is deleted on the client side
         # but remains on the proxy side.
         # it is important to keep these two in sync, so commit before activating.
-        if not tools.config['test_enable'] and not modules.module.current_test:
+        if not modules.loading.running_test:
             self.env.cr.commit()
 
         company_details = {

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -3,14 +3,13 @@
 
 import logging
 import pytz
-import threading
 from ast import literal_eval
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
 from markupsafe import Markup, escape
 from psycopg2 import sql
 
-from odoo import api, fields, models, tools, SUPERUSER_ID
+from odoo import api, fields, models, tools, SUPERUSER_ID, modules
 from odoo.addons.iap.tools import iap_tools
 from odoo.addons.mail.tools import mail_validation
 from odoo.addons.phone_validation.tools import phone_validation
@@ -2322,7 +2321,7 @@ class Lead(models.Model):
         # - avoid blocking the table for too long with a too big transaction
         transactions_count, transactions_failed_count = 0, 0
         cron_update_lead_start_date = datetime.now()
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.loading.running_test
         self.flush_model()
         for probability, probability_lead_ids in probability_leads.items():
             for lead_ids_current in tools.split_every(PLS_UPDATE_BATCH_STEP, probability_lead_ids):

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -4,12 +4,11 @@
 import datetime
 import logging
 import random
-import threading
 
 from ast import literal_eval
 from markupsafe import Markup
 
-from odoo import api, exceptions, fields, models, _
+from odoo import api, exceptions, fields, models, _, modules
 from odoo.osv import expression
 from odoo.tools import float_compare, float_round
 from odoo.tools.safe_eval import safe_eval
@@ -448,7 +447,7 @@ class Team(models.Model):
 
         BUNDLE_HOURS_DELAY = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.delay', default=0))
         BUNDLE_COMMIT_SIZE = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.commit.bundle', 100))
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.loading.running_test
 
         # leads
         max_create_dt = self.env.cr.now() - datetime.timedelta(hours=BUNDLE_HOURS_DELAY)

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -3,13 +3,11 @@
 
 import datetime
 import logging
-import math
-import threading
 import random
 
 from ast import literal_eval
 
-from odoo import api, exceptions, fields, models, _
+from odoo import api, exceptions, fields, models, _, modules
 from odoo.osv import expression
 
 _logger = logging.getLogger(__name__)
@@ -154,7 +152,7 @@ class TeamMember(models.Model):
         leads_done_ids = set()
         counter = 0
         # auto-commit except in testing mode
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.loading.running_test
         commit_bundle_size = int(self.env['ir.config_parameter'].sudo().get_param('crm.assignment.commit.bundle', 100))
         while population and any(weights):
             counter += 1

--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -3,13 +3,12 @@
 
 import logging
 import random
-import threading
 
 from collections import namedtuple
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models, tools
+from odoo import api, fields, models, modules
 from odoo.tools import exception_to_unicode
 from odoo.tools.translate import _
 from odoo.exceptions import MissingError, ValidationError
@@ -272,7 +271,7 @@ You receive this email because you are:
                 self.env.invalidate_all()
                 self._warn_template_error(scheduler, e)
             else:
-                if autocommit and not getattr(threading.current_thread(), 'testing', False):
+                if autocommit and not modules.loading.running_test:
                     self.env.cr.commit()
         return True
 

--- a/addons/hr/models/res_config_settings.py
+++ b/addons/hr/models/res_config_settings.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import threading
-from odoo import fields, models, api, _
+from odoo import fields, models, api, _, modules
 from odoo.exceptions import ValidationError
 
 
@@ -24,7 +23,7 @@ class ResConfigSettings(models.TransientModel):
 
     @api.constrains('module_hr_presence', 'hr_presence_control_email', 'hr_presence_control_ip')
     def _check_advanced_presence(self):
-        test_mode = self.env.registry.in_test_mode() or getattr(threading.current_thread(), 'testing', False)
+        test_mode = modules.loading.running_test
         if self.env.context.get('install_mode', False) or test_mode:
             return
 

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import threading
-
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models, _, modules
 from odoo.exceptions import ValidationError
 
 from odoo.osv import expression
@@ -216,7 +214,7 @@ class Contract(models.Model):
 
     def _safe_write_for_cron(self, vals, from_cron=False):
         if from_cron:
-            auto_commit = not getattr(threading.current_thread(), 'testing', False)
+            auto_commit = not modules.loading.running_test
             for contract in self:
                 try:
                     with self.env.cr.savepoint():

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -6,7 +6,7 @@ import threading
 import uuid
 import werkzeug.urls
 
-from odoo import api, fields, models
+from odoo import api, fields, models, modules
 from odoo.addons.iap.tools import iap_tools
 
 _logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ class IapAccount(models.Model):
                 IapAccount.search(domain + [('account_token', '=', False)]).sudo().unlink()
                 accounts = accounts - accounts_without_token
         if not accounts:
-            if hasattr(threading.current_thread(), 'testing') and threading.current_thread().testing:
+            if modules.loading.running_test:
                 # During testing, we don't want to commit the creation of a new IAP account to the database
                 return self.create({'service_name': service_name})
 

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -8,7 +8,7 @@ import requests
 import threading
 import uuid
 
-from odoo import exceptions, _
+from odoo import exceptions, _, modules
 from odoo.tools import email_normalize, pycompat
 
 _logger = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ def iap_jsonrpc(url, method='call', params=None, timeout=15):
     Calls the provided JSON-RPC endpoint, unwraps the result and
     returns JSON-RPC errors as exceptions.
     """
-    if hasattr(threading.current_thread(), 'testing') and threading.current_thread().testing:
+    if modules.loading.running_test:
         raise exceptions.AccessError("Unavailable during tests.")
 
     payload = {

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -7,14 +7,13 @@ import datetime
 import logging
 import psycopg2
 import smtplib
-import threading
 import re
 import pytz
 
 from collections import defaultdict
 from dateutil.parser import parse
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, modules
 from odoo import tools
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 
@@ -229,7 +228,7 @@ class MailMail(models.Model):
         res = None
         try:
             # auto-commit except in testing mode
-            auto_commit = not getattr(threading.current_thread(), 'testing', False)
+            auto_commit = not modules.loading.running_test
             res = self.browse(ids).send(auto_commit=auto_commit)
         except Exception:
             _logger.exception("Failed processing mail queue")

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -15,7 +15,6 @@ import logging
 import pytz
 import re
 import time
-import threading
 
 from collections import namedtuple
 from email.message import EmailMessage
@@ -25,7 +24,7 @@ from werkzeug import urls
 from xmlrpc import client as xmlrpclib
 from markupsafe import Markup, escape
 
-from odoo import _, api, exceptions, fields, models, tools, registry, SUPERUSER_ID, Command
+from odoo import _, api, exceptions, fields, models, tools, registry, SUPERUSER_ID, Command, modules
 from odoo.exceptions import MissingError, AccessError
 from odoo.osv import expression
 from odoo.tools import is_html_empty, html_escape, html2plaintext
@@ -3139,7 +3138,7 @@ class MailThread(models.AbstractModel):
         #   2. do not send emails immediately if the registry is not loaded,
         #      to prevent sending email during a simple update of the database
         #      using the command-line.
-        test_mode = getattr(threading.current_thread(), 'testing', False)
+        test_mode = modules.loading.running_test
         force_send = self.env.context.get('mail_notify_force_send', force_send)
         if force_send and len(emails) < recipients_max and (not self.pool._init or test_mode):
             # unless asked specifically, send emails after the transaction to

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -10,7 +10,6 @@ import lxml
 import random
 import re
 import requests
-import threading
 import werkzeug.urls
 from ast import literal_eval
 from dateutil.relativedelta import relativedelta
@@ -18,7 +17,7 @@ from markupsafe import Markup
 from werkzeug.urls import url_join
 from PIL import Image, UnidentifiedImageError
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, _, modules
 from odoo.addons.base_import.models.base_import import ImportValidationError
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
@@ -1107,7 +1106,7 @@ class MassMailing(models.Model):
 
             # auto-commit except in testing mode
             composer._action_send_mail(
-                auto_commit=not getattr(threading.current_thread(), 'testing', False)
+                auto_commit=not modules.loading.running_test,
             )
             mailing.write({
                 'state': 'done',

--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -3,10 +3,9 @@
 
 import json
 import logging
-import threading
 
 from odoo.addons.iap.tools import iap_tools
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, _, modules
 
 _logger = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class ResCompany(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
-        if not getattr(threading.current_thread(), 'testing', False):
+        if not modules.loading.running_test:
             res.iap_enrich_auto()
         return res
 

--- a/addons/sale_timesheet/models/product.py
+++ b/addons/sale_timesheet/models/product.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import threading
-
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, _, modules
 from odoo.exceptions import ValidationError
 
 
@@ -114,7 +112,7 @@ class ProductTemplate(models.Model):
 
     def write(self, vals):
         # timesheet product can't be archived
-        test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
+        test_mode = modules.loading.running_test
         if not test_mode and 'active' in vals and not vals['active']:
             time_product = self.env.ref('sale_timesheet.time_product')
             if time_product.product_tmpl_id in self:
@@ -163,7 +161,7 @@ class ProductProduct(models.Model):
 
     def write(self, vals):
         # timesheet product can't be archived
-        test_mode = getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()
+        test_mode = modules.loading.running_test
         if not test_mode and 'active' in vals and not vals['active']:
             time_product = self.env.ref('sale_timesheet.time_product')
             if time_product in self:

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -2,9 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import threading
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, _, modules
 
 _logger = logging.getLogger(__name__)
 
@@ -96,7 +95,7 @@ class SmsSms(models.Model):
         for batch_ids in self._split_batch():
             self.browse(batch_ids)._send(unlink_failed=unlink_failed, unlink_sent=unlink_sent, raise_exception=raise_exception)
             # auto-commit if asked except in testing mode
-            if auto_commit is True and not getattr(threading.current_thread(), 'testing', False):
+            if auto_commit is True and not modules.loading.running_test:
                 self._cr.commit()
 
     def resend_failed(self):
@@ -145,7 +144,7 @@ class SmsSms(models.Model):
         res = None
         try:
             # auto-commit except in testing mode
-            auto_commit = not getattr(threading.current_thread(), 'testing', False)
+            auto_commit = not modules.loading.running_test
             res = self.browse(ids).send(unlink_failed=False, unlink_sent=True, auto_commit=auto_commit, raise_exception=False)
         except Exception:
             _logger.exception("Failed processing SMS queue")

--- a/addons/stock_sms/models/stock_picking.py
+++ b/addons/stock_sms/models/stock_picking.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
-
-import threading
+from odoo import models, _, modules
 
 
 class Picking(models.Model):
@@ -23,7 +21,7 @@ class Picking(models.Model):
             is_delivery = picking.company_id.stock_move_sms_validation \
                     and picking.picking_type_id.code == 'outgoing' \
                     and (picking.partner_id.mobile or picking.partner_id.phone)
-            if is_delivery and not getattr(threading.current_thread(), 'testing', False) \
+            if is_delivery and not modules.loading.running_test \
                     and not self.env.registry.in_test_mode() \
                     and not picking.company_id.has_received_warning_stock_sms \
                     and picking.company_id.stock_move_sms_validation:
@@ -55,7 +53,7 @@ class Picking(models.Model):
 
     def _send_confirmation_email(self):
         super(Picking, self)._send_confirmation_email()
-        if not self.env.context.get('skip_sms') and not getattr(threading.current_thread(), 'testing', False) and not self.env.registry.in_test_mode():
+        if not self.env.context.get('skip_sms') and not modules.loading.running_test:
             pickings = self.filtered(lambda p: p.company_id.stock_move_sms_validation and p.picking_type_id.code == 'outgoing' and (p.partner_id.mobile or p.partner_id.phone))
             for picking in pickings:
                 # Sudo as the user has not always the right to read this sms template.

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -57,11 +57,6 @@ class Session(http.Controller):
         except Exception as e:
             return {"error": e, "title": _("Languages")}
 
-    @http.route('/web/session/modules', type='json', auth="user")
-    def modules(self):
-        # return all installed modules. Web client is smart enough to not load a module twice
-        return list(request.env.registry._init_modules.union([module.current_test] if module.current_test else []))
-
     @http.route('/web/session/check', type='json', auth="user")
     def check(self):
         return  # ir.http@_authenticate does the job

--- a/addons/web/tests/test_session_info.py
+++ b/addons/web/tests/test_session_info.py
@@ -59,9 +59,3 @@ class TestSessionInfo(common.HttpCase):
             result['user_companies'],
             expected_user_companies,
             "The session_info['user_companies'] does not have the expected structure")
-
-    def test_session_modules(self):
-        self.authenticate(self.user.login, self.user_password)
-        response = self.url_open("/web/session/modules", data=self.payload, headers=self.headers)
-        data = response.json()
-        self.assertTrue(isinstance(data['result'], list))

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -2,8 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import threading
-from odoo import api, fields, models
+from odoo import api, fields, models, modules
 from odoo.tools.translate import xml_translate
 from odoo.modules.module import get_resource_from_path
 
@@ -371,7 +370,7 @@ class IrUiView(models.Model):
         # During a theme module update, theme views' copies receiving an arch
         # update should not be considered as `arch_updated`, as this is not a
         # user made change.
-        test_mode = getattr(threading.current_thread(), 'testing', False)
+        test_mode = modules.loading.running_test
         if not (test_mode or self.pool._init):
             return super().write(vals)
         no_arch_updated_views = other_views = self.env['ir.ui.view']

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -6,9 +6,8 @@ from psycopg2 import sql
 
 import hashlib
 import pytz
-import threading
 
-from odoo import fields, models, api, _
+from odoo import fields, models, api, _, modules
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
 from odoo.tools import split_every
@@ -335,7 +334,7 @@ class WebsiteVisitor(models.Model):
         Visitors were previously archived but we came to the conclusion that
         archived visitors have very little value and bloat the database for no
         reason. """
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not modules.loading.running_test
         visitor_model = self.env['website.visitor']
         for inactive_visitors_batch in split_every(
             1000,

--- a/addons/website/tests/test_iap.py
+++ b/addons/website/tests/test_iap.py
@@ -4,6 +4,7 @@ import threading
 from unittest.mock import patch
 
 import odoo.tests
+from odoo import modules
 
 @odoo.tests.tagged('website_nightly', '-standard')
 class TestIap(odoo.tests.HttpCase):
@@ -13,7 +14,7 @@ class TestIap(odoo.tests.HttpCase):
         supported by the configurator."""
         def _get_industries(lang):
             # Calls to IAP are disabled during testing, we need to remove the testing flag to let it perform the calls
-            with patch.object(threading.current_thread(), 'testing', False):
+            with patch.object(modules.loading, 'running_test', False):
                 industries = self.env['website']._website_api_rpc('/api/website/1/configurator/industries', {'lang': lang})['industries']
             return {industry['id']: industry['label'] for industry in industries}
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -224,8 +224,6 @@ class IrHttp(models.AbstractModel):
         _logger.info("Generating routing map for key %s", str(key))
         registry = Registry(threading.current_thread().dbname)
         installed = registry._init_modules.union(odoo.conf.server_wide_modules)
-        if tools.config['test_enable'] and odoo.modules.module.current_test:
-            installed.add(odoo.modules.module.current_test)
         mods = sorted(installed)
         # Note : when routing map is generated, we put it on the class `cls`
         # to make it available for all instance. Since `env` create an new instance

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -578,7 +578,7 @@ class Module(models.Model):
         if not self.env.registry.ready or self.env.registry._init:
             raise UserError(_('The method _button_immediate_install cannot be called on init or non loaded registries. Please use button_install instead.'))
 
-        if getattr(threading.current_thread(), 'testing', False):
+        if modules.loading.running_test:
             raise RuntimeError(
                 "Module operations inside tests are not transactional and thus forbidden.\n"
                 "If you really need to perform module operations to test a specific behavior, it "

--- a/odoo/addons/base/models/res_users_deletion.py
+++ b/odoo/addons/base/models/res_users_deletion.py
@@ -2,10 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-import threading
 
-
-from odoo import api, fields, models
+from odoo import api, fields, models, modules
 
 _logger = logging.getLogger(__name__)
 
@@ -55,7 +53,7 @@ class ResUsersDeletion(models.Model):
         todo_requests = delete_requests - done_requests
         batch_requests = todo_requests[:batch_size]
 
-        auto_commit = not getattr(threading.current_thread(), "testing", False)
+        auto_commit = not modules.loading.running_test
 
         for delete_request in batch_requests:
             user = delete_request.user_id

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -320,7 +320,7 @@ class MockSmtplibCase:
 
         with patch('smtplib.SMTP_SSL', side_effect=lambda *args, **kwargs: self.testing_smtp_session), \
              patch('smtplib.SMTP', side_effect=lambda *args, **kwargs: self.testing_smtp_session), \
-             patch.object(type(IrMailServer), '_is_test_mode', lambda self: False), \
+             patch.object(type(IrMailServer), '_disable_mail', lambda self: False), \
              patch.object(type(IrMailServer), 'connect', wraps=IrMailServer, side_effect=connect_origin) as connect_mocked, \
              patch.object(type(IrMailServer), '_find_mail_server', side_effect=find_mail_server_origin) as find_mail_server_mocked:
             self.connect_mocked = connect_mocked

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 import email.policy
 import email.message
 import re
-import threading
 
+from odoo import modules
 from odoo.addons.base.models.ir_mail_server import extract_rfc2822_addresses
 from odoo.addons.base.models.ir_qweb_fields import nl2br_enclose
 from odoo.tests import tagged
@@ -546,7 +546,7 @@ class TestEmailMessage(TransactionCase):
         return self.env['ir.mail_server'].build_email(**kwargs)
 
     def send_email(self, msg):
-        with patch.object(threading.current_thread(), 'testing', False):
+        with patch.object(type(self.env['ir.mail_server']), '_disable_mail', lambda self: False):
             self.env['ir.mail_server'].send_email(msg, smtp_session=self._fake_smtp)
         return self._fake_smtp.messages.pop()
 

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -62,7 +62,7 @@ def load_data(env, idref, mode, kind, package):
     filename = None
     try:
         if kind in ('demo', 'test'):
-            threading.current_thread().testing = True
+            threading.current_thread().demo_loading = True
         for filename in _get_files_of_kind(kind):
             _logger.info("loading %s/%s", package.name, filename)
             noupdate = False
@@ -71,7 +71,7 @@ def load_data(env, idref, mode, kind, package):
             tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
     finally:
         if kind in ('demo', 'test'):
-            threading.current_thread().testing = False
+            threading.current_thread().demo_loading = False
 
     return bool(filename)
 
@@ -280,7 +280,7 @@ def load_module_graph(env, graph, status=None, perform_checks=True,
                     registry.setup_models(env.cr)
                 # Python tests
                 tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, module_name)
+                test_results = loader.run_suite(suite)
                 report.update(test_results)
                 test_time = time.time() - tests_t0
                 test_queries = odoo.sql_db.sql_counter - tests_q0
@@ -630,3 +630,5 @@ def reset_modules_state(db_name):
             "UPDATE ir_module_module SET state='uninstalled' WHERE state='to install'"
         )
         _logger.warning("Transient module states were reset")
+
+running_test = False

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -447,6 +447,3 @@ def adapt_version(version):
                          f" `{serie}.x.y` or `{serie}.x.y.z`.")
 
     return version
-
-
-current_test = None

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -20,6 +20,7 @@ import warnings
 import psycopg2
 
 import odoo
+from odoo.modules import loading
 from odoo.modules.db import FunctionStatus
 from odoo.osv.expression import get_unaccent_wrapper
 from .. import SUPERUSER_ID
@@ -89,6 +90,11 @@ class Registry(Mapping):
     def new(cls, db_name, force_demo=False, status=None, update_module=False):
         """ Create and return a new registry for the given database name. """
         t0 = time.time()
+
+        if loading.running_test:
+            _logger.error('Cannot initiate a registry while running a test')
+            return cls.registries.get(db_name)
+
         registry = object.__new__(cls)
         registry.init(db_name)
 
@@ -765,9 +771,6 @@ class Registry(Mapping):
 
     def setup_signaling(self):
         """ Setup the inter-process signaling on this registry. """
-        if self.in_test_mode():
-            return
-
         with self.cursor() as cr:
             # The `base_registry_signaling` sequence indicates when the registry
             # must be reloaded.
@@ -805,7 +808,7 @@ class Registry(Mapping):
         """ Check whether the registry has changed, and performs all necessary
         operations to update the registry. Return an up-to-date registry.
         """
-        if self.in_test_mode():
+        if loading.running_test:
             return self
 
         with closing(self.cursor()) as cr:
@@ -835,7 +838,7 @@ class Registry(Mapping):
 
     def signal_changes(self):
         """ Notifies other processes if registry or cache has been invalidated. """
-        if self.in_test_mode():
+        if loading.running_test:
             if self.registry_invalidated:
                 self.registry_sequence += 1
             for cache_name in self.cache_invalidated or ():

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1273,7 +1273,10 @@ def _reexec(updated_modules=None):
 def load_test_file_py(registry, test_file):
     # pylint: disable=import-outside-toplevel
     from odoo.tests.suite import OdooSuite
-    threading.current_thread().testing = True
+    _logger.warning('--test-file is deprecated. Please use --test-tags (e.g. --test-tags /base/test/test_views.py)')
+    if not config['test_file']:
+        return
+    odoo.modules.loading.running_test = True
     try:
         test_path, _ = os.path.splitext(os.path.abspath(test_file))
         for mod in [m for m in get_modules() if '%s%s%s' % (os.path.sep, m, os.path.sep) in test_file]:
@@ -1289,7 +1292,7 @@ def load_test_file_py(registry, test_file):
                         _logger.error('%s: at least one error occurred in a test', test_file)
                     return
     finally:
-        threading.current_thread().testing = False
+        odoo.modules.loading.running_test = False
 
 def preload_registries(dbnames):
     """ Preload a registries, possibly run a test file."""

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -77,7 +77,6 @@ except ImportError:
 
 _logger = logging.getLogger(__name__)
 
-
 # backward compatibility: Form was defined in this file
 def __getattr__(name):
     # pylint: disable=import-outside-toplevel
@@ -750,6 +749,7 @@ class TransactionCase(BaseCase):
                 with cls.registry.cursor() as cr:
                     cls.registry.setup_models(cr)
             cls.registry.registry_invalidated = False
+            cls.registry.registry_sequence = cls.registry_start_sequence
             cls.registry.clear_all_caches()
             cls.registry.cache_invalidated.clear()
 


### PR DESCRIPTION
A common error is to have a registry being reloaded in the midle of a a test because of a `check_signaling` catching a `signal_change` from another test while not being in test_mode.

The main issue is that the `in_test_mode` is manual, by using an HttpCase or calling enter_test_mode in the test.

The proposed solution stores a flag to know for sure if a test is running or not.
The `threading.current_thread().testing` flag is not enough when doing a request.
The `module.current_test` is not enough for post_install. (module is empty)

Those methods are used in the code to define if a test is running but nor are perfect. The new flag will replace previous solutions to have a reliable way to define if a test is running or not.

This check is also added in registry.new, logging an error and returning the same registry. This could also be changed by checking if another registry exists for this database, and if the ready and loaded states are coherent, but this may have more impact than this check. This is the reason why the check can be removed from `setup_signaling` since it is only called from registry.new

A check is also added in run_suite to avoid calling run_suite inside test. This is mainly to ensure that we don't remove the flag by mistake.
