### PR TITLE
[IMP] mail: don't convert iterables to arrays in t-foreach

### DIFF
--- a/addons/mail/static/src/core/web/follower_list.xml
+++ b/addons/mail/static/src/core/web/follower_list.xml
@@ -15,7 +15,7 @@
         <div t-if="props.thread.followers.size > 0" role="separator" class="dropdown-divider"/>
     </t>
     <t t-if="props.thread.followers.size > 0">
-        <t t-foreach="[...props.thread.followers]" t-as="follower" t-key="follower.id">
+        <t t-foreach="props.thread.followers" t-as="follower" t-key="follower.id">
             <t t-call="mail.Follower">
                 <t t-set="follower" t-value="follower"/>
             </t>

--- a/addons/mail/static/src/core/web/recipient_list.xml
+++ b/addons/mail/static/src/core/web/recipient_list.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-RecipientList p-2 overflow-auto">
             <ul class="list-unstyled mb-0">
                 <li t-if="props.thread.selfFollower" t-out="props.thread.selfFollower.partner.email"/>
-                <li t-foreach="[...props.thread.followers]" t-as="follower" t-key="follower.id">
+                <li t-foreach="props.thread.followers" t-as="follower" t-key="follower.id">
                     <t t-out="follower.partner.email"/>
                 </li>
                 <span t-if="!props.thread.followersFullyLoaded" class="btn btn-link w-100" t-on-click="() => threadService.loadMoreFollowers(props.thread)" t-ref="load-more">Load more</span>

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -55,10 +55,6 @@ export class Call extends Component {
         useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);
     }
 
-    get callNotifications() {
-        return [...this.rtc.notifications.values()];
-    }
-
     get isActiveCall() {
         return Boolean(this.props.thread.id === this.rtc.state?.channel?.id);
     }

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -30,7 +30,7 @@
                     </div>
                 </div>
                 <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': state.isFullscreen, 'ps-2 pb-2': !state.isFullscreen }">
-                    <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': state.isFullscreen, 'p-2': !state.isFullscreen }" t-foreach="callNotifications" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
+                    <span class="text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': state.isFullscreen, 'p-2': !state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
                 </div>
             </div>
             <div t-if="state.sidebar and props.thread.activeRtcSession" class="o-discuss-Call-sidebar d-flex align-items-center h-100 flex-column">

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -28,7 +28,7 @@
                         </div>
                     </div>
                     <t t-if="state.categories.length === 0">
-                        <t t-foreach="[...Array(10).keys()]" t-as="category" t-key="category_index">
+                        <t t-foreach="Array(10).keys()" t-as="category" t-key="category_index">
                             <div class="col">
                                 <div class="position-relative ratio ratio-16x9 cursor-pointer" aria-label="list-item">
                                     <div class="position-absolute w-100 h-100 top-0 start-0 text-center o-text-white align-middle fs-2 o-bg-black bg-opacity-50"/>


### PR DESCRIPTION
As of Owl 2.2, it is now possible to use iterable directly in t-foreach without having to convert it to array first.

This commit takes advantage of this new feature to remove the unnecessary array conversions from the Discuss code.