### PR TITLE
[FIX] mail,lunch,base_automation: invalid literal base10 for partner_to field

### DIFF
--- a/addons/base_automation/tests/test_mail_composer.py
+++ b/addons/base_automation/tests/test_mail_composer.py
@@ -10,8 +10,8 @@ class TestMailFullComposer(HttpCase):
     def test_full_composer_tour(self):
         self.env['mail.template'].create({
             'name': 'Test template',  # name hardcoded for test
-            'partner_to': '${object.id}',
-            'lang': '${object.lang}',
+            'partner_to': '{{object.id}}',
+            'lang': '{{object.lang}',
             'auto_delete': True,
             'model_id': self.ref('base.model_res_partner'),
         })

--- a/addons/lunch/data/mail_template_data.xml
+++ b/addons/lunch/data/mail_template_data.xml
@@ -4,10 +4,10 @@
     <record id="lunch_order_mail_supplier" model="mail.template">
         <field name="name">Lunch: Supplier Order</field>
         <field name="model_id" ref="lunch.model_lunch_supplier"/>
-        <field name="email_from">{{ ctx['order']['email_from'] }}</field>
-        <field name="partner_to">{{ ctx['order']['supplier_id'] }}</field>
-        <field name="subject">Orders for {{ ctx['order']['company_name'] }}</field>
-        <field name="lang">{{ ctx.get('default_lang') }}</field>
+        <field name="email_from">{{  ctx.get('order') and ctx['order']['email_from'] }}</field>
+        <field name="partner_to">{{ ctx.get('order') and  ctx['order']['supplier_id'] }}</field>
+        <field name="subject">Orders for {{  ctx.get('order') and  ctx['order']['company_name'] }}</field>
+        <field name="lang">{{ ctx.get('default_lang')  and ctx['default_lang'] }}</field>
         <field name="description">Sent to vendor with the order of the day</field>
         <field name="body_html" type="html">
 <table border="0" cellpadding="0" cellspacing="0" style="padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;"><tr><td align="center">
@@ -36,7 +36,7 @@
                     <td valign="top" style="font-size: 13px;">
     <div>
         <t t-set="lines" t-value="ctx.get('lines', [])"/>
-        <t t-set="order" t-value="ctx.get('order')"/>
+        <t t-set="order" t-value="ctx.get('order',{})"/>
         <t t-set="currency" t-value="user.env['res.currency'].browse(order.get('currency_id'))"/>
         <p>
         Dear <t t-out="order.get('supplier_name', '')">Laurie Poiret</t>,
@@ -86,7 +86,7 @@
                     <td></td>
                     <td></td>
                     <td style="width: 100%; font-size: 13px; border-top: 1px solid black;"><strong>Total</strong></td>
-                    <td style="width: 100%; font-size: 13px; border-top: 1px solid black;" align="right"><strong t-out="format_amount(order['amount_total'], currency) or ''">$ 10.00</strong></td>
+                    <td style="width: 100%; font-size: 13px; border-top: 1px solid black;" align="right"><strong t-out="order.get('amount_total') and format_amount(order['amount_total'], currency) or ''">$ 10.00</strong></td>
                 </tr>
             </tbody>
         </table>

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -89,6 +89,20 @@ class MailTemplate(models.Model):
     can_write = fields.Boolean(compute='_compute_can_write',
                                help='The current user can edit the template.')
 
+    @api.constrains('partner_to')
+    def _constrain_template_rendering(self):
+        for template in self:
+            model = template.model_id.model
+            if model:
+                record = template.env[model].search([], limit=1)
+                MAIL_TEMPLATE_FIELDS = [
+                    'partner_to'
+                ]
+                try:
+                    template._generate_template(record.ids, MAIL_TEMPLATE_FIELDS)
+                except:
+                    raise ValidationError(_("There are issues in the Architecture of this template"))
+
     # Overrides of mail.render.mixin
     @api.depends('model')
     def _compute_render_model(self):


### PR DESCRIPTION
This problem arises when the customer enters an unsupported data type in the 
partner To(partner to) field of the email template.

Step To Reproduce:-
- Install the sale_management,mail.
- Open Email Template
- Go to Note Page > Click on Email Configuration > To (Partners) 
  > Enter String  > Save It.
- Open Sales > open one record > Click on Send By Email > 
  (Select the template that you changed) > Send. 
Trackback would appear.  

Traceback: -
```
ValueError: invalid literal for int() with base 10: 'jekn@odoo.com'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/form.py", line 46, in website_form
    return self._handle_website_form(model_name, **kwargs)
  File "addons/website_mass_mailing/controllers/website_form.py", line 26, in _handle_website_form
    return super()._handle_website_form(model_name, **kwargs)
  File "addons/website/controllers/form.py", line 69, in _handle_website_form
    id_record = self.insert_record(request, model_record, data['record'], data['custom'], data.get('meta'))
  File "addons/website_form_project/controllers/main.py", line 15, in insert_record
    return super().insert_record(request, model, values, custom, meta=meta)
  File "addons/website/controllers/form.py", line 223, in insert_record
    ).create(values)
  File "<decorator-gen-566>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/base_automation/models/base_automation.py", line 390, in create
    action._process(action._filter_post(records))
  File "addons/base_automation/models/base_automation.py", line 340, in _process
    raise e
  File "addons/base_automation/models/base_automation.py", line 337, in _process
    action_server.sudo().with_context(**ctx).run()
  File "odoo/addons/base/models/ir_actions.py", line 702, in run
    res = runner(run_self, eval_context=eval_context)
  File "addons/mail/models/ir_actions_server.py", line 217, in _run_action_mail_post_multi
    template.send_mail(
  File "addons/mail/models/mail_template.py", line 559, in send_mail
    values = self._generate_template(
  File "addons/mail/models/mail_template.py", line 499, in _generate_template
    template._generate_template_recipients(
  File "addons/mail/models/mail_template.py", line 377, in _generate_template_recipients
    all_partner_to = {
  File "addons/mail/models/mail_template.py", line 378, in <setcomp>
    int(pid)
```

When a customer attempts to send an email to a user by filling out the Partner
To field's string information, at that time error will be generated,

sentry-4336102278 