### PR TITLE
[IMP] stock: products created from replenishment default to storable

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -44,7 +44,7 @@
                 <field name="product_category_id" invisible="1"/>
                 <field name="product_tmpl_id" invisible="1"/>
                 <field name="unwanted_replenish" invisible="1"/>
-                <field name="product_id" attrs="{'readonly': [('product_id', '!=', False)]}" force_save="1"/>
+                <field name="product_id" attrs="{'readonly': [('product_id', '!=', False)]}" force_save="1" context="{'default_detailed_type': 'product'}"/>
                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                 <field name="warehouse_id" options="{'no_create': True}" groups="stock.group_stock_multi_warehouses" optional="hide"/>
                 <field name="qty_on_hand" force_save="1"/>


### PR DESCRIPTION
When creating a product by using the "create" or "create and edit" widget in the Replenishment view, make the product a "storable product" by default, instead of "consumable".

task-3439196


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
