### PR TITLE
[IMP] project: generate a portal user when sharing a project/a task

### DIFF
--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -21,7 +21,7 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
     trigger: '.ui-autocomplete a.dropdown-item:contains("Georges")',
     in_modal: false,
 }, {
-    trigger: 'footer > button[name="action_send_mail"]',
+    trigger: 'footer > button[name="action_share_record"]',
     content: 'Confirm the project sharing with this portal user.',
 }, {
     trigger: '.o_web_client',

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -21,7 +21,23 @@
                 </group>
                 <field name="note" placeholder="Add a note" nolabel="1"/>
                 <footer>
-                    <button string="Send" name="action_send_mail" attrs="{'invisible': [('access_warning', '!=', '')]}" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Send" name="action_share_record" attrs="{'invisible': [('access_warning', '!=', '')]}" type="object" class="btn-primary" data-hotkey="q"/>
+                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="project_share_wizard_confirm_form" model="ir.ui.view">
+        <field name="name">project.share.wizard.view.form</field>
+        <field name="model">project.share.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Confirmation">
+                <p>People invited to collaborate on the project will have portal access rights.</p>
+                <p>They can edit shared project tasks and view specific documents in read-only mode on your website. This includes leads/opportunities, quotations/sales orders, purchase orders, invoices and bills, timesheets, and tickets.</p>
+                <p>You have full control and can revoke portal access anytime. Are you ready to proceed?</p>
+                <footer>
+                    <button string="Grant Portal Access" name="action_send_mail" type="object" class="btn-primary" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
                 </footer>
             </form>


### PR DESCRIPTION
Currently, when the creation of an user access is set to `invitation only` in the website settings, a project shared to a partner with no user account will not be accessible to that partner. The link sent to this partner will instead redirect him to the homepage of the website.

This commit address this situation by allowing the partner that receive the link to create a portal access. The user that share the project/the task is warned that partners will be able to create user accounts and offered the option to proceed or not.

task-3356419