### PR TITLE
[15.0][FIX] stock_account: rounding_adjustment missing pop in stock replenish call

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -572,7 +572,7 @@ class ProductProduct(models.Model):
                     svl_vals = product._prepare_in_svl_vals(quantity_svl, product.standard_price)
                 else:
                     svl_vals = product._prepare_out_svl_vals(abs(quantity_svl), self.env.company)
-                svl_vals['description'] = description
+                svl_vals['description'] = description + svl_vals.pop('rounding_adjustment', '')
                 svl_vals['company_id'] = self.env.company.id
                 refill_stock_svl_list.append(svl_vals)
         return refill_stock_svl_list


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In some cases, when changing cost method for a product category, a `ValueError: Invalid field 'rounding_adjustment' on model 'stock.valuation.layer'` is raised.

This is because in commit https://github.com/odoo/odoo/commit/862d3bdfb581437210fbbf57d833d5b03cbe0e58 a bug was introduced: a `_prepare_out_svl_vals()` call was added, without `rouding_adjustment` `svl_vals` dict `pop` when SVL final description is defined.

**Current behavior before PR:**

Error raised in some cases when product category cost method is changed.

**Desired behavior after PR is merged:**

No error should be fired.

cc @richard-willdooit @amoyaux 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
