### PR TITLE
[FIX] base: handle syntax error for decoration in base view

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -5697,6 +5697,16 @@ msgid ""
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/ir_ui_view.py:0
+#, python-format
+msgid ""
+"\n"
+"The Decoration contains syntax error:\n"
+"'%s'"
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,description:base.module_repair
 msgid ""
 "\n"

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1811,6 +1811,13 @@ actual arch.
                     )
 
             elif attr.startswith('decoration-'):
+                try:
+                    get_variable_names(expr)
+                except SyntaxError:
+                    msg = _(
+                        "\nThe Decoration contains syntax error:\n'%s'", expr
+                    )
+                    self._raise_view_error(msg, node)
                 vnames = get_variable_names(expr)
                 if vnames:
                     name_manager.must_have_fields(node, vnames, f"{attr}={expr}")


### PR DESCRIPTION
When the user passes the incorrect syntax in the decoration of the tree
architecture of view and tries to access that then the syntax error will
generated.

Steps to reproduce:-

- Install Expense module.
- Open Setting > Technical > user Interface > views
- Now open ```hr_expense_view_expenses_analysis_tree```
  view. Edit tree architecture.
- Like decoration-success='state in ['approved', ```done'```]'.
  (remove the opening string of done state)
- Save it. Traceback will be generated.

Traceback:
```
SyntaxError: unterminated string literal (detected at line 1) (<unknown>, line 1)
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/website/models/theme_models.py", line 376, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 93, in write
    return super(View, self).write(vals)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4046, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1396, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 363, in _inverse_arch_base
    view_wo_lang.arch = view.arch_base
  File "odoo/fields.py", line 1320, in __set__
    records.write({self.name: write_value})
  File "addons/website/models/theme_models.py", line 376, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 93, in write
    return super(View, self).write(vals)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4046, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1396, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 345, in _inverse_arch
    view.write(data)
  File "addons/website/models/theme_models.py", line 376, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 93, in write
    return super(View, self).write(vals)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4036, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1411, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 460, in _check_xml
    view._validate_view(combined_arch, view.model)
  File "odoo/addons/base/models/ir_ui_view.py", line 1459, in _validate_view
    self._validate_attrs(node, name_manager, node_info)
  File "odoo/addons/base/models/ir_ui_view.py", line 1814, in _validate_attrs
    vnames = get_variable_names(expr)
  File "odoo/tools/view_validation.py", line 73, in get_variable_names
    expr = ast.parse(expr.strip(), mode='eval').body
  File "ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
```
See-
https://github.com/odoo/odoo/blob/08ffe5f3b0e5c80c0c3a90982f7cc8713d4c969b/odoo/addons/base/models/ir_ui_view.py#L1813-L1814

Applying this changes will handle the exception if syntax error is generated in
decoration.

Sentry-4340016594