### PR TITLE
[FIX] mail, web: fix duplicate rpc when switching record

### DIFF
--- a/addons/mail/static/src/views/web/form/form_controller.js
+++ b/addons/mail/static/src/views/web/form/form_controller.js
@@ -4,8 +4,11 @@ import { patch } from "@web/core/utils/patch";
 import { FormController } from "@web/views/form/form_controller";
 
 patch(FormController.prototype, "mail/views/web", {
-    onWillLoadRoot() {
-        if (this.model.root) {
+    onWillLoadRoot(nextConfiguration) {
+        const isSameThread =
+            this.model.root?.resId === nextConfiguration.resId &&
+            this.model.root?.resModel === nextConfiguration.resModel;
+        if (isSameThread) {
             // not first load
             const { resModel, resId } = this.model.root;
             this.env.bus.trigger("MAIL:RELOAD-THREAD", { resModel, resId });

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -63,7 +63,7 @@ import {
 
 /**
  * @typedef Hooks
- * @property {Function} [onWillLoadRoot]
+ * @property {(nextConfiguration: Config) => void} [onWillLoadRoot]
  * @property {Function} [onWillSaveRecord]
  * @property {Function} [onRecordSaved]
  * @property {Function} [onWillSaveMulti]
@@ -305,7 +305,7 @@ export class RelationalModel extends Model {
      */
     async _loadData(config) {
         if (config.isRoot) {
-            this.hooks.onWillLoadRoot();
+            this.hooks.onWillLoadRoot(config);
         }
         if (config.isMonoRecord) {
             const evalContext = {


### PR DESCRIPTION
Since [1], switching from one record to another in a form view would send two `/mail/messages` rpc. This is due to the `onWillLoadRoot` hook that triggers a `MAIL:RELOAD-THREAD` event while the thread is going to change. As a consequence, messages are fetched for the currently active record and the one that will be activated.

This PR fixes the issue by ensuring the thread won't change before triggering this event.

[1]: https://github.com/odoo/odoo/pull/114024

