### PR TITLE
[FIX] mail, hr: fix avatar card

### DIFF
--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -13,12 +13,19 @@ export const patchAvatarCardPopover = {
     get fieldNames(){
         let fields = this._super();
         return fields.concat([
-            "work_phone", 
+            "work_phone",
+            "work_email", 
             "job_title", 
             "department_id", 
             "employee_parent_id",
             "employee_id",
         ])
+    },
+    get email(){
+        return this.user.work_email || this.user.email;
+    },
+    get phone(){
+        return this.user.work_phone || this.user.phone;
     },
     async onClickViewEmployee(){
         const employeeId = this.user.employee_id[0];

--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.xml
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.xml
@@ -7,14 +7,7 @@
     </t>
 
     <t t-name="hr.avatarCardUserInfos" owl="1">
-        <span class="fw-bold" t-esc="user.name"/>
         <small class="text-muted" t-if="user.job_title" t-esc="user.job_title"/>
         <span class="text-muted" t-if="user.department_id" data-tooltip="Department" t-esc="user.department_id[1]"/>
-        <a t-att-href="'mailto:'+user.email">
-            <i class="fa fa-fw fa-envelope"/> <t t-esc="user.email"/>
-        </a>
-        <a t-att-href="'tel:'+user.work_phone">
-            <i class="fa fa-fw fa-phone"/> <t t-esc="user.work_phone"/>
-        </a>
     </t>
 </templates>

--- a/addons/hr/static/tests/web/m2x_avatar_user_tests.js
+++ b/addons/hr/static/tests/web/m2x_avatar_user_tests.js
@@ -55,15 +55,22 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
         const userId = pyEnv["res.users"].create({
             name: "Mario",
             email: "Mario@odoo.test",
+            work_email: "Mario@odoo.pro",
             im_status: "online",
+            phone: "+78786987",
             work_phone: "+585555555",
             job_title: "sub manager",
             department_id: departmentId,
         });
         const mockRPC = (route, args) => {
             if(route === "/web/dataset/call_kw/res.users/read"){
-                assert.deepEqual(args.args[1], ['name', 'email', 'im_status',
+                assert.deepEqual(args.args[1], [
+                "name", 
+                "email", 
+                "phone", 
+                "im_status",
                 "work_phone",
+                "work_email",
                 "job_title",
                 "department_id",
                 "employee_parent_id",
@@ -101,7 +108,7 @@ QUnit.module("M2XAvatarUser", ({ beforeEach }) => {
         await triggerEvent(target, ".o_m2o_avatar > img", "mouseover");
         assert.verifySteps(["setTimeout of 350ms", "setTimeout of 250ms", "user read"]);
         assert.containsOnce(target, ".o_avatar_card");
-        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_card_user_infos > *")), ['Mario', 'sub manager', 'Managemment', ' Mario@odoo.test', ' +585555555']);
+        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_card_user_infos > *")), ['Mario', 'sub manager', 'Managemment', ' Mario@odoo.pro', ' +585555555']);
         // Close card
         await triggerEvent(target, ".o_control_panel", "mouseover");
         assert.verifySteps(["setTimeout of 400ms"]);

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -9,24 +9,27 @@ export class AvatarCardPopover extends Component {
 
     static props = {
         id: { type: Number, required: true },
-        relation: { type: String, required: true },
         close: { type: Function, required: true },
     };
 
     setup() {
         this.orm = useService("orm");
-        this.openChat = useOpenChat(this.props.relation);
+        this.openChat = useOpenChat("res.users");
         onWillStart(async () => {
-            [this.user] = await this.orm.read(
-                this.props.relation,
-                [this.props.id],
-                this.fieldNames
-            );
+            [this.user] = await this.orm.read("res.users", [this.props.id], this.fieldNames);
         });
     }
 
     get fieldNames() {
-        return ["name", "email", "im_status"];
+        return ["name", "email", "phone", "im_status"];
+    }
+
+    get email() {
+        return this.user.email;
+    }
+
+    get phone() {
+        return this.user.phone;
     }
 
     onSendClick() {

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -6,7 +6,7 @@
                 <div class="d-flex align-items-start gap-2">
                     <span class="o_avatar pt-1 position-relative o_card_avatar">
                         <img t-if="props.id"
-                            t-attf-src="/web/image/{{props.relation}}/{{props.id}}/avatar_128"
+                            t-attf-src="/web/image/res.users/{{props.id}}/avatar_128"
                             class="rounded"
                         />
                         <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center">
@@ -17,12 +17,14 @@
                             <i t-elif="!user.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>
                         </span>
                     </span>
-                    <div t-if="userInfoTemplate" t-call="{{userInfoTemplate}}" class="d-flex flex-column o_card_user_infos"/>
-                    <div t-else="" class="d-flex flex-column o_card_user_infos">
+                    <div class="d-flex flex-column o_card_user_infos">
                         <span class="fw-bold" t-esc="user.name"/>
-                        <a t-att-href="'mailto:'+user.email">
-                            <i class="fa fa-envelope me-1"> </i>
-                            <t t-esc="user.email"/>
+                        <t t-if="userInfoTemplate" t-call="{{userInfoTemplate}}"/>
+                        <a t-if="email" t-att-href="'mailto:'+email">
+                            <i class="fa fa-fw fa-envelope"/> <t t-esc="email"/>
+                        </a>
+                        <a t-if="phone" t-att-href="'tel:'+phone">
+                            <i class="fa fa-fw fa-phone"/> <t t-esc="phone"/>
                         </a>
                     </div>
                 </div>

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
@@ -41,7 +41,7 @@ const userChatter = {
             ...this._super(...arguments),
             onImageClicked: () => this.openChat(record.resId),
             openCard: (ev) => {
-                if (this.env.isSmall) {
+                if (this.env.isSmall || this.relation !== "res.users") {
                     return;
                 }
                 const target = ev.currentTarget;
@@ -52,7 +52,6 @@ const userChatter = {
                     ) {
                         this.avatarCard.open(target, {
                             id: record.resId,
-                            relation: this.relation,
                         });
                         this.lastOpenedId = record.resId;
                     }

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -37,15 +37,17 @@ const userChatter = {
     },
 
     openCard(ev) {
-        if (this.env.isSmall) {
+        if (this.env.isSmall || this.relation !== "res.users") {
             return;
         }
         const target = ev.currentTarget;
+        if (!target.querySelector(":scope > img")) {
+            return;
+        }
         this.openTimeout = browser.setTimeout(() => {
             if (!this.avatarCard.isOpen) {
                 this.avatarCard.open(target, {
                     id: this.props.record.data[this.props.name][0],
-                    relation: this.relation,
                 });
             }
         }, 350);

--- a/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
@@ -1,7 +1,13 @@
 /* @odoo-module */
 
 import { start, startServer } from "@mail/../tests/helpers/test_utils";
-import { click, patchWithCleanup, triggerHotkey, triggerEvent } from "@web/../tests/helpers/utils";
+import {
+    click,
+    patchWithCleanup,
+    triggerHotkey,
+    triggerEvent,
+    getNodesTextContent,
+} from "@web/../tests/helpers/utils";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { nextTick } from "@web/../tests/legacy/helpers/test_utils";
@@ -349,11 +355,12 @@ QUnit.test("avatar card preview", async (assert) => {
     const userId = pyEnv["res.users"].create({
         name: "Mario",
         email: "Mario@odoo.test",
+        phone: "+78786987",
         im_status: "online",
     });
     const mockRPC = (route, args) => {
         if (route === "/web/dataset/call_kw/res.users/read") {
-            assert.deepEqual(args.args[1], ["name", "email", "im_status"]);
+            assert.deepEqual(args.args[1], ["name", "email", "phone", "im_status"]);
             assert.step("user read");
         }
     };
@@ -387,10 +394,11 @@ QUnit.test("avatar card preview", async (assert) => {
     await triggerEvent(document, ".o_m2o_avatar > img", "mouseover");
     assert.verifySteps(["setTimeout of 350ms", "setTimeout of 250ms", "user read"]);
     assert.containsOnce(document.body, ".o_avatar_card");
-    assert.strictEqual(
-        document.querySelector(".o_card_user_infos").textContent,
-        "Mario Mario@odoo.test"
-    );
+    assert.deepEqual(getNodesTextContent(document.querySelectorAll(".o_card_user_infos > *")), [
+        "Mario",
+        " Mario@odoo.test",
+        " +78786987",
+    ]);
     // Close card
     await triggerEvent(document, ".o_control_panel", "mouseover");
     assert.verifySteps(["setTimeout of 400ms"]);


### PR DESCRIPTION
This commit introduces various fixes regarding the avatar card.
First one makes sure that the avatar card popover won't launch when there is no user image associated with the many2one_avatar_user_field. This would happen with the quick assign button.
Second one prevents the card from opening when the related model is not "res.users".
Third one allows to display the phone number of users even without hr installed and makes sure that the work_phone and work_email are shown in priority if available when hr is installed.

Direct fix to Task-3167110


