### PR TITLE
[FIX] hr_attendance: fixed no operator matches error

### DIFF
--- a/addons/hr_attendance/report/hr_attendance_report.py
+++ b/addons/hr_attendance/report/hr_attendance_report.py
@@ -39,7 +39,7 @@ class HRAttendanceReport(models.Model):
                             at time zone 'utc'
                             at time zone
                                 (SELECT calendar.tz FROM resource_calendar as calendar
-                                INNER JOIN hr_employee as employee ON employee.id = employee_id
+                                INNER JOIN hr_employee as employee ON employee.id = employee_id::integer
                                 WHERE calendar.id = employee.resource_calendar_id)
                     as DATE) as check_in,
                     worked_hours


### PR DESCRIPTION
When there is no record in attendance table, then
`employee_id` field of attendance give null value
and which we used to assign with employee.id
which raise error during upgrading database.

so need to add explicit type casts integer when
there is Null value in employee_id.

```
psycopg2.errors.UndefinedFunction: operator does not exist: integer = character varying
LINE 22: ...INNER JOIN hr_employee as employee ON employee.id = employee...
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
