### PR TITLE
[REF] web: remove expand parameters from web_read_group

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -225,8 +225,7 @@ class Base(models.AbstractModel):
         return values_list
 
     @api.model
-    def web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False,
-                       lazy=True, expand=False, expand_limit=None, expand_orderby=False):
+    def web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False, lazy=True):
         """
         Returns the result of a read_group (and optionally search for and read records inside each
         group), and the total number of groups matching the search domain.
@@ -238,16 +237,12 @@ class Base(models.AbstractModel):
         :param offset: see ``offset`` param of ``read_group``
         :param orderby: see ``orderby`` param of ``read_group``
         :param lazy: see ``lazy`` param of ``read_group``
-        :param expand: if true, and groupby only contains one field, read records inside each group
-        :param expand_limit: maximum number of records to read in each group
-        :param expand_orderby: order to apply when reading records in each group
         :return: {
             'groups': array of read groups
             'length': total number of groups
         }
         """
-        groups = self._web_read_group(domain, fields, groupby, limit, offset, orderby, lazy, expand,
-                                      expand_limit, expand_orderby)
+        groups = self._web_read_group(domain, fields, groupby, limit, offset, orderby, lazy)
 
         if not groups:
             length = 0
@@ -266,8 +261,7 @@ class Base(models.AbstractModel):
         }
 
     @api.model
-    def _web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False,
-                        lazy=True, expand=False, expand_limit=None, expand_orderby=False):
+    def _web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False, lazy=True):
         """
         Performs a read_group and optionally a web_search_read for each group.
         See ``web_read_group`` for params description.
@@ -276,13 +270,6 @@ class Base(models.AbstractModel):
         """
         groups = self.read_group(domain, fields, groupby, offset=offset, limit=limit,
                                  orderby=orderby, lazy=lazy)
-
-        if expand and len(groupby) == 1:
-            for group in groups:
-                group['__data'] = self.web_search_read(domain=group['__domain'], fields=fields,
-                                                       offset=0, limit=expand_limit,
-                                                       order=expand_orderby)
-
         return groups
 
     @api.model

--- a/addons/web/static/src/legacy/js/core/rpc.js
+++ b/addons/web/static/src/legacy/js/core/rpc.js
@@ -67,13 +67,6 @@ const rpc = {
             orderBy = options.orderBy || params.orderBy || params.kwargs.orderby;
             params.kwargs.orderby = orderBy ? rpc._serializeSort(orderBy) : orderBy;
             params.kwargs.lazy = 'lazy' in options ? options.lazy : params.lazy;
-
-            if (options.method === 'web_read_group') {
-                params.kwargs.expand = options.expand || params.expand || params.kwargs.expand;
-                params.kwargs.expand_limit = options.expand_limit || params.expand_limit || params.kwargs.expand_limit;
-                var expandOrderBy = options.expand_orderby || params.expand_orderby || params.kwargs.expand_orderby;
-                params.kwargs.expand_orderby = expandOrderBy ? rpc._serializeSort(expandOrderBy) : expandOrderBy;
-            }
         }
 
         if (options.method === 'search_read') {

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1370,17 +1370,6 @@ export class MockServer {
 
     mockWebReadGroup(modelName, kwargs) {
         const groups = this.mockReadGroup(modelName, kwargs);
-        if (kwargs.expand && kwargs.groupby.length === 1) {
-            groups.forEach((group) => {
-                group.__data = this.mockSearchReadController({
-                    domain: group.__domain,
-                    model: modelName,
-                    fields: kwargs.fields,
-                    limit: kwargs.expand_limit,
-                    sort: kwargs.expand_orderby,
-                });
-            });
-        }
         const allGroups = this.mockReadGroup(modelName, {
             domain: kwargs.domain,
             fields: ["display_name"],

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1890,26 +1890,10 @@ var MockServer = Class.extend({
      * @param {boolean} kwargs.lazy still mostly ignored
      * @param {integer} [kwargs.limit]
      * @param {integer} [kwargs.offset]
-     * @param {boolean} [kwargs.expand=false] if true, read records inside each
-     *   group
-     * @param {integer} [kwargs.expand_limit]
-     * @param {integer} [kwargs.expand_orderby]
      * @returns {Object[]}
      */
     _mockWebReadGroup: function (model, kwargs) {
-        var self = this;
         var groups = this._mockReadGroup(model, kwargs);
-        if (kwargs.expand && kwargs.groupby.length === 1) {
-            groups.forEach(function (group) {
-                group.__data = self._mockSearchReadController({
-                    domain: group.__domain,
-                    model: model,
-                    fields: kwargs.fields,
-                    limit: kwargs.expand_limit,
-                    order: kwargs.expand_orderby,
-                });
-            });
-        }
         var allGroups = this._mockReadGroup(model, {
             domain: kwargs.domain,
             fields: ['display_name'],

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -4206,11 +4206,6 @@ QUnit.module("Views", (hooks) => {
                         assert.step(
                             `web_read_group.orderby: ${args.kwargs.orderby || "default order"}`
                         );
-                        assert.step(
-                            `web_read_group.expand_orderby: ${
-                                args.kwargs.expand_orderby || "default order"
-                            }`
-                        );
                     }
                     if (method === "unity_web_search_read") {
                         assert.step(
@@ -4226,7 +4221,6 @@ QUnit.module("Views", (hooks) => {
             );
             assert.verifySteps([
                 "web_read_group.orderby: default order",
-                "web_read_group.expand_orderby: default order",
                 "web_search_read.order: default order",
             ]);
 
@@ -4237,7 +4231,6 @@ QUnit.module("Views", (hooks) => {
             );
             assert.verifySteps([
                 "web_read_group.orderby: default order",
-                "web_read_group.expand_orderby: default order",
                 "web_search_read.order: foo ASC",
             ]);
         }


### PR DESCRIPTION
The expand, expand_limit and expand_groupby allowed to ask read_group to populate groups with search_read results directly. It was only used in the list view, when `expand="1"` was set on its root node in the arch. Since [1], the list view no longer uses these arguments, as we uniformized the logic between list and kanban (where groups are always opened by default).

[1] https://github.com/odoo/odoo/pull/114024

Part of task~3179751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
