### PR TITLE
[FIX] test_lint: avoid memory error

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -421,7 +421,7 @@ def get_modules():
             _logger.warning("addons path does not exist: %s", ad)
             continue
         plist.extend(listdir(ad))
-    return list(set(plist))
+    return sorted(set(plist))
 
 def get_modules_with_version():
     modules = get_modules()


### PR DESCRIPTION
It looks like memory error starts to become a problem for test_lint. The suspicion is that the increasing number of files may cause an increase in the pylint memory usage. Splitting test by module will help to solve this issue by reducing the number of file to check.


This solution works to limit memory (tested in community)

Before:
```
2023-07-24 10:54:51,996 Memory:  1956339712  (1.82 GiB) (+10.7%)
```
After:

```
2023-07-27 09:32:24,346 Memory:   601157632 (573.31 MiB) (+10.9%)
2023-07-27 09:32:59,696 Memory:   292704256 (279.14 MiB) (+12.9%)
2023-07-27 09:33:08,066 Memory:   261238784 (249.14 MiB) (+14.1%)
2023-07-27 09:33:16,410 Memory:   282439680 (269.36 MiB) (+14.2%)
2023-07-27 09:33:50,688 Memory:   210915328 (201.14 MiB) (+15.2%)
2023-07-27 09:33:51,725 Memory:   172118016 (164.14 MiB) (-18.4%)
...
2023-07-27 09:40:09,365 Memory:   140697600 (134.18 MiB) (-22.9%)
```

But this is also slower unfortunately (3 minutes before, 9 minutes after