### PR TITLE
[FIX] base: handle traceback while restore default view

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -26074,6 +26074,12 @@ msgid "You have to specify a filter for your selection."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_ui_view.py:0
+#, python-format
+msgid "You must select the Model of the view."
+msgstr ""
+
+#. module: base
 #: model_terms:ir.actions.act_window,help:base.open_module_tree
 msgid "You should try other search criteria."
 msgstr ""

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -435,6 +435,11 @@ actual arch.
         if not self._check_recursion(parent='inherit_id'):
             raise ValidationError(_('You cannot create recursive inherited views.'))
 
+    @api.constrains('model')
+    def _check_model(self):
+        if self.type != "qweb" and not self.model:
+            raise ValidationError(_('You must select the Model of the view.'))
+
     _sql_constraints = [
         ('inheritance_mode',
          "CHECK (mode != 'extension' OR inherit_id IS NOT NULL)",


### PR DESCRIPTION
When the user tries to restore the default view using web studio but the `model` field is not defined in the respective `ir.ui.view` model then the user will face the `KeyError`.

Steps to produce:
- Install Studio, Sales > Activate Studio > Open Sales module
- Click on 'View' > Click on 'MORE' (With debugger mode on)
- Click on 'EDIT' > Remove the current value of the model and make it empty
- Save it and go back to Studio
- Click on 'RESTORE DEFAULT VIEW' > Click on 'OK'

See Traceback
```
KeyError: False
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/controllers/main.py", line 484, in restore_default_view
    return self._return_view(view, studio_view)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/controllers/main.py", line 466, in _return_view
    ViewModel = request.env[view.model]
  File "odoo/api.py", line 521, in __getitem__
    return self.registry[model_name](self, (), ())
  File "odoo/modules/registry.py", line 190, in __getitem__
    return self.models[model_name]
```

Here, to restore the default view `model` is required for that particular view, but if user keep `model` empty then the traceback appears.

Sentry-4341141709