### PR TITLE
[FIX] web: onchange create a record in an invisible x2m

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -246,19 +246,17 @@ export class StaticList extends DataPoint {
                 record._applyDefaultValues();
                 for (const fieldName in record.activeFields) {
                     if (["one2many", "many2many"].includes(record.fields[fieldName].type)) {
-                        if (activeFields[fieldName].related) {
-                            const list = record.data[fieldName];
-                            const patch = {
-                                activeFields: activeFields[fieldName].related.activeFields,
-                                fields: activeFields[fieldName].related.fields,
-                            };
-                            for (const subRecord of Object.values(list._cache)) {
-                                this.model._updateConfig(subRecord.config, patch, {
-                                    noReload: true,
-                                });
-                            }
-                            this.model._updateConfig(list.config, patch, { noReload: true });
+                        const list = record.data[fieldName];
+                        const patch = {
+                            activeFields: activeFields[fieldName].related.activeFields,
+                            fields: activeFields[fieldName].related.fields,
+                        };
+                        for (const subRecord of Object.values(list._cache)) {
+                            this.model._updateConfig(subRecord.config, patch, {
+                                noReload: true,
+                            });
                         }
+                        this.model._updateConfig(list.config, patch, { noReload: true });
                     }
                 }
                 record._applyValues(data);

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -13560,6 +13560,58 @@ QUnit.module("Fields", (hooks) => {
         }
     );
 
+    QUnit.test("onchange create a record in an invisible x2many", async function (assert) {
+        serverData.models.partner.onchanges = {
+            foo: function () {},
+        };
+        serverData.models.partner.records[0].p = [2];
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            resId: 1,
+            arch: `
+                <form>
+                    <field name="foo"/>
+                    <field name="p">
+                        <tree>
+                            <field name="display_name" required="1"/>
+                            <field name="p" invisible="1"/>
+                        </tree>
+                    </field>
+                </form>`,
+            async mockRPC(route, args) {
+                if (args.method === "onchange2") {
+                    return {
+                        value: {
+                            p: [
+                                [
+                                    1,
+                                    2,
+                                    {
+                                        display_name: "plop",
+                                        p: [[0, false, {}]],
+                                    },
+                                ],
+                            ],
+                        },
+                    };
+                }
+            },
+        });
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_data_row")].map((el) => el.textContent),
+            ["second record"]
+        );
+
+        await editInput(target, ".o_field_widget[name=foo] input", "new foo value");
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_data_row")].map((el) => el.textContent),
+            ["plop"]
+        );
+    });
+
     QUnit.test("forget command for nested x2manys in form, not in list", async function (assert) {
         assert.expect(8);
 


### PR DESCRIPTION
Before this commit, in a form view with an x2many that contains an
invisible x2many, if an onchange returns a create command for the
invisible x2many field, a crash is displayed.

Problem:
The getCommands function for processing CREATE commands needs the
activeField of the x2many to be present with activeFields and fields.
Currently, the activeField of an invisible x2many has no related fields.

Solution:
All x2many fields have "related" in the activeField by default.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
