### PR TITLE
[REF] hr_expense: fix create report button

### DIFF
--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -57,7 +57,7 @@ export class ExpenseListController extends ListController {
     async onClick (action) {
         const records = this.model.root.selection;
         const recordIds = records.map((a) => a.resId);
-        const model = this.model.rootParams.resModel;
+        const model = this.model.config.resModel;
         const res = await this.orm.call(model, action, [recordIds]);
         if (res) {
             await this.actionService.doAction(res, {
@@ -77,7 +77,7 @@ export class ExpenseListController extends ListController {
 
     async action_show_expenses_to_submit () {
         const records = this.model.root.selection;
-        const res = await this.orm.call(this.model.rootParams.resModel, 'get_expenses_to_submit', [records.map((record) => record.resId)]);
+        const res = await this.orm.call(this.model.config.resModel, 'get_expenses_to_submit', [records.map((record) => record.resId)]);
         if (res) {
             await this.actionService.doAction(res, {});
         }


### PR DESCRIPTION
On the hr.expense.tree view the create report button
raises an error since some recent framework refactor
This applies the related changes missed during the refactoring

related commit: https://github.com/odoo/odoo/commit/26a2d4f8ab3a327145ca3ac6c04f32b83a1fee3f

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
