### PR TITLE
[FIX] project: fix traceback when trying to open project sharing

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -188,8 +188,11 @@
             'web_editor/static/src/scss/web_editor.backend.scss',
 
             'web_editor/static/src/js/frontend/loader.js',
+            'web_editor/static/src/js/frontend/loadWysiwygFromTextarea.js',
             'web_editor/static/src/js/backend/**/*',
             'web_editor/static/src/xml/backend.xml',
+
+            ('include', 'web_editor.assets_wysiwyg'),
 
             'mail/static/src/scss/variables/*.scss',
             'mail/static/src/views/web/form/form_renderer.scss',


### PR DESCRIPTION
Steps:
- Install project app.
- Share a project editable.
- Try to open project sharing view.

Issue:
- Traceback.

Cause:
- Following wysiwyg to owl conversation there forgot to add updated files in project sharing web client.

Fix:
- Add required files in project sharing web client.
