### PR TITLE
[FIX] resource: reflect absence of calendar in validity intervals

### DIFF
--- a/addons/hr_calendar/models/res_partner.py
+++ b/addons/hr_calendar/models/res_partner.py
@@ -45,19 +45,19 @@ class ResPartner(models.Model):
             return {}
         interval_by_calendar = defaultdict()
         calendar_periods_by_employee = defaultdict(list)
-        employees_by_calendar = defaultdict(list)
+        resources_by_calendar = defaultdict(list)
 
         # Compute employee's calendars's period and order employee by his involved calendars
         employees = sum(employees_by_partner.values(), start=self.env['hr.employee'])
         calendar_periods_by_employee = employees._get_calendar_periods(start_period, stop_period)
         for employee, calendar_periods in calendar_periods_by_employee.items():
             for _start, _stop, calendar in calendar_periods:
-                employees_by_calendar[calendar].append(employee)
+                resources_by_calendar[calendar].append(employee.resource_id)
 
         # Compute all work intervals per calendar
-        for calendar, employees in employees_by_calendar.items():
+        for calendar, resources in resources_by_calendar.items():
             calendar = calendar or self.env.company.resource_calendar_id # No calendar if fully flexible
-            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=employees, tz=timezone(calendar.tz))
+            work_intervals = calendar._work_intervals_batch(start_period, stop_period, resources=resources, tz=timezone(calendar.tz))
             del work_intervals[False]
             # Merge all employees intervals to avoid to compute it multiples times
             if merge:
@@ -75,7 +75,7 @@ class ResPartner(models.Model):
                 if merge:
                     calendar_interval = interval_by_calendar[calendar]
                 else:
-                    calendar_interval = interval_by_calendar[calendar][employee.id]
+                    calendar_interval = interval_by_calendar[calendar][employee.resource_id.id]
                 employee_interval = employee_interval | (calendar_interval & interval)
             schedule_by_employee[employee] = employee_interval
 

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -170,8 +170,7 @@ class ResourceResource(models.Model):
             # if no resource, add the company resource calendar.
             resource_calendars_within_period[False][default_calendar] = Intervals([(start, end, self.env['resource.calendar.attendance'])])
         for resource in self:
-            calendar = resource.calendar_id or resource.company_id.resource_calendar_id or default_calendar
-            resource_calendars_within_period[resource.id][calendar] = Intervals([(start, end, self.env['resource.calendar.attendance'])])
+            resource_calendars_within_period[resource.id][resource.calendar_id] = Intervals([(start, end, self.env['resource.calendar.attendance'])])
         return resource_calendars_within_period
 
     def _get_valid_work_intervals(self, start, end, calendars=None, compute_leaves=True):

--- a/addons/test_resource/tests/test_performance.py
+++ b/addons/test_resource/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestResourcePerformance(TransactionCase):
             start = pytz.utc.localize(datetime.now() + relativedelta(month=1, day=1))
             stop = pytz.utc.localize(datetime.now() + relativedelta(month=12, day=31))
             start_time = time.time()
-            calendar._attendance_intervals_batch(start, stop, resources=resources)
+            calendar._attendance_intervals_batch(start, stop, resources=resources.resource_id)
             _logger.info('Attendance Intervals Batch (100): --- %s seconds ---', time.time() - start_time)
             # Before
             #INFO master test_performance: Attendance Intervals Batch (100): --- 2.0667169094085693 seconds ---


### PR DESCRIPTION
The field `calendar_id` is not required anymore.
When absent, it means that the resource has a flexible schedule (is always available).
`ResourceResource._get_calendars_validity_within_period` returns a dict of intervals per resource calendar per resource. When a resource has no calendar, it takes the calendar of its company or the calendar of the default company or the calendar of the environment's company. As a result, what it returns doesn't reflect the fact that the resource is flexible.
This commit ensures that, when a resource has no calendar, no other calendar is attributed to it.

task-3231732




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
