### PR TITLE
[IMP] test_discuss_full, im_livechat: fix write on computed field

### DIFF
--- a/addons/im_livechat/tests/test_get_random_operator.py
+++ b/addons/im_livechat/tests/test_get_random_operator.py
@@ -1,16 +1,9 @@
 import odoo
 from odoo.tests import HttpCase
 from odoo.tests.common import new_test_user
-from unittest.mock import patch
-from odoo.addons.bus.models.res_users import ResUsers
-
-def _compute_im_status(self):
-    for record in self:
-        record.im_status = 'online'
 
 
 @odoo.tests.tagged('-at_install', 'post_install')
-@patch.object(ResUsers, '_compute_im_status', _compute_im_status)
 class TestGetRandomOperator(HttpCase):
     def _create_operator(self, lang_code=None, country_code=None):
         operator = new_test_user(self.env, login=f'operator_{lang_code or country_code}_{self.operator_id}')
@@ -19,6 +12,7 @@ class TestGetRandomOperator(HttpCase):
             'lang': lang_code,
             'country_id': self.env['res.country'].search([('code', '=', country_code)]).id if country_code else None,
         })
+        self.env['bus.presence'].create({'user_id': operator.id, 'status': 'online'})  # Simulate online status
         self.operator_id += 1
         return operator
 

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -27,7 +27,7 @@ class TestImLivechatMessage(TransactionCase):
     @users('emp')
     def test_message_format(self):
         im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
-        self.users[0].im_status = 'online'  # make available for livechat (ignore leave)
+        self.env['bus.presence'].create({'user_id': self.users[0].id, 'status': 'online'})  # make available for livechat (ignore leave)
         channel_livechat_1 = self.env['discuss.channel'].browse(im_livechat_channel._open_livechat_discuss_channel(anonymous_name='anon 1', previous_operator_id=self.users[0].partner_id.id, user_id=self.users[1].id, country_id=self.env.ref('base.in').id)['id'])
         record_rating = self.env['rating.rating'].create({
             'res_model_id': self.env['ir.model']._get('discuss.channel').id,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -81,7 +81,7 @@ class TestDiscussFullPerformance(TransactionCase):
         self.channel_group_1 = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group((self.users[0] + self.users[12]).partner_id.ids)['id'])
         # create livechats
         im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
-        self.users[0].im_status = 'online'  # make available for livechat (ignore leave)
+        self.env['bus.presence'].create({'user_id': self.users[0].id, 'status': 'online'})  # make available for livechat (ignore leave)
         self.channel_livechat_1 = self.env['discuss.channel'].browse(im_livechat_channel._open_livechat_discuss_channel(anonymous_name='anon 1', previous_operator_id=self.users[0].partner_id.id, user_id=self.users[1].id, country_id=self.env.ref('base.in').id)['id'])
         self.channel_livechat_1.with_user(self.users[1]).message_post(body="test")
         self.channel_livechat_2 = self.env['discuss.channel'].browse(im_livechat_channel.with_user(self.env.ref('base.public_user'))._open_livechat_discuss_channel(anonymous_name='anon 2', previous_operator_id=self.users[0].partner_id.id, country_id=self.env.ref('base.be').id)['id'])
@@ -131,7 +131,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                     'active': True,
                                     'email': 'e.e@example.com',
                                     'id': self.users[0].partner_id.id,
-                                    'im_status': 'offline',
+                                    'im_status': 'online',
                                     'name': 'Ernest Employee',
                                     'out_of_office_date_end': False,
                                     'user': {
@@ -181,7 +181,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                     'active': True,
                                     'email': 'e.e@example.com',
                                     'id': self.users[0].partner_id.id,
-                                    'im_status': 'offline',
+                                    'im_status': 'online',
                                     'name': 'Ernest Employee',
                                     'out_of_office_date_end': False,
                                     'user': {
@@ -231,7 +231,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                     'active': True,
                                     'email': 'e.e@example.com',
                                     'id': self.users[0].partner_id.id,
-                                    'im_status': 'offline',
+                                    'im_status': 'online',
                                     'name': 'Ernest Employee',
                                     'out_of_office_date_end': False,
                                     'user': {
@@ -281,7 +281,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                     'active': True,
                                     'email': 'e.e@example.com',
                                     'id': self.users[0].partner_id.id,
-                                    'im_status': 'offline',
+                                    'im_status': 'online',
                                     'name': 'Ernest Employee',
                                     'out_of_office_date_end': False,
                                     'user': {
@@ -331,7 +331,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                     'active': True,
                                     'email': 'e.e@example.com',
                                     'id': self.users[0].partner_id.id,
-                                    'im_status': 'offline',
+                                    'im_status': 'online',
                                     'name': 'Ernest Employee',
                                     'out_of_office_date_end': False,
                                     'user': {
@@ -382,7 +382,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                         'active': True,
                                         'email': 'e.e@example.com',
                                         'id': self.users[0].partner_id.id,
-                                        'im_status': 'offline',
+                                        'im_status': 'online',
                                         'name': 'Ernest Employee',
                                         'out_of_office_date_end': False,
                                         'user': {
@@ -468,7 +468,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                         'active': True,
                                         'email': 'e.e@example.com',
                                         'id': self.users[0].partner_id.id,
-                                        'im_status': 'offline',
+                                        'im_status': 'online',
                                         'name': 'Ernest Employee',
                                         'out_of_office_date_end': False,
                                         'user': {
@@ -554,7 +554,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                         'active': True,
                                         'email': 'e.e@example.com',
                                         'id': self.users[0].partner_id.id,
-                                        'im_status': 'offline',
+                                        'im_status': 'online',
                                         'name': 'Ernest Employee',
                                         'out_of_office_date_end': False,
                                         'user': {
@@ -640,7 +640,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                         'active': True,
                                         'email': 'e.e@example.com',
                                         'id': self.users[0].partner_id.id,
-                                        'im_status': 'offline',
+                                        'im_status': 'online',
                                         'name': 'Ernest Employee',
                                         'out_of_office_date_end': False,
                                         'user': {
@@ -726,7 +726,7 @@ class TestDiscussFullPerformance(TransactionCase):
                                         'active': True,
                                         'email': 'e.e@example.com',
                                         'id': self.users[0].partner_id.id,
-                                        'im_status': 'offline',
+                                        'im_status': 'online',
                                         'name': 'Ernest Employee',
                                         'out_of_office_date_end': False,
                                         'user': {
@@ -989,7 +989,7 @@ class TestDiscussFullPerformance(TransactionCase):
                 'active': True,
                 'email': 'e.e@example.com',
                 'id': self.users[0].partner_id.id,
-                'im_status': 'offline',
+                'im_status': 'online',
                 'name': 'Ernest Employee',
                 'out_of_office_date_end': False,
                 'user': {


### PR DESCRIPTION
This commit fixes tests that write on the `im_status` computed field of `res.users`. This leads to incoherent data being asserted. This will ease the diff of the PR introducing the guests for livechat visitors.

part of task-3332628