### PR TITLE
[FIX] web: can partially evaluate complex dynamic context

### DIFF
--- a/addons/web/static/tests/core/context_tests.js
+++ b/addons/web/static/tests/core/context_tests.js
@@ -1,8 +1,8 @@
 /** @odoo-module **/
 
-import { makeContext } from "@web/core/context";
+import { evalPartialContext, makeContext } from "@web/core/context";
 
-QUnit.module("utils", {}, () => {
+QUnit.module("Context", {}, () => {
     QUnit.module("makeContext");
 
     QUnit.test("return empty context", (assert) => {
@@ -41,5 +41,39 @@ QUnit.module("utils", {}, () => {
     QUnit.test("initial evaluation context", (assert) => {
         assert.deepEqual(makeContext(["{'a': a + 1}"], { a: 1 }), { a: 2 });
         assert.deepEqual(makeContext(["{'b': a + 1}"], { a: 1 }), { b: 2 });
+    });
+
+    QUnit.module("evalPartialContext");
+
+    QUnit.test("static contexts", (assert) => {
+        assert.deepEqual(evalPartialContext("{}", {}), {});
+        assert.deepEqual(evalPartialContext("{'a': 1}", {}), { a: 1 });
+        assert.deepEqual(evalPartialContext("{'a': 'b'}", {}), { a: "b" });
+        assert.deepEqual(evalPartialContext("{'a': true}", {}), { a: true });
+        assert.deepEqual(evalPartialContext("{'a': None}", {}), { a: null });
+    });
+
+    QUnit.test("complete dynamic contexts", (assert) => {
+        assert.deepEqual(evalPartialContext("{'a': a, 'b': 1}", { a: 2 }), { a: 2, b: 1 });
+    });
+
+    QUnit.test("partial dynamic contexts", (assert) => {
+        assert.deepEqual(evalPartialContext("{'a': a}", {}), {});
+        assert.deepEqual(evalPartialContext("{'a': a, 'b': 1}", {}), { b: 1 });
+        assert.deepEqual(evalPartialContext("{'a': a, 'b': b}", { a: 2 }), { a: 2 });
+    });
+
+    QUnit.test("value of type obj (15)", (assert) => {
+        assert.deepEqual(evalPartialContext("{'a': a.b.c}", {}), {});
+        assert.deepEqual(evalPartialContext("{'a': a.b.c}", { a: {} }), {});
+        assert.deepEqual(evalPartialContext("{'a': a.b.c}", { a: { b: { c: 2 } } }), { a: 2 });
+    });
+
+    QUnit.test("value of type op (14)", (assert) => {
+        assert.deepEqual(evalPartialContext("{'a': a + 1}", {}), {});
+        assert.deepEqual(evalPartialContext("{'a': a + b}", {}), {});
+        assert.deepEqual(evalPartialContext("{'a': a + b}", { a: 2 }), {});
+        assert.deepEqual(evalPartialContext("{'a': a + 1}", { a: 2 }), { a: 3 });
+        assert.deepEqual(evalPartialContext("{'a': a + b}", { a: 2, b: 3 }), { a: 5 });
     });
 });

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -3833,6 +3833,52 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".o_field_x2many_list_row_add a"));
     });
 
+    QUnit.test("form with one2many with dynamic context", async (assert) => {
+        assert.expect(2);
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="int_field"/>
+                    <field name="p" editable="bottom" context="{'static': 4, 'dynamic': int_field * 2}">
+                        <tree>
+                            <field name="foo"/>
+                        </tree>
+                    </field>
+                </form>`,
+            resId: 1,
+            mockRPC(route, args) {
+                if (args.method === "web_read") {
+                    assert.deepEqual(args.kwargs.specification, {
+                        display_name: {},
+                        int_field: {},
+                        p: {
+                            fields: {
+                                foo: {},
+                            },
+                            context: { static: 4 },
+                            limit: 40,
+                            order: "",
+                        },
+                    });
+                }
+                if (args.method === "onchange2") {
+                    assert.deepEqual(args.kwargs.context, {
+                        dynamic: 20,
+                        lang: "en",
+                        static: 4,
+                        tz: "taht",
+                        uid: 7,
+                    });
+                }
+            },
+        });
+
+        await addRow(target);
+    });
+
     QUnit.test("reference field in one2many list", async function (assert) {
         serverData.models.partner.records[0].reference = "partner,2";
         serverData.views = {


### PR DESCRIPTION
Have a form view with an x2many field, and a context on that field, depending on other fields of the view. For instance:
 ```xml
   <form>
     <field name="a"/>
     <field name="b_ids" context="{'key1': a, 'key2': 4}"/>
   </form>
 ```

As we read records in a single rpc (unity read), we need to be able to (at least partially) evaluate the context set on b_ids to build the field specification for the web_read call. The problem is that the evaluation context is incomplete when we want to evalute it, as we don't know the value of `a`.

Before this commit, we evaluated that context by adding "sentinel" values in the evaluation context (a sentinel being a Symbol), and we removed all keys whose values had been evaluated to the sentinel afterwards. This worked for the example above (we were able to generate the context `{ key2: 4 }`).

However, this wasn't flawless. For instance, with
 ```xml
    <field name="b_ids" context="{'key1': a + b}"/>
 ```
our sentinel strategy didn't work, because you can't perform such operations on a Symbol.

This commit comes with another strategy, which is actually easier, and which handles the above case. We now parse the context, and evaluate each value individually (if it needs to be evaluated). If the evaluation crashes, we swallow the error and do not add that particular key to the evaluated context.

Part of task~3179751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
