### PR TITLE
[IMP] mass_mailing: prepend test mail subject with [TEST]

### DIFF
--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -46,6 +46,7 @@ class TestMassMailing(models.TransientModel):
         else:
             full_body = mailing._prepend_preview(mailing.body_html, mailing.preview)
             subject = mailing.subject
+        subject = f'[TEST] {subject}'
 
         # Convert links in absolute URLs before the application of the shortener
         full_body = self.env['mail.render.mixin']._replace_local_links(full_body)

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -95,7 +95,7 @@ class TestMailingTest(TestMassMailCommon):
         expected_body = 'Hello {{ object.name }} Mitchell Admin'
 
         self.assertSentEmail(self.env.user.partner_id, ['test@test.com'],
-            subject=expected_subject,
+            subject='[TEST] ' + expected_subject,
             body_content=expected_body)
 
         with self.mock_mail_gateway():


### PR DESCRIPTION
When sending a test for a mass mailing

Before this commit:
- subject is the same as for a non-test
- default email adress is the current user's

After this commit:
- subject is prepended with '[TEST]'
- default email adress is the one used for a previous test if there is one, otherwise the current user's

Task-3378043