### PR TITLE
[FIX] web: JS error on calendar model with empty X2Many filters

### DIFF
--- a/addons/web/static/src/legacy/js/fields/field_utils.js
+++ b/addons/web/static/src/legacy/js/fields/field_utils.js
@@ -296,7 +296,7 @@ function formatMany2one(value, field, options) {
  * @returns {string}
  */
 function formatX2Many(value) {
-    if (value.data.length === 0) {
+    if (!value.data || value.data.length === 0) {
         return _t('No records');
     } else if (value.data.length === 1) {
         return _t('1 record');


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixes the JS error below when defining filters="1" on a One2many field with possible empty values.

Current behavior before PR:

`TypeError: undefined is not an object (evaluating 'value.data.length')
    formatX2Many@http://localhost:8069/web/assets/debug/web.assets_backend.js:56273:19 (/web/static/src/legacy/js/fields/field_utils.js:299)
    @http://localhost:8069/web/assets/debug/web.assets_backend.js:72824:63 (/web/static/src/legacy/js/views/calendar/calendar_model.js:680)
    @http://localhost:8069/web/assets/debug/web.assets_common.js:2112:17 (/web/static/lib/underscore/underscore.js:145)
    @http://localhost:8069/web/assets/debug/web.assets_backend.js:72819:23 (/web/static/src/legacy/js/views/calendar/calendar_model.js:675)
    @http://localhost:8069/web/assets/debug/web.assets_common.js:2112:17 (/web/static/lib/underscore/underscore.js:145)
    @http://localhost:8069/web/assets/debug/web.assets_backend.js:72812:19 (/web/static/src/legacy/js/views/calendar/calendar_model.js:668)
    @http://localhost:8069/web/assets/debug/web.assets_common.js:2117:17 (/web/static/lib/underscore/underscore.js:150)
    _loadRecordsToFilters@http://localhost:8069/web/assets/debug/web.assets_backend.js:72793:15 (/web/static/src/legacy/js/views/calendar/calendar_model.js:649)
    @http://localhost:8069/web/assets/debug/web.assets_backend.js:72670:47 (/web/static/src/legacy/js/views/calendar/calendar_model.js:526)`

Steps to reproduce:

1. Define a model with a One2many field and create records where some records have the field filled and others do not.
2. Define a calendar view where the field defined above has its filters attribute set to 1.
3. Attempt to load the view.

Desired behavior after PR is merged:

No more error when loading the same calendar view.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
