### PR TITLE
[FIX] web_editor: do not cache promise forever pending

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2956,11 +2956,11 @@ export class Wysiwyg extends Component {
     }
 
     _getColorpickerTemplate() {
-        return this.orm.call(
+        return this.env.services.orm.call(
             'ir.ui.view',
             'render_public_asset',
             ['web_editor.colorpicker', {}]
-        )
+        );
     }
 
     // -----------------------------------------------------------------------------


### PR DESCRIPTION
The wysiwyg component uses the ColorPalette, and gives it a callback in props (getTemplate). This callback does an orm service call and thus returns a promise. It is called by the ColorPalette in its willStart, and the result (the promise) is stored in the closure of the js module defining the ColorPalette, s.t. subsequent willStart directly reuse the promise instead of calling getTemplate.

The problem is that the orm service (when defined via useService) is bound to the component using it. If the component is destroyed before the rpc returns, the promise is kept pending forever. It might thus happen that the ColorPalette stored a promise forever pending, leading to a screen never loading. It was for instance the case in Invoices (list view), when you clicked on a record: the form view might never open. In this situation, two renderings where initiated, the first one triggered the rpc, and the second one cancelled the first one, making the promise being pending forever.

This commit bypasses useService to use the orm, which isn't the best solution but it's the easiest and fastest one. Ideally, this rpc should be done by a service, which could keep the promise in its closure. However, a lot of test suites would need to be adapted to make the service available for its tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
