### PR TITLE
[FIX] maintenance: compute method failed to assign error

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -95,9 +95,9 @@ class MaintenanceEquipment(models.Model):
     @api.depends('serial_no')
     def _compute_display_name(self):
         for record in self:
-            if record.name and record.serial_no:
+            if record.serial_no:
                 record.display_name = record.name + '/' + record.serial_no
-            if record.name and not record.serial_no:
+            else:
                 record.display_name = record.name
 
     @api.model


### PR DESCRIPTION
before this commit, on opening equipment form view a traceback is shown saying ompute method failed to assign error for field display_name

this is related to: https://github.com/odoo/odoo/commit/3c62ca1eb96d571b2b686b5caee370324c589ab4

after this commit, no traceback wont be shown to user

![Screenshot from 2023-07-28 10-18-56](https://github.com/odoo/odoo/assets/27989791/5d9a8a70-d1aa-42a8-bd8c-ef8cf4c980b8)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
