### PR TITLE
[FIX] web: fix qunit tests failing randomly

### DIFF
--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -8,7 +8,6 @@ import { makeTestEnv } from "../../helpers/mock_env";
 import {
     click,
     getFixture,
-    legacyExtraNextTick,
     patchWithCleanup,
     mount,
     nextTick,
@@ -16,7 +15,12 @@ import {
     editInput,
     getNodesTextContent,
 } from "../../helpers/utils";
-import { pagerNext, switchView, toggleMenuItem, toggleSearchBarMenu } from "@web/../tests/search/helpers";
+import {
+    pagerNext,
+    switchView,
+    toggleMenuItem,
+    toggleSearchBarMenu,
+} from "@web/../tests/search/helpers";
 import { session } from "@web/session";
 import {
     createWebClient,
@@ -215,7 +219,7 @@ QUnit.module("ActionManager", (hooks) => {
             action: 1,
         });
         await nextTick();
-        await legacyExtraNextTick();
+        await nextTick();
         assert.containsOnce(target, ".o_control_panel");
         assert.containsOnce(target, ".o_kanban_view");
         assert.verifySteps([
@@ -279,7 +283,7 @@ QUnit.module("ActionManager", (hooks) => {
             view_type: "form",
         });
         await nextTick();
-        await legacyExtraNextTick();
+        await nextTick();
         assert.containsOnce(target, ".o_form_view");
         assert.verifySteps([
             "/web/webclient/load_menus",
@@ -300,7 +304,7 @@ QUnit.module("ActionManager", (hooks) => {
             view_type: "kanban",
         });
         await nextTick();
-        await legacyExtraNextTick();
+        await nextTick();
         assert.containsNone(target, ".o_list_view");
         assert.containsOnce(target, ".o_kanban_view");
         assert.verifySteps([
@@ -329,7 +333,7 @@ QUnit.module("ActionManager", (hooks) => {
                 view_type: "form",
             });
             await nextTick();
-            await legacyExtraNextTick();
+            await nextTick();
             assert.containsNone(target, ".o_list_view");
             assert.containsOnce(target, ".o_form_view");
             assert.deepEqual(getBreadCrumbTexts(target), ["Partners", "Second record"]);
@@ -401,7 +405,7 @@ QUnit.module("ActionManager", (hooks) => {
             view_type: "kanban",
         });
         await nextTick();
-        await legacyExtraNextTick();
+        await nextTick();
         assert.containsNone(target, ".o_list_view");
         assert.containsOnce(target, ".o_kanban_view");
         // switch to form view, open record 4
@@ -411,7 +415,7 @@ QUnit.module("ActionManager", (hooks) => {
             view_type: "form",
         });
         await nextTick();
-        await legacyExtraNextTick();
+        await nextTick();
         assert.containsNone(target, ".o_kanban_view");
         assert.containsOnce(target, ".o_form_view");
         assert.deepEqual(getBreadCrumbTexts(target), ["Partners", "Fourth record"]);
@@ -445,6 +449,7 @@ QUnit.module("ActionManager", (hooks) => {
             id: 4,
             view_type: "form",
         });
+        await nextTick();
         await nextTick();
         assert.containsOnce(target, ".o_form_view");
         assert.deepEqual(getBreadCrumbTexts(target), ["Partners", "Fourth record"]);
@@ -485,7 +490,7 @@ QUnit.module("ActionManager", (hooks) => {
         });
         assert.verifySteps(["push_state"], "should have pushed the final state");
         await click(target.querySelector("tr .o_data_cell"));
-        await legacyExtraNextTick();
+        await nextTick();
         currentHash = webClient.env.services.router.current.hash;
         assert.deepEqual(currentHash, {
             action: 3,
@@ -588,7 +593,7 @@ QUnit.module("ActionManager", (hooks) => {
             assert.step(route);
         };
         await createWebClient({ serverData, mockRPC });
-        await legacyExtraNextTick();
+        await nextTick();
         assert.containsOnce(target, ".o_kanban_view", "should display a kanban view");
         assert.deepEqual(getBreadCrumbTexts(target), ["Partners Action 1"]);
         assert.verifySteps([
@@ -660,7 +665,6 @@ QUnit.module("ActionManager", (hooks) => {
             assert.containsOnce(target, ".o_list_view", "should now display the list view");
 
             await switchView(target, "kanban");
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_kanban_view", "should now display the kanban view");
 
             const hash = webClient.env.services.router.current.hash;


### PR DESCRIPTION
Since [1], a load_state test sometimes failed on runbot, because we replace the legacy implementation of nextTick by the new one, which is slightly different and sometimes a little bit faster. In the faulty test, two nextTicks are actually required. Indeed, changes in the url are batched in a timeout, so we must wait for an extra tick to see the change in the DOM. This commit takes the shot to remove/replace calls to legacyExtraNextTick in this file, as there's no legacy layer anymore (some of them needed to be converted into a nextTick, for the reason stated above).

[1] f40d4dc98bbcb24a345bbb7c5f1170e6de31fc61
Fixes runbot issue~23601

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
