### PR TITLE
[IMP] account: Add quick search on an amount in the journal items.

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -314,6 +314,7 @@
                     <field name="ref"/>
                     <field name="date"/>
                     <field name="invoice_date"/>
+                    <field name="balance" string="Amount" filter_domain="['|', ('credit', '=', self), ('debit', '=', self)]"/>
                     <field name="account_id"/>
                     <field name="account_type"/>
                     <field name="partner_id"/>
@@ -1295,6 +1296,7 @@
                     <field name="ref"/>
                     <field name="date"/>
                     <field name="invoice_date"/>
+                    <field name="amount_total"/>
                     <field name="partner_id"/>
                     <field name="journal_id"/>
                     <filter string="Unposted" name="unposted" domain="[('state', '=', 'draft')]" help="Unposted Journal Entries"/>


### PR DESCRIPTION
Problem
---------
User want to search on journal items based on the amount. This is doable through custom searches but that is not user-friendly.

Objective
---------
Add a search based on the amount of an journal item (in credit or in debit) to make it more user-friendly.

*Secondary objective*: Add a similar search for journal entry amounts.

Solution
---------
Declare a computed field for journal entries that the search will be based on and add this field in the search view of the journal items.

*Secondary solution*: Add amount_total in the search view of the journal entries.

task-3439520
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
