### PR TITLE
[IMP] sale_stock: set sale_id as readonly

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -69,7 +69,7 @@ class StockRule(models.Model):
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    sale_id = fields.Many2one(related="group_id.sale_id", string="Sales Order", store=True, readonly=False, index='btree_not_null')
+    sale_id = fields.Many2one(related="group_id.sale_id", string="Sales Order", store=True, index='btree_not_null')
 
     def _auto_init(self):
         """


### PR DESCRIPTION
This commit makes `sale_id` in `stock.picking` readonly, this allows us to edit `sale_id` on a picking without affecting `sale_id` in `group_id`

taskID: 3380442
Enterprise PR: odoo/enterprise#44696

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
