### PR TITLE
[IMP] web: `o_searchview_facet` interaction design

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.scss
+++ b/addons/web/static/src/search/search_bar/search_bar.scss
@@ -10,9 +10,4 @@
     }
 
     animation: animate .25s ease-out;
-    &.o_facet_with_domain:hover .o_searchview_facet_label {
-        cursor: pointer;
-        background: var(--SearchBar-facet-background, $o-enterprise-action-color);
-        border-color: var(--SearchBar-facet-background, $o-enterprise-action-color);
-    }
 }

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -3,14 +3,18 @@
 
     <t t-name="web.SearchBar.Facets" owl="1">
         <t t-foreach="env.searchModel.facets" t-as="facet" t-key="facet_index">
-            <div class="o_searchview_facet d-inline-flex align-items-stretch text-nowrap position-relative"
+            <div class="o_searchview_facet position-relative d-inline-flex align-items-stretch rounded-2 bg-200 text-nowrap opacity-trigger-hover"
                 t-att-class="{o_facet_with_domain: facet.domain }"
                 role="listitem"
                 aria-label="search"
                 tabindex="0"
                 t-on-keydown="ev => this.onFacetKeydown(facet, facet_index, ev)"
                 >
-                <div class="o_searchview_facet_label rounded-start-2"
+
+                <!-- :hover overlay -->
+                <div class="position-absolute start-0 top-0 bottom-0 end-0 bg-white border rounded-2 shadow opacity-0 opacity-100-hover"/>
+
+                <div class="o_searchview_facet_label position-relative rounded-start-2 px-1"
                     t-on-click="(ev) => this.onFacetLabelClick(ev.target, facet)"
                     t-att-role="facet.domain ? 'button' : 'img'"
                     t-att-class="{
@@ -19,16 +23,24 @@
                         'btn btn-favourite rounded-end-0 p-0': facet.type == 'favorite'
                     }"
                     >
-                    <i t-if="facet.icon" class="px-1 small" t-att-class="facet.icon" role="image"/>
-                    <small t-else="" class="px-2" t-esc="facet.title"/>
+                    <i t-if="facet.icon" class="small fa-fw" t-att-class="facet.icon" role="image"/>
+                    <small t-else="" class="px-1" t-esc="facet.title"/>
+
+                    <!-- Editable facets' overlay -->
+                    <span t-if="facet.domain"
+                        class="position-absolute start-0 top-0 bottom-0 end-0 o-bg-inherit opacity-0 opacity-100-hover"
+                        t-att-class="{'px-2 transition-base': !facet.icon}"
+                        >
+                        <i class="fa fa-fw fa-cog"/>
+                    </span>
                 </div>
 
-                <div class="o_facet_values d-flex align-items-center ps-2 bg-200 rounded-end-2">
+                <div class="o_facet_values position-relative d-flex align-items-center ps-2 rounded-end-2">
                     <t t-foreach="facet.values" t-as="facetValue" t-key="facetValue_index">
                         <em t-if="!facetValue_first" class="o_facet_values_sep small fw-bold mx-1 opacity-50" t-esc="facet.separator"/>
                         <small class="o_facet_value" t-esc="facetValue"/>
                     </t>
-                    <button class="o_facet_remove oi oi-close btn btn-link py-0 px-2 opacity-50 opacity-100-hover text-900"
+                    <button class="o_facet_remove oi oi-close btn btn-link py-0 px-2 text-danger"
                         role="button"
                         aria-label="Remove"
                         title="Remove"


### PR DESCRIPTION
Enhances the `o_searchview_facet` design with hover interactions, focusing
on providing a clearer visual representation when facets are selected:

- Implemented an overlay to indicate when a facet is selected, similar
  to https://github.com/odoo/odoo/pull/129991.
- Replaced the facet's icon with a cog icon, serving as a visual cue
  that the domain is now editable, improving user understanding.
- Overall appearance improvements, resulting in a more polished and
  user-friendly design.

Current behavior before PR:

https://github.com/odoo/odoo/assets/8558351/2edf4438-35bf-4c2f-b51c-35d11bced152


Desired behavior after PR is merged:

https://github.com/odoo/odoo/assets/8558351/088ac346-5cce-4f89-8d56-948aef12ab47


task-3444675

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
