### PR TITLE
[FIX] data_recycle: add notification service to list controller

### DIFF
--- a/addons/data_recycle/static/src/views/data_cleaning_common_list.js
+++ b/addons/data_recycle/static/src/views/data_cleaning_common_list.js
@@ -10,6 +10,7 @@ export class DataCleaningCommonListController extends ListController {
         super.setup();
         this.orm = useService("orm");
         this.actionService = useService("action");
+        this.notificationService = useService("notification");
     }
 
     /**


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/114024, the notification service is no longer used in the `ListController`. However, this service is needed in the data_merge list controller.
This PR adds the service to `DataCleaningCommonListController` so that it can be used in data_merge.
