### PR TITLE
[FIX] account: Fix division taxes for l10n_br

### DIFF
--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -1074,6 +1074,56 @@ class TestTax(TestTaxCommon):
             (tax_10_fix + tax_21).compute_all(1210),
         )
 
+    def test_brazilian_tax_division(self):
+        taxes = self.env['account.tax'].create([
+            {
+                'name': "tax_5",
+                'amount_type': 'division',
+                'amount': 5.0,
+                'price_include': True,
+            },
+            {
+                'name': "tax_3",
+                'amount_type': 'division',
+                'amount': 3.0,
+                'price_include': True,
+            },
+            {
+                'name': "tax_0_65",
+                'amount_type': 'division',
+                'amount': 0.65,
+                'price_include': True,
+            },
+            {
+                'name': "tax_9",
+                'amount_type': 'division',
+                'amount': 9.0,
+                'price_include': True,
+            },
+            {
+                'name': "tax_15",
+                'amount_type': 'division',
+                'amount': 15.0,
+                'price_include': True,
+            },
+        ])
+
+        self._check_compute_all_results(
+            48.0,       # 'total_included'
+            32.33,      # 'total_excluded'
+            [
+                # base , amount
+                # ---------------
+                (32.33, 2.4),
+                (32.33, 1.44),
+                (32.33, 0.31),
+                (32.33, 4.32),
+                (32.33, 7.20),
+                # ---------------
+            ],
+            taxes.compute_all(48),
+        )
+
     def test_price_included_repartition_sum_0(self):
         """ Tests the case where a tax with a non-zero value has a sum
         of tax repartition factors of zero and is included in price. It


### PR DESCRIPTION
The current tax engine doesn't work with division taxes because the tax amounts must be computed
on the price included amount but can't be on the price excluded one.
Unfortunately, the current engine is finding first the price excluded amount before computing "really" the tax
amounts.

It means, 20% division price included on 100 should be computed as: 100 * 0.2 = 20
However, when trying to compute the tax amount on 100 - 20 = 80, we are not able to retrieve the original tax amount of 20.

opw: 3443703

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
