### PR TITLE
[IMP] account: Make due date invisible for cancelled invoices/bills.

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -414,7 +414,7 @@
                     <field name="invoice_date" optional="show" invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund','in_receipt')" string="Bill Date"/>
                     <field name="invoice_date" optional="show" invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund','out_receipt')" string="Invoice Date"/>
                     <field name="date" optional="hide" string="Accounting Date"/>
-                    <field name="invoice_date_due" widget="remaining_days" optional="show" attrs="{'invisible': [['payment_state', 'in', ('paid', 'in_payment', 'reversed')]]}"/>
+                    <field name="invoice_date_due" widget="remaining_days" optional="show" attrs="{'invisible': ['|', ['payment_state', 'in', ('paid', 'in_payment', 'reversed')], ('state', '=', 'cancel')]}"/>
                     <field name="invoice_origin" optional="hide" string="Source Document"/>
                     <field name="payment_reference" optional="hide" invisible="context.get('default_move_type') in ('out_invoice', 'out_refund','out_receipt')"/>
                     <field name="ref" optional="hide"/>


### PR DESCRIPTION
Problem
---------
When an invoice or bill has been canceled, the Due Date for the payment is still showing, even though this information is not relevant anymore as no payment is expected. 

Objective
---------
Make due date invisible when the invoice/bill is cancelled.

Solution
---------
Modify the invisible attrs condition of the field in the account_move tree view by add a condition on the state.

task-3439357

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
