### PR TITLE
[PERF] website_{forum_}slides: lessen complexity of logged_in rules

### DIFF
--- a/addons/website_slides/models/res_partner.py
+++ b/addons/website_slides/models/res_partner.py
@@ -13,10 +13,6 @@ class ResPartner(models.Model):
         compute='_compute_slide_channel_values',
         search='_search_slide_channel_ids',
         groups="website_slides.group_website_slides_officer")
-    slide_channel_all_ids = fields.Many2many(
-        'slide.channel', 'slide_channel_partner', 'partner_id', 'channel_id',
-        string='eLearning Courses and Invitations',
-        groups="website_slides.group_website_slides_officer", copy=False)
     slide_channel_completed_ids = fields.One2many(
         'slide.channel', string='Completed Courses',
         compute='_compute_slide_channel_values',


### PR DESCRIPTION
(Introduced in 16.3, https://github.com/odoo/odoo/commit/86c6266d6cadf9a398190bea62a907d4807e7624)

--- ISSUE

From there, partner_ids and partner_all_ids m2m fields became computed
fields in order to return only active records as we read them from
the slide.channel.partner table, not checking the active field of that
table (not supported by framework).

Ir rules of records check if current user's partner is inside partner_ids,
or partner_all_ids of a given course. (joined the course for partner_ids,
invited or joined the course for partner_all_ids)

The issue is that all ir rules searching on these fields lead to very
slow loading of slides (channel, slide, homepage) and forum pages (as
soon as we have a forum linked to a course). This comes from the fact
that in some templates, we read records and evaluate rules on the spot,
in python. (for instance tags of courses on homepage)

As some courses have tens of thousands of attendees, this evaluation is
very slow in python, and there is no quick solution at framework level.
Therefore, computing thousands of partners for each access rule linked
to a course is too slow.

--- SOLUTION

The existing fields is_member and is_member_invited are used inside ir
rules instead. _search methods are added and we check whether course
is inside courses of current user's partner ones. It improved all times
a lot, see BENCHMARK below.

-> Existing tests already assert functioning

--- FIELDS REMOVED

- partner_all_ids on slide.channel has no use anymore. It is removed
as well as its search method. Tests are updated accordingly.

- slide_channel_all_ids on res.partner was not used anymore. It is
removed as well.

--- LOCAL BENCHMARK - IntelCore i5-8265U CPU 1.60GHz - Firefox

PAGE                        ----                       BEFORE (s)   to     AFTER (s)
/slides               ----                             4.3              to  < 0.15
/slides/all                ----              8               to  < 0.15
/slides/course_c        ----                 3.5        to       < 0.15
/forum                       ----            6.3            to  < 0.15
/forum/forum_c          ----                 8         to        < 0.4
/forum/forum_c/post_y     ----               4     to            < 0.3
/forum/forum_c/post_y/edit_answer    ----    2.7 to              < 0.4
/forum/forum_c/post_y/edit       ----        3.1           to    < 0.4
/forum/forum_c/post_y/reply      ----        3 (+4 post)  to      < 0.5 total
/profile/user/id         ----                2.24             to < 0.2

--DETAILS

- course_c: 43k attendees
- forum_c: forum of course_c
- post_y: 2-3 answers
- logged user: 'portal', with 7 courses

--POPULATIONS

- 20k   forum.forum (avg 2 answers)
- 20k   mail.message (about 2 answers per post)
- 10    forum.forum (+20 on courses)
- 20    slide.channel (half 'members' visibility)
- 300k  slide.channel.partner
- 'large' for other models

--- LINKS

UPG PR: https://github.com/odoo/upgrade/pull/5218
Task-3444633
