### PR TITLE
[IMP] *: add generic make_jsonrpc method in tests

### DIFF
--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -2,32 +2,19 @@
 
 import json
 
-from odoo.tests import common
+from odoo.tests import common, JsonRpcException
 
 
 class TestWebsocketController(common.HttpCase):
-    def _make_rpc(self, route, params, headers=None):
-        data = json.dumps({
-            'id': 0,
-            'jsonrpc': '2.0',
-            'method': 'call',
-            'params': params,
-        }).encode()
-        headers = headers or {}
-        headers['Content-Type'] = 'application/json'
-        return self.url_open(route, data, headers=headers)
-
     def test_websocket_peek(self):
-        response = json.loads(
-            self._make_rpc('/websocket/peek_notifications', {
-                'channels': [],
-                'last': 0,
-                'is_first_poll': True,
-            }).content.decode()
-        )
+        result = self.make_jsonrpc_request('/websocket/peek_notifications', {
+            'channels': [],
+            'last': 0,
+            'is_first_poll': True,
+        })
+
         # Response containing channels/notifications is retrieved and is
         # conform to excpectations.
-        result = response.get('result')
         self.assertIsNotNone(result)
         channels = result.get('channels')
         self.assertIsNotNone(channels)
@@ -36,20 +23,19 @@ class TestWebsocketController(common.HttpCase):
         self.assertIsNotNone(notifications)
         self.assertIsInstance(notifications, list)
 
-        response = json.loads(
-            self._make_rpc('/websocket/peek_notifications', {
-                'channels': [],
-                'last': 0,
-                'is_first_poll': False,
-            }).content.decode()
-        )
+        result = self.make_jsonrpc_request('/websocket/peek_notifications', {
+            'channels': [],
+            'last': 0,
+            'is_first_poll': False,
+        })
+
         # Reponse is received as long as the session is valid.
-        self.assertIn('result', response)
+        self.assertIsNotNone(result)
 
     def test_websocket_peek_session_expired_login(self):
         session = self.authenticate(None, None)
         # first rpc should be fine
-        self._make_rpc('/websocket/peek_notifications', {
+        self.make_jsonrpc_request('/websocket/peek_notifications', {
             'channels': [],
             'last': 0,
             'is_first_poll': True,
@@ -58,21 +44,17 @@ class TestWebsocketController(common.HttpCase):
         self.authenticate('admin', 'admin')
         # rpc with outdated session should lead to error.
         headers = {'Cookie': f'session_id={session.sid};'}
-        response = json.loads(
-            self._make_rpc('/websocket/peek_notifications', {
+        with self.assertRaises(JsonRpcException, msg='odoo.http.SessionExpiredException'):
+            self.make_jsonrpc_request('/websocket/peek_notifications', {
                 'channels': [],
                 'last': 0,
                 'is_first_poll': False,
-            }, headers=headers).content.decode()
-        )
-        error = response.get('error')
-        self.assertIsNotNone(error, 'Sending a poll with an outdated session should lead to error')
-        self.assertEqual('odoo.http.SessionExpiredException', error['data']['name'])
+            }, headers=headers)
 
     def test_websocket_peek_session_expired_logout(self):
         session = self.authenticate('demo', 'demo')
         # first rpc should be fine
-        self._make_rpc('/websocket/peek_notifications', {
+        self.make_jsonrpc_request('/websocket/peek_notifications', {
             'channels': [],
             'last': 0,
             'is_first_poll': True,
@@ -80,13 +62,9 @@ class TestWebsocketController(common.HttpCase):
         self.url_open('/web/session/logout')
         # rpc with outdated session should lead to error.
         headers = {'Cookie': f'session_id={session.sid};'}
-        response = json.loads(
-            self._make_rpc('/websocket/peek_notifications', {
+        with self.assertRaises(JsonRpcException, msg='odoo.http.SessionExpiredException'):
+            self.make_jsonrpc_request('/websocket/peek_notifications', {
                 'channels': [],
                 'last': 0,
                 'is_first_poll': False,
-            }, headers=headers).content.decode()
-        )
-        error = response.get('error')
-        self.assertIsNotNone(error, 'Sending a poll with an outdated session should lead to error')
-        self.assertEqual('odoo.http.SessionExpiredException', error['data']['name'])
+            }, headers=headers)

--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -33,8 +33,12 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
         self.assertEqual(created_lead.type, 'lead')
 
     def _chatbot_create_lead(self, user):
-        channel_info = self.livechat_channel._open_livechat_discuss_channel(
-            anonymous_name='Test Visitor', chatbot_script=self.chatbot_script, user_id=user.id)
+        channel_info = self.make_jsonrpc_request("/im_livechat/get_session", {
+            'anonymous_name': 'Test Visitor',
+            'channel_id': self.livechat_channel.id,
+            'chatbot_script_id': self.chatbot_script.id,
+            'user_id': user.id,
+        })
         discuss_channel = self.env['discuss.channel'].sudo().browse(channel_info['id'])
 
         self._post_answer_and_trigger_next_step(

--- a/addons/crm_mail_plugin/tests/test_crm_mail_plugin.py
+++ b/addons/crm_mail_plugin/tests/test_crm_mail_plugin.py
@@ -15,7 +15,7 @@ class TestCrmMailPlugin(TestMailPluginControllerCommon):
             {"name": "Partner 2"},
         ])
 
-        result = self._make_rpc_call("/mail_plugin/partner/get", {"partner_id": partner.id})
+        result = self.make_jsonrpc_request("/mail_plugin/partner/get", {"partner_id": partner.id})
 
         self.assertNotIn("leads", result,
             msg="The user has no access to crm.lead, the leads section should not be visible")
@@ -27,7 +27,7 @@ class TestCrmMailPlugin(TestMailPluginControllerCommon):
             {"name": "Lead Partner 2", "partner_id": partner_2.id},
         ])
 
-        result = self._make_rpc_call("/mail_plugin/partner/get", {"partner_id": partner.id})
+        result = self.make_jsonrpc_request("/mail_plugin/partner/get", {"partner_id": partner.id})
 
         self.assertIn(
             "leads",
@@ -71,7 +71,7 @@ class TestCrmMailPlugin(TestMailPluginControllerCommon):
             'email_subject': 'test subject',
         }
 
-        result = self._make_rpc_call('/mail_plugin/lead/create', params)
+        result = self.make_jsonrpc_request('/mail_plugin/lead/create', params)
 
         # Check that the created lead record has the correct company and return the lead_id
         self.assertIn(
@@ -87,27 +87,3 @@ class TestCrmMailPlugin(TestMailPluginControllerCommon):
             company_b,
             msg='The created record should belong to company_B',
         )
-
-    def _make_rpc_call(self, url, params):
-        """
-        Makes an RPC call to the specified URL with the given parameters, and returns the 'result' key from the response.
-
-        :param params (dict): A dictionary containing the parameters to send in the RPC call.
-        :param url (str): The URL to send the RPC call to.
-        :return (dict): The 'result' key from the response.
-        """
-
-        data = {
-            'id': 0,
-            'jsonrpc': '2.0',
-            'method': 'call',
-            'params': params,
-        }
-
-        response = self.url_open(
-            url,
-            data=json.dumps(data).encode(),
-            headers={'Content-Type': 'application/json'}
-        ).json()
-
-        return response['result']

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -4,7 +4,7 @@
 from odoo.tests import common
 
 
-class ChatbotCase(common.TransactionCase):
+class ChatbotCase(common.HttpCase):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/im_livechat/tests/common.py
+++ b/addons/im_livechat/tests/common.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import HttpCase
 
 
-class TestImLivechatCommon(TransactionCase):
+class TestImLivechatCommon(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.password = 'Pl1bhD@2!kXZ'
         cls.operators = cls.env['res.users'].create([{
             'name': 'Michel',
             'login': 'michel',
+            'password': cls.password,
             'livechat_username': "Michel Operator",
             'email': 'michel@example.com',
         }, {

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -44,8 +44,11 @@ class ChatbotCase(chatbot_common.ChatbotCase):
                          "Only step 'step_no_one_available' should be flagged as forward operator child.")
 
     def test_chatbot_steps(self):
-        channel_info = self.livechat_channel._open_livechat_discuss_channel(
-            anonymous_name='Test Visitor', chatbot_script=self.chatbot_script)
+        channel_info = self.make_jsonrpc_request("/im_livechat/get_session", {
+            'anonymous_name': 'Test Visitor',
+            'chatbot_script_id': self.chatbot_script.id,
+            'channel_id': self.livechat_channel.id,
+        })
         discuss_channel = self.env['discuss.channel'].browse(channel_info['id'])
 
         self.assertEqual(discuss_channel.chatbot_current_step_id, self.step_dispatch)

--- a/addons/payment/tests/test_multicompany_flows.py
+++ b/addons/payment/tests/test_multicompany_flows.py
@@ -128,6 +128,6 @@ class TestMultiCompanyFlows(PaymentHttpCommon):
 
         # Archive token in company A
         url = self._build_url('/payment/archive_token')
-        self._make_json_rpc_request(url, {'token_id': token.id})
+        self.make_jsonrpc_request(url, {'token_id': token.id})
 
         self.assertFalse(token.active)

--- a/addons/payment_demo/tests/test_processing_flows.py
+++ b/addons/payment_demo/tests/test_processing_flows.py
@@ -20,5 +20,5 @@ class TestProcessingFlows(PaymentDemoCommon, PaymentHttpCommon):
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
             '._handle_notification_data'
         ) as handle_notification_data_mock:
-            self._make_json_rpc_request(url, data=self.notification_data)
+            self.make_jsonrpc_request(url, params=self.notification_data)
         self.assertEqual(handle_notification_data_mock.call_count, 1)

--- a/addons/pos_online_payment/tests/online_payment_common.py
+++ b/addons/pos_online_payment/tests/online_payment_common.py
@@ -23,10 +23,7 @@ class OnlinePaymentCommon(PaymentHttpCommon):
     def _fake_request_pos_order_pay_transaction_page(self, pos_order_id, route_values):
         uri = f'/pos/pay/transaction/{pos_order_id}'
         url = self._build_url(uri)
-        response = self._make_json_rpc_request(url, route_values)
-        self.assertEqual(response.status_code, 200)
-        resp_content = json.loads(response.content)
-        return resp_content['result']
+        return self.make_jsonrpc_request(url, route_values)
 
     def _fake_open_pos_order_pay_confirmation_page(self, pos_order_id, access_token, tx_id):
         self._fake_http_get_request(PaymentPortal._get_landing_route(pos_order_id, access_token, tx_id=tx_id))

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -81,24 +81,13 @@ class TestPortalControllers(TestPortal):
         """Test retrieving chatter messages through the portal controller"""
         self.authenticate(None, None)
         message_fetch_url = '/mail/chatter_fetch'
-        payload = json.dumps({
-            'jsonrpc': '2.0',
-            'method': 'call',
-            'id': 0,
-            'params': {
+
+        def get_chatter_message_count():
+            return self.make_jsonrpc_request(message_fetch_url, {
                 'res_model': 'mail.test.portal',
                 'res_id': self.record_portal.id,
                 'token': self.record_portal.access_token,
-            },
-        })
-
-        def get_chatter_message_count():
-            res = self.url_open(
-                url=message_fetch_url,
-                data=payload,
-                headers={'Content-Type': 'application/json'}
-            )
-            return res.json().get('result', {}).get('message_count', 0)
+            }).get('message_count', 0)
 
         self.assertEqual(get_chatter_message_count(), 0)
 

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -7,7 +7,7 @@ from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 
 
 @tests.tagged('post_install', '-at_install')
-class TestLivechatChatbotUI(tests.HttpCase, TestLivechatCommon, ChatbotCase):
+class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
     def setUp(self):
         super().setUp()
         self.env['im_livechat.channel'].search([

--- a/addons/website_sale/tests/test_delivery_express_checkout_flows.py
+++ b/addons/website_sale/tests/test_delivery_express_checkout_flows.py
@@ -11,6 +11,7 @@ from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website_sale.controllers.delivery import WebsiteSaleDelivery as WebsiteSaleDeliveryController
+from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 @tagged('post_install', '-at_install')
@@ -107,31 +108,6 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'state': self.user_demo.partner_id.state_id.code,
         }
 
-    def _make_json_rpc_request(self, url, data=None):
-        """ Make a JSON-RPC request to the provided URL.
-
-        :param str url: The URL to make the request to
-        :param dict data: The data to be send in the request body in JSON-RPC 2.0 format
-        :return dict: The result of the JSON-RPC request
-        """
-        rpc_request = {
-            "jsonrpc": "2.0",
-            "method": "call",
-             "id": str(uuid4()),
-            "params": data,
-        }
-
-        result = self.url_open(
-            url,
-            data=json.dumps(rpc_request).encode(),
-            headers={"Content-Type": "application/json"},
-        )
-
-        if not result.ok:
-            return {}
-
-        return result.json().get("result", {})
-
     def test_express_checkout_public_user_shipping_address_change(self):
         """ Test that when using express checkout as a public user and selecting a shipping address,
             a new partner is created if the partner of the SO is the public partner.
@@ -143,10 +119,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values)
                 }
             )
@@ -175,18 +151,18 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values)
                 }
             )
             new_partner = self.sale_order.partner_shipping_id
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values_2)
                 }
             )
@@ -213,10 +189,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values)
                 }
             )
@@ -235,10 +211,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values)
                 }
             )
@@ -269,18 +245,18 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values)
                 }
             )
             new_partner = self.sale_order.partner_shipping_id
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_shipping_values_2)
                 }
             )
@@ -325,16 +301,16 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            shipping_options = self._make_json_rpc_request(
+            shipping_options = self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_demo_shipping_values)
                 }
             )
             self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
 
-            self._make_json_rpc_request(urls.url_join(self.base_url(), '/shop/express'), data={
+            self.make_jsonrpc_request(urls.url_join(self.base_url(), WebsiteSale._express_checkout_route), params={
                 'billing_address': dict(self.express_checkout_billing_values),
                 'shipping_address': dict(self.express_checkout_demo_shipping_values),
                 'shipping_option': shipping_options[0],
@@ -355,10 +331,10 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
         ):
             # Won't create a new partner because the partial information are the same the an
             # exisiting partner linked to the SO
-            shipping_options = self._make_json_rpc_request(
+            shipping_options = self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_shipping_route
-                ), data={
+                ), params={
                     'partial_shipping_address': dict(self.express_checkout_anonymized_demo_shipping_values)
                 }
             )
@@ -366,11 +342,11 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(HttpCaseWithUserDemo):
 
             # Will create a new partner because the complete shipping information are different than
             # the partner actually selected.
-            self._make_json_rpc_request(
+            self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(),
                     WebsiteSaleDeliveryController._express_checkout_route
-                ), data={
+                ), params={
                     'billing_address': dict(self.express_checkout_billing_values),
                     'shipping_address': dict(self.express_checkout_demo_shipping_values_2),
                     'shipping_option': shipping_options[0],

--- a/addons/website_sale/tests/test_express_checkout_flows.py
+++ b/addons/website_sale/tests/test_express_checkout_flows.py
@@ -47,41 +47,16 @@ class TestWebsiteSaleExpressCheckoutFlows(HttpCaseWithUserDemo):
             'state': 'AL',
         }
 
-    def _make_json_rpc_request(self, url, data=None):
-        """ Make a JSON-RPC request to the provided URL.
-
-        :param str url: The URL to make the request to
-        :param dict data: The data to be send in the request body in JSON-RPC 2.0 format
-        :return dict: The result of the JSON-RPC request
-        """
-        rpc_request = {
-            "jsonrpc": "2.0",
-            "method": "call",
-             "id": str(uuid4()),
-            "params": data,
-        }
-
-        result = self.url_open(
-            url,
-            data=json.dumps(rpc_request).encode(),
-            headers={"Content-Type": "application/json"},
-        )
-
-        if not result.ok:
-            return {}
-
-        return result.json().get("result", {})
-
     def test_express_checkout_public_user(self):
         """ Test that when using express checkout as a public user, a new partner is created. """
         session = self.authenticate(None, None)
         session['sale_order_id'] = self.sale_order.id
         root.session_store.save(session)
 
-        self._make_json_rpc_request(
+        self.make_jsonrpc_request(
             urls.url_join(
                 self.base_url(), WebsiteSaleController._express_checkout_route
-            ), data={
+            ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
             }
         )
@@ -105,10 +80,10 @@ class TestWebsiteSaleExpressCheckoutFlows(HttpCaseWithUserDemo):
         session['sale_order_id'] = self.sale_order.id
         root.session_store.save(session)
 
-        self._make_json_rpc_request(
+        self.make_jsonrpc_request(
             urls.url_join(
                 self.base_url(), WebsiteSaleController._express_checkout_route
-            ), data={
+            ), params={
                 'billing_address': {
                     'name': self.user_demo.partner_id.name,
                     'email': self.user_demo.partner_id.email,
@@ -152,10 +127,10 @@ class TestWebsiteSaleExpressCheckoutFlows(HttpCaseWithUserDemo):
         session['sale_order_id'] = self.sale_order.id
         root.session_store.save(session)
 
-        self._make_json_rpc_request(
+        self.make_jsonrpc_request(
             urls.url_join(
                 self.base_url(), WebsiteSaleController._express_checkout_route
-            ), data={
+            ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
             }
         )
@@ -173,10 +148,10 @@ class TestWebsiteSaleExpressCheckoutFlows(HttpCaseWithUserDemo):
         session['sale_order_id'] = self.sale_order.id
         root.session_store.save(session)
 
-        self._make_json_rpc_request(
+        self.make_jsonrpc_request(
             urls.url_join(
                 self.base_url(), WebsiteSaleController._express_checkout_route
-            ), data={
+            ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
             }
         )


### PR DESCRIPTION
*: bus, crm_livechat, crm_mail_plugin, im_livechat, payment, payment_demo,
pos_online_payment, test_discuss_full, test_mail_full, tests, website_livechat,
website_sale.

Several python tests have their own way to make jsonrpc requests. This PR adds a
generic `make_jsonrpc_request` method to the `HttpCase` in order to provide a
generic way to do so.

At the same time, calls to `_open_livechat_channel` are removed in favor of
jsonrpc request to `get_session`. This makes the tests more realistics (some
incoherences were present like passing `country_id` to the open channel method
while the user country id is not set...)

Finally, this will ease the diff in the PR introducing livechat visitors as mail
guests.

enterprise: https://github.com/odoo/enterprise/pull/44840