### PR TITLE
[IMP] l10n_*: Allow export FEC for all France "country".

### DIFF
--- a/addons/l10n_gp/__init__.py
+++ b/addons/l10n_gp/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_gp/__manifest__.py
+++ b/addons/l10n_gp/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Guadeloupe - Accounting',
+    'icon': '/account/static/description/l10n.png',
+    'countries': ['gp'],
+    'version': '2.1',
+    'category': 'Accounting/Localizations/Account Charts',
+    'depends': [
+        'account',
+        'l10n_fr_fec',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_gy/__init__.py
+++ b/addons/l10n_gy/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_gy/__manifest__.py
+++ b/addons/l10n_gy/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Guyana - Accounting',
+    'icon': '/account/static/description/l10n.png',
+    'countries': ['gy'],
+    'version': '2.1',
+    'category': 'Accounting/Localizations/Account Charts',
+    'depends': [
+        'account',
+        'l10n_fr_fec',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_mq/__init__.py
+++ b/addons/l10n_mq/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_mq/__manifest__.py
+++ b/addons/l10n_mq/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Martinique - Accounting',
+    'icon': '/account/static/description/l10n.png',
+    'countries': ['mq'],
+    'version': '2.1',
+    'category': 'Accounting/Localizations/Account Charts',
+    'depends': [
+        'account',
+        'l10n_fr_fec',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_re/__init__.py
+++ b/addons/l10n_re/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_re/__manifest__.py
+++ b/addons/l10n_re/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Réunion - Accounting',
+    'icon': '/account/static/description/l10n.png',
+    'countries': ['re'],
+    'version': '2.1',
+    'category': 'Accounting/Localizations/Account Charts',
+    'depends': [
+        'account',
+        'l10n_fr_fec',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_yt/__init__.py
+++ b/addons/l10n_yt/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/l10n_yt/__manifest__.py
+++ b/addons/l10n_yt/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Mayotte - Accounting',
+    'icon': '/account/static/description/l10n.png',
+    'countries': ['yt'],
+    'version': '2.1',
+    'category': 'Accounting/Localizations/Account Charts',
+    'depends': [
+        'account',
+        'l10n_fr_fec',
+    ],
+    'license': 'LGPL-3',
+}


### PR DESCRIPTION
*: gp, mq, gy, re, yt

Problem
---------
Some France departement are considered as country in Odoo, but they need France's report like FEC which is not accessible so far.

Objective
---------
We need to add the FEC export to country manage in l10n_fr:
- Guadeloupe [GP]
- Martinique [MQ]
- Guyana [GY]
- Réunion [RE]
- Mayotte [YT]

Solution
---------
For each "country", create a localization that depends on the France FEC export module.

task-3418552
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
