### PR TITLE
[REF] *: remove model.notify()

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -63,14 +63,12 @@ export class AccountPaymentField extends Component {
     async assignOutstandingCredit(id) {
         await this.orm.call(this.props.record.resModel, 'js_assign_outstanding_line', [this.move_id, id], {});
         await this.props.record.model.root.load();
-        this.props.record.model.notify();
     }
 
     async removeMoveReconcile(moveId, partialId) {
         this.popover.close();
         await this.orm.call(this.props.record.resModel, 'js_remove_outstanding_partial', [moveId, partialId], {});
         await this.props.record.model.root.load();
-        this.props.record.model.notify();
     }
 
     async openMove(moveId) {

--- a/addons/crm/static/src/views/forecast_kanban/forecast_kanban_renderer.js
+++ b/addons/crm/static/src/views/forecast_kanban/forecast_kanban_renderer.js
@@ -42,7 +42,6 @@ export class ForecastKanbanRenderer extends CrmKanbanRenderer {
             })
             .expand();
         await this.props.list.load();
-        this.props.list.model.notify();
     }
 }
 

--- a/addons/data_recycle/static/src/views/data_recycle_list_view.js
+++ b/addons/data_recycle/static/src/views/data_recycle_list_view.js
@@ -13,7 +13,6 @@ export class DataRecycleListController extends DataCleaningCommonListController 
 
         await this.orm.call('data_recycle.record', 'action_validate', [record_ids]);
         await this.model.load();
-        this.model.notify();
     }
 };
 

--- a/addons/hr/static/src/views/archive_employee_hook.js
+++ b/addons/hr/static/src/views/archive_employee_hook.js
@@ -23,7 +23,6 @@ export function useArchiveEmployee() {
         }, {
             onClose: async () => {
                 await component.model.load();
-                component.model.notify();
             },
         });
     }

--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -70,9 +70,7 @@ export class ExpenseListController extends ListController {
                 }
             });
         }
-        // sgv note: we tried this.model.notify(); and does not work
         await this.model.root.load();
-        this.render(true);
     }
 
     async action_show_expenses_to_submit () {

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -301,7 +301,6 @@ export class Chatter extends Component {
         await this.props.saveRecord?.();
         if (this.props.webRecord) {
             await this.props.webRecord.load();
-            this.props.webRecord.model.notify();
         }
     }
 

--- a/addons/mrp/static/src/views/mrp_documents_kanban/mrp_documents_kanban_controller.js
+++ b/addons/mrp/static/src/views/mrp_documents_kanban/mrp_documents_kanban_controller.js
@@ -15,7 +15,6 @@ export class MrpDocumentsKanbanController extends KanbanController {
             "FILE_UPLOAD_LOADED",
             async () => {
                 await this.model.root.load();
-                this.model.notify();
             },
         );
     }

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
@@ -36,7 +36,6 @@ export class ProjectTaskKanbanHeader extends KanbanHeader {
             title: this.env._t('Edit Personal Stage'),
             onRecordSaved: async () => {
                 await this.props.list.load();
-                this.props.list.model.notify();
             },
         });
     }

--- a/addons/sms/static/src/components/sms_button/sms_button.js
+++ b/addons/sms/static/src/components/sms_button/sms_button.js
@@ -31,7 +31,6 @@ export class SendSMSButton extends Component {
         }, {
             onClose: () => {
                 this.props.record.load();
-                this.props.record.model.notify();
             },
         });
     }

--- a/addons/web/static/src/views/fields/translation_button.js
+++ b/addons/web/static/src/views/fields/translation_button.js
@@ -32,7 +32,6 @@ export function useTranslationDialog() {
             isComingFromTranslationAlert: false,
             onSave: async () => {
                 await record.load();
-                record.model.notify();
             },
         });
     }

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -278,7 +278,6 @@ export class KanbanRecord extends Component {
                 context: record.context,
                 onClose: async () => {
                     await record.model.root.load();
-                    record.model.notify();
                 },
             });
         } else if (forceGlobalClick || this.allowGlobalClick) {

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -238,7 +238,6 @@ export class ListController extends Component {
                 context: record.context,
                 onClose: async () => {
                     await record.model.root.load();
-                    record.model.notify();
                 },
             });
         } else {


### PR DESCRIPTION
Since the relational model was rewritten (PR 114024), it is now reactive, so it is no longer necessary to use model.notify() to render the view.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
