### PR TITLE
[FIX] *: convert record.data.id => record.resId

### DIFF
--- a/addons/account/static/src/components/mail_attachments/mail_attachments.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.xml
@@ -39,7 +39,7 @@
                     multiUpload="true"
                     onUpload.bind="onFileUploaded"
                     resModel="props.record.resModel"
-                    resId="props.record.data.id or 0">
+                    resId="props.record.resId or 0">
                     <button class="btn btn-secondary o_attach" data-tooltip="Attach">
                         <span class="fa fa-paperclip" aria-label="Attach"/> Attachments
                     </button>

--- a/addons/hr_recruitment/static/src/views/form_view.js
+++ b/addons/hr_recruitment/static/src/views/form_view.js
@@ -17,7 +17,7 @@ export class InterviewerFormController extends FormController {
             return result;
         }
         result["o_applicant_interviewer_form"] = root.data.interviewer_ids.records.findIndex(
-            interviewer => interviewer.data.id === root.data.user_id[0]) > -1;
+            interviewer => interviewer.resId === root.data.user_id[0]) > -1;
         return result;
     }
 }

--- a/addons/sale/static/src/js/product_discount_field.js
+++ b/addons/sale/static/src/js/product_discount_field.js
@@ -28,7 +28,7 @@ export class ProductDiscountField extends FloatField {
             return;
         }
 
-        const isFirstOrderLine = this.props.record.resId === orderLines[0].data.id;
+        const isFirstOrderLine = this.props.record.resId === orderLines[0].resId;
         if (isFirstOrderLine && sameValue(orderLines)) {
             this.dialogService.add(ConfirmationDialog, {
                 body: _lt("Do you want to apply this value to all lines?"),

--- a/addons/stock/static/src/views/picking_form/picking_form_model.js
+++ b/addons/stock/static/src/views/picking_form/picking_form_model.js
@@ -10,7 +10,7 @@ export class StockPickingAutoSaveRecord extends Record {
         });
         await new Promise((resolve) => {
             this.model.env.bus.trigger("STOCK_MOVE:SAVED", {
-                id: this.data.id,
+                id: this.resId,
                 product_id: this.data.product_id,
                 resolve,
             });

--- a/addons/stock/static/src/widgets/forecast_widget.js
+++ b/addons/stock/static/src/widgets/forecast_widget.js
@@ -8,10 +8,10 @@ import { useService } from "@web/core/utils/hooks";
 
 export class ForecastWidgetField extends FloatField {
     setup() {
-        const { data, fields } = this.props.record;
+        const { data, fields, resId } = this.props.record;
         this.actionService = useService("action");
         this.orm = useService("orm");
-        this.resId = data.id;
+        this.resId = resId;
 
         this.reservedAvailability = formatFloat(data.reserved_availability, {
             ...fields.reserved_availability,

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
@@ -14,7 +14,7 @@
                     multiUpload="true"
                     onUpload.bind="onFileUploaded"
                     resModel="props.record.resModel"
-                    resId="props.record.data.id or 0"
+                    resId="props.record.resId or 0"
                 >
                     <button class="btn btn-secondary o_attach" data-tooltip="Attach">
                         <span class="fa fa-paperclip" aria-label="Attach"/> <t t-esc="uploadText"/>


### PR DESCRIPTION
Since the relational model was rewritten (PR 114024), the record id is no longer present in data by default. The correct way to access the id of a record is to do record.resId.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
