### PR TITLE
[IMP] hr_expense, sale_expense: category on product form view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -519,28 +519,25 @@
                                 <field name="active" invisible="1"/>
                                 <field name="type" invisible="1"/>
                                 <field name="detailed_type" invisible="1"/>
-                                <field name="standard_price" help="When the cost of an expense product is different than 0, then the user using this product won't be able to change the amount of the expense, only the quantity. Use a cost different than 0 for expense categories funded by the company at fixed cost like allowances for mileage, per diem, accommodation or meal."/>
-                                <field name="uom_id" groups="uom.group_uom" options="{'no_create': True}"/>
+                                <field name="standard_price" class="w-25" help="When the cost of an expense product is different than 0, then the user using this product won't be able to change the amount of the expense, only the quantity. Use a cost different than 0 for expense categories funded by the company at fixed cost like allowances for mileage, per diem, accommodation or meal."/>
+                                <field name="uom_id" class="w-25" groups="uom.group_uom" options="{'no_create': True}"/>
                                 <field name="uom_po_id" invisible="1"/>
                                 <label for="default_code"/>
                                 <div>
-                                    <field name="default_code"/>
+                                    <field name="default_code" class="w-50"/>
                                     <span class="d-inline-block"><i class="text-muted">Use this reference as a subject prefix when submitting by email.</i></span>
                                 </div>
-                                <field name="company_id" groups="base.group_multi_company"/>
+                                <field name="categ_id" class="w-50"/>
+                                <field name="company_id" class="w-50" groups="base.group_multi_company"/>
                             </group>
                             <group string="Accounting">
-                                <field name="property_account_expense_id" groups="account.group_account_readonly"/>
-                                <field name="supplier_taxes_id" widget="many2many_tags"
+                                <field name="property_account_expense_id" class="w-50" groups="account.group_account_readonly"/>
+                                <field name="supplier_taxes_id" class="w-50" widget="many2many_tags"
                                        context="{'default_type_tax_use':'purchase', 'default_price_include': 1}"
                                        options="{'no_quick_create': True}"/>
                             </group>
                         </group>
-                        <notebook>
-                            <page string="Internal Note" name="internal_note">
-                                <field name="description" placeholder="This note will be shown to users when they select this expense product."/>
-                            </page>
-                        </notebook>
+                        <field name="description" class="mt-5" placeholder="This note will be shown to users when they select this expense product."/>
                     </sheet>
                 </form>
             </field>

--- a/addons/sale_expense/views/product_view.xml
+++ b/addons/sale_expense/views/product_view.xml
@@ -20,7 +20,7 @@
             </xpath>
             <xpath expr="//field[@name='supplier_taxes_id']" position="after">
                 <field name="taxes_id" widget="many2many_tags" invisible="expense_policy == 'no'"
-                       options="{'no_quick_create': True}"/>
+                       options="{'no_quick_create': True}" class="w-50"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Prior to this PR, when creating a new product.product model, a product.category is allocated. As it is not shown on the product.expense.form view, the user might make mistakes  if he did not set  the product.category himself. This can be fixed by adding the product.category field on the view to allow the user to modify it.

Also, some design changes are made at the same time to improve the form view.

This PR improves the product.product.expense.form view by adding the product.category field so the user can modify it and also by modifying the general layout of the view.

The view is modified adding the field, aligning the two first fields and removing the notebook page for the notes and placing it in the continuity of the view as it is the only page in the notebook

task-3413267




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
