### PR TITLE
[FIX] base,web: traceback on opening user group

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -142,6 +142,8 @@ class Base(models.AbstractModel):
                     continue
 
                 co_records = self[field_name]
+                if 'context' in field_spec:
+                    co_records = co_records.with_context(**field_spec['context'])
 
                 if 'order' in field_spec and field_spec['order']:
                     co_records = co_records.search([('id', 'in', co_records.ids)], order=field_spec['order'])
@@ -151,9 +153,6 @@ class Base(models.AbstractModel):
                     }
                     for values in values_list:
                         values[field_name] = sorted(values[field_name], key=order_key.__getitem__)
-
-                if 'context' in field_spec:
-                    co_records = co_records.with_context(**field_spec['context'])
 
                 if 'fields' in field_spec:
                     if field_spec.get('limit') is not None:

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -85,7 +85,7 @@
                             <field name="implied_ids"/>
                         </page>
                         <page string="Menus" name="menus">
-                            <field name="menu_access"/>
+                            <field name="menu_access" context="{'ir.ui.menu.full_list': True}"/>
                         </page>
                         <page string="Views" name="views">
                             <field name="view_access" groups="base.group_system"/>


### PR DESCRIPTION
before this commit, on opening show full accounting
features user group, is showing traceback

* open community instance 
* activate developer mode
* open user groups menu and search for full accounting feature
* open that user group

*the exception started after the introduction of web_read method in this
commit: https://github.com/odoo/odoo/commit/7d2baaa0c726a7b0dd4fe7226862f960c9c59b7


while opening the user form view, the read is triggered on the many2many 
field menu_access

```
elif field.type in ('one2many', 'many2many'):
    if not field_spec:
        continue

    co_records = self[field_name]
```

here value in the co_records will be the menu linked to this
user group.

`co_records = co_records.search([('id', 'in', co_records.ids)], order=field_spec['order'])
`

once search is triggered on the same model, with this menus ids, it returns empty
and thus the key error is raised.


on doing search on ir.ui.menu model, without "ir.ui.menu.full_list" 
it returns only menu's which has a action linked to it. so in order
to bypass it, context is added in the view level for the field.

```
@api.model
def search_fetch(self, domain, field_names, offset=0, limit=None, order=None):
    menus = super().search_fetch(domain, field_names, order=order)
    if menus:
        # menu filtering is done only on main menu tree, not other menu lists
        if not self._context.get('ir.ui.menu.full_list'):
            menus = menus._filter_visible_menus()
        if offset:
            menus = menus[offset:]
        if limit:
            menus = menus[:limit]
    return menus
```



after this commit, no traceback won't be shown

![user_group](https://github.com/odoo/odoo/assets/99093808/01cae681-a9ab-45ef-aedc-353baad277af)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
