### PR TITLE
[IMP] sale_project: add icon on company dependent fields

### DIFF
--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -12,8 +12,16 @@
             <field name="invoice_policy" position="after">
                 <field name="service_policy" string="Invoicing Policy" invisible="type != 'service'" required="type == 'service'"/>
                 <field name="service_tracking" required="1" invisible="type != 'service' or not sale_ok"/>
-                <field name="project_id" context="{'default_allow_billable': True}" invisible="service_tracking != 'task_global_project'" required="service_tracking == 'task_global_project'"/>
-                <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" invisible="service_tracking not in ['task_in_project', 'project_only']"/>
+                <div class="o_td_label d-inline-flex" invisible="service_tracking != 'task_global_project'">
+                    <label for='project_id'/>
+                    <span class='fa fa-lg fa-building-o fa-fw' title="Values set here are company-specific." groups="base.group_multi_company"/>
+                </div>
+                <field name="project_id" context="{'default_allow_billable': True}" invisible="service_tracking != 'task_global_project'" required="service_tracking == 'task_global_project'" nolabel="1"/>
+                <div class="o_td_label d-inline-flex" invisible="service_tracking not in ['task_in_project', 'project_only']">
+                    <label for='project_template_id'/>
+                    <span class='fa fa-lg fa-building-o fa-fw' title="Values set here are company-specific." groups="base.group_multi_company"/>
+                </div>
+                <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True}" invisible="service_tracking not in ['task_in_project', 'project_only']" nolabel="1"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This commit improves the visual indication of company dependent fields. add icon of 'fa fa-building' on side of fields label.

task-3186717
