### PR TITLE
 [REF] account, l10n_{bo,lv}: remove 'none' figure_type

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -16,7 +16,6 @@ FIGURE_TYPE_SELECTION_VALUES = [
     ('datetime', "Datetime"),
     ('boolean', 'Boolean'),
     ('string', 'String'),
-    ('none', "No Formatting"),
 ]
 
 DOMAIN_REGEX = re.compile(r'(-?sum)\((.*)\)')

--- a/addons/l10n_bo/data/account_tax_report_data.xml
+++ b/addons/l10n_bo/data/account_tax_report_data.xml
@@ -10,7 +10,7 @@
             <record id="l10n_bo_tax_report_code" model="account.report.column">
                 <field name="name">Code</field>
                 <field name="expression_label">code</field>
-                <field name="figure_type">none</field>
+                <field name="figure_type">string</field>
             </record>
             <record id="l10n_bo_tax_report_balance" model="account.report.column">
                 <field name="name">Balance</field>

--- a/addons/l10n_lv/data/vat_tax_report.xml
+++ b/addons/l10n_lv/data/vat_tax_report.xml
@@ -10,7 +10,7 @@
             <record id="vat_report_column_code" model="account.report.column">
                 <field name="name">Code</field>
                 <field name="expression_label">code</field>
-                <field name="figure_type">none</field>
+                <field name="figure_type">string</field>
             </record>
             <record id="vat_report_column_balance" model="account.report.column">
                 <field name="name">Balance</field>


### PR DESCRIPTION
[REF] account, l10n_{bo,lv}: remove 'none' figure_type

This commit removes the 'none' figure_type from the account_tax_report
because it is redundant since other figure_types have been added.
Especially 'string' which practically does the same thing.

task ID: 3434197

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr