### PR TITLE
[REF] *: remove always_reload many2one option from archs

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -796,7 +796,7 @@
                                             'res_partner_search_mode': (context.get('default_move_type', 'entry') in ('out_invoice', 'out_refund', 'out_receipt') and 'customer') or (context.get('default_move_type', 'entry') in ('in_invoice', 'in_refund', 'in_receipt') and 'supplier') or False,
                                             'show_address': 1, 'default_is_company': True, 'show_vat': True}"
                                        domain="[('company_id', 'in', (False, company_id))]"
-                                       options='{"always_reload": True, "no_quick_create": True}'
+                                       options='{"no_quick_create": True}'
                                        attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}"/>
 
                                 <field name="partner_shipping_id"

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -269,7 +269,7 @@
                                         <field name="company_id"
                                             groups="base.group_multi_company"
                                             options="{'no_create': True}"/>
-                                        <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
+                                        <field name="campaign_id" options="{'create_name_field': 'title'}"/>
                                         <field name="medium_id"/>
                                         <field name="source_id"/>
                                         <field name="referred"/>
@@ -315,7 +315,7 @@
                                         </div>
                                     </group>
                                     <group string="Marketing">
-                                        <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
+                                        <field name="campaign_id" options="{'create_name_field': 'title'}"/>
                                         <field name="medium_id" />
                                         <field name="source_id" />
                                         <field name="referred"/>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -52,9 +52,7 @@
                             <field name="organizer_id"/>
                             <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                             <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="address_id"
-                                context="{'show_address': 1}"
-                                options='{"always_reload": True}'/>
+                            <field name="address_id" context="{'show_address': 1}"/>
                             <label for="seats_limited" string="Limit Registrations"/>
                             <div>
                                 <field name="seats_limited"/>

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -81,7 +81,7 @@
                                         <group string="Location" name="location">
                                             <field name="address_id"
                                                 context="{'show_address': 1}"
-                                                options='{"always_reload": True, "highlight_first_line": True}'/>
+                                                options='{"highlight_first_line": True}'/>
                                             <field name="work_location_id"/>
                                         </group>
                                         <group name="managers" string="Approvers" invisible="1">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -116,7 +116,7 @@
                                         <group string="Location">
                                             <field name="address_id"
                                                 context="{'show_address': 1}"
-                                                options='{"always_reload": True, "highlight_first_line": True}'/>
+                                                options='{"highlight_first_line": True}'/>
                                             <field name="work_location_id" context="{'default_address_id': address_id}" />
                                         </group>
                                         <group name="managers" string="Approvers" class="hide-group-if-empty" invisible="1">

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -124,7 +124,7 @@
                                     <field name="department_id" attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                     <field name="address_id"
                                         context="{'show_address': 1}"
-                                        options='{"always_reload": True, "highlight_first_line": True}'
+                                        options='{"highlight_first_line": True}'
                                         attrs="{'readonly': [('can_edit', '=', False)]}"/>
                                 </group>
                                 <group name="managers" string="Approvers" class="hide-group-if-empty">

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -81,7 +81,7 @@
                     <group>
                         <group>
                             <field name="type_request_unit" invisible="1"/>
-                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}" options="{'always_reload': True}"/>
+                            <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}"/>
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>
                             <field name="is_officer" invisible="1"/>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -185,7 +185,7 @@
                 <label for="address_id"/>
                 <div class="o_row">
                     <span attrs="{'invisible': [('address_id', '!=', False)]}" class="oe_read_only">Remote</span>
-                    <field name="address_id" context="{'show_address': 1}" options="{'always_reload': True}" placeholder="Remote"/>
+                    <field name="address_id" context="{'show_address': 1}" placeholder="Remote"/>
                 </div>
                 <label for="alias_name" string="Email Alias" attrs="{'invisible': [('alias_domain', '=', False)]}" help="Define a specific contact address for this job position. If you keep it empty, the default email address will be used which is in human resources settings"/>
                 <div name="alias_def" attrs="{'invisible': [('alias_domain', '=', False)]}">

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -48,7 +48,7 @@
                                 <field name="short_url"/>
                             </group>
                             <group name="utm" string="UTM">
-                                <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
+                                <field name="campaign_id" options="{'create_name_field': 'title'}"/>
                                 <field name="medium_id"/>
                                 <field name="source_id"/>
                             </group>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -345,7 +345,7 @@
                                         <field name="campaign_id"
                                             string="Campaign"
                                             groups="mass_mailing.group_mass_mailing_campaign"
-                                            options="{'create_name_field': 'title', 'always_reload': True}"
+                                            options="{'create_name_field': 'title'}"
                                             attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <field name="medium_id"
                                              string="Medium"

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -39,7 +39,7 @@
                         name="utm_link"
                         groups="base.group_no_one"
                         attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund'))]}">
-                    <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
+                    <field name="campaign_id" options="{'create_name_field': 'title'}"/>
                     <field name="medium_id"/>
                     <field name="source_id"/>
                 </group>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -298,17 +298,14 @@
                         <field name="partner_id"
                                widget="res_partner_many2one"
                                context="{'res_partner_search_mode': 'customer', 'show_address': 1, 'show_vat': True}"
-                               options="{'always_reload': True}"
                                placeholder="Type to find a customer..."/>
                         <field name="partner_invoice_id"
                               groups="account.group_delivery_invoice_address"
                               context="{'default_type':'invoice'}"
-                              options="{'always_reload': True}"
                               attrs="{'readonly': ['|', ('state', '=', 'cancel'), ('locked', '=', True)]}"/>
                         <field name="partner_shipping_id"
                               groups="account.group_delivery_invoice_address"
                               context="{'default_type':'delivery'}"
-                              options="{'always_reload': True}"
                               attrs="{'readonly': ['|', ('state', '=', 'cancel'), ('locked', '=', True)]}"/>
                     </group>
                     <group name="order_details">
@@ -730,7 +727,7 @@
                             </group>
                             <group string="Tracking" name="sale_reporting">
                                 <field name="origin"/>
-                                <field name="campaign_id" options="{'create_name_field': 'title', 'always_reload': True}"/>
+                                <field name="campaign_id" options="{'create_name_field': 'title'}"/>
                                 <field name="medium_id"/>
                                 <field name="source_id"/>
                             </group>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -113,7 +113,6 @@
                 <field name="has_any_so_with_nothing_to_invoice" invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="options">{'always_reload': True}</attribute>
                 <attribute name="attrs">{'invisible': [('allow_billable', '=', False)]}</attribute>
             </xpath>
             <xpath expr="//group[@name='group_time_managment']" position="after">
@@ -186,7 +185,6 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="attributes">
-                <attribute name="options">{'always_reload': True}</attribute>
                 <attribute name="attrs">{'invisible': [('allow_billable', '=', False)]}</attribute>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -11,7 +11,7 @@
                     <group>
                         <field name="name"/>
                         <field name="url"/>
-                        <field name="view_id" context="{'display_website': True}" options="{'always_reload': True}"/>
+                        <field name="view_id" context="{'display_website': True}"/>
                         <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                         <field name="track"/>
                     </group>
@@ -179,7 +179,6 @@
     <field name="arch" type="xml">
         <field name="inherit_id" position="attributes">
             <attribute name="context">{'display_website': True}</attribute>
-            <attribute name="options">{'always_reload': True}</attribute>
         </field>
         <field name="model" position="before">
             <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>

--- a/addons/website_event/views/event_event_add.xml
+++ b/addons/website_event/views/event_event_add.xml
@@ -10,7 +10,7 @@
                 <field name="website_url" invisible="1"/>
                 <field name="company_id" invisible="1"/>
                 <field name="name" placeholder="e.g. &quot;Conference for Architects&quot;" string="Event Name"/>
-                <field name="address_id" context="{'show_address': 1}" options='{"always_reload": True}'/>
+                <field name="address_id" context="{'show_address': 1}"/>
                 <field name="date_begin" string="Start &#8594; End" widget="daterange" options="{'end_date_field': 'date_end'}" />
                 <field name="date_end" invisible="1" />
             </group>

--- a/odoo/addons/base/wizard/base_partner_merge_views.xml
+++ b/odoo/addons/base/wizard/base_partner_merge_views.xml
@@ -58,8 +58,7 @@
                                 <field name="dst_partner_id"
                                     domain="[('id', 'in', partner_ids or False)]"
                                     attrs="{'required': [('state', '=', 'selection')]}"
-                                    context="{'partner_show_db_id': True}"
-                                    options="{'always_reload': True}"/>
+                                    context="{'partner_show_db_id': True}"/>
                             </group>
                             <field name="partner_ids" nolabel="1">
                                 <tree string="Partners">


### PR DESCRIPTION
This option is no longer necessary since [1] as the value is now reloaded by default.

[1] odoo/odoo#114024
Part of task~3179751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
