### PR TITLE
[REF] web: RelationalModel: add option to display invalid notif

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -133,11 +133,11 @@ export class Record extends DataPoint {
         return this.model.mutex.exec(() => this._toggleArchive(true));
     }
 
-    async checkValidity() {
+    async checkValidity({ displayNotification } = {}) {
         if (!this._urgentSave) {
             await this.model._askChanges();
         }
-        return this._checkValidity();
+        return this._checkValidity({ displayNotification });
     }
 
     delete() {
@@ -206,21 +206,6 @@ export class Record extends DataPoint {
             throw new Error("Record.load() does not accept arguments");
         }
         return this.model.mutex.exec(() => this._load());
-    }
-
-    openInvalidFieldsNotification() {
-        if (this._invalidFields.size) {
-            const items = [...this._invalidFields].map((fieldName) => {
-                return `<li>${escape(this.fields[fieldName].string || fieldName)}</li>`;
-            }, this);
-            this._closeInvalidFieldsNotification = this.model.notification.add(
-                markup(`<ul>${items.join("")}</ul>`),
-                {
-                    title: _t("Invalid fields: "),
-                    type: "danger",
-                }
-            );
-        }
     }
 
     async save(options) {
@@ -321,7 +306,7 @@ export class Record extends DataPoint {
         this._setEvalContext();
     }
 
-    _checkValidity({ silent } = {}) {
+    _checkValidity({ silent, displayNotification } = {}) {
         const unsetRequiredFields = [];
         for (const fieldName in this.activeFields) {
             const fieldType = this.fields[fieldName].type;
@@ -364,7 +349,20 @@ export class Record extends DataPoint {
             this._unsetRequiredFields.add(fieldName);
             this._setInvalidField(fieldName);
         }
-        return !this._invalidFields.size;
+        const isValid = !this._invalidFields.size;
+        if (!isValid && displayNotification) {
+            const items = [...this._invalidFields].map((fieldName) => {
+                return `<li>${escape(this.fields[fieldName].string || fieldName)}</li>`;
+            }, this);
+            this._closeInvalidFieldsNotification = this.model.notification.add(
+                markup(`<ul>${items.join("")}</ul>`),
+                {
+                    title: _t("Invalid fields: "),
+                    type: "danger",
+                }
+            );
+        }
+        return isValid;
     }
 
     _computeDataContext() {
@@ -776,8 +774,7 @@ export class Record extends DataPoint {
                 this.data[fieldName]._abandonRecords();
             }
         }
-        if (!this._checkValidity()) {
-            this.openInvalidFieldsNotification();
+        if (!this._checkValidity({ displayNotification: true })) {
             return false;
         }
         const changes = this._getChanges();

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -590,7 +590,7 @@ export class X2ManyFieldDialog extends Component {
 
     async save({ saveAndNew }) {
         const disabledButtons = this.disableButtons();
-        if (await this.record.checkValidity()) {
+        if (await this.record.checkValidity({ displayNotification: true })) {
             try {
                 await this.props.save(this.record);
             } catch (error) {
@@ -601,7 +601,6 @@ export class X2ManyFieldDialog extends Component {
                 this.record = await this.props.addNew();
             }
         } else {
-            this.record.openInvalidFieldsNotification();
             this.enableButtons(disabledButtons);
             return false;
         }


### PR DESCRIPTION
This commit removes a function from the Record datapoint, and replaces it by an option to checkValidity, as we want Record to have a few public methods as possible.

Part of task~3179751

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
