### PR TITLE
[FIX] web_editor, *: store the correct mimetype of an image with a shape

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -87,6 +87,7 @@ const DEFAULT_PALETTE = {
 const BACKGROUND_IMAGE_ATTRIBUTES = new Set([
     "originalId", "originalSrc", "mimetype", "resizeWidth", "glFilter", "quality", "bgSrc",
     "filterOptions",
+    "mimetypeBeforeConversion",
 ]);
 
 /**

--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -458,6 +458,7 @@ async function loadImageInfo(img, rpc, attachmentSrc = '') {
         img.dataset.originalId = original.id;
         img.dataset.originalSrc = original.image_src;
         img.dataset.mimetype = original.mimetype;
+        img.dataset.mimetypeBeforeConversion = original.mimetype;
     }
 }
 

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5847,9 +5847,9 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
         };
         widths[img.naturalWidth] = [sprintf(_t("%spx"), img.naturalWidth), 'image/webp'];
         widths[optimizedWidth] = [sprintf(_t("%spx (Suggested)"), optimizedWidth), 'image/webp'];
-        const imgMimetype = this._getImageMimetype(img);
-        widths[maxWidth] = [sprintf(_t("%spx (Original)"), maxWidth), imgMimetype];
-        if (imgMimetype !== 'image/webp') {
+        const mimetypeBeforeConversion = img.dataset.mimetypeBeforeConversion;
+        widths[maxWidth] = [sprintf(_t("%spx (Original)"), maxWidth), mimetypeBeforeConversion];
+        if (mimetypeBeforeConversion !== "image/webp") {
             // Avoid a key collision by subtracting 0.1 - putting the webp
             // above the original format one of the same size.
             widths[maxWidth - 0.1] = [sprintf(_t("%spx"), maxWidth), 'image/webp'];

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -36,6 +36,7 @@ safe_attrs = clean.defs.safe_attrs | frozenset(
      'data-publish', 'data-id', 'data-res_id', 'data-interval', 'data-member_id', 'data-scroll-background-ratio', 'data-view-id',
      'data-class', 'data-mimetype', 'data-original-src', 'data-original-id', 'data-gl-filter', 'data-quality', 'data-resize-width',
      'data-shape', 'data-shape-colors', 'data-file-name', 'data-original-mimetype',
+     'data-mimetype-before-conversion',
      'data-behavior-props', 'data-prop-name',  # knowledge commands
      ])
 SANITIZE_TAGS = {


### PR DESCRIPTION
[FIX] web_editor, *: store the correct mimetype of an image with a shape
*: base

Steps to reproduce the bug:
- Add an image on the website.
- Replace it by a "jpeg". Note that the mimetype of the image is
"image/webp" at the upload since [1].
- Add a shape on the image.
- Save and Edit.

-> If you check on the available "Format", the mimetype of the
"Original" is "wepb" but it should be "jpeg".

Before this commit, there were two types of mimetype data attribute:
- "mimetype": the current mimetype of the image.
- "originalMimetype": the mimetype of the image without a shape.
Before [1], it was also the mimetype of the original image. However,
since [1], the user has to possibility to change the mimetype of the
image so the "originalMimetype" attribute does not always reffer to the
mimetype of the original image anymore.

To resolve the problem, an other data attribute has to be introduced.
Here is a summary of the mimetype related attribute:
- `mimetypeBeforeConversion`: the mimetype of the original image. It is
needed in order to be able to change the format of an image and come
back to the original one.
- `originalMimetype`: the mimetype of the image before a shape has
been applied. It is needed when removing a shape to recover the correct
mimetype.
- `mimetype`: the current mimetype of an image.

In the case of an uploaded "jpeg" image on which a shape has been
applied, `mimetypeBeforeConversion` is "image/jpeg", `originalMimetype`
is "image/webp" (since [1]) and `mimetype` is "image/svg+xml".

[1]: https://github.com/odoo/odoo/commit/0449fe85cb0e1d639a4e1aeba26e90906f79254d