### PR TITLE
[FIX] mail, im_livechat: fix channel member wrap

### DIFF
--- a/addons/im_livechat/static/src/core/channel_member_list_patch.xml
+++ b/addons/im_livechat/static/src/core/channel_member_list_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[@t-ref='displayName']" position="replace">
             <div class="d-flex flex-column">
                 <t>$0</t>
-                <div t-if="member.thread.type === 'livechat'" class="ms-2 d-flex">
+                <div t-if="member.thread.type === 'livechat'" class="ms-2 d-flex flex-wrap">
                     <span t-if="member.getLangName()" class="me-2">
                         <i class="fa fa-comment-o me-1" aria-label="Lang"/>
                         <t t-esc="member.getLangName()"/>


### PR DESCRIPTION
Both language and country are displayed in the channel member list. Before this commit, this was displayed in one line when available which looked bad. This commit allow those items to wrap for a better display.

Before
----------
After

![image](https://github.com/odoo/odoo/assets/48757558/839ac7d5-f794-4f44-9b47-1935b0c99c25)

