### PR TITLE
[REF] web,*: tests: remove legacyExtraNextTick

### DIFF
--- a/addons/mail/static/tests/web/debug_menu_tests.js
+++ b/addons/mail/static/tests/web/debug_menu_tests.js
@@ -3,12 +3,7 @@
 import { manageMessages } from "@mail/js/tools/debug_manager";
 
 import { registry } from "@web/core/registry";
-import {
-    click,
-    getFixture,
-    legacyExtraNextTick,
-    patchWithCleanup,
-} from "@web/../tests/helpers/utils";
+import { click, getFixture, patchWithCleanup } from "@web/../tests/helpers/utils";
 import {
     createWebClient,
     doAction,
@@ -46,14 +41,12 @@ QUnit.test("Manage Messages", async (assert) => {
     const target = getFixture();
     const wc = await createWebClient({ serverData, mockRPC });
     await doAction(wc, 3, { viewType: "form", props: { resId: 5 } });
-    await legacyExtraNextTick();
     await click(target, ".o_debug_manager .dropdown-toggle");
     const dropdownItems = target.querySelectorAll(".o_debug_manager .dropdown-menu .dropdown-item");
     assert.strictEqual(dropdownItems.length, 1);
     assert.strictEqual(dropdownItems[0].innerText.trim(), "Manage Messages");
 
     await click(dropdownItems[0]);
-    await legacyExtraNextTick();
     assert.verifySteps(["message_read"]);
     assert.strictEqual(
         target.querySelector(".o_breadcrumb .active > span").innerText.trim(),

--- a/addons/spreadsheet_dashboard/static/tests/clickable_cells/clickable_cells.js
+++ b/addons/spreadsheet_dashboard/static/tests/clickable_cells/clickable_cells.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
-import { getFixture } from "@web/../tests/helpers/utils";
+import { getFixture, nextTick } from "@web/../tests/helpers/utils";
 import { getDashboardServerData } from "../utils/data";
 import { createSpreadsheetDashboard } from "../utils/dashboard_action";
 import { getBasicData } from "@spreadsheet/../tests/utils/data";
@@ -20,6 +20,7 @@ async function createDashboardWithModel(model) {
         ...getBasicData(),
     };
     await createSpreadsheetDashboard({ serverData, spreadsheetId: dashboard.id });
+    await nextTick();
     return getFixture();
 }
 

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
@@ -1,12 +1,6 @@
 /** @odoo-module */
 
-import {
-    getFixture,
-    click,
-    legacyExtraNextTick,
-    nextTick,
-    editInput,
-} from "@web/../tests/helpers/utils";
+import { getFixture, click, nextTick, editInput } from "@web/../tests/helpers/utils";
 import { getDashboardServerData } from "../utils/data";
 import { getBasicData, getBasicListArchs } from "@spreadsheet/../tests/utils/data";
 import { createSpreadsheetDashboard } from "../utils/dashboard_action";
@@ -148,10 +142,8 @@ QUnit.test(
         await createSpreadsheetDashboard({ serverData });
         await click(fixture, ".o_search_panel li:last-child");
         await click(fixture, ".o-dashboard-clickable-cell");
-        await legacyExtraNextTick();
         assert.containsOnce(fixture, ".o_list_view");
         await click(document.body.querySelector(".o_back_button"));
-        await legacyExtraNextTick();
         assert.hasClass(fixture.querySelector(".o_search_panel li:last-child"), "active");
     }
 );

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -7,13 +7,7 @@ import { serializeDate } from "@web/core/l10n/dates";
 
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
 
-import {
-    editInput,
-    legacyExtraNextTick,
-    patchWithCleanup,
-    click,
-    patchDate,
-} from "@web/../tests/helpers/utils";
+import { editInput, patchWithCleanup, click, patchDate } from "@web/../tests/helpers/utils";
 import { doAction } from "@web/../tests/webclient/helpers";
 import { session } from "@web/session";
 import { toggleSearchBarMenu } from "@web/../tests/search/helpers";
@@ -671,11 +665,9 @@ QUnit.module("test_mail", {}, function () {
         await testUtils.dom.click(
             document.querySelector(".o_activity_view .o_data_row .o_activity_empty_cell")
         );
-        await legacyExtraNextTick();
         assert.containsOnce($, ".modal.o_technical_modal", "Activity Modal should be opened");
 
         await testUtils.dom.click($('.modal.o_technical_modal button[special="cancel"]'));
-        await legacyExtraNextTick();
         assert.containsNone($, ".modal.o_technical_modal", "Activity Modal should be closed");
     });
 
@@ -717,7 +709,6 @@ QUnit.module("test_mail", {}, function () {
             const { webClient } = await start({ serverData });
             await doAction(webClient, 1);
 
-            await legacyExtraNextTick();
             assert.containsN(document.body, ".o_m2o_avatar", 2);
             assert.containsOnce(
                 document.body,

--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -65,8 +65,6 @@ function makeMenus(env, menusData, fetchLoadMenus) {
             if (menu && menu.appID !== currentAppId) {
                 currentAppId = menu.appID;
                 env.bus.trigger("MENUS:APP-CHANGED");
-                // FIXME: lock API: maybe do something like
-                // pushState({menu_id: ...}, { lock: true}); ?
                 env.services.router.pushState({ menu_id: menu.id }, { lock: true });
             }
         },

--- a/addons/web/static/tests/core/debug/debug_manager_tests.js
+++ b/addons/web/static/tests/core/debug/debug_manager_tests.js
@@ -22,7 +22,6 @@ import {
     click,
     getFixture,
     getNodesTextContent,
-    legacyExtraNextTick,
     mount,
     nextTick,
     patchWithCleanup,
@@ -421,7 +420,6 @@ QUnit.module("DebugMenu", (hooks) => {
         await doAction(webClient, 1);
         await click(target.querySelector(".o_debug_manager button"));
         await click(target.querySelector(".o_debug_manager .dropdown-item"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".breadcrumb-item");
         assert.containsOnce(target, ".o_breadcrumb .active");
         assert.strictEqual(target.querySelector(".o_breadcrumb .active").textContent, "Edit view");
@@ -484,7 +482,6 @@ QUnit.module("DebugMenu", (hooks) => {
 
         await click(target.querySelector(".o_debug_manager button"));
         await click(target.querySelector(".o_debug_manager .dropdown-item"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".breadcrumb-item");
         assert.containsOnce(target, ".o_breadcrumb .active");
         assert.strictEqual(target.querySelector(".o_breadcrumb .active").textContent, "Edit view");

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -639,10 +639,6 @@ export async function triggerHotkey(hotkey, addOverlayModParts = false, eventAtt
     return { keydownEvent, keyupEvent };
 }
 
-export async function legacyExtraNextTick() {
-    return nextTick();
-}
-
 export function mockDownload(cb) {
     patchWithCleanup(download, { _download: cb });
 }

--- a/addons/web/static/tests/mobile/webclient/burger_menu/burger_menu_tests.js
+++ b/addons/web/static/tests/mobile/webclient/burger_menu/burger_menu_tests.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
-import { click, legacyExtraNextTick } from "@web/../tests/helpers/utils";
+import { click, nextTick } from "@web/../tests/helpers/utils";
 import {
     createWebClient,
     doAction,
@@ -59,9 +59,7 @@ QUnit.test("Burger Menu on an App", async (assert) => {
 
     await createWebClient({ serverData });
     await click(document.body, ".o_navbar_apps_menu .dropdown-toggle");
-    await legacyExtraNextTick();
     await click(document.body, ".o_app:nth-of-type(2)");
-    await legacyExtraNextTick();
 
     assert.containsNone(document.body, ".o_burger_menu");
 
@@ -89,9 +87,7 @@ QUnit.test("Burger Menu on an App without SubMenu", async (assert) => {
 
     await createWebClient({ serverData });
     await click(document.body, ".o_navbar_apps_menu .dropdown-toggle");
-    await legacyExtraNextTick();
     await click(document.body, ".o_app:nth-of-type(2)");
-    await legacyExtraNextTick();
 
     assert.containsNone(document.body, ".o_burger_menu");
 
@@ -111,7 +107,6 @@ QUnit.test("Burger menu closes when an action is requested", async (assert) => {
     assert.containsOnce(document.body, ".o_burger_menu");
 
     await doAction(wc, 1);
-    await legacyExtraNextTick();
     assert.containsNone(document.body, ".o_burger_menu");
     assert.containsOnce(document.body, ".o_kanban_view");
 });
@@ -131,9 +126,7 @@ QUnit.test("Burger menu closes when click on menu item", async (assert) => {
     };
     await createWebClient({ serverData });
     await click(document.body, ".o_navbar_apps_menu .dropdown-toggle");
-    await legacyExtraNextTick();
     await click(document.body, ".o_app:nth-of-type(2)");
-    await legacyExtraNextTick();
 
     assert.containsNone(document.body, ".o_burger_menu");
 
@@ -144,7 +137,6 @@ QUnit.test("Burger menu closes when click on menu item", async (assert) => {
         "SubMenu"
     );
     await click(document.body, ".o_burger_menu nav.o_burger_menu_content li");
-    await legacyExtraNextTick();
-    await legacyExtraNextTick();
+    await nextTick();
     assert.containsNone(document.body, ".o_burger_menu");
 });

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -34,7 +34,6 @@ import {
     editSelect,
     getFixture,
     getNodesTextContent,
-    legacyExtraNextTick,
     makeDeferred,
     mouseEnter,
     nextTick,
@@ -13532,7 +13531,6 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_group_header", 3); // page 1
 
         await pagerNext(target);
-        await legacyExtraNextTick();
         assert.deepEqual(getPagerValue(target), [4, 4]);
         assert.containsN(target, ".o_group_header", 1); // page 2
 

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -6,7 +6,6 @@ import { makeFakeLocalizationService, makeFakeUserService } from "../helpers/moc
 import {
     click,
     getFixture,
-    legacyExtraNextTick,
     makeDeferred,
     mockDownload,
     nextTick,
@@ -3245,7 +3244,6 @@ QUnit.module("Views", (hooks) => {
                 </pivot>`,
         });
 
-
         assert.strictEqual(
             target.querySelector("table tbody tr").innerText.replace(/\s/g, ""),
             "Total1124",
@@ -4096,7 +4094,6 @@ QUnit.module("Views", (hooks) => {
             await nextTick();
 
             await click(target.querySelectorAll(".o_pivot_cell_value")[1]);
-            await legacyExtraNextTick();
 
             assert.containsOnce(target, ".o_list_view");
 
@@ -4739,7 +4736,6 @@ QUnit.module("Views", (hooks) => {
 
         // switch to list view
         await click(target.querySelector(".o_control_panel .o_switch_view.o_list"));
-        await legacyExtraNextTick();
 
         assert.containsOnce(target, ".o_list_view");
         assert.verifySteps(["unity_web_search_read"]);
@@ -4785,7 +4781,6 @@ QUnit.module("Views", (hooks) => {
 
         // switch to list view
         await click(target.querySelector(".o_control_panel .o_switch_view.o_list"));
-        await legacyExtraNextTick();
 
         assert.containsOnce(target, ".o_list_view");
 
@@ -4829,7 +4824,6 @@ QUnit.module("Views", (hooks) => {
 
         // switch to list view
         await click(target.querySelector(".o_control_panel .o_switch_view.o_list"));
-        await legacyExtraNextTick();
 
         assert.containsOnce(target, ".o_list_view");
 

--- a/addons/web/static/tests/webclient/actions/client_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/client_action_tests.js
@@ -199,6 +199,7 @@ QUnit.module("ActionManager", (hooks) => {
                 sticky: true,
             },
         });
+        await nextTick(); // wait for the notification to be displayed
         const notificationSelector = ".o_notification_manager .o_notification";
         assert.containsOnce(
             document.body,
@@ -245,6 +246,7 @@ QUnit.module("ActionManager", (hooks) => {
                 ],
             },
         });
+        await nextTick(); // wait for the notification to be displayed
         const notificationSelector = ".o_notification_manager .o_notification";
         assert.containsOnce(
             document.body,
@@ -285,6 +287,7 @@ QUnit.module("ActionManager", (hooks) => {
                 ],
             },
         });
+        await nextTick(); // wait for the notification to be displayed
         assert.containsOnce(
             document.body,
             notificationSelector,
@@ -321,6 +324,7 @@ QUnit.module("ActionManager", (hooks) => {
             },
             options
         );
+        await nextTick(); // wait for the notification to be displayed
         const notificationSelector = ".o_notification_manager .o_notification";
         assert.containsOnce(
             document.body,

--- a/addons/web/static/tests/webclient/actions/close_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/close_action_tests.js
@@ -2,13 +2,7 @@
 
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { registerCleanup } from "../../helpers/cleanup";
-import {
-    click,
-    getFixture,
-    legacyExtraNextTick,
-    nextTick,
-    patchWithCleanup,
-} from "../../helpers/utils";
+import { click, getFixture, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
 import { registry } from "@web/core/registry";
@@ -149,7 +143,6 @@ QUnit.module("ActionManager", (hooks) => {
 
         await click(target, ".modal-header button.btn-close");
         await nextTick();
-        await legacyExtraNextTick();
         assert.containsNone(target, ".modal");
         assert.containsNone(target, ".o_list_view");
         assert.containsOnce(target, ".o_kanban_view");
@@ -181,7 +174,6 @@ QUnit.module("ActionManager", (hooks) => {
             list.env.config.historyBack();
             assert.verifySteps(["on_close"], "should have called the on_close handler");
             await nextTick();
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_list_view");
             assert.containsNone(target, ".modal");
         }
@@ -214,7 +206,6 @@ QUnit.module("ActionManager", (hooks) => {
         // display a form view
         await testUtils.dom.click($(target).find(".o_list_view .o_data_cell:first"));
         assert.verifySteps([]);
-        await legacyExtraNextTick();
         readOnFirstRecordDef.reject(new Error("not working as intended"));
         await nextTick();
         assert.verifySteps(["error"]);
@@ -223,7 +214,6 @@ QUnit.module("ActionManager", (hooks) => {
         await testUtils.dom.click(
             $(target).find(".o_list_view .o_data_row:eq(2) .o_data_cell:first")
         );
-        await legacyExtraNextTick();
         assert.containsNone(target, ".o_list_view", "there should not be a list view in dom");
         assert.containsOnce(target, ".o_form_view", "there should be a form view in dom");
     });

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -4,7 +4,6 @@ import {
     click,
     getFixture,
     getNodesTextContent,
-    legacyExtraNextTick,
     makeDeferred,
     nextTick,
 } from "@web/../tests/helpers/utils";
@@ -420,15 +419,12 @@ QUnit.module("ActionManager", (hooks) => {
             const webClient = await createWebClient({ serverData });
             doAction(webClient, "slowAction");
             await nextTick();
-            await legacyExtraNextTick();
             assert.containsNone(target, ".client_action", "client action isn't ready yet");
             doAction(webClient, 4);
             await nextTick();
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_kanban_view", "should have loaded a kanban view");
             slowWillStartDef.resolve();
             await nextTick();
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_kanban_view", "should still display the kanban view");
         }
     );

--- a/addons/web/static/tests/webclient/actions/effects_tests.js
+++ b/addons/web/static/tests/webclient/actions/effects_tests.js
@@ -3,13 +3,7 @@
 import { registry } from "@web/core/registry";
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { clearRegistryWithCleanup } from "../../helpers/mock_env";
-import {
-    click,
-    getFixture,
-    legacyExtraNextTick,
-    nextTick,
-    patchWithCleanup,
-} from "../../helpers/utils";
+import { click, getFixture, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 import { session } from "@web/session";
 
@@ -37,16 +31,13 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsNone(target, ".o_reward");
         webClient.env.services.effect.add({ type: "rainbow_man", message: "", fadeout: "no" });
         await nextTick();
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_reward");
         assert.containsOnce(target, ".o_kanban_view");
         await testUtils.dom.click(target.querySelector(".o_kanban_record"));
-        await legacyExtraNextTick();
         assert.containsNone(target, ".o_reward");
         assert.containsOnce(target, ".o_kanban_view");
         webClient.env.services.effect.add({ type: "rainbow_man", message: "", fadeout: "no" });
         await nextTick();
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_reward");
         assert.containsOnce(target, ".o_kanban_view");
         // Do not force rainbow man to destroy on doAction
@@ -100,7 +91,6 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData, mockRPC });
         await doAction(webClient, 6);
         await click(target.querySelector('button[name="object"]'));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_reward");
         assert.strictEqual(
             target.querySelector(".o_reward .o_reward_msg_content").textContent,

--- a/addons/web/static/tests/webclient/actions/error_handling_tests.js
+++ b/addons/web/static/tests/webclient/actions/error_handling_tests.js
@@ -45,6 +45,7 @@ QUnit.module("ActionManager", (hooks) => {
         } catch (e) {
             assert.ok(e.cause instanceof TypeError);
         }
+        await nextTick();
         assert.containsOnce(target, ".o_kanban_view");
         assert.strictEqual(target.querySelector(".o_breadcrumb").textContent, "Partners Action 1");
         assert.deepEqual(

--- a/addons/web/static/tests/webclient/actions/misc_tests.js
+++ b/addons/web/static/tests/webclient/actions/misc_tests.js
@@ -207,11 +207,13 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("document's title is updated when an action is executed", async function (assert) {
         const defaultTitle = { zopenerp: "Odoo" };
         const webClient = await createWebClient({ serverData });
+        await nextTick();
         let currentTitle = webClient.env.services.title.getParts();
         assert.deepEqual(currentTitle, defaultTitle);
         let currentHash = webClient.env.services.router.current.hash;
         assert.deepEqual(currentHash, {});
         await doAction(webClient, 4);
+        await nextTick();
         currentTitle = webClient.env.services.title.getParts();
         assert.deepEqual(currentTitle, {
             ...defaultTitle,
@@ -220,6 +222,7 @@ QUnit.module("ActionManager", (hooks) => {
         currentHash = webClient.env.services.router.current.hash;
         assert.deepEqual(currentHash, { action: 4, model: "partner", view_type: "kanban" });
         await doAction(webClient, 8);
+        await nextTick();
         currentTitle = webClient.env.services.title.getParts();
         assert.deepEqual(currentTitle, {
             ...defaultTitle,
@@ -329,6 +332,7 @@ QUnit.module("ActionManager", (hooks) => {
             await click(target.querySelector(".o_form_view .o_data_row .o_data_cell"));
             assert.containsOnce(document.body, ".modal .o_form_view");
             await doAction(webClient, 1); // target != 'new'
+            await nextTick(); // wait for the dialog to be closed
             assert.containsNone(document.body, ".modal");
         }
     );

--- a/addons/web/static/tests/webclient/actions/push_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/push_state_tests.js
@@ -4,14 +4,7 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
-import {
-    click,
-    getFixture,
-    legacyExtraNextTick,
-    makeDeferred,
-    nextTick,
-    patchWithCleanup,
-} from "../../helpers/utils";
+import { click, getFixture, makeDeferred, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
 import { Component, xml } from "@odoo/owl";
@@ -65,6 +58,7 @@ QUnit.module("ActionManager", (hooks) => {
         );
         assert.strictEqual(target.querySelector(".o_menu_brand").textContent, "App2");
         await doAction(webClient, 1001, { clearBreadcrumbs: true });
+        await nextTick();
         urlState = webClient.env.services.router.current;
         assert.strictEqual(urlState.hash.action, 1001);
         assert.strictEqual(urlState.hash.menu_id, 2);
@@ -94,10 +88,12 @@ QUnit.module("ActionManager", (hooks) => {
         let urlState = webClient.env.services.router.current;
         assert.deepEqual(urlState.hash, {});
         await doAction(webClient, "client_action_pushes");
+        await nextTick();
         urlState = webClient.env.services.router.current;
         assert.strictEqual(urlState.hash.action, "client_action_pushes");
         assert.strictEqual(urlState.hash.menu_id, undefined);
         await click(target, ".test_client_action");
+        await nextTick();
         urlState = webClient.env.services.router.current;
         assert.strictEqual(urlState.hash.action, "client_action_pushes");
         assert.strictEqual(urlState.hash.arbitrary, "actionPushed");
@@ -123,10 +119,12 @@ QUnit.module("ActionManager", (hooks) => {
         assert.deepEqual(urlState.hash, {});
         await doAction(webClient, "client_action_pushes");
         await click(target, ".test_client_action");
+        await nextTick();
         urlState = webClient.env.services.router.current;
         assert.strictEqual(urlState.hash.action, "client_action_pushes");
         assert.strictEqual(urlState.hash.arbitrary, "actionPushed");
         await doAction(webClient, 1001);
+        await nextTick();
         urlState = webClient.env.services.router.current;
         assert.strictEqual(urlState.hash.action, 1001);
         assert.strictEqual(urlState.hash.arbitrary, undefined);
@@ -174,18 +172,21 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, 1001);
         assert.containsOnce(target, ".modal .test_client_action");
+        await nextTick();
     });
 
     QUnit.test("properly push state", async function (assert) {
         assert.expect(3);
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, 4);
+        await nextTick();
         assert.deepEqual(webClient.env.services.router.current.hash, {
             action: 4,
             model: "partner",
             view_type: "kanban",
         });
         await doAction(webClient, 8);
+        await nextTick();
         assert.deepEqual(webClient.env.services.router.current.hash, {
             action: 8,
             model: "pony",
@@ -232,15 +233,16 @@ QUnit.module("ActionManager", (hooks) => {
         };
         const webClient = await createWebClient({ serverData, mockRPC });
         await doAction(webClient, 8);
+        await nextTick();
         assert.deepEqual(webClient.env.services.router.current.hash, {
             action: 8,
             model: "pony",
             view_type: "list",
         });
         await testUtils.dom.click($(target).find("tr.o_data_row:first"));
-        await legacyExtraNextTick();
         // we make sure here that the list view is still in the dom
         assert.containsOnce(target, ".o_list_view", "there should still be a list view in dom");
+        await nextTick();
         assert.deepEqual(webClient.env.services.router.current.hash, {
             action: 8,
             model: "pony",

--- a/addons/web/static/tests/webclient/actions/reports/report_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/reports/report_action_tests.js
@@ -6,7 +6,13 @@ import { session } from "@web/session";
 import { ReportAction } from "@web/webclient/actions/reports/report_action";
 import { clearRegistryWithCleanup } from "@web/../tests/helpers/mock_env";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
-import { mockDownload, patchWithCleanup, getFixture, click } from "@web/../tests/helpers/utils";
+import {
+    mockDownload,
+    nextTick,
+    patchWithCleanup,
+    getFixture,
+    click,
+} from "@web/../tests/helpers/utils";
 import {
     createWebClient,
     doAction,
@@ -389,7 +395,7 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
 
         await doAction(webClient, 12); // 12 is a html report action in serverData
-
+        await nextTick();
         const hash = webClient.router.current.hash;
         // used to put report.client_action in the url
         assert.strictEqual(hash.action === "report.client_action", false);

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -483,10 +483,13 @@ QUnit.module("ActionManager", (hooks) => {
         ] = `<form><button name="1" type="action" class="oe_stat_button" /></form>`;
         const webClient = await createWebClient({ serverData });
         await doAction(webClient, 6);
+        await nextTick(); // for the webclient to react and remove the navbar
         assert.isNotVisible(target.querySelector(".o_main_navbar"));
         await click(target.querySelector("button[name='1']"));
+        await nextTick();
         assert.isNotVisible(target.querySelector(".o_main_navbar"));
         await click(target.querySelector(".breadcrumb li a"));
+        await nextTick();
         assert.isNotVisible(target.querySelector(".o_main_navbar"));
     });
 

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -20,7 +20,6 @@ import {
     editInput,
     getFixture,
     getNodesTextContent,
-    legacyExtraNextTick,
     makeDeferred,
     nextTick,
     patchWithCleanup,
@@ -111,17 +110,14 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_list_view", "should display the list view");
         // switch to kanban view
         await cpHelpers.switchView(target, "kanban");
-        await legacyExtraNextTick();
         assert.containsNone(target, ".o_list_view", "should no longer display the list view");
         assert.containsOnce(target, ".o_kanban_view", "should display the kanban view");
         // switch back to list view
         await cpHelpers.switchView(target, "list");
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_list_view", "should display the list view");
         assert.containsNone(target, ".o_kanban_view", "should no longer display the kanban view");
         // open a record in form view
         await testUtils.dom.click(target.querySelector(".o_list_view .o_data_cell"));
-        await legacyExtraNextTick();
         assert.containsNone(target, ".o_list_view", "should no longer display the list view");
         assert.containsOnce(target, ".o_form_view", "should display the form view");
         assert.strictEqual(
@@ -131,7 +127,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // go back to list view using the breadcrumbs
         await testUtils.dom.click(target.querySelector(".o_control_panel .breadcrumb a"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_list_view", "should display the list view");
         assert.containsNone(target, ".o_form_view", "should no longer display the form view");
         assert.verifySteps([
@@ -260,7 +255,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // switch to kanban view
         await cpHelpers.switchView(target, "kanban");
-        await legacyExtraNextTick();
         assert.containsNone(target, ".o_control_panel .breadcrumb-item");
         assert.strictEqual(
             target.querySelector(".o_control_panel .o_breadcrumb .active").innerText,
@@ -313,7 +307,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // switch to kanban view
         await cpHelpers.switchView(target, "kanban");
-        await legacyExtraNextTick();
         assert.containsN(
             target,
             ".o_control_panel .o_switch_view",
@@ -337,7 +330,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // switch back to list view
         await cpHelpers.switchView(target, "list");
-        await legacyExtraNextTick();
         assert.containsN(
             target,
             ".o_control_panel .o_switch_view",
@@ -351,7 +343,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // open a record in form view
         await testUtils.dom.click(target.querySelector(".o_list_view .o_data_cell"));
-        await legacyExtraNextTick();
         assert.containsNone(
             target,
             ".o_control_panel .o_switch_view",
@@ -359,7 +350,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // go back to list view using the breadcrumbs
         await testUtils.dom.click($(target).find(".o_control_panel .breadcrumb a"));
-        await legacyExtraNextTick();
         assert.containsN(
             target,
             ".o_control_panel .o_switch_view",
@@ -389,7 +379,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // switch to list view
         await cpHelpers.switchView(target, "list");
-        await legacyExtraNextTick();
         assert.strictEqual(
             $(target).find(".o_control_panel .o_pager_value").text(),
             "1-3",
@@ -402,7 +391,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // open a record in form view
         await testUtils.dom.click(target.querySelector(".o_list_view .o_data_cell"));
-        await legacyExtraNextTick();
         assert.strictEqual(
             $(target).find(".o_control_panel .o_pager_value").text(),
             "1",
@@ -415,7 +403,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // go back to list view using the breadcrumbs
         await testUtils.dom.click(target.querySelector(".o_control_panel .breadcrumb a"));
-        await legacyExtraNextTick();
         assert.strictEqual(
             $(target).find(".o_control_panel .o_pager_value").text(),
             "1-3",
@@ -428,7 +415,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // switch back to kanban view
         await cpHelpers.switchView(target, "kanban");
-        await legacyExtraNextTick();
         assert.strictEqual(
             $(target).find(".o_control_panel .o_pager_value").text(),
             "1-5",
@@ -520,19 +506,15 @@ QUnit.module("ActionManager", (hooks) => {
         // activate a domain
         await cpHelpers.toggleSearchBarMenu(target);
         await cpHelpers.toggleMenuItem(target, "Bar");
-        await legacyExtraNextTick();
         assert.containsN(target, ".o_data_row", 2);
         // switch to kanban
         await cpHelpers.switchView(target, "kanban");
-        await legacyExtraNextTick();
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         // remove the domain
         await testUtils.dom.click(target.querySelector(".o_searchview .o_facet_remove"));
-        await legacyExtraNextTick();
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 5);
         // switch back to list
         await cpHelpers.switchView(target, "list");
-        await legacyExtraNextTick();
         assert.containsN(target, ".o_data_row", 5);
     });
 
@@ -573,7 +555,6 @@ QUnit.module("ActionManager", (hooks) => {
         await testUtils.dom.click(
             $(target).find(".o_list_view .o_data_row:first .o_data_cell:first")
         );
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_form_view", "The form view should be displayed");
 
         // Delete the current record
@@ -583,10 +564,8 @@ QUnit.module("ActionManager", (hooks) => {
                 (e) => e.textContent === "Delete"
             )
         );
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".modal", "a confirm modal should be displayed");
         await testUtils.dom.click(target.querySelector(".modal-footer button.btn-primary"));
-        await legacyExtraNextTick();
 
         // The form view is automatically switched to the next record
         // Go back to the previous (now deleted) record
@@ -597,7 +576,6 @@ QUnit.module("ActionManager", (hooks) => {
             view_type: "form",
         });
         await testUtils.nextTick();
-        await legacyExtraNextTick();
 
         // Go back to the list view
         webClient.env.bus.trigger("test:hashchange", {
@@ -606,13 +584,11 @@ QUnit.module("ActionManager", (hooks) => {
             view_type: "list",
         });
         await testUtils.nextTick();
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_list_view", "should still display the list view");
 
         await testUtils.dom.click(
             $(target).find(".o_list_view .o_data_row:first .o_data_cell:first")
         );
-        await legacyExtraNextTick();
         assert.containsOnce(
             target,
             ".o_form_view",
@@ -772,7 +748,6 @@ QUnit.module("ActionManager", (hooks) => {
         await doAction(webClient, 3);
         // open a record in form view
         await click(target.querySelector(".o_list_view .o_data_cell"));
-        await legacyExtraNextTick();
         assert.strictEqual(
             $(target).find(".o_field_widget[name=foo] input").val(),
             "yop",
@@ -780,7 +755,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // click on 'Call method' button (should call an Object method)
         await testUtils.dom.click($(target).find(".o_form_view button:contains(Call method)"));
-        await legacyExtraNextTick();
         assert.strictEqual(
             $(target).find(".o_field_widget[name=foo] input").val(),
             "value changed",
@@ -826,25 +800,21 @@ QUnit.module("ActionManager", (hooks) => {
             assert.containsOnce(target, ".o_list_view");
             // open first record in form view
             await testUtils.dom.click(target.querySelector(".o_list_view .o_data_cell"));
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_form_view");
             // click on 'Execute action', to execute action 4 in a dialog
             await testUtils.dom.click(target.querySelector('.o_form_view button[name="4"]'));
-            await legacyExtraNextTick();
             assert.ok(
                 target.querySelector(".o_form_button_create").disabled,
                 "control panel buttons should be disabled"
             );
             def.resolve();
             await nextTick();
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".modal .o_form_view");
             assert.notOk(
                 target.querySelector(".o_form_button_create").disabled,
                 "control panel buttons should have been re-enabled"
             );
             await testUtils.dom.click(target.querySelector(".modal .cancel-btn"));
-            await legacyExtraNextTick();
             assert.notOk(
                 target.querySelector(".o_form_button_create").disabled,
                 "control panel buttons should still be enabled"
@@ -870,7 +840,6 @@ QUnit.module("ActionManager", (hooks) => {
             click(target.querySelector('.o_form_view button[name="object"]'));
             assert.ok(target.querySelector(".o_form_button_create").disabled);
             await nextTick();
-            await legacyExtraNextTick();
             assert.notOk(target.querySelector(".o_form_button_create").disabled);
         }
     );
@@ -899,7 +868,6 @@ QUnit.module("ActionManager", (hooks) => {
             assert.containsOnce(target, ".modal .o_form_view");
             assert.ok(target.querySelector(".modal footer button").disabled);
             await testUtils.nextTick();
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".modal .o_form_view");
             assert.notOk(target.querySelector(".modal footer button").disabled);
         }
@@ -955,10 +923,8 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_form_view");
         assert.containsOnce(target, ".o_form_button_create:not([disabled]):visible");
         await testUtils.dom.click(target.querySelector(".oe_stat_button"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_kanban_view");
         await testUtils.dom.click(target.querySelector(".breadcrumb-item"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_form_view");
         assert.containsOnce(target, ".o_form_button_create:not([disabled]):visible");
         assert.verifySteps(["web_read", "unity_web_search_read", "web_read"]);
@@ -977,7 +943,6 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_form_view");
         assert.containsOnce(target, ".o_form_button_create:not([disabled]):visible");
         await testUtils.dom.click(target.querySelector(".oe_stat_button"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_form_view");
         assert.containsOnce(target, ".o_form_button_create:not([disabled]):visible");
         assert.verifySteps([
@@ -1008,11 +973,9 @@ QUnit.module("ActionManager", (hooks) => {
             await doAction(webClient, 3);
             // open a record in form view
             await click(target.querySelector(".o_list_view .o_data_cell"));
-            await legacyExtraNextTick();
             // click on 'Call method' button (should call an Object method)
             def = testUtils.makeTestPromise();
             await testUtils.dom.click($(target).find(".o_form_view button:contains(Call method)"));
-            await legacyExtraNextTick();
             // Buttons should be disabled
             assert.strictEqual(
                 $(target).find(".o_form_view button:contains(Call method)").attr("disabled"),
@@ -1022,7 +985,6 @@ QUnit.module("ActionManager", (hooks) => {
             // Release the 'read' call
             def.resolve();
             await testUtils.nextTick();
-            await legacyExtraNextTick();
             // Buttons should be enabled after the reload
             assert.strictEqual(
                 $(target).find(".o_form_view button:contains(Call method)").attr("disabled"),
@@ -1162,7 +1124,6 @@ QUnit.module("ActionManager", (hooks) => {
         );
         // switch to graph view
         await cpHelpers.switchView(target, "graph");
-        await legacyExtraNextTick();
         assert.doesNotHaveClass(
             $(target).find(".o_control_panel .o_switch_view.o_list")[0],
             "active",
@@ -1194,7 +1155,6 @@ QUnit.module("ActionManager", (hooks) => {
         await cpHelpers.toggleSearchBarMenu(target);
         // click on foo link
         await cpHelpers.toggleMenuItem(target, "foo");
-        await legacyExtraNextTick();
         assert.hasClass(
             $(target).find(".o_list_table")[0],
             "o_list_table_grouped",
@@ -1266,7 +1226,6 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         // switch to kanban view
         await cpHelpers.switchView(target, "kanban");
-        await legacyExtraNextTick();
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
     });
 
@@ -1307,13 +1266,11 @@ QUnit.module("ActionManager", (hooks) => {
             await doAction(webClient, 3);
             // open a record in form view
             await click(target.querySelector(".o_list_view .o_data_cell"));
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_form_view .o_form_editable");
             // do some other action
             await doAction(webClient, 4);
             // go back to form view
             await click(target.querySelectorAll(".o_control_panel .breadcrumb a")[1]);
-            await legacyExtraNextTick();
             assert.containsOnce(target, ".o_form_view .o_form_editable");
         }
     );
@@ -1392,7 +1349,6 @@ QUnit.module("ActionManager", (hooks) => {
         assert.containsOnce(target, ".o_list_view", "should display the list view");
         // try to open a record in a form view
         testUtils.dom.click($(target).find(".o_list_view .o_data_row:first"));
-        await legacyExtraNextTick();
         assert.containsOnce(target, ".o_list_view", "should still display the list view");
         assert.containsNone(target, ".o_form_view", "should not display the form view");
         assert.verifySteps([
@@ -2042,6 +1998,7 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         // Open Partner form in create mode
         await doAction(webClient, 3, { viewType: "form" });
+        await nextTick();
         const prevHash = Object.assign({}, webClient.env.services.router.current.hash);
         // Edit another partner in a dialog
         await doAction(webClient, {
@@ -2053,6 +2010,7 @@ QUnit.module("ActionManager", (hooks) => {
             target: "new",
             view_mode: "form",
         });
+        await nextTick();
         assert.deepEqual(
             webClient.env.services.router.current.hash,
             prevHash,
@@ -2076,15 +2034,12 @@ QUnit.module("ActionManager", (hooks) => {
       </form>`;
         const webClient = await createWebClient({ serverData, mockRPC });
         await doAction(webClient, 3, { viewType: "form", props: { resId: 1 } });
-        await legacyExtraNextTick();
         await editInput(target, "div[name='display_name'] input", "Edited value");
         assert.isVisible(target.querySelector(".o_form_button_save"));
         assert.isVisible(target.querySelector(".o_statusbar_buttons button[name=do_something]"));
         await click(target.querySelector(".o_statusbar_buttons button[name=do_something]"));
-        await legacyExtraNextTick();
         assert.isVisible(target.querySelector(".o_form_button_save"));
         await click(target.querySelector(".o_form_button_save"));
-        await legacyExtraNextTick();
         assert.isNotVisible(target.querySelector(".o_form_buttons_view .o_form_button_save"));
     });
 
@@ -2131,7 +2086,6 @@ QUnit.module("ActionManager", (hooks) => {
         await click(target.querySelector(".o_pivot_measure_row"));
         assert.hasClass(target.querySelector(".o_pivot_measure_row"), "o_pivot_sort_order_asc");
         await cpHelpers.switchView(target, "pivot");
-        await legacyExtraNextTick();
         assert.hasClass(target.querySelector(".o_pivot_measure_row"), "o_pivot_sort_order_asc");
         assert.verifySteps([
             "read_group", // initial read_group

--- a/addons/web/static/tests/webclient/helpers.js
+++ b/addons/web/static/tests/webclient/helpers.js
@@ -32,13 +32,7 @@ import {
     makeFakeHTTPService,
     makeFakeUserService,
 } from "../helpers/mock_services";
-import {
-    getFixture,
-    legacyExtraNextTick,
-    mount,
-    nextTick,
-    patchWithCleanup,
-} from "../helpers/utils";
+import { getFixture, mount, nextTick, patchWithCleanup } from "../helpers/utils";
 import session from "web.session";
 import LegacyMockServer from "@web/../tests/legacy/helpers/mock_server";
 import Widget from "@web/legacy/js/core/widget";
@@ -237,15 +231,11 @@ export async function createWebClient(params) {
     return wc;
 }
 
-export async function doAction(env, ...args) {
+export function doAction(env, ...args) {
     if (env instanceof Component) {
         env = env.env;
     }
-    try {
-        await env.services.action.doAction(...args);
-    } finally {
-        await legacyExtraNextTick();
-    }
+    return env.services.action.doAction(...args);
 }
 
 export async function loadState(env, state) {
@@ -256,10 +246,10 @@ export async function loadState(env, state) {
     // wait the asynchronous hashchange
     // (the event hashchange must be triggered in a nonBlocking stack)
     await nextTick();
+    // wait for BlankComponent
+    await nextTick();
     // wait for the regular rendering
     await nextTick();
-    // wait for the legacy rendering below owl layer
-    await legacyExtraNextTick();
 }
 
 export function getActionManagerServerData() {


### PR DESCRIPTION
Now that most of the webclient codebase (fields, views, client actions...) has been converted to owl, the legacy extra next tick used in a lot of tests is no longer necessary. This commit removes the helper and its usage. At some places, a real tick was needed, but we didn't see it because of the use of the legacy extra next tick.

Part of task~3439226

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
