### PR TITLE
[REF] website_*: Change registerTours of tour_utils

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -25,7 +25,7 @@ wTourUtils.registerWebsitePreviewTour('test_custom_snippet', {
     url: '/',
     edition: true,
     test: true,
-}, [
+}, () => [
     {
         content: "drop a snippet",
         trigger: ".oe_snippet[name='Banner'] .oe_snippet_thumbnail:not(.o_we_already_dragging)",

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -22,7 +22,7 @@ wTourUtils.registerWebsitePreviewTour('test_image_link', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: 's_text_image',
         name: 'Text - Image',

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -63,7 +63,7 @@ wTourUtils.registerWebsitePreviewTour('test_image_upload_progress', {
     url: '/test_image_progress',
     test: true,
     edition: true,
-}, [
+}, () => [
     ...setupSteps,
     // 1. Check multi image upload
     {
@@ -205,7 +205,7 @@ wTourUtils.registerWebsitePreviewTour('test_image_upload_progress_unsplash', {
     url: '/test_image_progress',
     test: true,
     edition: true,
-}, [
+}, () => [
     ...setupSteps,
     // 1. Check multi image upload
     {

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -13,7 +13,7 @@ wTourUtils.registerWebsitePreviewTour('test_replace_media', {
     url: '/',
     test: true,
     edition: true,
-}, [
+}, () => [
     {
         trigger: "body",
         run: function () {

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -18,7 +18,7 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part1'
     // 1. Edit the page through Edit Mode, it will COW the view
     edition: true,
 },
-    [
+    () => [
         {
             content: "drop a snippet",
             trigger: ".oe_snippet:has(.s_cover) .oe_snippet_thumbnail",
@@ -60,7 +60,7 @@ wTourUtils.registerWebsitePreviewTour('test_reset_page_view_complete_flow_part2'
     test: true,
     url: '/test_page_view',
 },
-    [
+    () => [
         {
             content: "check that the view got fixed",
             trigger: 'iframe p:containsExact("Test Page View")',

--- a/addons/website/static/src/js/tours/configurator_tour.js
+++ b/addons/website/static/src/js/tours/configurator_tour.js
@@ -5,41 +5,42 @@ import core from "@web/legacy/js/services/core";
 import "@web/legacy/translations_loaded";
 const _t = core._t;
 
-let titleSelector = '#wrap > section:first-child';
-let title = $(titleSelector).find('h1, h2').first();
-if (!title.length) {
-    titleSelector = titleSelector.replace('section:first-child', 'section:nth-child(2)');
-    title = $(titleSelector).find('h1, h2').first();
-}
-let isTitleTextImage = $(titleSelector).hasClass('s_text_image');
-titleSelector = titleSelector.concat(` ${title.is('h1') ? 'h1' : 'h2'}`);
+wTourUtils.registerThemeHomepageTour('configurator_tour', () => {
 
-const shapeSelector = '#wrap > section[data-oe-shape-data]';
-const backgroundSelector = '#wrap > section:nth-child(2)';
-
-const imageStep = isTitleTextImage ?
-    wTourUtils.changeImage(titleSelector.replace('h2', 'img')) : wTourUtils.changeBackground();
-
-const backgroundColorStep = [wTourUtils.changeBackgroundColor()];
-if (!isTitleTextImage) {
-    backgroundColorStep.unshift(wTourUtils.clickOnSnippet(backgroundSelector));
-}
-
-const shapeStep = [];
-if ($(shapeSelector).first().length) {
-    if (!$(backgroundSelector).is($(shapeSelector))) {
-        shapeStep.push(wTourUtils.clickOnSnippet(shapeSelector));
+    let titleSelector = '#wrap > section:first-child';
+    let title = $(titleSelector).find('h1, h2').first();
+    if (!title.length) {
+        titleSelector = titleSelector.replace('section:first-child', 'section:nth-child(2)');
+        title = $(titleSelector).find('h1, h2').first();
     }
-    shapeStep.push(wTourUtils.changeOption('BackgroundShape', 'we-toggler', _t('Background Shape')));
-    shapeStep.push(wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls)', _t('Background Shape')));
-}
+    let isTitleTextImage = $(titleSelector).hasClass('s_text_image');
+    titleSelector = titleSelector.concat(` ${title.is('h1') ? 'h1' : 'h2'}`);
 
-const steps = [
-    wTourUtils.clickOnText(titleSelector),
-    imageStep,
-    ...backgroundColorStep,
-    ...shapeStep,
-    wTourUtils.changePaddingSize('top'),
-];
+    const shapeSelector = '#wrap > section[data-oe-shape-data]';
+    const backgroundSelector = '#wrap > section:nth-child(2)';
 
-wTourUtils.registerThemeHomepageTour('configurator_tour', steps);
+    const imageStep = isTitleTextImage ?
+        wTourUtils.changeImage(titleSelector.replace('h2', 'img')) : wTourUtils.changeBackground();
+
+    const backgroundColorStep = [wTourUtils.changeBackgroundColor()];
+    if (!isTitleTextImage) {
+        backgroundColorStep.unshift(wTourUtils.clickOnSnippet(backgroundSelector));
+    }
+
+    const shapeStep = [];
+    if ($(shapeSelector).first().length) {
+        if (!$(backgroundSelector).is($(shapeSelector))) {
+            shapeStep.push(wTourUtils.clickOnSnippet(shapeSelector));
+        }
+        shapeStep.push(wTourUtils.changeOption('BackgroundShape', 'we-toggler', _t('Background Shape')));
+        shapeStep.push(wTourUtils.selectNested('we-select-page', 'BackgroundShape', ':not(.o_we_pager_controls)', _t('Background Shape')));
+    }
+
+    return [
+        wTourUtils.clickOnText(titleSelector),
+        imageStep,
+        ...backgroundColorStep,
+        ...shapeStep,
+        wTourUtils.changePaddingSize('top'),
+    ];
+});

--- a/addons/website/static/src/js/tours/homepage.js
+++ b/addons/website/static/src/js/tours/homepage.js
@@ -29,7 +29,7 @@ const snippets = [
     },
 ];
 
-wTourUtils.registerThemeHomepageTour('homepage', [
+wTourUtils.registerThemeHomepageTour('homepage', () => [
     wTourUtils.dragNDrop(snippets[0]),
     wTourUtils.clickOnText(snippets[0], 'h1'),
     wTourUtils.goBackToBlocks(),

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -320,61 +320,79 @@ function clickOnExtraMenuItem(stepOptions, backend = false) {
  * @param {object} options The tour options
  * @param {string} options.url The page to edit
  * @param {boolean} [options.edition] If the tour starts in edit mode
- * @param {object[]} steps The steps of the tour
+ * @param {() => TourStep[]} steps The steps of the tour. Has to be a function to avoid direct interpolation of steps. 
  */
 function registerWebsitePreviewTour(name, options, steps) {
-    const tourSteps = [...steps];
-    const url = getClientActionUrl(options.url, !!options.edition);
-
-    // Note: for both non edit mode and edit mode, we set a high timeout for the
-    // first step. Indeed loading both the backend and the frontend (in the
-    // iframe) and potentially starting the edit mode can take a long time in
-    // automatic tests. We'll try and decrease the need for this high timeout
-    // of course.
-    if (options.edition) {
-        tourSteps.unshift({
-            content: "Wait for the edit mode to be started",
-            trigger: '.o_website_preview.editor_enable.editor_has_snippets',
-            timeout: 30000,
-            auto: true,
-            run: () => {}, // It's a check
-        });
-    } else {
-        tourSteps[0].timeout = 20000;
+    if(typeof steps !== "function") {
+        throw new Error(`tour.steps has to be a function that returns TourStep[]`)
     }
-
-    return registry.category("web_tour.tours").add(name, Object.assign({}, options, { url, steps: () => tourSteps}));
+    return registry
+        .category("web_tour.tours")
+        .add(name, {
+            ...options,
+            url : getClientActionUrl(options.url, !!options.edition), 
+            steps: () => {
+                const tourSteps = [...steps()];
+                // Note: for both non edit mode and edit mode, we set a high timeout for the
+                // first step. Indeed loading both the backend and the frontend (in the
+                // iframe) and potentially starting the edit mode can take a long time in
+                // automatic tests. We'll try and decrease the need for this high timeout
+                // of course.
+                if (options.edition) {
+                    tourSteps.unshift({
+                        content: "Wait for the edit mode to be started",
+                        trigger: '.o_website_preview.editor_enable.editor_has_snippets',
+                        timeout: 30000,
+                        auto: true,
+                        run: () => {}, // It's a check
+                    });
+                } else {
+                    tourSteps[0].timeout = 20000;
+                }
+                return tourSteps;
+            }
+        });
 }
 
 function registerThemeHomepageTour(name, steps) {
+    if(typeof steps !== "function") {
+        throw new Error(`tour.steps has to be a function that returns TourStep[]`)
+    }
     return registerWebsitePreviewTour(name, {
         url: '/',
         edition: true,
         sequence: 1010,
         saveAs: "homepage",
-    }, prepend_trigger(
-        steps.concat(clickOnSave()),
+    }, () => prepend_trigger(
+        steps().concat(clickOnSave()),
         ".o_website_preview[data-view-xmlid='website.homepage'] "
     ));
 }
 
 function registerBackendAndFrontendTour(name, options, steps) {
+    if(typeof steps !== "function") {
+        throw new Error(`tour.steps has to be a function that returns TourStep[]`)
+    }
     if (window.location.pathname === '/web') {
-        const newSteps = [];
-        for (const step of steps) {
-            const newStep = Object.assign({}, step);
-            newStep.trigger = `iframe ${step.trigger}`;
-            if (step.extra_trigger) {
-                newStep.extra_trigger = `iframe ${step.extra_trigger}`;
+        return registerWebsitePreviewTour(name, options, () => {
+            const newSteps = [];
+            for (const step of steps()) {
+                const newStep = Object.assign({}, step);
+                newStep.trigger = `iframe ${step.trigger}`;
+                if (step.extra_trigger) {
+                    newStep.extra_trigger = `iframe ${step.extra_trigger}`;
+                }
+                newSteps.push(newStep);
             }
-            newSteps.push(newStep);
-        }
-        return registerWebsitePreviewTour(name, options, newSteps);
+            return newSteps
+        });
     }
 
     return registry.category("web_tour.tours").add(name, {
         url: options.url,
-        steps: () => steps,
+        steps: () => {
+            return steps()
+        },
     });
 }
 

--- a/addons/website/static/tests/tours/automatic_editor.js
+++ b/addons/website/static/tests/tours/automatic_editor.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('automatic_editor_on_new_website', {
     test: true,
     url: '/',
 },
-[
+() => [
     {
         content: "Select the language dropdown",
         trigger: 'iframe .js_language_selector .dropdown-toggle'

--- a/addons/website/static/tests/tours/carousel_content_removal.js
+++ b/addons/website/static/tests/tours/carousel_content_removal.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("carousel_content_removal", {
     test: true,
     url: '/',
     edition: true,
-}, [{
+}, () => [{
     trigger: "#snippet_structure .oe_snippet:has(span:contains('Carousel')) .oe_snippet_thumbnail",
     content: "Drag the Carousel block and drop it in your page.",
     run: "drag_and_drop iframe #wrap",

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('client_action_iframe_fallback', {
     test: true,
     url: '/',
 },
-[
+() => [
     {
         content: "Ensure we are on the expected page",
         trigger: 'body iframe html[data-view-xmlid="website.homepage"]',

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -44,7 +44,7 @@ wTourUtils.registerWebsitePreviewTour('conditional_visibility_1', {
     edition: true,
     url: '/',
     test: true,
-}, [
+}, () => [
 wTourUtils.dragNDrop(snippets[0]),
 wTourUtils.clickOnSnippet(snippets[0]),
 wTourUtils.changeOption('ConditionalVisibility', 'we-toggler'),
@@ -94,7 +94,7 @@ wTourUtils.registerWebsitePreviewTour("conditional_visibility_3", {
     test: true,
     url: "/",
 },
-[
+() => [
 checkEyeIcon("Text - Image", true),
 // Drag a "Banner" snippet on the website.
 wTourUtils.dragNDrop(snippets[1]),
@@ -143,7 +143,7 @@ wTourUtils.registerWebsitePreviewTour("conditional_visibility_4", {
     test: true,
     url: "/",
 },
-[
+() => [
 // Click on the "Text-Image" snippet.
 wTourUtils.clickOnSnippet(snippets[0]),
 {

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("default_shape_gets_palette_colors", {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: 's_text_image',
         name: 'Text - Image',

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -29,7 +29,7 @@ wTourUtils.registerWebsitePreviewTour('edit_link_popover', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     // 1. Test links in page content (web_editor)
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -18,7 +18,7 @@ wTourUtils.registerWebsitePreviewTour('edit_megamenu', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     // Add a megamenu item to the top menu.
     {
         content: "Click on a menu item",

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -5,7 +5,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
 wTourUtils.registerWebsitePreviewTour('edit_menus', {
     test: true,
     url: '/',
-}, [
+}, () => [
     // Add a megamenu item from the menu.
     {
         content: "open site menu",

--- a/addons/website/static/tests/tours/focus_blur_snippets.js
+++ b/addons/website/static/tests/tours/focus_blur_snippets.js
@@ -53,7 +53,7 @@ wTourUtils.registerWebsitePreviewTour("focus_blur_snippets", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     {
         content: 'Drag the custom block into the page',
         trigger: '#snippet_structure .oe_snippet:has(.oe_snippet_body.s_focusblur) .oe_snippet_thumbnail',

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -24,7 +24,7 @@ wTourUtils.registerWebsitePreviewTour('website_gray_color_palette', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     {
         content: "Go to theme options",
         trigger: '.o_we_customize_theme_btn',

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('website_replace_grid_image', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: 's_text_image',
         name: 'Text - Image',

--- a/addons/website/static/tests/tours/homepage_edit_discard.js
+++ b/addons/website/static/tests/tours/homepage_edit_discard.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('homepage_edit_discard', {
     test: true,
     url: '/',
     edition: true,
-}, [{
+}, () => [{
     trigger: "#oe_snippets button[data-action=\"cancel\"]:not([disabled])",
     extra_trigger: "body:not(:has(.o_dialog))",
     content: "<b>Click Discard</b> to Discard all Changes.",

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -11,7 +11,7 @@ wTourUtils.registerWebsitePreviewTour('html_editor_multiple_templates', {
     edition: true,
     test: true,
 },
-    [
+    () => [
         {
             content: "drop a snippet",
             trigger: ".oe_snippet:has(.s_cover) .oe_snippet_thumbnail",
@@ -71,7 +71,7 @@ wTourUtils.registerWebsitePreviewTour('test_html_editor_scss', {
     url: '/contactus',
     test: true,
 },
-    [
+    () => [
         // 1. Open Html Editor and select a scss file
         {
             content: "open site menu",
@@ -157,7 +157,7 @@ wTourUtils.registerWebsitePreviewTour('test_html_editor_scss_2', {
     url: '/',
     test: true,
 },
-    [
+    () => [
         // This part of the test ensures that a restricted user can still use
         // the HTML Editor if someone else made a customization previously.
 

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -11,7 +11,7 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     // 1. Create a new link from scratch.
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("website_media_dialog_undraw", {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
 wTourUtils.dragNDrop({
     id: 's_text_image',
     name: 'Text - Image',
@@ -24,7 +24,7 @@ wTourUtils.registerWebsitePreviewTour('website_media_dialog_icons', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: 's_process_steps',
         name: 'Steps',
@@ -64,7 +64,7 @@ wTourUtils.registerWebsitePreviewTour("website_media_dialog_image_shape", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: "s_text_image",
         name: "Text - Image",

--- a/addons/website/static/tests/tours/multi_edition.js
+++ b/addons/website/static/tests/tours/multi_edition.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('website_multi_edition', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     {
         content: 'Check the current page has not the elements that will be added',
         trigger: 'iframe body:not(:has(.s_text_image)):not(:has(.s_hr))',

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -77,7 +77,7 @@ const homePage = 'tr:contains("Home")';
 wTourUtils.registerWebsitePreviewTour('website_page_manager', {
     test: true,
     url: '/',
-}, [
+}, () => [
     {
         content: "Click on Site",
         trigger: 'button.dropdown-toggle[data-menu-xmlid="website.menu_site"]',

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -8,7 +8,7 @@ wTourUtils.registerWebsitePreviewTour("test_parallax", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop(coverSnippet),
     wTourUtils.clickOnSnippet(coverSnippet),
     wTourUtils.changeOption("BackgroundOptimize", "we-toggler"),

--- a/addons/website/static/tests/tours/restricted_editor.js
+++ b/addons/website/static/tests/tours/restricted_editor.js
@@ -5,6 +5,6 @@ import wTourUtils from "@website/js/tours/tour_utils";
 wTourUtils.registerWebsitePreviewTour("restricted_editor", {
     test: true,
     url: "/",
-}, [
+}, () => [
     ...wTourUtils.clickOnEditAndWaitEditMode(),
 ]);

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -13,7 +13,7 @@ wTourUtils.registerWebsitePreviewTour('rte_translator', {
     test: true,
     url: '/',
     wait_for: ready,
-}, [{
+}, () => [{
     content: "click language dropdown",
     trigger: 'iframe .js_language_selector .dropdown-toggle',
 }, {

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -95,7 +95,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_background_edition', {
     edition: true,
     test: true,
 },
-[
+() => [
 wTourUtils.dragNDrop(snippets[0]),
 wTourUtils.clickOnSnippet(snippets[0]),
 

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_cache_across_websites', {
     edition: true,
     test: true,
     url: '/@/'
-}, [
+}, () => [
     {
         content: "Check that the custom snippet is displayed",
         trigger: '#snippet_custom_body span:contains("custom_snippet_test")',

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_countdown', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({id: 's_countdown', name: 'Countdown'}),
     wTourUtils.clickOnSnippet({id: 's_countdown', name: 'Countdown'}),
     wTourUtils.changeOption('countdown', 'we-select:has([data-end-action]) we-toggler', 'end action'),

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_editor_panel_options', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
 wTourUtils.dragNDrop({
     id: 's_text_image',
     name: 'Text - Image',

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -13,7 +13,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_empty_parent_autoremove', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     // Base case: remove both columns from text - image
     wTourUtils.dragNDrop({
         id: 's_text_image',

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_image_gallery', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({id: 's_image_gallery', name: 'Images Wall'}),
     ...wTourUtils.clickOnSave(),
     {
@@ -25,7 +25,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_image_gallery_remove", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: "s_image_gallery",
         name: "Image Gallery",

--- a/addons/website/static/tests/tours/snippet_image_quality.js
+++ b/addons/website/static/tests/tours/snippet_image_quality.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('website_image_quality', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: 's_text_image',
         name: 'Text - Image',

--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -18,7 +18,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_images_wall", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: "s_images_wall",
         name: "Images Wall",

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_popup_add_remove', {
     test: true,
     url: '/',
     edition: true,
-}, [{
+}, () => [{
     content: 'Drop s_popup snippet',
     trigger: '.oe_snippet:has( > [data-snippet="s_popup"]) .oe_snippet_thumbnail',
     run: "drag_and_drop iframe #wrap",

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -30,7 +30,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_and_animations", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop(snippets[1]), // Media List
     wTourUtils.dragNDrop(snippets[1]), // Media List
     wTourUtils.dragNDrop(snippets[2]), // Columns

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -37,7 +37,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop(snippets[1]), // Media List
     wTourUtils.dragNDrop(snippets[0]), // Popup
     checkScrollbar(false),

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_display_on_click", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({id: "s_text_image", name: "Image - Text"}),
     wTourUtils.dragNDrop({id: "s_popup", name: "Popup"}),
     {

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -59,7 +59,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_social_media', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({id: 's_social_media', name: 'Social Media'}),
     wTourUtils.clickOnSnippet({id: 's_social_media', name: 'Social Media'}),
     ...addNewSocialNetwork(7, 7, 'https://www.youtu.be/y7TlnAv6cto'),

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -23,7 +23,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_table_of_content', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({id: 's_table_of_content', name: 'Table of Content'}),
     wTourUtils.dragNDrop({id: 's_table_of_content', name: 'Table of Content'}),
     // To make sure that the public widgets of the two previous ones started.

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_translation', {
     url: '/',
     edition: true,
     test: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({name: 'Cover'}),
     {
         content: "Check that contact us contain Parseltongue",
@@ -22,7 +22,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_translation', {
 wTourUtils.registerWebsitePreviewTour('snippet_translation_changing_lang', {
     url: '/',
     test: true,
-}, [
+}, () => [
     {
         content: "Change language to Parseltongue",
         trigger: 'iframe .js_language_selector .btn',

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_version", {
     edition: true,
     url: "/",
     test: true,
-}, [{
+}, () => [{
     content: "Drop s_test_snip snippet",
     trigger: '#oe_snippets .oe_snippet:has(.s_test_snip) .oe_snippet_thumbnail',
     run: "drag_and_drop iframe #wrap",

--- a/addons/website/static/tests/tours/specific_website_editor.js
+++ b/addons/website/static/tests/tours/specific_website_editor.js
@@ -6,7 +6,7 @@ import wTourUtils from "@website/js/tours/tour_utils";
 wTourUtils.registerWebsitePreviewTour("generic_website_editor", {
     test: true,
     edition: true,
-}, [{
+}, () => [{
     trigger: 'iframe body:not([data-hello="world"])',
     content: 'Check that the editor DOM matches its website-generic features',
     run: function () {}, // Simple check

--- a/addons/website/static/tests/tours/start_cloned_snippet.js
+++ b/addons/website/static/tests/tours/start_cloned_snippet.js
@@ -13,7 +13,7 @@ wTourUtils.registerWebsitePreviewTour('website_start_cloned_snippet', {
     edition: true,
     test: true,
     url: '/',
-}, [
+}, () => [
     dragNDropOutOfFooter,
     wTourUtils.clickOnSnippet(countdownSnippet),
     {

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("text_animations", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: "s_cover",
         name: "Cover",

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('translate_menu_name', {
     url: '/pa_GB',
     test: true,
     edition: false,
-}, [
+}, () => [
     {
         content: "activate translate mode",
         trigger: '.o_translate_website_container a',

--- a/addons/website/static/tests/tours/website_click_tests.js
+++ b/addons/website/static/tests/tours/website_click_tests.js
@@ -10,7 +10,7 @@ const cover = {
 wTourUtils.registerWebsitePreviewTour('website_click_tour', {
     test: true,
     url: '/',
-}, [
+}, () => [
     {
         content: "trigger a page navigation",
         trigger: 'iframe a[href="/contactus"]',

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -128,7 +128,7 @@
         url: '/',
         edition: true,
         test: true,
-    }, [
+    }, () => [
         // Drop a form builder snippet and configure it
         {
             content: "Drop the form snippet",
@@ -535,7 +535,7 @@
         url: '/contactus',
         edition: true,
         test: true,
-    }, editContactUs([
+    }, () => editContactUs([
         {
             content: 'Change the Recipient Email',
             trigger: '[data-field-name="email_to"] input',
@@ -546,7 +546,7 @@
         url: '/contactus',
         edition: true,
         test: true,
-    }, editContactUs([
+    }, () => editContactUs([
         {
             content: "Change a random option",
             trigger: '[data-set-mark] input',
@@ -558,7 +558,7 @@
         test: true,
         url: '/',
         edition: true,
-    }, [
+    }, () => [
         // Create a form with two checkboxes: the second one required but
         // invisible when the first one is checked. Basically this should allow
         // to have: both checkboxes are visible by default but the form can

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('website_page_options', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
     wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
     wTourUtils.changeOption('TopMenuVisibility', 'we-button[data-visibility="transparent"]'),

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("website_snippets_menu_tabs", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.goToTheme(),
     {
         content: "Click on the empty 'DRAG BUILDING BLOCKS HERE' area.",

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -15,7 +15,7 @@ wTourUtils.registerWebsitePreviewTour("website_style_edition", {
     test: true,
     url: '/',
     edition: true,
-}, [{
+}, () => [{
     content: "Go to theme options",
     trigger: '.o_we_customize_theme_btn',
 }, {

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -8,7 +8,7 @@ wTourUtils.registerWebsitePreviewTour('website_text_edition', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     {
         content: "Go to theme options",
         trigger: '.o_we_customize_theme_btn',

--- a/addons/website_blog/static/src/js/tours/website_blog.js
+++ b/addons/website_blog/static/src/js/tours/website_blog.js
@@ -7,7 +7,7 @@
 
     wTourUtils.registerWebsitePreviewTour("blog", {
         url: "/",
-    }, [{
+    }, () => [{
         trigger: "body:not(:has(#o_new_content_menu_choices)) .o_new_content_container > a",
         content: _t("Click here to add new content to your website."),
         consumeVisibleOnly: true,

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -9,7 +9,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
 wTourUtils.registerWebsitePreviewTour('blog_tags', {
     test: true,
     url: '/blog',
-}, [{
+}, () => [{
         content: "Go to first blog",
         trigger: "iframe article[name=blog_post] a",
     },

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -7,7 +7,7 @@
         test: true,
         url: '/contactus',
         edition: true,
-    }, [{
+    }, () => [{
         content: "Select contact form",
         trigger: "iframe #wrap.o_editable section.s_website_form",
     }, {

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -9,7 +9,7 @@
     wTourUtils.registerWebsitePreviewTour("website_event_tour", {
         test: true,
         url: "/",
-    }, [{
+    }, () => [{
         content: _t("Click here to add new content to your website."),
         trigger: ".o_menu_systray .o_new_content_container > a",
         consumeVisibleOnly: true,

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -8,7 +8,7 @@
 
     wTourUtils.registerBackendAndFrontendTour("question", {
         url: '/forum/1',
-    }, [{
+    }, () => [{
         trigger: ".o_wforum_ask_btn",
         position: "left",
         content: _t("Create a new post in this forum by clicking on the button."),

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -63,7 +63,7 @@
     wTourUtils.registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
         test: true,
         url: '/jobs',
-    }, [{
+    }, () => [{
         content: 'Go to the Guru job page',
         trigger: 'iframe a[href*="guru"]',
     }, {

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
     test: true,
     url: '/',
     edition: true,
-}, [
+}, () => [
     // Put a Newsletter block.
     wTourUtils.dragNDrop({
         id: 's_newsletter_block',

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
@@ -7,7 +7,7 @@ wTourUtils.registerWebsitePreviewTour("snippet_newsletter_popup_edition", {
     test: true,
     url: "/",
     edition: true,
-}, [
+}, () => [
     wTourUtils.dragNDrop({
         id: 's_newsletter_subscribe_popup',
         name: 'Newsletter Popup',

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -8,7 +8,7 @@
     wTourUtils.registerWebsitePreviewTour("shop", {
         url: '/shop',
         sequence: 130,
-    }, [{
+    }, () => [{
         trigger: ".o_menu_systray .o_new_content_container > a",
         content: _t("Let's create your first product."),
         extra_trigger: "iframe .js_sale",

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -15,7 +15,7 @@ wTourUtils.registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         edition: true,
         test: true,
     },
-    [
+    () => [
         wTourUtils.dragNDrop({name: 'Add to Cart Button'}),
 
         // Basic product with no variants

--- a/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/website_sale_category_page_and_products_snippet.js
@@ -9,7 +9,7 @@ wTourUtils.registerWebsitePreviewTour('category_page_and_products_snippet_editio
     test: true,
     url: `/shop/category/${PRODUCT_CATEGORY_ID}`,
     edition: true,
-}, [
+}, () => [
     Object.assign(wTourUtils.dragNDrop({id: 's_dynamic_snippet_products', name: 'Products'}), {
         content: "Drag and drop the product snippet inside the category area",
         run: 'drag_and_drop iframe #category_header',

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('website_sale_tour_backend', {
     test: true,
     url: '/shop/cart',
     edition: true,
-}, [
+}, () => [
         {
             content: "open customize tab",
             trigger: '.o_we_customize_snippet_btn',

--- a/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
+++ b/addons/website_sale/static/tests/tours/website_sale_restricted_editor_ui.js
@@ -5,7 +5,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
 wTourUtils.registerWebsitePreviewTour('website_sale_restricted_editor_ui', {
     test: true,
     url: `/shop`,
-}, [
+}, () => [
     {
         content: "Open the site menu to check what is inside",
         trigger: '[data-menu-xmlid="website.menu_site"]',

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -8,7 +8,7 @@ wTourUtils.registerWebsitePreviewTour('shop_customize', {
     edition: true,
     test: true,
 },
-    [
+    () => [
         ...wTourUtils.clickOnSave(),
         {
             content: "select product attribute Steel",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour("shop_editor", {
     test: true,
     url: "/shop",
     edition: true,
-}, [{
+}, () => [{
     content: "Click on pricelist dropdown",
     trigger: "iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
 }, {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_list_view_b2c.js
@@ -7,7 +7,7 @@ wTourUtils.registerWebsitePreviewTour('shop_list_view_b2c', {
     test: true,
     url: '/shop?search=Test Product',
 },
-    [
+    () => [
         {
             content: "check price on /shop",
             trigger: 'iframe .oe_product_cart .oe_currency_value:contains("825.00")',

--- a/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
+++ b/addons/website_sale/static/tests/tours/website_sale_snippet_products.js
@@ -42,7 +42,7 @@ wTourUtils.registerWebsitePreviewTour('website_sale.snippet_products', {
     url: '/',
     edition: true,
 },
-[
+() => [
     wTourUtils.dragNDrop(productsSnippet),
     wTourUtils.clickOnSnippet(productsSnippet),
     ...templatesSteps,
@@ -60,7 +60,7 @@ wTourUtils.registerWebsitePreviewTour('website_sale.products_snippet_recently_vi
     url: '/',
     edition: true,
 },
-[
+() => [
     wTourUtils.dragNDrop(productsSnippet),
     wTourUtils.clickOnSnippet(productsSnippet),
     ...changeTemplate('dynamic_filter_template_product_product_add_to_cart'),

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist_admin.js
@@ -6,7 +6,7 @@ wTourUtils.registerWebsitePreviewTour('shop_wishlist_admin', {
     url: '/shop?search=Rock',
     test: true,
 },
-    [
+    () => [
         {
             content: "Go to Rock shop page",
             trigger: 'iframe a:contains("Rock"):first',

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -7,7 +7,7 @@ import "@web/legacy/translations_loaded";
 
 wTourUtils.registerWebsitePreviewTour('slides_tour', {
     url: '/slides',
-}, [{
+}, () => [{
     trigger: "body:not(.editor_has_snippets) .o_new_content_container > a",
     content: Markup(_t("Welcome on your course's home page. It's still empty for now. Click on \"<b>New</b>\" to write your first course.")),
     consumeVisibleOnly: true,

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -13,7 +13,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
 wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
     url: '/slides',
     test: true,
-}, [{
+}, () => [{
     content: 'eLearning: click on New (top-menu)',
     trigger: 'div.o_new_content_container a'
 }, {

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -14,7 +14,7 @@ wTourUtils.registerWebsitePreviewTour('course_publisher', {
     // TODO: replace by wTourUtils.getClientActionURL when it's added
     url: '/slides',
     test: true
-}, [{
+}, () => [{
     content: 'eLearning: click on New (top-menu)',
     trigger: 'div.o_new_content_container a',
 }, {

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -15,7 +15,7 @@ import wTourUtils from '@website/js/tours/tour_utils';
  wTourUtils.registerWebsitePreviewTour('full_screen_web_editor', {
     url: '/slides',
     test: true,
-}, [{
+}, () => [{
     // open to the course
     trigger: 'iframe a:contains("Basics of Gardening")'
 }, {


### PR DESCRIPTION
As steps are encapsuled in an arrow function from 69a5d8e3ce47238 for steps tour definition to avoid direct Markup(_t()) interpretation, the same is done for registerWebsitePreviewTour() of "odoo/addons/website/static/src/js/tours/tour_utils.js" in this commit.

This is done in anticipation of the use of _t() (import from @web/core/l10n/translation) with registerWebsitePreviewTour().

task-3292454
PR design-themes : https://github.com/odoo/design-themes/pull/678
