### PR TITLE
[CLN] website_sale: remove unused kwargs from delivery

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1566,14 +1566,11 @@ class WebsiteSale(http.Controller):
            paying / canceling
         """
         carrier_id = post.get('carrier_id')
-        keep_carrier = post.get('keep_carrier', False)
-        if keep_carrier:
-            keep_carrier = bool(int(keep_carrier))
         if carrier_id:
             carrier_id = int(carrier_id)
         order = request.website.sale_get_order()
         if order:
-            order._check_carrier_quotation(force_carrier_id=carrier_id, keep_carrier=keep_carrier)
+            order._check_carrier_quotation(force_carrier_id=carrier_id)
             if carrier_id:
                 return request.redirect("/shop/payment")
 

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1565,14 +1565,7 @@ class WebsiteSale(http.Controller):
            did go to a payment.provider website but closed the tab without
            paying / canceling
         """
-        carrier_id = post.get('carrier_id')
-        if carrier_id:
-            carrier_id = int(carrier_id)
         order = request.website.sale_get_order()
-        if order:
-            order._check_carrier_quotation(force_carrier_id=carrier_id)
-            if carrier_id:
-                return request.redirect("/shop/payment")
 
         redirection = self.checkout_redirection(order) or self.checkout_check_address(order)
         if redirection:

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -551,7 +551,7 @@ class SaleOrder(models.Model):
             action['url'] = f'/@{action["url"]}'
         return action
 
-    def _check_carrier_quotation(self, force_carrier_id=None, keep_carrier=False):
+    def _check_carrier_quotation(self, force_carrier_id=None):
         self.ensure_one()
         DeliveryCarrier = self.env['delivery.carrier']
 
@@ -561,7 +561,7 @@ class SaleOrder(models.Model):
         else:
             self = self.with_company(self.company_id)
             # attempt to use partner's preferred carrier
-            if not force_carrier_id and self.partner_shipping_id.property_delivery_carrier_id and not keep_carrier:
+            if not force_carrier_id and self.partner_shipping_id.property_delivery_carrier_id:
                 force_carrier_id = self.partner_shipping_id.property_delivery_carrier_id.id
 
             carrier = force_carrier_id and DeliveryCarrier.browse(force_carrier_id) or self.carrier_id


### PR DESCRIPTION
Remove unused:
- `keep_carrier` from the kwargs of `_check_carrier_quotation`
- `carrier_id` from the kwargs of the '/shop/payment' route