### PR TITLE
[FIX] portal: update the login of portal user

### DIFF
--- a/addons/portal/tests/test_message_format_portal.py
+++ b/addons/portal/tests/test_message_format_portal.py
@@ -39,3 +39,31 @@ class TestMessageFormatPortal(common.SavepointCase):
         formatted_result = message_note.portal_message_format()
         # subtype is note -> should return True
         self.assertTrue(formatted_result[0].get('is_message_subtype_note'))
+
+    def test_check_email_is_update(self):
+        ''' Test the scenario where we update the partner's email and grant them portal
+        access for the second time. Verify that upon the second update, the user's login
+        should reflect the newly updated email of the partner.'''
+
+        partner = self.env['res.partner'].create({
+            'name': 'Testing_1',
+            'email': 'testing@gmail.com',
+        })
+
+        portal_wizard = self.env['portal.wizard'].create({
+            'user_ids': [(0, 0, {
+                'partner_id' : partner.id,
+                'email': partner.email,
+                'in_portal': True,
+            })]
+        })
+        portal_wizard.action_apply()
+        portal_wizard.user_ids.write({'in_portal': False})
+        portal_wizard.action_apply()
+
+        portal_wizard.user_ids.write({
+            'email': 'testing@odoo.com',
+            'in_portal': True,
+        })
+        portal_wizard.action_apply()
+        self.assertEqual(portal_wizard.user_ids.email, portal_wizard.user_ids.user_id.login)

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -144,6 +144,9 @@ class PortalWizardUser(models.TransientModel):
                     user_portal = wizard_user.sudo().with_company(company_id)._create_user()
                 else:
                     user_portal = user
+                    if user_portal.login != wizard_user.email:
+                        user_portal.write({'login': wizard_user.partner_id.email})
+
                 wizard_user.write({'user_id': user_portal.id})
                 if not wizard_user.user_id.active or group_portal not in wizard_user.user_id.groups_id:
                     wizard_user.user_id.write({'active': True, 'groups_id': [(4, group_portal.id)]})


### PR DESCRIPTION
Steps to Reproduce
===================
1. Create a contact and give it an email address. 
2. ​Grant portal access to that contact, a first email is sent. 
3. ​Revoke the access, and change the email address. 
4. Again grant access to that contact.
=> The second email which is sent after the updation of the email, contains the previous email rather than the updated email.

Technical
========
When we grant the portal access to the partner it creates the user if user is not present and at the time of the revoke it just archives the user.

So next time when we grant portal access to the same partner again then the user was already created so our email was not getting updated.

After this PR
==========
Now the email will be updated and set as the partner's email if the partner's email and portal user's login are different.

Task-3410250