### PR TITLE
[REF] web: RelationalModel: add option to save after update

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -41,13 +41,13 @@ export class ProjectTaskKanbanDynamicGroupList extends RelationalModel.DynamicGr
 }
 
 export class ProjectTaskRecord extends RelationalModel.Record {
-    async _update(changes, options) {
+    _update(changes, options) {
         const value = changes.personal_stage_type_ids;
         if (Array.isArray(value)) {
             delete changes.personal_stage_type_ids;
             changes.personal_stage_type_id = value;
         }
-        await super._update(changes, options);
+        return super._update(changes, options);
     }
 
     get context() {

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -119,10 +119,10 @@ export class DynamicGroupList extends DynamicList {
             sourceGroup._addRecord(record, oldIndex);
         };
         try {
-            await record.update({ [targetGroup.groupByField.name]: value });
-            const res = await record.save({ noReload: true });
+            const changes = { [targetGroup.groupByField.name]: value };
+            const res = await record.update(changes, { save: true });
             if (!res) {
-                revert();
+                return revert();
             }
         } catch (e) {
             // revert changes

--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.js
@@ -19,10 +19,8 @@ export class BooleanFavoriteField extends Component {
     };
 
     async update() {
-        await this.props.record.update({ [this.props.name]: !this.props.record.data[this.props.name] });
-        if (this.props.autosave) {
-            await this.props.record.save();
-        }
+        const changes = { [this.props.name]: !this.props.record.data[this.props.name] };
+        await this.props.record.update(changes, { save: this.props.autosave });
     }
 }
 

--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
@@ -12,10 +12,8 @@ export class BooleanToggleField extends BooleanField {
     };
 
     async onChange(newValue) {
-        await this.props.record.update({ [this.props.name]: newValue });
-        if (this.props.autosave) {
-            return this.props.record.save();
-        }
+        const changes = { [this.props.name]: newValue };
+        await this.props.record.update(changes, { save: this.props.autosave });
     }
 }
 

--- a/addons/web/static/src/views/fields/boolean_toggle/list_boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/list_boolean_toggle_field.js
@@ -8,12 +8,8 @@ export class ListBooleanToggleField extends BooleanToggleField {
 
     async onClick() {
         if (!this.props.readonly && this.props.record.isInEdition) {
-            await this.props.record.update({
-                [this.props.name]: !this.props.record.data[this.props.name],
-            });
-            if (this.props.autosave) {
-                return this.props.record.save();
-            }
+            const changes = { [this.props.name]: !this.props.record.data[this.props.name] };
+            await this.props.record.update(changes, { save: this.props.autosave });
         }
     }
 }

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -352,10 +352,10 @@ export class Many2ManyTagsFieldColorEditable extends Many2ManyTagsField {
         if (tagRecord.data[this.props.colorField] != 0) {
             this.previousColorsMap[tagRecord.resId] = tagRecord.data[this.props.colorField];
         }
-        tagRecord.update({
+        const changes = {
             [this.props.colorField]: isHidden ? 0 : this.previousColorsMap[tagRecord.resId] || 1,
-        });
-        tagRecord.save();
+        };
+        tagRecord.update(changes, { save: true });
         this.popover.close();
     }
 
@@ -363,8 +363,7 @@ export class Many2ManyTagsFieldColorEditable extends Many2ManyTagsField {
         const tagRecord = this.props.record.data[this.props.name].records.find(
             (record) => record.id === tag.id
         );
-        tagRecord.update({ [this.props.colorField]: colorIndex });
-        tagRecord.save();
+        tagRecord.update({ [this.props.colorField]: colorIndex }, { save: true });
         this.popover.close();
     }
 }

--- a/addons/web/static/src/views/fields/priority/priority_field.js
+++ b/addons/web/static/src/views/fields/priority/priority_field.js
@@ -82,10 +82,7 @@ export class PriorityField extends Component {
     }
 
     async updateRecord(value) {
-        await this.props.record.update({ [this.props.name]: value });
-        if (this.props.autosave) {
-            return this.props.record.save();
-        }
+        await this.props.record.update({ [this.props.name]: value }, { save: this.props.autosave });
     }
 }
 

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -75,10 +75,7 @@ export class ProgressBarField extends Component {
         if (this.props.record.fields[fieldName].type === "integer") {
             parsedValue = Math.floor(parsedValue);
         }
-        this.props.record.update({ [fieldName]: parsedValue });
-        if (this.props.readonly) {
-            this.props.record.save();
-        }
+        this.props.record.update({ [fieldName]: parsedValue }, { save: this.props.readonly });
     }
     onCurrentValueChange(ev) {
         this.onValueChange(ev.target.value, this.currentValueField);

--- a/addons/web/static/src/views/fields/state_selection/state_selection_field.js
+++ b/addons/web/static/src/views/fields/state_selection/state_selection_field.js
@@ -71,10 +71,7 @@ export class StateSelectionField extends Component {
     }
 
     async updateRecord(value) {
-        await this.props.record.update({ [this.props.name]: value });
-        if (this.props.autosave) {
-            return this.props.record.save();
-        }
+        await this.props.record.update({ [this.props.name]: value }, { save: this.props.autosave });
     }
 }
 

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.js
@@ -59,8 +59,7 @@ export class KanbanCoverImageDialog extends Component {
 
     async setCover() {
         const id = this.state.selectedAttachmentId ? [this.state.selectedAttachmentId] : false;
-        await this.props.record.update({ [this.props.fieldName]: id });
-        await this.props.record.save();
+        await this.props.record.update({ [this.props.fieldName]: id }, { save: true });
         this.props.close();
     }
 

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -297,8 +297,7 @@ export class KanbanRecord extends Component {
 
     async selectColor(colorIndex) {
         const { archInfo, record } = this.props;
-        await record.update({ [archInfo.colorField]: colorIndex });
-        await record.save();
+        await record.update({ [archInfo.colorField]: colorIndex }, { save: true });
     }
 
     /**

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -13097,12 +13097,7 @@ QUnit.module("Fields", (hooks) => {
         assert.verifySteps(["get_views partner", "web_read partner"]);
 
         await click(target, ".o_boolean_toggle");
-        assert.verifySteps([
-            "onchange2 turtle",
-            "onchange2 partner",
-            "write turtle",
-            "web_read turtle",
-        ]);
+        assert.verifySteps(["onchange2 partner", "write turtle", "web_read turtle"]);
     });
 
     QUnit.test("create a new record with an x2m invisible", async function (assert) {


### PR DESCRIPTION
[REF] web: RelationalModel: add option to save after update

This commit adds an option to save the record after an update. When the
save option is set to true, the record will be saved and reload after
the update. Note that, the onChange is not done in this case.