### PR TITLE
[FIX] payment: handle validation error while post-processing transaction cron

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -970,6 +970,12 @@ class PaymentTransaction(models.Model):
                 self.env.cr.commit()
             except psycopg2.OperationalError:
                 self.env.cr.rollback()  # Rollback and try later.
+            except ValidationError as e:
+                _logger.warning(
+                    "encountered an error while post-processing transaction with reference %s:\n%s",
+                    tx.reference, e
+                )
+                self.env.cr.rollback()
             except Exception as e:
                 _logger.exception(
                     "encountered an error while post-processing transaction with reference %s:\n%s",


### PR DESCRIPTION
This problem happens when a customer creates a single sale order record in the subscription module before creating the draft invoice for that order.  When the customer creates a new draft invoice for the same order while the original draft invoice is still in existence, at that time the validation error would be generated.

Also, this issue was created while a Scheduled Action called "post-processing transaction cron" was being executed.

Traceback:- 
```
ValidationError: Für die folgenden wiederkehrenden Aufträge liegen Rechnungsentwürfe vor. Bitte bestätigen Sie diese oder stornieren Sie sie, bevor Sie neue Rechnungen erstellen. S00013
  File "addons/payment/models/payment_transaction.py", line 969, in _cron_finalize_post_processing
    tx._finalize_post_processing()
  File "addons/website_payment/models/payment_transaction.py", line 14, in _finalize_post_processing
    super()._finalize_post_processing()
  File "addons/account_payment/models/payment_transaction.py", line 216, in _finalize_post_processing
    super()._finalize_post_processing()
  File "addons/payment/models/payment_transaction.py", line 985, in _finalize_post_processing
    self.filtered(lambda tx: tx.operation != 'validation')._reconcile_after_done()
  File "home/odoo/src/enterprise/saas-16.3/sale_subscription/models/payment_transaction.py", line 35, in _reconcile_after_done
    res = super()._reconcile_after_done()
  File "addons/sale/models/payment_transaction.py", line 115, in _reconcile_after_done
    self._invoice_sale_orders()
  File "home/odoo/src/enterprise/saas-16.3/sale_subscription/models/payment_transaction.py", line 70, in _invoice_sale_orders
    res = super(PaymentTransaction, transaction_to_invoice)._invoice_sale_orders()
  File "addons/sale/models/payment_transaction.py", line 170, in _invoice_sale_orders
    invoices = confirmed_orders.with_context(
  File "home/odoo/src/enterprise/saas-16.3/sale_subscription/models/sale_order.py", line 1519, in _create_invoices
    raise ValidationError(_("The following recurring orders have draft invoices. Please Confirm them or cancel them "
```

sentry:4348513316