### PR TITLE
[REF] web: RelationalModel: unity always return an object for many2one

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -285,8 +285,11 @@ export function getFieldsSpec(
             properties.push(fieldName);
         }
         // M2O
-        if (fields[fieldName].type === "many2one" && invisible !== true) {
-            fieldsSpec[fieldName].fields = { display_name: {} };
+        if (fields[fieldName].type === "many2one") {
+            fieldsSpec[fieldName].fields = {};
+            if (invisible !== true) {
+                fieldsSpec[fieldName].fields.display_name = {};
+            }
         }
         if (["many2one", "one2many", "many2many"].includes(fields[fieldName].type)) {
             let context = activeFields[fieldName].context;
@@ -367,11 +370,8 @@ export function parseServerValue(field, value) {
         }
         case "many2one": {
             if (Array.isArray(value)) {
+                // Used for web_read_group, where the value is an array of [id, display_name]
                 return value;
-            }
-            if (Number.isInteger(value)) {
-                // for always invisible many2ones, unity directly returns the id, not a pair
-                return [value, ""];
             }
             return value ? [value.id, value.display_name] : false;
         }

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -2547,10 +2547,14 @@ export class MockServer {
                 case "many2one": {
                     for (const record of records) {
                         if (record[fieldName] !== false) {
-                            const displayName = record[fieldName][1];
-                            record[fieldName] = { id: record[fieldName][0] };
-                            if (relatedFields && relatedFields.display_name) {
-                                record[fieldName].display_name = displayName;
+                            if (!relatedFields) {
+                                record[fieldName] = record[fieldName][0];
+                            } else {
+                                const displayName = record[fieldName][1];
+                                record[fieldName] = { id: record[fieldName][0] };
+                                if ("display_name" in relatedFields) {
+                                    record[fieldName].display_name = displayName;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Before this commit, in some cases (many2one invisible) unity returned an integer as value.

Now, to be consistent, unity always return an object for many2one.

Note that, web_read_group still returns an array as value for many2one.

part-of task-id~3179751