### PR TITLE
[FIX] account: inconsistency in invoice report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -182,7 +182,6 @@
                                 </t>
                             </tbody>
                         </table>
-                        <div>
                             <div id="right-elements" t-attf-class="#{'col-5' if report_type != 'html' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
                                 <div id="total" class="clearfix row">
                                     <div class="ms-auto">
@@ -227,6 +226,7 @@
                                 </div>
                                 <t t-call="account.document_tax_totals_company_currency_template"/>
                             </div>
+                    </div>
                             <div id="payment_term" t-attf-class="#{'col-7' if report_type != 'html' else '' } clearfix" class="clearfix col-5">
                                 <div class="justify-text">
                                     <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note" class="mb-2">


### PR DESCRIPTION
Steps to reproduce:
1. Install l10n_din5008
2. Settings > document layout > din5008
3. create an invoice and print it
4. there is an offset between the tax table and the rest of the invoice

Issue:
during 3764914, the tax_totals table
was put in a different div than invoice_line_table, while this might not cause issues in the default layout, it does once you introduce a layout that changes the width settings as the two elements now would behave differently.

Fix:
put them back under `<div class="page mb-4">`

opw-3414289