### PR TITLE
change move quantity reporting

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1919,7 +1919,6 @@ class MrpProduction(models.Model):
         for production in self:
             production.write({
                 'date_finished': fields.Datetime.now(),
-                'product_qty': production.qty_produced,
                 'priority': '0',
                 'is_locked': True,
                 'state': 'done',

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -374,8 +374,8 @@
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger" column_invisible="parent.state != 'draft'" invisible="forecast_availability &gt;= 0"/>
                                     <field name="forecast_availability" string="Reserved" column_invisible="parent.state in ('draft', 'done')" widget="forecast_widget"/>
                                     <field name="quantity_done" string="Consumed"
-                                        decoration-success="not is_done and (quantity_done - should_consume_qty == 0)"
-                                        decoration-warning="not is_done and (quantity_done - should_consume_qty &gt; 0.0001)"
+                                        decoration-success="product_uom_qty - quantity_done &gt; 0.0001"
+                                        decoration-warning="quantity_done - product_uom_qty &gt; 0.0001"
                                         column_invisible="parent.state == 'draft'"
                                         readonly="has_tracking != 'none'"
                                         force_save="1" widget="mrp_consumed"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -650,39 +650,11 @@
             parent="menu_mrp_manufacturing"
             sequence="1"/>
 
-        <record id="mrp_production_report" model="ir.actions.act_window">
-            <field name="name">Manufacturing Orders</field>
-            <field name="res_model">mrp.production</field>
-            <field name="view_mode">graph,pivot,form</field>
-            <field name="target">current</field>
-            <field name="context">{
-                'search_default_product': 1,
-                'search_default_scheduled_date': 2,
-                'search_default_filter_confirmed': True,
-                'search_default_filter_planned': True,
-                'default_company_id': allowed_company_ids[0],
-                'allowed_company_ids': allowed_company_ids
-            }</field>
-            <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    No data yet!
-                </p><p>
-                    Create a new manufacturing order
-                </p>
-            </field>
-        </record>
-
         <menuitem id="menu_mrp_workorder_todo"
                 name="Work Orders"
                 action="mrp_workorder_todo"
                 parent="menu_mrp_manufacturing"
                 groups="group_mrp_routings"/>
-
-        <menuitem id="menu_mrp_production_report"
-            name="Manufacturing Orders"
-            parent="menu_mrp_reporting"
-            action="mrp_production_report"
-            sequence="11"/>
 
         <menuitem id="menu_mrp_work_order_report"
             name="Work Orders"

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -342,7 +342,7 @@ class PurchaseOrderLine(models.Model):
                     if move.state == 'done':
                         if move._is_purchase_return():
                             if move.to_refund:
-                                total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                                total -= move.product_uom._compute_quantity(move.quantity_done, line.product_uom, rounding_method='HALF-UP')
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
                             # Edge case: the dropship is returned to the stock, no to the supplier.
                             # In this case, the received quantity on the PO is set although we didn't
@@ -350,7 +350,7 @@ class PurchaseOrderLine(models.Model):
                             # quantity twice, we do nothing.
                             pass
                         else:
-                            total += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                            total += move.product_uom._compute_quantity(move.quantity_done, line.product_uom, rounding_method='HALF-UP')
                 line._track_qty_received(total)
                 line.qty_received = total
 

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -147,7 +147,7 @@ class SaleOrderLine(models.Model):
             if not line.is_expense and line.product_id.type in ['consu', 'product']:
                 line.qty_delivered_method = 'stock_move'
 
-    @api.depends('move_ids.state', 'move_ids.scrapped', 'move_ids.product_uom_qty', 'move_ids.product_uom')
+    @api.depends('move_ids.state', 'move_ids.scrapped', 'move_ids.quantity_done', 'move_ids.product_uom')
     def _compute_qty_delivered(self):
         super(SaleOrderLine, self)._compute_qty_delivered()
 
@@ -158,11 +158,11 @@ class SaleOrderLine(models.Model):
                 for move in outgoing_moves:
                     if move.state != 'done':
                         continue
-                    qty += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                    qty += move.product_uom._compute_quantity(move.quantity_done, line.product_uom, rounding_method='HALF-UP')
                 for move in incoming_moves:
                     if move.state != 'done':
                         continue
-                    qty -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
+                    qty -= move.product_uom._compute_quantity(move.quantity_done, line.product_uom, rounding_method='HALF-UP')
                 line.qty_delivered = qty
 
     @api.model_create_multi

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -2758,7 +2758,7 @@ class StockMove(TransactionCase):
         backorder_move = backorder.move_ids
         self.assertEqual(backorder_move.state, 'done')
         self.assertEqual(backorder_move.quantity_done, 12.0)
-        self.assertEqual(backorder_move.product_uom_qty, 12.0)
+        self.assertEqual(backorder_move.product_uom_qty, 6.0)
         self.assertEqual(backorder_move.product_uom, self.uom_unit)
 
         # the second move should now be reservable

--- a/addons/stock/tests/test_report_stock_quantity.py
+++ b/addons/stock/tests/test_report_stock_quantity.py
@@ -36,13 +36,9 @@ class TestReportStockQuantity(tests.TransactionCase):
             'product_id': cls.product1.id,
             'product_uom': cls.uom_unit.id,
             'product_uom_qty': 100.0,
+            'quantity_done': 100.0,
             'state': 'done',
             'date': fields.Datetime.now(),
-        })
-        cls.quant1 = cls.env['stock.quant'].create({
-            'product_id': cls.product1.id,
-            'location_id': cls.wh.lot_stock_id.id,
-            'quantity': 100.0,
         })
         # ship
         cls.move2 = cls.env['stock.move'].create({

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -139,10 +139,10 @@ class TestStockFlow(TestStockCommon):
             self.assertEqual(move.state, 'done', 'Wrong state of move line.')
         # Check product A done quantity must be 3 and 1
         moves = self.MoveObj.search([('product_id', '=', self.productA.id), ('picking_id', '=', picking_in.id)])
-        self.assertEqual(moves.product_uom_qty, 4.0, 'Wrong move quantity for product A.')
+        self.assertEqual(moves.quantity_done, 4.0, 'Wrong move quantity for product A.')
         # Check product B done quantity must be 4 and 1
         moves = self.MoveObj.search([('product_id', '=', self.productB.id), ('picking_id', '=', picking_in.id)])
-        self.assertEqual(moves.product_uom_qty, 5.0, 'Wrong move quantity for product B.')
+        self.assertEqual(moves.quantity_done, 5.0, 'Wrong move quantity for product B.')
         # Check product C done quantity must be 7
         c_done_qty = self.MoveObj.search([('product_id', '=', self.productC.id), ('picking_id', '=', picking_in.id)], limit=1).product_uom_qty
         self.assertEqual(c_done_qty, 7.0, 'Wrong move quantity of product C (%s found instead of 7)' % (c_done_qty))
@@ -398,13 +398,13 @@ class TestStockFlow(TestStockCommon):
             self.assertEqual(move.state, 'done', 'Wrong state of move lines.')
         # Check product A done quantity must be 10
         movesA = self.MoveObj.search([('product_id', '=', self.productA.id), ('picking_id', '=', back_order_in.id)])
-        self.assertEqual(movesA.product_uom_qty, 10, "Wrong move quantity of product A (%s found instead of 10)" % (movesA.product_uom_qty))
+        self.assertEqual(movesA.quantity_done, 10, "Wrong move quantity of product A (%s found instead of 10)" % (movesA.quantity_done))
         # Check product C done quantity must be 3.0, 1.0, 2.0
         movesC = self.MoveObj.search([('product_id', '=', self.productC.id), ('picking_id', '=', back_order_in.id)])
-        self.assertEqual(movesC.product_uom_qty, 6.0, 'Wrong quantity of moves product C.')
+        self.assertEqual(movesC.quantity_done, 6.0, 'Wrong quantity of moves product C.')
         # Check product D done quantity must be 5.0 and 3.0
         movesD = self.MoveObj.search([('product_id', '=', self.productD.id), ('picking_id', '=', back_order_in.id)])
-        d_done_qty = [move.product_uom_qty for move in movesD]
+        d_done_qty = [move.quantity_done for move in movesD]
         self.assertEqual(set(d_done_qty), set([8.0]), 'Wrong quantity of moves product D.')
         # Check no back order is created.
         self.assertFalse(self.PickingObj.search([('backorder_id', '=', back_order_in.id)]), "Should not create any back order.")
@@ -678,23 +678,23 @@ class TestStockFlow(TestStockCommon):
         self.assertEqual(len(picking_in_B.move_ids), 5, 'Wrong number of move lines')
         # Check product DozA done quantity.
         moves_DozA = self.MoveObj.search([('product_id', '=', self.DozA.id), ('picking_id', '=', picking_in_B.id)], limit=1)
-        self.assertEqual(moves_DozA.product_uom_qty, 96, 'Wrong move quantity (%s found instead of 96)' % (moves_DozA.product_uom_qty))
+        self.assertEqual(moves_DozA.quantity_done, 96, 'Wrong move quantity (%s found instead of 96)' % (moves_DozA.product_uom_qty))
         self.assertEqual(moves_DozA.product_uom.id, self.uom_unit.id, 'Wrong uom in move for product DozA.')
         # Check product SDozA done quantity.
         moves_SDozA = self.MoveObj.search([('product_id', '=', self.SDozA.id), ('picking_id', '=', picking_in_B.id)], limit=1)
-        self.assertEqual(moves_SDozA.product_uom_qty, 1512, 'Wrong move quantity (%s found instead of 1512)' % (moves_SDozA.product_uom_qty))
+        self.assertEqual(moves_SDozA.quantity_done, 1512, 'Wrong move quantity (%s found instead of 1512)' % (moves_SDozA.product_uom_qty))
         self.assertEqual(moves_SDozA.product_uom.id, self.uom_unit.id, 'Wrong uom in move for product SDozA.')
         # Check product SDozARound done quantity.
         moves_SDozARound = self.MoveObj.search([('product_id', '=', self.SDozARound.id), ('picking_id', '=', picking_in_B.id)], limit=1)
-        self.assertEqual(moves_SDozARound.product_uom_qty, 1584, 'Wrong move quantity (%s found instead of 1584)' % (moves_SDozARound.product_uom_qty))
+        self.assertEqual(moves_SDozARound.quantity_done, 1584, 'Wrong move quantity (%s found instead of 1584)' % (moves_SDozARound.product_uom_qty))
         self.assertEqual(moves_SDozARound.product_uom.id, self.uom_unit.id, 'Wrong uom in move for product SDozARound.')
         # Check product kgB done quantity.
         moves_kgB = self.MoveObj.search([('product_id', '=', self.kgB.id), ('picking_id', '=', picking_in_B.id)], limit=1)
-        self.assertEqual(moves_kgB.product_uom_qty, 20, 'Wrong quantity in move (%s found instead of 20)' % (moves_kgB.product_uom_qty))
+        self.assertEqual(moves_kgB.quantity_done, 20, 'Wrong quantity in move (%s found instead of 20)' % (moves_kgB.product_uom_qty))
         self.assertEqual(moves_kgB.product_uom.id, self.uom_gm.id, 'Wrong uom in move for product kgB.')
         # Check two moves created for product gB with quantity (0.525 kg and 0.3 g)
         moves_gB_kg = self.MoveObj.search([('product_id', '=', self.gB.id), ('picking_id', '=', picking_in_B.id), ('product_uom', '=', self.uom_kg.id)], limit=1)
-        self.assertEqual(moves_gB_kg.product_uom_qty, 0.526, 'Wrong move quantity (%s found instead of 0.526)' % (moves_gB_kg.product_uom_qty))
+        self.assertEqual(moves_gB_kg.quantity_done, 0.526, 'Wrong move quantity (%s found instead of 0.526)' % (moves_gB_kg.product_uom_qty))
         self.assertEqual(moves_gB_kg.product_uom.id, self.uom_kg.id, 'Wrong uom in move for product gB.')
 
         # TODO Test extra move once the uom is editable in the move_lines
@@ -1713,18 +1713,10 @@ class TestStockFlow(TestStockCommon):
 
         move_ids = picking.move_ids
         move_done = move_ids.browse(move_a.id)
-        move_canceled = move_ids - move_done
 
         # Checking that the original move was set to done
-        self.assertEqual(move_done.product_uom_qty, 4)
+        self.assertEqual(move_done.product_uom_qty, 10)
         self.assertEqual(move_done.state, 'done')
-
-        # Checking that the new move created was canceled
-        self.assertEqual(move_canceled.product_uom_qty, 6)
-        self.assertEqual(move_canceled.state, 'cancel')
-
-        # Checking that the canceled move is in the original picking
-        self.assertIn(move_canceled.id, picking.move_ids.mapped('id'))
 
     def test_backorder_setting(self):
         """Create 3 pickings with each has different backorder settings on its

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -44,9 +44,10 @@
                     <field name="product_packaging_id" groups="product.group_stock_packaging"
                         optional="hide" context="{'default_product_id': product_id}"
                         readonly="not product_id"/>
-                    <field name="product_uom_qty" string="Quantity" sum="Total Quantity"
+                    <field name="product_uom_qty" sum="Total Demand" readonly="state == 'done'"/>
+                    <field name="quantity_done" string="Done" sum="Total Done"
                         decoration-danger="(location_usage in ('internal','transit')) and (location_dest_usage not in ('internal','transit'))"
-                        decoration-success="(location_usage not in ('internal','transit')) and (location_dest_usage in ('internal','transit'))" readonly="state == 'done'"/>
+                        decoration-success="(location_usage not in ('internal','transit')) and (location_dest_usage in ('internal','transit'))"/>
                     <field name="product_uom" options="{'no_open': True, 'no_create': True}" string="Unit" groups="uom.group_uom"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <field name="state" widget='badge' optional="show"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -307,7 +307,8 @@
                                     <field name="reserved_availability" string="Reserved"
                                         column_invisible="parent.state in ['draft', 'done'] or parent.picking_type_code in ['incoming', 'outgoing'] or parent.immediate_transfer"/>
                                     <field name="product_qty" readonly="1" column_invisible="True"/>
-                                    <field name="quantity_done" string="Done" column_invisible="parent.state == 'draft' and not parent.immediate_transfer" readonly="not product_id"/>
+                                    <field name="quantity_done" string="Done" column_invisible="parent.state == 'draft' and not parent.immediate_transfer" readonly="not product_id"
+                                        decoration-danger="quantity_done > product_uom_qty"/>
                                     <field name="product_uom" readonly="state != 'draft' and not additional" options="{'no_open': True, 'no_create': True}" string="Unit" groups="uom.group_uom"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         groups="stock.group_production_lot"

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -645,8 +645,7 @@ class TestBatchPicking(TransactionCase):
         self.assertEqual(self.batch.picking_ids, self.picking_client_1 | self.picking_client_2)
         self.assertRecordValues(self.batch.move_ids.sorted('id'), [
             {'product_id': self.productA.id, 'product_uom_qty': 10.0, 'quantity_done': 10.0, 'state': 'done'},
-            {'product_id': self.productB.id, 'product_uom_qty': 7.0, 'quantity_done': 7.0, 'state': 'done'},
-            {'product_id': self.productB.id, 'product_uom_qty': 3.0, 'quantity_done': 0.0, 'state': 'cancel'},
+            {'product_id': self.productB.id, 'product_uom_qty': 10.0, 'quantity_done': 7.0, 'state': 'done'},
         ])
 
 @tagged('-at_install', 'post_install')


### PR DESCRIPTION
Currently on stock moves, product_uom_qty indicates the demand qty
before the move is done and it indicates the acutual done qty when
the move is done.
As a result,  when validate a stock move with qty_done !=
product_uom_qty, a new move is always created for the difference.
And the product_uom_qty of the original move will be changed to match
qty_done.

In this commit, we change to that product_uom_qty will always indicate
the demand qty, and qty_done will always indicate actually done
quantity.
To do that, when underconsumption, we won't split the move when no
backorder. and when overconsumption, we will always merge the extra move
back to the original move.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
