### PR TITLE
[IMP] various: update wording of action labels

### DIFF
--- a/addons/crm/views/crm_team_views.xml
+++ b/addons/crm/views/crm_team_views.xml
@@ -144,7 +144,8 @@
                             string="Assign Leads"
                             class="oe_highlight"
                             confirm="This will assign leads to all members. Do you want to proceed?"
-                            invisible="not use_leads and not use_opportunities or not assignment_enabled"/>
+                            invisible="not use_leads and not use_opportunities or not assignment_enabled"
+                            confirm-label="Assign Leads"/>
                     </header>
                 </xpath>
                 <xpath expr="//div[@name='options_active']" position="inside">

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -29,6 +29,9 @@ patch(AttendeeCalendarController.prototype, {
                     title: _t("Configuration"),
                     body: _t("The Google Synchronization needs to be configured before you can use it, do you want to do it now?"),
                     confirm: this.actionService.doAction.bind(this.actionService, syncResult.action),
+                    confirmLabel: _t("Configure"),
+                    cancel: () => {},
+                    cancelLabel: _t("Discard"),
                 });
             } else {
                 this.dialog.add(AlertDialog, {
@@ -44,6 +47,7 @@ patch(AttendeeCalendarController.prototype, {
     async onStopGoogleSynchronization() {
         this.dialog.add(ConfirmationDialog, {
             body: _t("You are about to stop the synchronization of your calendar with Google. Are you sure you want to continue?"),
+            confirmLabel: _t("Stop Synchronization"),
             confirm: async () => {
                 await this.orm.call(
                     "res.users",

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.js
@@ -66,6 +66,7 @@ export class DiscussSidebarCategories extends Component {
         return new Promise((resolve) => {
             this.dialogService.add(ConfirmationDialog, {
                 body: body,
+                confirmLabel: _t("Leave Conversation"),
                 confirm: resolve,
                 cancel: () => {},
             });

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
@@ -28,6 +28,9 @@ patch(AttendeeCalendarController.prototype, {
                     title: _t("Configuration"),
                     body: _t("The Outlook Synchronization needs to be configured before you can use it, do you want to do it now?"),
                     confirm: this.actionService.doAction.bind(this.actionService, syncResult.action),
+                    confirmLabel: _t("Configure"),
+                    cancel: () => {},
+                    cancelLabel: _t("Discard"),
                 });
             } else {
                 this.dialog.add(AlertDialog, {
@@ -43,6 +46,7 @@ patch(AttendeeCalendarController.prototype, {
     async onStopMicrosoftSynchronization() {
         this.dialog.add(ConfirmationDialog, {
             body: _t("You are about to stop the synchronization of your calendar with Outlook. Are you sure you want to continue?"),
+            confirmLabel: _t("Stop Synchronization"),
             confirm: async () => {
                 await this.orm.call(
                     "res.users",

--- a/addons/web/static/src/core/debug/debug_menu_items.xml
+++ b/addons/web/static/src/core/debug/debug_menu_items.xml
@@ -112,4 +112,13 @@
             </table>
         </Dialog>
     </t>
+
+    <t t-name="web.DebugMenu.GetViewDialog">
+        <Dialog title="title">
+            <pre t-esc="props.arch.outerHTML"/>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Close</button>
+            </t>
+        </Dialog>
+    </t>
 </templates>

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -203,7 +203,8 @@ export class SearchBarMenu extends Component {
             title: _t("Warning"),
             body: userId
                 ? _t("Are you sure that you want to remove this filter?")
-                : _t("This filter is global and will be removed for everybody if you continue."),
+                : _t("This filter is global and will be removed for everyone."),
+            confirmLabel: _t("Delete Filter"),
             confirm: () => this.env.searchModel.deleteFavorite(itemId),
             cancel: () => {},
         };

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -24,17 +24,17 @@ debugRegistry.category("view").add("viewSeparator", viewSeparator);
 // Get view
 //------------------------------------------------------------------------------
 
-class GetViewDialog extends Component {}
-GetViewDialog.template = xml`
-<Dialog title="this.constructor.title">
-    <pre t-esc="props.arch.outerHTML"/>
-</Dialog>`;
+class GetViewDialog extends Component {
+    setup() {
+        this.title = _t("Get View");
+    }
+}
+GetViewDialog.template = "web.DebugMenu.GetViewDialog";
 GetViewDialog.components = { Dialog };
 GetViewDialog.props = {
     arch: { type: Element },
     close: { type: Function },
 };
-GetViewDialog.title = _t("Get View");
 
 export function getView({ component, env }) {
     return {

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -491,7 +491,7 @@ export class PropertiesField extends Component {
         event.preventDefault();
         if (!(await this.checkDefinitionWriteAccess())) {
             this.notification.add(
-                _t("You need to be able to edit parent first to configure property fields"),
+                _t("You need edit access on the parent document to update these property fields"),
                 { type: "warning" }
             );
             return;
@@ -582,7 +582,7 @@ export class PropertiesField extends Component {
     async onPropertyCreate() {
         if (!(await this.checkDefinitionWriteAccess())) {
             this.notification.add(
-                _t("You need to be able to edit parent first to configure property fields"),
+                _t("You need edit access on the parent document to update these property fields"),
                 { type: "warning" }
             );
             return;

--- a/addons/web_tour/static/src/debug/tour_dialog_component.js
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.js
@@ -8,6 +8,7 @@ import { Component } from "@odoo/owl";
 
 export default class ToursDialog extends Component {
     setup() {
+        this.title = _t("Tours");
         this.tourService = useService("tour_service");
         this.onboardingTours = this.tourService.getSortedTours().filter(tour => !tour.test);
         this.testingTours = this.tourService.getSortedTours().filter(tour => tour.test);
@@ -40,4 +41,3 @@ export default class ToursDialog extends Component {
 }
 ToursDialog.template = "web_tour.ToursDialog";
 ToursDialog.components = { Dialog };
-ToursDialog.title = _t("Tours");

--- a/addons/web_tour/static/src/debug/tour_dialog_component.xml
+++ b/addons/web_tour/static/src/debug/tour_dialog_component.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web_tour.ToursDialog">
-    <Dialog title="this.constructor.title">
+    <Dialog title="title">
         <t t-call="web_tour.ToursDialog.Table">
             <t t-set="caption">Onboarding tours</t>
             <t t-set="tours" t-value="onboardingTours"/>
@@ -10,6 +10,9 @@
         <t t-if="testingTours.length" t-call="web_tour.ToursDialog.Table">
             <t t-set="caption">Testing tours</t>
             <t t-set="tours" t-value="testingTours"/>
+        </t>
+        <t t-set-slot="footer">
+            <button class="btn btn-primary o-default-button" t-on-click="() => props.close()">Close</button>
         </t>
     </Dialog>
 </t>


### PR DESCRIPTION
This PR changes the wording of actions and notifications in the modules listed below:
1) Discuss (Leave Conversation)
2) Web (Delete Filter, Get View - Close, Tours - Close and property field
   access warning)
3) Calendar (Stop Synchronization, Configure, and Discard)
4) CRM (Assign Leads)
5) POS (replaced `this.env._t` with `_t`)

**Task**-3390780
