### PR TITLE
[IMP] mail: Allow screen and video sharing at the same time

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -107,7 +107,7 @@ export class Thread extends Record {
     channel;
     /** @type {import("@mail/core/common/channel_member_model").ChannelMember[]} */
     channelMembers = [];
-    /** @type {RtcSession{}} */
+    /** @type {Object<number, import("@mail/discuss/call/common/rtc_session_model").RtcSession>} */
     rtcSessions = {};
     invitingRtcSessionId;
     /** @type {Set<number>} */
@@ -481,7 +481,7 @@ export class Thread extends Record {
 
     get videoCount() {
         return Object.values(this._store.RtcSession.records).filter(
-            (session) => session.videoStream
+            (session) => session.videoStreams.size
         ).length;
     }
 

--- a/addons/mail/static/src/discuss/call/common/call.scss
+++ b/addons/mail/static/src/discuss/call/common/call.scss
@@ -32,7 +32,7 @@
     aspect-ratio: 16/9;
 }
 
-.o-discuss-Call-mainCard {
+.o-discuss-Call-mainCardStyle {
     width: var(--width);
     height: var(--height);
     min-width: var(--width);
@@ -55,6 +55,7 @@
     &::-webkit-scrollbar {
         background: map-get($grays, '900');
     }
+
     &::-webkit-scrollbar-thumb {
         background: map-get($grays, '700');
     }

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -5,7 +5,7 @@
         <div class="o-discuss-Call user-select-none d-flex" t-att-class="{'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen, 'o-minimized': minimized, 'position-relative': !state.isFullscreen }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
                 <div
-                    class="d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
+                    class="o-discuss-Call-mainCards d-flex align-items-center overflow-hidden h-100 w-100 flex-wrap justify-content-center"
                     t-attf-style="--height:{{state.tileHeight}}px; --width:{{state.tileWidth}}px;"
                     t-on-click="() => this.showOverlay()"
                     t-on-mousemove="onMousemoveMain"
@@ -13,7 +13,7 @@
                 >
                     <CallParticipantCard t-foreach="visibleMainCards" t-as="cardData" t-key="cardData.key"
                         cardData="cardData"
-                        className="'o-discuss-Call-mainCard'"
+                        className="'o-discuss-Call-mainCardStyle'"
                         minimized="minimized"
                         thread="props.thread"
                     />
@@ -40,6 +40,13 @@
                     thread="props.thread"
                 />
             </div>
+            <CallParticipantCard
+                t-if="props.thread.videoCount > 0 and state.insetCard"
+                cardData="state.insetCard"
+                className="'o-discuss-Call-mainCardStyle'"
+                thread="props.thread"
+                inset.bind="setInset"
+            />
         </div>
     </t>
 

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -4,8 +4,16 @@ import { CallContextMenu } from "@mail/discuss/call/common/call_context_menu";
 import { CallParticipantVideo } from "@mail/discuss/call/common/call_participant_video";
 import { useHover } from "@mail/utils/common/hooks";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
+import { browser } from "@web/core/browser/browser";
 
-import { Component, onMounted, onWillUnmount, useRef, useState } from "@odoo/owl";
+import {
+    Component,
+    onMounted,
+    onWillUnmount,
+    useRef,
+    useState,
+    useExternalListener,
+} from "@odoo/owl";
 
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
@@ -13,18 +21,21 @@ import { useService } from "@web/core/utils/hooks";
 const HIDDEN_CONNECTION_STATES = new Set(["connected", "completed"]);
 
 export class CallParticipantCard extends Component {
-    static props = ["className", "cardData", "thread", "minimized?"];
+    static props = ["className", "cardData", "thread", "minimized?", "inset?"];
     static components = { CallParticipantVideo };
     static template = "discuss.CallParticipantCard";
 
     setup() {
         this.contextMenuAnchorRef = useRef("contextMenuAnchor");
+        this.root = useRef("root");
         this.popover = usePopover(CallContextMenu);
         this.rpc = useService("rpc");
         this.rtc = useState(useService("discuss.rtc"));
         this.store = useState(useService("mail.store"));
+        this.ui = useState(useService("ui"));
         this.rootHover = useHover("root");
         this.threadService = useService("mail.thread");
+        this.state = useState({ drag: false, dragPos: undefined });
         onMounted(() => {
             if (!this.rtcSession) {
                 return;
@@ -41,6 +52,7 @@ export class CallParticipantCard extends Component {
                 viewCountIncrement: -1,
             });
         });
+        useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);
     }
 
     get isContextMenuAvailable() {
@@ -82,23 +94,46 @@ export class CallParticipantCard extends Component {
     }
 
     get hasVideo() {
-        return Boolean(this.rtcSession?.videoStream);
+        return Boolean(this.props.cardData.videoStream);
     }
 
     get isTalking() {
         return Boolean(this.rtcSession && this.rtcSession.isTalking && !this.rtcSession.isMute);
     }
 
+    get hasRaisingHand() {
+        const screenStream = this.rtcSession.videoStreams.get("screen");
+        return Boolean(
+            this.rtcSession.raisingHand &&
+                (!screenStream || screenStream !== this.props.cardData.videoStream)
+        );
+    }
+
     async onClick(ev) {
         if (isEventHandled(ev, "CallParticipantCard.clickVolumeAnchor")) {
             return;
         }
+        if (this.state.drag) {
+            this.state.drag = false;
+            return;
+        }
         if (this.rtcSession) {
             const channel = this.rtcSession.channel;
-            if (this.rtcSession.eq(channel.activeRtcSession)) {
+            if (this.rtcSession.eq(channel.activeRtcSession) && !this.props.inset) {
                 channel.activeRtcSession = undefined;
+                this.rtcSession.mainVideoStream = undefined;
             } else {
+                const activeRtcSession = channel.activeRtcSession;
+                const mainVideoStream = this.rtcSession.mainVideoStream;
                 channel.activeRtcSession = this.rtcSession;
+                this.rtcSession.mainVideoStream = this.props.cardData.videoStream;
+                if (this.props.inset && activeRtcSession) {
+                    const videoType =
+                        activeRtcSession.videoStreams.get("camera") === mainVideoStream
+                            ? "camera"
+                            : "screen";
+                    this.props.inset(activeRtcSession, videoType);
+                }
             }
             return;
         }
@@ -131,5 +166,68 @@ export class CallParticipantCard extends Component {
         this.popover.open(this.contextMenuAnchorRef.el, {
             rtcSession: this.rtcSession,
         });
+    }
+
+    onMouseDown() {
+        if (!this.props.inset) {
+            return;
+        }
+        const onMousemove = (ev) => this.drag(ev);
+        const onMouseup = () => {
+            const insetEl = this.root.el;
+            if (parseInt(insetEl.style.left) < insetEl.parentNode.offsetWidth / 2) {
+                insetEl.style.left = "1vh";
+                insetEl.style.right = "";
+            } else {
+                insetEl.style.left = "";
+                insetEl.style.right = "1vh";
+            }
+            if (parseInt(insetEl.style.top) < insetEl.parentNode.offsetHeight / 2) {
+                insetEl.style.top = "1vh";
+                insetEl.style.bottom = "";
+            } else {
+                insetEl.style.bottom = "1vh";
+                insetEl.style.top = "";
+            }
+            document.removeEventListener("mouseup", onMouseup);
+            document.removeEventListener("mousemove", onMousemove);
+        };
+        document.addEventListener("mouseup", onMouseup);
+        document.addEventListener("mousemove", onMousemove);
+    }
+
+    drag(ev) {
+        this.state.drag = true;
+        const insetEl = this.root.el;
+        const parent = insetEl.parentNode;
+        const clientX = ev.clientX ?? ev.touches[0].clientX;
+        const clientY = ev.clientY ?? ev.touches[0].clientY;
+        if (!this.state.dragPos) {
+            this.state.dragPos = { posX: clientX, posY: clientY };
+        }
+        const dX = this.state.dragPos.posX - clientX;
+        const dY = this.state.dragPos.posY - clientY;
+        this.state.dragPos.posX = Math.min(
+            Math.max(clientX, parent.offsetLeft),
+            parent.offsetLeft + parent.offsetWidth - insetEl.clientWidth
+        );
+        this.state.dragPos.posY = Math.min(
+            Math.max(clientY, parent.offsetTop),
+            parent.offsetTop + parent.offsetHeight - insetEl.clientHeight
+        );
+        insetEl.style.left =
+            Math.min(
+                Math.max(insetEl.offsetLeft - dX, 0),
+                parent.offsetWidth - insetEl.clientWidth
+            ) + "px";
+        insetEl.style.top =
+            Math.min(
+                Math.max(insetEl.offsetTop - dY, 0),
+                parent.offsetHeight - insetEl.clientHeight
+            ) + "px";
+    }
+
+    onFullScreenChange() {
+        this.root.el.style = "left:''; top:''";
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -4,6 +4,30 @@
 
     &.o-isTalking {
         box-shadow: inset 0 0 0 map-get($spacers, 1) darken($o-enterprise-action-color, 5%);
+
+        &.o-inset {
+            box-shadow: inset 0 0 0 map-get($spacers, 1)/2 darken($o-enterprise-action-color, 5%);
+        }
+    }
+
+    &.o-inset {
+        height: 20%;
+        max-height: 125px !important;
+        right: 1vh;
+        bottom: 1vh;
+        position: absolute !important;
+        cursor: move !important;
+
+        &.o-small {
+            width: 30%;
+            left: 0;
+            top: 0;
+        }
+
+        .o-discuss-CallParticipantCard-avatar img {
+            max-height: #{"min(70%, 70px)"};
+            max-width: #{"min(70%, 70px)"};
+        }
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -6,16 +6,20 @@
             t-att-class="{
                 'o-isTalking': !props.minimized and isTalking,
                 'o-isInvitation opacity-50': !rtcSession,
+                'o-inset': props.inset,
+                'o-small': props.inset and (ui.isSmall or props.minimized)
             }"
             t-att-title="name"
             t-att-aria-label="name"
             t-attf-class="{{ props.className }}"
             t-on-click="onClick"
             t-on-contextmenu="onContextMenu"
+            t-on-mousedown="onMouseDown"
+            t-on-touchmove="(ev) => this.drag(ev)"
             t-ref="root"
         >
             <!-- card -->
-            <CallParticipantVideo t-if="hasVideo" session="rtcSession"/>
+            <CallParticipantVideo t-if="hasVideo" session="rtcSession" videoStream="props.cardData.videoStream"/>
             <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized }" draggable="false">
                 <img alt="Avatar"
                         t-att-class="{
@@ -30,13 +34,13 @@
             <t t-if="rtcSession">
                 <!-- overlay -->
                 <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-index-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
-                    <span t-if="!props.minimized" class="p-1 rounded-1 text-truncate" t-esc="name"/>
+                    <span t-if="!props.minimized and !props.inset" class="p-1 rounded-1 text-truncate" t-esc="name"/>
                     <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
                 <div class="o-discuss-CallParticipantCard-overlay position-absolute top-0 end-0 d-flex flex-row-reverse">
-                    <span t-if="rtcSession.raisingHand" class="d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="raising hand" aria-label="raising hand">
+                    <span t-if="hasRaisingHand" class="d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="raising hand" aria-label="raising hand">
                         <i class="fa fa-hand-paper-o"/>
                     </span>
                     <span t-if="rtcSession.isSelfMuted and !rtcSession.isDeaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="muted" aria-label="muted">

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.js
@@ -3,8 +3,14 @@
 import { Component, onMounted, onPatched, useExternalListener, useRef, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
+/**
+ * @typedef {Object} Props
+ * @property {import("@mail/discuss/call/common/rtc_session_model").RtcSession} session
+ * @property {MediaStream} [videoStream]
+ * @extends {Component<Props, Env>}
+ */
 export class CallParticipantVideo extends Component {
-    static props = ["session"];
+    static props = ["session", "videoStream?"];
     static template = "discuss.CallParticipantVideo";
 
     setup() {
@@ -21,10 +27,10 @@ export class CallParticipantVideo extends Component {
         if (!this.root.el) {
             return;
         }
-        if (!this.props.session || !this.props.session.videoStream) {
+        if (!this.props.session || !this.props.videoStream) {
             this.root.el.srcObject = undefined;
         } else {
-            this.root.el.srcObject = this.props.session.videoStream;
+            this.root.el.srcObject = this.props.videoStream;
         }
         this.root.el.load();
     }

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -62,8 +62,10 @@ export class RtcSession extends Record {
     /** @type {Date|undefined} */
     raisingHand;
     videoComponentCount = 0;
+    /** @type {Map<'screen'|'camera', MediaStream>} */
+    videoStreams = new Map();
     /** @type {MediaStream} */
-    videoStream;
+    mainVideoStream;
     // RTC stats
     connectionState;
     localCandidateType;

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -7,7 +7,7 @@ import { mockGetMedia, start } from "@mail/../tests/helpers/test_utils";
 
 import { browser } from "@web/core/browser/browser";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
-import { click, contains } from "@web/../tests/utils";
+import { click, contains, triggerEvents } from "@web/../tests/utils";
 
 QUnit.module("call");
 
@@ -160,6 +160,7 @@ QUnit.test("can share screen", async () => {
     await click(".o-discuss-CallActionList [title='More']");
     await click("[title='Share Screen']");
     await contains(".o-discuss-CallParticipantCard video");
+    await triggerEvents(".o-discuss-Call-mainCards", ["mousemove"]); // show overlay
     await click(".o-discuss-CallActionList [title='More']");
     await click("[title='Stop Sharing Screen']");
     await contains(".o-discuss-CallParticipantCard video", { count: 0 });


### PR DESCRIPTION
Before:
- sharing the screen stops sharing video and vice versa

After:
- If user starts to share screen at the same time with video sharing, a pip of video sharing appears on the call when user focuses on the sharing screen and vice versa. This pip is draggable and depends on the nearest corner to drag situation, will be located on the corner.

Task-3374606
