### PR TITLE
[FIX] pos_self_order: raise not found error when pos_config_id is None

### DIFF
--- a/addons/pos_self_order/controllers/controllers.py
+++ b/addons/pos_self_order/controllers/controllers.py
@@ -43,6 +43,8 @@ class PosSelfOrderController(http.Controller):
         :return: the rendered template
         """
         _, pos_config_id = unslug(pos_name)
+        if not pos_config_id:
+            raise werkzeug.exceptions.NotFound()
         pos_config_sudo = self._get_pos_config_sudo(pos_config_id)
         session_info = request.env["ir.http"].get_frontend_session_info()
         session_info.update({


### PR DESCRIPTION
This error occurs when user has removed `pos_config_id` form the URL.

Steps to produce:
- install pos_self_order module.
- Go to Point of Sale > Navigate to bar point of sale > Click on the three dots.
- Click on Mobile menu. > Click on the view menu
- From that  resulting URL : `/menu/2/products`
- Remove the `pos_config_id` which is 2 from the above URL.
- Press the Enter > Error will be generated.

see the traceback:
```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1840, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/pos_self_order/controllers/controllers.py", line 46, in pos_self_order_start
    pos_config_sudo = self._get_pos_config_sudo(pos_config_id)
  File "addons/pos_self_order/controllers/controllers.py", line 126, in _get_pos_config_sudo
    int(pos_config_id))
```

Afterward, if the user removes the pos_config_id, they will see the `404 Not Found` error.

Sentry-4351886827

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
