### PR TITLE
[FIX] l10n_in_upi: move xpath from l10n_in_upi to l10n_in

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -26,24 +26,6 @@
             <attribute name="t-if" add="and o.company_id.account_fiscal_country_id.code != 'IN'" separator=" "/>
         </xpath>
 
-        <xpath expr="//div[@id='qrcode_info']" position="after">
-            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
-                <div style="display:-webkit-flex;" class="flex-column">
-                    <strong>PAYMENT QR CODE</strong>
-                    <div t-if="o.company_id.l10n_in_upi_id" class="mt-1 mb-1">
-                        <p class="mb-0">UPI ID:</p>
-                        <span class="mb-0" t-field="o.company_id.l10n_in_upi_id"/>
-                    </div>
-                    <div class="d-flex flex-row" t-attf-style="#{'-webkit-transform:translateX(-0.5rem);' if report_type != 'html' else '-webkit-transform:translate(-0.5rem,-0.8rem);'}">
-                        <img src="/l10n_in/static/src/img/PhonePe-Logo.svg" style="width:4.5rem;"/>
-                        <img src="/l10n_in/static/src/img/Google_Pay-Logo.svg" style="width:3.5rem;"/>
-                        <img src="/l10n_in/static/src/img/Paytm-Logo.svg" style="width:4rem;"/>
-                        <img src="/l10n_in/static/src/img/Upi-logo.svg" t-attf-style="#{'' if report_type != 'html' else 'padding:0.5rem;'} width:4rem;"/>
-                    </div>
-                </div>
-            </t>
-        </xpath>
-
         <xpath expr="//h2" position="replace">
             <h2>
                 <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'" t-field="o.journal_id.name"/>

--- a/addons/l10n_in_upi/__manifest__.py
+++ b/addons/l10n_in_upi/__manifest__.py
@@ -12,7 +12,10 @@ To print UPI Qr code add UPI id in company and tick "QR Codes" in configuration
   """,
     'category': 'Accounting/Localizations',
     'depends': ['l10n_in'],
-    'data': ['views/res_company_views.xml'],
+    'data': [
+        'views/res_company_views.xml',
+        'views/report_invoice.xml',
+    ],
     'license': 'LGPL-3',
     'auto_install': True,
 }

--- a/addons/l10n_in_upi/views/report_invoice.xml
+++ b/addons/l10n_in_upi/views/report_invoice.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="l10n_in_upi_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
+        <xpath expr="//div[@id='qrcode_info']" position="after">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
+                <div style="display:-webkit-flex;" class="flex-column">
+                    <strong>PAYMENT QR CODE</strong>
+                    <div t-if="o.company_id.l10n_in_upi_id" class="mt-1 mb-1">
+                        <p class="mb-0">UPI ID:</p>
+                        <span class="mb-0" t-field="o.company_id.l10n_in_upi_id"/>
+                    </div>
+                    <div class="d-flex flex-row" t-attf-style="#{'-webkit-transform:translateX(-0.5rem);' if report_type != 'html' else '-webkit-transform:translate(-0.5rem,-0.8rem);'}">
+                        <img src="/l10n_in/static/src/img/PhonePe-Logo.svg" style="width:4.5rem;"/>
+                        <img src="/l10n_in/static/src/img/Google_Pay-Logo.svg" style="width:3.5rem;"/>
+                        <img src="/l10n_in/static/src/img/Paytm-Logo.svg" style="width:4rem;"/>
+                        <img src="/l10n_in/static/src/img/Upi-logo.svg" t-attf-style="#{'' if report_type != 'html' else 'padding:0.5rem;'} width:4rem;"/>
+                    </div>
+                </div>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
When a user tries to print an invoice AttributeError occurs:

- Install `l10n_in`.
- Unistall `l10n_in_upi`
- Switch to IN Company
- Accounting > Configuration> Setting> RQ Codes (Enable).
- Accounting > Invoice >  Open any invoice and Print this Invoice.

traceback on sentry:
```
AttributeError: 'res.company' object has no attribute 'l10n_in_upi_id'
  File "<672>", line 2521, in template_672
  File "<672>", line 2503, in template_672_content
  File "<672>", line 2345, in template_672_t_call_0
QWebException: Error while render the template
AttributeError: 'res.company' object has no attribute 'l10n_in_upi_id'
Template: account.report_invoice_document
Path: /t/t/div[2]/div[3]/div[4]/t/div/div[1]
Node: <div t-if="o.company_id.l10n_in_upi_id" class="mt-1 mb-1"/>
  File "addons/web/controllers/report.py", line 113, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "addons/account/models/ir_actions_report.py", line 58, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "odoo/addons/base/models/ir_actions_report.py", line 810, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "odoo/addons/base/models/ir_actions_report.py", line 711, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
  File "odoo/addons/base/models/ir_actions_report.py", line 887, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "odoo/addons/base/models/ir_actions_report.py", line 626, in _render_template
    return view_obj._render_template(template, values).encode()
  File "odoo/addons/base/models/ir_ui_view.py", line 2164, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 588, in _render
    result = ''.join(rendering)
  File "<675>", line 86, in template_675
  File "<675>", line 68, in template_675_content
  File "<675>", line 56, in template_675_t_call_0
  File "<672>", line 2527, in template_672

```

This is because the 'l10n_in_upi_id' field is used in 'l10n_in' module but it belongs to 'l10n_in_upi'.

This commit fixes the above issue by moving
the 'l10n_in_upi_report_invoice_document_inherit'
from 'l10n_in' module to 'l10n_in_upi' to which it belongs.

sentry-4347295630
