### PR TITLE
[FIX] calendar: prevent the deletion of meeting by non-organizers

### DIFF
--- a/addons/calendar/i18n/calendar.pot
+++ b/addons/calendar/i18n/calendar.pot
@@ -43,6 +43,12 @@ msgid "%(day)s at (%(start)s To %(end)s) (%(timezone)s)"
 msgstr ""
 
 #. module: calendar
+#: code:addons/calendar/models/calendar_event.py:0
+#, python-format
+msgid "You cannot delete a meeting if you are not the organizer"
+msgstr ""
+
+#. module: calendar
 #: code:addons/calendar/models/calendar_attendee.py:0
 #, python-format
 msgid "%s has accepted invitation"

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -573,6 +573,11 @@ class Meeting(models.Model):
         return super(Meeting, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
 
     def unlink(self):
+        if not self:
+            return super().unlink()
+        if self.user_id and self.user_id != self.env.user and not self.env.su:
+            raise ValidationError(_('You cannot delete a meeting if you are not the organizer'))
+
         # Get concerned attendees to notify them if there is an alarm on the unlinked events,
         # as it might have changed their next event notification
         events = self.filtered_domain([('alarm_ids', '!=', False)])


### PR DESCRIPTION
### Current behaviour
In calendar module in the list view, we can delete meetings even if we are not the organizer

### Expected behaviour
Not being able to delete a meeting if we are not the organizer.

### Steps to reproduce
- Go to calendar and create a meeting.
- Edit it and change the organizer to another person.
- Change the view to list view.
- Select the meeting and try to delete it.

### Issue
The record is deleted.

### Reason of the problem
When entering the ``CalendarEvent.unlink()`` we don't check if the user trying to delete the record is the organizer.

### Fix
In ``CalendarEvent.unlink()``, we raise a ``ValidationError`` if:
- There is an organizer for the meeting
- And the logged user is different from the organizer
- And it's not an Admin account which is logged(Special case for OdooBot,...)

### Affected versions
- 15.0+

opw-3437384