### PR TITLE
[FIX] point_of_sale: Error pos category

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -30,7 +30,7 @@ class PosCategory(models.Model):
     def _get_hierarchy(self) -> List[str]:
         """ Returns a list representing the hierarchy of the categories. """
         self.ensure_one()
-        return (self.parent_id._get_hierarchy() if self.parent_id else []) + [self.name]
+        return (self.parent_id._get_hierarchy() if self.parent_id else []) + [(self.name or '')]
 
     @api.depends('parent_id')
     def _compute_display_name(self):


### PR DESCRIPTION
Impacted Version : Master only

Issue: Traceback when clicking on the `New` button in the `POS Product category` view. 

Steps to reproduce :

	Step 1: Open POS 

	Step 2: Go to Configuration

	Step 3: Open product category

	Step 4: Click on New -> traceback appears

[Reference Video](https://drive.google.com/file/d/1_ATd7B7R1t4-2Rlpk5LTQ2kRXI5Ri78d/view?usp=sharing)

[Traceback Log](https://pastebin.com/1WBqLyW7)

The cause of the issue is trying to access properties on a record that is not yet created.
The solution is simple: we adapt the code such that it
can handle the case where the record is not yet created

Task: 3450117





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
