### PR TITLE
[ADD] web: human readable integer field

### DIFF
--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -8,7 +8,7 @@ import { formatFloat } from "../formatters";
 import { parseFloat } from "../parsers";
 import { standardFieldProps } from "../standard_field_props";
 
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 
 export class FloatField extends Component {
     static template = "web.FloatField";
@@ -19,19 +19,34 @@ export class FloatField extends Component {
         step: { type: Number, optional: true },
         digits: { type: Array, optional: true },
         placeholder: { type: String, optional: true },
+        humanReadable: { type: Boolean, optional: true },
+        decimals: { type: Number, optional: true },
     };
     static defaultProps = {
         formatNumber: true,
         inputType: "text",
+        humanReadable: false,
+        decimals:0,
     };
 
     setup() {
+        this.state = useState({
+            hasFocus: false, 
+        })
         this.inputRef = useInputField({
             getValue: () => this.formattedValue,
             refName: "numpadDecimal",
             parse: (v) => this.parse(v),
         });
         useNumpadDecimal();
+    }
+
+    onFocusIn() {
+        this.state.hasFocus = true
+    }
+
+    onFocusOut() {
+        this.state.hasFocus = false
     }
 
     parse(value) {
@@ -49,7 +64,11 @@ export class FloatField extends Component {
         ) {
             return this.value;
         }
-        return formatFloat(this.value, { digits: this.digits });
+        if (this.props.humanReadable && !this.state.hasFocus) {
+            return formatFloat(this.value, { digits: this.digits, humanReadable: true, decimals: this.props.decimals });
+        } else {
+            return formatFloat(this.value, { digits: this.digits, humanReadable: false});
+        }
     }
 
     get value() {
@@ -102,9 +121,11 @@ export const floatField = {
                     ? Boolean(options.enable_formatting)
                     : true,
             inputType: options.type,
+            humanReadable: !!options.human_readable,
             step: options.step,
             digits,
             placeholder: attrs.placeholder,
+            decimals: options.decimals || 0,
         };
     },
 };

--- a/addons/web/static/src/views/fields/float/float_field.xml
+++ b/addons/web/static/src/views/fields/float/float_field.xml
@@ -3,7 +3,17 @@
 
     <t t-name="web.FloatField">
         <span t-if="props.readonly" t-esc="formattedValue" />
-        <input t-else="" t-att-id="props.id" t-ref="numpadDecimal"  t-att-placeholder="props.placeholder" t-att-type="props.inputType" inputmode="decimal" class="o_input" t-att-step="props.step" />
+        <input 
+            t-else="" 
+            t-on-focusin="onFocusIn" 
+            t-on-focusout="onFocusOut" 
+            t-att-id="props.id" 
+            t-ref="numpadDecimal"  
+            t-att-placeholder="props.placeholder" 
+            t-att-type="props.inputType" 
+            inputmode="decimal" 
+            class="o_input" 
+            t-att-step="props.step" />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -91,6 +91,7 @@ export function formatChar(value, options) {
  * @param {string} [options.thousandsSep] thousands separator to insert
  * @param {number[]} [options.grouping] array of relative offsets at which to
  *   insert `thousandsSep`. See `insertThousandsSep` method.
+ * @param {number} [options.decimals] used for humanNumber formmatter
  * @param {boolean} [options.noTrailingZeros=false] if true, the decimal part
  *   won't contain unnecessary trailing zeros.
  * @returns {string}
@@ -190,6 +191,7 @@ export function formatFloatTime(value, options = {}) {
  * @param {boolean} [options.isPassword=false] if returns true, acts like
  * @param {string} [options.thousandsSep] thousands separator to insert
  * @param {number[]} [options.grouping] array of relative offsets at which to
+ * @param {number} [options.decimals] used for humanNumber formmatter
  *   insert `thousandsSep`. See `insertThousandsSep` method.
  * @returns {string}
  */

--- a/addons/web/static/src/views/fields/integer/integer_field.xml
+++ b/addons/web/static/src/views/fields/integer/integer_field.xml
@@ -3,7 +3,17 @@
 
     <t t-name="web.IntegerField">
         <span t-if="props.readonly" t-esc="formattedValue" />
-        <input t-ref="numpadDecimal" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" inputmode="numeric" t-else="" class="o_input" t-att-step="props.step" />
+        <input 
+            t-else="" 
+            t-ref="numpadDecimal" 
+            t-on-focusin="onFocusIn" 
+            t-on-focusout="onFocusOut" 
+            t-att-id="props.id" 
+            t-att-type="props.inputType" 
+            t-att-placeholder="props.placeholder" 
+            inputmode="numeric" 
+            class="o_input" 
+            t-att-step="props.step" />
     </t>
 
 </templates>

--- a/addons/web/static/tests/views/fields/float_field_tests.js
+++ b/addons/web/static/tests/views/fields/float_field_tests.js
@@ -24,6 +24,9 @@ QUnit.module("Fields", (hooks) => {
                         { id: 3, float_field: -3.89859 },
                         { id: 4, float_field: false },
                         { id: 5, float_field: 9.1 },
+                        { id: 100, float_field: 2.034567e3 },
+                        { id: 101, float_field: 3.75675456e6 },
+                        { id: 102, float_field: 6.67543577586e12 },
                     ],
                 },
             },
@@ -33,6 +36,66 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.module("FloatField");
+
+    QUnit.test("human readable format 1", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 101,
+            arch: `<form><field name="float_field" options="{'human_readable': 'true'}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input").value,
+            "4M",
+            "The value should be rendered in human readable format (k, M, G, T)."
+        );
+    });
+
+    QUnit.test("human readable format 2", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 100,
+            arch: `<form><field name="float_field" options="{'human_readable': 'true', 'decimals': 1}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input").value,
+            "2.0k",
+            "The value should be rendered in human readable format (k, M, G, T)."
+        );
+    });
+    
+    QUnit.test("human readable format 3", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 102,
+            arch: `<form><field name="float_field" options="{'human_readable': 'true', 'decimals': 4}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input").value,
+            "6.6754T",
+            "The value should be rendered in human readable format (k, M, G, T)."
+        );
+    });
+
+    QUnit.test("still human readable when readonly", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 102,
+            arch: `<form><field readonly="true" name="float_field" options="{'human_readable': 'true', 'decimals': 4}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget span").textContent,
+            "6.6754T",
+            "The value should be rendered in human readable format when input is readonly."
+        );
+    });
 
     QUnit.test("unset field should be set to 0", async function (assert) {
         await makeView({

--- a/addons/web/static/tests/views/fields/integer_field_tests.js
+++ b/addons/web/static/tests/views/fields/integer_field_tests.js
@@ -31,6 +31,9 @@ QUnit.module("Fields", (hooks) => {
                         { id: 1, int_field: 10 },
                         { id: 2, int_field: false },
                         { id: 3, int_field: 8069 },
+                        { id: 100, int_field: 2.034567e3 },
+                        { id: 101, int_field: 3.75675456e6 },
+                        { id: 102, int_field: 6.67543577586e12 },
                     ],
                 },
             },
@@ -40,6 +43,66 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.module("IntegerField");
+
+    QUnit.test("human readable format 1", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 101,
+            arch: `<form><field name="int_field" options="{'human_readable': 'true'}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input").value,
+            "4M",
+            "The value should be rendered in human readable format (k, M, G, T)."
+        );
+    });
+
+    QUnit.test("human readable format 2", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 100,
+            arch: `<form><field name="int_field" options="{'human_readable': 'true', 'decimals': 1}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input").value,
+            "2.0k",
+            "The value should be rendered in human readable format (k, M, G, T)."
+        );
+    });
+    
+    QUnit.test("human readable format 3", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 102,
+            arch: `<form><field name="int_field" options="{'human_readable': 'true', 'decimals': 4}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget input").value,
+            "6.6754T",
+            "The value should be rendered in human readable format (k, M, G, T)."
+        );
+    });
+
+    QUnit.test("still human readable when readonly", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 102,
+            arch: `<form><field readonly="true" name="int_field" options="{'human_readable': 'true', 'decimals': 4}"/></form>`,
+        });
+        assert.strictEqual(
+            target.querySelector(".o_field_widget span").textContent,
+            "6.6754T",
+            "The value should be rendered in human readable format when input is readonly."
+        );
+    });
 
     QUnit.test("should be 0 when unset", async function (assert) {
         await makeView({


### PR DESCRIPTION
Allow developers to format integers/float
using "human_readable" options for integer
field (e.G. 500G instead of 500,000,000,000)
Use decimals options to choose how many float
number are displayed.
Let's see in unit test for examples.

task-3418678