### PR TITLE
[IMP] account: Logging and tracking of some fields.

### DIFF
--- a/addons/account/tests/test_account_tax.py
+++ b/addons/account/tests/test_account_tax.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+
+from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 @tagged('post_install', '-at_install')
@@ -28,3 +30,98 @@ class TestAccountTax(AccountTestInvoicingCommon):
 
         with self.assertRaises(UserError), self.cr.savepoint():
             self.company_data['default_tax_sale'].company_id = self.company_data_2['company']
+
+    def test_tax_is_used_when_in_transactions(self):
+        ''' Ensures that a tax is set to used when it is part of some transactions '''
+
+        # Account.move is one type of transaction
+        tax_invoice = self.env['account.tax'].create({
+            'name': 'test_is_used_invoice',
+            'amount': '100',
+        })
+
+        self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2023-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'invoice_line',
+                    'quantity': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(tax_invoice.ids)],
+                }),
+            ],
+        })
+        tax_invoice.invalidate_model(fnames=['is_used'])
+        self.assertTrue(tax_invoice.is_used)
+
+        # Account.reconcile is another of transaction
+        tax_reconciliation = self.env['account.tax'].create({
+            'name': 'test_is_used_reconcilition',
+            'amount': '100',
+        })
+        self.env['account.reconcile.model'].create({
+            'name': "test_tax_is_used",
+            'rule_type': 'writeoff_suggestion',
+            'auto_reconcile': False,
+            'line_ids': [Command.create({
+                'account_id': self.company_data['default_account_revenue'].id,
+                'tax_ids': [Command.set(tax_reconciliation.ids)],
+            })],
+        })
+        tax_reconciliation.invalidate_model(fnames=['is_used'])
+        self.assertTrue(tax_reconciliation.is_used)
+
+    def test_tax_is_used_restrictions(self):
+        ''' You should not be able to modify some values of a used tax '''
+
+        tax = self.env['account.tax'].create({
+            'name': 'test_is_used',
+            'amount': '100',
+        })
+
+        # A newly created tax should not be used
+        self.assertFalse(tax.is_used)
+
+        self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2023-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'invoice_line',
+                    'quantity': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(tax.ids)],
+                }),
+            ],
+        })
+        tax.invalidate_model(fnames=['is_used'])
+
+        #   amount_type
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            tax.amount_type = 'fixed'
+
+        #   type_tax_use
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            tax.type_tax_use = 'purchase'
+
+        #   price_include
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            tax.price_include = True
+
+        #   include_base_amount
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            tax.include_base_amount = True
+
+        #   add repartition lines
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            self.env['account.tax.repartition.line'].create([
+                {'tax_id': tax.id, 'document_type': 'invoice', 'repartition_type': 'tax', 'factor': -100},
+                {'tax_id': tax.id, 'document_type': 'refund', 'repartition_type': 'tax', 'factor': -100},
+            ])
+
+        #   remove repartition lines
+        with self.assertRaises(ValidationError), self.cr.savepoint():
+            invoice_repartition_lines = tax.invoice_repartition_line_ids
+            for rep_line in invoice_repartition_lines:
+                rep_line.unlink()

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -37,7 +37,7 @@
             <field name="model">account.tax.repartition.line</field>
             <field name="arch" type="xml">
                 <tree editable="bottom" create="1" delete="1">
-                    <field name="sequence" widget="handle"/>
+                    <field name="sequence" widget="handle" column_invisible="parent.is_used"/>
                     <field name="factor_percent" invisible="repartition_type == 'base'"/>
                     <field name="repartition_type"/>
                     <field name="account_id" invisible="repartition_type == 'base'" options="{'no_create': True}"/>
@@ -140,11 +140,12 @@
                         <group>
                             <field name="name"/>
                             <field name="description"/>
-                            <field name="amount_type"/>
+                            <field name="amount_type" readonly="is_used"/>
                             <field name="active" widget="boolean_toggle"/>
                         </group>
                         <group>
-                            <field name="type_tax_use"/>
+                            <field name="is_used" invisible="1"/>
+                            <field name="type_tax_use" readonly="is_used"/>
                             <field name="tax_scope"/>
                             <label for="amount" invisible="amount_type not in ('fixed', 'percent', 'division')"/>
                             <div invisible="amount_type not in ('fixed', 'percent', 'division')">
@@ -183,8 +184,8 @@
                                     <field name="country_id" required="True"/>
                                 </group>
                                 <group name="advanced_booleans">
-                                    <field name="price_include" invisible="amount_type == 'group'" />
-                                    <field name="include_base_amount" invisible="amount_type == 'group'" />
+                                    <field name="price_include" invisible="amount_type == 'group'" readonly="is_used"/>
+                                    <field name="include_base_amount" invisible="amount_type == 'group'" readonly="is_used"/>
                                     <field name="is_base_affected"
                                            invisible="amount_type == 'group' or price_include"
                                            groups="base.group_no_one"/>
@@ -196,6 +197,10 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
                 </form>
               </field>
         </record>

--- a/addons/hr_expense/models/__init__.py
+++ b/addons/hr_expense/models/__init__.py
@@ -5,6 +5,7 @@ from . import hr_employee
 from . import account_move
 from . import account_move_line
 from . import account_payment
+from . import account_tax
 from . import hr_department
 from . import hr_expense
 from . import product_template

--- a/addons/hr_expense/models/account_tax.py
+++ b/addons/hr_expense/models/account_tax.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from collections import Counter
+from odoo import models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    def _hook_compute_is_used(self):
+        # OVERRIDE in order to count the usage of taxes in expenses
+
+        taxes_in_transactions_ctr = Counter(dict(self.env['hr.expense']._read_group([], groupby=['tax_ids'], aggregates=['__count'])))
+
+        return super()._hook_compute_is_used() + taxes_in_transactions_ctr

--- a/addons/hr_expense/tests/__init__.py
+++ b/addons/hr_expense/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_expenses
 from . import test_expenses_access_rights
 from . import test_expenses_mail_import
 from . import test_expenses_multi_company
+from . import test_expenses_tax

--- a/addons/hr_expense/tests/test_expenses_tax.py
+++ b/addons/hr_expense/tests/test_expenses_tax.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from odoo import Command
+from odoo.addons.hr_expense.tests.common import TestExpenseCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestExpensesTax(TestExpenseCommon):
+    def test_tax_is_used_when_in_transactions(self):
+        ''' Ensures that a tax is set to used when it is part of some transactions '''
+
+        # Account.move is one type of transaction
+        tax_expense = self.env['account.tax'].create({
+            'name': 'test_is_used_expenses',
+            'amount': '100',
+            'include_base_amount': True,
+        })
+
+        self.env['hr.expense'].create({
+            'name': 'Test Tax Used',
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+            'unit_amount': 350.00,
+            'tax_ids': [Command.set(tax_expense.ids)]
+        })
+        tax_expense.invalidate_model(fnames=['is_used'])
+        self.assertTrue(tax_expense.is_used)

--- a/addons/point_of_sale/models/account_tax.py
+++ b/addons/point_of_sale/models/account_tax.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collections import Counter
 from odoo import _, api, models
 from odoo.exceptions import UserError
 from odoo.tools import split_every
@@ -26,3 +27,10 @@ class AccountTax(models.Model):
                     ))
                 lines_chunk.invalidate_recordset(['tax_ids'])
         return super(AccountTax, self).write(vals)
+
+    def _hook_compute_is_used(self):
+        # OVERRIDE in order to count the usage of taxes in pos order lines
+
+        taxes_in_transactions_ctr = Counter(dict(self.env['pos.order.line']._read_group([], groupby=['tax_ids'], aggregates=['__count'])))
+
+        return super()._hook_compute_is_used() + taxes_in_transactions_ctr

--- a/addons/point_of_sale/tests/test_pos_products_with_tax.py
+++ b/addons/point_of_sale/tests/test_pos_products_with_tax.py
@@ -541,3 +541,13 @@ class TestPoSProductsWithTax(TestPoSCommon):
             {'account_id': self.sale_account.id, 'balance': 0},
             {'account_id': self.cash_pm1.receivable_account_id.id, 'balance': 1},
         ])
+
+    def test_tax_is_used_when_in_transactions(self):
+        ''' Ensures that a tax is set to used when it is part of some transactions '''
+
+        # Call another test that uses product_1
+        tax_pos = self.product1.taxes_id
+        self.assertFalse(tax_pos.is_used)
+        self.test_orders_no_invoiced()
+        tax_pos.invalidate_model(fnames=['is_used'])
+        self.assertTrue(tax_pos.is_used)

--- a/addons/purchase/models/__init__.py
+++ b/addons/purchase/models/__init__.py
@@ -4,6 +4,7 @@
 from . import account_invoice
 from . import analytic_account
 from . import analytic_applicability
+from . import account_tax
 from . import purchase
 from . import product
 from . import res_company

--- a/addons/purchase/models/account_tax.py
+++ b/addons/purchase/models/account_tax.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from collections import Counter
+from odoo import models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    def _hook_compute_is_used(self):
+        # OVERRIDE in order to count the usage of taxes in purchase order lines
+
+        taxes_in_transactions_ctr = Counter(dict(self.env['purchase.order.line']._read_group([], groupby=['taxes_id'], aggregates=['__count'])))
+
+        return super()._hook_compute_is_used() + taxes_in_transactions_ctr


### PR DESCRIPTION
Problem
---------
All fields in the tax definition are currently modifiable even after the
tax has been used. This raises some issues in tax reports and make
investigations difficult when things go wrong in tax report.

Objective
---------
Once an account tax has been used:
 - Some fields in the account tax should not be modifiable anymore to
 avoid tax report issues;
 - Other fields should be logged when modified to ease debugging and
 investigations.

Solution
---------
1. Add a logger to the tax form to track the modification of some fields
2. Track whether the tax is being used in transactions or not
3. Make the fields that should not be modified anymore readonly when the
tax is being used.

Task-3450002
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
