### PR TITLE
[FIX] mail: fix no author in channel message

### DIFF
--- a/addons/mail/static/src/core_ui/message_in_reply.js
+++ b/addons/mail/static/src/core_ui/message_in_reply.js
@@ -22,7 +22,7 @@ export class MessageInReply extends Component {
     get authorAvatarUrl() {
         if (
             this.message.type === "email" &&
-            !["partner", "guest"].includes(this.props.message.author.type)
+            !(this.props.message.author && ["partner", "guest"].includes(this.props.message.author.type))
         ) {
             return url("/mail/static/src/img/email_icon.png");
         }


### PR DESCRIPTION
__Current behavior before commit:__
When entering a channel where a message has no `author_id`, the page crashes.

__Description of the fix:__
Check if the `author` field of the message is set. If not we can still display the email icon.

opw-3439668
