### PR TITLE
[FIX] im_livechat: use public user during tests instead of admin

### DIFF
--- a/addons/bus/static/tests/helpers/model_definitions_setup.js
+++ b/addons/bus/static/tests/helpers/model_definitions_setup.js
@@ -39,9 +39,9 @@ insertRecords("res.groups", [{ id: TEST_GROUP_IDS.groupUserId, name: "Internal U
 insertRecords("res.users", [
     {
         display_name: "Your Company, Mitchell Admin",
-        id: TEST_USER_IDS.currentUserId,
+        id: TEST_USER_IDS.adminUserId,
         name: "Mitchell Admin",
-        partner_id: TEST_USER_IDS.currentPartnerId,
+        partner_id: TEST_USER_IDS.adminPartnerId,
     },
     {
         active: false,
@@ -55,12 +55,13 @@ insertRecords("res.partner", [
     {
         active: false,
         display_name: "Public user",
+        name: "Public user",
         id: TEST_USER_IDS.publicPartnerId,
         is_public: true,
     },
     {
         display_name: "Your Company, Mitchell Admin",
-        id: TEST_USER_IDS.currentPartnerId,
+        id: TEST_USER_IDS.adminPartnerId,
         name: "Mitchell Admin",
     },
     {

--- a/addons/bus/static/tests/helpers/test_constants.js
+++ b/addons/bus/static/tests/helpers/test_constants.js
@@ -6,8 +6,12 @@ export const TEST_GROUP_IDS = {
 
 export const TEST_USER_IDS = {
     odoobotId: 2,
-    currentPartnerId: 3,
-    currentUserId: 2,
+    adminPartnerId: 3,
+    adminUserId: 2,
     publicPartnerId: 4,
     publicUserId: 3,
 };
+Object.assign(TEST_USER_IDS, {
+    currentPartnerId: TEST_USER_IDS.adminPartnerId,
+    currentUserId: TEST_USER_IDS.adminUserId,
+});

--- a/addons/im_livechat/static/tests/embed/autopopup_tests.js
+++ b/addons/im_livechat/static/tests/embed/autopopup_tests.js
@@ -16,12 +16,12 @@ QUnit.test("persisted session", async (assert) => {
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.adminPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: pyEnv.currentPartnerId,
+        livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
     setCookie("im_livechat_session", JSON.stringify(channelInfo));

--- a/addons/im_livechat/static/tests/embed/helper/test_utils.js
+++ b/addons/im_livechat/static/tests/embed/helper/test_utils.js
@@ -1,5 +1,6 @@
 /* @odoo-module */
 
+import { TEST_USER_IDS } from "@bus/../tests/helpers/test_constants";
 import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
 
 import { LivechatButton } from "@im_livechat/embed/core_ui/livechat_button";
@@ -38,6 +39,11 @@ export function setCookie(key, val) {
 // SETUP
 // =============================================================================
 
+Object.assign(TEST_USER_IDS, {
+    currentPartnerId: TEST_USER_IDS.adminPartnerId,
+    currentUserId: TEST_USER_IDS.adminUserId,
+});
+
 /**
  * Setup the server side of the livechat app.
  *
@@ -46,7 +52,7 @@ export function setCookie(key, val) {
 export async function loadDefaultConfig() {
     const pyEnv = await getPyEnv();
     const livechatChannelId = pyEnv["im_livechat.channel"].create({
-        user_ids: [pyEnv.currentUserId],
+        user_ids: [pyEnv.adminUserId],
     });
     patchWithCleanup(session, {
         livechatData: {

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -14,17 +14,17 @@ QUnit.test("persisted session history", async (assert) => {
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.adminPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: pyEnv.currentPartnerId,
+        livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
     setCookie("im_livechat_session", JSON.stringify(channelInfo));
     pyEnv["mail.message"].create({
-        author_id: pyEnv.currentPartnerId,
+        author_id: pyEnv.adminPartnerId,
         body: "Old message in history",
         res_id: channelId,
         model: "discuss.channel",

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -17,12 +17,12 @@ QUnit.test("Unsuccessful message post shows session expired", async (assert) => 
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.adminPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: pyEnv.currentPartnerId,
+        livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
     setCookie("im_livechat_session", JSON.stringify(channelInfo));

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -14,12 +14,12 @@ QUnit.test("new message from operator displays unread counter", async (assert) =
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.adminPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: pyEnv.currentPartnerId,
+        livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
     setCookie("im_livechat_session", JSON.stringify(channelInfo));
@@ -27,7 +27,7 @@ QUnit.test("new message from operator displays unread counter", async (assert) =
     $(".o-mail-Composer-input").blur();
     await afterNextRender(() => {
         env.services.rpc("/mail/message/post", {
-            context: { mockedUserId: pyEnv.currentUserId },
+            context: { mockedUserId: pyEnv.adminUserId },
             post_data: { body: "Are you there?", message_type: "comment" },
             thread_id: channelId,
             thread_model: "discuss.channel",
@@ -42,12 +42,12 @@ QUnit.test("focus on unread livechat marks it as read", async (assert) => {
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [
-            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: pyEnv.adminPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: pyEnv.currentPartnerId,
+        livechat_operator_id: pyEnv.adminPartnerId,
     });
     const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
     setCookie("im_livechat_session", JSON.stringify(channelInfo));
@@ -55,7 +55,7 @@ QUnit.test("focus on unread livechat marks it as read", async (assert) => {
     $(".o-mail-Composer-input").blur();
     await afterNextRender(() => {
         env.services.rpc("/mail/message/post", {
-            context: { mockedUserId: pyEnv.currentUserId },
+            context: { mockedUserId: pyEnv.adminUserId },
             post_data: { body: "Are you there?", message_type: "comment" },
             thread_id: channelId,
             thread_model: "discuss.channel",

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/im_livechat_channel.js
@@ -1,5 +1,7 @@
 /* @odoo-module */
 
+import { Command } from "@mail/../tests/helpers/command";
+
 import { patch } from "@web/core/utils/patch";
 import { MockServer } from "@web/../tests/helpers/mock_server";
 
@@ -42,15 +44,14 @@ patch(MockServer.prototype, "im_livechat/models/im_livechat_channel", {
                 },
             ],
         ];
-        let visitor_user;
-        if (user_id) {
-            const visitor_user = this.getRecords("res.users", [["id", "=", user_id]])[0];
-            if (visitor_user && visitor_user.active && visitor_user !== operator) {
-                // valid session user (not public)
-                membersToAdd.push([0, 0, { partner_id: visitor_user.partner_id.id }]);
-            }
-        } else {
-            membersToAdd.push([0, 0, { partner_id: this.publicPartnerId }]);
+        const visitor_user = this.getRecords("res.users", [["id", "=", user_id]])[0];
+        if (
+            visitor_user &&
+            visitor_user.id === this.pyEnv.currentUserId &&
+            visitor_user !== operator
+        ) {
+            // valid session user (not public)
+            membersToAdd.push(Command.create({ partner_id: visitor_user.partner_id }));
         }
         const membersName = [
             visitor_user ? visitor_user.display_name : anonymous_name,

--- a/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
@@ -47,7 +47,9 @@ QUnit.test("can invite users in channel from chat window", async (assert) => {
     await click("[title='Open Actions Menu']");
     await click("[title='Add Users']");
     assert.containsOnce($, ".o-discuss-ChannelInvitation");
-    await click("div:contains(TestPartner) input[type='checkbox']");
+    await click(
+        ".o-discuss-ChannelInvitation-selectable:contains(TestPartner) input[type='checkbox']"
+    );
     await click("[title='Invite to Channel']");
     assert.containsNone($, ".o-discuss-ChannelInvitation");
     assert.containsOnce(

--- a/addons/mail/static/tests/web/activity/activity_widget_tests.js
+++ b/addons/mail/static/tests/web/activity/activity_widget_tests.js
@@ -160,7 +160,7 @@ QUnit.test("list activity widget: open dropdown", async (assert) => {
         },
         {
             display_name: "Meet FP",
-            date_deadline: serializeDate(DateTime.now().plus({days:1})), // tomorrow
+            date_deadline: serializeDate(DateTime.now().plus({ days: 1 })), // tomorrow
             can_write: true,
             state: "planned",
             user_id: pyEnv.currentUserId,

--- a/addons/website_livechat/static/tests/embed/chat_request_tests.js
+++ b/addons/website_livechat/static/tests/embed/chat_request_tests.js
@@ -13,13 +13,14 @@ QUnit.test("chat request opens chat window", async (assert) => {
     const pyEnv = await startServer();
     const channelId = await loadDefaultConfig();
     const [channel] = pyEnv["im_livechat.channel"].searchRead([["id", "=", channelId]]);
+    const [adminPartner] = pyEnv["res.partner"].searchRead([["id", "=", pyEnv.adminPartnerId]]);
     patchWithCleanup(session.livechatData, {
         options: {
             ...session.livechatData.options,
             chat_request_session: {
                 folded: false,
                 id: channel.id,
-                operator_pid: [pyEnv.currentPartnerId, pyEnv.currentPartner.name],
+                operator_pid: [adminPartner.id, adminPartner.name],
                 name: channel.name,
                 uuid: channel.uuid,
                 isChatRequest: true,


### PR DESCRIPTION
Before this PR, the user during livechat embed tests was the admin partner while it should be the public partner. This commit fixes the issue.

part of task-3332628