### PR TITLE
[IMP] project: set parent milestone on subtasks

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -384,6 +384,7 @@ class Project(models.Model):
             'name': task.name,
             'state': task.state,
             'company_id': project.company_id.id,
+            'project_id': project.id,
         }
 
     def map_tasks(self, new_project_id):
@@ -399,11 +400,6 @@ class Project(models.Model):
             defaults = self._map_tasks_default_valeus(task, project)
             new_tasks |= task.copy(defaults)
         project.write({'tasks': [Command.set(new_tasks.ids)]})
-        new_tasks._get_all_subtasks().filtered(
-            lambda child: child.project_id == self
-        ).write({
-            'project_id': project.id
-        })
         return True
 
     @api.returns('self', lambda value: value.id)


### PR DESCRIPTION
As sub-tasks are a sub-set of a task that should logically be completed for the parent task to be completed, it would make sense for the sub-tasks to share the same milestone as their parent task by default.

The milestone of a parent task is automatically set to its subtasks if:
- The subtask has no milestone set
- They belong to the same project or the subtask has no project set

task-3450281