### PR TITLE
[FIX] web: complete x2m activeField

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -3,6 +3,7 @@
 import { x2ManyCommands } from "@web/core/orm_service";
 import { intersection } from "@web/core/utils/arrays";
 import { pick } from "@web/core/utils/objects";
+import { completeActiveFields } from "@web/model/relational_model/utils";
 import { DataPoint } from "./datapoint";
 import { fromUnityToServerValues, getId, patchActiveFields } from "./utils";
 
@@ -202,6 +203,7 @@ export class StaticList extends DataPoint {
     extendRecord(params, record) {
         return this.model.mutex.exec(async () => {
             // extend fields and activeFields of the list with those given in params
+            completeActiveFields(this.config.activeFields, params.activeFields);
             Object.assign(this.fields, params.fields);
             const activeFields = { ...params.activeFields };
             for (const fieldName in this.activeFields) {

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -70,6 +70,20 @@ function completeActiveField(activeField, extra) {
     }
 }
 
+export function completeActiveFields(activeFields, extraActiveFields) {
+    for (const fieldName in extraActiveFields) {
+        const extraActiveField = {
+            ...extraActiveFields[fieldName],
+            invisible: true,
+        };
+        if (fieldName in activeFields) {
+            completeActiveField(activeFields[fieldName], extraActiveField);
+        } else {
+            activeFields[fieldName] = extraActiveField;
+        }
+    }
+}
+
 export function createPropertyActiveField(property) {
     const { type } = property;
 
@@ -182,20 +196,10 @@ export function extractFieldsFromArchInfo({ fieldNodes, widgetNodes }, fields) {
                             fieldNode.views.form,
                             fieldNode.views.form.fields
                         );
-                        for (const fieldName in formArchInfo.activeFields) {
-                            const formActiveField = {
-                                ...formArchInfo.activeFields[fieldName],
-                                invisible: true,
-                            };
-                            if (fieldName in activeField.related.activeFields) {
-                                completeActiveField(
-                                    activeField.related.activeFields[fieldName],
-                                    formActiveField
-                                );
-                            } else {
-                                activeField.related.activeFields[fieldName] = formActiveField;
-                            }
-                        }
+                        completeActiveFields(
+                            activeField.related.activeFields,
+                            formArchInfo.activeFields
+                        );
                         Object.assign(activeField.related.fields, formArchInfo.fields);
                     }
                 }


### PR DESCRIPTION
The goal of this commit is to complete the list of activeFields for an x2many in list mode when a record is opened with the fields present in its form view. This ensures that there is always an activeField for all the data in a record. Before this commit, when the x2many's form view was not inline, when the form view was closed, the fields not present in the list view no longer had an activeField, which could cause crashes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
