### PR TITLE
[FIX] website_sale: Fix access to partner from website sale

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1040,7 +1040,7 @@ class WebsiteSale(http.Controller):
                 data["vat"] = Partner.fix_eu_vat_number(country_id, data.get("vat"))
             partner_dummy = Partner.new(self._get_vat_validation_fields(data))
             try:
-                partner_dummy.check_vat()
+                partner_dummy.sudo().check_vat()
             except ValidationError as exception:
                 error["vat"] = 'error'
                 error_message.append(exception.args[0])


### PR DESCRIPTION
When the user is not signed up, in the address tab of the cart, an error appears because this user does not have the access to the model l10n_latam.identification.type with 403 Forbidden. The model is accessed by [1] [2], therefore sudo is required to access the information of the partner.

**References:**

- [1] https://github.com/odoo/odoo/blob/600bd9c8/addons/website_sale/controllers/main.py#L1043
- [2] https://github.com/odoo/odoo/blob/600bd9c8/addons/l10n_latam_base/models/res_partner.py#L21

**Address Tab:**
![Screenshot from 2023-08-01 12-57-08](https://github.com/odoo/odoo/assets/90422721/0208b04f-0698-45bc-9c47-0343d8e59139)

**Before sudo:**
![Screenshot from 2023-08-01 12-57-19](https://github.com/odoo/odoo/assets/90422721/df827ba3-9d6f-41e5-8c8e-9ea5a266283d)

**After sudo:**
![Screenshot from 2023-08-01 12-59-20](https://github.com/odoo/odoo/assets/90422721/8fb908dd-7ffc-4c2e-b788-ede408c5e8f3)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
