### PR TITLE
[FIX] mail: fix setup manager copy registry

### DIFF
--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -37,26 +37,24 @@ export function copyRegistry(source, target) {
     for (const [name, service] of source.getEntries()) {
         target.add(name, service);
     }
-    source.addEventListener("UPDATE", ({ operation, key, value }) => {
-        if (operation === "add") {
-            target.add(key, value);
-        }
-    });
 }
 
 // Copy registries before they are cleared by the test setup in
 // order to restore them during `getWebClientReady`.
 const mailServicesRegistry = registry.category("mail.services");
 const webServicesRegistry = registry.category("services");
-copyRegistry(webServicesRegistry, mailServicesRegistry);
 
 const mailMainComponentsRegistry = registry.category("mail.main_components");
 const webMainComponentsRegistry = registry.category("main_components");
-copyRegistry(webMainComponentsRegistry, mailMainComponentsRegistry);
 
 const mailSystrayRegistry = registry.category("mail.systray");
 const webSystrayRegistry = registry.category("systray");
-copyRegistry(webSystrayRegistry, mailSystrayRegistry);
+
+QUnit.begin(() => {
+    copyRegistry(webServicesRegistry, mailServicesRegistry);
+    copyRegistry(webMainComponentsRegistry, mailMainComponentsRegistry);
+    copyRegistry(webSystrayRegistry, mailSystrayRegistry);
+});
 
 /**
  * @returns function that returns an `XMLHttpRequest`-like object whose response


### PR DESCRIPTION
Before this commit, an event listener was added on several registries to copy the required registry for mail tests. The registries should be copied once when the test suite begin to avoid side effects in tests.

enterprise: https://github.com/odoo/enterprise/pull/45014