### PR TITLE
[IMP] mail, im_livechat: create livechat channel with appropriate name

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
-            <field name="name">Visitor #234, Mitchell Admin</field>
+            <field name="name">Visitor #234</field>
             <field name="anonymous_name">Visitor #234</field>
         </record>
         <record id="im_livechat.livechat_channel_session_1_member_admin" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data>
         <record id="livechat_channel_session_10" model="discuss.channel">
-            <field name="name">Visitor, Mitchell Admin</field>
+            <field name="name">Visitor</field>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data>
         <record id="livechat_channel_session_11" model="discuss.channel">
-            <field name="name">Visitor, Mitchell Admin</field>
+            <field name="name">Visitor</field>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="create_date" eval="datetime.now()"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_demo"/>
-            <field name="name">Visitor #323, Marc Demo</field>
+            <field name="name">Visitor #323</field>
             <field name="anonymous_name">Visitor #323</field>
         </record>
         <record id="im_livechat.livechat_channel_session_2_member_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
-            <field name="name">Joel Willis, Mitchell Admin</field>
+            <field name="name">Joel Willis (United States)</field>
             <field name="anonymous_name">Joel Willis</field>
         </record>
         <record id="im_livechat.livechat_channel_session_3_member_admin" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_demo"/>
-            <field name="name">Joel Willis, Marc Demo</field>
+            <field name="name">Joel Willis (United States)</field>
             <field name="anonymous_name">Joel Willis</field>
         </record>
         <record id="im_livechat.livechat_channel_session_4_member_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
-            <field name="name">Visitor #532, Mitchell Admin</field>
+            <field name="name">Visitor #532</field>
             <field name="anonymous_name">Visitor #532</field>
         </record>
         <record id="im_livechat.livechat_channel_session_5_member_admin" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
-            <field name="name">Visitor #649, Mitchell Admin</field>
+            <field name="name">Visitor #649</field>
             <field name="anonymous_name">Visitor #649</field>
         </record>
         <record id="im_livechat.livechat_channel_session_6_member_admin" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
-            <field name="name">Joel Willis, Mitchell Admin</field>
+            <field name="name">Joel Willis (United States)</field>
             <field name="anonymous_name">Joel Willis</field>
         </record>
         <record id="im_livechat.livechat_channel_session_7_member_admin" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -5,7 +5,7 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_operator_id" ref="base.partner_demo"/>
-            <field name="name">Visitor #722, Marc Demo</field>
+            <field name="name">Visitor #722</field>
             <field name="anonymous_name">Visitor #722</field>
         </record>
         <record id="im_livechat.livechat_channel_session_8_member_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data>
         <record id="livechat_channel_session_9" model="discuss.channel">
-            <field name="name">Visitor, Mitchell Admin</field>
+            <field name="name">Visitor</field>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -142,13 +142,10 @@ class ImLivechatChannel(models.Model):
             if visitor_user and visitor_user.active and operator and visitor_user != operator:  # valid session user (not public)
                 members_to_add.append(Command.create({'partner_id': visitor_user.partner_id.id}))
 
-        if chatbot_script:
-            name = chatbot_script.title
-        else:
-            name = ' '.join([
-                visitor_user.display_name if visitor_user else anonymous_name,
-                operator.livechat_username if operator.livechat_username else operator.name
-            ])
+        name = visitor_user.display_name if visitor_user else anonymous_name
+        country = self.env['res.country'].browse(country_id)
+        if country.name:
+            name = f'{name} ({country.name})'
 
         return {
             'channel_member_ids': members_to_add,

--- a/addons/im_livechat/static/src/core/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/thread_model_patch.js
@@ -50,21 +50,6 @@ patch(Thread.prototype, "im_livechat", {
         return correspondent;
     },
 
-    get displayName() {
-        if (this.type !== "livechat" || !this.correspondent) {
-            return this._super();
-        }
-        if (!this.correspondent.is_public && this.correspondent.country) {
-            return `${this.getMemberName(this.correspondent)} (${this.correspondent.country.name})`;
-        }
-        if (this.channel?.anonymous_country) {
-            return `${this.getMemberName(this.correspondent)} (${
-                this.channel.anonymous_country.name
-            })`;
-        }
-        return this.getMemberName(this.correspondent);
-    },
-
     get imgUrl() {
         if (this.type !== "livechat") {
             return this._super();

--- a/addons/im_livechat/static/src/embed/core/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/core/thread_model_patch.js
@@ -23,6 +23,13 @@ patch(Thread.prototype, "im_livechat", {
         return this.newestMessage?.isSelfAuthored;
     },
 
+    get displayName() {
+        if (this.type !== "livechat") {
+            return this._super();
+        }
+        return this.operator.name;
+    },
+
     get imgUrl() {
         if (this.type !== "livechat") {
             return this._super();

--- a/addons/im_livechat/static/tests/channel_invite_tests.js
+++ b/addons/im_livechat/static/tests/channel_invite_tests.js
@@ -15,7 +15,6 @@ QUnit.test("Can invite a partner to a livechat channel", async (assert) => {
         user_ids: [userId],
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 20",
         name: "Visitor 20",
         channel_member_ids: [
             Command.create({ partner_id: pyEnv.currentPartnerId }),
@@ -49,7 +48,7 @@ QUnit.test("Available operators come first", async (assert) => {
         available_operator_ids: [Command.create({ partner_id: ronId })],
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #1",
+        name: "Visitor #1",
         channel_member_ids: [
             Command.create({ partner_id: pyEnv.currentPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),
@@ -78,7 +77,7 @@ QUnit.test("Partners invited most frequently by the current user come first", as
         user_ids: [pyEnv["res.users"].create({ name: "Albert" })],
     });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #1",
+        name: "Visitor #1",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({ partner_id: pyEnv.currentPartnerId }),
@@ -87,7 +86,7 @@ QUnit.test("Partners invited most frequently by the current user come first", as
         livechat_operator_id: pyEnv.currentPartnerId,
     });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #2",
+        name: "Visitor #2",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({ partner_id: pyEnv.currentPartnerId }),

--- a/addons/im_livechat/static/tests/chat_window_patch_tests.js
+++ b/addons/im_livechat/static/tests/chat_window_patch_tests.js
@@ -7,7 +7,7 @@ QUnit.module("chat window (patch)");
 QUnit.test("No call buttons", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],

--- a/addons/im_livechat/static/tests/composer_patch_tests.js
+++ b/addons/im_livechat/static/tests/composer_patch_tests.js
@@ -45,7 +45,7 @@ QUnit.test("Attachment upload via drag and drop disabled", async (assert) => {
 QUnit.test("Can execute help command on livechat channels", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -74,6 +74,7 @@ QUnit.test('Receives visitor typing status "is typing"', async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 20",
+        name: "Visitor 20",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -99,7 +100,7 @@ QUnit.test('Receives visitor typing status "is typing"', async (assert) => {
 QUnit.test('display canned response suggestions on typing ":"', async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Mario",
+        name: "Mario",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -121,7 +122,7 @@ QUnit.test('display canned response suggestions on typing ":"', async (assert) =
 QUnit.test("use a canned response", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Mario",
+        name: "Mario",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -150,7 +151,7 @@ QUnit.test("use a canned response", async (assert) => {
 QUnit.test("use a canned response some text", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Mario",
+        name: "Mario",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -181,7 +182,7 @@ QUnit.test("use a canned response some text", async (assert) => {
 QUnit.test("add an emoji after a canned response", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 20",
+        name: "Visitor 20",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],

--- a/addons/im_livechat/static/tests/discuss_patch_tests.js
+++ b/addons/im_livechat/static/tests/discuss_patch_tests.js
@@ -13,7 +13,7 @@ QUnit.module("discuss (patch)");
 QUnit.test("No call buttons", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -30,7 +30,7 @@ QUnit.test("No call buttons", async (assert) => {
 QUnit.test("No reaction button", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_type: "livechat",
         livechat_operator_id: pyEnv.currentPartnerId,
         channel_partner_ids: [pyEnv.currentPartnerId, pyEnv.publicPartnerId],
@@ -49,7 +49,7 @@ QUnit.test("No reaction button", async (assert) => {
 QUnit.test("No reply button", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_type: "livechat",
         livechat_operator_id: pyEnv.currentPartnerId,
         channel_partner_ids: [pyEnv.currentPartnerId, pyEnv.publicPartnerId],
@@ -73,7 +73,7 @@ QUnit.test("add livechat in the sidebar on visitor sending first message", async
         user_ids: [pyEnv.currentUserId],
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor (Belgium)",
+        name: "Visitor (Belgium)",
         channel_member_ids: [
             [0, 0, { is_pinned: false, partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -109,7 +109,7 @@ QUnit.test("add livechat in the sidebar on visitor sending first message", async
 QUnit.test("reaction button should not be present on livechat", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_type: "livechat",
         livechat_operator_id: pyEnv.currentPartnerId,
         channel_partner_ids: [pyEnv.currentPartnerId, pyEnv.publicPartnerId],
@@ -125,7 +125,7 @@ QUnit.test("reaction button should not be present on livechat", async (assert) =
 QUnit.test("invite button should be present on livechat", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -144,7 +144,7 @@ QUnit.test(
         const pyEnv = await startServer();
         pyEnv["discuss.channel"].create([
             {
-                anonymous_name: "Visitor 11",
+                name: "Visitor 11",
                 channel_member_ids: [
                     [
                         0,
@@ -160,7 +160,7 @@ QUnit.test(
                 livechat_operator_id: pyEnv.currentPartnerId,
             },
             {
-                anonymous_name: "Visitor 12",
+                name: "Visitor 12",
                 channel_member_ids: [
                     [
                         0,

--- a/addons/im_livechat/static/tests/go_to_oldest_unread_thread_tests.js
+++ b/addons/im_livechat/static/tests/go_to_oldest_unread_thread_tests.js
@@ -14,17 +14,16 @@ QUnit.test("tab on discuss composer goes to oldest unread livechat", async (asse
     const pyEnv = await startServer();
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 Command.create({ partner_id: pyEnv.currentPartnerId }),
                 Command.create({ partner_id: pyEnv.publicPartnerId }),
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
+            name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -35,10 +34,9 @@ QUnit.test("tab on discuss composer goes to oldest unread livechat", async (asse
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 2",
         },
         {
-            anonymous_name: "Visitor 13",
+            name: "Visitor 13",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -49,7 +47,6 @@ QUnit.test("tab on discuss composer goes to oldest unread livechat", async (asse
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 3",
         },
     ]);
     pyEnv["mail.message"].create([
@@ -88,7 +85,7 @@ QUnit.test("switching to folded chat window unfolds it", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -99,10 +96,9 @@ QUnit.test("switching to folded chat window unfolds it", async (assert) => {
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
+            name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -115,7 +111,6 @@ QUnit.test("switching to folded chat window unfolds it", async (assert) => {
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 2",
         },
     ]);
     await start();
@@ -141,7 +136,7 @@ QUnit.test("switching to hidden chat window unhides it", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -151,10 +146,9 @@ QUnit.test("switching to hidden chat window unhides it", async (assert) => {
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
+            name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -166,7 +160,6 @@ QUnit.test("switching to hidden chat window unhides it", async (assert) => {
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 2",
         },
         {
             channel_member_ids: [
@@ -198,17 +191,16 @@ QUnit.test("tab on composer doesn't switch thread if user is typing", async (ass
     const pyEnv = await startServer();
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 Command.create({ partner_id: pyEnv.currentPartnerId }),
                 Command.create({ partner_id: pyEnv.publicPartnerId }),
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
+            name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: pyEnv.currentPartnerId,
@@ -219,7 +211,6 @@ QUnit.test("tab on composer doesn't switch thread if user is typing", async (ass
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 2",
         },
     ]);
 
@@ -235,24 +226,22 @@ QUnit.test("tab on composer doesn't switch thread if no unread thread", async (a
     const pyEnv = await startServer();
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 Command.create({ partner_id: pyEnv.currentPartnerId }),
                 Command.create({ partner_id: pyEnv.publicPartnerId }),
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
+            name: "Visitor 12",
             channel_member_ids: [
                 Command.create({ partner_id: pyEnv.currentPartnerId }),
                 Command.create({ partner_id: pyEnv.publicPartnerId }),
             ],
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
-            name: "Livechat 2",
         },
     ]);
 

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/im_livechat_channel.js
@@ -52,20 +52,22 @@ patch(MockServer.prototype, "im_livechat/models/im_livechat_channel", {
         } else {
             membersToAdd.push([0, 0, { partner_id: this.publicPartnerId }]);
         }
-        const membersName = [
-            visitor_user ? visitor_user.display_name : anonymous_name,
-            operator.livechat_username ? operator.livechat_username : operator.name,
-        ];
+        let name = visitor_user ? visitor_user.display_name : anonymous_name;
+        const country = country_id
+            ? this.pyEnv["res.country"].searchRead([["id", "=", country_id]])[0]
+            : false;
+        if (country) {
+            name = `${name} (${country.name})`;
+        }
         return {
             channel_partner_ids: [operator_partner_id],
             channel_member_ids: membersToAdd,
             livechat_active: true,
             livechat_operator_id: operator_partner_id,
             livechat_channel_id: id,
-            anonymous_name: user_id ? false : anonymous_name,
             country_id: country_id,
             channel_type: "livechat",
-            name: membersName.join(" "),
+            name,
         };
     },
     /**

--- a/addons/im_livechat/static/tests/message_patch_tests.js
+++ b/addons/im_livechat/static/tests/message_patch_tests.js
@@ -10,6 +10,7 @@ QUnit.test("redirect to author (open profile) in livechat", async (assert) => {
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
     pyEnv["res.users"].create({ partner_id: partnerId });
     const channelId = pyEnv["discuss.channel"].create({
+        name: "Visitor 20",
         channel_member_ids: [
             Command.create({ partner_id: pyEnv.currentPartnerId }),
             Command.create({ partner_id: partnerId }),

--- a/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
@@ -8,7 +8,7 @@ QUnit.module("messaging menu (patch)");
 QUnit.test('livechats should be in "chat" filter', async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -30,7 +30,7 @@ QUnit.test('livechats should be in "livechat" tab in mobile', async (assert) => 
     patchUiSize({ height: 360, width: 640 });
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
@@ -21,7 +21,7 @@ QUnit.test(
     async (assert) => {
         const pyEnv = await startServer();
         pyEnv["discuss.channel"].create({
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 [0, 0, { partner_id: pyEnv.currentPartnerId }],
                 [0, 0, { partner_id: pyEnv.publicPartnerId }],

--- a/addons/im_livechat/static/tests/sidebar_patch_tests.js
+++ b/addons/im_livechat/static/tests/sidebar_patch_tests.js
@@ -10,7 +10,7 @@ QUnit.module("discuss sidebar (patch)");
 QUnit.test("Unknown visitor", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -22,29 +22,6 @@ QUnit.test("Unknown visitor", async (assert) => {
     await openDiscuss();
     assert.containsOnce($, ".o-mail-DiscussSidebar .o-mail-DiscussSidebarCategory-livechat");
     assert.containsOnce($, ".o-mail-DiscussSidebarChannel:contains(Visitor 11)");
-});
-
-QUnit.test("Known user with country", async (assert) => {
-    const pyEnv = await startServer();
-    const countryId = pyEnv["res.country"].create({
-        code: "be",
-        name: "Belgium",
-    });
-    const partnerId = pyEnv["res.partner"].create({
-        country_id: countryId,
-        name: "Jean",
-    });
-    pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            [0, 0, { partner_id: pyEnv.currentPartnerId }],
-            [0, 0, { partner_id: partnerId }],
-        ],
-        channel_type: "livechat",
-        livechat_operator_id: pyEnv.currentPartnerId,
-    });
-    const { openDiscuss } = await start();
-    await openDiscuss();
-    assert.containsOnce($, ".o-mail-DiscussSidebarChannel:contains(Jean (Belgium))");
 });
 
 QUnit.test("Do not show channel when visitor is typing", async (assert) => {
@@ -88,7 +65,7 @@ QUnit.test("Do not show channel when visitor is typing", async (assert) => {
 QUnit.test("Close should update the value on the server", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -121,7 +98,7 @@ QUnit.test("Close should update the value on the server", async (assert) => {
 QUnit.test("Open should update the value on the server", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -154,7 +131,7 @@ QUnit.test("Open should update the value on the server", async (assert) => {
 QUnit.test("Open from the bus", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -189,7 +166,7 @@ QUnit.test("Open from the bus", async (assert) => {
 QUnit.test("Close from the bus", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -224,7 +201,7 @@ QUnit.test("Close from the bus", async (assert) => {
 QUnit.test("Smiley face avatar for an anonymous livechat item", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -245,6 +222,7 @@ QUnit.test("Partner profile picture for livechat item linked to a partner", asyn
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Jean" });
     const channelId = pyEnv["discuss.channel"].create({
+        name: "Jean",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: partnerId }],
@@ -264,7 +242,7 @@ QUnit.test("Partner profile picture for livechat item linked to a partner", asyn
 QUnit.test("No counter if the category is unfolded and with unread messages", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [
                 0,
@@ -291,7 +269,7 @@ QUnit.test("No counter if the category is unfolded and with unread messages", as
 QUnit.test("No counter if category is folded and without unread messages", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -317,7 +295,7 @@ QUnit.test(
     async (assert) => {
         const pyEnv = await startServer();
         pyEnv["discuss.channel"].create({
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 [
                     0,
@@ -348,7 +326,7 @@ QUnit.test(
 QUnit.test("Close manually by clicking the title", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -375,7 +353,7 @@ QUnit.test("Close manually by clicking the title", async (assert) => {
 QUnit.test("Open manually by clicking the title", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -405,7 +383,7 @@ QUnit.test("Open manually by clicking the title", async (assert) => {
 QUnit.test("Category item should be invisible if the category is closed", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -431,7 +409,7 @@ QUnit.test(
     async (assert) => {
         const pyEnv = await startServer();
         pyEnv["discuss.channel"].create({
-            anonymous_name: "Visitor 11",
+            name: "Visitor 11",
             channel_member_ids: [
                 [0, 0, { partner_id: pyEnv.currentPartnerId }],
                 [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -461,7 +439,7 @@ QUnit.test(
 QUnit.test("Clicking on unpin button unpins the channel", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -484,7 +462,7 @@ QUnit.test("Message unread counter", async (assert) => {
     const partnerId = pyEnv["res.partner"].create({ name: "Harry" });
     const userId = pyEnv["res.users"].create({ name: "Harry", partner_id: partnerId });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
+        name: "Visitor 11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],

--- a/addons/im_livechat/static/tests/thread_icon_patch_tests.js
+++ b/addons/im_livechat/static/tests/thread_icon_patch_tests.js
@@ -8,6 +8,7 @@ QUnit.test("Public website visitor is typing", async (assert) => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 20",
+        name: "Visitor 20",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],

--- a/addons/im_livechat/static/tests/thread_model_patch_tests.js
+++ b/addons/im_livechat/static/tests/thread_model_patch_tests.js
@@ -15,7 +15,7 @@ QUnit.test("Thread name unchanged when inviting new users", async (assert) => {
         user_ids: [userId],
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
+        name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: pyEnv.currentPartnerId }),
             Command.create({ partner_id: pyEnv.publicPartnerId }),

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -82,7 +82,7 @@ class TestImLivechatMessage(HttpCase):
                 'ratingText': record_rating.rating_text,
             },
             'recipients': [],
-            'record_name': "test1 Ernest Employee",
+            'record_name': "test1",
             'res_id': channel_livechat_1.id,
             'scheduledDatetime': False,
             'sms_ids': [],

--- a/addons/mail/static/tests/helpers/webclient_setup.js
+++ b/addons/mail/static/tests/helpers/webclient_setup.js
@@ -37,26 +37,24 @@ export function copyRegistry(source, target) {
     for (const [name, service] of source.getEntries()) {
         target.add(name, service);
     }
-    source.addEventListener("UPDATE", ({ operation, key, value }) => {
-        if (operation === "add") {
-            target.add(key, value);
-        }
-    });
 }
 
 // Copy registries before they are cleared by the test setup in
 // order to restore them during `getWebClientReady`.
 const mailServicesRegistry = registry.category("mail.services");
 const webServicesRegistry = registry.category("services");
-copyRegistry(webServicesRegistry, mailServicesRegistry);
 
 const mailMainComponentsRegistry = registry.category("mail.main_components");
 const webMainComponentsRegistry = registry.category("main_components");
-copyRegistry(webMainComponentsRegistry, mailMainComponentsRegistry);
 
 const mailSystrayRegistry = registry.category("mail.systray");
 const webSystrayRegistry = registry.category("systray");
-copyRegistry(webSystrayRegistry, mailSystrayRegistry);
+
+QUnit.begin(() => {
+    copyRegistry(webServicesRegistry, mailServicesRegistry);
+    copyRegistry(webMainComponentsRegistry, mailMainComponentsRegistry);
+    copyRegistry(webSystrayRegistry, mailSystrayRegistry);
+});
 
 /**
  * @returns function that returns an `XMLHttpRequest`-like object whose response

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -873,7 +873,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'last_interest_dt': self.channel_livechat_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_livechat_1._channel_last_message_ids()),
                     'message_needaction_counter': 0,
-                    'name': 'test1 Ernest Employee',
+                    'name': 'test1 (India)',
                     'operator_pid': (self.users[0].partner_id.id, 'Ernest Employee'),
                     'rtcSessions': [('insert', [])],
                     'seen_partners_info': [
@@ -955,7 +955,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'last_interest_dt': self.channel_livechat_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'last_message_id': next(res['message_id'] for res in self.channel_livechat_2._channel_last_message_ids()),
                     'message_needaction_counter': 0,
-                    'name': 'anon 2 Ernest Employee',
+                    'name': 'anon 2 (Belgium)',
                     'operator_pid': (self.users[0].partner_id.id, 'Ernest Employee'),
                     'rtcSessions': [('insert', [])],
                     'seen_partners_info': [

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -77,7 +77,7 @@ class WebsiteVisitor(models.Model):
                 'channel_type': 'livechat',
                 'country_id': country.id,
                 'anonymous_name': visitor_name,
-                'name': ', '.join([visitor_name, operator.livechat_username if operator.livechat_username else operator.name]),
+                'name': visitor_name,
                 'livechat_visitor_id': visitor.id,
                 'livechat_active': True,
             })

--- a/addons/website_livechat/static/tests/helpers/mock_server/models/website_visitor.js
+++ b/addons/website_livechat/static/tests/helpers/mock_server/models/website_visitor.js
@@ -23,6 +23,7 @@ patch(MockServer.prototype, "website_livechat/models/website_visitor", {
             }
             const livechatId = this.pyEnv["discuss.channel"].create({
                 anonymous_name: visitor_name,
+                name: visitor_name,
                 channel_member_ids: membersToAdd,
                 channel_type: "livechat",
                 livechat_operator_id: this.currentPartnerId,

--- a/addons/website_livechat/static/tests/thread_patch_tests.js
+++ b/addons/website_livechat/static/tests/thread_patch_tests.js
@@ -18,7 +18,7 @@ QUnit.test("Rendering of visitor banner", async (assert) => {
         display_name: `Visitor #${visitorId}`,
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: `Visitor #${visitorId}`,
+        name: `Visitor #${visitorId}`,
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -36,7 +36,10 @@ QUnit.test("Rendering of visitor banner", async (assert) => {
     );
     assert.containsOnce($, ".o-website_livechat-VisitorBanner .o-mail-ImStatus");
     assert.containsOnce($, ".o_country_flag[data-src='/base/static/img/country_flags/be.png']");
-    assert.containsOnce($, `.o-website_livechat-VisitorBanner span:contains(Visitor #${visitorId})`);
+    assert.containsOnce(
+        $,
+        `.o-website_livechat-VisitorBanner span:contains(Visitor #${visitorId})`
+    );
     assert.containsOnce($, "span:contains(English)");
     assert.containsOnce($, "span>:contains(General website)");
     assert.containsOnce($, "span:contains(Home → Contact)");
@@ -54,7 +57,7 @@ QUnit.test("Livechat with non-logged visitor should show visitor banner", async 
         website_name: "General website",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #11",
+        name: "Visitor #11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: pyEnv.publicPartnerId }],
@@ -82,6 +85,7 @@ QUnit.test("Livechat with logged visitor should show visitor banner", async (ass
         website_name: "General website",
     });
     const channelId = pyEnv["discuss.channel"].create({
+        name: "Partner Visitor",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: partnerId }],
@@ -100,7 +104,7 @@ QUnit.test("Livechat without visitor should not show visitor banner", async (ass
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Harry" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #11",
+        name: "Visitor #11",
         channel_member_ids: [
             [0, 0, { partner_id: pyEnv.currentPartnerId }],
             [0, 0, { partner_id: partnerId }],

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -49,7 +49,7 @@ class TestLivechatBasicFlowHttpCase(tests.HttpCase, TestLivechatCommon):
         channel_1 = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)], limit=1)
 
         # Check Channel naming
-        self.assertEqual(channel_1.name, "%s %s" % (f'Visitor #{channel_1.livechat_visitor_id.id}', self.operator.livechat_username))
+        self.assertEqual(channel_1.name, f'Visitor #{channel_1.livechat_visitor_id.id}')
         channel_1.unlink()
 
         # Remove livechat_username
@@ -67,7 +67,7 @@ class TestLivechatBasicFlowHttpCase(tests.HttpCase, TestLivechatCommon):
         channel_2 = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)], limit=1)
 
         # Check Channel naming
-        self.assertEqual(channel_2.name, "%s %s" % (f'Visitor #{channel_2.livechat_visitor_id.id}', self.operator.name))
+        self.assertEqual(channel_2.name, f'Visitor #{channel_2.livechat_visitor_id.id}')
 
     def test_basic_flow_with_rating(self):
         channel = self._common_basic_flow()
@@ -119,7 +119,7 @@ class TestLivechatBasicFlowHttpCase(tests.HttpCase, TestLivechatCommon):
 
         # Check Channel and Visitor naming
         self.assertEqual(self.visitor.display_name, "%s #%s" % (_("Website Visitor"), self.visitor.id))
-        self.assertEqual(channel.name, "%s %s" % (f'Visitor #{channel.livechat_visitor_id.id}', self.operator.livechat_username))
+        self.assertEqual(channel.name, "%s" % f'Visitor #{channel.livechat_visitor_id.id}')
 
         # Post Message from visitor
         self._send_message(channel, self.visitor.display_name, "Message from Visitor")


### PR DESCRIPTION
Since [1], livechat thread names should be the visitor name from the operator point of view and the operator name from the visitor point of view. Thus, the way the server assigns a name when `get_session` is called is outdated (visitor_name, operator_name) and leads to complex logic in the javascript code.

This PR adapts the server code in order to reflect those changes: the channel name is now always the name of the visitor, with its country if this information is available. The javascript code either displays the thread name as is (backend) or the operator name (frontend).

part of task-3332628

[1]: https://github.com/odoo/odoo/pull/125931