### PR TITLE
[IMP] website_forum: display other user forum links in the sidebar

### DIFF
--- a/addons/website_forum/tests/__init__.py
+++ b/addons/website_forum/tests/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from . import common
+from . import test_forum_controller
 from . import test_forum_internals
 from . import test_forum_karma_access
 from . import test_forum_tag

--- a/addons/website_forum/tests/common.py
+++ b/addons/website_forum/tests/common.py
@@ -44,6 +44,13 @@ class TestForumCommon(common.TransactionCase):
             'karma': 0,
             'groups_id': [(6, 0, [group_employee_id])]
         })
+        cls.user_employee_2 = cls.env['res.users'].create({
+            'name': 'Merlin Employee',
+            'login': 'Merlin',
+            'email': 'merlin.employee@example.com',
+            'karma': KARMA['ask'],
+            'groups_id': [(6, 0, [cls.env.ref('base.group_user').id])],
+        })
         cls.user_portal = TestUsersEnv.create({
             'name': 'Beatrice Portal',
             'login': 'Beatrice',
@@ -58,6 +65,7 @@ class TestForumCommon(common.TransactionCase):
             'karma': 0,
             'groups_id': [(6, 0, [group_public_id])]
         })
+        cls.user_admin = cls.env.ref('base.user_admin')
 
         # Test forum
         cls.forum = Forum.create({

--- a/addons/website_forum/tests/test_forum_controller.py
+++ b/addons/website_forum/tests/test_forum_controller.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_forum.controllers.website_forum import WebsiteForum
+from odoo.addons.website_forum.tests.common import KARMA, TestForumCommon
+
+
+class TestForumController(TestForumCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._activate_multi_website()
+        cls.minimum_karma_allowing_to_post = KARMA['ask']
+        cls.forums = cls.env['forum.forum'].create([{
+            'name': f'Forum {idx + 2}',
+            'karma_ask': cls.minimum_karma_allowing_to_post,
+            'website_id': website.id,
+        } for idx, website in enumerate(
+            (cls.base_website, cls.base_website, cls.base_website, cls.website_2, cls.website_2))])
+        cls.forum_1, cls.forum_2, cls.forum_3, cls.forum_1_website_2, cls.forum_2_website_2 = cls.forums
+        cls.controller = WebsiteForum()
+
+    def _get_my_other_forums(self, forum):
+        """ Get user other forums limited to the forums of the test (self.forums). """
+        return self.forums & self.controller._prepare_user_values(forum=forum).get('my_other_forums')
+
+    def forum_post(self, user, forum):
+        return self.env['forum.post'].with_user(user).create({
+            'content': 'A post ...',
+            'forum_id': forum.id,
+            'name': 'Post...',
+        })
+
+    def test_prepare_user_values_my_other_forum(self):
+        """ Test user other forums values (my_other_forums) in various contexts. """
+        employee_2_forum_2_post = self.forum_post(self.user_employee_2, self.forum_2)
+        employee_2_website_2_forum_2_post = self.forum_post(self.user_employee_2, self.forum_2_website_2)
+        for user in (self.user_admin, self.user_employee, self.user_portal, self.user_public):
+            with self.with_user(user.login), MockRequest(self.env, website=self.base_website):
+                self.assertFalse(self._get_my_other_forums(self.forum_1))
+                self.assertFalse(self._get_my_other_forums(None))
+                self.assertFalse(self._get_my_other_forums(True))
+                if user != self.user_public:
+                    self.env.user.karma = self.minimum_karma_allowing_to_post
+                    # Like a post on forum 2 and verify that forum 2 is now in "my other forum"
+                    employee_2_forum_2_post.favourite_ids += self.env.user
+                    self.assertEqual(self._get_my_other_forums(self.forum_1), self.forum_2)
+                    self.assertFalse(self._get_my_other_forums(self.forum_2))
+                    # Check similarly with posting and also checking that we don't see forum of website 2
+                    self.forum_post(self.env.user, self.forum_3)
+                    self.forum_post(self.env.user, self.forum_1_website_2)
+                    self.assertEqual(self._get_my_other_forums(self.forum_1), self.forum_2 + self.forum_3)
+                    self.assertEqual(self._get_my_other_forums(self.forum_2), self.forum_3)
+                    self.assertEqual(self._get_my_other_forums(self.forum_3), self.forum_2)
+            with self.with_user(user.login), MockRequest(self.env, website=self.website_2):
+                self.assertFalse(self._get_my_other_forums(None))
+                self.assertFalse(self._get_my_other_forums(True))
+                if user != self.user_public:
+                    self.assertFalse(self._get_my_other_forums(self.forum_1_website_2))
+                    self.assertEqual(self._get_my_other_forums(self.forum_2_website_2), self.forum_1_website_2)
+                    employee_2_website_2_forum_2_post.favourite_ids += self.env.user
+                    self.assertEqual(self._get_my_other_forums(self.forum_1_website_2), self.forum_2_website_2)

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -338,6 +338,15 @@
             <t t-out="tag.name"/>
         </a>
     </div>
+    <div t-if="my_other_forums" class="o_wforum_sidebar_section pt-3">
+        <div class="px-3 pb-1 fw-bold">My forums</div>
+        <t t-foreach="my_other_forums.sorted(lambda f: f.name.casefold())" t-as="my_forum">
+            <a class="nav-link my-1 py-1 text-reset" t-attf-href="/forum/#{slug(my_forum)}">
+                <i class="fa fa-file-o fa-fw opacity-50"/>
+                <t t-out="my_forum.name"/>
+            </a>
+        </t>
+    </div>
 </template>
 
 <template id="header_welcome_message" inherit_id="website_forum.header" name="Forum Welcome Message (oe_structure_forum_top)">


### PR DESCRIPTION
Links of the current website forums belonging to the user are now displayed in
the sidebar. A forum is considered to "belongs" to a user if either he has
posted a message on it or he has added one of the post in his favourites.

Technical note: we add the value "my_other_forums" in _prepare_user_values
method to display the other user forums of the website in the side menu on
various pages. That value is only added when the "forum" value is a forum
indicating that the page is currently displaying one of the forum. In order to
do that, we need to test the type of the "forum" variable as it can have
multiple types: True, None, a forum recordset, ...

Task-3354382