### PR TITLE
[FIX] web: fix empty html field

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -447,6 +447,8 @@ export class Record extends DataPoint {
             return value ? serializeDateTime(value) : false;
         } else if (fieldType === "char" || fieldType === "text") {
             return value !== "" ? value : false;
+        } else if (fieldType === "html") {
+            return value && value.length ? value : false;
         } else if (fieldType === "many2one") {
             return value ? value[0] : false;
         } else if (fieldType === "reference") {

--- a/addons/web/static/tests/views/fields/html_field_tests.js
+++ b/addons/web/static/tests/views/fields/html_field_tests.js
@@ -1,6 +1,12 @@
 /** @odoo-module **/
 
-import { click, editInput, getFixture, patchWithCleanup } from "@web/../tests/helpers/utils";
+import {
+    click,
+    clickSave,
+    editInput,
+    getFixture,
+    patchWithCleanup,
+} from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { registry } from "@web/core/registry";
 import { htmlField } from "@web/views/fields/html/html_field";
@@ -291,4 +297,34 @@ QUnit.module("Fields", ({ beforeEach }) => {
             "spellcheck is re-enabled once the field is focused"
         );
     });
+
+    QUnit.test(
+        "Setting an html field to empty string is saved as a false value",
+        async function (assert) {
+            assert.expect(1);
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <form>
+                        <sheet>
+                            <group>
+                                <field name="txt" />
+                            </group>
+                        </sheet>
+                    </form>`,
+                resId: 1,
+                mockRPC(route, { args, method }) {
+                    if (method === "write") {
+                        assert.strictEqual(args[1].txt, false, "the txt value should be false");
+                    }
+                },
+            });
+
+            await editInput(target, ".o_field_widget[name=txt] textarea", "");
+            await clickSave(target);
+        }
+    );
 });


### PR DESCRIPTION
Markup("") on a HTML field should be counted as an empty field. Check now the length of the value and assign false for HTML field if we have an empty string inside markup.
This was leading to an issue where empty alert message were displayed based on computed HTML field.