### PR TITLE
[FIX] point_of_sale: make sure cash moves are not duplicated

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/cash_move_popup/cash_move_popup.js
@@ -11,6 +11,7 @@ import { usePos } from "@point_of_sale/app/pos_hook";
 import { AbstractAwaitablePopup } from "@point_of_sale/js/Popups/AbstractAwaitablePopup";
 import { ErrorPopup } from "@point_of_sale/js/Popups/ErrorPopup";
 import { useValidateCashInput } from "@point_of_sale/js/custom_hooks";
+import { useAsyncLockedMethod } from "../../../js/custom_hooks";
 
 export class CashMovePopup extends AbstractAwaitablePopup {
     static template = "point_of_sale.CashMovePopup";
@@ -32,6 +33,7 @@ export class CashMovePopup extends AbstractAwaitablePopup {
         });
         this.amountInput = useAutofocus({ refName: "amountInput" });
         useValidateCashInput('amountInput');
+        this.confirm = useAsyncLockedMethod(this.confirm);
     }
     async confirm() {
         let amount;

--- a/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PartnerListScreen/PartnerListScreen.js
@@ -9,6 +9,7 @@ import { PartnerDetailsEdit } from "./PartnerDetailsEdit";
 import { usePos } from "@point_of_sale/app/pos_hook";
 import { Component, onWillUnmount, useRef, useState } from "@odoo/owl";
 import { sprintf } from "@web/core/utils/strings";
+import { useAsyncLockedMethod } from "../../custom_hooks";
 
 /**
  * Render this screen using `showTempScreen` to select partner.
@@ -48,6 +49,7 @@ export class PartnerListScreen extends Component {
             currentOffset: 0,
         });
         this.updatePartnerList = debounce(this.updatePartnerList, 70);
+        this.saveChanges = useAsyncLockedMethod(this.saveChanges);
         onWillUnmount(this.updatePartnerList.cancel);
         this.partnerEditor = {}; // create an imperative handle for PartnerDetailsEdit
     }

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -17,6 +17,7 @@ import { PaymentScreenStatus } from "./PaymentScreenStatus";
 import { usePos } from "@point_of_sale/app/pos_hook";
 import { Component, useState } from "@odoo/owl";
 import { sprintf } from "@web/core/utils/strings";
+import { useAsyncLockedMethod } from "../../custom_hooks";
 
 export class PaymentScreen extends Component {
     static template = "PaymentScreen";
@@ -43,6 +44,7 @@ export class PaymentScreen extends Component {
         useErrorHandlers();
         this.payment_interface = null;
         this.error = false;
+        this.validateOrder = useAsyncLockedMethod(this.validateOrder);
     }
 
     showMaxValueError() {

--- a/addons/point_of_sale/static/src/js/custom_hooks.js
+++ b/addons/point_of_sale/static/src/js/custom_hooks.js
@@ -133,5 +133,20 @@ export function useValidateCashInput(inputRef, startingValue) {
         if (cashInput.el) {
             cashInput.el.removeEventListener("input", handleCashInputChange);
         }
-    })
+    });
+}
+export function useAsyncLockedMethod(method) {
+    const component = useComponent();
+    let called = false;
+    return async (...args) => {
+        if (called) {
+            return;
+        }
+        try {
+            called = true;
+            await method.call(component, ...args);
+        } finally {
+            called = false;
+        }
+    };
 }


### PR DESCRIPTION
Current behavior:
When your connection is slow and you try to create a cash move, and you click multiple times on the confirm button. The cash move is created multiple times.
This happens because the function is not locked while the asynchronous call is not finished. To fix this we added a custom hook to lock the function while the asynchronous call is not finished.

Steps to reproduce:
- Open the POS
- Press F12 and in the network tab of the developper tools, set the connection to slow 3G
- Open the cash move popup, enter an amount and click on confirm multiple times.
- Close the session, and check the cash moves created.

opw-3431775
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
