### PR TITLE
[FIX] pos_loyalty: install issue when gift card email template not set

### DIFF
--- a/addons/pos_loyalty/data/gift_card_data.xml
+++ b/addons/pos_loyalty/data/gift_card_data.xml
@@ -9,7 +9,8 @@
         <field name="taxes_id" eval="False"/>
     </record>
     <!-- Gift Cards -->
-    <record id="loyalty.gift_card_program" model="loyalty.program">
-        <field name="pos_report_print_id" ref="loyalty.report_gift_card"/>
-    </record>
+    <function name="write" model="loyalty.program">
+        <value model="loyalty.program" eval="obj().search([('id', '=', ref('loyalty.gift_card_program'))]).filtered(lambda l: l.mail_template_id.id == ref('loyalty.mail_template_gift_card')).ids"/>
+        <value eval="{'pos_report_print_id': ref('loyalty.report_gift_card')}"/>
+    </function>
 </odoo>


### PR DESCRIPTION
When the user removes the Email Template from the 'Gift Cards' program and tries to install the pos_loyalty module, they will encounter a ParseError with the message: `You must set 'Email template' before setting 'Print Report'.` As a result, the installation process will be aborted.

Steps to produce:
- Install the 'Sales' and 'Coupons & Loyalty' modules.
- Sales > Products > Gift cards & eWallet.
- Open the 'Gift Cards' program and remove the Email template from the field.
- Apps > 'Point of Sale - Coupons & Loyalty' > Activate.
- ParseError and stops the installation process.

When the `post_init_hook` method is called during installation, it should check whether the 'Gift Card' program has an Email Template configured.

Traceback:
```
UserError: You must set 'Email template' before setting 'Print Report'.
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 451, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "odoo/models.py", line 4644, in _load_records
    data['record']._load_records_write(data['values'])
  File "odoo/models.py", line 4575, in _load_records_write
    self.write(values)
  File "addons/loyalty/models/loyalty_program.py", line 405, in write
    return super().write(vals)
  File "odoo/models.py", line 4046, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1396, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 99, in determine
    return needle(*args)
  File "addons/pos_loyalty/models/loyalty_program.py", line 33, in _inverse_pos_report_print_id
    raise UserError(_("You must set '%s' before setting '%s'.", mail_template_label, pos_report_print_label))
ParseError: while parsing /home/odoo/src/odoo/saas-16.3/addons/pos_loyalty/data/gift_card_data.xml:12, somewhere inside
<record id="loyalty.gift_card_program" model="loyalty.program">
        <field name="pos_report_print_id" ref="loyalty.report_gift_card"/>
    </record>
  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

Sentry-4356842814


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
