### PR TITLE
[FIX] point_of_sale: traceback pos product category. 

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -30,7 +30,7 @@ class PosCategory(models.Model):
     def _get_hierarchy(self) -> List[str]:
         """ Returns a list representing the hierarchy of the categories. """
         self.ensure_one()
-        return (self.parent_id._get_hierarchy() if self.parent_id else []) + [self.name]
+        return (self.parent_id._get_hierarchy() if self.parent_id else []) + ([self.name] if self.name else [])
 
     @api.depends('parent_id')
     def _compute_display_name(self):


### PR DESCRIPTION
Before this commit
==================
Traceback occurred when click on the New button in the POS Product category. 

Step to reproduced
==================
- Open POS and Go to Configuration
- Open product category Click on New at this time traceback appear 

After this commit
=================
In this commit no more error when we click on New button in POS Product category.

task-3450117