### PR TITLE
[FIX] base_import: prohibited unidentified image while upload in url form

### DIFF
--- a/addons/base_import/i18n/base_import.pot
+++ b/addons/base_import/i18n/base_import.pot
@@ -101,6 +101,12 @@ msgid "Cancel"
 msgstr ""
 
 #. module: base_import
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
+msgid "The uploaded image URL is unable to identify."
+msgstr ""
+
+#. module: base_import
 #. openerp-web
 #: code:addons/base_import/static/src/legacy/xml/base_import.xml:0
 #, python-format


### PR DESCRIPTION
When a user attempts to import or upload a file into the invoice module and that
file is attached to the image with url form as text or html, an error is raised.
 then the error would be produced when trying to test that file.

  Step to Produce:-
 - import CSV file (Ex.'product.product' model)
    > that CSV file must have one URL Image(In that URL has content of text or
      Html form [Image LInk](https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.searchenginejournal.com%2Fbest-image-search-engines%2F299963%2F&psig=AOvVaw18huTMgmZKP5kcAZ1982MU&ust=1682141253339000&source=images&cd=vfe&ved=0CBEQjRxqFwoTCMi_ztCeuv4CFQAAAAAdAAAAABAJ))
 - Click On the 'Test' Button.

Traceback:- 
```
UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x7f69a7a94ae0>
  File "addons/base_import/models/base_import.py", line 1258, in _import_image_by_url
    image = Image.open(io.BytesIO(content))
  File "PIL/Image.py", line 3008, in open
    raise UnidentifiedImageError(
```
  Applying these changes will resolve this issue.

  sentry:-3957460597
