### PR TITLE
[IMP] stock: rework properties button and kanban view

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -26,6 +26,7 @@
         'data/stock_data.xml',
         'data/stock_sequence_data.xml',
         'data/stock_traceability_report_data.xml',
+        'data/ir_actions_client_data.xml',
 
         'report/report_stock_quantity.xml',
         'report/report_stock_reception.xml',

--- a/addons/stock/data/ir_actions_client_data.xml
+++ b/addons/stock/data/ir_actions_client_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="stock_lot_action_configure_properties_field" model="ir.actions.client">
+        <field name="name">Add Properties</field>
+        <field name="res_model">stock.lot</field>
+        <field name="tag">action_configure_properties_field</field>
+        <field name="binding_model_id" ref="stock.model_stock_lot"/>
+        <field name="binding_view_types">form</field>
+    </record>
+</odoo>

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -47,7 +47,7 @@
                         <field name="last_delivery_partner_id" invisible="not last_delivery_partner_id" groups="stock.group_stock_manager"/>
                     </group>
                     <group></group>
-                    <field name="lot_properties" nolabel="1" columns="2"/>
+                    <field name="lot_properties" nolabel="1" columns="2" hideAddButton="1"/>
                 </group>
                 <notebook invisible="not display_complete">
                     <page string="Description" name="description">


### PR DESCRIPTION
The properties button has been moved to the contextual action menu. 
The kanban view now shows partner locations and internal location directly under a view location

task 3444583

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
