### PR TITLE
[FIX] base_vat: update log when vies check fails

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -207,7 +207,7 @@ class ResPartner(models.Model):
                     elif isinstance(e, InvalidComponent):
                         msg = _("The VAT number %s could not be interpreted by the VIES server.", partner.vies_vat_to_check)
                     partner._origin.message_post(body=msg)
-                _logger.exception("The VAT number %s failed VIES check.", partner.vies_vat_to_check)
+                _logger.warning("The VAT number %s failed VIES check.", partner.vies_vat_to_check, exc_info=True)
                 partner.vies_valid = False
 
     @api.model


### PR DESCRIPTION
When the user will enter an incorrect VAT number in a partner, the logger exception will occur.

See Traceback:

```
RemoteDisconnected: Remote end closed connection without response
  File "urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
    # Permission is hereby granted, free of charge, to any person obtaining a copy
  File "urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "http/client.py", line 1374, in getresponse
    response.begin()
  File "http/client.py", line 318, in begin
    version, status, reason = self._read_status()
  File "http/client.py", line 287, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
  File "requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "urllib3/connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "urllib3/util/retry.py", line 532, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "six.py", line 718, in reraise
    raise value.with_traceback(tb)
  File "urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
    # Permission is hereby granted, free of charge, to any person obtaining a copy
  File "urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "http/client.py", line 1374, in getresponse
    response.begin()
  File "http/client.py", line 318, in begin
    version, status, reason = self._read_status()
  File "http/client.py", line 287, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
  File "addons/base_vat/models/res_partner.py", line 200, in _compute_vies_valid
    vies_valid = check_vies(partner.vies_vat_to_check, timeout=10)
  File "stdnum/eu/vat.py", line 131, in check_vies
    client = get_soap_client(vies_wsdl, timeout)
  File "stdnum/util.py", line 263, in get_soap_client
    client = Client(wsdlurl, transport=transport).service
  File "zeep/client.py", line 73, in __init__
    self.wsdl = Document(wsdl, self.transport, settings=self.settings)
  File "zeep/wsdl/wsdl.py", line 92, in __init__
    self.load(location)
  File "zeep/wsdl/wsdl.py", line 95, in load
    document = self._get_xml_document(location)
  File "zeep/wsdl/wsdl.py", line 155, in _get_xml_document
    return load_external(
  File "zeep/loader.py", line 87, in load_external
    content = transport.load(url)
  File "zeep/transports.py", line 122, in load
    content = self._load_remote_data(url)
  File "zeep/transports.py", line 134, in _load_remote_data
    response = self.session.get(url, timeout=self.load_timeout)
  File "requests/sessions.py", line 557, in get
    return self.request('GET', url, **kwargs)
  File "requests/sessions.py", line 544, in request
    resp = self.send(prep, **send_kwargs)
  File "requests/sessions.py", line 657, in send
    r = adapter.send(request, **kwargs)
  File "requests/adapters.py", line 498, in send
    raise ConnectionError(err, request=request)
```

When the user enters VAT Number it will check through 'check_vies' method in this method, The logger is updated to use the 'warning' level instead of the 'exception' level.

https://github.com/odoo/odoo/blob/475ea457d8bfd61da19f2339950c0fcc21e25bcf/addons/base_vat/models/res_partner.py#L210

This change reflects a less severe logging level for cases where a request to VIES check fails.

sentry - 4346743977

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
