### PR TITLE
[IMP] base: improve record rules view

### DIFF
--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -21,10 +21,10 @@ class IrRule(models.Model):
     model_id = fields.Many2one('ir.model', string='Model', index=True, required=True, ondelete="cascade")
     groups = fields.Many2many('res.groups', 'rule_group_rel', 'rule_group_id', 'group_id', ondelete='restrict')
     domain_force = fields.Text(string='Domain')
-    perm_read = fields.Boolean(string='Apply for Read', default=True)
-    perm_write = fields.Boolean(string='Apply for Write', default=True)
-    perm_create = fields.Boolean(string='Apply for Create', default=True)
-    perm_unlink = fields.Boolean(string='Apply for Delete', default=True)
+    perm_read = fields.Boolean(string='Read', default=True)
+    perm_write = fields.Boolean(string='Write', default=True)
+    perm_create = fields.Boolean(string='Create', default=True)
+    perm_unlink = fields.Boolean(string='Delete', default=True)
 
     _sql_constraints = [
         ('no_access_rights',

--- a/odoo/addons/base/views/ir_rule_views.xml
+++ b/odoo/addons/base/views/ir_rule_views.xml
@@ -60,10 +60,10 @@
                     <field name="model_id"/>
                     <field name="groups" widget="many2many_tags" options="{'no_create':True}"/>
                     <field name="domain_force"/>
-                    <field name="perm_read"/>
-                    <field name="perm_write"/>
-                    <field name="perm_create"/>
-                    <field name="perm_unlink"/>
+                    <field name="perm_read" width="85px"/>
+                    <field name="perm_write" width="85px"/>
+                    <field name="perm_create" width="85px"/>
+                    <field name="perm_unlink" width="85px"/>
                 </tree>
             </field>
         </record>
@@ -73,19 +73,23 @@
             <field name="arch" type="xml">
                 <search string="Record Rules">
                     <field name="name" string="Record Rule"/>
+                    <field name="domain_force"/>
                     <field name="model_id"/>
                     <field name="groups"/>
                     <filter string="Global" name="global" domain="[('global', '=', True)]"/>
+                    <filter string="Group-based" name="group_based" domain="[('global', '=', False)]"/>
                     <separator/>
-                    <filter string="Full Access Right" name="full_access_right" domain="[('perm_read', '=', True), ('perm_write', '=', True), ('perm_create', '=', True), ('perm_unlink', '=', True)]"/>
-                    <filter string="Read Access Right" name="read_access_right" domain="[('perm_read', '=', True)]"/>
-                    <filter string="Write Access Right" name="write_access_right" domain="[('perm_write', '=', True)]"/>
-                    <filter string="Create Access Right" name="create_access_right" domain="[('perm_create', '=' ,True)]"/>
-                    <filter string="Delete Access Right" name="delete_access_right" domain="[('perm_unlink', '=', True)]"/>
+                    <filter string="Full Access" name="full_access_right" domain="[('perm_read', '=', True), ('perm_write', '=', True), ('perm_create', '=', True), ('perm_unlink', '=', True)]"/>
+                    <filter string="Read" name="read_access_right" domain="[('perm_read', '=', True)]"/>
+                    <filter string="Write" name="write_access_right" domain="[('perm_write', '=', True)]"/>
+                    <filter string="Create" name="create_access_right" domain="[('perm_create', '=' ,True)]"/>
+                    <filter string="Delete" name="delete_access_right" domain="[('perm_unlink', '=', True)]"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group string="Group By">
                         <filter string="Model" name="group_by_object" domain="[]" context="{'group_by': 'model_id'}"/>
+                        <separator/>
+                        <filter string="Group" name="group_by_group" domain="[]" context="{'group_by': 'groups'}"/>
                     </group>
                 </search>
             </field>


### PR DESCRIPTION
Purpose
=======
Promenade of the record rules views

Specification
=============
In the record rules search view:
- add a group by 'Group' separated with a separator.
- below the 'Global' filter, add a 'Group-specific' filter which only displays the record rules with groups.
- shorten the labels of the other search filters.
- in the quick search, add the domain_force field below the name.

In the tree view:
- rename the read, write, create and delete columns to make their labels readable (reduce their length to prevent text overflow).

Task-3451884

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
