### PR TITLE
[FIX] point_of_sale: ignore cancelled orders

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -34,6 +34,7 @@ class PosOrder(models.Model):
     @api.model
     def remove_from_ui(self, server_ids):
         order_ids = self.env['pos.order'].browse(server_ids)
+        print("\n # pos_order.py:35 - self order ():  server_ids :", server_ids)
         order_ids.state = 'cancel'
         self._send_notification(order_ids)
 


### PR DESCRIPTION
The POS orders can currently be saved in the database, then removed which in reality puts them in the cancelled state. Those cancelled orders are processed when their session is closed, which results in unbalanced accounting lines and inventory pickings still created.

Steps to reproduce:

With a shop:
- Set a trusted POS for the shop to use
- Open a session for that shop
- Create an order with 1 product
- Click on the "Save" button of the trusted POS feature (in the product screen, above the numpad)
- Open the orders with the top right dropdown menu
- Click on the trash to delete the previously created and saved order
- Close the session

With a restaurant:
- Open a session
- Create an order with 1 product
- Click on the "Back" button (to save the order in the database)
- Open the orders with the top right dropdown menu
- Click on the trash to delete the previously created and saved order
- Close the session

In both cases, the "Force Close Session" error popup appears.
After closing the session with the "Close Session & Post Entries" backend button, the inventory picking is created and validated, accounting Product Sales and Tax lines are created, and there is a "difference at closing POS session".

The fix consists of not processing cancelled orders when closing POS sessions.
The payments of cancelled orders are still saved in the database, but not taken into account in the sessions closing process.

task-id: 3452353