### PR TITLE
[IMP] survey: ensure scored can be passed

### DIFF
--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -96,10 +96,12 @@
     <!-- ============================================================ -->
 
     <template id="survey_button_form_view" name="Survey: back to form view">
-        <div groups="survey.group_survey_manager" t-ignore="true" class="alert alert-info p-2 border-0 rounded-0 d-print-none css_editable_mode_hidden mb-0">
-            <div t-ignore="true" class="text-center">
-                <a t-attf-href="/web#view_type=form&amp;model=survey.survey&amp;id=#{survey.id}&amp;action=survey.action_survey_form"><span t-if="answer and answer.test_entry">This is a Test Survey. </span><i class="oi oi-fw oi-arrow-right"/>Edit Survey</a>
-            </div>
+        <div groups="survey.group_survey_user" t-ignore="true" class="alert alert-info p-2 border-0 rounded-0 d-print-none css_editable_mode_hidden mb-0 text-center">
+            <a t-attf-href="/web#view_type=form&amp;model=survey.survey&amp;id=#{survey.id}&amp;action=survey.action_survey_form"><span>This is a Test Survey Entry. </span><i class="oi oi-fw oi-arrow-right"/>Edit Survey</a>
+        </div>
+        <div groups="survey.group_survey_user" t-if="survey.scoring_type != 'no_scoring' and survey.scoring_max_obtainable &lt;= 0"
+            t-ignore="true" class="alert alert-warning p-2 border-0 rounded-0 d-print-none css_editable_mode_hidden mb-0 text-center">
+            <i class="fa fa-exclamation-triangle"/> It is currently not possible to pass this assessment because no question is configured to give any points.
         </div>
     </template>
 


### PR DESCRIPTION
Before this commit, it was possible to have users fill-in a scored survey with no way possible to pass it because no answer had any positive score obtainable.

We keep here the check on sharing of the survey to avoid errors while configuring the survey, the same way it is already done when trying to share a survey without any question at all.

Task-3374592
