### PR TITLE
[FIX] web: drag and drop kanban flicker

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -86,7 +86,7 @@ export class DynamicGroupList extends DynamicList {
         const targetGroup = this.groups.find((g) => g.id === targetGroupId);
         if (dataGroupId === targetGroupId) {
             // move a record inside the same group
-            targetGroup.list.records = await targetGroup.list._resequence(
+            await targetGroup.list._resequence(
                 targetGroup.list.records,
                 this.resModel,
                 dataRecordId,
@@ -125,7 +125,7 @@ export class DynamicGroupList extends DynamicList {
             throw e;
         }
         if (!targetGroup.isFolded) {
-            targetGroup.list.records = await targetGroup.list._resequence(
+            await targetGroup.list._resequence(
                 targetGroup.list.records,
                 this.resModel,
                 dataRecordId,
@@ -140,7 +140,7 @@ export class DynamicGroupList extends DynamicList {
         }
 
         return this.model.mutex.exec(async () => {
-            this.groups = await this._resequence(
+            await this._resequence(
                 this.groups,
                 this.groupByField.relation,
                 movedGroupId,
@@ -220,12 +220,8 @@ export class DynamicGroupList extends DynamicList {
         const group = this._createGroupDatapoint(data);
         if (lastGroup) {
             const groups = [...this.groups, group];
-            this.groups = await this._resequence(
-                groups,
-                this.groupByField.relation,
-                group.id,
-                lastGroup.id
-            );
+            await this._resequence(groups, this.groupByField.relation, group.id, lastGroup.id);
+            this.groups = groups;
         } else {
             this.groups.push(group);
         }

--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -88,12 +88,7 @@ export class DynamicRecordList extends DynamicList {
     async resequence(movedRecordId, targetRecordId) {
         return this.model.mutex.exec(
             async () =>
-                (this.records = await this._resequence(
-                    this.records,
-                    this.resModel,
-                    movedRecordId,
-                    targetRecordId
-                ))
+                await this._resequence(this.records, this.resModel, movedRecordId, targetRecordId)
         );
     }
 

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -12577,13 +12577,13 @@ QUnit.module("Views", (hooks) => {
             [...target.querySelectorAll(".o_kanban_record:not(.o_kanban_ghost)")].map(
                 (el) => el.innerText
             ),
-            ["blip", "blip", "yop", "gnap"]
+            ["blip", "yop", "blip", "gnap"]
         );
         assert.verifySteps(["resequence"]);
 
         // try again
         await dragAndDrop(".o_kanban_record:nth-child(2)", ".o_kanban_record:nth-child(3)");
-        -assert.verifySteps([]);
+        assert.verifySteps([]);
 
         def.resolve();
         await nextTick();


### PR DESCRIPTION
Before this commit, in a kanban view, if you resequence records or groups by dragging and dropping, there is a flicker.

How to reproduce:
- Go to a kanban view
- Drag and drop a kanban card

Before this commit:
    The moved kanban card returns to its previous position during a render.

After this commit:
    The kanban card keeps its new position.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
