### PR TITLE
[FIX] base: neutralize outgoing mail server

### DIFF
--- a/odoo/addons/base/data/neutralize.sql
+++ b/odoo/addons/base/data/neutralize.sql
@@ -2,6 +2,9 @@
 UPDATE ir_mail_server
    SET active = false;
 
+INSERT INTO ir_mail_server (name, smtp_port, smtp_host, smtp_encryption, active, smtp_authentication)
+VALUES ('neutralize emails', 1025, 'smtp.example.org', 'none', true, 'login');
+
 -- deactivate crons
 UPDATE ir_cron
    SET active = false


### PR DESCRIPTION
Before this commit:
The neutralization script was incomplete because it did not take into account the possibility to specify a default mail server (and its credentials) as a command line argument (--smtp  and --smtp-XXX)

