### PR TITLE
[FIX] web_editor: upload unsupported image in web editor

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -191,7 +191,7 @@ class Web_Editor(http.Controller):
             try:
                 data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
                 mimetype = guess_mimetype(b64decode(data))
-                if mimetype not in SUPPORTED_IMAGE_MIMETYPES:
+                if mimetype == 'image/svg+xml' or mimetype not in SUPPORTED_IMAGE_MIMETYPES:
                     return {'error': format_error_msg}
             except UserError:
                 # considered as an image by the browser file input, but not


### PR DESCRIPTION
This traceback appears when user tries to import 'svg' image by changing its extension to some other supported subtype.

Steps to reproduce:
1) Install `note` module.
2) Download any `svg` image and change its extension to supported
   mimetypes ( e.g: '`JPEG`)
3) Open `Notes` > click on `Create` button.
4) Type `/img` command to open editor for uploading image.
5) Click on `UPLOAD AN IMAGE` button > Select that image.

See the traaceback:

```
AttributeError: 'bool' object has no attribute 'size'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web_editor/controllers/main.py", line 266, in add_data
    attachment = self._attachment_create(name=name, data=data, res_id=res_id, res_model=res_model)
  File "addons/web_editor/controllers/main.py", line 389, in _attachment_create
    attachment = IrAttachment.create(attachment_data)
  File "<decorator-gen-270>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/website/models/ir_attachment.py", line 23, in create
    return super().create(vals_list)
  File "<decorator-gen-57>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/addons/base/models/ir_attachment.py", line 630, in create
    values = self._check_contents(values)
  File "odoo/addons/base/models/ir_attachment.py", line 364, in _check_contents
    values = self._postprocess_contents(values)
  File "odoo/addons/base/models/ir_attachment.py", line 334, in _postprocess_contents
    w, h = img.image.size
```

When the extension of svg image is changed to 'supported_subtype' and so it tries to access the value of 'size' attribute while the value of 'img.image' attribute is 'False', That's why this error is coming that 'bool' object has no attribute 'size'.

sentry-4336547180

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
