### PR TITLE
[IMP/FIX] mass_mailing: improve test mailing behavior

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -21,6 +21,7 @@ from PIL import Image, UnidentifiedImageError
 from odoo import api, fields, models, tools, _
 from odoo.addons.base_import.models.base_import import ImportValidationError
 from odoo.exceptions import UserError, ValidationError
+from odoo.http import request
 from odoo.osv import expression
 from odoo.tools.float_utils import float_round
 
@@ -617,6 +618,8 @@ class MassMailing(models.Model):
     def action_test(self):
         self.ensure_one()
         ctx = dict(self.env.context, default_mass_mailing_id=self.id, dialog_size='medium')
+        if request.session.get('test_mailing_email_to'):
+            ctx.update(default_email_to=request.session['test_mailing_email_to'])
         return {
             'name': _('Test Mailing'),
             'type': 'ir.actions.act_window',

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -46,6 +46,7 @@ class TestMassMailing(models.TransientModel):
         else:
             full_body = mailing._prepend_preview(mailing.body_html, mailing.preview)
             subject = mailing.subject
+        subject = f'[TEST] {subject}'
 
         # Convert links in absolute URLs before the application of the shortener
         full_body = self.env['mail.render.mixin']._replace_local_links(full_body)

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -4,6 +4,7 @@
 from markupsafe import Markup
 
 from odoo import _, fields, models, tools
+from odoo.http import request
 from odoo.tools.misc import file_open
 
 
@@ -30,6 +31,9 @@ class TestMassMailing(models.TransientModel):
                 valid_emails.append(test_email[0])
             else:
                 invalid_candidates.append(candidate)
+
+        if request:
+            request.session['test_mailing_email_to'] = self.email_to
 
         mailing = self.mass_mailing_id
         record = self.env[mailing.mailing_model_real].search([], limit=1)

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -92,7 +92,7 @@ class TestMassMailing(models.TransientModel):
         mails_sudo.unlink()
 
         if notification_messages:
-            self.mass_mailing_id._message_log(body=Markup('<ul>%s</ul>') % ''.join(
+            self.mass_mailing_id._message_log(body=Markup('<ul>%s</ul>') % Markup('').join(
                 [Markup('<li>%s</li>') % notification_message for notification_message in notification_messages]
             ))
 

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -97,7 +97,7 @@ class TestMailingTest(TestMassMailCommon):
         expected_body = 'Hello {{ object.name }}' + f' {expected_test_record.name}'
 
         self.assertSentEmail(self.env.user.partner_id, ['test@test.com'],
-            subject=expected_subject,
+            subject='[TEST] ' + expected_subject,
             body_content=expected_body)
 
         with self.mock_mail_gateway():


### PR DESCRIPTION
When sending a test for a mass mailing

Before this commit:
- subject is the same as for a non-test
- default email adress is the current user's
- logged chatter messages are incorrectly marked up

After this commit:
- subject is prepended with '[TEST]'
- default email adress is the one used for a previous test if there is one, otherwise the current user's
- markup is fixed

Task-3378043