### PR TITLE
[IMP] pos_restaurant: back button temp screen

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/components/navbar/back_button/back_button.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/back_button/back_button.js
@@ -18,6 +18,10 @@ patch(BackButton.prototype, {
      * the logic of the back button changes a bit.
      */
     async backToFloorScreen() {
+        if(this.pos.tempScreen) {
+            this.pos.closeTempScreen();
+            return;
+        }
         if (this.pos.mainScreen.component && this.pos.config.module_pos_restaurant) {
             if (
                 (this.pos.mainScreen.component === ProductScreen &&


### PR DESCRIPTION
There are some cases where we can press the back button with a temporary screen is opened. When doing this, there could have some issues.
Now, when we press the back button, instead of rendering the previous screen, we close the temporary screen.
Thus, if you want to see the previous screen, you have to press it twice.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
