### PR TITLE
[FIX] web: tooltip of hidden elements is not cleared

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip_service.js
+++ b/addons/web/static/src/core/tooltip/tooltip_service.js
@@ -77,6 +77,9 @@ export const tooltipService = {
             if (hasTouch()) {
                 return !touchPressed;
             }
+            if (window.getComputedStyle(target).visibility === "hidden") {
+                return true; // target is no longer visible
+            }
             return false;
         }
 


### PR DESCRIPTION
Reproduction:
1. Install Note, make sure you are not in developer mode
2. Create a new note and write a random message
3. Hover on the save button and click it after the tooltip shows up
4. The tooltip is not cleared until click somewhere else

Fix: add another condition that cleans the tooltip when the element is hidden in the window

task-3453514


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
