### PR TITLE
[IMP] core: delay translation

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -645,10 +645,10 @@ class AccountAccount(models.Model):
         super().copy_translations(new, excluded=tuple(excluded)+('name',))
         if new.name == _('%s (copy)', self.name):
             name_field = self._fields['name']
-            self.env.cache.update_raw(new, name_field, [{
+            name_field.set_cache(new, {
                 lang: _('%s (copy)', tr)
                 for lang, tr in name_field._get_stored_translations(self).items()
-            }], dirty=True)
+            }, dirty=True)
 
     @api.model
     def load(self, fields, data):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -706,7 +706,7 @@ class AccountMove(models.Model):
         journal = None
         # the currency is not a hard dependence, it triggers via manual add_to_compute
         # avoid computing the currency before all it's dependences are set (like the journal...)
-        if self.env.cache.contains(self, self._fields['currency_id']):
+        if len(self) == 1 and 'currency_id' in self._cache:
             currency_id = self.currency_id.id or self._context.get('default_currency_id')
             if currency_id and currency_id != company.currency_id.id:
                 currency_domain = domain + [('currency_id', '=', currency_id)]

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -443,8 +443,8 @@ class AccountMoveLine(models.Model):
     def _compute_display_type(self):
         for line in self.filtered(lambda l: not l.display_type):
             # avoid cyclic dependencies with _compute_account_id
-            account_set = self.env.cache.contains(line, line._fields['account_id'])
-            tax_set = self.env.cache.contains(line, line._fields['tax_line_id'])
+            account_set = 'account_id' in line._cache
+            tax_set = 'tax_line_id' in line._cache
             line.display_type = (
                 'tax' if tax_set and line.tax_line_id else
                 'payment_term' if account_set and line.account_id.account_type in ['asset_receivable', 'liability_payable'] else
@@ -1322,8 +1322,7 @@ class AccountMoveLine(models.Model):
         # Invalidate cache of related moves
         if fnames is None or 'move_id' in fnames:
             field = self._fields['move_id']
-            lines = self.env.cache.get_records(self, field)
-            move_ids = {id_ for id_ in self.env.cache.get_values(lines, field) if id_}
+            move_ids = {id_ for id_ in field._cache(self.env).values() if id_}
             if move_ids:
                 self.env['account.move'].browse(move_ids).invalidate_recordset()
         return super().invalidate_model(fnames, flush)
@@ -1331,8 +1330,7 @@ class AccountMoveLine(models.Model):
     def invalidate_recordset(self, fnames=None, flush=True):
         # Invalidate cache of related moves
         if fnames is None or 'move_id' in fnames:
-            field = self._fields['move_id']
-            move_ids = {id_ for id_ in self.env.cache.get_values(self, field) if id_}
+            move_ids = {id_ for record in self if (id_ := record._cache.get('move_id'))}
             if move_ids:
                 self.env['account.move'].browse(move_ids).invalidate_recordset()
         return super().invalidate_recordset(fnames, flush)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1322,7 +1322,7 @@ class AccountMoveLine(models.Model):
         # Invalidate cache of related moves
         if fnames is None or 'move_id' in fnames:
             field = self._fields['move_id']
-            move_ids = {id_ for id_ in field._cache(self.env).values() if id_}
+            move_ids = {id_ for id_ in field.get_cache_mapping(self.env).values() if id_}
             if move_ids:
                 self.env['account.move'].browse(move_ids).invalidate_recordset()
         return super().invalidate_model(fnames, flush)

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -88,7 +88,7 @@ class AccountChartTemplate(models.AbstractModel):
         # We assume that the field is always computed for all the modules at once (by this function)
         field = self.env['ir.module.module']._fields['account_templates']
         modules = (
-            self.env['ir.module.module'].browse(field._cache(self.env))
+            self.env['ir.module.module'].browse(field.get_cache_mapping(self.env))
             or self.env['ir.module.module'].search([])
         )
 

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -88,7 +88,7 @@ class AccountChartTemplate(models.AbstractModel):
         # We assume that the field is always computed for all the modules at once (by this function)
         field = self.env['ir.module.module']._fields['account_templates']
         modules = (
-            self.env.cache.get_records(self.env['ir.module.module'], field)
+            self.env['ir.module.module'].browse(field._cache(self.env))
             or self.env['ir.module.module'].search([])
         )
 

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -793,7 +793,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
     def _get_cache_count(self, model_name='account.move', field_name='name'):
         model = self.env[model_name]
         field = model._fields[field_name]
-        return len(self.env.cache.get_records(model, field))
+        return len(field._cache(self.env))
 
     def test_cache_invalidation(self):
         self.env.invalidate_all()

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -793,7 +793,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
     def _get_cache_count(self, model_name='account.move', field_name='name'):
         model = self.env[model_name]
         field = model._fields[field_name]
-        return len(field._cache(self.env))
+        return len(field.get_cache_mapping(self.env))
 
     def test_cache_invalidation(self):
         self.env.invalidate_all()

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -605,7 +605,7 @@ class Meeting(models.Model):
             replacement = field.convert_to_cache(
                 _('Busy') if field.name == 'name' else False,
                 others_private_events)
-            self.env.cache.update(others_private_events, field, repeat(replacement))
+            field.update_cache(others_private_events, repeat(replacement))
 
         return events
 

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -252,10 +252,14 @@ class HrEmployeePrivate(models.Model):
         # copy them to the cache of self; non-public data will be missing from
         # cache, and interpreted as an access error
         for fname in field_names:
-            values = self.env.cache.get_values(public, public._fields[fname])
-            if self._fields[fname].translate:
+            field = self._fields[fname]
+            public_field = public._fields[fname]
+            # no cache miss should be promised
+            values = self.env.cache.get_values(public_field, public.env.cache_key(public_field), public._ids)
+            if field.translate:
                 values = [(value.copy() if value else None) for value in values]
-            self.env.cache.update_raw(self, self._fields[fname], values)
+            # TODO: check Property and x2many fields deepcopy?
+            field.update_cache(self, values)
 
     @api.model
     def _cron_check_work_permit_validity(self):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -254,11 +254,9 @@ class HrEmployeePrivate(models.Model):
         for fname in field_names:
             field = self._fields[fname]
             public_field = public._fields[fname]
-            # no cache miss should be promised
-            values = self.env.cache.get_values(public_field, public.env.cache_key(public_field), public._ids)
+            values = public_field.get_cache_values(public)
             if field.translate:
                 values = [(value.copy() if value else None) for value in values]
-            # TODO: check Property and x2many fields deepcopy?
             field.update_cache(self, values)
 
     @api.model

--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -76,7 +76,7 @@ class LeaveReportCalendar(models.Model):
     def _fetch_query(self, query, fields):
         records = super()._fetch_query(query, fields)
         if self.env.context.get('hide_employee_name') and 'employee_id' in self.env.context.get('group_by', []):
-            self.env.cache.update(records, self._fields['name'], [
+            self._fields['name'].update_cache(records, [
                 record.name.split(':')[-1].strip()
                 for record in records.with_user(SUPERUSER_ID)
             ])

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -163,7 +163,7 @@ class IapAccount(models.Model):
                 # as self's cursor cannot see this account
                 account_token = account.account_token
             account = self.browse(account.id)
-            self.env.cache.set(account, IapAccount._fields['account_token'], account_token)
+            IapAccount._fields['account_token'].set_cache(account, account_token)
             return account
         accounts_with_company = accounts.filtered(lambda acc: acc.company_ids)
         if accounts_with_company:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1417,10 +1417,11 @@ class SaleOrder(models.Model):
 
     def _track_finalize(self):
         """ Override of `mail` to prevent logging changes when the SO is in a draft state. """
+        state_field = self._fields['state']
         if (len(self) == 1
             # The method _track_finalize is sometimes called too early or too late and it
             # might cause a desynchronization with the cache, thus this condition is needed.
-            and self.env.cache.contains(self, self._fields['state']) and self.state == 'draft'):
+            and 'state' in self._cache and self.state == 'draft'):
             self.env.cr.precommit.data.pop(f'mail.tracking.{self._name}', {})
             self.env.flush_all()
             return

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1417,7 +1417,6 @@ class SaleOrder(models.Model):
 
     def _track_finalize(self):
         """ Override of `mail` to prevent logging changes when the SO is in a draft state. """
-        state_field = self._fields['state']
         if (len(self) == 1
             # The method _track_finalize is sometimes called too early or too late and it
             # might cause a desynchronization with the cache, thus this condition is needed.

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -964,7 +964,7 @@ class Base(models.AbstractModel):
                         field.convert_to_cache(line[field_name], new_line, validate=False)
                         for new_line, line in zip(new_lines, lines)
                     ]
-                    cache.update(new_lines, field, line_values)
+                    field.update_cache(new_lines, line_values)
 
         # Isolate changed values, to handle inconsistent data sent from the
         # client side: when a form view contains two one2many fields that

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2678,7 +2678,10 @@ export class Wysiwyg extends Component {
             escapedHtml,
             !$el.data('oe-expression') && $el.data('oe-xpath') || null
         ], {
-            context,
+            context: {
+                ...context,
+                delay_translations: true,
+            },
         });
         return result;
     }

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -534,7 +534,7 @@ class IrModuleModule(models.Model):
             for lang in langs_update:
                 specific_arch_db[lang] = field.translate(
                     lambda term: specific_translation_dictionary.get(term, {lang: None})[lang], specific_arch_db_en)
-            field.update_cache(View.browse(specific_id), [specific_arch_db], dirty=True)
+            field.set_cache(View.browse(specific_id), specific_arch_db, dirty=True)
 
         default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
         if not default_menu:

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -199,21 +199,26 @@ class IrModuleModule(models.Model):
             if dst_mname != new_rec._name:
                 continue
             old_field = old_rec._fields[src_fname]
-            old_translations = {
-                lang: value
-                for lang, value in old_field._get_stored_translations(old_rec).items()
-                if lang in valid_langs
-            }
-            if not old_translations:
+            old_stored_translations = old_field._get_stored_translations(old_rec)
+            if not old_stored_translations:
                 continue
-            if not callable(old_field.translate):
-                if old_rec[src_fname] == new_rec[dst_fname]:
-                    new_rec.update_field_translations(dst_fname, old_translations)
+            if old_field.translate is True:
+                if old_rec[src_fname] != new_rec[dst_fname]:
+                    continue
+                new_rec.update_field_translations(dst_fname, {
+                    k: v for k, v in old_stored_translations.items() if k in valid_langs and k != cur_lang
+                })
             else:
-                old_translation_lang = old_translations.get(cur_lang) or old_translations.get('en_US')
+                old_translations = {
+                    k: old_stored_translations.get(f'_{k}', v)
+                    for k, v in old_stored_translations.items()
+                    if k in valid_langs
+                }
                 # {from_lang_term: {lang: to_lang_term}
-                translation_dictionary = old_field.get_translation_dictionary(old_translation_lang, {
-                    lang: value for lang, value in old_translations.items() if lang != cur_lang})
+                translation_dictionary = old_field.get_translation_dictionary(
+                    old_translations.pop(cur_lang, old_translations['en_US']),
+                    old_translations
+                )
                 # {lang: {old_term: new_term}
                 translations = defaultdict(dict)
                 for from_lang_term, to_lang_terms in translation_dictionary.items():

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -529,7 +529,7 @@ class IrModuleModule(models.Model):
             for lang in langs_update:
                 specific_arch_db[lang] = field.translate(
                     lambda term: specific_translation_dictionary.get(term, {lang: None})[lang], specific_arch_db_en)
-            cache.update_raw(View.browse(specific_id), field, [specific_arch_db], dirty=True)
+            field.update_cache(View.browse(specific_id), [specific_arch_db], dirty=True)
 
         default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
         if not default_menu:

--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -120,7 +120,10 @@ class Property(models.Model):
             values.get('res_id') is False and any(record.res_id for record in self)
         ) or any(
             # changing a fallback value
-            not record.res_id and any(record[fname] != self._fields[fname].convert_to_record(value, self) for fname, value in values.items())
+            not record.res_id and any(
+                record[fname] != self._fields[fname].convert_to_record(self._fields[fname].convert_to_cache(value, self), self)
+                for fname, value in values.items()
+            )
             for record in self
         )
         r = super().write(values)

--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -121,8 +121,9 @@ class Property(models.Model):
         ) or any(
             # changing a fallback value
             not record.res_id and any(
-                record[fname] != self._fields[fname].convert_to_record(self._fields[fname].convert_to_cache(value, self), self)
+                record[fname] != field.convert_to_record(field.convert_to_cache(value, self), self)
                 for fname, value in values.items()
+                if (field := self._fields[fname])
             )
             for record in self
         )

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -214,7 +214,7 @@ actual arch.
     model_id = fields.Many2one("ir.model", string="Model of the view", compute='_compute_model_id', inverse='_inverse_compute_model_id')
 
     @api.depends('arch_db', 'arch_fs', 'arch_updated')
-    @api.depends_context('read_arch_from_file', 'lang', 'edit_translations')
+    @api.depends_context('read_arch_from_file', 'lang', 'edit_translations', 'check_translations')
     def _compute_arch(self):
         def resolve_external_ids(arch_fs, view_xml_id):
             def replacer(m):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -628,8 +628,8 @@ actual arch.
         views = self.browse(row[0] for row in rows)
 
         # optimization: fill in cache of inherit_id and mode
-        self.env.cache.update(views, type(self).inherit_id, [row[1] for row in rows])
-        self.env.cache.update(views, type(self).mode, [row[2] for row in rows])
+        type(self).inherit_id.update_cache(views, [row[1] for row in rows])
+        type(self).mode.update_cache(views, [row[2] for row in rows])
 
         # During an upgrade, we can only use the views that have been
         # fully upgraded already.

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -488,7 +488,7 @@ class Users(models.Model):
             if self.check_access_rights('write', raise_exception=False):
                 return records
             for fname in USER_PRIVATE_FIELDS:
-                self.env.cache.update(records, self._fields[fname], repeat('********'))
+                self._fields[fname].update_cache(records, repeat('********'))
         return records
 
     @api.constrains('company_id', 'company_ids', 'active')

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -47,7 +47,7 @@ class BaseCommon(TransactionCase):
         # Enforce constant currency
         currency = cls._enable_currency(currency_code)
         if not cls.env.company.currency_id == currency:
-            cls.env.transaction.cache.set(cls.env.company, type(cls.env.company).currency_id, currency.id, dirty=True)
+            type(cls.env.company).currency_id.set_cache(cls.env.company, currency.id, dirty=True)
             # this is equivalent to cls.env.company.currency_id = currency but without triggering buisness code checks.
             # The value is added in cache, and the cache value is set as dirty so that that
             # the value will be written to the database on next flush.

--- a/odoo/addons/base/tests/test_cache.py
+++ b/odoo/addons/base/tests/test_cache.py
@@ -24,7 +24,7 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         def check1(record, field, value):
             # value is None means no value in cache
             context_key = record.env.cache_key(field)
-            self.assertEqual(cache.contains(field, context_key, record._ids), value is not None)
+            self.assertEqual(cache.contains(field, context_key, record.id), value is not None)
             cache_value = cache.get(field, context_key, record._ids[0])
             if cache_value is not NOTHING:
                 self.assertEqual(cache_value, value)

--- a/odoo/addons/base/tests/test_cache.py
+++ b/odoo/addons/base/tests/test_cache.py
@@ -24,7 +24,7 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         def check1(record, field, value):
             # value is None means no value in cache
             context_key = record.env.cache_key(field)
-            self.assertEqual(cache.contains(field, context_key, record.id), value is not None)
+            self.assertEqual(cache.contains(field, context_key, record._ids), value is not None)
             cache_value = cache.get(field, context_key, record._ids[0])
             if cache_value is not NOTHING:
                 self.assertEqual(cache_value, value)

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1280,8 +1280,8 @@ class TestQueries(TransactionCase):
         with self.assertQueries(['''
             SELECT "res_partner_title"."id"
             FROM "res_partner_title"
-            WHERE (COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>'en_US') like %s)
-            ORDER BY COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>'en_US')
+            WHERE (COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s) like %s)
+            ORDER BY COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>%s)
         ''']):
             Model.search([('name', 'like', 'foo')])
 
@@ -1325,10 +1325,10 @@ class TestQueries(TransactionCase):
         self.assertEqual(Model._rec_names_search, ['name', 'model'])
 
         with self.assertQueries(['''
-            SELECT "ir_model"."id", "ir_model"."name"->>'en_US'
+            SELECT "ir_model"."id", "ir_model"."name"->>%s
             FROM "ir_model"
             WHERE (
-                ("ir_model"."name"->>'en_US' ILIKE %s)
+                ("ir_model"."name"->>%s ILIKE %s)
                 OR ("ir_model"."model"::text ILIKE %s)
             )
             ORDER BY "ir_model"."model"
@@ -1337,10 +1337,10 @@ class TestQueries(TransactionCase):
             Model.name_search('foo')
 
         with self.assertQueries(['''
-            SELECT "ir_model"."id", "ir_model"."name"->>'en_US'
+            SELECT "ir_model"."id", "ir_model"."name"->>%s
             FROM "ir_model"
             WHERE (
-                ("ir_model"."name" is NULL OR "ir_model"."name"->>'en_US' not ilike %s)
+                ("ir_model"."name" is NULL OR "ir_model"."name"->>%s not ilike %s)
                 AND (("ir_model"."model"::text NOT ILIKE %s) OR "ir_model"."model" IS NULL)
             )
             ORDER BY "ir_model"."model"

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -522,6 +522,16 @@ class TestTranslation(TransactionCase):
             self.assertEqual(category_en.name, 'Customers')
             self.assertEqual(category_zh.name, 'Customers')
 
+        categories = category_en + category_en.copy() + category_en.copy()
+        categories.invalidate_recordset()
+
+        with self.assertQueryCount(1):
+            for category in categories:
+                self.assertDictEqual(
+                    category._fields['name']._get_stored_translations(category),
+                    {'en_US': 'Customers', 'nl_NL': 'Klanten', 'fr_FR': 'Clients'}
+                )
+
 
     # TODO Currently, the unique constraint doesn't work for translatable field
     # def test_111_unique_en(self):

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -1754,32 +1754,32 @@ class RelatedTranslation2(models.Model):
     _name = 'test_new_api.related_translation_2'
     _description = 'A model to test translation for related fields'
 
-    parent_id = fields.Many2one('test_new_api.related_translation_1', string='Parent Model')
-    name = fields.Char('Name Related', related='parent_id.name', readonly=False)
-    html = fields.Html('HTML Related', related='parent_id.html', readonly=False)
+    related_id = fields.Many2one('test_new_api.related_translation_1', string='Parent Model')
+    name = fields.Char('Name Related', related='related_id.name', readonly=False)
+    html = fields.Html('HTML Related', related='related_id.html', readonly=False)
     computed_name = fields.Char('Name Computed', compute='_compute_name')
     computed_html = fields.Char('HTML Computed', compute='_compute_html')
 
     @api.depends_context('lang')
-    @api.depends('parent_id.name')
+    @api.depends('related_id.name')
     def _compute_name(self):
         for record in self:
-            record.computed_name = record.parent_id.name
+            record.computed_name = record.related_id.name
 
     @api.depends_context('lang')
-    @api.depends('parent_id.html')
+    @api.depends('related_id.html')
     def _compute_html(self):
         for record in self:
-            record.computed_html = record.parent_id.html
+            record.computed_html = record.related_id.html
 
 
 class RelatedTranslation3(models.Model):
     _name = 'test_new_api.related_translation_3'
     _description = 'A model to test translation for related fields'
 
-    parent_id = fields.Many2one('test_new_api.related_translation_2', string='Parent Model')
-    name = fields.Char('Name Related', related='parent_id.name', readonly=False)
-    html = fields.Html('HTML Related', related='parent_id.html', readonly=False)
+    related_id = fields.Many2one('test_new_api.related_translation_2', string='Parent Model')
+    name = fields.Char('Name Related', related='related_id.name', readonly=False)
+    html = fields.Html('HTML Related', related='related_id.html', readonly=False)
 
 
 class IndexedTranslation(models.Model):

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -46,19 +46,19 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE (jsonb_path_query_array("test_new_api_indexed_translation"."name", '$.*')::text ILIKE %s
-            AND "test_new_api_indexed_translation"."name"->>'en_US' ILIKE %s)
+            AND "test_new_api_indexed_translation"."name"->>%s ILIKE %s)
             ORDER BY "test_new_api_indexed_translation"."id"
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE (jsonb_path_query_array("test_new_api_indexed_translation"."name", '$.*')::text ILIKE %s
-            AND COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>'en_US') ILIKE %s)
+            AND COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>%s) ILIKE %s)
             ORDER BY "test_new_api_indexed_translation"."id"
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
             WHERE ("test_new_api_indexed_translation"."name" IS NULL
-            OR COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>'en_US') ILIKE %s)
+            OR COALESCE("test_new_api_indexed_translation"."name"->>%s, "test_new_api_indexed_translation"."name"->>%s) ILIKE %s)
             ORDER BY "test_new_api_indexed_translation"."id"
         """]):
             record_en.search([('name', 'ilike', 'foo')])

--- a/odoo/addons/test_new_api/tests/test_json_field.py
+++ b/odoo/addons/test_new_api/tests/test_json_field.py
@@ -17,7 +17,12 @@ class JsonFieldTest(TransactionCase):
         self.assertEqual(self.discussion_1.history, {'delete_messages': []})
 
         # Check that it is not the value of the cache return by convert_to_record
-        self.assertIsNot(self.discussion_1.history, self.env.cache.get(self.discussion_1, type(self.discussion_1).history))
+        history_field = type(self.discussion_1).history
+        self.assertIsNot(self.discussion_1.history, self.env.cache.get(
+            history_field,
+            self.discussion_1.env.cache_key(history_field),
+            self.discussion_1._ids[0]
+        ))
 
         self.assertEqual(self.discussion_1.history, {'delete_messages': []})
 

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -2805,9 +2805,9 @@ class TestFields(TransactionCaseWithUserDemo):
 
         with self.assertQueries(["""
             SELECT "test_new_api_prefetch"."id",
-                   "test_new_api_prefetch"."name"->>'en_US',
-                   "test_new_api_prefetch"."description"->>'en_US',
-                   "test_new_api_prefetch"."html_description"->>'en_US',
+                   "test_new_api_prefetch"."name"->>%s,
+                   "test_new_api_prefetch"."description"->>%s,
+                   "test_new_api_prefetch"."html_description"->>%s,
                    "test_new_api_prefetch"."create_uid",
                    "test_new_api_prefetch"."create_date",
                    "test_new_api_prefetch"."write_uid",

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -3561,7 +3561,7 @@ class TestMany2oneReference(common.TransactionCase):
         reference.res_model = record._name
 
         # the model field 'res_model' is not in database yet
-        self.assertTrue(self.env.cache.has_dirty_fields(reference, [type(reference).res_model]))
+        self.assertTrue(reference._has_dirty_fields([type(reference).res_model]))
 
         # searching on the one2many should flush the field 'res_model'
         records = record.search([('model_ids.create_date', '!=', False)])

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -1442,7 +1442,8 @@ class PropertiesCase(TestPropertiesMixin):
         self.assertEqual(message.attributes, {'state': 'draft'})
 
         # check cached value
-        cached_value = self.env.cache.get(message, message._fields['attributes'])
+        attibutes_field = message._fields['attributes']
+        cached_value = self.env.cache.get(attibutes_field, message.env.cache_key(attibutes_field), message._ids[0])
         self.assertEqual(cached_value, {'state': 'draft'})
 
         # change the definition record, change the definition and add default values

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -278,7 +278,7 @@ class PropertiesCase(TestPropertiesMixin):
                        "test_new_api_message"."author",
                        "test_new_api_message"."name",
                        "test_new_api_message"."important",
-                       "test_new_api_message"."label"->>'en_US',
+                       "test_new_api_message"."label"->>%s,
                        "test_new_api_message"."priority",
                        "test_new_api_message"."active",
                        "test_new_api_message"."create_uid",

--- a/odoo/addons/test_new_api/tests/test_related_translation.py
+++ b/odoo/addons/test_new_api/tests/test_related_translation.py
@@ -139,6 +139,31 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
             translation_importer.save(overwrite=True)
         self.assertEqual(self.test2.with_context(lang='fr_FR').name, 'Nouveau couteau')
 
+    def test_write_from_ori_term(self):
+        self.test1.with_context(lang='fr_FR').html = '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+    def test_delay_write_from_ori_term(self):
+        self.test1.with_context(lang='fr_FR', delay_translations=True).html = '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+        self.assertEqual(self.test1.with_context(lang='en_US', check_translations=True).html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR', check_translations=True).html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US', check_translations=True).html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR', check_translations=True).html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test3.with_context(lang='en_US', check_translations=True).html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test3.with_context(lang='fr_FR', check_translations=True).html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
     def test_translate_from_ori_term(self):
         self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
         self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Couteau</p><p>Fourchette</p><p>Cuiller</p>')
@@ -157,6 +182,31 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         self.assertEqual(self.test2.with_context(lang='fr_FR').computed_html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
         self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
         self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+    def test_write_from_related_term(self):
+        self.test3.with_context(lang='fr_FR').html = '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+    def test_delay_write_from_related_term(self):
+        self.test3.with_context(lang='fr_FR', delay_translations=True).html = '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>'
+        self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+
+        self.assertEqual(self.test1.with_context(lang='en_US', check_translations=True).html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test1.with_context(lang='fr_FR', check_translations=True).html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test2.with_context(lang='en_US', check_translations=True).html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test2.with_context(lang='fr_FR', check_translations=True).html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
+        self.assertEqual(self.test3.with_context(lang='en_US', check_translations=True).html, '<p>Nouveau couteau</p><p>Fork</p><p>Spoon</p>')
+        self.assertEqual(self.test3.with_context(lang='fr_FR', check_translations=True).html, '<p>Nouveau couteau</p><p>Fourchette</p><p>Cuiller</p>')
 
     def test_translate_from_related_term(self):
         self.assertEqual(self.test1.with_context(lang='en_US').html, '<p>Knife</p><p>Fork</p><p>Spoon</p>')

--- a/odoo/addons/test_new_api/tests/test_related_translation.py
+++ b/odoo/addons/test_new_api/tests/test_related_translation.py
@@ -37,10 +37,10 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
             'Spoon 2': 'Cuiller 2',
         }})
         cls.test2 = cls.env['test_new_api.related_translation_2'].with_context(lang='en_US').create({
-            'parent_id': cls.test1.id,
+            'related_id': cls.test1.id,
         })
         cls.test3 = cls.env['test_new_api.related_translation_3'].with_context(lang='en_US').create({
-            'parent_id': cls.test2.id,
+            'related_id': cls.test2.id,
         })
 
     def test_read(self):
@@ -230,7 +230,7 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
     def test_translate_change_many2one(self):
         self.assertEqual(self.test2.with_context(lang='en_US').name, 'Knife')
         self.assertEqual(self.test2.with_context(lang='fr_FR').name, 'Couteau')
-        self.test2.with_context(lang='fr_FR').parent_id = self.test12
+        self.test2.with_context(lang='fr_FR').related_id = self.test12
         self.assertEqual(self.test2.with_context(lang='en_US').name, 'Knife 2')
         self.assertEqual(self.test2.with_context(lang='fr_FR').name, 'Couteau 2')
         self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Knife 2</p><p>Fork 2</p><p>Spoon 2</p>')
@@ -240,3 +240,28 @@ class TestRelatedTranslation(odoo.tests.TransactionCase):
         self.assertEqual(self.test2.with_context(lang='fr_FR').name, 'Couteau 2')
         self.assertEqual(self.test3.with_context(lang='en_US').html, '<p>Knife 2</p><p>Fork 2</p><p>Spoon 2</p>')
         self.assertEqual(self.test3.with_context(lang='fr_FR').html, '<p>Couteau 2</p><p>Fourchette 2</p><p>Cuiller 2</p>')
+
+    def test_translate_mapped(self):
+        self.assertEqual(self.test2.with_context(lang='en_US').mapped('name'), ['Knife'])
+        self.test1.with_context(lang='en_US').name = 'New knife'
+        self.assertEqual(self.test1.with_context(lang='en_US').mapped('name'), ['New knife'])
+        self.assertEqual(self.test1.with_context(lang='fr_FR').mapped('name'), ['Couteau'])
+        self.assertEqual(self.test2.with_context(lang='en_US').mapped('name'), ['New knife'])
+        self.assertEqual(self.test2.with_context(lang='en_US').mapped('related_id.name'), ['New knife'])
+        self.assertEqual(self.test2.with_context(lang='fr_FR').mapped('name'), ['Couteau'])
+        self.assertEqual(self.test2.with_context(lang='fr_FR').mapped('related_id.name'), ['Couteau'])
+        self.assertEqual(self.test3.with_context(lang='en_US').mapped('name'), ['New knife'])
+        self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('related_id.name'), ['Couteau'])
+        self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('name'), ['Couteau'])
+        self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('related_id.name'), ['Couteau'])
+        self.test1.with_context(lang='fr_FR').name = 'Nouveau couteau'
+        self.assertEqual(self.test1.with_context(lang='en_US').mapped('name'), ['New knife'])
+        self.assertEqual(self.test1.with_context(lang='fr_FR').mapped('name'), ['Nouveau couteau'])
+        self.assertEqual(self.test2.with_context(lang='en_US').mapped('name'), ['New knife'])
+        self.assertEqual(self.test2.with_context(lang='en_US').mapped('related_id.name'), ['New knife'])
+        self.assertEqual(self.test2.with_context(lang='fr_FR').mapped('name'), ['Nouveau couteau'])
+        self.assertEqual(self.test2.with_context(lang='fr_FR').mapped('related_id.name'), ['Nouveau couteau'])
+        self.assertEqual(self.test3.with_context(lang='en_US').mapped('name'), ['New knife'])
+        self.assertEqual(self.test3.with_context(lang='en_US').mapped('related_id.name'), ['New knife'])
+        self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('name'), ['Nouveau couteau'])
+        self.assertEqual(self.test3.with_context(lang='fr_FR').mapped('related_id.name'), ['Nouveau couteau'])

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -16,6 +16,7 @@ __all__ = [
 
 import logging
 import warnings
+import operator
 from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -28,7 +29,7 @@ try:
 except ImportError:
     from decorator import decorator
 
-from .exceptions import AccessError, CacheMiss
+from .exceptions import AccessError
 from .tools import frozendict, lazy_property, OrderedSet, Query, SQL, StackMap
 from .tools.translate import _
 
@@ -820,7 +821,7 @@ class Environment(Mapping):
                     else:
                         return val
 
-            result = tuple(get(key) for key in self.registry.field_depends_context[field])
+            result = tuple(get(key) for key in self.registry.field_depends_context[field]) or None
             self._cache_key[field] = result
             return result
 
@@ -868,36 +869,45 @@ class Transaction:
 
 
 # sentinel value for optional parameters
-NOTHING = object()
+class CacheDefault:
+    def __bool__(self):
+        return False
+
+
+NOTHING = CacheDefault()
 EMPTY_DICT = frozendict()
 
 
-class Cache(object):
+class Cache:
     """ Implementation of the cache of records.
 
-    For most fields, the cache is simply a mapping from a record and a field to
-    a value.  In the case of context-dependent fields, the mapping also depends
-    on the environment of the given record.  For the sake of performance, the
-    cache is first partitioned by field, then by record.  This makes some
-    common ORM operations pretty fast, like determining which records have a
-    value for a given field, or invalidating a given field on all possible
-    records.
+    The cache can be treated as a three level nested dictionary with dirty flags
+    self._data: {field: {context_key: {record_id: cache_value}}}
+    self._dirty: {field: set[record_id]}
+
+    The context_key for context-dependent fields is a tuple of their context keys
+    from the environment. For non-context-independent fields, the context_key
+    is ``None``. For the sake of performance, the cache is first  partitioned by
+    field, then by context_key, then by record_id. This makes some common ORM
+    operations pretty fast, like determining which records have a value for a
+    given field, or invalidating a given field on all possible records.
 
     The cache can also mark some entries as "dirty".  Dirty entries essentially
     marks values that are different from the database.  They represent database
     updates that haven't been done yet.  Note that dirty entries only make
-    sense for stored fields.  Note also that if a field is dirty on a given
-    record, and the field is context-dependent, then all the values of the
-    record for that field are considered dirty.  For the sake of consistency,
-    the values that should be in the database must be in a context where all
-    the field's context keys are ``None``.
+    sense for stored fields.
+
+    Note that since the database doesn't have context. The cache value for
+    context_key ``None`` reflects the data in the database. When flushing stored
+    context-dependent fields, the ORM will only flush the cache value for context_key
+    ``None``.
     """
 
     def __init__(self):
-        # {field: {record_id: value}, field: {context_key: {record_id: value}}}
+        # field: {context_key: {record_id: value}}}
         self._data = defaultdict(dict)
 
-        # {field: set[id]} stores the fields and ids that are changed in the
+        # {field: set[record_id]} stores the fields and ids that are changed in the
         # cache, but not yet written in the database; their changed values are
         # in `_data`
         self._dirty = defaultdict(OrderedSet)
@@ -922,63 +932,33 @@ class Cache(object):
                 }
         return repr(data)
 
-    def _get_field_cache(self, model, field):
+    def _get_field_cache(self, field, context):
         """ Return the field cache of the given field, but not for modifying it. """
-        field_cache = self._data.get(field, EMPTY_DICT)
-        if field_cache and model.pool.field_depends_context[field]:
-            field_cache = field_cache.get(model.env.cache_key(field), EMPTY_DICT)
-        return field_cache
+        return self._data.get(field, EMPTY_DICT).get(context, EMPTY_DICT)
 
-    def _set_field_cache(self, model, field):
+    def _set_field_cache(self, field, context):
         """ Return the field cache of the given field for modifying it. """
-        field_cache = self._data[field]
-        if model.pool.field_depends_context[field]:
-            field_cache = field_cache.setdefault(model.env.cache_key(field), {})
-        return field_cache
+        return self._data[field].setdefault(context, {})
 
-    def contains(self, record, field):
+    def contains(self, field, context, id_, validator=None):
         """ Return whether ``record`` has a value for ``field``. """
-        field_cache = self._get_field_cache(record, field)
-        if field.translate:
-            cache_value = field_cache.get(record.id, EMPTY_DICT)
-            if cache_value is None:
-                return True
-            lang = record.env.lang or 'en_US'
-            context = record.env.context
-            if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
-                lang = f'_{lang}'
-            return lang in cache_value
-
-        return record.id in field_cache
+        field_cache = self._get_field_cache(field, context)
+        if id_ not in field_cache:
+            return False
+        if validator:
+            return validator(field_cache[id_])
+        return True
 
     def contains_field(self, field):
         """ Return whether ``field`` has a value for at least one record. """
-        cache = self._data.get(field)
-        if not cache:
-            return False
-        # 'cache' keys are tuples if 'field' is context-dependent, record ids otherwise
-        if isinstance(next(iter(cache)), tuple):
-            return any(value for value in cache.values())
-        return True
+        return any(self._data.get(field, EMPTY_DICT).values())
 
-    def get(self, record, field, default=NOTHING):
+    def get(self, field, context, id_):
         """ Return the value of ``field`` for ``record``. """
-        try:
-            field_cache = self._get_field_cache(record, field)
-            cache_value = field_cache[record._ids[0]]
-            if field.translate and cache_value is not None:
-                lang = record.env.lang or 'en_US'
-                context = record.env.context
-                if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
-                    lang = f'_{lang}'
-                return cache_value[lang]
-            return cache_value
-        except KeyError:
-            if default is NOTHING:
-                raise CacheMiss(record, field)
-            return default
+        field_cache = self._get_field_cache(field, context)
+        return field_cache.get(id_, NOTHING)
 
-    def set(self, record, field, value, dirty=False, check_dirty=True):
+    def set(self, field, context, id_, value, dirty=False, check_dirty=True, setter=None):
         """ Set the value of ``field`` for ``record``.
         One can normally make a clean field dirty but not the other way around.
         Updating a dirty field without ``dirty=True`` is a programming error and
@@ -989,31 +969,22 @@ class Cache(object):
         :param check_dirty: whether updating a dirty field without making it
             dirty must raise an exception
         """
-        field_cache = self._set_field_cache(record, field)
-        if field.translate and value is not None:
-            # only for model translated fields
-            lang = record.env.lang or 'en_US'
-            cache_value = field_cache.get(record._ids[0]) or {}
-            cache_value[lang] = value
-            value = cache_value
-        field_cache[record._ids[0]] = value
+        field_cache = self._set_field_cache(field, context)
+        if setter:
+            setter(field_cache, id_, value)
+        else:
+            # if condition + key lookup is faster than dict.__setitem__
+            field_cache[id_] = value
 
         if not check_dirty:
             return
         if dirty:
-            assert field.column_type and field.store and record.id
-            self._dirty[field].add(record.id)
-            if record.pool.field_depends_context[field]:
-                # put the values under conventional context key values {'context_key': None},
-                # in order to ease the retrieval of those values to flush them
-                context_none = dict.fromkeys(record.pool.field_depends_context[field])
-                record = record.with_env(record.env(context=context_none))
-                field_cache = self._set_field_cache(record, field)
-                field_cache[record._ids[0]] = value
-        elif record.id in self._dirty.get(field, ()):
-            _logger.error("cache.set() removing flag dirty on %s.%s", record, field.name, stack_info=True)
+            assert field.column_type and field.store and id_
+            self._dirty[field].add(id_)
+        elif id_ in self._dirty.get(field, ()):
+            _logger.error("cache.set() removing flag dirty on %s.%s", id_, field.name, stack_info=True)
 
-    def update(self, records, field, values, dirty=False, check_dirty=True):
+    def update(self, field, context, ids, values, dirty=False, check_dirty=True, updater=None):
         """ Set the values of ``field`` for several ``records``.
         One can normally make a clean field dirty but not the other way around.
         Updating a dirty field without ``dirty=True`` is a programming error and
@@ -1024,165 +995,74 @@ class Cache(object):
         :param check_dirty: whether updating a dirty field without making it
             dirty must raise an exception
         """
-        if field.translate:
-            # only for model translated fields
-            lang = records.env.lang or 'en_US'
-            field_cache = self._get_field_cache(records, field)
-            cache_values = []
-            for id_, value in zip(records._ids, values):
-                if value is None:
-                    cache_values.append(None)
-                else:
-                    cache_value = field_cache.get(id_) or {}
-                    cache_value[lang] = value
-                    cache_values.append(cache_value)
-            values = cache_values
+        field_cache = self._set_field_cache(field, context)
+        if updater:
+            for id_, val in zip(ids, values):
+                updater(field_cache, id_, val)
+        else:
+            field_cache.update(zip(ids, values))
 
-        self.update_raw(records, field, values, dirty, check_dirty)
-
-    def update_raw(self, records, field, values, dirty=False, check_dirty=True):
-        """ This is a variant of method :meth:`~update` without the logic for
-        translated fields.
-        """
-        field_cache = self._set_field_cache(records, field)
-        field_cache.update(zip(records._ids, values))
         if not check_dirty:
             return
         if dirty:
-            assert field.column_type and field.store and all(records._ids)
-            self._dirty[field].update(records._ids)
-            if records.pool.field_depends_context[field]:
-                # put the values under conventional context key values {'context_key': None},
-                # in order to ease the retrieval of those values to flush them
-                context_none = dict.fromkeys(records.pool.field_depends_context[field])
-                records = records.with_env(records.env(context=context_none))
-                field_cache = self._set_field_cache(records, field)
-                field_cache.update(zip(records._ids, values))
+            assert field.column_type and field.store and all(ids)
+            self._dirty[field].update(ids)
         else:
             dirty_ids = self._dirty.get(field)
-            if dirty_ids and not dirty_ids.isdisjoint(records._ids):
-                _logger.error("cache.update() removing flag dirty on %s.%s", records, field.name, stack_info=True)
+            if dirty_ids and not dirty_ids.isdisjoint(ids):
+                _logger.error("cache.update() removing flag dirty on %s.%s", str(ids), field.name, stack_info=True)
 
-    def insert_missing(self, records, field, values):
+    def insert_missing(self, field, context, ids, values, inserter=None):
         """ Set the values of ``field`` for the records in ``records`` that
         don't have a value yet.  In other words, this does not overwrite
         existing values in cache.
         """
-        field_cache = self._set_field_cache(records, field)
-        if field.translate:
-            if records.env.context.get('prefetch_langs'):
-                langs = {lang for lang, _ in records.env['res.lang'].get_installed()} | {'en_US'}
-                for id_, val in zip(records._ids, values):
-                    if val is None:
-                        field_cache.setdefault(id_, None)
-                    else:
-                        val_all_en = dict.fromkeys(langs, val['en_US'])
-                        field_cache[id_] = {**val_all_en, **val}
-            else:
-                lang = records.env.lang or 'en_US'
-                context = records.env.context
-                if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
-                    lang = f'_{lang}'
-                for id_, val in zip(records._ids, values):
-                    if val is None:
-                        field_cache.setdefault(id_, None)
-                    else:
-                        cache_value = field_cache.setdefault(id_, {})
-                        if cache_value is not None:
-                            cache_value.setdefault(lang, val)
-        else:
-            for id_, val in zip(records._ids, values):
-                field_cache.setdefault(id_, val)
+        if inserter is None:
+            inserter = dict.setdefault
+        self.update(field, context, ids, values, dirty=False, check_dirty=False, updater=inserter)
 
-    def remove(self, record, field):
+    def remove(self, field, context, id_):
         """ Remove the value of ``field`` for ``record``. """
-        assert record.id not in self._dirty.get(field, ())
-        try:
-            field_cache = self._set_field_cache(record, field)
-            del field_cache[record._ids[0]]
-        except KeyError:
-            pass
+        assert id_ not in self._dirty.get(field, ())
+        field_cache = self._set_field_cache(field, context)
+        field_cache.pop(id_, NOTHING)
 
-    def get_values(self, records, field):
+    def get_values(self, field, context, ids, getter=None, on_cache_miss=None):
         """ Return the cached values of ``field`` for ``records``. """
-        field_cache = self._get_field_cache(records, field)
-        for record_id in records._ids:
-            try:
-                yield field_cache[record_id]
-            except KeyError:
-                pass
-
-    def get_until_miss(self, records, field):
-        """ Return the cached values of ``field`` for ``records`` until a value is not found. """
-        field_cache = self._get_field_cache(records, field)
-        if field.translate:
-            lang = records.env.lang or 'en_US'
-            context = records.env.context
-            if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
-                lang = f'_{lang}'
-
-            def get_value(id_):
-                cache_value = field_cache[id_]
-                return None if cache_value is None else cache_value[lang]
+        field_cache = self._get_field_cache(field, context) if on_cache_miss is None else self._set_field_cache(field, context)
+        if getter is None:
+            getter = dict.get
+        if on_cache_miss is None:
+            for id_ in ids:
+                yield getter(field_cache, id_, NOTHING)
         else:
-            get_value = field_cache.__getitem__
+            for id_ in ids:
+                value = getter(field_cache, id_, NOTHING)
+                if value is NOTHING:
+                    yield on_cache_miss(field_cache, id_)
+                else:
+                    yield value
 
-        vals = []
-        for record_id in records._ids:
-            try:
-                vals.append(get_value(record_id))
-            except KeyError:
-                break
-        return vals
-
-    def get_records_different_from(self, records, field, value):
+    def get_ids_different_from(self, field, context, ids, value, cmp=operator.ne):
         """ Return the subset of ``records`` that has not ``value`` for ``field``. """
-        field_cache = self._get_field_cache(records, field)
-        if field.translate:
-            lang = records.env.lang or 'en_US'
+        field_cache = self._get_field_cache(field, context)
+        ids_ = []
+        for id_ in ids:
+            val = field_cache.get(id_, NOTHING)
+            if val is NOTHING or cmp(val, value):
+                ids_.append(id_)
+        return ids_
 
-            def get_value(id_):
-                cache_value = field_cache[id_]
-                return None if cache_value is None else cache_value[lang]
-        else:
-            get_value = field_cache.__getitem__
-
-        ids = []
-        for record_id in records._ids:
-            try:
-                val = get_value(record_id)
-            except KeyError:
-                ids.append(record_id)
-            else:
-                if val != value:
-                    ids.append(record_id)
-        return records.browse(ids)
-
-    def get_fields(self, record):
-        """ Return the fields with a value for ``record``. """
-        for name, field in record._fields.items():
-            if name != 'id' and record.id in self._get_field_cache(record, field):
-                yield field
-
-    def get_records(self, model, field):
-        """ Return the records of ``model`` that have a value for ``field``. """
-        field_cache = self._get_field_cache(model, field)
-        return model.browse(field_cache)
-
-    def get_missing_ids(self, records, field):
+    def get_missing_ids(self, field, context, ids, validator=None):
         """ Return the ids of ``records`` that have no value for ``field``. """
-        field_cache = self._get_field_cache(records, field)
-        if field.translate:
-            lang = records.env.lang or 'en_US'
-            context = records.env.context
-            if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
-                lang = f'_{lang}'
-            for record_id in records._ids:
-                cache_value = field_cache.get(record_id, False)
-                if cache_value is False or not (cache_value is None or lang in cache_value):
+        field_cache = self._get_field_cache(field, context)
+        if validator:
+            for record_id in ids:
+                cache_value = field_cache.get(record_id, NOTHING)
+                if cache_value is NOTHING or not validator(cache_value):
                     yield record_id
         else:
-            for record_id in records._ids:
+            for record_id in ids:
                 if record_id not in field_cache:
                     yield record_id
 
@@ -1190,11 +1070,11 @@ class Cache(object):
         """ Return the fields that have dirty records in cache. """
         return self._dirty.keys()
 
-    def get_dirty_records(self, model, field):
+    def get_dirty_ids(self, field):
         """ Return the records that for which ``field`` is dirty in cache. """
-        return model.browse(self._dirty.get(field, ()))
+        return self._dirty.get(field, ())
 
-    def has_dirty_fields(self, records, fields=None):
+    def has_dirty_fields(self, records, fields=None):  # TODO: cwg
         """ Return whether any of the given records has dirty fields.
 
         :param fields: a collection of fields or ``None``; the value ``None`` is
@@ -1242,8 +1122,7 @@ class Cache(object):
                 cache = self._data.get(field)
                 if not cache:
                     continue
-                caches = cache.values() if isinstance(next(iter(cache)), tuple) else [cache]
-                for field_cache in caches:
+                for field_cache in cache.values():
                     for id_ in ids:
                         field_cache.pop(id_, None)
 

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -944,6 +944,9 @@ class Cache(object):
             if cache_value is None:
                 return True
             lang = record.env.lang or 'en_US'
+            context = record.env.context
+            if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
+                lang = f'_{lang}'
             return lang in cache_value
 
         return record.id in field_cache
@@ -965,6 +968,9 @@ class Cache(object):
             cache_value = field_cache[record._ids[0]]
             if field.translate and cache_value is not None:
                 lang = record.env.lang or 'en_US'
+                context = record.env.context
+                if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
+                    lang = f'_{lang}'
                 return cache_value[lang]
             return cache_value
         except KeyError:
@@ -985,6 +991,7 @@ class Cache(object):
         """
         field_cache = self._set_field_cache(record, field)
         if field.translate and value is not None:
+            # only for model translated fields
             lang = record.env.lang or 'en_US'
             cache_value = field_cache.get(record._ids[0]) or {}
             cache_value[lang] = value
@@ -1018,6 +1025,7 @@ class Cache(object):
             dirty must raise an exception
         """
         if field.translate:
+            # only for model translated fields
             lang = records.env.lang or 'en_US'
             field_cache = self._get_field_cache(records, field)
             cache_values = []
@@ -1072,6 +1080,9 @@ class Cache(object):
                         field_cache[id_] = {**val_all_en, **val}
             else:
                 lang = records.env.lang or 'en_US'
+                context = records.env.context
+                if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
+                    lang = f'_{lang}'
                 for id_, val in zip(records._ids, values):
                     if val is None:
                         field_cache.setdefault(id_, None)
@@ -1106,6 +1117,9 @@ class Cache(object):
         field_cache = self._get_field_cache(records, field)
         if field.translate:
             lang = records.env.lang or 'en_US'
+            context = records.env.context
+            if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
+                lang = f'_{lang}'
 
             def get_value(id_):
                 cache_value = field_cache[id_]
@@ -1160,6 +1174,9 @@ class Cache(object):
         field_cache = self._get_field_cache(records, field)
         if field.translate:
             lang = records.env.lang or 'en_US'
+            context = records.env.context
+            if callable(field.translate) and (context.get('edit_translations') or context.get('check_translations')):
+                lang = f'_{lang}'
             for record_id in records._ids:
                 cache_value = field_cache.get(record_id, False)
                 if cache_value is False or not (cache_value is None or lang in cache_value):

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -80,7 +80,7 @@ class AccessError(UserError):
     """
 
 
-class CacheMiss(KeyError):
+class CacheMiss(KeyError):   # TODO: cwg remove
     """Missing value(s) in cache.
 
     .. admonition:: Example
@@ -88,8 +88,8 @@ class CacheMiss(KeyError):
         When you try to read a value in a flushed cache.
     """
 
-    def __init__(self, record, field):
-        super().__init__("%r.%s" % (record, field.name))
+    def __init__(self, record_id, field):
+        super().__init__("%r.%s" % (record_id, field.name))
 
 
 class MissingError(UserError):

--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -80,18 +80,6 @@ class AccessError(UserError):
     """
 
 
-class CacheMiss(KeyError):   # TODO: cwg remove
-    """Missing value(s) in cache.
-
-    .. admonition:: Example
-
-        When you try to read a value in a flushed cache.
-    """
-
-    def __init__(self, record_id, field):
-        super().__init__("%r.%s" % (record_id, field.name))
-
-
 class MissingError(UserError):
     """Missing record(s).
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1839,6 +1839,7 @@ class _String(Field):
         : return: {'en_US': 'value_en_US', 'fr_FR': 'French'}
         """
         # assert (self.translate and self.store and record)
+        record._recompute_recordset([self.name])  # for stored computed translated fields
         context_key = record.env.cache_key(self)
         cache_value = record.env.cache.get(self, context_key, record._ids[0])
         if not (cache_value is None or isinstance(cache_value, TranslatedCacheValue)):
@@ -1905,8 +1906,6 @@ class _String(Field):
             if not new_terms:
                 new_translations_list.append({'en_US': value, lang: value})
                 continue
-            # _get_stored_translations can be refactored and prefetches translations for multi records,
-            # but it is really rare to write the same non-False/None/no-term value to multi records
             stored_translations = self._get_stored_translations(record)
             if not stored_translations:
                 new_translations_list.append({'en_US': value, lang: value})

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3834,7 +3834,7 @@ class BaseModel(metaclass=MetaModel):
             field = self._fields.get(field_name)
             if not field:
                 raise ValueError(f"Invalid field {field_name!r} on model {self._name!r}")
-            if ignore_when_in_cache and not field.has_cache_miss_ids(self):
+            if ignore_when_in_cache and not any(field.get_cache_miss_ids(self)):
                 # field is already in cache: don't fetch it
                 continue
             if field.store:
@@ -4398,7 +4398,7 @@ class BaseModel(metaclass=MetaModel):
             for fields in determine_inverses.values():
                 # write again on non-stored fields that have been invalidated from cache
                 for field in fields:
-                    if not field.store and field.has_cache_miss_ids(real_recs):
+                    if not field.store and any(field.get_cache_miss_ids(real_recs)):
                         field.write(real_recs, vals[field.name])
 
                 # inverse records that are not being computed
@@ -6979,7 +6979,7 @@ class RecordCache(Mapping):
         """ Return whether `record` has a cached value for field ``name``. """
         field = self._record._fields[name]
         env = self._record.env
-        return env.cache.contains(field, env.cache_key(field), self._record._ids)
+        return env.cache.contains(field, env.cache_key(field), self._record._ids[0])
 
     def __getitem__(self, name):
         """ Return the cached value of field ``name`` for `record`. """

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2819,10 +2819,11 @@ class BaseModel(metaclass=MetaModel):
 
         elif field.translate and not self.env.context.get('prefetch_langs'):
             sql_field = SQL.identifier(alias, fname)
-            lang = self.env.lang or 'en_US'
-            if lang == 'en_US':
-                return SQL("%s->>'en_US'", sql_field)
-            return SQL("COALESCE(%s->>%s, %s->>'en_US')", sql_field, lang, sql_field)
+            langs = field.get_translation_fallback_langs(self.env)
+            sql_field_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
+            if len(sql_field_langs) == 1:
+                return sql_field_langs[0]
+            return SQL(f"COALESCE({', '.join('%s' for _ in sql_field_langs)})", *sql_field_langs)
 
         elif field.type == 'properties' and property_name:
             return self._field_properties_to_sql(alias, fname, property_name, query)
@@ -3618,13 +3619,17 @@ class BaseModel(metaclass=MetaModel):
             # assert record_fr.with_context(lang='fr_FR') == '<div>English 1</div><div>French 2<div/>'
             # assert record_nl.with_context(lang='nl_NL') == '<div>English 3</div><div>English 2<div/>'
 
-            old_translations = field._get_stored_translations(self)
-            if not old_translations:
+            stored_translations = field._get_stored_translations(self)
+            if not stored_translations:
                 return False
-            new_translations = old_translations
-            old_value_en = old_translations.get('en_US')
+            old_translations = {
+                (_k := f'_{k}'): stored_translations.get(_k, v)
+                for k, v in stored_translations.items()
+                if not k.startswith('_')
+            }
             for lang, translation in translations.items():
-                old_value = new_translations.get(lang, old_value_en)
+                _lang = '_' + lang
+                old_value = old_translations.get(_lang) or old_translations.get('_en_US')
                 if digest:
                     old_terms = field.get_trans_terms(old_value)
                     old_terms_digested2value = {digest(old_term): old_term for old_term in old_terms}
@@ -3633,8 +3638,9 @@ class BaseModel(metaclass=MetaModel):
                         for key, value in translation.items()
                         if key in old_terms_digested2value
                     }
-                new_translations[lang] = field.translate(translation.get, old_value)
-            self.env.cache.update_raw(self, field, [new_translations], dirty=True)
+                stored_translations[lang] = field.translate(translation.get, old_value)
+                stored_translations.pop(_lang, None)
+            self.env.cache.update_raw(self, field, [stored_translations], dirty=True)
 
         # the following write is incharge of
         # 1. mark field as modified
@@ -3657,16 +3663,17 @@ class BaseModel(metaclass=MetaModel):
         field = self._fields[field_name]
         # We don't forbid reading inactive/non-existing languages,
         langs = set(langs or [l[0] for l in self.env['res.lang'].get_installed()])
-        val_en = self.with_context(lang='en_US')[field_name]
+        self_lang = self.with_context(check_translations=True, prefetch_langs=True)
+        val_en = self_lang.with_context(lang='en_US')[field_name]
         if not callable(field.translate):
             translations = [{
                 'lang': lang,
                 'source': val_en,
-                'value': self.with_context(lang=lang)[field_name]
+                'value': self_lang.with_context(lang=lang)[field_name]
             } for lang in langs]
         else:
             translation_dictionary = field.get_translation_dictionary(
-                val_en, {lang: self.with_context(lang=lang)[field_name] for lang in langs}
+                val_en, {lang: self_lang.with_context(lang=lang)[field_name] for lang in langs}
             )
             translations = [{
                 'lang': lang,
@@ -5474,28 +5481,33 @@ class BaseModel(metaclass=MetaModel):
 
             elif field.translate and field.store and name not in excluded and old[name]:
                 # for translatable fields we copy their translations
-                old_translations = field._get_stored_translations(old)
-                if not old_translations:
+                old_stored_translations = field._get_stored_translations(old)
+                if not old_stored_translations:
                     continue
                 lang = self.env.lang or 'en_US'
-                old_value_lang = old_translations.pop(lang, old_translations['en_US'])
-                old_translations = {
-                    lang: value
-                    for lang, value in old_translations.items()
-                    if lang in valid_langs
-                }
-                if not old_translations:
-                    continue
                 if not callable(field.translate):
-                    new.update_field_translations(name, old_translations)
+                    new.update_field_translations(name, {
+                        k: v for k, v in old_stored_translations.items() if k in valid_langs and k != lang
+                    })
                 else:
+                    _lang = '_' + lang
+                    _value = {
+                        (_k := f'_{k}'): old_stored_translations.get(_k, v)
+                        for k, v in old_stored_translations.items()
+                        if not k.startswith('_')
+                    }
                     # {lang: {old_term: new_term}}
                     translations = defaultdict(dict)
                     # {from_lang_term: {lang: to_lang_term}
-                    translation_dictionary = field.get_translation_dictionary(old_value_lang, old_translations)
+                    translation_dictionary = field.get_translation_dictionary(
+                        _value.pop(_lang, _value['_en_US']),
+                        _value
+                    )
                     for from_lang_term, to_lang_terms in translation_dictionary.items():
-                        for lang, to_lang_term in to_lang_terms.items():
-                            translations[lang][from_lang_term] = to_lang_term
+                        for _lang, to_lang_term in to_lang_terms.items():
+                            lang = _lang[1:]
+                            if lang in valid_langs:
+                                translations[lang][from_lang_term] = to_lang_term
                     new.update_field_translations(name, translations)
 
     @api.returns('self', lambda value: value.id)

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1444,11 +1444,12 @@ class expression(object):
                     check_null = len(params) < len(right)
                     if params:
                         params = [field.convert_to_column(p, model, validate=False).adapted['en_US'] for p in params]
-                        lang = model.env.lang or 'en_US'
-                        if lang == 'en_US':
-                            sql_left = SQL("%s->>'en_US'", sql_field)
+                        langs = field.get_translation_fallback_langs(model.env)
+                        sql_left_langs = [SQL("%s->>%s", sql_field, lang) for lang in langs]
+                        if len(sql_left_langs) == 1:
+                            sql_left = sql_left_langs[0]
                         else:
-                            sql_left = SQL("COALESCE(%s->>%s, %s->>'en_US')", sql_field, lang, sql_field)
+                            sql_left = SQL(f"COALESCE({', '.join('%s' for _ in sql_left_langs)})", *sql_left_langs)
                         sql = SQL("%s %s %s", sql_left, sql_operator, tuple(params))
                     else:
                         # The case for (left, 'in', []) or (left, 'not in', []).


### PR DESCRIPTION
After writing a model terms translated field in one language, keep old translations for other languages until any user confirms those new translations from the website TRANSLATE page or the translation dialog.

DB:
Jsonb data structure of model_terms translated fields' columns
```sql
'{
	"en_US": "<div>Apple</div>"
	"fr_FR": "<div>Pomme</div><div>Banane</div>"
	"_fr_FR": "<div>Pomme</div>"
}'::jsonb
```

logic constraint
"column" IS NULL OR "column"->>'en_US' IS NOT NULL

`"column"->>'lang'`
1. stores last confirmed value
2. logically fallbacks to the following when read `lang`
```sql
    COALESCE(
        "column"->>'lang',
        "column"->>'en_US'
    )
```

`"column"->>'_lang'`
1. stores translations and the last written html/xml structure
2. shares the same html/xml structure with other "column"->>'_lang'
3. logically fallbacks to the following when read `lang` with context `check_translations`/`edit_translations`
```sql
    COALESCE(
        "column"->>'_lang',
        "column"->>'lang',
        "column"->>'_en_US',
        "column"->>'en_US'
    )
```

Data flow for column value, cache value and record value
(make sure the window is wide enough to see the graph)
contexts:
`check_translations`: used to read _lang value and get current translation mappings
`edit_translations`: used to read _lang value and wrap each term to let web client identify them

```
                             +- - - - - - - - - - - - - - - - - - - - - - - - - - - -+
                             ' Record(str):                                          '
                             '                                                       '
                             ' +---------------------------------------------------+ '               +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
                             ' | "<div><span data-oe-model='model'                 | '               {            read fr_FR             {
                             ' | data-oe-id='id' ...>French</span></div>"          | ' <------------ } context.get('edit_translations')  } <+
                             ' +---------------------------------------------------+ '               +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+  |
                             ' +---------------------------------------------------+ '               +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+  |
                             ' | "<div>French</div>"                               | '               {            read fr_FR             {  |
                             ' |                                                   | ' <------------ } context.get('check_translations') } <+
                             ' +---------------------------------------------------+ '               +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+  |
+~~~~~~~~~~~~+               ' +---------------------------------------------------+ '                                                      |
{ read fr_FR { ------------> ' | "<a>French</a>"                                   | '                                                      |
+~~~~~~~~~~~~+               ' +---------------------------------------------------+ '                                                      |
  ^                          '                                                       '                                                      |
  |                          +- - - - - - - - - - - - - - - - - - - - - - - - - - - -+                                                      |
  |                                                                                                                                         |
  |                                                                                                                                         |
  |                                                                                                                                         |
  |                          +- - - - - - - - - - - - - - - - - - - - - - - - - - - -+                                                      |
  |                          ' Cache(dict):                                          '                                                      |
  |                          '                                                       '                                                      |
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' |                                                   | ' -----------------------------------------------------+
  |                          ' | "_fr_FR": "<div>French</div>"                     | '
  |                          ' |                                                   | ' <----------------------------------------------------+
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' +---------------------------------------------------+ '               +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
  +------------------------- ' |                                                   | '               {              fetch fr_FR               {
                             ' | "fr_FR": "<a>French</a>"                          | '               }    context.get('edit_translations')    }
  +------------------------> ' |                                                   | '               {  or context.get('check_translations')  {
  |                          ' +---------------------------------------------------+ '               +~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+
+~~~~~~~~~~~~~~~~~+          '                                                       '                                                      ^
{   fetch fr_FR   {          +- - - - - - - - - - - - - - - - - - - - - - - - - - - -+                              COALESCE(               |
+~~~~~~~~~~~~~~~~~+                                                                                                     "c"->>'_fr_FR',     |
  ^                                                                                                                     "c"->>'fr_FR',      |
  | COALESCE(                                                                                                           "c"->>'_en_US',     |
  |     "c"->>'fr_FR',       +- - - - - - - - - - - - - - - - - - - - - - - - - - - -+                                  "c"->>'en_US'       |
  |     "c"->>'en_US'        ' Database(jsonb):                                      '                              )                       |
  | )                        '                                                       '                                                      |
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' | "_fr_FR": "<div>French</div>"                     | ' -----------------------------------------------------+
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' +---------------------------------------------------+ '                                                      |
  +------------------------- ' | "fr_FR": "<a>French</a>"                          | ' -----------------------------------------------------+
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' | "_en_US": "<div>English</div>"                    | ' -----------------------------------------------------+
  |                          ' +---------------------------------------------------+ '                                                      |
  |                          ' +---------------------------------------------------+ '                                                      |
  +------------------------- ' | "en_US": "<div>English1</div><div>English2</div>" | ' -----------------------------------------------------+
                             ' +---------------------------------------------------+ '
                             '                                                       '
                             +- - - - - - - - - - - - - - - - - - - - - - - - - - - -+
```


[IMP] core: refactor cache to decouple cache and ORM
1. This commit changes cache structure from a 2-or-3-layer nested dict
{field: {context_key: {id: cache_value}}} or {field: {id: cache_value}}
to a 3-layer nested dict
{field: {context_key: {id: cache_value}}}
which allows cache hack easier from outside

2. simpler cache flush logic
before: ORM needs to flush
cache[field] if field is not context dependent or
cache[field][(None, None, ...)] if field is context dependent
after: ORM only need to flush
cache[field][None]

3. Cache miss will return NOTHING instead of raising CacheMiss error.
There are many places we want to ignore those missing cache value for caches.
Returning Nothing can avoid the slow python Exception handling process

4. decouple the cache logic from the field logic. Cache knows nothing about
field customizations, and only use field as a dict key
make the cache api as generic as possible.
fields define how to use(get/set/check/...) the cache by using cache hooks
fields update cache data by calling the cache's api
models update cache data by calling fields' api

5. cache value for translated field is defined as
a. dict: which contains part of translations without fallback logics
b. TranslatedCacheValue: which contains all translations with fallback logics