### PR TITLE
[FIX] product: allow to delete product with product packaging

### DIFF
--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -17,7 +17,7 @@ class ProductPackaging(models.Model):
 
     name = fields.Char('Product Packaging', required=True)
     sequence = fields.Integer('Sequence', default=1, help="The first in the sequence is the default one.")
-    product_id = fields.Many2one('product.product', string='Product', check_company=True, required=True)
+    product_id = fields.Many2one('product.product', string='Product', check_company=True, required=True, ondelete='cascade')
     qty = fields.Float('Contained Quantity', default=1, digits='Product Unit of Measure', help="Quantity of products contained in the packaging.")
     barcode = fields.Char('Barcode', copy=False, help="Barcode used for packaging identification. Scan this packaging barcode from a transfer in the Barcode app to move all the contained units")
     product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', readonly=True)


### PR DESCRIPTION
when the user tries to delete the product with the packaging. then traceback will be generated.

Steps to reproduce:
- Install inventory.
- Open Inventory > configuration > settings.
- Enable "Product Packagings".
- Create a new Product.
- In the Inventory tab of the new product add packaging.
- Now save this product.
- Delete the product. traceback will be generated in the terminal.

Traceback-
```
ForeignKeyViolation: update or delete on table "product_product" violates foreign key constraint "product_packaging_product_id_fkey" on table "product_packaging"
DETAIL:  Key (id)=(1064) is still referenced from table "product_packaging".

  File "addons/product/models/product_product.py", line 382, in _unlink_or_archive
    self.unlink()
  File "addons/product/models/product_product.py", line 347, in unlink
    res = super(ProductProduct, unlink_products).unlink()
  File "addons/rating/models/mail_thread.py", line 22, in unlink
    result = super().unlink()
  File "addons/mail/models/mail_thread.py", line 327, in unlink
    res = super(MailThread, self).unlink()
  File "addons/mail/models/mail_activity_mixin.py", line 246, in unlink
    result = super(MailActivityMixin, self).unlink()
  File "odoo/models.py", line 3838, in unlink
    cr.execute(query, (sub_ids,))
  File "odoo/sql_db.py", line 319, in execute
    res = self._obj.execute(query, params)
```

Applying  ondelete='cascade' will allow to deleting the data from the
product_packaging table when we delete the product on product_product table.

See-
https://github.com/odoo/odoo/blob/1f5333c42d8daaf1bbb60921909e06b2cfaedf1b/addons/product/models/product_packaging.py#L20
sentry-4360853454