### PR TITLE
[IMP] project: display project color in calendar

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -741,7 +741,6 @@
                 </xpath>
                 <xpath expr="//field[@name='project_id']" position="attributes">
                     <attribute name="filters">1</attribute>
-                    <attribute name="color">color</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
In this commit, we have implemented the functionality to show the color of the project in the left side panel of the calendar and calendar entries.

