### PR TITLE
[FIX] mail: fix chatter z-index

### DIFF
--- a/addons/mail/static/src/views/form/form_compiler.js
+++ b/addons/mail/static/src/views/form/form_compiler.js
@@ -52,7 +52,7 @@ function compileChatter(node, params) {
         saveRecord: "() => __comp__.saveButtonClicked and __comp__.saveButtonClicked()",
     });
     const chatterContainerHookXml = createElement("div");
-    chatterContainerHookXml.classList.add("o-mail-Form-chatter");
+    chatterContainerHookXml.classList.add("o-mail-Form-chatter", "z-index-0");
     append(chatterContainerHookXml, chatterContainerXml);
     return chatterContainerHookXml;
 }


### PR DESCRIPTION
This PR fixes the z-index issue the chatter topbar had with the project dropdown filter.
The dropdown filter and the chatter topbar are in different stacking contexts, so their z-indexes have no influence, and it's the last one displayed that counts. In this case, in the DOM, dropdown is before chatter, so chatter takes precedence (the last is displayed on top). This was causing display issues.

task-3452373
Related to task-3326263

BEFORE 
![41397951-88db5bacbc14c4dbf4d881bafb843775](https://github.com/odoo/odoo/assets/108661430/cddbde2c-27d5-4695-b0e7-96bccb99f7e9)

AFTER
![Screenshot 2023-08-02 at 15 26 39](https://github.com/odoo/odoo/assets/108661430/9246fc29-b1ef-4b4c-9255-8803f4a768fd)

