### PR TITLE
[FIX] point_of_sale: missing classes on save button

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/save_button/save_button.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/save_button/save_button.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.SaveButton" owl="1">
-        <div class="control-button" t-on-click="onClick">
+        <div class="control-button btn btn-light rounded-0 fw-bolder" t-on-click="onClick">
             <i class="fa fa-upload" role="img" aria-label="Save" title="Save" />
             Save
         </div>


### PR DESCRIPTION
During the bootstrap refactoring we forgot to add some classes to the save button of the POS (`btn btn-light rounded-0 fw-bolder`) which are used on the other buttons of the POS.

They are now added to the save button.


Before:
![image](https://github.com/odoo/odoo/assets/63289800/51d4b087-34c1-4fc4-bbdd-162e86c64218)

After:
![image](https://github.com/odoo/odoo/assets/63289800/218cb3e5-706e-4bf3-8cd4-93625534bd00)
