### PR TITLE
[FIX] spreadsheet: Fix global filter display name

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/records_selector/records_selector.js
+++ b/addons/spreadsheet/static/src/global_filters/components/records_selector/records_selector.js
@@ -48,11 +48,11 @@ export class RecordsSelector extends Component {
     }
 
     /**
-     * @param {{ id: number; name?: string}[]} records
+     * @param {{ id: number; display_name?: string}[]} records
      */
     update(records) {
-        for (const record of records.filter((record) => record.name)) {
-            this.displayNames[record.id] = record.name;
+        for (const record of records.filter((record) => record.display_name)) {
+            this.displayNames[record.id] = record.display_name;
         }
         this.notifyChange(this.props.resIds.concat(records.map(({ id }) => id)));
     }


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This PR fixes the bug of undefined filter display name.

A few weeks ago the property names of record when updating record selector have been modified. Previously it's `name` but now it's `display_name`. This is the root cause of the bug.

### Current behavior before PR:

When exporting the global filters, the last value won't be exported correctly. 

### Desired behavior after PR is merged:

Now it's exported correctly. 

task 3453374

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
