### PR TITLE
Master knowledge macros fix batch abd

### DIFF
--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -53,7 +53,7 @@
                                </tree>
                            </field>
                        </page>
-                       <page string="Notes">
+                       <page string="Notes" name="notes">
                            <group>
                                 <label for="note" string="Note" />
                                 <br />

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -158,7 +158,7 @@
                                 </group>
                             </group>
                         </page>
-                        <page string="Note">
+                        <page string="Note" name="note">
                             <field name="description" nolabel="1" placeholder="Write here any other information related to this vehicle" />
                         </page>
                     </notebook>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -160,7 +160,7 @@
                     </group>
                 </group>
                 <notebook>
-                    <page string="Application Summary">
+                    <page string="Application Summary" name="application_summary">
                         <field name="description" placeholder="Motivations..."/>
                     </page>
                 </notebook>

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -74,11 +74,11 @@
                             <button class="btn border-0 fa fa-smile-o rounded-pill" aria-label="Emojis" t-on-click="onClickAddEmoji" t-ref="emoji-button"/>
                             <FileUploader t-if="allowUpload" multiUpload="true" onUploaded="(data) => { attachmentUploader.uploadData(data) }">
                                 <t t-set-slot="toggler">
-                                    <button t-att-disabled="!state.active" class="btn fa fa-paperclip border-0 rounded-pill" title="Attach files" aria-label="Attach files" type="button" t-on-click="onClickAddAttachment"/>
+                                    <button t-att-disabled="!state.active" class="o-mail-Composer-attachFiles btn fa fa-paperclip border-0 rounded-pill" title="Attach files" aria-label="Attach files" type="button" t-on-click="onClickAddAttachment"/>
                                 </t>
                             </FileUploader>
                         </div>
-                        <button t-if="thread and thread.type === 'chatter'" class="btn fa fa-expand mx-1 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer"/>
+                        <button t-if="thread and thread.type === 'chatter'" class="o-mail-Composer-fullComposer btn fa fa-expand mx-1 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer"/>
                     </div>
                     <t t-if="!extended" t-call="mail.Composer.sendButton"/>
                 </div>

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -135,7 +135,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles" owl="1">
-    <button class="btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <span t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -158,7 +158,7 @@
                         </field>
                         <div class="clearfix"/>
                     </page>
-                    <page string="Repair Notes">
+                    <page string="Repair Notes" name="repair_notes">
                         <field name="internal_notes" placeholder="Add internal notes."/>
                     </page>
                     <page string="Miscellaneous">


### PR DESCRIPTION
Knowledge macros rely on the `name` attribute of a notebook page to switch
between tabs in a Form notebook. That attribute is not mandatory, so some views
with a valid `html_field` did not have one. This commit add the `name` attribute
so those fields can now be manipulated by Knowledge macros.

task-3410128