### PR TITLE
[FIX] navbar with tempScreen

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.Navbar" owl="1">
         <div class="pos-topheader d-flex w-100 p-0 m-0 bg-white border-bottom">
-            <div t-if="pos.tempScreen" class="block-top-header" />
+            <div t-if="pos.tempScreen" class="block-top-header position-absolute top-0 start-0 bg-black opacity-50 w-100 h-inherit z-1000" />
             <div t-if="!ui.isSmall" class="pos-branding d-flex justify-content-start flex-grow-1 h-100 p-0 my-0 text-start">
                 <img class="pos-logo h-75 ms-3 me-auto align-self-center" t-on-click="() => debug.toggleWidget()" src="/web/static/img/logo.png" alt="Logo" />
             </div>

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -52,6 +52,14 @@ button {
     }
 }
 
+.z-1000 {
+    z-index: 1000;
+}
+
+.h-inherit {
+    height: inherit;
+}
+
 /*  ********* The Webkit Scrollbar  ********* */
 
 .pos *::-webkit-scrollbar{


### PR DESCRIPTION
With the introduction of Bootstrap in the PoS, the navbar was still accessible when showing a tempScreen as the PartnerListScreen. This is not intended as the tempScreen act "like a big popup" where the user must do the action on the tempScreen before doing anything else.

The problem here is that the Bootstrap integretion forgot to add the correct style to the div "block-top-header" which is done in this PR (background-color, width, height and position).

For example, the top of the PartnerListScreen looked like this before
![image](https://github.com/odoo/odoo/assets/118442417/1352d791-1428-4d5b-b92f-b7e7f3b3a395)

and now looks like this
![image](https://github.com/odoo/odoo/assets/118442417/83e060b7-b78c-415f-99df-fd54166cdaa2)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
