### PR TITLE
[REM] hr_timesheet: remove access rule for group_hr_timesheet_user

### DIFF
--- a/addons/hr_timesheet/security/ir.model.access.csv
+++ b/addons/hr_timesheet/security/ir.model.access.csv
@@ -3,7 +3,6 @@ access_account_analytic_line_user,analytic.account.analytic.line.timesheet.user,
 access_account_analytic_user,analytic.account.analytic.timesheet.user,analytic.model_account_analytic_account,hr_timesheet.group_hr_timesheet_user,1,1,0,0
 access_uom_uom_hr_timesheet,uom.uom.timesheet.user,uom.model_uom_uom,hr_timesheet.group_hr_timesheet_user,1,0,0,0
 access_project_project,project.project.timesheet.user,model_project_project,hr_timesheet.group_hr_timesheet_user,1,0,0,0
-access_project_task,project.task.timesheet.user,model_project_task,hr_timesheet.group_hr_timesheet_user,1,1,0,0
 access_timesheets_analysis_report_manager,timesheets.analysis.report,model_timesheets_analysis_report,hr_timesheet.group_timesheet_manager,1,0,0,0
 access_timesheets_analysis_report_user,timesheets.analysis.report,model_timesheets_analysis_report,hr_timesheet.group_hr_timesheet_user,1,0,0,0
 access_hr_employee_delete_wizard,hr.employee.delete.wizard,model_hr_employee_delete_wizard,hr.group_hr_user,1,1,1,0


### PR DESCRIPTION
Before this commit, access rule for group_hr_timesheet_user is define for read and write permission for task which allow internal user to edit task if link is provided even if user have no access.

In this commit, we have remove access rule for group_hr_timesheet_user because it is not required anymore since read access is already given to internal user which does not allow user to edit task if user have no access.

task-3354831