### PR TITLE
[IMP] point_of_sale: Prepare MX CFDI global invoice

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -149,6 +149,7 @@
                             <group string="Other Information">
                                 <field name="pos_reference"/>
                                 <field name="tracking_number"/>
+                                <field name="country_code" invisible="1"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="pricelist_id" groups="product.group_product_pricelist" readonly="state != 'draft'"/>
                             </group>


### PR DESCRIPTION
Add a common way to convert the pos.order.lines into dictionaries to compute taxes and to generate the invoice.

task: 3345475

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
