### PR TITLE
[FIX] mail: close popover on marking activity as done

### DIFF
--- a/addons/mail/static/src/core/web/activity_button.js
+++ b/addons/mail/static/src/core/web/activity_button.js
@@ -73,6 +73,7 @@ export class ActivityButton extends Component {
                 activityIds: this.props.record.data.activity_ids.currentIds,
                 onActivityChanged: () => {
                     this.props.record.load();
+                    this.popover.close();
                 },
                 resId: this.props.record.resId,
                 resModel: this.props.record.resModel,

--- a/addons/mail/static/src/views/web/activity/activity_cell.js
+++ b/addons/mail/static/src/views/web/activity/activity_cell.js
@@ -51,6 +51,7 @@ export class ActivityCell extends Component {
                 defaultActivityTypeId: this.props.activityTypeId,
                 onActivityChanged: () => {
                     this.props.reloadFunc();
+                    this.popover.close();
                 },
                 resId: this.props.resId,
                 resModel: this.props.resModel,

--- a/addons/mail/static/src/views/web/activity/activity_renderer.xml
+++ b/addons/mail/static/src/views/web/activity/activity_renderer.xml
@@ -65,9 +65,11 @@
 <t t-name="mail.ActivityViewRow" owl="1">
     <tr class="o_data_row h-100" t-attf-class="{{ activeFilter.resIds.includes(resId) ? 'o_activity_filter_' + activeFilter.progressValue.active : '' }}">
         <t t-set="record" t-value="getRecord(resId)"/>
-        <ActivityRecord archInfo="props.archInfo" record="record" openRecord="props.openRecord" />
-        <t t-foreach="activeColumns" t-as="type" t-key="type[0]">
-            <t t-call="mail.ActivityViewCell"/>
+        <t t-if="record">
+            <ActivityRecord archInfo="props.archInfo" record="record" openRecord="props.openRecord" />
+            <t t-foreach="activeColumns" t-as="type" t-key="type[0]">
+                <t t-call="mail.ActivityViewCell"/>
+            </t>
         </t>
         <td/>
     </tr>


### PR DESCRIPTION
Since [1], marking the activity as done from the activity popover was not automatically closing it.

Steps to reproduce:
- Open Contact kanban view
- Schedule an activity on a contact
- Click on activity widget on kanban card
- Edit activity and mark it as done => The activity popover was not automatically closed

Also fixes a bug where marking activity as done in activity view was crashing.

[1] https://github.com/odoo/odoo/pull/114024
