### PR TITLE
[IMP] mrp_repair: use stock output account instead of stock productio…

### DIFF
--- a/addons/mrp_repair/models/__init__.py
+++ b/addons/mrp_repair/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import repair
+from . import stock_move

--- a/addons/mrp_repair/models/stock_move.py
+++ b/addons/mrp_repair/models/stock_move.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_dest_account(self, accounts_data):
+        if self.repair_line_type == 'add' and self.repair_id.under_warranty:
+            return accounts_data['expense'].id
+        elif self.repair_line_type:
+            return accounts_data['stock_output'].id
+        return super()._get_dest_account(accounts_data)


### PR DESCRIPTION
Before this commit
==================
when processing repair orders, system using the stock production account to counteract the stock valuation account. This approach is causing inaccuracies in balance sheet.

After this commit
=================
resolves the issue of using the cost of production account for counteracting the stock valuation account in repair orders. The problem was causing inaccuracies in our accounting
resolves the issue by using stock output account for repair.

task - 2652200