### PR TITLE
[IMP] translation: remove _lt in o-spreadsheet

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/odoo_module.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/odoo_module.js
@@ -1,7 +1,7 @@
 odoo.define("@odoo/o-spreadsheet", ["@web/core/l10n/translation"], function (require) {
     "use strict";
-    const { _t } = require("@web/core/l10n/translation");
+    const { _t, translationLoaded, translatedTerms } = require("@web/core/l10n/translation");
     const spreadsheet = window.o_spreadsheet;
-    spreadsheet.setTranslationMethod(_t);
+    spreadsheet.setTranslationMethod(_t, () => translatedTerms[translationLoaded]);
     return spreadsheet;
 });


### PR DESCRIPTION
## Task Description

Following https://github.com/odoo/odoo/pull/130179, this PR aims to remove the use of _lt function, using now _t instead. To be able to take translations loading into account, a new function _loaded has been added to the setTranslationFunction method, indicating wether the translation has been loaded or not.

By default, we then have _t returning only lazy string, and once a translation has been loaded, it will return translated string directly.

## Related Task
Task: : [3446734](https://www.odoo.com/web#id=3446734&action=333&active_id=2328&model=project.task&view_type=form&cids=1&menu_id=4720)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
