### PR TITLE
[IMP] website: pass context keys from form snippet

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -45,9 +45,10 @@ const FormEditor = options.Class.extend({
                 method: 'search_read',
                 args: [
                     field.domain,
-                    ['display_name']
+                    field.name_field || ['display_name']
                 ],
             });
+            field.records.forEach(r => r.display_name = r[field.name_field]);
         }
         return field.records;
     },

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -45,7 +45,7 @@ const FormEditor = options.Class.extend({
                 method: 'search_read',
                 args: [
                     field.domain,
-                    field.name_field || ['display_name']
+                    field.name_field ? [field.name_field] : ['display_name'],
                 ],
             });
             field.records.forEach(r => r.display_name = r[field.name_field]);

--- a/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
+++ b/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
@@ -22,5 +22,6 @@ FormEditorRegistry.add('create_mailing_contact', {
         required: true,
         string: _t('Subscribe to'),
         type: 'many2many',
+        name_field: 'name',
     }],
 });


### PR DESCRIPTION
Before this commit, the form snippet in the website automatically fetched
`display_name` when fetching records.

With this commit, we allow using a `name_field` key with the
`FormEditorRegistry` so we can choose what field is used for displaying the
record's name.

When fetching the record fields, we fetch `name_field` instead of `display_name`
if it's specified and then add the `display_name` key to the final object since it's
the key used for rendering.

Task-3370751