### PR TITLE
[IMP] project: improve Last Stage Update

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1102,8 +1102,7 @@ class Task(models.Model):
                 if task.allow_task_dependencies:
                     if task.is_blocked_by_dependences() and vals['state'] not in CLOSED_STATES and vals['state'] != '04_waiting_normal':
                         task.state = '04_waiting_normal'
-                if vals['state'] in CLOSED_STATES:
-                    task.date_last_stage_update = now
+                task.date_last_stage_update = now
 
         self._task_message_auto_subscribe_notify({task: task.user_ids - old_user_ids[task] - self.env.user for task in self})
         return result

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -652,6 +652,7 @@
                     <field name="company_id" column_invisible="True"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" invisible="state in ['1_done', '1_canceled']"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
+                    <field name="date_last_stage_update" optional="hide"/>
                     <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show"/>
                 </tree>
             </field>


### PR DESCRIPTION
This PR brings two small improvements related to the "Last Stage Update" task field:

- Update the field when changing the task to any state, not just a closing state.
- Display the field in the project.task list view, just before the state.

Task-3455177