### PR TITLE
[FIX] website: ensure images wall snippet doesn't accept text input

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -120,7 +120,7 @@ options.registry.gallery = options.Class.extend({
                 this.trigger_up('snippet_edition_request', {exec: () => {
                     for (const image of images) {
                         $('<img/>', {
-                            class: $images.length > 0 ? $images[0].className : 'img img-fluid d-block ',
+                            class: $images.length > 0 ? $images[0].className : 'img img-fluid d-block o_editable_media',
                             src: image.src,
                             'data-index': ++index,
                             alt: image.alt || '',

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -3,7 +3,7 @@
 
 <template id="s_image_gallery" name="Image Gallery">
     <section class="s_image_gallery o_slideshow s_image_gallery_show_indicators s_image_gallery_indicators_rounded pt24 o_not_editable" data-vcss="001" data-columns="3" style="height: 500px; overflow: hidden;">
-        <div class="container">
+        <div class="container o_editable_media">
             <div id="slideshow_sample" class="carousel slide" data-bs-ride="carousel" data-bs-interval="0" style="margin: 0 12px;">
                 <div class="carousel-inner" style="padding: 0;">
                     <div class="carousel-item active">
@@ -42,7 +42,7 @@
 
 <template id="s_images_wall" name="Images Wall">
     <section class="s_image_gallery o_spc-small o_masonry o_not_editable pt24 pb24" data-vcss="001" data-columns="3" style="overflow: hidden;">
-        <div class="container">
+        <div class="container o_editable_media">
             <div class="row s_nb_column_fixed">
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
                     <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_03" data-index="0" data-name="Image"/>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -2,18 +2,18 @@
 <odoo>
 
 <template id="s_image_gallery" name="Image Gallery">
-    <section class="s_image_gallery o_slideshow s_image_gallery_show_indicators s_image_gallery_indicators_rounded pt24" data-vcss="001" data-columns="3" style="height: 500px; overflow: hidden;">
+    <section class="s_image_gallery o_slideshow s_image_gallery_show_indicators s_image_gallery_indicators_rounded pt24 o_not_editable" data-vcss="001" data-columns="3" style="height: 500px; overflow: hidden;">
         <div class="container">
             <div id="slideshow_sample" class="carousel slide" data-bs-ride="carousel" data-bs-interval="0" style="margin: 0 12px;">
                 <div class="carousel-inner" style="padding: 0;">
                     <div class="carousel-item active">
-                        <img class="img img-fluid d-block" src="/web/image/website.library_image_08" data-name="Image" data-index="0"/>
+                        <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_08" data-name="Image" data-index="0"/>
                     </div>
                     <div class="carousel-item">
-                        <img class="img img-fluid d-block" src="/web/image/website.library_image_03" data-name="Image" data-index="1"/>
+                        <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_03" data-name="Image" data-index="1"/>
                     </div>
                     <div class="carousel-item">
-                        <img class="img img-fluid d-block" src="/web/image/website.library_image_02" data-name="Image" data-index="2"/>
+                        <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_02" data-name="Image" data-index="2"/>
                     </div>
                 </div>
                 <ul class="carousel-indicators">
@@ -41,20 +41,20 @@
 </template>
 
 <template id="s_images_wall" name="Images Wall">
-    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24" data-vcss="001" data-columns="3" style="overflow: hidden;">
+    <section class="s_image_gallery o_spc-small o_masonry o_not_editable pt24 pb24" data-vcss="001" data-columns="3" style="overflow: hidden;">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block" src="/web/image/website.library_image_03" data-index="0" data-name="Image"/>
-                    <img class="img img-fluid d-block" src="/web/image/website.library_image_10" data-index="3" data-name="Image"/>
+                    <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_03" data-index="0" data-name="Image"/>
+                    <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_10" data-index="3" data-name="Image"/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block" src="/web/image/website.library_image_13" data-index="1" data-name="Image"/>
-                    <img class="img img-fluid d-block" src="/web/image/website.library_image_05" data-index="4" data-name="Image"/>
+                    <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_13" data-index="1" data-name="Image"/>
+                    <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_05" data-index="4" data-name="Image"/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block" src="/web/image/website.library_image_14" data-index="2" data-name="Image"/>
-                    <img class="img img-fluid d-block" src="/web/image/website.library_image_16" data-index="5" data-name="Image"/>
+                    <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_14" data-index="2" data-name="Image"/>
+                    <img class="img img-fluid d-block o_editable_media" src="/web/image/website.library_image_16" data-index="5" data-name="Image"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Steps to reproduce:
 1. Go to the website
 2. Drag Images wall snippet
 3. Click on an image
 4. Write some text => text in between images.

Before this commit, when we select an image on an images wall snippet
and try to add some text to the snippet, it gets added between the
images.

This commit added `o_not_editable` on the parent column to make sure no
text can be added in that column and `o_editable_media` to make inner
images editable.

In the `addImages` function, we currently add `o_editable_media` that
enables the adding of images via double-click. However, a significant
issue has emerged while executing a tour, particularly concerning the
`ImageGallery` Snippet. The tour encounters a failure when attempting to
add images after removing all existing ones, as the image option becomes
unavailable.

To address this issue, we have made the Image Gallery Snippet as
non-editable as well.

----
We added the `o_not_editable` class to the `s_image_gallery` section,
rendering the entire section non-editable. However, this caused an issue
as the addition of this class to the section's image parent prevented
the removal of images in a non-editable environment. To address this
complexity, we implemented a solution by checking whether the first
non-editable ancestor is within an editable parent. We then introduced
the `o_editable_media` class to the container inside the
`s_image_section` gallery. This modification successfully bypasses the
[condition](https://github.com/odoo/odoo/blob/15.0/addons/web_editor/static/src/js/editor/snippets.editor.js#L236-L238) that adds the `d-none` class to `oe_snippet_remove`.

task-3380599