### PR TITLE
[IMP] account_reports: hide line at 0

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -93,6 +93,11 @@ class AccountReport(models.Model):
         string="Unfold All",
         compute=lambda x: x._compute_report_option_filter('filter_unfold_all'), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
+    filter_hide_0_lines = fields.Selection(
+        string="Hide lines at 0",
+        selection=[('by_default', "Enabled by Default"), ('optional', "Optional"), ('never', "Never")],
+        compute=lambda x: x._compute_report_option_filter('filter_hide_0_lines', 'optional'), readonly=False, store=True, depends=['root_report_id'],
+    )
     filter_period_comparison = fields.Boolean(
         string="Period Comparison",
         compute=lambda x: x._compute_report_option_filter('filter_period_comparison', True), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],


### PR DESCRIPTION
In the enterprise PR, we allow to have a new options on reports that can hide line that are equals to zero under certain condition.

A line should be visible depending on its value and the ones of its children. For parent lines, it's visible if there is at least one child with a value different from zero or if a child is visible, indicating it's a parent line. For leaf nodes, it's visible if the value is different from zero.

This commit add the filter in the account_reports model.

task: 3359936



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
