### PR TITLE
[FIX] account: delete bank statement

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -136,7 +136,7 @@ export class AccountMoveListController extends ListController {
 
     async onDeleteSelectedRecords() {
         const selectedResIds = await this.getSelectedResIds();
-        if (!await this.account_move_service.addDeletionDialog(this, selectedResIds)) {
+        if (this.props.resModel !== "account.move" || !await this.account_move_service.addDeletionDialog(this, selectedResIds)) {
             return super.onDeleteSelectedRecords(...arguments);
         }
     }


### PR DESCRIPTION
When trying to delete a bank statement,
if there is no move with the same id,
we get an error "Record doesn't exist or
has been deleted".

The reason is we call the
account_move.check_move_sequence_chain()
method wih the id of the statement.
We avoid using account_move_service if
the model is not account_move as it make
no sense to call an account_move method
from a bank statement record.

Root cause: https://github.com/odoo/enterprise/blob/fd6586e8b098f018a54c715c53a2c12fe192bf7c/account_bank_statement_import/views/account_bank_statement_import_view.xml#L28

opw-3425826
