### PR TITLE
[FIX] point_of_sale: flow of parsing of order date

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -365,7 +365,9 @@ export class TicketScreen extends Component {
         return this._getOrderList().filter(predicate);
     }
     getDate(order) {
-        return deserializeDate(order.validation_date).toFormat("yyyy-MM-dd HH:mm a");
+        const creation_date = (luxon.DateTime.fromJSDate(order.creation_date)).toFormat("yyyy-MM-dd HH:mm:ss");
+        const date = order.validation_date ? order.validation_date : creation_date;
+        return deserializeDate(date).toFormat("yyyy-MM-dd HH:mm:ss");
     }
     getTotal(order) {
         return this.env.utils.formatCurrency(order.get_total_with_tax());

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1881,8 +1881,8 @@ export class Order extends PosModel {
     }
 
     initialize_validation_date() {
-        this.validation_date = new Date();
-        this.formatted_validation_date = formatDateTime(DateTime.fromJSDate(this.validation_date));
+        this.validation_date = luxon.DateTime.now()
+        this.formatted_validation_date = formatDateTime(this.validation_date);
     }
 
     set_tip(tip) {

--- a/addons/pos_restaurant/static/src/overrides/models/models.js
+++ b/addons/pos_restaurant/static/src/overrides/models/models.js
@@ -29,7 +29,7 @@ patch(Order.prototype, {
         super.init_from_JSON(...arguments);
         if (this.pos.config.module_pos_restaurant) {
             this.tableId = json.table_id;
-            this.validation_date = moment.utc(json.creation_date).local().toDate();
+            this.validation_date = json.creation_date;
             this.customerCount = json.customer_count;
         }
     },


### PR DESCRIPTION
Before this commit
==================
 Previously, the order date was being passed in the incorrect format:
 'Fri Aug 04 2023 18:37:27 GMT+0530 (India Standard Time)'. Our code
 requires the format 'yyyy-MM-dd HH:mm:ss'."

After this commit
=================
Implemented changes to rectify the order date format, ensuring compatibility
with 'yyyy-MM-dd HH:mm:ss'. This update includes adjustments to the processing
flow to precise handling of order dates.

task - 3451384