### PR TITLE
[FIX] l10n_gcc_invoice: Display the terms and condition in the right language on invoice

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -456,7 +456,7 @@
                 <p t-if="o.narration" name="comment">
                     <div class="row">
                         <div class="col-6 text-left">
-                            <span t-field="o.narration"/>
+                            <span t-field="o.with_context(lang=o.company_id.partner_id.lang or o.env.lang).company_id.invoice_terms"/>
                         </div>
                         <div class="col-6 text-right">
                             <span t-field="o_sec.narration"/>


### PR DESCRIPTION

### Steps
- Set the company to Saudi Arabia.
- install l10n_sa and l10n_gcc_invoice.
- add arabic language to DB.
- create a default payment terms note in Settings > Invoicing/Accounting and translate it to arabic
- create an invoice and print it

### Issue
Both the english and arabic sides of the payment terms will be in the language of the customer on the invoice.

### Reason
The ``narration`` field in ``l10n_gcc_invoice.AccountMove`` is ``translate=True`` and computed to the partner_id.lang so it will always be displayed in the customer language. As it is computed from the ``AccountMove.company_id.invoice_terms`` we can just use it.

### Versions affected
14.0+

opw-3338257
