### PR TITLE
[FIX] web_editor: deleteBackwars doesn't work for some header elements

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
@@ -164,7 +164,7 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false, 
          */
         if (
             !this.previousElementSibling &&
-            ['BLOCKQUOTE', 'H1', 'H2', 'H3', 'PRE'].includes(this.nodeName) &&
+            ['BLOCKQUOTE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'PRE'].includes(this.nodeName) &&
             !closestLi
         ) {
             const p = document.createElement('p');


### PR DESCRIPTION
**Before this commit:**

When header elements like h4,h5,h6 is made the first elemenet of a note, and 
deleteBackwards is used on them, they are not removed completely.

**After this commit:**

Header elements are removed completely completely when used deleteBackwards 
on them.

task-3456815
