### PR TITLE
[IMP] project: display `display_in_project` in task from

### DIFF
--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -283,15 +283,11 @@ class TestTimesheet(TestCommonTimesheet):
         self.assertEqual(len(task_child.timesheet_ids), 1, "The timesheet still should be linked to task_child")
         self.assertEqual(len(task_grandchild.timesheet_ids), 1, "The timesheet still should be linked to task_grandchild")
 
-        # It is forbidden to unset the project of a task with timesheet...
+        # It is forbidden to unset the project of a task with timesheet
         with self.assertRaises(UserError):
             self.task1.write({
                 'project_id': False
             })
-        # ...except if one of its ascendant has one.
-        task_child.write({
-            'project_id': False
-        })
 
     def test_recompute_amount_for_multiple_timesheets(self):
         """ Check that amount is recomputed correctly when setting unit_amount for multiple timesheets at once. """
@@ -489,7 +485,7 @@ class TestTimesheet(TestCommonTimesheet):
             {
                 'name': 'Subtask 2',
                 'project_id': self.project_customer.id,
-                'child_ids': [Command.create({'name': 'Subsubtask'})],
+                'child_ids': [Command.create({'name': 'Subsubtask', 'project_id': self.project_customer.id})],
             },
         ])
         subsubtask = subtask_2.child_ids
@@ -647,12 +643,10 @@ class TestTimesheet(TestCommonTimesheet):
             self.task1.project_id = False
 
         self.task1.parent_id = self.task2
-        self.task1.project_id = False
-
         self.task1.project_id = self.project_customer
 
         with self.assertRaises(UserError):
-            self.task1.write({'project_id': False, 'parent_id': False})
+            self.task1.project_id = False
 
     def test_percentage_of_allocated_hours(self):
         """ Test the percentage of allocated hours on a task. """

--- a/addons/project/static/src/components/project_many2one_field/project_many2one_field.js
+++ b/addons/project/static/src/components/project_many2one_field/project_many2one_field.js
@@ -8,25 +8,11 @@ export class ProjectMany2OneField extends Many2OneField {
     static template = "project.ProjectMany2OneField";
     get Many2XAutocompleteProps() {
         const props = super.Many2XAutocompleteProps;
-        const { project_id, parent_id } = this.props.record.data;
-        const isProjectIdRequired = this.props.record._isRequired("project_id");
-        if (!project_id && !parent_id && !isProjectIdRequired) {
+        const { record } = this.props;
+        if (!record.data.project_id && !record._isRequired("project_id")) {
             props.placeholder = _t("Private");
         }
         return props;
-    }
-
-    get displayName() {
-        const { project_id, display_in_project } = this.props.record.data;
-        return project_id && !display_in_project ? "" : super.displayName;
-    }
-
-    updateRecord(value) {
-        const { display_in_project } = this.props.record.data;
-        if (!display_in_project && value) {
-            this.props.record.update({ "display_in_project": true });
-        }
-        super.updateRecord(value);
     }
 }
 
@@ -35,7 +21,6 @@ export const projectMany2OneField = {
     component: ProjectMany2OneField,
     fieldDependencies: [
         ...(many2OneField.fieldDependencies || []),
-        { name: "display_in_project", type: "boolean" },
     ],
 };
 

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -73,7 +73,12 @@ export class SubtaskKanbanList extends Component {
     }
 
     async _onSubtaskCreateNameChanged(name) {
-        await this.orm.create("project.task", [{ display_name: name, parent_id: this.props.record.resId, user_ids: this.props.record.data.user_ids.resIds }]);
+        await this.orm.create("project.task", [{
+            display_name: name,
+            parent_id: this.props.record.resId,
+            project_id: this.props.record.data.project_id[0],
+            user_ids: this.props.record.data.user_ids.resIds,
+        }]);
         this.subtaskCreate.open = false;
         this.subtaskCreate.name = "";
         this.props.record.load();

--- a/addons/project/tests/test_project_milestone.py
+++ b/addons/project/tests/test_project_milestone.py
@@ -248,6 +248,7 @@ class TestProjectMilestone(TestProjectCommon):
         self.assertEqual(task_2.milestone_id, extra_milestone_pigs, "The milestone of the child task should not be modified has it has already one set.")
 
         # C. Child task with no milestone set but belonging to another project
+        task_2.display_in_project = True
         self.task_1.project_id = self.project_goats
         task_2.milestone_id = False
         self.assertFalse(self.task_1.milestone_id)

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -318,6 +318,7 @@
                     <field name="project_id" invisible="1"/>
                     <field name="is_closed" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
+                    <field name="show_display_in_project" invisible="1"/>
                     <header>
                         <field name="stage_id" widget="statusbar_duration" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="not project_id and not stage_id"/>
                         <field name="state" widget="statusbar" options="{'clickable': '1', 'fold_field': 'fold'}" invisible="1"/>
@@ -399,12 +400,23 @@
                     </div>
                     <group>
                         <group>
-                            <field name="display_in_project" invisible="1" force_save="1"/>
-                            <field name="project_id"
-                                   domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
-                                   widget="project"
-                            />
-                            <field name="display_in_project" invisible="True" force_save="1"/>
+                            <label for="project_id"/>
+                            <div name="project" class="d-inline-flex w-100">
+                                <field name="project_id"
+                                       domain="[('active', '=', True), '|', ('company_id', '=', False), ('company_id', '=?', company_id)]"
+                                       widget="project"
+                                />
+                                <field name="display_in_project" string="Display the sub-task in your pipeline"
+                                       widget="boolean_icon" options="{'icon': 'fa-eye-slash'}"
+                                       class="ms-0" style="width: fit-content;" force_save="1"
+                                       invisible="display_in_project or not show_display_in_project"
+                                />
+                                <field name="display_in_project" string="Hide the sub-task in your pipeline"
+                                       widget="boolean_icon" options="{'icon': 'fa-eye'}"
+                                       class="ms-0" style="width: fit-content;" force_save="1"
+                                       invisible="not display_in_project or not show_display_in_project"
+                                />
+                            </div>
                             <field name="milestone_id"
                                 placeholder="e.g. Product Launch"
                                 context="{'default_project_id': project_id}"

--- a/addons/project_todo/tests/test_todo_ui.py
+++ b/addons/project_todo/tests/test_todo_ui.py
@@ -32,7 +32,8 @@ class TestTodoUi(HttpCase):
             'child_ids': [
                 Command.create({
                     'name': 'New Sub-Task!',
-                    'project_id': False,
+                    'project_id': project.id,
+                    'display_in_project': False,
                 }),
             ]
         }])

--- a/addons/sale_project/tests/test_child_tasks.py
+++ b/addons/sale_project/tests/test_child_tasks.py
@@ -229,11 +229,15 @@ class TestNestedTaskUpdate(TransactionCase):
             'child_ids': [
                 Command.create({
                     'name': 'Subtask 1',
+                    'display_in_project': True,
                     'project_id': self.project.id,
                 }),
                 Command.create({
                     'name': 'Subtask 2',
-                    'child_ids': [Command.create({'name': 'Subsubtask'})],
+                    'project_id': self.project.id,
+                    'child_ids': [
+                        Command.create({'name': 'Subsubtask', 'project_id': self.project.id})
+                    ],
                 }),
             ],
         })

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -334,16 +334,7 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         sub_B_second = task_B.child_ids.filtered(lambda sub: sub.name == 'Sub B in second project')
         self.assertEqual(sub_B_second.sale_line_id, sale_order_line_B)
 
-        # [CASE 3] Without project --> no sale order line defined
-        task_B.write({
-            'child_ids': [
-                Command.create({'name': 'Sub B without project'}),
-            ]
-        })
-        sub_B_without = task_B.child_ids.filtered(lambda sub: sub.name == 'Sub B without project')
-        self.assertEqual(sub_B_without.sale_line_id, task_B.sale_line_id)
-
-        # [CASE 4] Without parent --> use sale order line of the project
+        # [CASE 3] Without parent --> use sale order line of the project
         task_D = self.env['project.task'].create({
             'name': 'Task D',
             'project_id': project_first.id,


### PR DESCRIPTION
With https://github.com/odoo/odoo/pull/128281, we've introduced the field `display_in_project` whose purpose is, when set to False, to not display it in the main pipeline of the project, while still keeping a link with this project and the feature it allows or not. One of the good consequences of that is that now, each task that doesn't have a project can be inferred as private.

The way this task implements it is, as prior to the commit, by allowing the user to only edit the `project_id` field. Not only isn't it obvious for the user that e.g., unsetting the project won't break the link with the project and its features. It also means we have to force the value of `project_id` back in the vals which, as much as it works, also feels a little twisted.

With this commit, we stop forcing the value of `project_id`. Rather, we add a `boolean_icon` button in the task form, next to the project, to manually set `display_in_project`. This button is only visible when the task has a parent with the same project.

task-3450270




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
