### PR TITLE
[FIX] web_editor: enter issues after creating a link

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -12,6 +12,7 @@ export class LinkDialog extends Link {
         focusField: { type: String, optional: true },
         close: { type: Function },
         onSave: { type: Function },
+        setSaveAction: { type: Function},
     };
     inputTextRef = useRef('inputText');
     inputUrlRef = useRef('inputUrl');
@@ -64,6 +65,7 @@ export class LinkDialog extends Link {
             };
         }
         data.linkDialog = this;
+        this.props.setSaveAction(true);
         this.props.close();
         this.props.onSave(data);
     }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1493,6 +1493,7 @@ export class Wysiwyg extends Component {
             if (!link) {
                 return
             }
+            let saved = false;
             this._shouldDelayBlur = true;
             this.env.services.dialog.add(LinkDialog, {
                 ...this.options.linkOptions,
@@ -1515,9 +1516,15 @@ export class Wysiwyg extends Component {
                     setSelection(link, 0, link, link.childNodes.length, false);
                     link.focus();
                 },
-                close: () => {
+                setSaveAction: (data) => {
+                    saved = data;
+                }
+            }, {
+                onClose: () => {
                     this.odooEditor.historyUnpauseSteps();
-                    this.odooEditor.historyRevertUntil(historyStepIndex)
+                    if (!saved) {
+                        this.odooEditor.historyRevertUntil(historyStepIndex);
+                    }
                 }
             });
         }


### PR DESCRIPTION
**Current behaviour before commit:**

After creating a link, pressing enter at the end
of link removes whole link.

**Desired behaviour after commit:**

Now pressing enter at the end of the link adds
new paragraph without removing the link.

task-3446357


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
