### PR TITLE
[FIX] hr_leave: fix timeoff calendar traceback issue

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -135,7 +135,7 @@ class HolidaysRequest(models.Model):
         "hr.leave.type", compute='_compute_from_employee_id', store=True, string="Time Off Type", required=True, readonly=False,
         domain="[('company_id', '?=', employee_company_id), '|', ('requires_allocation', '=', 'no'), ('has_valid_allocation', '=', True)]", tracking=True)
     holiday_allocation_id = fields.Many2one(
-        'hr.leave.allocation', compute='_compute_from_holiday_status_id', string="Allocation", store=True, readonly=False)
+        'hr.leave.allocation', string="Allocation")
     color = fields.Integer("Color", related='holiday_status_id.color')
     validation_type = fields.Selection(string='Validation Type', related='holiday_status_id.leave_validation_type', readonly=False)
     # HR data


### PR DESCRIPTION
Before this commit:
if user is not employee and then click on calendar to set timeoff then traceback
occcured.

cause:
https://github.com/odoo/odoo/commit/29ad9e881efaa2facff3e54d5d8589c874c553c6
in this commit the method was deleted but still this method is calling  so traceback
produced (_compute_from_holiday_status_id)

After the commit:
removed _compute_from_holiday_status_id from field holiday_allocation_id, and 
now if user is not an employee and try to set timeoff then an error message will show.

task-3453211
