### PR TITLE
FIX Python 3.11 Error, ADD new Opcodes  Update safe_eval.py 

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -66,6 +66,8 @@ _CONST_OPCODES = set(to_opcodes([
     # 3.6: literal map with constant keys https://bugs.python.org/issue27140
     'BUILD_CONST_KEY_MAP',
     'LIST_EXTEND', 'SET_UPDATE',
+    # 3.11: new opcodes https://docs.python.org/3/whatsnew/3.11.html#new-opcodes
+    'CALL', 'PRECALL', 'RESUME',
 ])) - _BLACKLIST
 
 # operations which are both binary and inplace, same order as in doc'


### PR DESCRIPTION
[Fix] [ADD] new opcodes  Add Python 3.11 compatibility

Description of the issue/feature this PR addresses:

When Deploy Odoo 15 in SO linux with python 3.11 (E.G. Debian 12 Bookworm) when load Odoo first time Explorer displays  an Error: 

`KeyError: ('ir.qweb', <function IrQWeb._compile at 0x7f3d213fd8a0>, <Element html at 0x7f3d1e10bd90>, (None, None, None, None, None, None, None, None))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 180, in _compile
    self._compile_node(element, _options, 1) +
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 346, in _compile_node
    return self._compile_static_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 689, in _compile_static_node
    body = self._compile_directive_content(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 946, in _compile_directive_content
    body.extend(self._compile_node(item, options, indent))
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 346, in _compile_node
    return self._compile_static_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 689, in _compile_static_node
    body = self._compile_directive_content(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 946, in _compile_directive_content
    body.extend(self._compile_node(item, options, indent))
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 346, in _compile_node
    return self._compile_static_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 689, in _compile_static_node
    body = self._compile_directive_content(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 946, in _compile_directive_content
    body.extend(self._compile_node(item, options, indent))
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 346, in _compile_node
    return self._compile_static_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 689, in _compile_static_node
    body = self._compile_directive_content(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 946, in _compile_directive_content
    body.extend(self._compile_node(item, options, indent))
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 346, in _compile_node
    return self._compile_static_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 689, in _compile_static_node
    body = self._compile_directive_content(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 946, in _compile_directive_content
    body.extend(self._compile_node(item, options, indent))
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 365, in _compile_node
    return body + self._compile_directives(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 383, in _compile_directives
    return self._compile_directive(el, options, directive, indent)
  File "/opt/odoo15/odoo/odoo/tools/profiler.py", line 320, in _tracked_compile_directive
    return method_compile_directive(self, el, options, directive, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 177, in _compile_directive
    return super()._compile_directive(el, options, directive, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 827, in _compile_directive
    return compile_handler(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 1011, in _compile_directive_if
    orelse = self._compile_node(next_el, dict(options, t_if=True), indent + 1) + self._flushText(options, indent + 1)
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 171, in _compile_node
    return super()._compile_node(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 365, in _compile_node
    return body + self._compile_directives(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 383, in _compile_directives
    return self._compile_directive(el, options, directive, indent)
  File "/opt/odoo15/odoo/odoo/tools/profiler.py", line 320, in _tracked_compile_directive
    return method_compile_directive(self, el, options, directive, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 177, in _compile_directive
    return super()._compile_directive(el, options, directive, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 827, in _compile_directive
    return compile_handler(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 980, in _compile_directive_elif
    compiled = self._compile_directive_if(el, options, indent)
  File "/opt/odoo15/odoo/odoo/addons/base/models/qweb.py", line 1013, in _compile_directive_if
    code.append(self._indent(f"if {self._compile_expr(expr)}:", indent))
  File "/opt/odoo15/odoo/odoo/addons/base/models/ir_qweb.py", line 389, in _compile_expr
    assert_valid_codeobj(_SAFE_QWEB_OPCODES, compile(namespace_expr, '<>', 'eval'), expr)
  File "/opt/odoo15/odoo/odoo/tools/safe_eval.py", line 168, in assert_valid_codeobj
    raise ValueError("forbidden opcode(s) in %r: %s" % (expr, ', '.join(opname[x] for x in (code_codes - allowed_codes))))
ValueError: forbidden opcode(s) in 'insecure and databases': CALL, PRECALL, RESUME
`

Current behavior before PR:

You won not be able to run Odoo after this error

Desired behavior after PR is merged:

Odoo should load the database manager in the browser for the first time after doing a clean install



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
