### PR TITLE
[FIX] base: handle syntax error for edited view

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -5697,6 +5697,16 @@ msgid ""
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/ir_ui_view.py:0
+#, python-format
+msgid ""
+"\n"
+"The 'attr' contains syntax error:\n"
+"'%s'"
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,description:base.module_repair
 msgid ""
 "\n"

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3433,6 +3433,16 @@ Forbidden attribute used in arch (t-attf-data-tooltip-template)."""
 Forbidden use of `__comp__` in arch."""
         )
 
+    def test_validate_attrs_syntax_error(self):
+        arch = """
+            <tree>
+                <field name="groups_id"/>
+                <button type="object" name="action_archive" attrs="{'invisible': [('groups_id, '=', True)]}" string="Button1"/>
+            </tree>
+        """
+        with self.assertRaises(ValidationError):
+            self.assertValid(arch)
+
 
 @tagged('post_install', '-at_install')
 class TestDebugger(common.TransactionCase):


### PR DESCRIPTION
This traceback appears when user edits the "attr" ('attrs', 'context', 'decoration-') through
studio which have invalid syntax in the tree architecture of view.

Steps to reproduce:
1) Install `sale_management`, `web_studio` module. 
2) Open `Sales` and click on any `Quotation`.
3) Now, click on `Studio` button > `View` > `</>XML` button to open the
   xml code.
4) Now, in `sale.view_order_form` view, edit the architecture. 
5) Example: attrs="{'invisible': [('invoice_status', '!=', `'to invoice`)]}"
   (i.e. remove the closing single quote of `to invoice`).
6) Click on `Save` button and traceback will be generated in backend.

See this traceback:

```
SyntaxError: invalid syntax (<unknown>, line 1)
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 234, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/controllers/main.py", line 610, in edit_view
    self._set_studio_view(view, new_arch)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/controllers/main.py", line 435, in _set_studio_view
    studio_view.arch_db = arch
  File "odoo/fields.py", line 1320, in __set__
    records.write({self.name: write_value})
  File "addons/website/models/theme_models.py", line 376, in write
    return super().write(vals)
  File "addons/website/models/ir_ui_view.py", line 93, in write
    return super(View, self).write(vals)
  File "home/odoo/src/enterprise/saas-16.3/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 587, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4036, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1411, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 460, in _check_xml
    view._validate_view(combined_arch, view.model)
  File "odoo/addons/base/models/ir_ui_view.py", line 1456, in _validate_view
    validator(node, name_manager, node_info)
  File "odoo/addons/base/models/ir_ui_view.py", line 1554, in _validate_tag_field
    sub_manager = self._validate_view(
  File "odoo/addons/base/models/ir_ui_view.py", line 1459, in _validate_view
    self._validate_attrs(node, name_manager, node_info)
  File "odoo/addons/base/models/ir_ui_view.py", line 1778, in _validate_attrs
    for key, val_ast in get_dict_asts(expr).items():
  File "odoo/tools/view_validation.py", line 85, in get_dict_asts
    expr = ast.parse(expr.strip(), mode='eval').body
  File "ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
```

sentry-3962890873

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
