### PR TITLE
[FIX] web, *: record key is reactive in KanbanRecord

### DIFF
--- a/addons/im_livechat/static/src/views/livechat_channel_kanban/livechat_channel_kanban_menu.xml
+++ b/addons/im_livechat/static/src/views/livechat_channel_kanban/livechat_channel_kanban_menu.xml
@@ -3,7 +3,7 @@
     <t t-name="im_livechat.KanbanRecordMenu" t-inherit="web.KanbanRecordMenu">
          <xpath expr="//Dropdown" position="attributes">
             <attribute name="position">'bottom-start'</attribute>
-            <attribute name="menuClass" add="` rounded-0 ${record.available_operator_ids.raw_value.length > 0 ? 'o-livechat-ChannelKanban-highlighted': ''}`" separator="+"/>
+            <attribute name="menuClass" add="` rounded-0 ${props.record.data.available_operator_ids.count > 0 ? 'o-livechat-ChannelKanban-highlighted': ''}`" separator="+"/>
             <attribute name="togglerClass" add="' bg-transparent px-2'" separator="+"/>
         </xpath>
     </t>

--- a/addons/sale/static/src/js/product_catalog/kanban_record.js
+++ b/addons/sale/static/src/js/product_catalog/kanban_record.js
@@ -21,7 +21,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
         useSubEnv({
             currencyId: this.props.record.context.product_catalog_currency_id,
             orderId: this.props.record.context.product_catalog_order_id,
-            productId: this.record.id.raw_value,
+            productId: this.props.record.resId,
             addProduct: this.addProduct.bind(this),
             removeProduct: this.removeProduct.bind(this),
             increaseQuantity: this.increaseQuantity.bind(this),

--- a/addons/sale/static/src/js/product_catalog/kanban_record.xml
+++ b/addons/sale/static/src/js/product_catalog/kanban_record.xml
@@ -11,7 +11,7 @@
                  t-att-class="{'text-bg-primary': state.quantity || props.record.productCatalogData.readOnly}">
                 <t t-call="{{ templates[this.constructor.KANBAN_BOX_ATTRIBUTE] }}"
                    t-call-context="this.renderingContext"/>
-                <ProductCatalogSOL productId="record.id.raw_value"
+                <ProductCatalogSOL productId="props.record.resId"
                                    quantity="state.quantity"
                                    price="state.price"
                                    readOnly="props.record.productCatalogData.readOnly"/>

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -125,7 +125,7 @@
     </t>
 
     <t t-name="web.KanbanColorPicker" owl="1">
-        <ul t-if="this.widget.editable" class="oe_kanban_colorpicker">
+        <ul t-if="this.dataState.widget.editable" class="oe_kanban_colorpicker">
             <!--
                 Used in KanbanRecord
                 Note: `props` is only accessible through `this` as we call the compiled template with


### PR DESCRIPTION
Before this commit, calls to record[fieldname][value/raw_value] in the arch of a kanban view did not take into account updates on the Record Datapoint. So if any data in the Record changed, the [raw_value/value] was not modified.

In a custom KanbanRecord, you should never use the record containing the value and raw_value. We will therefore replace this call by using the datapoint record directly.

How to reproduce:
    - Have a kanban view with a record.my_field.value and a widget allowing
        you to modify the value of my_field.
    - Click on the widget

Before this commit:
    The value of my_field does not change

After this commit:
    The value of my_field has been updated.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
