### PR TITLE
[FIX] crm_iap_mine: Correction of industries used for lead generation

### DIFF
--- a/addons/crm_iap_mine/__manifest__.py
+++ b/addons/crm_iap_mine/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Lead Generation',
     'summary': 'Generate Leads/Opportunities based on country, industries, size, etc.',
     'category': 'Sales/CRM',
-    'version': '1.2',
+    'version': '1.3',
     'depends': [
         'iap_crm',
         'iap_mail',

--- a/addons/crm_iap_mine/data/crm.iap.lead.industry.csv
+++ b/addons/crm_iap_mine/data/crm.iap.lead.industry.csv
@@ -1,24 +1,66 @@
-"id",name,reveal_ids,sequence
-"crm_iap_mine_industry_30_155","Consumer Discretionary","30,155",1
-"crm_iap_mine_industry_33","Consumer Staples","33",4
-"crm_iap_mine_industry_69_157","Banks & Insurance","69,157",2
-"crm_iap_mine_industry_86","Media","86",7
-"crm_iap_mine_industry_114","Real Estate","114",21
-"crm_iap_mine_industry_136","Transportation","136",16
-"crm_iap_mine_industry_138_156","Energy & Utilities ","138",22
-"crm_iap_mine_industry_148","Materials","148",17
-"crm_iap_mine_industry_149","Telecommunication Services","149",20
-"crm_iap_mine_industry_150_151","Consumer Services","150,151",9
-"crm_iap_mine_industry_152","Retailing","152",3
-"crm_iap_mine_industry_153_154","Food, Beverage & Tobacco","153,154",12
-"crm_iap_mine_industry_158_159","Diversified Financials & Financial Services","158,159",15
-"crm_iap_mine_industry_160","Health Care Equipment & Services","160",11
-"crm_iap_mine_industry_161","Pharmaceuticals, Biotechnology & Life Sciences","161",13
-"crm_iap_mine_industry_162","Capital Goods","162",6
-"crm_iap_mine_industry_163","Commercial & Professional Services","163",5
-"crm_iap_mine_industry_165","Software & Services","165",8
-"crm_iap_mine_industry_166","Technology Hardware & Equipment","166",19
-"crm_iap_mine_industry_167","Construction Materials","167",23
-"crm_iap_mine_industry_168","Independent Power and Renewable Electricity Producers","168",14
-"crm_iap_mine_industry_238","Automobiles & Components","238",18
-"crm_iap_mine_industry_239","Consumer Durables & Apparel","239",10
+id,name,reveal_ids,sequence
+crm_iap_mine_industry_1,Aerospace & Defense,1,1
+crm_iap_mine_industry_2,Air Freight & Logistics,2,2
+crm_iap_mine_industry_3,Airlines,3,3
+crm_iap_mine_industry_4,Automotive,4,4
+crm_iap_mine_industry_5,Banks,5,5
+crm_iap_mine_industry_6,Beverages,6,6
+crm_iap_mine_industry_7,Biotechnology,7,7
+crm_iap_mine_industry_148,Building Materials,148,8
+crm_iap_mine_industry_9,Capital Goods,9,9
+crm_iap_mine_industry_10,Capital Markets,10,10
+crm_iap_mine_industry_11,Chemicals,11,11
+crm_iap_mine_industry_12,Commercial Services & Supplies,12,12
+crm_iap_mine_industry_13,Communications Equipment,13,13
+crm_iap_mine_industry_14,Construction & Engineering,14,14
+crm_iap_mine_industry_15,Consumer Discretionary,15,15
+crm_iap_mine_industry_16,Consumer Goods,16,16
+crm_iap_mine_industry_17,Consumer Services,17,17
+crm_iap_mine_industry_33,Consumer Staples,33,18
+crm_iap_mine_industry_19,Containers & Packaging,19,19
+crm_iap_mine_industry_20,Distributors,20,20
+crm_iap_mine_industry_21,Diversified Consumer Services,21,21
+crm_iap_mine_industry_22,Diversified Financial Services,22,22
+crm_iap_mine_industry_23,Diversified Telecommunication Services,23,23
+crm_iap_mine_industry_24,Education Services,24,24
+crm_iap_mine_industry_25,Electric Utilities,25,25
+crm_iap_mine_industry_26,Electrical Equipment,26,26
+crm_iap_mine_industry_27,"Electronic Equipment, Instruments & Components",27,27
+crm_iap_mine_industry_28,Family Services,28,28
+crm_iap_mine_industry_29,Food & Staples Retailing,29,29
+crm_iap_mine_industry_30,Food Products,30,30
+crm_iap_mine_industry_31,Gas Utilities,31,31
+crm_iap_mine_industry_32,Health Care Equipment & Supplies,32,32
+crm_iap_mine_industry_18,Health Care Providers & Services,18,33
+crm_iap_mine_industry_34,"Hotels, Restaurants & Leisure",34,34
+crm_iap_mine_industry_35,Household Durables,35,35
+crm_iap_mine_industry_36,IT Services,36,36
+crm_iap_mine_industry_37,Industrial Conglomerates,37,37
+crm_iap_mine_industry_38,Industrials,38,38
+crm_iap_mine_industry_39,Insurance,39,39
+crm_iap_mine_industry_40,Internet Software & Services,40,40
+crm_iap_mine_industry_41,Leisure Products,41,41
+crm_iap_mine_industry_42,Life Sciences Tools & Services,42,42
+crm_iap_mine_industry_43,Machinery,43,43
+crm_iap_mine_industry_44,Marine,44,44
+crm_iap_mine_industry_45,Media,45,45
+crm_iap_mine_industry_46,Metals & Mining,46,46
+crm_iap_mine_industry_47,Paper & Forest Products,47,47
+crm_iap_mine_industry_48,Personal Products,48,48
+crm_iap_mine_industry_49,Pharmaceuticals,49,49
+crm_iap_mine_industry_50,Professional Services,50,50
+crm_iap_mine_industry_51,Real Estate,51,51
+crm_iap_mine_industry_52,Renewable Electricity,52,52
+crm_iap_mine_industry_53,Retailing,53,53
+crm_iap_mine_industry_54,Road & Rail,54,54
+crm_iap_mine_industry_55,Semiconductors & Semiconductor Equipment,55,55
+crm_iap_mine_industry_56,Software,56,56
+crm_iap_mine_industry_57,Specialized Consumer Services,57,57
+crm_iap_mine_industry_58,Specialty Retail,58,58
+crm_iap_mine_industry_59,"Technology Hardware, Storage & Peripherals",59,59
+crm_iap_mine_industry_60,"Textiles, Apparel & Luxury Goods",60,60
+crm_iap_mine_industry_61,Tobacco,61,61
+crm_iap_mine_industry_62,Trading Companies & Distributors,62,62
+crm_iap_mine_industry_63,Transportation,63,63
+crm_iap_mine_industry_64,Utilities,64,64
+crm_iap_mine_industry_65,Wireless Telecommunication Services,65,65

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -207,15 +207,11 @@ class CRMLeadMiningRequest(models.Model):
             payload.update({'company_size_min': self.company_size_min,
                             'company_size_max': self.company_size_max})
         if self.industry_ids:
-            # accumulate all reveal_ids (separated by ',') into one list
-            # eg: 3 records with values: "175,176", "177" and "190,191"
-            # will become ['175','176','177','190','191']
-            all_industry_ids = [
-                reveal_id.strip()
-                for reveal_ids in self.mapped('industry_ids.reveal_ids')
-                for reveal_id in reveal_ids.split(',')
-            ]
-            payload['industry_ids'] = all_industry_ids
+            # return a list of all industry names
+            all_industry_names = []
+            for industry in self.industry_ids:
+                all_industry_names.append(industry.name)
+            payload['industry_names'] = all_industry_names
         if self.search_type == 'people':
             payload.update({'contact_number': self.contact_number,
                             'contact_filter_type': self.contact_filter_type})
@@ -255,7 +251,7 @@ class CRMLeadMiningRequest(models.Model):
             raise UserError(_("Your request could not be executed: %s", e))
 
     def _iap_contact_mining(self, params, timeout=300):
-        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/iap/clearbit/1/lead_mining_request'
+        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/api/directory/2/lead/mining_request'
         return iap_tools.iap_jsonrpc(endpoint, params=params, timeout=timeout)
 
     def _create_leads_from_response(self, result):

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -251,7 +251,7 @@ class CRMLeadMiningRequest(models.Model):
             raise UserError(_("Your request could not be executed: %s", e))
 
     def _iap_contact_mining(self, params, timeout=300):
-        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/api/directory/2/lead/mining_request'
+        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/api/clearbit/2/lead_mining_request'
         return iap_tools.iap_jsonrpc(endpoint, params=params, timeout=timeout)
 
     def _create_leads_from_response(self, result):


### PR DESCRIPTION
The values used in the industry to obtain lead generations did not align with those of our provider. This posed a problem, as it meant that some queries inevitably returned zero leads.

Description of the issue/feature this PR addresses:
When a lead mining request was made using the lead generation tool, several industry categories returned no results when selected, even for countries such as the USA. 

Current behavior before PR:
The user's query returned industry ids that did not match up correctly with the keywords used in the lead search. 

Desired behavior after PR is merged:
Now users will be able to choose their industry from a revised list. In addition, the query sent will now contain the name of the industry rather than an id. 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
