### PR TITLE
[FIX] point_of_sale: create new pos product category in Preparation Printers

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -30,7 +30,7 @@ class PosCategory(models.Model):
     def _get_hierarchy(self) -> List[str]:
         """ Returns a list representing the hierarchy of the categories. """
         self.ensure_one()
-        return (self.parent_id._get_hierarchy() if self.parent_id else []) + [self.name]
+        return (self.parent_id._get_hierarchy() if self.parent_id else []) + [(self.name or '')]
 
     @api.depends('parent_id')
     def _compute_display_name(self):


### PR DESCRIPTION
When user creates new Pos Product Category in Preparation Printers,
a traceback will appear.

Steps to reproduce the error:
- Go to Point of Sale
- Configuration > Settings > Connected Devices > Enable Preparation Printers
- Go to Orders > Preparation Printers > Open any Preparation Printer
- In PoS Product Category > Add a line > New

Traceback:
```
KeyError: <NewId 0x7f636bc13ca0>
  File "odoo/api.py", line 960, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'pos.category(<NewId 0x7f636bc13ca0>,).display_name'
  File "odoo/fields.py", line 1159, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 967, in get
    raise CacheMiss(record, field)
TypeError: sequence item 0: expected str instance, bool found
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6751, in onchange
    snapshot1 = Snapshot(record, nametree)
  File "odoo/models.py", line 6525, in __init__
    self.fetch(name)
  File "odoo/models.py", line 6535, in fetch
    self[name] = record[name]
  File "odoo/models.py", line 6171, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1210, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4524, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 100, in determine
    return needle(*args)
  File "addons/point_of_sale/models/pos_category.py", line 38, in _compute_display_name
    cat.display_name = " / ".join(cat._get_hierarchy())
```

https://github.com/odoo/odoo/blob/dca6ef8051aac367b94c1b5287f988456ae1d905/addons/point_of_sale/models/pos_category.py#L33
When user creates new pos product category,
Here, 'self.name' will be False in '_get_hierarchy' method.
'_get_hierarchy' method is called in '_compute_display_name' method.
So it will lead to above traceback.

sentry-4379442099

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
