### PR TITLE
[FIX] project: unsupported data type while export the excel file

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -224,7 +224,7 @@ class ExportXlsxWriter:
                 cell_value = pycompat.to_text(cell_value)
             except UnicodeDecodeError:
                 raise UserError(_("Binary fields can not be exported to Excel unless their content is base64-encoded. That does not seem to be the case for %s.", self.field_names)[column])
-        elif isinstance(cell_value, (list, tuple)):
+        elif isinstance(cell_value, (list, tuple, dict)):
             cell_value = pycompat.to_text(cell_value)
 
         if isinstance(cell_value, str):


### PR DESCRIPTION
This error occurs when the user export records having a value in the 'properties' is the column which is of datatype, 'properties', and while that data gets formed a dictionary, at that time, this error is produced, which is
 unsupported type <class 'dict'> in write().

step to reproduce: -
-install Project Module.
-click on Menu > My task(project.task).
-open any one task.
-create the one property('task_properties')
 > select any data type(such as text) - then, 
   export that task('task_properties' this field must 
    be included while exporting).

-error would be generated.

Traceback:
```
TypeError: float() argument must be a string or a real number, not 'dict'
  File "xlsxwriter/worksheet.py", line 512, in _write
    f = float(token)
TypeError: Unsupported type <class 'dict'> in write()
  File "addons/web/controllers/export.py", line 560, in web_export_xlsx
    return self.base(data)
  File "addons/web/controllers/export.py", line 496, in base
    response_data = self.from_group_data(fields, tree)
  File "addons/web/controllers/export.py", line 582, in from_group_data
    x, y = xlsx_writer.write_group(x, y, group_name, group)
  File "addons/web/controllers/export.py", line 261, in write_group
    row, column = self._write_row(row, column, record)
  File "addons/web/controllers/export.py", line 266, in _write_row
    self.write_cell(row, column, value)
  File "addons/web/controllers/export.py", line 241, in write_cell
    self.write(row, column, cell_value, cell_style)
  File "addons/web/controllers/export.py", line 213, in write
    self.worksheet.write(row, column, cell_value, style)
  File "xlsxwriter/worksheet.py", line 85, in cell_wrapper
    return method(self, *args, **kwargs)
  File "xlsxwriter/worksheet.py", line 445, in write
    return self._write(row, col, *args)
  File "xlsxwriter/worksheet.py", line 517, in _write
    raise TypeError("Unsupported type %s in write()" % type(token))
```

The user could not export that field.

sentry-4050303285