### PR TITLE
[IMP] product,hr_expense: product.product kanban view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -543,6 +543,20 @@
             </field>
         </record>
 
+        <record id="product_product_expense_kanban_view" model="ir.ui.view">
+            <field name="name">product.product.kanban.expense</field>
+            <field name="inherit_id" ref="product.product_kanban_view"/>
+            <field name="mode">primary</field>
+            <field name="model">product.product</field>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@name='product_lst_price']" position="after">
+                    <div name="product_standard_price" class="mt-1">
+                        Cost: <field name="standard_price"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
         <record id="product_product_expense_tree_view" model="ir.ui.view">
             <field name="name">product.product.expense.tree</field>
             <field name="model">product.product</field>
@@ -600,6 +614,7 @@
         <record id="hr_expense_product_kanban" model="ir.actions.act_window.view">
             <field name="sequence" eval="2"/>
             <field name="view_mode">kanban</field>
+            <field name="view_id" ref="product_product_expense_kanban_view"/>
             <field name="act_window_id" ref="hr_expense_product"/>
         </record>
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -437,22 +437,26 @@
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                         <t t-name="kanban-box">
-                            <div class="oe_kanban_global_click">
-                                <div class="o_kanban_image">
+                            <div class="oe_kanban_card oe_kanban_global_click">
+                                <div class="o_kanban_image me-1">
                                     <img t-att-src="kanban_image('product.product', 'image_128', record.id.raw_value)" alt="Product" class="o_image_64_contain"/>
                                 </div>
                                 <div class="oe_kanban_details">
-                                    <field name="priority" widget="priority" readonly="1"/>
-                                    <strong class="o_kanban_record_title">
-                                        <field name="name"/>
-                                        <small t-if="record.default_code.value">[<field name="default_code"/>]</small>
-                                    </strong>
+                                    <div class="o_kanban_record_top mb-0">
+                                        <div class="o_kanban_record_headings">
+                                            <strong class="o_kanban_record_title">
+                                                <field name="name"/>
+                                            </strong>
+                                        </div>
+                                        <field name="priority" widget="priority"/>
+                                    </div>
+                                    <t t-if="record.default_code.value">[<field name="default_code"/>]</t>
                                     <div class="o_kanban_tags_section">
                                         <field name="product_template_variant_value_ids" groups="product.group_product_variant" widget="many2many_tags" options="{'color_field': 'color'}"/>
                                     </div>
-                                    <ul>
-                                        <li><strong>Price: <field name="lst_price"></field></strong></li>
-                                    </ul>
+                                    <div name="product_lst_price" class="mt-1">
+                                        Price: <field name="lst_price"></field>
+                                    </div>
                                     <div name="tags"/>
                                 </div>
                             </div>


### PR DESCRIPTION
As the product.product view hasn't change since v15 some of its UI isn't working properly.

Expense also requires the cost to be shown

task-3457035

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
