### PR TITLE
[FIX] account: hide inactive tax_ids in aml dropdown

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -938,7 +938,7 @@
                                         <field name="discount" string="Disc.%" optional="hide"/>
                                         <field name="tax_ids" widget="many2many_tags"
                                                domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', '=', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
-                                               context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain}"
+                                               context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain, 'active_test': True}"
                                                options="{'no_create': True}"
                                                optional="show"/>
                                         <field name="price_subtotal"
@@ -1123,7 +1123,7 @@
                                         <field name="tax_ids" widget="autosave_many2many_tags"
                                                optional="hide"
                                                domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain)]"
-                                               context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain}"
+                                               context="{'append_type_to_tax_name': not parent.invoice_filter_type_domain, 'active_test': True}"
                                                options="{'no_create': True}"
                                                force_save="1"
                                                attrs="{'readonly': [


### PR DESCRIPTION
The "test_active": False context of the field specifies that this field will ignore whether a record is active or not when fetching it.

Due to recent changes in the javascript, the "test_active": False context of the tax_ids field on the account move model is propagated through into the name_search query. This means that inactive taxes appear in the dropdown when selecting a tax.

This is an issue as there are a few localisations that hide a number of their taxes by default (by making them "inactive").

The solution is to add the key, value pair "active_test":False to the context of the field on the view, effectively overriding the context that gets used in the name_search query, thus only retrieving active taxes.