### PR TITLE
[FIX] hr_expense: handle not null violation error

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -868,6 +868,8 @@ class MailThread(models.AbstractModel):
                     self._routing_create_bounce_email(email_from, body, message, references=message_id)
                 return False
 
+        else:
+            self._routing_warn(_('model %s alias does not match or does not exist', model), message_id, route, raise_exception)
         return (model, thread_id, route[2], route[3], route[4])
 
     @api.model


### PR DESCRIPTION
When the user sends the mail for creating an expense record from his mail account, if the user's email is not found in the hr.employee object, then a "NotNullViolation" traceback error occurs.

Steps to reproduce:
- Install the "hr_expense" module.
- Settings > Technical > Email > Incoming Mail Servers
- Create a new incoming mail server for creating new expense records from incoming mail, along with the required details, and click on the "Test & Confirm" button.
- Go to Expenses > Configuration > Settings, check the "Incoming Emails" checkbox, and set up your domain alias.
- After that, Send the email, which is configured on the incoming email server.
- While the "Mail: Fetchmail Service" schedule action will run after that, a traceback will be generated.

Error:
null value in column "employee_id" of relation "hr_expense" violates not-null constraint DETAIL:  Failing row contains (34, null, null, null, null, 1, 124, 517, null, 6, 6, test, own_account, draft, null, 2023-07-25, null, null, null, 0.00, 1.00, null, null, null, null, null, null, 2023-07-25 13:45:06.395908, 2023-07-25 13:45:06.395908, miscellaneous, no_extract_requested, null, null, null, null, null)

Traceback:
```NotNullViolation: null value in column "employee_id" of relation "hr_expense" violates not-null constraint
DETAIL:  Failing row contains (34, null, null, null, null, 1, 124, 517, null, 6, 6, test, own_account, draft, null, 2023-07-25, null, null, null, 0.00, 1.00, null, null, null, null, null, null, 2023-07-25 13:45:06.395908, 2023-07-25 13:45:06.395908, miscellaneous, no_extract_requested, null, null, null, null, null).

  File "odoo/http.py", line 2125, in __call__
    response = request._serve_nodb()
  File "odoo/http.py", line 1668, in _serve_nodb
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1929, in dispatch
    result = endpoint(**self.request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "home/odoo/src/custom/default/saas_worker/controllers/main.py", line 2218, in smtp
    proxy.message_process(None, message)
  File "addons/mail/models/mail_thread.py", line 1274, in message_process
    thread_id = self._message_route_process(message, msg_dict, routes)
  File "addons/mail/models/mail_thread.py", line 1170, in _message_route_process
    thread = ModelCtx.message_new(message_dict, custom_values)
  File "addons/hr_expense/models/hr_expense.py", line 697, in message_new
    return super().message_new(msg_dict, custom_values=custom_values)
  File "addons/mail/models/mail_thread.py", line 1309, in message_new
    return self.create(data)
  File "<decorator-gen-122>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/mail/models/mail_thread.py", line 254, in create
    threads = super(MailThread, self).create(vals_list)
  File "<decorator-gen-172>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "addons/analytic/models/analytic_mixin.py", line 83, in create
    return super().create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4212, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4415, in _create
    cr.execute(
  File "odoo/sql_db.py", line 319, in execute
    res = self._obj.execute(query, params)
```

Before creating the expense record from the email, we need to configure the incoming mail server along with the expense alias and its alias domain. user needs to match his email, which should be Work Email" in the `hr.employee` object. Otherwise, the fetchmail server will not be creating the record in the `hr.expense` object.


sentry: 4338964732
