### PR TITLE
[FIX] account: prevent to change applicability

### DIFF
--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
 from odoo import osv
+from odoo.exceptions import ValidationError
 
 
 class AccountAccountTag(models.Model):
@@ -46,6 +47,13 @@ class AccountAccountTag(models.Model):
             ('country_id', '=', country_id),
             ('applicability', '=', 'taxes')
         ]
+
+    def write(self, vals):
+        for record in self:
+            applicability = vals.get('applicability', False)
+            if applicability and applicability != 'taxes' and record._origin.applicability == 'taxes' and record._get_related_tax_report_expressions():
+                raise ValidationError(_("You cannot update applicability"))
+        return super().write(vals)
 
     def _get_related_tax_report_expressions(self):
         if not self:


### PR DESCRIPTION
When the user changes  `applicability` in `Account Tags` and then installs the stock_account module, the user will face the `KeyError`.

Steps to produce:
- Install l10n_gr and account_accountant.
- Open Account Tags > Look for `+303 Πωλήσεις 19-23%` (With debugger mode on)
- Change Applicability from Taxes to  Accounts and save it
- Install `stock_account`

See traceback
```
Traceback (most recent call last):
  File "/home/odoo/odoo/community/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/odoo/community/odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/home/odoo/odoo/community/odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/odoo/community/odoo/modules/loading.py", line 245, in load_module_graph
    getattr(py_module, post_init)(env)
  File "/home/odoo/odoo/community/addons/stock_account/__init__.py", line 14, in _configure_journals
    full_data = ChartTemplate._get_chart_template_data(template_code)
  File "/home/odoo/odoo/community/addons/account/models/chart_template.py", line 566, in _get_chart_template_data
    data = func(self, template_code)
  File "/home/odoo/odoo/community/addons/account/models/chart_template.py", line 50, in wrapper
    return func(*args, **kwargs)
  File "/home/odoo/odoo/community/addons/account/models/chart_template.py", line 819, in _get_account_tax
    self._deref_account_tags(template_code, tax_data)
  File "/home/odoo/odoo/community/addons/account/models/chart_template.py", line 935, in _deref_account_tags
    repartition['tag_ids'] = [Command.set(mapper(*tags.split(TAX_TAG_DELIMITER)))]
  File "/home/odoo/odoo/community/addons/account/models/chart_template.py", line 925, in <lambda>
    return lambda *args: [tags[re.sub(r'\s+', ' ', x.strip())] for x in args]
  File "/home/odoo/odoo/community/addons/account/models/chart_template.py", line 925, in <listcomp>
    return lambda *args: [tags[re.sub(r'\s+', ' ', x.strip())] for x in args]
KeyError: '+303 Πωλήσεις 19-23%'
```

In the write method of the model, added validation to prevent updates on the `applicability` field when transitioning from 'taxes' applicability. If there are related tax report expressions, the update is disallowed to maintain data integrity and consistency. This change helps avoid unintended modifications to tax-related configurations.

Sentry-4368462533