### PR TITLE
[FIX] mail: no follower spinner on draft record

### DIFF
--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -34,9 +34,9 @@
                     <t t-else="" t-call="mail.Chatter.attachFiles"/>
                     <Dropdown t-if="props.hasFollowers" position="'bottom-end'" disabled="isDisabled" class="'o-mail-Followers d-flex me-1'" menuClass="'o-mail-Followers-dropdown flex-column'" menuDisplay="'d-flex'" title="followerButtonLabel" togglerClass="'o-mail-Followers-button btn btn-link text-action px-1 ' + (props.compactHeight ? '' : 'my-2')">
                         <t t-set-slot="toggler">
-                            <i class="fa fa-user-o" role="img"/>
-                            <i t-if="state.thread.followersCount === undefined" class="fa fa-circle-o-notch fa-spin"/>
-                            <span t-else="" class="o-mail-Followers-counter ps-1" t-esc="state.thread.followersCount"/>
+                            <i class="fa fa-user-o me-1" role="img"/>
+                            <i t-if="state.thread.id and state.thread.followersCount === undefined" class="fa fa-circle-o-notch fa-spin"/>
+                            <span t-else="" class="o-mail-Followers-counter" t-esc="state.thread.followersCount ?? 0"/>
                         </t>
                         <t t-set-slot="default">
                             <FollowerList onAddFollowers.bind="onAddFollowers" onFollowerChanged.bind="onFollowerChanged" thread="state.thread"/>

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -761,3 +761,9 @@ QUnit.test("upload attachment on draft record", async (assert) => {
     await afterNextRender(() => dropFiles($(".o-mail-Dropzone")[0], [file]));
     await waitUntil("button[aria-label='Attach files']:contains(1)");
 });
+
+QUnit.test("Follower count of draft record is set to 0", async (assert) => {
+    const { openView } = await start();
+    await openView({ res_model: "res.partner", views: [[false, "form"]] });
+    assert.containsOnce($, ".o-mail-Followers:contains(0)");
+});


### PR DESCRIPTION
Before this commit, the follower loading spinner was shown for draft records until it was saved. This is incorrect, follower count should instead be 0. This commit fixes this issue.

