### PR TITLE
[FIX] account: Fix tax repartition line error on deletion.

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -346,11 +346,13 @@ class AccountTax(models.Model):
             fname = f"{doc_type}_repartition_line_ids"
             if fname in sanitized:
                 repartition = sanitized.setdefault('repartition_line_ids', [])
-                repartition.extend([
-                    (command, id, {'document_type': doc_type, **v}) if command in (Command.CREATE, Command.UPDATE)
-                    else (command, id, v)
-                    for command, id, v in sanitized.pop(fname)
-                ])
+                for command_vals in sanitized.pop(fname):
+                    if command_vals[0] == Command.CREATE:
+                        repartition.append(Command.create({'document_type': doc_type, **command_vals[2]}))
+                    elif command_vals[0] == Command.UPDATE:
+                        repartition.append(Command.update(command_vals[1], {'document_type': doc_type, **command_vals[2]}))
+                    else:
+                        repartition.append(command_vals)
                 sanitized[fname] = []
         return sanitized
 


### PR DESCRIPTION
Problem
---------
When deleting a tax repartition line, an error occurred. When popping the modified values during deletion, only two values were
present in the modified values. Thus, unpacking to 3 variables resulted in an error: `v` did not exist.

Objective
---------
Make repartition lines deletable again.

Solution
---------
Instead of popping 3 values for every command, we pop 1 stored as a list. We access the relevant elements using the index 
when necessary.

task-xxxxxxx

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
