### PR TITLE
[FIX] uom: do not allow uom.uom creation from tree view

### DIFF
--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -4,7 +4,7 @@
         <field name="name">uom.uom.tree</field>
         <field name="model">uom.uom</field>
         <field name="arch" type="xml">
-            <tree string="Units of Measure">
+            <tree string="Units of Measure" create="false">
                 <field name="name"/>
                 <field name="category_id"/>
                 <field name="uom_type"/>


### PR DESCRIPTION
Since 6f182eeeab082b094563836a7a3dc2f4e56375f0,
UoM should be created through the UoM category tab as the UoM form view is now unusable.

Previous bugfix commit 58a3954d606d48b2a4cf678eb0bf13d6e28b1aef disabled the menu from the different applications, but later changes in sale brought back the menu again.

Since it doesn't hurt to have the menu in debug mode, the lowest solution would be to disable the creation of uoms from the uoms tree view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
