### PR TITLE
[FIX] point_of_sale: invalid money input display

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/hooks.js
+++ b/addons/point_of_sale/static/src/app/utils/hooks.js
@@ -101,18 +101,21 @@ export function useValidateCashInput(inputRef, startingValue) {
     const decimalPoint = localization.decimalPoint;
     const env = useEnv();
     function handleCashInputChange(event) {
-        let inputValue = (event.target.value || "").trim();
+        const inputValue = (event.target.value || "").trim();
 
         // Check if the current input value is a valid float
+        const inputElement = event.target.closest(".input-container") || event.target;
         if (!env.utils.isValidFloat(inputValue)) {
-            event.target.classList.add('invalid-cash-input');
+            inputElement.classList.add("is-invalid");
+            event.target.classList.add("invalid-cash-input");
         } else {
-            event.target.classList.remove('invalid-cash-input');
+            inputElement.classList.remove("is-invalid");
+            event.target.classList.remove("invalid-cash-input");
         }
     }
     onMounted(() => {
         if (cashInput.el) {
-            cashInput.el.value = (startingValue || 0).toString().replace('.', decimalPoint);
+            cashInput.el.value = (startingValue || 0).toString().replace(".", decimalPoint);
             cashInput.el.addEventListener("input", handleCashInputChange);
         }
     });
@@ -120,5 +123,5 @@ export function useValidateCashInput(inputRef, startingValue) {
         if (cashInput.el) {
             cashInput.el.removeEventListener("input", handleCashInputChange);
         }
-    })
+    });
 }


### PR DESCRIPTION
Since the use of Bootstrap, the money inputs using the useValidateCashInput hook are no longer correctly displayed when the user input is invalid.

Steps to reproduce:

 - Open a session in a shop
 - Open the "Cash In/Out" menu with the top right dropdown menu
 - Enter an invalid amount, like "invalid" for example
 
The input is not displayed with red borders.

This commit fixes the display of invalid inputs in the Cash In/Out and Closing Session popups, using the Bootstrap is-invalid CSS class.

task-id: 3444048
