### PR TITLE
[FIX] mail: padding on chatter message edit

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -8,7 +8,6 @@
     <div t-ref="composer">
         <div class="o-mail-Composer d-grid flex-shrink-0 pt-0"
                 t-att-class="{
-                    'pt-4': env.inChatter and props.type !== 'message',
                     'px-3 pb-2': extended and !props.composer.message,
                     'o-extended': extended,
                     'o-isUiSmall': ui.isSmall,

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -79,7 +79,7 @@
                 </t>
                 <t t-set="type" t-value="state.composerType === 'message' ? 'message' : 'note'"/>
                 <SuggestedRecipientsList t-if="props.hasFollowers and state.composerType !== 'note'" className="'px-3'" styleString="'margin-left:48px;'" thread="state.thread"/>
-                <Composer composer="state.thread.composer" autofocus="true" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" type="state.composerType"/>
+                <Composer composer="state.thread.composer" autofocus="true" className="state.composerType === 'message' ? '' : 'pt-4'" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" type="state.composerType"/>
             </t>
         </div>
         <div class="o-mail-Chatter-content">


### PR DESCRIPTION
Before this PR a huge padding was present when editing a message on the chatter. This commit fixes the issue.

Before
![image](https://github.com/odoo/odoo/assets/48757558/2c25db3f-ff48-4ff7-8c76-b4c256b8c1b0)

After
![image](https://github.com/odoo/odoo/assets/48757558/10132778-4cbb-4015-8eaa-3cabba8ba3ba)
