### PR TITLE
[IMP] web: add spacing between items inside `o_field_many2one_selection`

### DIFF
--- a/addons/sms/static/src/components/sms_button/sms_button.xml
+++ b/addons/sms/static/src/components/sms_button/sms_button.xml
@@ -6,7 +6,7 @@
             t-att-title="title"
             t-att-href="phoneHref"
             t-on-click.prevent.stop="onClick"
-            class="ms-3 d-inline-flex align-items-center o_field_phone_sms"
+            class="ms-2 d-inline-flex align-items-center o_field_phone_sms"
         ><i class="fa fa-mobile"></i><small class="fw-bold ms-1">SMS</small></a>
     </t>
 

--- a/addons/web/static/src/legacy/scss/fields_extra.scss
+++ b/addons/web/static/src/legacy/scss/fields_extra.scss
@@ -18,17 +18,4 @@
             top: $o-input-padding-y;
         }
     }
-
-    // Many2one
-    &.o_field_many2one .o_external_button {
-        flex: 0 0 auto;
-        padding: 0;
-        margin-left: 2px;
-        font-size: 19px;
-        color: #7C7BAD;
-        border: none;
-        &:hover {
-            background-color: transparent;
-        }
-    }
 }

--- a/addons/web/static/src/legacy/xml/base.xml
+++ b/addons/web/static/src/legacy/xml/base.xml
@@ -540,7 +540,7 @@
     </t>
     <div t-if="widget.mode === 'edit'" class="o_field_widget o_field_many2one" aria-atomic="true">
         <div class="o_field_many2one_selection">
-            <div class="o_input_dropdown">
+            <div class="o_input_dropdown d-flex gap-1">
                 <input type="text" class="o_input form-control"
                     t-att-barcode_events="widget.nodeOptions.barcode_events"
                     t-att-tabindex="widget.attrs.tabindex"

--- a/addons/web/static/src/views/fields/email/email_field.xml
+++ b/addons/web/static/src/views/fields/email/email_field.xml
@@ -8,7 +8,7 @@
             </div>
         </t>
         <t t-else="">
-            <div class="d-inline-flex w-100">
+            <div class="d-inline-flex w-100 gap-1">
                 <input
                     class="o_input"
                     t-att-id="props.id"
@@ -26,7 +26,7 @@
             <a
                 t-if="props.record.data[props.name]"
                 t-att-href="'mailto:'+props.record.data[props.name]"
-                class="ms-3 d-inline-flex align-items-center"
+                class="d-inline-flex align-items-center"
                 target="_blank"
             >
                 <i class="fa fa-envelope" data-tooltip="Send Email" aria-label="Send Email"></i>

--- a/addons/web/static/src/views/fields/many2one/many2one_field.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.xml
@@ -40,7 +40,7 @@
             </t>
         </t>
         <t t-else="">
-            <div class="o_field_many2one_selection">
+            <div class="o_field_many2one_selection gap-1">
                 <Many2XAutocomplete t-props="Many2XAutocompleteProps"/>
                 <t t-if="hasExternalButton">
                     <button

--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PhoneField" owl="1">
-        <div class="o_phone_content d-inline-flex w-100">
+        <div class="o_phone_content d-inline-flex w-100 gap-1">
             <t t-if="props.readonly">
                 <a t-if="props.record.data[props.name]" class="o_form_uri" t-att-href="phoneHref" t-esc="props.record.data[props.name]"/>
             </t>
@@ -23,7 +23,7 @@
             <a
                 t-if="props.record.data[props.name]"
                 t-att-href="phoneHref"
-                class="o_phone_form_link ms-3 d-inline-flex align-items-center"
+                class="o_phone_form_link d-inline-flex align-items-center"
             >
                 <i class="fa fa-phone"></i><small class="fw-bold ms-1">Call</small>
             </a>

--- a/addons/web/static/src/views/fields/url/url_field.xml
+++ b/addons/web/static/src/views/fields/url/url_field.xml
@@ -6,7 +6,7 @@
             <a class="o_field_widget o_form_uri" t-on-click.stop="" t-att-href="formattedHref" t-esc="props.text || props.record.data[props.name] || ''" target="_blank"/>
         </t>
         <t t-else="">
-            <div class="d-inline-flex w-100">
+            <div class="d-inline-flex w-100 gap-1">
                 <input
                     class="o_input"
                     t-att-id="props.id"
@@ -24,7 +24,7 @@
             <a
                 t-if="props.record.data[props.name]"
                 t-att-href="formattedHref"
-                class="ms-3 d-inline-flex align-items-center"
+                class="d-inline-flex align-items-center"
                 target="_blank"
             >
                 <i class="fa fa-globe" data-tooltip="Go to URL" aria-label="Go to URL"></i>

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -344,12 +344,11 @@
                 }
                 .o_input_dropdown,
                 .o_datepicker {
-                    > .o_input {
-                        padding-right: 15px; // to prevent caret overlapping
+                    > .dropdown .o_input {
+                        padding-right: ($caret-width * 2.5) + $o-input-padding-x;; // to prevent caret overlapping
                     }
                     > .o_dropdown_button,
                     .o_datepicker_button {
-                        margin-right: 5px;
                         @include o-position-absolute(0, 0);
                     }
                 }


### PR DESCRIPTION
Before this commit, when the external button is showing, it was too close to the input. In versions prior to the "Milk" refactoring, the button had more padding around the arrow and this problem wasn't apparent.

By adding a `gap-1` we add spacing only if the field has more than one element inside it.

task-3458751
part of task-3326263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
