### PR TITLE
[IMP] account_edi: add edi document export button

### DIFF
--- a/addons/account_edi/__init__.py
+++ b/addons/account_edi/__init__.py
@@ -1,3 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 from . import models
+from . import controller

--- a/addons/account_edi/controller/__init__.py
+++ b/addons/account_edi/controller/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/account_edi/controller/main.py
+++ b/addons/account_edi/controller/main.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import http
+from odoo.http import request, content_disposition
+
+
+class EdiDocumentDownloadController(http.Controller):
+    @http.route('/account_edi/download_edi_documents', type='http', auth='user')
+    def download_edi_documents(self, **args):
+        ids = list(map(int, request.httprequest.args.getlist('ids')))
+
+        moves = request.env['account.move'].browse(ids)
+        moves.check_access_rights('read')
+        moves.check_access_rule('read')
+
+        content = moves._create_zipped()
+        headers = [
+            ('Content-Type', 'zip'),
+            ('X-Content-Type-Options', 'nosniff'),
+            ('Content-Length', len(content)),
+            ('Content-Disposition', content_disposition('edi_documents.zip')),
+        ]
+        return request.make_response(content, headers)

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -142,5 +142,16 @@
                 </xpath>
             </field>
         </record>
+        <record id="model_account_download_electronic_invoice" model="ir.actions.server">
+            <field name="name">Download Electronic Invoices</field>
+            <field name="model_id" ref="model_account_move"/>
+            <field name="binding_model_id" ref="model_account_move"/>
+            <field name="binding_view_types">list</field>
+            <field name="state">code</field>
+            <field name="code">
+                if records:
+                    action = records._action_download_electronic_invoice()
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
backport of the following commit that was done in 16.1: https://github.com/odoo/odoo/commit/5171f607e1fddde06b769ebb78d82548ad4dc84d?diff=unified

In some occasions, we want to be able to download all edi documents so the user can upload them on a governemental platform. From the list view of all the invoice, it is now possible to selected as many invoice as we want, and with a newly added action download them into a zip.

A slight modification from the original commit is that we no longer filter for only sent and cancelled edi documents, but also 'to_send' and 'to_cancel'. The reason lies behind the fact that for the Italian Localization, they want to be able to use the feature without using the send & print button. Also, we improved the security with a check on access right on the model and records.

task: 3458310

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
