### PR TITLE
[FIX] project_todo: avoid traceback when converting a todo

### DIFF
--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -31,7 +31,7 @@ export class TodoFormController extends FormController {
             filteredActions.push({
                 description: this.env._t("Convert to Task"),
                 callback: () => {
-                    this.model.actionService.doAction(
+                    this.model.action.doAction(
                         "project_todo.project_task_action_convert_todo_to_task",
                         {
                             props: {


### PR DESCRIPTION
Steps
=====
- Open To-Do app
- Create a To-Do
- In its form view click on action > Convert to task

Issue
=====
A traceback appears indicating that the
function doAction does not exist.

Cause
=====
actionService has been renamed to action on relational model. Therefore accessing `this.model.actionService.doAction` doesn't work anymore.

Fix
===
action is used instead of actionService

task-3458999

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
