### PR TITLE
Master website recruitment at least one of resume or linked in mafl

### DIFF
--- a/addons/website_hr_recruitment/__manifest__.py
+++ b/addons/website_hr_recruitment/__manifest__.py
@@ -28,6 +28,7 @@
     'assets': {
         'web.assets_frontend': [
             'website_hr_recruitment/static/src/scss/**/*',
+            'website_hr_recruitment/static/src/js/website_hr_applicant_form.js',
         ],
         'website.assets_wysiwyg': [
             'website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js',

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import warnings
+from datetime import datetime, timedelta
 
 from odoo import http, _
 from odoo.addons.http_routing.models.ir_http import slug
@@ -277,3 +278,13 @@ class WebsiteHrRecruitment(http.Controller):
             contract_type_id=contract_type_id,
             **kwargs
         )
+
+    @http.route('/website_hr_recruitment/check_recent_application', type='json', auth="public")
+    def check_recent_application(self, email, job_id):
+        date_limit = datetime.now() - timedelta(days=90)
+        domain = [('email_from', '=ilike', email),
+                  ('create_date', '>=', date_limit)]
+        recent_applications = http.request.env['hr.applicant'].sudo().search(domain)
+        response = {'applied_same_job': any(a.job_id.id == int(job_id) for a in recent_applications),
+                    'applied_other_job': bool(recent_applications)}
+        return response

--- a/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
@@ -1,0 +1,83 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import { _t } from "@web/core/l10n/translation";
+
+publicWidget.registry.hrRecruitment = publicWidget.Widget.extend({
+    selector : '#hr_recruitment_form',
+    events: {
+        'click #apply-btn': '_onClickApplyButton',
+        'focusout #recruitment2' : '_onFocusOutMail',
+        'focusout #recruitment4' : '_onFocusOutLinkedin',
+    },
+
+    init: function () {
+        this._super.apply(this, arguments);
+    },
+
+    willStart() {
+        return Promise.all([
+            this._super(),
+        ]);
+    },
+
+    _onClickApplyButton (ev) {
+        const linkedin_profile = $('#recruitment4').val();
+        const resume = $('#recruitment6').val();
+        if (linkedin_profile.trim() === '' &&
+            resume.trim() === '') {
+            $('#recruitment4').attr('required', true);
+            $('#recruitment6').attr('required', true);
+        } else {
+            $('#recruitment4').attr('required', false);
+            $('#recruitment6').attr('required', false);
+        }
+    },
+
+    async _onFocusOutLinkedin (ev) {
+        const linkedin = $(ev.currentTarget).val();
+        if (!linkedin) {
+            $(ev.currentTarget).removeClass('border-warning');
+            $('#linkedin-message').removeClass('alert-warning').hide();
+            return;
+        }
+        const linkedin_regex = /^(https?:\/\/)?([\w\.]*)linkedin\.com\/in\/(.*?)(\/.*)?$/;
+        if (!linkedin_regex.test(linkedin)) {
+            $('#linkedin-message').removeClass('alert-warning').hide();
+            $(ev.currentTarget).addClass('border-warning');
+            $('#linkedin-message').text(_t("The value entered doesn't seems like a linkedin profile.")).addClass('alert-warning').show();
+        } else {
+            $(ev.currentTarget).removeClass('border-warning');
+            $('#linkedin-message').removeClass('alert-warning').hide();
+        }
+    },
+
+    async _onFocusOutMail (ev) {
+        const email = $(ev.currentTarget).val();
+        if (!email) {
+            $(ev.currentTarget).removeClass('border-warning');
+            $('#email-message').removeClass('alert-warning').hide();
+            return;
+        }
+        const job_id = $('#recruitment7').val();
+        const data = await this._rpc({
+            route: '/website_hr_recruitment/check_recent_application',
+            params: {
+                email: email,
+                job_id: job_id,
+            }
+        });
+        if (data.applied_same_job)  {
+            $('#email-message').removeClass('alert-warning').hide();
+            $(ev.currentTarget).addClass('border-warning');
+            $('#email-message').text(_t('You already applied to this job position recently.')).addClass('alert-warning').show();
+        } else if (data.applied_other_job)  {
+            $('#email-message').removeClass('alert-warning').hide();
+            $(ev.currentTarget).addClass('border-warning');
+            $('#email-message').text(_t("You already applied to another position recently. You can continue if it's not a mistake.")).addClass('alert-warning').show();
+        } else {
+            $(ev.currentTarget).removeClass('border-warning');
+            $('#email-message').removeClass('alert-warning').hide();
+        }
+    },
+});

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -23,6 +23,10 @@
             trigger: "input[name=partner_mobile]",
             run: `text ${application.phone}`,
         }, {
+            content: "Complete LinkedIn profile",
+            trigger: "input[name=linkedin_profile]",
+            run: `text linkedin.com/in/${application.name.toLowerCase().replace(' ', '-')}`,
+        }, {
             content: "Complete Subject",
             trigger: "textarea[name=description]",
             run: `text ${application.subject}`,

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -216,6 +216,7 @@
                                                     class="form-control s_website_form_input"
                                                     name="email_from" required=""
                                                     data-fill-with="email"/>
+                                                <div class="alert alert-warning mt-2" id="email-message" style="display:none;"></div>
                                             </div>
                                         </div>
                                     </div>
@@ -241,13 +242,14 @@
                                                 <span class="s_website_form_label_content">LinkedIn Profile</span>
                                             </label>
                                             <div class="col-sm" style="position: relative">
-                                                <i class="fa fa-linkedin fa-2x m-1 o_linkedin_icon"></i>
+                                                <i class="fa fa-linkedin fa-2x m-1 o_linkedin_icon" style="max-height: 37px;"></i>
                                                 <input id="recruitment4" type="text"
                                                     class="form-control s_website_form_input pl64"
                                                     placeholder="e.g. https://www.linkedin.com/in/fpodoo/"
                                                     style="padding-left: 40px"
                                                     name="linkedin_profile"
                                                     data-fill-with="linkedin_profile"/>
+                                                <div class="alert alert-warning mt-2" id="linkedin-message" style="display:none;"></div>
                                             </div>
                                         </div>
                                     </div>
@@ -261,11 +263,9 @@
                                                 <input id="recruitment6" type="file"
                                                     class="form-control s_website_form_input o_resume_input"
                                                     name="Resume"/>
-                                                <span class="text-muted" style="font-size: 0.8rem">Optional if you provided a Linkedin profile</span>
+                                                <span class="text-muted small">Provide either a resume file or a linkedin profile</span>
                                             </div>
                                         </div>
-                                        <!-- TODO: remove in master -->
-                                        <span class="d-none text-muted" style="margin-left: 200px; font-size: 0.8rem">The resume is optional if you have a Linkedin profile</span>
                                     </div>
                                     <div class="col-12 mb-0 py-2 s_website_form_field"
                                         data-type="text" data-name="Field">
@@ -291,6 +291,9 @@
                                                     class="form-control s_website_form_input"
                                                     name="job_id"/>
                                             </div>
+                                            <div class="col-sm">
+                                                <input id="csrf_token" type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="col-12 mb-0 py-2 s_website_form_field s_website_form_dnone">
@@ -307,7 +310,7 @@
                                     </div>
                                     <div class="col-12 s_website_form_submit mb64" data-name="Submit Button">
                                         <div style="width: 200px" class="s_website_form_label"/>
-                                        <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send">I'm feeling lucky</a>
+                                        <a href="#" role="button" class="btn btn-primary btn-lg s_website_form_send" id="apply-btn">I'm feeling lucky</a>
                                         <span id="s_website_form_result"></span>
                                     </div>
                                 </div>


### PR DESCRIPTION
[IMP] website_hr_recruitment: Enhance UI/UX
Previously, applicants could submit job applications without providing a
resume or LinkedIn profile URL. Additionally, there was no notification
for applicants if they had recently applied for the same job or another
position, and no checks or notification were in place for malformed
LinkedIn URLs.

This PR addresses these issues by:
- Requiring at least one of Resume or LinkedIn profile for an applicant
  to apply.
- Notifying applicants about prior applications for the same job or
  different positions.
- Adding a LinkedIn URL an notifying the applicants that he has
  probably made a mistake if the regex doesn't match his input.

task-3446696

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
