### PR TITLE
[IMP] web: add link to readonly many2one_avatar widget

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -47,15 +47,15 @@ QUnit.test("many2one_avatar_employee widget in list view", async function (asser
         views: [[false, "list"]],
     });
     assert.strictEqual(
-        document.querySelector(".o_data_cell span:not(.o_m2o_avatar) span").innerText,
+        document.querySelector(".o_data_cell div[name='employee_id']").innerText,
         "Mario"
     );
     assert.strictEqual(
-        document.querySelectorAll(".o_data_cell span:not(.o_m2o_avatar) span")[1].innerText,
+        document.querySelectorAll(".o_data_cell div[name='employee_id']")[1].innerText,
         "Luigi"
     );
     assert.strictEqual(
-        document.querySelectorAll(".o_data_cell span:not(.o_m2o_avatar) span")[2].innerText,
+        document.querySelectorAll(".o_data_cell div[name='employee_id']")[2].innerText,
         "Mario"
     );
 

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -10,7 +10,7 @@
                      class="rounded"
                 />
             </span>
-            <Many2OneField t-props="many2OneProps" canOpen="!props.readonly"/>
+            <Many2OneField t-props="many2OneProps"/>
         </div>
     </t>
 

--- a/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
@@ -186,7 +186,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         assert.deepEqual(
-            getNodesTextContent(target.querySelectorAll(".o_data_cell[name='user_id'] span span")),
+            getNodesTextContent(target.querySelectorAll(".o_data_cell[name='user_id']")),
             ["Aline", "Christine", "Aline", ""]
         );
         const imgs = target.querySelectorAll(".o_m2o_avatar > img");
@@ -204,7 +204,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         assert.deepEqual(
-            getNodesTextContent(target.querySelectorAll(".o_data_cell[name='user_id'] span span")),
+            getNodesTextContent(target.querySelectorAll(".o_data_cell[name='user_id']")),
             ["Aline", "Christine", "Aline", ""]
         );
 
@@ -254,7 +254,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         await click(target.querySelectorAll(".o_data_row")[0], ".o_list_record_selector input");
-        await click(target.querySelector(".o_data_row .o_data_cell [name='user_id'] span span"));
+        await click(target.querySelector(".o_data_row .o_data_cell [name='user_id']"));
         assert.hasClass(target.querySelector(".o_data_row"), "o_selected_row");
 
         assert.verifySteps([]);
@@ -279,7 +279,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         await click(target.querySelectorAll(".o_data_row")[0], ".o_list_record_selector input");
-        await click(target.querySelector(".o_data_row .o_data_cell [name='user_id'] span span"));
+        await click(target.querySelector(".o_data_row .o_data_cell [name='user_id']"));
         assert.hasClass(target.querySelector(".o_data_row"), "o_selected_row");
 
         assert.verifySteps([]);
@@ -303,10 +303,22 @@ QUnit.module("Fields", (hooks) => {
                 </tree>`,
         });
 
-        await click(target.querySelector(".o_data_row .o_data_cell [name='user_id'] span span"));
+        await click(target.querySelector(".o_data_row .o_data_cell [name='user_id']"));
         assert.containsNone(target, ".o_selected_row");
 
         assert.verifySteps(["openRecord"]);
+    });
+
+    QUnit.test("readonly many2one_avatar should contain a link", async function (assert) {
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 1,
+            arch: `<form><field name="user_id" widget="many2one_avatar" readonly="1"/></form>`,
+        });
+
+        assert.containsOnce(target, "[name='user_id'] a");
     });
 
     QUnit.test("cancelling create dialog should clear value in the field", async function (assert) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- For some reason, there is a condition where a many2one field can't be opened when the field is readonly and using the many2one_avatar (or its descendants) widget. This commit aims at removing that condition.

Current behavior before PR:
- a readonly Many2One field that have a widget of "many2one_avatar" / "many2one_avatar_user" / "many2one_avatar_employee" can't be opened to view/edit their form

Desired behavior after PR is merged:
- a readonly Many2One field that have a widget of "many2one_avatar" / "many2one_avatar_user" / "many2one_avatar_employee" will have a link to view/edit their form

task-id: 3454944