### PR TITLE
[FIX] base_automation: handle error while updating contacts

### DIFF
--- a/addons/base_automation/i18n/base_automation.pot
+++ b/addons/base_automation/i18n/base_automation.pot
@@ -268,6 +268,12 @@ msgid ""
 msgstr ""
 
 #. module: base_automation
+#: code:addons/base_automation/models/base_automation.py:0
+#, python-format
+msgid "Invalid domain %s in base automation"
+msgstr ""
+
+#. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation____last_update
 msgid "Last Modified on"
 msgstr ""


### PR DESCRIPTION
When user creates a custom char field and adds a compute function to calculate the amount, and from the automated action applies a domain where two different data types are being compared then the error is generated.

Steps to Produce:
- Install 'contact', 'purchase_stock'and 'web_studio'
- Go to 'contact' and open any contact
- Click on toggle studio
- Add a char field and set label total. and click on more
- Add code in compute (https://cdn.discordapp.com/attachments/1022433496985260083/1133006076724383804/Screenshot_from_2023-07-24_17-31-12.png)
- Go to Automated action and create record (https://cdn.discordapp.com/attachments/1022433496985260083/1133002924990152804/Screenshot_from_2023-07-24_17-18-57.png)
- Add domain [('x_studio_total', '<=', '1000')] on 'Apply on' (filter_domain)
- Close the studio and update any contact

Traceback will be generated
Error: TypeError: '<=' not supported between instances of 'bool' and 'str'

See:-
```
TypeError: '<=' not supported between instances of 'bool' and 'str'
  File "odoo/http.py", line 2123, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1699, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1726, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1927, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 190, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 716, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/custom/trial/saas_trial/models/res_users.py", line 119, in write
    res = super(ResUsers, self).write(values)
  File "addons/hr/models/res_users.py", line 266, in write
    result = super(User, self).write(vals)
  File "addons/gamification/models/res_users.py", line 96, in write
    return super().write(values)
  File "addons/auth_totp_mail/models/res_users.py", line 11, in write
    res = super().write(vals)
  File "addons/mail/models/discuss/res_users.py", line 21, in write
    res = super().write(vals)
  File "addons/mail/models/res_users.py", line 119, in write
    write_res = super(Users, self).write(vals)
  File "addons/resource/models/res_users.py", line 17, in write
    rslt = super().write(vals)
  File "odoo/addons/base/models/res_users.py", line 1604, in write
    res = super(UsersView, self).write(values)
  File "odoo/addons/base/models/res_users.py", line 1300, in write
    return super(UsersImplied, self).write(values)
  File "odoo/addons/base/models/res_users.py", line 612, in write
    res = super(Users, self).write(values)
  File "odoo/models.py", line 4046, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1396, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 102, in determine
    return needle(records, *args)
  File "odoo/fields.py", line 721, in _inverse_related
    target[field.name] = record_value[record]
  File "odoo/models.py", line 6140, in __setitem__
    return self._fields[key].__set__(self, value)
  File "odoo/fields.py", line 1320, in __set__
    records.write({self.name: write_value})
  File "addons/base_automation/models/base_automation.py", line 414, in write
    records, domain_post = action._filter_post_export_domain(pre[action])
  File "addons/base_automation/models/base_automation.py", line 288, in _filter_post_export_domain
    return records.sudo().filtered_domain(domain).with_env(records.env), domain
  File "odoo/models.py", line 5759, in filtered_domain
    ok = any(x is not None and x <= value for x in data)
  File "odoo/models.py", line 5759, in <genexpr>
    ok = any(x is not None and x <= value for x in data)
```



sentry-4335808183