### PR TITLE
[FIX] l10n_de/de_reports: fix updating DE balance sheet

### DIFF
--- a/addons/l10n_de/data/account_account_tags_data.xml
+++ b/addons/l10n_de/data/account_account_tags_data.xml
@@ -775,6 +775,10 @@
         <field name="name">Bilanz-Passiva: A V-Jahresüberschuß/Jahresfehlbetrag</field>
         <field name="applicability">accounts</field>
     </record>
+    <record id="tag_de_liabilities_bs_B" model="account.account.tag">
+        <field name="name">Bilanz-Passiva: B Sonderposten mit Rücklageanteil</field>
+        <field name="applicability">accounts</field>
+    </record>
     <record id="tag_de_liabilities_bs_B_1" model="account.account.tag">
         <field name="name">Bilanz-Passiva: B 1-Rückstellungen für Pensionen und ähnliche Verpflichtungen</field>
         <field name="applicability">accounts</field>


### PR DESCRIPTION
The changes done in odoo/odoo/pull/126249 were not complete and caused some issues in their FW ports. This fixes it by:
- Adding the tag_de_liabilities_bs_B tag back again in account_account_tags_data.xml as this tag was not renamed thus removed during the upgrade. Deleting this tag means we should check if it's used elsewhere which is not simple.
- Rename the xmlids in balance_sheet.xml to new ones. Before they were renamed to already existing ones, d_1 to c_1 for example. During the 16.0 FW, as the way reports are written changed, this caused some issues like: C should not have a groupby but still did after the upgrade as B had a groupby.

Enterprise PR: odoo/enterprise/pull/45522