### PR TITLE
[FIX] project: remove exception while fail sync record

### DIFF
--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -42,9 +42,8 @@ def after_commit(func):
                 env = api.Environment(cr, uid, context)
                 try:
                     func(self.with_env(env), *args, **kwargs)
-                except Exception as e:
-                    _logger.warning("Could not sync record now: %s" % self)
-                    _logger.exception(e)
+                except TypeError:
+                    _logger.warning("Could not sync record now: %s", self, exc_info=True)
 
     return wrapped
 


### PR DESCRIPTION
The HTTP connection would time out during the attempt to synchronize or
update a Microsoft Calendar record, which would result in the error would be
generated.

traceback:-
```
TypeError: string indices must be integers
  File "addons/microsoft_calendar/models/microsoft_sync.py", line 44, in called_after
    func(self.with_env(env), *args, **kwargs)
  File "addons/microsoft_calendar/models/microsoft_sync.py", line 443, in _microsoft_insert
    event_id, uid = microsoft_service.insert(values, token=token, timeout=timeout)
  File "addons/microsoft_calendar/utils/microsoft_calendar.py", line 20, in wrapped
    return func(self, *args, **kwargs)
  File "addons/microsoft_calendar/utils/microsoft_calendar.py", line 141, in insert
    return data['id'], data['iCalUId']
```

The logger is updated to remove the exception due to this change
reflects a less severe logging level for cases when synced
records.

sentry-4339147197

