### PR TITLE
[FIX] point_of_sale: name in customer creation not working

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.xml
@@ -13,7 +13,7 @@
                         </t>
                         <input type="file" class="image-uploader" t-on-change="uploadImage" />
                     </div>
-                    <input class="detail partner-name form-control form-control-lg" name="name" t-att-value="props.partner.name or ''" placeholder="Name" t-on-change="captureChange" />
+                    <input class="detail partner-name form-control form-control-lg" name="name" t-model="changes.name" placeholder="Name" />
                 </div>
                 <div class="partner-details-box row row-cols-1 row-cols-sm-2 gy-3 mt-3">
                     <t t-foreach="['Street', 'City', 'Zip', 'Email', 'Phone', 'Mobile', 'Barcode' ]" t-as="item" t-key="item">


### PR DESCRIPTION
The introduction of bootstrap in PoS reset the changes made on the field "name" in the partner_editor by this PR (odoo/odoo#126021). This led to the "name" field not working properly and sending a traceback when changed (see under). This PR puts back the changes made.

![image](https://github.com/odoo/odoo/assets/118442417/d6da2b27-f235-4741-a2aa-9d2feaba8403)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
