### PR TITLE
[FIX] website, web_editor: prevent entering edit mode for drag/drop block

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2881,7 +2881,9 @@ export class Wysiwyg extends Component {
         if (node?.querySelectorAll) {
             for (const element of node.querySelectorAll('.o_editable, .o_not_editable')) {
                 const editable = element.classList.contains('o_editable');
-                if (element.isContentEditable !== editable) {
+                if(element.hasAttribute('data-oe-not-contenteditable') && !element.firstChild) {
+                    element.contentEditable = false;
+                } else if (element.isContentEditable !== editable) {
                     element.contentEditable = editable;
                 }
             }

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -447,7 +447,9 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         this.$editorMessageElement = $wrap.not('[data-editor-message]')
                 .attr('data-editor-message-default', true)
                 .attr('data-editor-message', this.env._t('DRAG BUILDING BLOCKS HERE'));
-        $wrap.filter(':empty').attr('contenteditable', false);
+        // Using "data-oe-not-contenteditable" as marker, to keep node
+        // contenteditable = false while having "o_editable" class.
+        $wrap.filter(':empty').attr('data-oe-not-contenteditable', '');
         for (let htmlEl of $wrap.not("[placeholder]").filter('[data-oe-sanitize="no_block"]')) {
             const placeholderText = this.env._t("Type in text here...");
             // Put the placeholder in the same location as the powerbox hint.


### PR DESCRIPTION
Steps to reproduce :
1. Enter the edit mode of the homepage
2. Click on the page
-> Bug: Drag building block is editable
-> Bug: the "Type / to enter a command message" appear and stays

With this PR [1], we are using the `o_editable` and `o_not_editable`
classes as markers for contentEditable values in HTML. Before this, we
only considered the `o_not_editable` class as a marker.

We have an `o_editable` class with contrast of `contenteditable=false`
attribute in the drag/drop block. So it's getting set to `true` by the
observer during sanitizing the field that makes the block editable.

To prevent it, added the flag attribute `data-oe-not-contenteditable`
which will keep the value of contenteditable = 'false'  by sanitize the
function.

[1]: https://github.com/odoo/odoo/commit/17ee75a84d00eedb1778edcdbd541025e8473ef0

Behaviour before this PR :
![image](https://github.com/odoo/odoo/assets/125337508/d2af15a5-222d-49f9-8f2c-86c623f30c69)

Behaviour after this PR :
Drag/drop building block is no more text editable. 

task-3443430