### PR TITLE
[FIX] payment, website_sale, website_sale_picking: manage on site pick

### DIFF
--- a/addons/website_sale_picking/static/src/js/checkout_form.js
+++ b/addons/website_sale_picking/static/src/js/checkout_form.js
@@ -75,8 +75,6 @@ publicWidget.registry.websiteSaleDelivery.include({
         if (!atLeastOneOptionAvailable) {
             this.warning.classList.remove('d-none');
             disabledReasons.noOptionAvailableOnsite = true;
-        } else if (this.paymentOptions.length === 1) {
-            $(this.paymentOptions[0]).click(); // Make sure the option is selected if that's the only one, because the input is hidden in that case.
         }
         $payButton.data('disabled_reasons', disabledReasons);
     }


### PR DESCRIPTION
Steps to reproduce:
-------------------
- install website_sale;
- install website_sale_picking;
- enable just "Pay in store when picking the product" provider;
- pusblish just "[On Site Pick] My Shop 1" shipping method;
- go to ecommerce and make the purchase flow.

Issue:
------
A traceback appears on the "/shop/payment" page.

Solution:
---------
The sale picking part must not manage payments.

opw-3451097