### PR TITLE
[IMP] base: make country state names translatable

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -160,7 +160,7 @@ class CountryState(models.Model):
     _order = 'code'
 
     country_id = fields.Many2one('res.country', string='Country', required=True)
-    name = fields.Char(string='State Name', required=True,
+    name = fields.Char(string='State Name', required=True, translate=True,
                help='Administrative divisions of a country. E.g. Fed. State, Departement, Canton')
     code = fields.Char(string='State Code', help='The state code.', required=True)
 


### PR DESCRIPTION
Country states are used in multiple customer facing flows, most notably eCommerce and pdf reports. Quite a few countries are multi-lingual and might have localized names for country states (e.g. Namur/Namen in Belgium, Nouveau-Brunswick/New-Brunswick in Canada, Fribourg/Freiburg/Friburgo/Friburg in Switwerland, etc.).

This commit makes it possible to translate these names for better customer-facing experiences.

Task-3285734