### PR TITLE
[FIX] account_edi_ubl_cii: add account_edi module in depends

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -22,7 +22,7 @@ Note also that in order for Chorus Pro to automatically detect the "PDF/A-3 (Fac
 the "Factur-X PDF/A-3" option on the journal. This option will also validate the xml against the Factur-X and Chorus
 Pro rules and show the errors.
     """,
-    'depends': ['account', 'base_vat'],
+    'depends': ['account', 'account_edi', 'base_vat'],
     'data': [
         'data/cii_22_templates.xml',
         'data/ubl_20_templates.xml',


### PR DESCRIPTION
When user creates new invoice and tries to Send & Print,
a traceback will appear.

Steps to reproduce the error:
- Install 'account_edi_ubl_cii'
- Go to Invoicing > create new invoice
- Fill required fields > confirm > Send & Print > Send & Print

Traceback:
```
AttributeError: 'account.move' object has no attribute '_prepare_edi_vals_to_export'
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 233, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/account/wizard/account_move_send.py", line 620, in action_send_and_print
    self._generate_invoice_documents(moves_data, allow_fallback_pdf=allow_fallback_pdf)
  File "addons/account/wizard/account_move_send.py", line 564, in _generate_invoice_documents
    form._hook_invoice_document_after_pdf_report_render(invoice, invoice_data)
  File "addons/account_edi_ubl_cii/models/account_move_send.py", line 143, in _hook_invoice_document_after_pdf_report_render
    xml_facturx = self.env['account.edi.xml.cii']._export_invoice(invoice)[0]
  File "addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py", line 236, in _export_invoice
    vals = self._export_invoice_vals(invoice)
  File "addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py", line 166, in _export_invoice_vals
    **invoice._prepare_edi_vals_to_export(),
```

https://github.com/odoo/odoo/blob/abc44e8027e4d3518b3de284f4773d6fbea20374/addons/account_edi_ubl_cii/__manifest__.py#L25 Here, 'account_edi' module is not in the depends.
So it will lead to above traceback.

From commit: https://github.com/odoo/odoo/commit/2d2faafb744abdb09f199ab85f11d317ee1d065e
```'auto_install': True``` is removed from ```account_edi```,
so when we install ```account_edi_ubl_cii```, it will install invoice,
but due to this commit ```account_edi``` will not be installed.

sentry-4380547757

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
