### PR TITLE
[FIX] web: fix the unity read with relational properties

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -311,7 +311,7 @@ export class Record extends DataPoint {
         const unsetRequiredFields = [];
         for (const fieldName in this.activeFields) {
             const fieldType = this.fields[fieldName].type;
-            if (this._isInvisible(fieldName)) {
+            if (this._isInvisible(fieldName) || this.fields[fieldName].relatedPropertyField) {
                 continue;
             }
             switch (fieldType) {
@@ -603,9 +603,9 @@ export class Record extends DataPoint {
                 if (field.type === "properties") {
                     for (const property of parsedValues[fieldName]) {
                         const fieldPropertyName = `${fieldName}.${property.name}`;
-                        if (property.type === "one2many" || property.type === "many2many") {
+                        if (property.type === "many2many") {
                             const staticList = this._createStaticListDatapoint(
-                                property.value.map((record) => ({
+                                (property.value || []).map((record) => ({
                                     id: record[0],
                                     display_name: record[1],
                                 })),
@@ -788,7 +788,8 @@ export class Record extends DataPoint {
     async _save({ noReload, onError } = {}) {
         // before saving, abandon new invalid, untouched records in x2manys
         for (const fieldName in this.activeFields) {
-            if (["one2many", "many2many"].includes(this.fields[fieldName].type)) {
+            const field = this.fields[fieldName];
+            if (["one2many", "many2many"].includes(field.type) && !field.relatedPropertyField) {
                 this.data[fieldName]._abandonRecords();
             }
         }

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -214,6 +214,8 @@ export class RelationalModel extends Model {
                                 propertyName: property.name,
                                 relation: property.comodel,
                             };
+                        }
+                        if (!config.activeFields[propertyFieldName]) {
                             config.activeFields[propertyFieldName] =
                                 createPropertyActiveField(property);
                         }

--- a/odoo/addons/test_new_api/tests/test_unity_read.py
+++ b/odoo/addons/test_new_api/tests/test_unity_read.py
@@ -755,3 +755,36 @@ class TestUnityRead(TransactionCase):
                 'm2o_reference_model': False,
             }
         ])
+
+    def test_properties(self):
+        """Check that the display name of the relational properties are always loaded."""
+        discussion = self.env['test_new_api.discussion'].create({
+            'name': 'Test Discussion',
+            'attributes_definition': [{
+                'name': 'discussion_color_code',
+                'string': 'Color Code',
+                'type': 'char',
+                'default': 'blue',
+            }, {
+                'name': 'moderator_partner_id',
+                'string': 'Partner',
+                'type': 'many2one',
+                'comodel': 'test_new_api.partner',
+            }],
+            'participants': [Command.link(self.env.user.id)],
+        })
+        partner = self.env['test_new_api.partner'].create({'name': 'Test Partner Properties'})
+        message = self.env['test_new_api.message'].create({
+            'name': 'Test Message',
+            'discussion': discussion.id,
+            'author': self.env.user.id,
+            'attributes': {
+                'discussion_color_code': 'Test',
+                'moderator_partner_id': partner.id,
+            },
+        })
+        values = message.web_read({'attributes': False})[0]['attributes']
+        self.assertEqual(len(values), 2)
+        self.assertEqual(values[0]['name'], 'discussion_color_code')
+        self.assertEqual(values[1]['name'], 'moderator_partner_id')
+        self.assertEqual(values[1]['value'], (partner.id, 'Test Partner Properties'))

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3365,7 +3365,7 @@ class BaseModel(metaclass=MetaModel):
                     except MissingError:
                         vals.clear()
 
-                results = field.convert_to_read_multi(values_list, self.browse(records), use_display_name)
+                results = field.convert_to_read_multi(values_list, self.browse(records))
                 for record_read_vals, convert_result in zip(data, results):
                     record_read_vals[1][name] = convert_result
                 continue


### PR DESCRIPTION
Bug 1
=====
Since 7d2baaa0c726a7b0dd4fe7226862f960c9c59b73 , we read the field with `web_read`. We don't load the display name when calling read, but instead we load them after.

But, since this change, the display names of the relational properties are not loaded.

Bug 2
=====
Since https://github.com/odoo/odoo/commit/8723f020c3587a900c811b8cc23f53fe34b98df3 , they are some tracebacks with the properties when switching the views. For example, if you open a many2many properties record (by clicking on the badge), and then go back to the original form view, a traceback is raised.

Task-3460126