### PR TITLE
[FIX] point_of_sale, *: fix cancelled orders

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -114,7 +114,7 @@ class PosSession(models.Model):
             if cash_payment_method:
                 total_cash_payment = 0.0
                 last_session = session.search([('config_id', '=', session.config_id.id), ('id', '<', session.id)], limit=1)
-                result = self.env['pos.payment']._read_group([('session_id', '=', session.id), ('payment_method_id', '=', cash_payment_method.id)], aggregates=['amount:sum'])
+                result = self.env['pos.payment']._read_group(['&', '&', ('pos_order_id.state', '!=', 'cancel'), ('session_id', '=', session.id), ('payment_method_id', '=', cash_payment_method.id)], aggregates=['amount:sum'])
                 total_cash_payment = result[0][0] or 0.0
                 if session.state == 'closed':
                     session.cash_register_total_entry_encoding = session.cash_real_transaction + total_cash_payment
@@ -291,7 +291,7 @@ class PosSession(models.Model):
         self.ensure_one()
         data = {}
         sudo = self.user_has_groups('point_of_sale.group_pos_user')
-        if self.order_ids or self.sudo().statement_line_ids:
+        if self._get_valid_orders() or self.sudo().statement_line_ids:
             self.cash_real_transaction = sum(self.sudo().statement_line_ids.mapped('amount'))
             if self.state == 'closed':
                 raise UserError(_('This session is already closed.'))
@@ -300,7 +300,7 @@ class PosSession(models.Model):
             cash_difference_before_statements = self.cash_register_difference
             if self.update_stock_at_closing:
                 self._create_picking_at_end_of_session()
-                self.order_ids.filtered(lambda o: not o.is_total_cost_computed)._compute_total_cost_at_session_closing(self.picking_ids.move_ids)
+                self._get_valid_orders().filtered(lambda o: not o.is_total_cost_computed)._compute_total_cost_at_session_closing(self.picking_ids.move_ids)
             try:
                 with self.env.cr.savepoint():
                     data = self.with_company(self.company_id).with_context(check_move_validity=False, skip_invoice_sync=True)._create_account_move(balancing_account, amount_to_balance, bank_payment_method_diffs)
@@ -605,7 +605,7 @@ class PosSession(models.Model):
         else:
             session_destination_id = picking_type.default_location_dest_id.id
 
-        for order in self.order_ids:
+        for order in self._get_valid_orders():
             if order.company_id.anglo_saxon_accounting and order.is_invoiced or order.shipping_date:
                 continue
             destination_id = order.partner_id.property_stock_customer.id or session_destination_id
@@ -701,7 +701,7 @@ class PosSession(models.Model):
         rounded_globally = self.company_id.tax_calculation_rounding_method == 'round_globally'
         pos_receivable_account = self.company_id.account_default_pos_receivable_account_id
         currency_rounding = self.currency_id.rounding
-        for order in self.order_ids:
+        for order in self._get_valid_orders():
             order_is_invoiced = order.is_invoiced
             for payment in order.payment_ids:
                 amount = payment.amount
@@ -1153,7 +1153,7 @@ class PosSession(models.Model):
 
         # reconcile stock output lines
         pickings = self.picking_ids.filtered(lambda p: not p.pos_order_id)
-        pickings |= self.order_ids.filtered(lambda o: not o.is_invoiced).mapped('picking_ids')
+        pickings |= self._get_valid_orders().filtered(lambda o: not o.is_invoiced).mapped('picking_ids')
         stock_moves = self.env['stock.move'].search([('picking_id', 'in', pickings.ids)])
         stock_account_move_lines = self.env['account.move'].search([('stock_move_id', 'in', stock_moves.ids)]).mapped('line_ids')
         for account_id in stock_output_lines:
@@ -1470,9 +1470,10 @@ class PosSession(models.Model):
         return self.env['account.move.line'].search([('ref', 'in', diff_lines_ref + cost_move_lines)]).mapped('move_id')
 
     def _get_related_account_moves(self):
-        pickings = self.picking_ids | self.order_ids.mapped('picking_ids')
-        invoices = self.mapped('order_ids.account_move')
-        invoice_payments = self.mapped('order_ids.payment_ids.account_move_id')
+        valid_orders = self._get_valid_orders()
+        pickings = self.picking_ids | valid_orders.mapped('picking_ids')
+        invoices = valid_orders.mapped('account_move')
+        invoice_payments = valid_orders.mapped('payment_ids.account_move_id')
         stock_account_moves = pickings.mapped('move_ids.account_move_ids')
         cash_moves = self.statement_line_ids.mapped('move_id')
         bank_payment_moves = self.bank_payment_ids.mapped('move_id')
@@ -2217,6 +2218,8 @@ class PosSession(models.Model):
             ('product_id', 'in', product_ids)]
         return self.env['product.pricelist.item'].search_read(pricelist_item_domain, self._product_pricelist_item_fields())
 
+    def _get_valid_orders(self):
+        return self.order_ids.filtered(lambda o: o.state != 'cancel')
 
 class ProcurementGroup(models.Model):
     _inherit = 'procurement.group'

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -148,8 +148,6 @@ export class TicketScreen extends Component {
                 this._selectNextOrder(order);
             }
             this.pos.removeOrder(order);
-        }
-        if (this.pos.isOpenOrderShareable()) {
             this.pos._removeOrdersFromServer();
         }
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -464,7 +464,7 @@ export class PosStore extends Reactive {
                 delete this.toRefundLines[line.refunded_orderline_id];
             }
         }
-        if (this.isOpenOrderShareable() && removeFromServer) {
+        if (removeFromServer) {
             if (this.ordersToUpdateSet.has(order)) {
                 this.ordersToUpdateSet.delete(order);
             }
@@ -690,8 +690,7 @@ export class PosStore extends Reactive {
             );
             this.set_synch("connected");
             this._postRemoveFromServer(removedOrdersIds, removeOrdersResponseData);
-        } catch (reason) {
-            const error = reason.message;
+        } catch (error) {
             if (error.code === 200) {
                 // Business Logic Error, not a connection problem
                 //if warning do not need to display traceback!!

--- a/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
@@ -230,6 +230,14 @@ class Check {
             },
         ];
     }
+    isMissing(orderName) {
+        return [
+            {
+                trigger: `.ticket-screen:not(:has(.order-row > .col:nth-child(2):contains("${orderName}")))`,
+                isCheck: true,
+            },
+        ];
+    }
 }
 
 class Execute {}

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1899,3 +1899,193 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertEqual(refund.amount_total, -49.99)
         self.assertEqual(refund.amount_paid, -50.0)
         self.assertEqual(current_session.state, 'closed')
+
+    def test_cancel_order(self):
+        """ A draft order without any payment should be deleted from the database
+            when it is cancelled with the remove_from_ui method.
+            A draft/cancelled order with a payment should be kept with the 'cancel' state.
+        """
+        self.pos_config.open_ui()
+
+        current_session = self.pos_config.current_session_id
+        current_session.set_cashbox_pos(0, None)
+
+        untax, atax = self.compute_tax(self.led_lamp, 0.9)
+        # cancelled_order_with_payment is not fully paid to be a draft order.
+        cancelled_order_with_payment_paid_amount = (untax + atax) / 2
+        cancelled_order_with_payment_data = {
+            'data': {
+                'amount_paid': cancelled_order_with_payment_paid_amount,
+                'amount_return': 0,
+                'amount_tax': atax,
+                'amount_total': untax + atax,
+                'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+                'fiscal_position_id': False,
+                'lines': [[0, 0, {
+                    'discount': 0,
+                    'pack_lot_ids': [],
+                    'price_unit': 0.9,
+                    'product_id': self.led_lamp.id,
+                    'price_subtotal': 0.9,
+                    'price_subtotal_incl': 1.04,
+                    'qty': 1,
+                    'tax_ids': [(6, 0, self.led_lamp.taxes_id.ids)],
+                }]],
+                'name': 'Order 00042-003-0014',
+                'partner_id': False,
+                'pos_session_id': current_session.id,
+                'sequence_number': 2,
+                'statement_ids': [[0, 0, {
+                    'amount': cancelled_order_with_payment_paid_amount,
+                    'name': fields.Datetime.now(),
+                    'payment_method_id': self.bank_payment_method.id,
+                }]],
+                'uid': '00042-003-0014',
+                'user_id': self.env.uid,
+            },
+            'to_invoice': False,
+        }
+
+        cancelled_order_without_payment_data = {
+            'data': {
+                'amount_paid': 0,
+                'amount_return': 0,
+                'amount_tax': atax,
+                'amount_total': untax + atax,
+                'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+                'fiscal_position_id': False,
+                'lines': [[0, 0, {
+                    'discount': 0,
+                    'pack_lot_ids': [],
+                    'price_unit': 0.9,
+                    'product_id': self.led_lamp.id,
+                    'price_subtotal': 0.9,
+                    'price_subtotal_incl': 1.04,
+                    'qty': 1,
+                    'tax_ids': [(6, 0, self.led_lamp.taxes_id.ids)],
+                }]],
+                'name': 'Order 00042-003-0015',
+                'partner_id': False,
+                'pos_session_id': current_session.id,
+                'sequence_number': 2,
+                'statement_ids': [],
+                'uid': '00042-003-0015',
+                'user_id': self.env.uid,
+            },
+            'to_invoice': False,
+        }
+
+        orders_data = [cancelled_order_with_payment_data, cancelled_order_without_payment_data]
+        create_result = None
+        with mute_logger('odoo.addons.point_of_sale.models.pos_order'): # Ignore not fully paid log error
+            create_result = self.PosOrder.create_from_ui(orders_data)
+        self.assertEqual(len(orders_data), len(current_session.order_ids), 'Orders have not been correctly saved')
+
+        cancelled_order_without_payment_id = next(result_order_data for result_order_data in create_result if result_order_data['pos_reference'] == cancelled_order_without_payment_data['data']['name'])['id']
+        cancelled_order_with_payment_id = next(result_order_data for result_order_data in create_result if result_order_data['pos_reference'] == cancelled_order_with_payment_data['data']['name'])['id']
+
+        self.PosOrder.remove_from_ui([cancelled_order_with_payment_id, cancelled_order_without_payment_id])
+        self.assertFalse(self.env['pos.order'].search([('id', '=', cancelled_order_without_payment_id)], limit=1), 'The order should have been deleted from the database since it had no payment')
+        self.assertEqual(self.env['pos.order'].search([('id', '=', cancelled_order_with_payment_id)], limit=1).state, 'cancel', 'The order should be kept with the cancel state since it has a payment')
+
+    def test_close_session_with_cancelled_order_with_payment(self):
+        """ An order with at least one payment line should be kept in the database
+            even when it is cancelled with the remove_from_ui method.
+            Cancelled orders should be in the 'cancel' state.
+            Cancelled orders should not be processed when closing the session (no
+            accounting line, no picking...).
+        """
+        self.pos_config.open_ui()
+
+        current_session = self.pos_config.current_session_id
+        current_session.set_cashbox_pos(0, None)
+
+        untax, atax = self.compute_tax(self.led_lamp, 0.9)
+        # cancelled_order is half paid to trigger an accounting error in case
+        # it would be processed (it should not be processed since it is saved
+        # then cancelled).
+        cancelled_order_amount_paid = (untax + atax) / 2
+        cancelled_order_data = {
+            'data': {
+                'amount_paid': cancelled_order_amount_paid,
+                'amount_return': 0,
+                'amount_tax': atax,
+                'amount_total': untax + atax,
+                'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+                'fiscal_position_id': False,
+                'lines': [[0, 0, {
+                    'discount': 0,
+                    'pack_lot_ids': [],
+                    'price_unit': 0.9,
+                    'product_id': self.led_lamp.id,
+                    'price_subtotal': 0.9,
+                    'price_subtotal_incl': 1.04,
+                    'qty': 1,
+                    'tax_ids': [(6, 0, self.led_lamp.taxes_id.ids)],
+                }]],
+                'name': 'Order 00042-003-0014',
+                'partner_id': False,
+                'pos_session_id': current_session.id,
+                'sequence_number': 2,
+                'statement_ids': [[0, 0, {
+                    'amount': cancelled_order_amount_paid,
+                    'name': fields.Datetime.now(),
+                    'payment_method_id': self.cash_payment_method.id,
+                }]],
+                'uid': '00042-003-0014',
+                'user_id': self.env.uid,
+            },
+            'to_invoice': False,
+        }
+
+        untax, atax = self.compute_tax(self.whiteboard_pen, 1.2)
+        kept_order_data = {
+            'data': {
+                'amount_paid': untax + atax,
+                'amount_return': 0,
+                'amount_tax': atax,
+                'amount_total': untax + atax,
+                'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+                'fiscal_position_id': False,
+                'lines': [[0, 0, {
+                    'discount': 0,
+                    'pack_lot_ids': [],
+                    'price_unit': 1.2,
+                    'product_id': self.whiteboard_pen.id,
+                    'price_subtotal': 1.2,
+                    'price_subtotal_incl': 1.38,
+                    'qty': 1,
+                    'tax_ids': [(6, 0, self.whiteboard_pen.taxes_id.ids)],
+                }]],
+                'name': 'Order 00042-003-0015',
+                'partner_id': self.partner1.id,
+                'pos_session_id': current_session.id,
+                'sequence_number': self.pos_config.journal_id.id,
+                'statement_ids': [[0, 0, {
+                    'amount': untax + atax,
+                    'name': fields.Datetime.now(),
+                    'payment_method_id': self.cash_payment_method.id
+                }]],
+                'uid': '00042-003-0015',
+                'user_id': self.env.uid,
+            },
+            'to_invoice': False,
+        }
+
+        orders_data = [cancelled_order_data, kept_order_data]
+
+        create_result = None
+        with mute_logger('odoo.addons.point_of_sale.models.pos_order'): # Ignore not fully paid log error
+            create_result = self.PosOrder.create_from_ui(orders_data)
+        self.assertEqual(len(orders_data), len(current_session.order_ids), 'Orders have not been correctly saved')
+
+        cancelled_order_id = next(result_order_data for result_order_data in create_result if result_order_data['pos_reference'] == cancelled_order_data['data']['name'])['id']
+        self.PosOrder.remove_from_ui([cancelled_order_id])
+        self.assertEqual(self.env['pos.order'].search([('id', '=', cancelled_order_id)], limit=1).state, 'cancel', 'The order should be kept with the cancel state since it has a payment')
+
+        total_cash_payment = sum(current_session.order_ids.filtered(lambda o: o.state != 'cancel').payment_ids.filtered(lambda payment: payment.payment_method_id.type == 'cash').mapped('amount'))
+        current_session.post_closing_cash_details(total_cash_payment)
+        close_result = current_session.close_session_from_ui()
+
+        self.assertTrue(close_result['successful'])
+        self.assertEqual(current_session.state, 'closed', 'Session was not properly closed')

--- a/addons/pos_online_payment/models/pos_session.py
+++ b/addons/pos_online_payment/models/pos_session.py
@@ -20,7 +20,7 @@ class PosSession(models.Model):
 
         split_receivables_online = defaultdict(amounts)
         currency_rounding = self.currency_id.rounding
-        for order in self.order_ids:
+        for order in self._get_valid_orders():
             for payment in order.payment_ids:
                 amount = payment.amount
                 if tools.float_is_zero(amount, precision_rounding=currency_rounding):

--- a/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
@@ -9,9 +9,9 @@ import { registry } from "@web/core/registry";
 
 registry
     .category("web_tour.tours")
-    .add("PosResTicketScreenTour", { 
-        test: true, 
-        url: "/pos/ui", 
+    .add("PosResTicketScreenTour", {
+        test: true,
+        url: "/pos/ui",
         steps: () => {
             startSteps();
 
@@ -21,7 +21,7 @@ registry
             Chrome.do.clickTicketButton();
             TicketScreen.check.noNewTicketButton();
             TicketScreen.do.clickDiscard();
-            
+
             // Deleting the last order in the table brings back to floorscreen
             FloorScreen.do.clickTable("4");
             ProductScreen.check.isShown();
@@ -30,7 +30,7 @@ registry
             TicketScreen.check.nthRowContains(2, "-0001");
             TicketScreen.do.deleteOrder("-0001");
             TicketScreen.do.clickDiscard();
-            
+
             // Create 2 items in a table. From floorscreen, delete 1 item. Then select the other item.
             // Correct order and screen should be displayed and the BackToFloorButton is shown.
             FloorScreen.do.clickTable("2");
@@ -47,11 +47,12 @@ registry
             Chrome.do.clickTicketButton();
             TicketScreen.do.deleteOrder("-0003");
             Chrome.do.confirmPopup();
+            TicketScreen.check.isMissing("-0003");
             TicketScreen.do.selectOrder("-0002");
             ProductScreen.check.isShown();
             ProductScreen.check.totalAmountIs("2.0");
             Chrome.do.backToFloor();
-            
+
             // Make sure that order is deleted properly.
             FloorScreen.do.clickTable("5");
             ProductScreen.exec.addOrderline("Minute Maid", "1", "3");
@@ -62,10 +63,11 @@ registry
             Chrome.do.clickTicketButton();
             TicketScreen.do.deleteOrder("-0004");
             Chrome.do.confirmPopup();
+            TicketScreen.check.isMissing("-0004");
             TicketScreen.do.clickDiscard();
             FloorScreen.check.isShown();
             FloorScreen.do.clickTable("5");
             ProductScreen.check.orderIsEmpty();
-            return getSteps(); 
+            return getSteps();
         }
     });

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant.js
@@ -11,15 +11,15 @@ import { registry } from "@web/core/registry";
 
 registry
     .category("web_tour.tours")
-    .add("pos_restaurant_sync", { 
-        test: true, 
-        url: "/pos/ui", 
+    .add("pos_restaurant_sync", {
+        test: true,
+        url: "/pos/ui",
         steps: () => {
 
             startSteps();
-            
+
             ProductScreen.do.confirmOpeningPopup();
-            
+
             // Create first order
             FloorScreen.do.clickTable("5");
             ProductScreen.check.orderBtnIsPresent();
@@ -34,7 +34,7 @@ registry
             ProductScreen.check.orderlinesHaveNoChange();
             ProductScreen.check.isPrintingError();
             ProductScreen.check.totalAmountIs("4.40");
-            
+
             // Create 2nd order (paid)
             Chrome.do.clickMenuButton();
             Chrome.do.clickTicketButton();
@@ -48,13 +48,13 @@ registry
             PaymentScreen.do.clickPaymentMethod("Cash");
             PaymentScreen.do.clickValidate();
             ReceiptScreen.do.clickNextOrder();
-            
+
             // After clicking next order, floor screen is shown.
             // It should have 1 as number of draft synced order.
             FloorScreen.check.orderCountSyncedInTableIs("5", "1");
             FloorScreen.do.clickTable("5");
             ProductScreen.check.totalAmountIs("4.40");
-            
+
             // Create another draft order and go back to floor
             Chrome.do.clickMenuButton();
             Chrome.do.clickTicketButton();
@@ -64,10 +64,10 @@ registry
             ProductScreen.do.clickDisplayedProduct("Minute Maid");
             ProductScreen.check.selectedOrderlineHas("Minute Maid");
             Chrome.do.backToFloor();
-            
+
             // At floor screen, there should be 2 synced draft orders
             FloorScreen.check.orderCountSyncedInTableIs("5", "2");
-            
+
             // Delete the first order then go back to floor
             FloorScreen.do.clickTable("5");
             ProductScreen.check.isShown();
@@ -77,37 +77,38 @@ registry
             Chrome.do.confirmPopup();
             Chrome.check.isSyncStatusPending();
             Chrome.check.isSyncStatusConnected();
+            TicketScreen.check.isMissing("-0001");
             TicketScreen.do.selectOrder("-0003");
             Chrome.do.backToFloor();
-            
+
             // There should be 1 synced draft order.
             FloorScreen.check.orderCountSyncedInTableIs("5", "2");
-            return getSteps(); 
-        } 
+            return getSteps();
+        }
     });
-    
+
 /* pos_restaurant_sync_second_login
 *
 * This tour should be run after the first tour is done.
 */
 registry
     .category("web_tour.tours")
-    .add("pos_restaurant_sync_second_login", { 
-        test: true, 
-        url: "/pos/ui", 
+    .add("pos_restaurant_sync_second_login", {
+        test: true,
+        url: "/pos/ui",
         steps: () => {
-        
+
             startSteps();
-            
-            
+
+
             // There is one draft synced order from the previous tour
             FloorScreen.do.clickTable("5");
             ProductScreen.check.totalAmountIs("4.40");
-            
+
             // Test transfering an order
             ProductScreen.do.clickTransferButton();
             FloorScreen.do.clickTable("4");
-            
+
             // Test if products still get merged after transfering the order
             ProductScreen.do.clickDisplayedProduct("Coca-Cola");
             ProductScreen.check.selectedOrderlineHas("Coca-Cola", "2.0");
@@ -119,7 +120,7 @@ registry
             PaymentScreen.do.clickValidate();
             ReceiptScreen.do.clickNextOrder();
             // At this point, there are no draft orders.
-            
+
             FloorScreen.do.clickTable("2");
             ProductScreen.check.isShown();
             ProductScreen.check.orderIsEmpty();
@@ -129,6 +130,6 @@ registry
             ProductScreen.check.totalAmountIs("2.20");
             Chrome.do.backToFloor();
             FloorScreen.check.orderCountSyncedInTableIs("4", "1");
-            return getSteps(); 
-        } 
+            return getSteps();
+        }
     });

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -33,7 +33,7 @@ class PosOrder(models.Model):
 
     @api.model
     def remove_from_ui(self, server_ids):
-        order_ids = self.env['pos.order'].browse(server_ids)
+        order_ids = self.env['pos.order'].search(['&', ('id', 'in', server_ids), ('state', 'in', ['draft', 'cancel'])])
         order_ids.state = 'cancel'
         self._send_notification(order_ids)
 


### PR DESCRIPTION
*: pos_restaurant, pos_self_order

The POS orders can currently be saved in the database, then removed which in reality puts them in the 'cancel' state (since the commit https://github.com/odoo/odoo/commit/2222b6911e01cc607fca6537b0af489eddbe1574).
Those cancelled orders are processed when their session is closed, which results in unbalanced accounting lines and inventory pickings still created.

Steps to reproduce:

With a shop:
 - Set a trusted POS for the shop to use
 - Open a session for that shop
 - Create an order with 1 product
 - Click on the "Save" button of the trusted POS feature (in the product screen, above the numpad)
 - Open the orders with the top right dropdown menu
 - Click on the trash to delete the previously created and saved order
 - Close the session

With a restaurant:
 - Open a session
 - Create an order with 1 product
 - Click on the "Back" button (to save the order in the database)
 - Open the orders with the top right dropdown menu
 - Click on the trash to delete the previously created and saved order
 - Close the session

In both cases, the "Force Close Session" error popup appears.
After closing the session with the "Close Session & Post Entries" backend button, the inventory picking is created and validated, accounting Product Sales and Tax lines are created, and there is a "difference at closing POS session".

The fix consists in not processing cancelled orders when closing POS sessions.
The payments of cancelled orders are still saved in the database, but not taken into account in the sessions closing process.
Now the 'cancel' state of POS orders is only used for draft (not validated) orders that have at least one payment line (this keeps a record of their existence, particularly useful if their payment is successful). Draft orders with no payment are deleted from the database when remove_from_ui method is called for them.
Added some tests to ensure this behavior.

Additionnaly, this commit fixes other issues:
 - Fixes the test_01_pos_restaurant and test_04_ticket_screen tests in pos_restaurant module that were not working before this commit with the default step_delay of tours.
The fact that the code successfully passed the runbot tests execution is strange, probably explained by a step_delay different than when testing locally, for an unknown reason.
 - Fixes the MissingError triggered when calling remove_from_ui method with an already deleted order (since https://github.com/odoo/odoo/commit/2222b6911e01cc607fca6537b0af489eddbe1574 commit).
 - Fixes the error management in the _removeOrdersFromServer JS method.

task-id: 3452353