### PR TITLE
[FIX] mrp,repair,stock{_dropshipping}: correct show_operations visible

### DIFF
--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -129,9 +129,6 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
-            <field name="show_operations" position="attributes">
-                <attribute name="attrs">{"invisible": [("code", "=", "mrp_operation")]}</attribute>
-            </field>
             <xpath expr="//group[@name='stock_picking_type_lot']" position="after">
                 <group attrs='{"invisible": [("code", "!=", "mrp_operation")]}' string="Traceability" groups="stock.group_production_lot">
                     <field name="use_create_components_lots"/>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -20,11 +20,6 @@
                   {'invisible': [('code', '=', 'repair_operation')]}
                 </attribute>
             </field>
-            <field name="show_operations" position="attributes">
-                <attribute name="attrs">
-                  {'invisible': [('code', '=', 'repair_operation')]}
-                </attribute>
-            </field>
         </field>
     </record>
 

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -100,7 +100,7 @@
                             <field attrs='{"invisible": [("code", "not in", ["incoming", "outgoing", "internal"])]}' name="return_picking_type_id" string="Returns Type"/>
                             <field name="default_location_return_id" attrs='{"invisible": [("code", "not in", ["incoming", "outgoing", "internal"])]}' groups="stock.group_stock_multi_locations"/>
                             <field name="create_backorder"/>
-                            <field name="show_operations"/>
+                            <field name="show_operations" attrs='{"invisible": [("code", "not in", ["incoming", "outgoing", "internal"])]}'/>
                             <field name="show_reserved" attrs="{'invisible': [('code', '!=', 'incoming')]}"/>
                         </group>
                     </group>

--- a/addons/stock_dropshipping/views/stock_picking_views.xml
+++ b/addons/stock_dropshipping/views/stock_picking_views.xml
@@ -20,6 +20,17 @@
         <field name="search_view_id" ref="stock.view_picking_internal_search"/>
     </record>
 
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">Operation Types</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <field name="show_operations" position="attributes">
+                <attribute name="attrs">{"invisible": [("code", "not in", ["incoming", "outgoing", "internal", "dropship"])]}</attribute>
+            </field>
+        </field>
+    </record>
+
     <menuitem id="dropship_picking" name="Dropships" parent="stock.menu_stock_transfers"
         action="action_picking_tree_dropship" sequence="30"
         groups="stock.group_stock_manager,stock.group_stock_user"/>


### PR DESCRIPTION
PR odoo/odoo#106911 added the new picking.type for repair and hide the `show_operations` field from its form view. Unfortunately this writes over the existing invisible attr for mrp_operation (depending on the order of module installation, otherwise mrp will do the same to repair). Therefore we update the attribute logic to only include the picking types that should have the field visible.

Note that fix is only possible in master because a new record is added to ensure that dropshipping still shows the field.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
