### PR TITLE
Disable active_test in filtered_domain

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5519,7 +5519,7 @@ Fields:
             else:
                 (key, comparator, value) = d
                 if comparator in ('child_of', 'parent_of'):
-                    result.append(self.search([('id', 'in', self.ids), d]))
+                    result.append(self.with_context(active_test=False).search([('id', 'in', self.ids), d]))
                     continue
                 if key.endswith('.id'):
                     key = key[:-3]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
"filtered_domain" looses inactive records if domain contains child_of/parent_of

Current behavior before PR:
If a domain contains child_of or parent_of operators, "filtered_domain" performs a new search, but inactive records are lost, if active_test is not set in context (e.g. when records are browsed directly).

Since "check_access_rule" uses filtered_domain, this also means, that access to inactive records are lost, if a rule contains a child_of expression.

Desired behavior after PR is merged:
By setting active_test explicitly, we ensure that inactive records are kept in the recordset.

child_of/parent_of seems to be the only case, where inactive records are not returned, so I guess that this is not the desired behavior.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
