### PR TITLE
[FIX] project_todo: change model.actionService references

### DIFF
--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -31,7 +31,7 @@ export class TodoFormController extends FormController {
             filteredActions.push({
                 description: this.env._t("Convert to Task"),
                 callback: () => {
-                    this.model.actionService.doAction(
+                    this.model.action.doAction(
                         "project_todo.project_task_action_convert_todo_to_task",
                         {
                             props: {


### PR DESCRIPTION
the default model 'useAction' service is now named 'action' no longer 'actionService' 

Changed the reference where needed to avoid traceback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
