### PR TITLE
[FIX] stock: create return with correct dest location

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -123,6 +123,8 @@ class ReturnPicking(models.TransientModel):
             vals['location_id'] = self.picking_id.location_dest_id.id
         if self.location_id:
             vals['location_dest_id'] = self.location_id.id
+        elif self.picking_id.location_id:
+            vals['location_dest_id'] = self.picking_id.location_id.id
         return vals
 
     def _create_returns(self):


### PR DESCRIPTION
Steps to reproduce the bug:
- Disable “storage location” in the inventory settings
- Create a storable product “P1” and update the quantity
- Create a sale order with 1 unit of “P1”
- confirm the SO and validate the delivery
- Create a return

Problem:
The return will be created with the correct “source location= “Partners/customers”,but the destination location is incorrect, appearing as "Partners/customers" instead of the expected "Wh/stock."

opw-3269813
