### PR TITLE
[FIX] project: handle foreign key violation error

### DIFF
--- a/addons/project/__init__.py
+++ b/addons/project/__init__.py
@@ -24,3 +24,11 @@ def _check_exists_collaborators_for_project_sharing(env):
 def _project_post_init(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
     _check_exists_collaborators_for_project_sharing(env)
+
+def uninstall_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    project_wizard_ids = env['project.share.wizard'].search([])
+    if project_wizard_ids:
+        env.cr.execute(
+            'delete from project_share_wizard_res_partner_rel where project_share_wizard_id in %s',
+            (tuple(project_wizard_ids.ids),))

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -57,6 +57,7 @@
     'auto_install': False,
     'application': True,
     'post_init_hook': '_project_post_init',
+    'uninstall_hook': 'uninstall_hook',
     'assets': {
         'web.assets_backend': [
             'project/static/src/burndown_chart/*',


### PR DESCRIPTION
When the user installs a "project" module, share or send the project link with the respective recipients. After that, uninstall the project module, and then try to reinstall this module again. In that case, a traceback error will occur.

Steps to reproduce:
- Install the "project" module.
- Project > Configuration > Projects
- Select any project and click on the "SHARE READONLY" or "SHARE EDITABLE" buttons.
- After that, the "Share Project" wizard will open. Please fill out the required details and click on the "SEND" button.
- Go to the "Apps" menu and uninstall the "project" module. After that, try to reinstall the "project" module. A traceback error will be produced.
-  -Error:
ForeignKeyViolation
insert or update on table "project_share_wizard_res_partner_rel" violates foreign key constraint
"project_share_wizard_res_partner_r_project_share_wizard_id_fkey" DETAIL:  Key (project_share_wizard_id)=(1) is not present in table "project_share_wizard".

Traceback:
```
ForeignKeyViolation: insert or update on table "project_share_wizard_res_partner_rel" violates foreign key constraint "project_share_wizard_res_partner_r_project_share_wizard_id_fkey"
DETAIL:  Key (project_share_wizard_id)=(1) is not present in table "project_share_wizard".

  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 205, in load_module_graph
    registry.init_models(env.cr, model_names, {'module': package.name}, new_install)
  File "odoo/modules/registry.py", line 541, in init_models
    self.check_foreign_keys(cr)
  File "odoo/modules/registry.py", line 646, in check_foreign_keys
    sql.add_foreign_key(cr, table1, column1, table2, column2, ondelete)
  File "odoo/tools/sql.py", line 249, in add_foreign_key
    cr.execute(query.format(tablename1, columnname1, tablename2, columnname2, ondelete))
  File "odoo/sql_db.py", line 319, in execute
    res = self._obj.execute(query, params)
```
When the user installs a "project" module, share or send the project link with the respective recipients. After that, while the user uninstalls this module, it automatically deletes the "project_share_wizard_id" column value relevant records that are found in the "project_share_wizard_res_partner_rel" table and then tries to reinstall this module again.

sentry-4328169355
