### PR TITLE
[IMP] fleet: improve the search positioning and add filter_domain

### DIFF
--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -216,16 +216,17 @@
             <search string="All vehicles">
                 <field string="Vehicle" name="name" filter_domain="['|', ('name', 'ilike', self), ('license_plate', 'ilike', self)]"/>
                 <field string="Drivers" name="log_drivers" filter_domain="[
-                    '|', '|',
+                    '|', '|','|','|',
                     ('log_drivers.driver_id', 'ilike', self),
                     ('driver_id', 'ilike', self),
                     ('future_driver_id', 'ilike', self),
+                    ('driver_employee_id', 'ilike', self),
+                    ('future_driver_employee_id', 'ilike', self),
                 ]"/>
                 <field string="Model" name="model_id"/>
                 <field string="License Plate" name="license_plate"/>
                 <field name="tag_ids"/>
                 <field string="Status" name="state_id"/>
-                <field string="Current Driver" name="driver_id"/>
                 <field string="Properties" name="vehicle_properties"/>
                 <filter string="Available" name="available"
                     domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '|', '&amp;', ('plan_to_change_car', '=', True), ('vehicle_type', '=', 'car'), '&amp;', ('plan_to_change_bike', '=', True), ('vehicle_type', '=', 'bike')]"/>

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -78,12 +78,10 @@
             <xpath expr="//field[@name='license_plate']" position="after">
                 <field name="mobility_card"/>
             </xpath>
-            <xpath expr="//field[@name='driver_id']" position="after">
-                <field name="driver_employee_id" string="Current Driver (Employee)"/>
-            </xpath>
             <xpath expr="//field[@name='log_drivers']" position="attributes">
                 <attribute name="filter_domain">[
-                    '|', '|', '|', '|',
+                    '|', '|', '|', '|','|',
+                    ('log_drivers.driver_employee_id.name', 'ilike', self),
                     ('log_drivers.driver_id.name', 'ilike', self),
                     ('driver_id.name', 'ilike', self),
                     ('future_driver_id.name', 'ilike', self),


### PR DESCRIPTION
Before this commit, the 'Current Driver(Employee)' option was present within the search menu and appeared as the last choice in the search list.

IMP:
Following this commit, the 'Current Driver(Employee)' is renamed as 'Drivers(Employee)' and moved to the third position among the available search options and filter_domain is applied to get correct search results.

taskId: 3459896
