### PR TITLE
[IMP] partner_autocomplete: Added search with partial VAT

### DIFF
--- a/addons/partner_autocomplete/models/iap_autocomplete_api.py
+++ b/addons/partner_autocomplete/models/iap_autocomplete_api.py
@@ -38,7 +38,7 @@ class IapAutocompleteEnrichAPI(models.AbstractModel):
         :return tuple: results, error code
         """
         try:
-            results = self._contact_iap('/iap/partner_autocomplete', action, params, timeout=timeout)
+            results = self._contact_iap('/api/directory', action, params, timeout=timeout)
         except exceptions.ValidationError:
             return False, 'Insufficient Credit'
         except (ConnectionError, HTTPError, exceptions.AccessError, exceptions.UserError) as exception:

--- a/addons/partner_autocomplete/models/res_partner_autocomplete_sync.py
+++ b/addons/partner_autocomplete/models/res_partner_autocomplete_sync.py
@@ -25,7 +25,7 @@ class ResPartnerAutocompleteSync(models.Model):
 
             if partner.vat and partner._is_vat_syncable(partner.vat):
                 params['vat'] = partner.vat
-                _, error = self.env['iap.autocomplete.api']._request_partner_autocomplete('update', params)
+                _, error = self.env['iap.autocomplete.api']._request_partner_autocomplete('1/complete/update', params)
                 if error:
                     _logger.warning('Send Partner to sync failed: %s', str(error))
 

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -30,9 +30,19 @@ export function usePartnerAutocomplete() {
     async function isVATNumber(value) {
         // Lazyload jsvat only if the component is being used.
         await loadJS("/partner_autocomplete/static/lib/jsvat.js");
-
+        if (value.length >= 7) {
+            var firstTwoChars = value.substring(0, 2).toUpperCase();
+            var lastChars = value.substring(2);
+            var regexVAT = /^(AT|BE|BG|CY|CZ|DE|DK|EE|EL|ES|FI|FR|HR|HU|IE|IT|LT|LU|LV|MT|NL|PL|PT|RO|SE|SI|SK|XI|EU)/;
+            if (regexVAT.test(firstTwoChars)) {
+                var countNumericChars = (lastChars.match(/\d/g) || []).length;
+                if (countNumericChars / lastChars.length >= 0.5) {
+                    return true;
+                }
+            }
+        }
         // checkVATNumber is defined in library jsvat.
-        // It validates that the input has a valid VAT number format
+        // It validates that the input has a valid VAT number format.
         return checkVATNumber(sanitizeVAT(value));
     }
 

--- a/addons/partner_autocomplete/tests/common.py
+++ b/addons/partner_autocomplete/tests/common.py
@@ -80,7 +80,7 @@ class MockIAPPartnerAutocomplete(common.BaseCase):
             if default_data:
                 sim_result.update(default_data)
             # mock enrich only currently, to update further
-            if action == 'enrich':
+            if action == '1/complete/enrich':
                 if sim_error and sim_error == 'credit':
                     raise iap_tools.InsufficientCreditError('InsufficientCreditError')
                 elif sim_error and sim_error == 'jsonrpc_exception':


### PR DESCRIPTION
Linked to the following PR : https://github.com/odoo/iap-apps/pull/651

Description of the issue/feature this PR addresses:
The IAP partner_autocomplete service has been enhanced to support partial VAT searches and improved suggestions based on the user's company country. 

Current behavior before PR:
Prior to this PR, the user had to enter a full VAT number before the VAT-based search was launched. In addition, the suggestions did not take into account the user's company country. 

Desired behavior after PR is merged:
The Odoo client now supports searches with partial VAT and improves VAT suggestions based on the user's company country. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
