### PR TITLE
[FIX] mrp: use workorder registred costs

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -912,7 +912,7 @@ class MrpWorkorder(models.Model):
             wo.button_pending()
 
     def _compute_expected_operation_cost(self):
-        return (self.duration_expected / 60.0) * self.workcenter_id.costs_hour
+        return (self.duration_expected / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
 
     def _compute_current_operation_cost(self):
-        return (self.get_duration() / 60.0) * self.workcenter_id.costs_hour
+        return (self.get_duration() / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)


### PR DESCRIPTION
Steps to reproduce:
- Manufacturing -> Configuration -> Work Centers
- Create a new Work Center A with a cost per hour per workcenter of 10
- Operations -> Manufacturing Orders -> New
- Create a MO with a workorder using A with a duration of 10
- Hit 'Validate' then 'Produce all'.
- Go back to the Work Center and increase its cost to 100.
- Go back to the MO and open the Overview

Issue:
The costs displayed for the operations correspond to the duration * the current cost of the workcenter instead of the registred cost of the workcenter by the time the workorder was done.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
