### PR TITLE
[FIX] account: prevent server error

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3314,26 +3314,26 @@ class AccountMove(models.Model):
                     # Track the balance to handle the exchange difference.
                     open_balance -= vals['balance']
 
-        exchange_diff_sign = aml.company_currency_id.compare_amounts(open_balance, 0.0)
-        if exchange_diff_sign != 0.0:
+            exchange_diff_sign = aml.company_currency_id.compare_amounts(open_balance, 0.0)
+            if exchange_diff_sign != 0.0:
 
-            if exchange_diff_sign > 0.0:
-                exchange_line_account = aml.company_id.expense_currency_exchange_account_id
-            else:
-                exchange_line_account = aml.company_id.income_currency_exchange_account_id
+                if exchange_diff_sign > 0.0:
+                    exchange_line_account = aml.company_id.expense_currency_exchange_account_id
+                else:
+                    exchange_line_account = aml.company_id.income_currency_exchange_account_id
 
-            grouping_dict = {
-                'account_id': exchange_line_account.id,
-                'currency_id': aml.currency_id.id,
-                'partner_id': aml.partner_id.id,
-            }
-            line_vals = res['exchange_lines'].setdefault(frozendict(grouping_dict), {
-                **grouping_dict,
-                'name': _("Early Payment Discount (Exchange Difference)"),
-                'amount_currency': 0.0,
-                'balance': 0.0,
-            })
-            line_vals['balance'] += open_balance
+                grouping_dict = {
+                    'account_id': exchange_line_account.id,
+                    'currency_id': aml.currency_id.id,
+                    'partner_id': aml.partner_id.id,
+                }
+                line_vals = res['exchange_lines'].setdefault(frozendict(grouping_dict), {
+                    **grouping_dict,
+                    'name': _("Early Payment Discount (Exchange Difference)"),
+                    'amount_currency': 0.0,
+                    'balance': 0.0,
+                })
+                line_vals['balance'] += open_balance
 
         return {
             key: [

--- a/addons/account/tests/test_early_payment_discount.py
+++ b/addons/account/tests/test_early_payment_discount.py
@@ -24,6 +24,17 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
             })]
         })
 
+        cls.pay_term_net_30_days = cls.env['account.payment.term'].create({
+            'name': 'Net 30 days',
+            'line_ids': [
+                (0, 0, {
+                    'value_amount': 100,
+                    'value': 'percent',
+                    'nb_days': 30,
+                }),
+            ],
+        })
+
     def assert_tax_totals(self, document, expected_values):
         main_keys_to_ignore = {
             'formatted_amount_total', 'formatted_amount_untaxed', 'display_tax_base', 'subtotals_order'}
@@ -260,6 +271,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
             {'amount_currency': -3000.0},
+            {'amount_currency': 0},
             {'amount_currency': 300.0},
             {'amount_currency': 2700},
         ])
@@ -293,6 +305,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
             {'amount_currency': -3150.0},
+            {'amount_currency': 0},
             {'amount_currency': 300.0},
             {'amount_currency': 2850},
         ])
@@ -326,6 +339,7 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
         self.assertTrue(payments.is_reconciled)
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
             {'amount_currency': -3135.0},
+            {'amount_currency': 0},
             {'amount_currency': 300.0},
             {'amount_currency': 2835.0},
         ])
@@ -689,3 +703,43 @@ class TestAccountEarlyPaymentDiscount(AccountTestInvoicingCommon):
                 }) for price_unit, quantity, taxes in line_create_vals
             ]
         })
+
+    def test_register_payment_batch_with_discount_and_without_discount(self):
+        """
+        Test that a batch payment, that is
+            - not grouped
+            - with invoices having different payment terms (1 with discount, 1 without)
+        -> will not crash
+        """
+        out_invoice_1 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 1000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.pay_term_net_30_days.id,
+        })
+        out_invoice_2 = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2019-01-01',
+            'invoice_date': '2019-01-01',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id, 'price_unit': 2000.0, 'tax_ids': []})],
+            'invoice_payment_term_id': self.early_pay_10_percents_10_days.id,
+        })
+        (out_invoice_1 + out_invoice_2).action_post()
+        active_ids = (out_invoice_1 + out_invoice_2).ids
+
+        payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'payment_date': '2019-01-01', 'group_payment': False
+        })._create_payments()
+        self.assertTrue(all([p.is_reconciled for p in payments]))
+        self.assertRecordValues(payments.line_ids.sorted('balance'), [
+            {'amount_currency': -2000.0},
+            {'amount_currency': -1000.0},
+            {'amount_currency': 200.0},
+            {'amount_currency': 1000},
+            {'amount_currency': 1800},
+        ])

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -491,7 +491,7 @@ class AccountPaymentRegister(models.TransientModel):
         self.ensure_one()
         amount = 0.0
         mode = False
-        moves = self.line_ids.move_id
+        moves = [line.move_id for line in batch_result['lines']]
         for move in moves:
             if early_payment_discount and move._is_eligible_for_early_payment_discount(move.currency_id, self.payment_date):
                 amount += move.invoice_payment_term_id._get_amount_due_after_discount(move.amount_total, move.amount_tax)#todo currencies


### PR DESCRIPTION
Steps to reproduce:
- Create two Bills with different payment terms with one having no "early_discount" such as '30% Now, Balance 60 Days'
- Select the Bills and click on Register Payment (make sure the payment is not grouped)

Issue:
Server Error

Cause:
We try to Register Payment for all the Bills at once, but the "early_discount" is not defined for all the Bills. Therefore, when we call `_get_invoice_counterpart_amls_for_early_payment_discount` with an empty list since there is no early discount https://github.com/odoo/odoo/blob/0ffaaebfa5c25c4bf71fb0e02288767dbfac959d/addons/account/wizard/account_payment_register.py#L750-L755 https://github.com/odoo/odoo/blob/0ffaaebfa5c25c4bf71fb0e02288767dbfac959d/addons/account/wizard/account_payment_register.py#L760

Causing the "local variable 'aml' referenced before assignment" error.

Another issue arises for this batch payment that is not grouped in https://github.com/odoo/odoo/blob/b446fd1556e920989288ebcf8ddc402a7f66c12c/addons/account/wizard/account_payment_register.py#L500

We filter on the move_id from the whole batch, but since we do not group it, the amount is incorrectly computed as we add `aml.amount_residual_currency` from an aml that should be taken into account in this payment.

Note:
We have to change the test since we are now iterating through all aml when checking the `exchange_diff_sign`

opw-3281007