### PR TITLE
[FIX] web: handle access rights in readonly fields

### DIFF
--- a/addons/web/static/src/views/basic_relational_model.js
+++ b/addons/web/static/src/views/basic_relational_model.js
@@ -314,6 +314,9 @@ export class Record extends DataPoint {
      * @returns {boolean}
      */
     isReadonly(fieldName) {
+        if (!this.model.canEdit && !this.model.root.isNew) {
+            return true;
+        }
         const { readonly } = this.activeFields[fieldName].modifiers || {};
         return evalDomain(readonly, this.evalContext);
     }
@@ -1138,6 +1141,7 @@ export class RelationalModel extends Model {
         this.__component = params.component;
 
         this.root = null;
+        this.canEdit = params.canEdit !== false;
 
         this.__bm__ = new this.constructor.LegacyModel(this, {
             fields: params.fields || {},

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -132,6 +132,7 @@ export class FormController extends Component {
                 mode,
                 beforeLoadProm,
                 component: this,
+                canEdit: this.archInfo.activeActions.edit,
             },
             {
                 ignoreUseSampleModel: true,

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -34,6 +34,7 @@ export class KanbanController extends Component {
             openGroupsByDefault: true,
             tooltipInfo: archInfo.tooltipInfo,
             rootState,
+            canEdit: archInfo.activeActions.edit,
         });
 
         const rootRef = useRef("root");

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -178,7 +178,7 @@
     </t>
 
     <t t-name="web.KanbanColorPicker" owl="1">
-        <ul class="oe_kanban_colorpicker">
+        <ul t-if="this.widget.editable" class="oe_kanban_colorpicker">
             <t t-foreach="props.colors" t-as="color" t-key="color">
                 <li role="menuitem" t-on-click="() => this.selectColor(color_index)" t-att-title="color" t-att-aria-label="color">
                     <a href="#" t-attf-class="oe_kanban_color_{{ color_index }}" />

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -77,6 +77,7 @@ export class ListController extends Component {
             groupsLimit: this.archInfo.groupsLimit,
             multiEdit: this.multiEdit,
             rootState,
+            canEdit: this.archInfo.activeActions.edit,
         });
 
         this.optionalActiveFields = [];

--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -790,6 +790,9 @@ export class Record extends DataPoint {
      * @returns {boolean}
      */
     isReadonly(fieldName) {
+        if (!this.model.canEdit && !this.model.root.isNew) {
+            return true;
+        }
         const activeField = this.activeFields[fieldName];
         const { readonly } = activeField.modifiers || {};
         return readonly ? evalDomain(readonly, this.evalContext) : false;
@@ -3433,6 +3436,7 @@ export class RelationalModel extends Model {
 
         this.onCreate = params.onCreate;
         this.multiEdit = params.multiEdit || false;
+        this.canEdit = params.canEdit !== false;
         this.quickCreateView = params.quickCreateView;
         this.defaultGroupBy = params.defaultGroupBy || false;
         this.defaultOrderBy = params.defaultOrder;

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -8420,6 +8420,36 @@ QUnit.module("Views", (hooks) => {
         assert.hasClass(getCard(0), "oe_kanban_color_9");
     });
 
+    QUnit.test("colorpicker doesnt appear when missing access rights", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "category",
+            serverData,
+            arch: `
+                <kanban edit="0">
+                    <field name="color"/>
+                    <templates>
+                        <t t-name="kanban-menu">
+                            <div class="oe_kanban_colorpicker"/>
+                        </t>
+                        <t t-name="kanban-box">
+                            <div color="color">
+                                <field name="name"/>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>`,
+        });
+
+        await toggleRecordDropdown(0);
+
+        assert.containsNone(
+            target,
+            ".o_kanban_record:first-child .oe_kanban_colorpicker",
+            "there shouldn't be a color picker"
+        );
+    });
+
     QUnit.test("load more records in column", async (assert) => {
         await makeView({
             type: "kanban",


### PR DESCRIPTION
Work in progress
---
Steps to reproduce:
---
1. Install im_livechat
2. Go to Settings -> Users
3. Create a new user
4. Give the right Live Chat "User"
5. Logout and login with new user
6. Go to Live Chat -> website
7. Open an operator, try to modify a field
8. Error message: "You are not allowed to modify ..."

Fix:
---
Backport of https://github.com/odoo/odoo/commit/81dda7340fcc88f4d6c1186abf0bcbe5fa4d49dc

opw-3210277

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
