### PR TITLE
[FIX] tools: update translations according to their PO file

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1264,7 +1264,7 @@ class TranslationImporter:
         if xmlids and not isinstance(xmlids, set):
             xmlids = set(xmlids)
         for row in reader:
-            if not row.get('value') or not row.get('src'):  # ignore empty translations
+            if (not row.get('value') and not row.get('src')) or (row.get('value') and not row.get('src')):  # ignore empty translations
                 continue
             if row.get('type') == 'code':  # ignore code translations
                 continue
@@ -1345,7 +1345,7 @@ class TranslationImporter:
                         else:
                             # keep existing translations
                             for term_en, translations in record_dictionary.items():
-                                translations.update({k: v for k, v in translation_dictionary[term_en].items() if v != term_en})
+                                translations.update({k: v for k, v in record_dictionary[term_en].items() if v != term_en})
                                 translation_dictionary[term_en] = translations
 
                         for lang in langs:


### PR DESCRIPTION
After version 16, while upgrading database to next version(saas-16.1, saas-16.2..) and translation in PO file has been changed in next version then that translation is not updated in next version because in translation we are updating a value from old version translation directory that's why translations are updated in latest version.
Second case, if in [previous version](https://github.com/odoo/odoo/blob/saas-16.2/addons/website_slides/i18n/it.po#L902-L907) translation of 'src' is available but in [next version](https://github.com/odoo/odoo/blob/saas-16.3/addons/website_slides/i18n/it.po#L936-L941) translation has been removed for that case, I have improve condition while creating a record directory of translation according to new version.

OPW: 3448888, 3429011

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
