### PR TITLE
[FIX] stock: SN sequence

### DIFF
--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 import logging
@@ -636,3 +638,22 @@ class TestTraceability(TestMrpCommon):
         mo.action_generate_serial()
         lot_2 = mo.lot_producing_id.name
         self.assertEqual(lot_2, str(int(lot_1) + 1).zfill(7))
+
+    def test_generate_serial_button_sequence(self):
+        """Test if serial in form "00000dd" is manually created, the generate serial
+        correctly create new serial from sequence.
+        """
+        seq = self.env['ir.sequence'].search([('code', '=', 'stock.lot.serial')])
+        seq.prefix = 'xx%(doy)sxx'
+        mo, _bom, p_final, _p1, _p2 = self.generate_mo(qty_base_1=1, qty_base_2=1, qty_final=1, tracking_final='serial')
+
+        # manually create lot_1
+        self.env['stock.production.lot'].create({
+            'name': "test_000",
+            'product_id': p_final.id,
+            'company_id': self.env.company.id,
+        }).name
+        # generate lot lot_2 from the MO
+        mo.action_generate_serial()
+        lot_2 = mo.lot_producing_id.name
+        self.assertIn(datetime.now().strftime('%j'), lot_2)

--- a/addons/stock/models/stock_production_lot.py
+++ b/addons/stock/models/stock_production_lot.py
@@ -74,18 +74,15 @@ class ProductionLot(models.Model):
 
     @api.model
     def _get_new_serial(self, company, product):
-        if product.tracking == 'lot':
-            name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
-            exist_lot = self.env['stock.production.lot'].search([
-                ('product_id', '=', product.id),
-                ('company_id', '=', company.id),
-                ('name', '=', name),
-            ], limit=1)
-            if exist_lot:
-                return self.env['stock.production.lot']._get_next_serial(company, product)
-            return name
-
-        return self.env['stock.production.lot']._get_next_serial(company, product) or self.env['ir.sequence'].next_by_code('stock.lot.serial')
+        name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
+        exist_lot = self.env['stock.production.lot'].search([
+            ('product_id', '=', product.id),
+            ('company_id', '=', company.id),
+            ('name', '=', name),
+        ], limit=1)
+        if exist_lot:
+            return self.env['stock.production.lot']._get_next_serial(company, product)
+        return name
 
     @api.constrains('name', 'product_id', 'company_id')
     def _check_unique_lot(self):


### PR DESCRIPTION
Steps to reproduce:
- Create a serial tracked product
- Update quantity add random SN
- Edit "ir.sequence" for serial numbers (search sequence with dev mode enabled)
- Add a prefix for exemple "xx%(doy)sxx"
- Manufacture the product and generate new serial

Bug:
if a serial already exist next number in the sequence will be generated instead of using the sequence

Fix:
apply same logic than for lots i.e. first generate from sequence then take next number if it already exists

opw-3291532
