### PR TITLE
[FIX] {purchase_}stock: correct return picking locations

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -79,13 +79,11 @@ class ReturnPicking(models.TransientModel):
             vals['purchase_line_id'], vals['partner_id'] = return_line.move_id._get_purchase_line_and_partner_from_chain()
         return vals
 
-    def _create_returns(self):
-        new_picking_id, picking_type_id = super()._create_returns()
-        picking = self.env['stock.picking'].browse(new_picking_id)
-        if len(picking.move_ids.partner_id) == 1:
-            picking.partner_id = picking.move_ids.partner_id
-        return new_picking_id, picking_type_id
-
+    def _prepare_picking_default_values(self):
+        vals = super()._prepare_picking_default_values()
+        if len(self.picking_id.move_ids.partner_id) == 1:
+            vals['partner_id'] = self.picking_id.move_ids.partner_id.id
+        return vals
 
 class Orderpoint(models.Model):
     _inherit = "stock.warehouse.orderpoint"

--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -189,7 +189,6 @@ class ReturnPicking(models.TransientModel):
         # Override the context to disable all the potential filters that could have been set previously
         ctx = dict(self.env.context)
         ctx.update({
-            'default_partner_id': self.picking_id.partner_id.id,
             'search_default_picking_type_id': pick_type_id,
             'search_default_draft': False,
             'search_default_assigned': False,

--- a/addons/stock/wizard/stock_picking_return_views.xml
+++ b/addons/stock/wizard/stock_picking_return_views.xml
@@ -30,6 +30,7 @@
                 </field>
                 <group>
                     <field name="location_id" options="{'no_create': True, 'no_open': True}" groups="stock.group_stock_multi_locations" required="1"/>
+                    <field name="location_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
                 </group>
                 <footer>
                     <button name="create_returns" string="Return" type="object" class="btn-primary" data-hotkey="q"/>


### PR DESCRIPTION
Before this commit
==================
When creating, confirming sale orders, and validating from delivery, then
initiating a return, verify the return source location differs from the original
pick destination location. Similarly, for PO, the return destination location is
distinct from the initial pick source location.

Steps to Produce
=================
- Create a sales order and confirm it.
- Validate the order from delivery and initiate a return.
- Notice an incorrect source location assigned for the return picking.

Issue
======
The method `_create_returns(purchase_stock)` sets `partner_id`, which trigger
`_compute_location_id(stock)` in this method update location based on the
Customer/Vendor location available in partner data.

After this commit
=================
The return source location as the original pick destination location for sale orders.
Similarly, for PO, the return destination location matches the initial pick source location.

task - 3455076
