### PR TITLE
[FIX] web: menu action not executed if save fails

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -426,10 +426,15 @@ export class FormController extends Component {
     async shouldExecuteAction(item) {
         const dirty = await this.model.root.isDirty();
         if ((dirty || this.model.root.isNew) && !item.skipSave) {
-            return this.model.root.save({
+            let hasError = false;
+            const isSaved = await this.model.root.save({
                 stayInEdition: true,
-                onError: this.onSaveError.bind(this),
+                onError: (...args) => {
+                    hasError = true;
+                    return this.onSaveError(...args);
+                },
             });
+            return isSaved && !hasError;
         }
         return true;
     }


### PR DESCRIPTION
Before this commit, in the form view, clicking on an action in the menu action executed the action even though the record save had failed.

Expected behaviour:
When you click on an action, you want to save the record and execute the action if the record was saved without error.

How to reproduce:
- Go to a form view
- Create a new record
- Edit a field to ensure that the save returns an error
- Click on an action in the action menu (for example duplicate)
- The "Oh Snap" dialog opens
- Click on "Discard

Before this commit:
    The button action code executes and displays a crash

After this commit:
    The button action code does not execute

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
