### PR TITLE
[FIX] web: handle error while access uninstalled or invalid model

### DIFF
--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -3,8 +3,9 @@
 import logging
 import warnings
 
-from odoo import http
+from odoo import http, _
 from odoo.api import call_kw
+from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.models import check_method_name
 from .utils import clean_action
@@ -22,6 +23,8 @@ class DataSet(http.Controller):
         return request.env[model].web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
 
     def _call_kw(self, model, method, args, kwargs):
+        if model not in request.env.registry.models:
+            raise AccessError(_("The model '%s' you are trying to access is either not Install or Invalid", model))
         check_method_name(method)
         return call_kw(request.env[model], method, args, kwargs)
 

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -6962,6 +6962,14 @@ msgid "The field is empty, there's nothing to save."
 msgstr ""
 
 #. module: web
+#. odoo-python
+#: code:addons/web/controllers/dataset.py:0
+#, python-format
+msgid ""
+"The model '%s' you are trying to access is either not Install or Invalid"
+msgstr ""
+
+#. module: web
 #. odoo-javascript
 #: code:addons/web/static/src/core/errors/error_dialogs.xml:0
 #: code:addons/web/static/src/public/error_notifications.js:0


### PR DESCRIPTION
When the user tries to access the model which not Installed or Invalid.

Steps to produce:

- Install Stock
- Open Inventory > Click on Products > Click on Lots/Serial Number
- Create a new Lots/Serial Number and select any product (Don't save it)
- Duplicate that tab and uninstall Stock
- Move back to the previous tab and try to save the newly created Lots/Serial Number

See traceback
```
Traceback (most recent call last):
  File "/home/odoo/odoo/community/odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "/home/odoo/odoo/community/odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/odoo/community/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/odoo/community/odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/odoo/community/odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/odoo/community/odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/odoo/community/odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/odoo/community/addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/odoo/community/addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/odoo/community/odoo/api.py", line 521, in __getitem__
    return self.registry[model_name](self, (), ())
  File "/home/odoo/odoo/community/odoo/modules/registry.py", line 208, in __getitem__
    return self.models[model_name]
KeyError: 'stock.lot'
```

The added code in the `_call_kw` function verifies if the specified model is valid and installed in the current environment's registry of models. If not, it raises an AccessError to prevent potential issues and ensure secure and reliable model access.

Sentry-3937959802