### PR TITLE
[FIX] l10n_sa_edi: add lost dependency to account_edi

### DIFF
--- a/addons/l10n_sa_edi/__manifest__.py
+++ b/addons/l10n_sa_edi/__manifest__.py
@@ -6,6 +6,7 @@
     'icon': '/l10n_sa/static/description/icon.png',
     'version': '0.1',
     'depends': [
+        'account_edi',
         'account_edi_ubl_cii',
         'account_debit_note',
         'l10n_sa',
@@ -40,5 +41,6 @@
         'web.assets_backend': [
             'l10n_sa_edi/static/src/scss/form_view.scss',
         ]
-    }
+    },
+    'auto_install': ['l10n_sa', 'account_edi'],
 }


### PR DESCRIPTION
l10n_sa_edi still uses account_edi and depended on it through the account_edi_ubl_cii module, but that module lost the dependency with account_edi in saas-16.2.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
