### PR TITLE
[FIX] google_calendar: update log when record sync to google fails

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -192,7 +192,7 @@ class GoogleSync(models.AbstractModel):
             if not self.exists():
                 reason = "Google gave the following explanation: %s" % response['error'].get('message')
                 error_log = "Error while syncing record. It does not exists anymore in the database. %s" % reason
-                _logger.error(error_log)
+                _logger.warning(error_log)
                 return
 
             if self._name == 'calendar.event':


### PR DESCRIPTION
This error occurs when a user tries to sync the record with Google and the record does not exist or has been deleted.

```
Message: Error while syncing record. It does not exist anymore in the database.
         Google gave the following explanation: Bad Request
```

The logger is updated to use the 'warning' level instead of the 'error' level.

sentry-4367197269
