### PR TITLE
[FIX] web_editor: change tag between br

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -3397,7 +3397,7 @@ export class OdooEditor extends EventTarget {
                         for (const textFragment of textFragments) {
                             this._applyCommand('insertText', textFragment);
                             if (textIndex < textFragments.length) {
-                                this._applyCommand('oShiftEnter');
+                                this._applyCommand('oShiftEnter', false);
                             }
                             textIndex++;
                         }

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -43,6 +43,7 @@ import {
     isEmptyBlock,
     unwrapContents,
     getCursorDirection,
+    splitAroundBrs,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/g;
@@ -350,8 +351,15 @@ export const editorCommands = {
     // Change tags
     setTag(editor, tagName) {
         const restoreCursor = preserveCursor(editor.document);
-        const range = getDeepRange(editor.editable, { correctTripleClick: true });
-        const selectedBlocks = [...new Set(getTraversedNodes(editor.editable, range).map(closestBlock))];
+        const selectedNodes = getTraversedNodes(editor.editable);
+        let selectedBlocks = [...new Set(selectedNodes.map(closestBlock))].filter(n => (
+            [...n.querySelectorAll('br')].some(n => !n.classList.contains('oe_linebreak') && !isEmptyBlock(n.parentNode))
+        ));
+        for (const block of selectedBlocks) {
+            splitAroundBrs(editor.editable, block);
+        }
+        let range = getDeepRange(editor.editable, { correctTripleClick: true });
+        selectedBlocks = [...new Set(getTraversedNodes(editor.editable, range).map(closestBlock))];
         const deepestSelectedBlocks = selectedBlocks.filter(block => (
             !descendants(block).some(descendant => selectedBlocks.includes(descendant))
         ));
@@ -513,10 +521,16 @@ export const editorCommands = {
         return true;
     },
     toggleList: (editor, mode) => {
+        const selectedNodes = getTraversedNodes(editor.editable);
+        let selectedBlocks = [...new Set(selectedNodes.map(closestBlock))].filter(n => (
+            [...n.querySelectorAll('br')].some(n => !n.classList.contains('oe_linebreak') && !isEmptyBlock(n.parentNode))
+        ));
+        for (const block of selectedBlocks) {
+            splitAroundBrs(editor.editable, block);
+        }
         const li = new Set();
         const blocks = new Set();
-
-        const selectedBlocks = getTraversedNodes(editor.editable);
+        selectedBlocks = getTraversedNodes(editor.editable);
         const deepestSelectedBlocks = selectedBlocks.filter(block => (
             !descendants(block).some(descendant => selectedBlocks.includes(descendant))
         ));

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/shiftEnter.js
@@ -15,10 +15,11 @@ Text.prototype.oShiftEnter = function (offset) {
     return this.parentElement.oShiftEnter(splitTextNode(this, offset));
 };
 
-HTMLElement.prototype.oShiftEnter = function (offset) {
+HTMLElement.prototype.oShiftEnter = function (offset, editorsBr=true) {
     const restore = prepareUpdate(this, offset);
 
     const brEl = document.createElement('br');
+    editorsBr && brEl.classList.add("oe_linebreak");
     const brEls = [brEl];
     if (offset >= this.childNodes.length) {
         this.appendChild(brEl);
@@ -27,6 +28,7 @@ HTMLElement.prototype.oShiftEnter = function (offset) {
     }
     if (isFakeLineBreak(brEl) && getState(...leftPos(brEl), DIRECTIONS.LEFT).cType !== CTYPES.BR) {
         const brEl2 = document.createElement('br');
+        editorsBr && brEl2.classList.add("oe_linebreak");
         brEl.before(brEl2);
         brEls.unshift(brEl2);
     }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -723,14 +723,14 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>1ab<span>c12<br>34[]</span>f</div>',
+                    contentAfter: '<div>1ab<span>c12<br class="oe_linebreak">34[]</span>f</div>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<div>2a[b<span>c]d</span>ef</div>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>2a12<br>34[]<span>d</span>ef</div>',
+                    contentAfter: '<div>2a12<br class="oe_linebreak">34[]<span>d</span>ef</div>',
                 });
             });
             it('should paste a text when selection leave a span (2)', async () => {
@@ -767,7 +767,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>2a<span>b12<br>34[]</span>e<br>f</div>',
+                    contentAfter: '<div>2a<span>b12<br class="oe_linebreak">34[]</span>e<br>f</div>',
                 });
             });
         });
@@ -996,14 +996,14 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>1ab<span>c12<i><br>ii</i>[]</span>f</div>',
+                    contentAfter: '<div>1ab<span>c12<i><br class="oe_linebreak">ii</i>[]</span>f</div>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<div>2a[b<span>c]d</span>ef</div>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>2a12<i><br>ii</i>[]<span>d</span>ef</div>',
+                    contentAfter: '<div>2a12<i><br class="oe_linebreak">ii</i>[]<span>d</span>ef</div>',
                 });
             });
             it('should paste a text when selection leave a span (2)', async () => {
@@ -1037,7 +1037,7 @@ describe('Copy and paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, complexHtmlData);
                     },
-                    contentAfter: '<div>2a<span>b12<i><br>ii</i>[]</span>e<br>f</div>',
+                    contentAfter: '<div>2a<span>b12<i><br class="oe_linebreak">ii</i>[]</span>e<br>f</div>',
                 });
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2816,22 +2816,22 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<div>ab<a>[]cd</a></div>',
                         stepFunction: pressEnter,
-                        contentAfter: '<div>ab<br><a>[]cd</a></div>',
+                        contentAfter: '<div>ab<br class="oe_linebreak"><a>[]cd</a></div>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<div><a>a[]b</a></div>',
                         stepFunction: pressEnter,
-                        contentAfter: '<div><a>a<br>[]b</a></div>',
+                        contentAfter: '<div><a>a<br class="oe_linebreak">[]b</a></div>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<div><a>ab[]</a></div>',
                         stepFunction: pressEnter,
-                        contentAfter: '<div><a>ab</a><br>[]<br></div>',
+                        contentAfter: '<div><a>ab</a><br class="oe_linebreak">[]<br class="oe_linebreak"></div>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<div><a>ab[]</a>cd</div>',
                         stepFunction: pressEnter,
-                        contentAfter: '<div><a>ab</a><br>[]cd</div>',
+                        contentAfter: '<div><a>ab</a><br class="oe_linebreak">[]cd</div>',
                     });
                 });
             });
@@ -2978,7 +2978,7 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>[]<br></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><br>[]<br></p>',
+                        contentAfter: '<p><br class="oe_linebreak">[]<br></p>',
                     });
                     // TODO this cannot actually be tested currently as a
                     // backspace/delete in that case is not even detected
@@ -2999,34 +2999,34 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>[]abc</p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><br>[]abc</p>',
+                        contentAfter: '<p><br class="oe_linebreak">[]abc</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>[] abc</p>',
                         stepFunction: insertLineBreak,
                         // The space should have been parsed away.
-                        contentAfter: '<p><br>[]abc</p>',
+                        contentAfter: '<p><br class="oe_linebreak">[]abc</p>',
                     });
                 });
                 it('should insert a <br> within text', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[]cd</p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p>ab<br>[]cd</p>',
+                        contentAfter: '<p>ab<br class="oe_linebreak">[]cd</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab []cd</p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
-                        contentAfter: '<p>ab&nbsp;<br>[]cd</p>',
+                        contentAfter: '<p>ab&nbsp;<br class="oe_linebreak">[]cd</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab[] cd</p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's after a <br>).
-                        contentAfter: '<p>ab<br>[]&nbsp;cd</p>',
+                        contentAfter: '<p>ab<br class="oe_linebreak">[]&nbsp;cd</p>',
                     });
                 });
                 it('should insert a line break (2 <br>) at the end of a paragraph', async () => {
@@ -3035,7 +3035,7 @@ X[]
                         stepFunction: insertLineBreak,
                         // The second <br> is needed to make the first
                         // one visible.
-                        contentAfter: '<p>abc<br>[]<br></p>',
+                        contentAfter: '<p>abc<br class="oe_linebreak">[]<br class="oe_linebreak"></p>',
                     });
                 });
             });
@@ -3047,7 +3047,7 @@ X[]
                             await insertLineBreak(editor);
                             await insertLineBreak(editor);
                         },
-                        contentAfter: '<p><br><br>[]<br></p>',
+                        contentAfter: '<p><br class="oe_linebreak"><br class="oe_linebreak">[]<br></p>',
                     });
                     // TODO this cannot actually be tested currently as a
                     // backspace/delete in that case is not even detected
@@ -3079,7 +3079,7 @@ X[]
                             await insertLineBreak(editor);
                             await insertLineBreak(editor);
                         },
-                        contentAfter: '<p><br><br>[]abc</p>',
+                        contentAfter: '<p><br class="oe_linebreak"><br class="oe_linebreak">[]abc</p>',
                     });
                 });
                 it('should insert two <br> within text', async () => {
@@ -3089,7 +3089,7 @@ X[]
                             await insertLineBreak(editor);
                             await insertLineBreak(editor);
                         },
-                        contentAfter: '<p>ab<br><br>[]cd</p>',
+                        contentAfter: '<p>ab<br class="oe_linebreak"><br class="oe_linebreak">[]cd</p>',
                     });
                 });
                 it('should insert two line breaks (3 <br>) at the end of a paragraph', async () => {
@@ -3101,7 +3101,7 @@ X[]
                         },
                         // the last <br> is needed to make the first one
                         // visible.
-                        contentAfter: '<p>abc<br><br>[]<br></p>',
+                        contentAfter: '<p>abc<br class="oe_linebreak"><br class="oe_linebreak">[]<br class="oe_linebreak"></p>',
                     });
                 });
             });
@@ -3110,28 +3110,28 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abc[]<b>def</b></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p>abc<br><b>[]def</b></p>',
+                        contentAfter: '<p>abc<br class="oe_linebreak"><b>[]def</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to []<b>
                         contentBefore: '<p>abc<b>[]def</b></p>',
                         stepFunction: insertLineBreak,
                         // JW cAfter: '<p>abc<br><b>[]def</b></p>',
-                        contentAfter: '<p>abc<b><br>[]def</b></p>',
+                        contentAfter: '<p>abc<b><br class="oe_linebreak">[]def</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abc <b>[]def</b></p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
-                        contentAfter: '<p>abc&nbsp;<b><br>[]def</b></p>',
+                        contentAfter: '<p>abc&nbsp;<b><br class="oe_linebreak">[]def</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>abc<b>[] def </b></p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
-                        contentAfter: '<p>abc<b><br>[]&nbsp;def </b></p>',
+                        contentAfter: '<p>abc<b><br class="oe_linebreak">[]&nbsp;def </b></p>',
                     });
                 });
                 it('should insert a <br> after a format node', async () => {
@@ -3139,14 +3139,14 @@ X[]
                         contentBefore: '<p><b>abc</b>[]def</p>',
                         stepFunction: insertLineBreak,
                         // JW cAfter: '<p><b>abc[]<br></b>def</p>',
-                        contentAfter: '<p><b>abc</b><br>[]def</p>',
+                        contentAfter: '<p><b>abc</b><br class="oe_linebreak">[]def</p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to </b>[]
                         contentBefore: '<p><b>abc[]</b>def</p>',
                         stepFunction: insertLineBreak,
                         // JW cAfter: '<p><b>abc[]<br></b>def</p>',
-                        contentAfter: '<p><b>abc<br>[]</b>def</p>',
+                        contentAfter: '<p><b>abc<br class="oe_linebreak">[]</b>def</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>abc[]</b> def</p>',
@@ -3156,14 +3156,14 @@ X[]
                         // Visually, the caret does show _after_ the line
                         // break.
                         // JW cAfter: '<p><b>abc[]<br></b>&nbsp;def</p>',
-                        contentAfter: '<p><b>abc<br>[]</b>&nbsp;def</p>',
+                        contentAfter: '<p><b>abc<br class="oe_linebreak">[]</b>&nbsp;def</p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>abc []</b>def</p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
-                        contentAfter: '<p><b>abc&nbsp;<br>[]</b>def</p>',
+                        contentAfter: '<p><b>abc&nbsp;<br class="oe_linebreak">[]</b>def</p>',
                     });
                 });
                 it('should insert a <br> at the beginning of a format node', async () => {
@@ -3171,40 +3171,40 @@ X[]
                         contentBefore: '<p>[]<b>abc</b></p>',
                         stepFunction: insertLineBreak,
                         // JW cAfter: '<p><b><br>[]abc</b></p>',
-                        contentAfter: '<p><br><b>[]abc</b></p>',
+                        contentAfter: '<p><br class="oe_linebreak"><b>[]abc</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to []<b>
                         contentBefore: '<p><b>[]abc</b></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><b><br>[]abc</b></p>',
+                        contentAfter: '<p><b><br class="oe_linebreak">[]abc</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>[] abc</b></p>',
                         stepFunction: insertLineBreak,
                         // The space should have been parsed away.
-                        contentAfter: '<p><b><br>[]abc</b></p>',
+                        contentAfter: '<p><b><br class="oe_linebreak">[]abc</b></p>',
                     });
                 });
                 it('should insert a <br> within a format node', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>ab[]cd</b></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><b>ab<br>[]cd</b></p>',
+                        contentAfter: '<p><b>ab<br class="oe_linebreak">[]cd</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>ab []cd</b></p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking space so it
                         // is visible (because it's before a <br>).
-                        contentAfter: '<p><b>ab&nbsp;<br>[]cd</b></p>',
+                        contentAfter: '<p><b>ab&nbsp;<br class="oe_linebreak">[]cd</b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>ab[] cd</b></p>',
                         stepFunction: insertLineBreak,
                         // The space is converted to a non-breaking
                         // space so it is visible.
-                        contentAfter: '<p><b>ab<br>[]&nbsp;cd</b></p>',
+                        contentAfter: '<p><b>ab<br class="oe_linebreak">[]&nbsp;cd</b></p>',
                     });
                 });
                 it('should insert a line break (2 <br>) at the end of a format node', async () => {
@@ -3214,7 +3214,7 @@ X[]
                         // The second <br> is needed to make the first
                         // one visible.
                         // JW cAfter: '<p><b>abc<br>[]<br></b></p>',
-                        contentAfter: '<p><b>abc</b><br>[]<br></p>',
+                        contentAfter: '<p><b>abc</b><br class="oe_linebreak">[]<br class="oe_linebreak"></p>',
                     });
                     await testEditor(BasicEditor, {
                         // That selection is equivalent to </b>[]
@@ -3222,7 +3222,7 @@ X[]
                         stepFunction: insertLineBreak,
                         // The second <br> is needed to make the first
                         // one visible.
-                        contentAfter: '<p><b>abc<br>[]<br></b></p>',
+                        contentAfter: '<p><b>abc<br class="oe_linebreak">[]<br class="oe_linebreak"></b></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><b>abc[] </b></p>',
@@ -3230,7 +3230,7 @@ X[]
                         // The space should have been parsed away.
                         // The second <br> is needed to make the first
                         // one visible.
-                        contentAfter: '<p><b>abc<br>[]<br></b></p>',
+                        contentAfter: '<p><b>abc<br class="oe_linebreak">[]<br class="oe_linebreak"></b></p>',
                     });
                 });
             });
@@ -3241,14 +3241,14 @@ X[]
                             '<p><span class="a">dom to</span></p><p><span class="b">[]edit</span></p>',
                         stepFunction: insertLineBreak,
                         contentAfter:
-                            '<p><span class="a">dom to</span></p><p><span class="b"><br>[]edit</span></p>',
+                            '<p><span class="a">dom to</span></p><p><span class="b"><br class="oe_linebreak">[]edit</span></p>',
                     });
                 });
                 it('should insert a line break within a span with a bold', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><span><b>ab[]cd</b></span></p>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<p><span><b>ab<br>[]cd</b></span></p>',
+                        contentAfter: '<p><span><b>ab<br class="oe_linebreak">[]cd</b></span></p>',
                     });
                 });
             });
@@ -3259,13 +3259,13 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[ab]cd</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]cd</p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]cd</p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>]ab[cd</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]cd</p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]cd</p>',
                 });
             });
             it('should delete part of a paragraph, then insert a <br>', async () => {
@@ -3273,13 +3273,13 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a[bc]d</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p>a<br>[]d</p>',
+                    contentAfter: '<p>a<br class="oe_linebreak">[]d</p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a]bc[d</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p>a<br>[]d</p>',
+                    contentAfter: '<p>a<br class="oe_linebreak">[]d</p>',
                 });
             });
             it('should delete the last half of a paragraph, then insert a line break (2 <br>)', async () => {
@@ -3289,7 +3289,7 @@ X[]
                     stepFunction: insertLineBreak,
                     // the second <br> is needed to make the first one
                     // visible.
-                    contentAfter: '<p>ab<br>[]<br></p>',
+                    contentAfter: '<p>ab<br class="oe_linebreak">[]<br class="oe_linebreak"></p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
@@ -3297,7 +3297,7 @@ X[]
                     stepFunction: insertLineBreak,
                     // the second <br> is needed to make the first one
                     // visible.
-                    contentAfter: '<p>ab<br>[]<br></p>',
+                    contentAfter: '<p>ab<br class="oe_linebreak">[]<br class="oe_linebreak"></p>',
                 });
             });
             it('should delete all contents of a paragraph, then insert a line break', async () => {
@@ -3305,13 +3305,13 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[abcd]</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]<br></p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]<br></p>',
                 });
                 // Backward selection
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>]abcd[</p>',
                     stepFunction: insertLineBreak,
-                    contentAfter: '<p><br>[]<br></p>',
+                    contentAfter: '<p><br class="oe_linebreak">[]<br></p>',
                 });
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
@@ -901,6 +901,34 @@ describe('setTagName', () => {
                 contentAfter: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
             });
         });
+        it('should convert a heading 1 into a paragraph completely if brs contains class "ol_linebreak"', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h1>abcd<br class="oe_linebreak">efgh<br class="oe_linebreak">ijkl[]</h1>',
+                stepFunction: editor => editor.execCommand('setTag', 'p'),
+                contentAfter: '<p>abcd<br class="oe_linebreak">efgh<br class="oe_linebreak">ijkl[]</p>'
+            });
+        });
+        it('should convert first line of heading 1 seperated by br tag without class "oe_linebreak" into a paragraph', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h1>abcd[]<br>efgh<br>ijkl</h1>',
+                stepFunction: editor => editor.execCommand('setTag', 'p'),
+                contentAfter: '<p>abcd[]</p><h1>efgh<br>ijkl</h1>'
+            });
+        });
+        it('should convert middle line of heading 2 seperated by br tag without class "oe_linebreak" into a paragraph', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h2>abcd<br>efgh[]<br>ijkl</h2>',
+                stepFunction: editor => editor.execCommand('setTag', 'p'),
+                contentAfter: '<h2>abcd<br></h2><p>efgh[]</p><h2>ijkl</h2>',
+            });
+        });
+        it('should convert last line of heading 3 seperated by br tag withoug class "oe_linebreak" into a paragraph', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h3>abcd<br>efgh<br>ijkl[]</h3>',
+                stepFunction: editor => editor.execCommand('setTag', 'p'),
+                contentAfter: '<h3>abcd<br>efgh<br></h3><p>ijkl[]</p>'
+            })
+        });
     });
     describe('to heading 1', () => {
         it('should turn a paragraph into a heading 1', async () => {
@@ -943,6 +971,62 @@ describe('setTagName', () => {
                 contentBefore: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'h1'),
                 contentAfter: '<table><tbody><tr><td><h1>[a</h1></td><td><h1>b</h1></td><td><h1>c]</h1></td></tr></tbody></table>',
+            });
+        });
+        it('should convert a paragraph into a heading 1 completely if brs contains class "ol_linebreak"', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd<br class="oe_linebreak">efgh<br class="oe_linebreak">ijkl[]</p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<h1>abcd<br class="oe_linebreak">efgh<br class="oe_linebreak">ijkl[]</h1>',
+            });
+        });
+        it('should convert selected line of paragraph seperated by br tag without class "oe_linebreak" into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd[]<br>efgh<br>ijkl</p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<h1>abcd[]</h1><p>efgh<br>ijkl</p>',
+            });
+        });
+        it('should convert the selected lines of a paragraph seperated by br tag without class "oe_linebreak" into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a[bcd<br>efgh<br>ijkl]</p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<h1>a[bcd</h1><h1>efgh</h1><h1>ijkl]</h1>',
+            });
+        });
+        it('should convert the selected lines of a heading 2 seperated by br tag withoug class "oe_linebreak" into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h2>[abcd<br>efgh]<br>ijkl</h2>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<h1>[abcd</h1><h1>efgh]</h1><h2>ijkl</h2>',
+            });
+        });
+        it('should convert the selected lines of a heading 3 seperated by br tag withoug class "oe_linebreak" into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h3>abcd<br>e[fgh<br>ijkl]</h3>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<h3>abcd<br></h3><h1>e[fgh</h1><h1>ijkl]</h1>',
+            });
+        });
+        it('should convert selected text seperated by br without class "oe_linebreak" inside a table cell into a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<table><tbody><tr><td>ab[]cd<br>efgh</td><td></td></tr></tbody></table>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<table><tbody><tr><td><h1>ab[]cd</h1>efgh</td><td></td></tr></tbody></table>',
+            });
+        });
+        it('should convert selected text seperated by br without class "oe_linebreak" inside a table cell into a heading 1 (2)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<table><tbody><tr><td>abcd<br>[efgh]</td><td></td></tr></tbody></table>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<table><tbody><tr><td>abcd<br><h1>[efgh]</h1></td><td></td></tr></tbody></table>',
+            });
+        });
+        it('should convert selected text seperated by br without class "oe_linebreak" inside a table cell into a heading 1 (3)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<table><tbody><tr><td>[abcd<br>efgh]</td><td></td></tr></tbody></table>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<table><tbody><tr><td><h1>[abcd</h1><h1>efgh]</h1></td><td></td></tr></tbody></table>',
             });
         });
     });
@@ -989,6 +1073,62 @@ describe('setTagName', () => {
                 contentAfter: '<table><tbody><tr><td><h2>[a</h2></td><td><h2>b</h2></td><td><h2>c]</h2></td></tr></tbody></table>',
             });
         });
+        it('should convert a paragraph with combinations of br with and without class "oe_linebreak" properly to heading 2', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd<br class="oe_linebreak">efgh[]<br>ijkl</p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<h2>abcd<br class="oe_linebreak">efgh[]</h2><p>ijkl</p>',
+            });
+        });
+        it('should convert a paragraph with combinations of br with and without class "oe_linebreak" properly to heading 2 (2)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd<br>efgh[]<br class="oe_linebreak">ijkl</p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<p>abcd<br></p><h2>efgh[]<br class="oe_linebreak">ijkl</h2>',
+            });
+        });
+        it('should convert a deeply nested text containing br inside a paragraph into a heading 2', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p><strong><font><u>[abcd</u></font><br><span><font>efgh]</font></span></strong></p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<h2><strong><font><u>[abcd</u></font></strong></h2><h2><strong><span><font>efgh]</font></span></strong></h2>'
+            });
+        });
+        it('should convert a deeply nested text containing br inside a paragraph into a heading 2 (2)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p><strong><font><u>[abcd]</u></font><br><span><font>efgh</font></span></strong></p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<h2><strong><font><u>[abcd]</u></font></strong></h2><p><strong><span><font>efgh</font></span></strong></p>'
+            });
+        });
+        it('should convert a deeply nested text containing br inside a paragraph into a heading 2 (3)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p><strong><font><u>abcd</u></font><br><span><font>[efgh]</font></span></strong></p>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<p><strong><font><u>abcd</u></font><br></strong></p><h2><strong><span><font>[efgh]</font></span></strong></h2>'
+            });
+        });
+        it('should convert selected text seperated by br without class "oe_linebreak" inside a div into a heading 2 (1)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><span>[abcd]</span><br>efgh</div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<div><h2><span>[abcd]</span></h2>efgh</div>',
+            });
+        });
+        it('should convert selected text seperated by br without class "oe_linebreak" inside a div into a heading 2 (2)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><span>abcd</span><br>[efgh]</div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<div><span>abcd</span><br><h2>[efgh]</h2></div>',
+            });
+        });
+        it('should convert selected text seperated by br without class "oe_linebreak" inside a div into a heading 2 (2)', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div>[abcd<br>efgh]</div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<div><h2>[abcd</h2><h2>efgh]</h2></div>',
+            });
+        });
     });
     describe('to heading 3', () => {
         it('should turn a heading 1 into a heading 3', async () => {
@@ -1031,6 +1171,71 @@ describe('setTagName', () => {
                 contentBefore: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'h3'),
                 contentAfter: '<table><tbody><tr><td><h3>[a</h3></td><td><h3>b</h3></td><td><h3>c]</h3></td></tr></tbody></table>',
+            });
+        });
+        it('should convert a paragraph with styles, seperated by br without class "oe_linebreak" into heading 3', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                <p>
+                    [a
+                    <font style="color: red;">b</font>
+                    <font style="color: green;">c</font>
+                    <font style="color: blue;">d</font>
+                    <br>
+                    e
+                    <font style="color: yellow">fg]</font>
+                    h
+                    <br>
+                </p>
+                `),
+                stepFunction: editor => editor.execCommand('setTag', 'h3'),
+                contentAfter: unformat(`
+                <h3>
+                    [a
+                    <font style="color: red;">b</font>
+                    <font style="color: green;">c</font>
+                    <font style="color: blue;">d</font>
+                </h3>
+                <h3>
+                    e
+                    <font style="color: yellow">fg]</font>
+                    h
+                </h3>
+                `)
+            });
+        });
+        it('should convert a paragraph with styles, seperated by br without class "oe_linebreak" into heading 3', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                <p>
+                    a[]
+                    <font style="color: red;">b</font>
+                    <font style="color: green;">c</font>
+                    <font style="color: blue;">d</font>
+                    <br>
+                    e
+                    <font style="color: yellow">fg]</font>
+                    h
+                    <br>
+                    ijkl
+                </p>
+                `),
+                stepFunction: editor => editor.execCommand('setTag', 'h3'),
+                contentAfter: unformat(`
+                <h3>
+                    a[]
+                    <font style="color: red;">b</font>
+                    <font style="color: green;">c</font>
+                    <font style="color: blue;">d</font>
+                </h3>
+                <p>
+                    e
+                    <font style="color: yellow">fg]</font>
+                    h
+                    <br>
+                    ijkl
+                </p>
+                `)
             });
         });
     });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -115,7 +115,7 @@ describe('Link', () => {
                         await insertLineBreak(editor);
                     },
                     // Writing at the end of a link writes outside the link.
-                    contentAfter: '<p>a<a href="#">link</a>b<br>[]c</p>',
+                    contentAfter: '<p>a<a href="#">link</a>b<br class="oe_linebreak">[]c</p>',
                 });
             });
             it('should insert a link and write a character insert a <br> and another character', async () => {
@@ -128,7 +128,7 @@ describe('Link', () => {
                         await insertText(editor, 'c');
                     },
                     // Writing at the end of a link writes outside the link.
-                    contentAfter: '<p>a<a href="#">link</a>b<br>c[]d</p>',
+                    contentAfter: '<p>a<a href="#">link</a>b<br class="oe_linebreak">c[]d</p>',
                 });
             });
             it('should insert a <br> inside a link', async () => {
@@ -137,7 +137,7 @@ describe('Link', () => {
                     stepFunction: async editor => {
                         await insertLineBreak(editor);
                     },
-                    contentAfter: '<p><a href="#">a<br>[]b</a></p>',
+                    contentAfter: '<p><a href="#">a<br class="oe_linebreak">[]b</a></p>',
                 });
             });
         });
@@ -245,7 +245,7 @@ describe('Link', () => {
                         await insertLineBreak(editor);
                         await insertText(editor, 'odoo.com')
                     },
-                    contentAfter: '<p>a<a href="https://google.com">google.com<br>odoo.com[]</a></p>',
+                    contentAfter: '<p>a<a href="https://google.com">google.com<br class="oe_linebreak">odoo.com[]</a></p>',
                 });
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
@@ -94,6 +94,48 @@ describe('List', () => {
                             `),
                         });
                     });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd[]<br>efgh<br>ijkl</p>',
+                            stepFunction: toggleUnorderedList,
+                            contentAfter: '<ul><li>abcd[]</li></ul><p>efgh<br>ijkl</p>',
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list (2)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd<br>efgh[]<br>ijkl</p>',
+                            stepFunction: toggleUnorderedList,
+                            contentAfter: '<p>abcd<br></p><ul><li>efgh[]</li></ul><p>ijkl</p>',
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list (3)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd<br>efgh<br>ijkl[]</p>',
+                            stepFunction: toggleUnorderedList,
+                            contentAfter: '<p>abcd<br>efgh<br></p><ul><li>ijkl[]</li></ul>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>[abcd<br>efgh]<br>ijkl</p>',
+                            stepFunction: toggleUnorderedList,
+                            contentAfter: '<ul><li>[abcd</li><li>efgh]</li></ul><p>ijkl</p>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list (2)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd<br>[efgh<br>ijkl]</p>',
+                            stepFunction: toggleUnorderedList,
+                            contentAfter: '<p>abcd<br></p><ul><li>[efgh</li><li>ijkl]</li></ul>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list (3)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>[abcd<br>efgh<br>ijkl]</p>',
+                            stepFunction: toggleUnorderedList,
+                            contentAfter: '<ul><li>[abcd</li><li>efgh</li><li>ijkl]</li></ul>',
+                        });
+                    });
                 });
                 describe('Remove', () => {
                     it('should turn an empty list into a paragraph', async () => {
@@ -301,6 +343,48 @@ describe('List', () => {
                                     </tbody>
                                 </table>
                             `),
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd[]<br>efgh<br>ijkl</p>',
+                            stepFunction: toggleOrderedList,
+                            contentAfter: '<ol><li>abcd[]</li></ol><p>efgh<br>ijkl</p>',
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list (2)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd<br>efgh[]<br>ijkl</p>',
+                            stepFunction: toggleOrderedList,
+                            contentAfter: '<p>abcd<br></p><ol><li>efgh[]</li></ol><p>ijkl</p>',
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list (3)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd<br>efgh<br>ijkl[]</p>',
+                            stepFunction: toggleOrderedList,
+                            contentAfter: '<p>abcd<br>efgh<br></p><ol><li>ijkl[]</li></ol>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>[abcd<br>efgh]<br>ijkl</p>',
+                            stepFunction: toggleOrderedList,
+                            contentAfter: '<ol><li>[abcd</li><li>efgh]</li></ol><p>ijkl</p>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list (2)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abcd<br>[efgh<br>ijkl]</p>',
+                            stepFunction: toggleOrderedList,
+                            contentAfter: '<p>abcd<br></p><ol><li>[efgh</li><li>ijkl]</li></ol>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list (3)', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>[abcd<br>efgh<br>ijkl]</p>',
+                            stepFunction: toggleOrderedList,
+                            contentAfter: '<ol><li>[abcd</li><li>efgh</li><li>ijkl]</li></ol>',
                         });
                     });
                 });
@@ -560,6 +644,54 @@ describe('List', () => {
                                     </tbody>
                                 </table>
                             `),
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list', async () => {
+                        await testEditor(BasicEditor, {
+                            removeCheckIds: true,
+                            contentBefore: '<p>abcd[]<br>efgh<br>ijkl</p>',
+                            stepFunction: toggleCheckList,
+                            contentAfter: '<ul class="o_checklist"><li>abcd[]</li></ul><p>efgh<br>ijkl</p>',
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list (2)', async () => {
+                        await testEditor(BasicEditor, {
+                            removeCheckIds: true,
+                            contentBefore: '<p>abcd<br>efgh[]<br>ijkl</p>',
+                            stepFunction: toggleCheckList,
+                            contentAfter: '<p>abcd<br></p><ul class="o_checklist"><li>efgh[]</li></ul><p>ijkl</p>',
+                        });
+                    });
+                    it('should convert the text between br without class "oe_linebreak" in a paragraph into a list (3)', async () => {
+                        await testEditor(BasicEditor, {
+                            removeCheckIds: true,
+                            contentBefore: '<p>abcd<br>efgh<br>ijkl[]</p>',
+                            stepFunction: toggleCheckList,
+                            contentAfter: '<p>abcd<br>efgh<br></p><ul class="o_checklist"><li>ijkl[]</li></ul>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list', async () => {
+                        await testEditor(BasicEditor, {
+                            removeCheckIds: true,
+                            contentBefore: '<p>[abcd<br>efgh]<br>ijkl</p>',
+                            stepFunction: toggleCheckList,
+                            contentAfter: '<ul class="o_checklist"><li>[abcd</li><li>efgh]</li></ul><p>ijkl</p>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list (2)', async () => {
+                        await testEditor(BasicEditor, {
+                            removeCheckIds: true,
+                            contentBefore: '<p>abcd<br>[efgh<br>ijkl]</p>',
+                            stepFunction: toggleCheckList,
+                            contentAfter: '<p>abcd<br></p><ul class="o_checklist"><li>[efgh</li><li>ijkl]</li></ul>',
+                        });
+                    });
+                    it('should convert the selected text between br without class "oe_linebreak" in a paragraph into a list (3)', async () => {
+                        await testEditor(BasicEditor, {
+                            removeCheckIds: true,
+                            contentBefore: '<p>[abcd<br>efgh<br>ijkl]</p>',
+                            stepFunction: toggleCheckList,
+                            contentAfter: '<ul class="o_checklist"><li>[abcd</li><li>efgh</li><li>ijkl]</li></ul>',
                         });
                     });
                 });
@@ -6608,21 +6740,21 @@ describe('List', () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<ul><li>[]<br></li></ul>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<ul><li><br>[]<br></li></ul>',
+                        contentAfter: '<ul><li><br class="oe_linebreak">[]<br></li></ul>',
                     });
                 });
                 it('should insert a <br> at the beggining of a list item', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<ul><li>[]abc</li></ul>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<ul><li><br>[]abc</li></ul>',
+                        contentAfter: '<ul><li><br class="oe_linebreak">[]abc</li></ul>',
                     });
                 });
                 it('should insert a <br> within a list item', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<ul><li>ab[]cd</li></ul>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<ul><li>ab<br>[]cd</li></ul>',
+                        contentAfter: '<ul><li>ab<br class="oe_linebreak">[]cd</li></ul>',
                     });
                 });
                 it('should insert a line break (2 <br>) at the end of a list item', async () => {
@@ -6631,7 +6763,7 @@ describe('List', () => {
                         stepFunction: insertLineBreak,
                         // The second <br> is needed to make the first
                         // one visible.
-                        contentAfter: '<ul><li>abc<br>[]<br></li></ul>',
+                        contentAfter: '<ul><li>abc<br class="oe_linebreak">[]<br class="oe_linebreak"></li></ul>',
                     });
                 });
             });
@@ -6640,7 +6772,7 @@ describe('List', () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<ul><li>ab[cd]ef</li></ul>',
                         stepFunction: insertLineBreak,
-                        contentAfter: '<ul><li>ab<br>[]ef</li></ul>',
+                        contentAfter: '<ul><li>ab<br class="oe_linebreak">[]ef</li></ul>',
                     });
                 });
             });


### PR DESCRIPTION
Current behavior before PR:

When a single block containing 'br' element is copied and pasted and later changed the tag of a single line, the tag of the entire block would be changed.

Desired behavior after PR is merged:

Introducing class 'oe_linebreak' for 'br' elements created using shift+enter within odoo-editor. Now if changing the tag of the  text between 'br' element having the class 'oe_linebreak' will change the tag of the entire block. On the other hand, changing the tag of the text between 'br' elements having the class 'oe_linebreak', will only change the tag of the text between the 'br' elements.

task-2936891