### PR TITLE
[FIX] account_payment: handle foreign key violation errors while uninstallation

### DIFF
--- a/addons/account_payment/__init__.py
+++ b/addons/account_payment/__init__.py
@@ -14,9 +14,12 @@ def post_init_hook(env):
 
 
 def uninstall_hook(env):
-    """ Delete `account.payment.method` records created for the installed payment providers. """
+    """ Delete `account.payment.method` and `account.payment.method.line` records
+    created for the installed payment providers. """
     installed_providers = env['payment.provider'].search([('module_id.state', '=', 'installed')])
-    env['account.payment.method'].search([
+    payment_method_obj = env['account.payment.method'].search([
         ('code', 'in', installed_providers.mapped('code')),
-        ('payment_type', '=', 'inbound'),
-    ]).unlink()
+        ('payment_type', '=', 'inbound'),])
+    if payment_method_obj:
+        env.cr.execute('delete from account_payment_method_line where payment_method_id in %s', (tuple(payment_method_obj.ids),))
+    payment_method_obj.unlink()

--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -85,6 +85,9 @@ class PaymentProvider(models.Model):
 
     @api.model
     def _remove_provider(self, code):
-        """ Override of `payment` to delete the payment method of the provider. """
+        """ Override of `payment` to delete the payment method and line(s) of the provider. """
         super()._remove_provider(code)
-        self._get_provider_payment_method(code).unlink()
+        payment_method_obj = self._get_provider_payment_method(code)
+        if payment_method_obj:
+            self.env.cr.execute('delete from account_payment_method_line where payment_method_id in %s', (tuple(payment_method_obj.ids),))
+        payment_method_obj.unlink()


### PR DESCRIPTION
When the user purchases a product from the website and makes a payment using a payment provider, e.g., PayPal, and after that, try to uninstall the payment_paypal or account_payment module, and traceback will occur.

Steps to produce:
- Install the "website_sale" module.
- Invoicing > Configuration > Payments > Payment Providers
- Search for a "PayPal" payment provider and Click on Install it and configure it, along with filling out the required details.
- Go to the Website > Shop, choose a product's, "Add to Cart", "Process Checkout," and choose a payment delivery provider, e.g., PayPal, and click on the "Pay Now" button and provide Paypal user credentials like user name and password.
- Go to the "Apps" menu and search for the "account_payment" or "payment_paypal" module and try to uninstall it.
- After that, a traceback error will be produced. 

- Error:
ForeignKeyViolation
update or delete on table "account_payment_method" violates foreign key constraint "account_payment_method_line_payment_method_id_fkey"
 on table "account_payment_method_line"
DETAIL:  Key (id)=(3) is still referenced from table "account_payment_method_line".

Traceback:
```
ForeignKeyViolation: update or delete on table "account_payment_method" violates foreign key constraint "account_payment_method_line_payment_method_id_fkey" on table "account_payment_method_line"
DETAIL:  Key (id)=(3) is still referenced from table "account_payment_method_line".

  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 556, in load_modules
    getattr(py_module, uninstall_hook)(env)
  File "addons/account_payment/__init__.py", line 22, in uninstall_hook
    ]).unlink()
  File "odoo/models.py", line 3838, in unlink
    cr.execute(query, (sub_ids,))
  File "odoo/sql_db.py", line 319, in execute
    res = self._obj.execute(query, params)
```

When a user purchases products from a website and makes payment using any payment provider, e.g., Paypal, and then tries to uninstall the "account_payment" or "payment_paypal" module, a traceback occurs because in the existing addons code, the "account.payment.method" object is deleted while uninstalling the modules, but its object reference key is found in the "account.payment.method.line", so that "account.payment.method.line" object is also deleted along with the "account.payment.method" object.

code reference :
https://github.com/odoo/odoo/blob/saas-16.3/addons/account_payment/__init__.py#L19 

https://github.com/odoo/odoo/blob/saas-16.3/addons/account_payment/models/payment_provider.py#L90

sentry: 4261586022
