### PR TITLE
[FIX] website_forum: remove duplicated date information

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -62,7 +62,7 @@
                     <t t-set="show_name" t-value="True"/>
                     <t t-set="compact" t-value="True"/>
                 </t>
-                <small class="text-muted">
+                <small class="text-muted" t-if="not answer">
                     <i class="fa fa-calendar me-1"/><span t-field="question.write_date" t-options='{"format":"short"}'/>
                 </small>
             </div>


### PR DESCRIPTION
before this commit, in user profile, the date information is shown twice in the answers section.

* open user profile in forum
* click on answers tab
* date information is shown twice in the post

after this commit, the date information will be shown only once.

![Screenshot from 2023-08-11 17-29-07](https://github.com/odoo/odoo/assets/27989791/4abac5de-de89-4bf7-bf60-42c938786686)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
