### PR TITLE
[IMP] spreadsheet: export views with contextual domain

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -3,6 +3,7 @@ import * as spreadsheet from "@odoo/o-spreadsheet";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
 import CommandResult from "../../o_spreadsheet/cancelled_reason";
+import { Domain } from "@web/core/domain";
 
 const { CorePlugin } = spreadsheet;
 
@@ -140,6 +141,9 @@ export default class OdooChartCorePlugin extends CorePlugin {
                 for (const figure of sheet.figures) {
                     if (figure.tag === "chart" && figure.data.type.startsWith("odoo_")) {
                         figure.data.fieldMatching = this.getChartFieldMatch(figure.id);
+                        figure.data.searchParams.domain = new Domain(
+                            figure.data.searchParams.domain
+                        ).toJson();
                     }
                 }
             }

--- a/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
@@ -28,9 +28,14 @@ export class OdooViewsDataSource extends LoadableDataSource {
         this._metaData = JSON.parse(JSON.stringify(params.metaData));
         /** @protected */
         this._initialSearchParams = JSON.parse(JSON.stringify(params.searchParams));
+        const userContext = this._orm.user.context;
+        this._initialSearchParams.domain = new Domain(this._initialSearchParams.domain).toList({
+            ...this._initialSearchParams.context,
+            ...userContext,
+        });
         this._initialSearchParams.context = omit(
             this._initialSearchParams.context || {},
-            ...Object.keys(this._orm.user.context)
+            ...Object.keys(userContext)
         );
         /** @private */
         this._customDomain = this._initialSearchParams.domain;

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -8,6 +8,7 @@ import { _t } from "@web/core/l10n/translation";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { sprintf } from "@web/core/utils/strings";
 import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
+import { Domain } from "@web/core/domain";
 
 /**
  * @typedef {Object} ListDefinition
@@ -182,7 +183,7 @@ export default class ListCorePlugin extends CorePlugin {
         const def = this.lists[id].definition;
         return {
             columns: [...def.metaData.columns],
-            domain: [...def.searchParams.domain],
+            domain: def.searchParams.domain,
             model: def.metaData.resModel,
             context: { ...def.searchParams.context },
             orderBy: [...def.searchParams.orderBy],
@@ -411,6 +412,7 @@ export default class ListCorePlugin extends CorePlugin {
         data.lists = {};
         for (const id in this.lists) {
             data.lists[id] = JSON.parse(JSON.stringify(this.getListDefinition(id)));
+            data.lists[id].domain = new Domain(data.lists[id].domain).toJson();
             data.lists[id].fieldMatching = this.lists[id].fieldMatching;
         }
         data.listNextId = this.nextId;

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
@@ -32,6 +32,8 @@ import { _t } from "@web/core/l10n/translation";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { sprintf } from "@web/core/utils/strings";
 import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
+import { Domain } from "@web/core/domain";
+
 const { isDefined } = helpers;
 
 export default class PivotCorePlugin extends CorePlugin {
@@ -181,7 +183,7 @@ export default class PivotCorePlugin extends CorePlugin {
         return {
             colGroupBys: [...def.metaData.colGroupBys],
             context: { ...def.searchParams.context },
-            domain: [...def.searchParams.domain],
+            domain: def.searchParams.domain,
             id,
             measures: [...def.metaData.activeMeasures],
             model: def.metaData.resModel,
@@ -262,7 +264,6 @@ export default class PivotCorePlugin extends CorePlugin {
             definition,
             fieldMatching,
         };
-
         this.history.update("pivots", pivots);
     }
 
@@ -434,6 +435,7 @@ export default class PivotCorePlugin extends CorePlugin {
             data.pivots[id] = JSON.parse(JSON.stringify(this.getPivotDefinition(id)));
             data.pivots[id].measures = data.pivots[id].measures.map((elt) => ({ field: elt }));
             data.pivots[id].fieldMatching = this.pivots[id].fieldMatching;
+            data.pivots[id].domain = new Domain(data.pivots[id].domain).toJson();
         }
         data.pivotNextId = this.nextId;
     }

--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -172,6 +172,30 @@ export class Domain {
     toList(context) {
         return evaluate(this.ast, context);
     }
+
+    /**
+     * Converts the domain into a human-readable format for JSON representation.
+     * If the domain does not contain any contextual value, it is converted to a list.
+     * Otherwise, it is returned as a string.
+     *
+     * The string format is less readable due to escaped double quotes.
+     * Example: "[\"&\",[\"user_id\",\"=\",uid],[\"team_id\",\"!=\",false]]"
+     * @returns {DomainListRepr | string}
+     */
+    toJson() {
+        try {
+            // Attempt to evaluate the domain without context
+            const evaluatedAsList = this.toList({});
+            const evaluatedDomain = new Domain(evaluatedAsList);
+            if (evaluatedDomain.toString() === this.toString()) {
+                return evaluatedAsList;
+            }
+            return this.toString();
+        } catch {
+            // The domain couldn't be evaluated due to contextual values
+            return this.toString();
+        }
+    }
 }
 
 /**

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -25,6 +25,7 @@ import { useGetDomainTreeDescription } from "@web/core/domain_selector/utils";
 const { DateTime } = luxon;
 
 /** @typedef {import("@web/core/domain").DomainRepr} DomainRepr */
+/** @typedef {import("@web/core/domain").DomainListRepr} DomainListRepr */
 /** @typedef {import("../views/utils").OrderTerm} OrderTerm */
 
 /**
@@ -412,13 +413,20 @@ export class SearchModel extends EventBus {
     }
 
     /**
-     * @returns {DomainListRepr} should be imported from domain.js?
+     * @returns {DomainListRepr}
      */
     get domain() {
         if (!this._domain) {
             this._domain = this._getDomain();
         }
         return deepCopy(this._domain);
+    }
+
+    /**
+     * @returns {string}
+     */
+    get domainString() {
+        return this._getDomain({ raw: true }).toString();
     }
 
     get domainEvalContext() {

--- a/addons/web/static/tests/core/domain_tests.js
+++ b/addons/web/static/tests/core/domain_tests.js
@@ -218,6 +218,21 @@ QUnit.module("domain", {}, () => {
         );
     });
 
+    QUnit.test("toJson", function (assert) {
+        assert.deepEqual(new Domain([]).toJson(), []);
+        assert.deepEqual(new Domain("[]").toJson(), []);
+        assert.deepEqual(new Domain([["a", "=", 3]]).toJson(), [["a", "=", 3]]);
+        assert.deepEqual(new Domain('[("a", "=", 3)]').toJson(), [["a", "=", 3]]);
+        assert.strictEqual(
+            new Domain('[("user_id", "=", uid)]').toJson(),
+            '[("user_id", "=", uid)]'
+        );
+        assert.strictEqual(
+            new Domain('[("date", "=", context_today())]').toJson(),
+            '[("date", "=", context_today())]'
+        );
+    });
+
     QUnit.test("implicit &", function (assert) {
         const domain = new Domain([
             ["a", "=", 3],


### PR DESCRIPTION
Purpose
-------
Currently, views with a contextual filter/domain are not well managed: e.g.

Today Activities
=> domain=[('my_activity_date_deadline', '=', context_today().strftime('%Y-%m-%d'>

My pipeline
=> domain=[('user_id', '=', uid)]

Currently, 'context_today().strftime('%Y-%m-%d')' or 'uid' would be replaced by
their values when the view is inserted into a spreadsheet.
If the view is inserted on the 1st June 2023, the date "01/06/2023" is
hard-coded in the spreadsheet.

Specification
-------------
Preserve the domain dynamic parts when inserted into a spreadsheet.

Task: 3414027




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
