### PR TITLE
[IMP] Add account_id.internal_group in depends of _compute_amount_res…

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -690,7 +690,7 @@ class AccountMoveLine(models.Model):
             record.cumulated_balance = result[record.id]
 
     @api.depends('debit', 'credit', 'amount_currency', 'account_id', 'currency_id', 'company_id',
-                 'matched_debit_ids', 'matched_credit_ids')
+                 'matched_debit_ids', 'matched_credit_ids', 'account_id.internal_group')
     def _compute_amount_residual(self):
         """ Computes the residual amount of a move line from a reconcilable account in the company currency and the line's currency.
             This amount will be 0 for fully reconciled lines or lines from a non-reconcilable account, the original line amount


### PR DESCRIPTION
…idual

Description of the issue/feature this PR addresses:
This pr adds the account_id.internal_group field in the depends of the _compute_amount_residual method. The residual amount of an account line should be recalculated when the internal_group of an account changes. While this is not common practice, it may be necessary (mainly in migrated installations from previous versions). If recomputed, invoices may remain in the process of payment, when in fact they are paid and reconciled.

Current behavior before PR:
Don't recompute amount residual on change account type

Desired behavior after PR is merged:
Recompute amount residual on change account type



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
