### PR TITLE
[IMP] pos_restaurant: make floor name required

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.js
@@ -384,6 +384,11 @@ export class FloorScreen extends Component {
         if (!confirmed) {
             return;
         }
+        if (!newName) {
+            return this.popup.add(ErrorPopup, {
+                title: this.env._t("Floor Name Required"),
+            });
+        }
         const floor = await this.orm.call("restaurant.floor", "create_from_ui", [
             newName,
             "#ACADAD",


### PR DESCRIPTION
before this commit, on adding new floor from pos
user interface, even if user didn't enter the
floor name, floor is created with empty name

* open pos restaurant
* click add floor
* click confirm without entering name
* floor created without name

after this commit, if the name is not recorded
a pop up will be shown to customer asking to
record the floor name

Creating floor

![Screenshot from 2023-08-15 20-34-45](https://github.com/odoo/odoo/assets/27989791/15b1ab6d-72f3-47af-aa36-6a46ec421cec)

Pop up

![Screenshot from 2023-08-15 20-35-41](https://github.com/odoo/odoo/assets/27989791/0580d44c-e9b2-4efa-8da8-d7085c2a106c)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
