### PR TITLE
[IMP] point_of_sale: show opening and closing note as multi line

### DIFF
--- a/addons/point_of_sale/views/report_saledetails.xml
+++ b/addons/point_of_sale/views/report_saledetails.xml
@@ -447,12 +447,12 @@
                     <br/>
                     <t t-if="opening_note" id="opening_note">
                         <strong>Opening of session note:</strong>
-                        <t t-esc="opening_note" />
+                        <p t-esc="opening_note" t-options="{'widget': 'text'}"/>
                     </t>
                     <br/>
                     <t t-if="closing_note" id="closing_note">
                         <strong>End of session note:</strong>
-                        <t t-esc="closing_note" />
+                        <p t-esc="closing_note" t-options="{'widget': 'text'}"/>
                     </t>
                 </div>
             </t>


### PR DESCRIPTION
before this commit, on printing sales report from pos ui or from the backend, the opening note and closing note in the report is shown as single line text, even though user enter the input in multi line.

* point of sale -> reporting -> session report

after this commit, the opening and closing details in the same way in which user enter the input also fixed a typo opening session note


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
