### PR TITLE
[FIX] project: fixes trackback and remove quick create option

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -77,7 +77,8 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             ["1_canceled", _t("Canceled")],
             ["1_done", _t("Done")],
         ];
-        if (this.currentValue != "04_waiting_normal") {
+        const currentState = this.props.record.data[this.props.name];
+        if (currentState != "04_waiting_normal") {
             return [
                 ["01_in_progress", _t("In Progress")],
                 ["02_changes_requested", _t("Changes Requested")],

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -25,7 +25,7 @@
                         <label for="partner_ids" string="Invite People" invisible="access_mode == 'read'"/>
                         <label for="partner_ids" invisible="access_mode == 'edit'"/>
                     </div>
-                    <field name="partner_ids" widget="many2many_tags_email" placeholder="Add contacts to share the project..." nolabel="1" context="{'show_email': True}" class="mb-4"/>
+                    <field name="partner_ids" widget="many2many_tags_email" options="{'no_quick_create': True}" placeholder="Add contacts to share the project..." nolabel="1" context="{'show_email': True, 'force_email':True}" class="mb-4"/>
                 </group>
                 <field name="note" placeholder="Add a note" nolabel="1"/>
                 <footer>


### PR DESCRIPTION
In this PR fixes the trackback while deleting project task also remove quick create option 
from project sharing wizard.

Before this PR, 
- when user try to delete project task there is trackback which define recursion calling while getting options value.
- creating newly partner using quick create option in project sharing wizard partner is not set because of partner email is empty.

task-3460164


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
