### PR TITLE
[16.0][IMP] account: onchange amount currency

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -291,6 +291,18 @@ class AccountBankStatementLine(models.Model):
                 # The journal entry seems reconciled.
                 st_line.is_reconciled = True
 
+    @api.onchange('amount_currency')
+    def _onchange_amount_currency(self):
+        for st_line in self:
+            if st_line.foreign_currency_id == st_line.currency_id:
+                st_line.amount = st_line.amount_currency
+            elif st_line.date and st_line.foreign_currency_id:
+                st_line.amount = st_line.foreign_currency_id._convert(
+                    from_amount=st_line.amount_currency,
+                    to_currency=st_line.currency_id,
+                    company=st_line.company_id,
+                    date=st_line.date,
+                )
 
     # -------------------------------------------------------------------------
     # CONSTRAINT METHODS


### PR DESCRIPTION
- As a user, I want to input an amount in foreign currency, and the system will calculate the equivalent amount in the base currency.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
