### PR TITLE
[IMP] web, *: improve UX of custom group by menu

### DIFF
--- a/addons/board/static/tests/add_to_dashboard_tests.js
+++ b/addons/board/static/tests/add_to_dashboard_tests.js
@@ -10,14 +10,13 @@ import {
     triggerEvent,
 } from "@web/../tests/helpers/utils";
 import {
-    applyGroup,
     openAddCustomFilterDialog,
     removeFacet,
     switchView,
-    toggleAddCustomGroup,
     toggleSearchBarMenu,
     toggleMenuItem,
     toggleMenuItemOption,
+    selectGroup,
 } from "@web/../tests/search/helpers";
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
 import { browser } from "@web/core/browser/browser";
@@ -140,8 +139,7 @@ QUnit.module("Board", (hooks) => {
 
         // Group It
         await toggleSearchBarMenu(target);
-        await toggleAddCustomGroup(target);
-        await applyGroup(target);
+        await selectGroup(target, "foo");
 
         // add this action to dashboard
         await testUtils.dom.triggerEvent($(".o_add_to_board button.dropdown-toggle"), "mouseenter");

--- a/addons/web/static/src/core/select_menu/select_menu.scss
+++ b/addons/web/static/src/core/select_menu/select_menu.scss
@@ -66,10 +66,8 @@
 
 .dropup .o_select_menu_menu {
     box-shadow: 0 -7px 10px rgba(8, 8, 8, 0.319);
-    border-bottom: none;
 }
 
 .dropdown .o_select_menu_menu {
     box-shadow: 0 7px 10px rgba(8, 8, 8, 0.319);
-    border-top: none;
 }

--- a/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.js
+++ b/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.js
@@ -1,20 +1,22 @@
 /** @odoo-module **/
 
-import { AccordionItem } from "@web/core/dropdown/accordion_item";
-
-import { Component, useState } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 export class CustomGroupByItem extends Component {
-    setup() {
-        this.state = useState({});
-        if (this.props.fields.length) {
-            this.state.fieldName = this.props.fields[0].name;
+    get choices() {
+        return this.props.fields.map((f) => ({ label: f.string, value: f.name }));
+    }
+
+    onSelected(ev) {
+        if (ev.target.value) {
+            this.props.onAddCustomGroup(ev.target.value);
+            // reset the placeholder
+            ev.target.value = "";
         }
     }
 }
 
 CustomGroupByItem.template = "web.CustomGroupByItem";
-CustomGroupByItem.components = { AccordionItem };
 CustomGroupByItem.props = {
     fields: Array,
     onAddCustomGroup: Function,

--- a/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.scss
+++ b/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.scss
@@ -1,0 +1,4 @@
+.o_add_custom_group_menu {
+    background-position-x: calc(100% - 0.6em);
+    border: 0 !important;
+}

--- a/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.xml
+++ b/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.xml
@@ -1,24 +1,14 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CustomGroupByItem">
-        <AccordionItem class="'o_add_custom_group_menu text-truncate'" description="'Add Custom Group'">
-            <div class="px-3 py-2">
-                <select class="pe-3 text-truncate o_input" t-model="state.fieldName">
-                    <option t-foreach="props.fields" t-as="field" t-key="field.name"
-                    t-att-value="field.name"
-                    t-if="field.type !== 'properties' and !field.isProperty"
-                    t-esc="field.string"
-                    />
-                </select>
-            </div>
-            <div class="px-3 py-2">
-                <button class="btn btn-primary w-100"
-                    t-on-click="() => props.onAddCustomGroup(state.fieldName)"
-                    >
-                    Apply
-                </button>
-            </div>
-        </AccordionItem>
+        <select class="o_add_custom_group_menu o_menu_item dropdown-item" t-on-change="(ev) => this.onSelected(ev)">
+            <option value="" disabled="true" selected="true" hidden="true">Add Custom Group</option>
+            <option t-foreach="props.fields" t-as="field" t-key="field.name"
+                t-if="field.type !== 'properties' and !field.isProperty"
+                t-att-value="field.name"
+                t-esc="field.string"
+            />
+        </select>
     </t>
 
 </templates>

--- a/addons/web/static/tests/search/helpers.js
+++ b/addons/web/static/tests/search/helpers.js
@@ -280,25 +280,14 @@ export async function toggleGroupByMenu(el) {
     await click(findItem(el, `.o_group_by_menu .dropdown-toggle`));
 }
 
-export async function toggleAddCustomGroup(el) {
-    await click(findItem(el, `.o_add_custom_group_menu`));
-}
-
 export async function selectGroup(el, fieldName) {
-    const select = findItem(el, `.o_add_custom_group_menu + .o_accordion_values select`);
-    select.value = fieldName;
-    await triggerEvent(select, null, "change");
-}
-
-export async function applyGroup(el) {
-    await click(findItem(el, `.o_add_custom_group_menu + .o_accordion_values .btn`));
+    el.querySelector(".o_add_custom_group_menu").value = fieldName;
+    await triggerEvent(el, ".o_add_custom_group_menu", "change");
 }
 
 export async function groupByMenu(el, fieldName) {
     await toggleSearchBarMenu(el);
-    await toggleAddCustomGroup(el);
     await selectGroup(el, fieldName);
-    await applyGroup(el);
 }
 
 /** Favorite menu */

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -11,11 +11,9 @@ const checkKanbanGroupBy = [{
     extra_trigger: '.o_kanban_renderer',
     trigger: '.o_control_panel .o_searchview_dropdown_toggler',
 }, {
-    content: "Click on Add Custom Group",
-    trigger: '.o_add_custom_group_menu',
-}, {
-    content: "Click on Apply", // Active is selected by default
-    trigger: '.o_add_custom_group_menu + .o_accordion_values .btn-primary',
+    content: "Select 'Active' in the select of Add Custom Group",
+    trigger: ".o_add_custom_group_menu",
+    run: "text active",
 }, {
     content: "Click on List View",
     extra_trigger: '.o_kanban_renderer .o_kanban_header',


### PR DESCRIPTION
This commit simplifies the UX of the 'Custom Group by' menu. Before this
commit, many clicks were needed to apply another filter, from an accordion
menu.

Now, a select element is used instead, allowing a better user experience, by
enabling such group by directly, when an option is selected.

Some tests have been adapted to the new selectors and behaviors, and the
applyGroup and toggleAddCustomGroup has been removed, since groups are applied
when selected, and the value can be modified directly with selectGroup.

task-3458519

Before:
<img width="480" alt="image" src="https://github.com/odoo/odoo/assets/35101914/846e4b6a-b00d-4fc9-8120-46372c30d0a4">


After:
<img width="480" alt="image" src="https://github.com/odoo/odoo/assets/35101914/b4d2a06e-0a66-48b7-8fd7-711a42f6bc89">
