### PR TITLE
[FIX] pos_loyalty: wrong syntax for super call

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/product_screen.js
@@ -108,9 +108,9 @@ patch(ProductScreen.prototype, {
         this.currentOrder._updateRewards();
     },
     async _showDecreaseQuantityPopup() {
-        const result = await this._super();
-        if (result){
+        const result = await super._showDecreaseQuantityPopup();
+        if (result) {
             this.currentOrder._updateRewards();
         }
-    }
+    },
 });


### PR DESCRIPTION
The call to super was wrong, it was called in the old way this._super().

This has now been corrected with the new method super()."function name"()