### PR TITLE
[IMP] web: improve time taken to parse owl templates

### DIFF
--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -113,21 +113,9 @@ export const _loadXML = (assets.loadXML = function loadXML(xml, app = defaultApp
     }
 
     for (const element of doc.querySelectorAll("templates > [t-name]")) {
-        const name = element.getAttribute("t-name");
-        const previous = templates.querySelector(`[t-name="${name}"]`);
-        if (previous) {
-            console.debug("Override template: " + name);
-            previous.replaceWith(element);
-        } else {
-            templates.documentElement.appendChild(element);
-        }
+        templates.documentElement.appendChild(element);
     }
-    if (app || defaultApp) {
-        console.debug("Add templates in Owl app.");
-        app.addTemplates(templates, app || defaultApp);
-    } else {
-        console.debug("Add templates on window Owl container.");
-    }
+    app?.addTemplates(templates, app);
 });
 /**
  * Update the default app to load templates.


### PR DESCRIPTION
This commit removes some code that would allow one to define multiple templates with the same name, and would cause the the last template with a given name to override the previous one. This doesn't happen in practice, nor should it, and the code that is used to allow it repeatedly queries the document for a selector that is difficult to process (selecting for elements with a specific attribute value, especially when many elements in the document have that attribute).

A simple profile, with the crm and project apps installed, brings the time that it takes to load the owl templates from ~200ms to ~35ms