### PR TITLE
[FIX] sale_product_matrix: remove unnecessary matrix rows

### DIFF
--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -150,7 +150,13 @@ class PurchaseOrder(models.Model):
             # configurable products are only configured through the matrix in purchase, so no need to check product_add_mode.
             for template in grid_configured_templates:
                 if len(self.order_line.filtered(lambda line: line.product_template_id == template)) > 1:
-                    matrixes.append(self._get_matrix(template))
+                    matrix = self._get_matrix(template)
+                    matrix_data = []
+                    for row in matrix['matrix']:
+                        if any(column['qty'] != 0 for column in row[1:]):
+                            matrix_data.append(row)
+                    matrix['matrix'] = matrix_data
+                    matrixes.append(matrix)
         return matrixes
 
 

--- a/addons/sale_product_matrix/models/sale_order.py
+++ b/addons/sale_product_matrix/models/sale_order.py
@@ -158,6 +158,11 @@ class SaleOrder(models.Model):
             grid_configured_templates = self.order_line.filtered('is_configurable_product').product_template_id.filtered(lambda ptmpl: ptmpl.product_add_mode == 'matrix')
             for template in grid_configured_templates:
                 if len(self.order_line.filtered(lambda line: line.product_template_id == template)) > 1:
-                    # TODO do we really want the whole matrix even if there isn't a lot of lines ??
-                    matrixes.append(self._get_matrix(template))
+                    matrix = self._get_matrix(template)
+                    matrix_data = []
+                    for row in matrix['matrix']:
+                        if any(column['qty'] != 0 for column in row[1:]):
+                            matrix_data.append(row)
+                    matrix['matrix'] = matrix_data
+                    matrixes.append(matrix)
         return matrixes


### PR DESCRIPTION
**Prior to this commit:**
When generating a sale order report, all rows, including those with entirely null values are included in the report i.e. the entire matrix is displayed.

**Post this commit:**
The sale order report is generated with only the rows where at least one quantity is added, rather than including the entire matrix.

task-2860388