### PR TITLE
[FIX] mass_mailing: get mobile preview styling from assets

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -257,4 +257,4 @@ class MassMailController(http.Controller):
         We do this to avoid duplicating the template."""
         if not request.env.user.has_group('mass_mailing.group_mass_mailing_user'):
             raise NotFound
-        return request.env['ir.qweb']._render('mass_mailing.iframe_css_assets_edit')
+        return request.env['ir.qweb']._get_asset_bundle('mass_mailing.iframe_css_assets_edit').preprocess_css()

--- a/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
@@ -29,7 +29,7 @@ export class MassMailingMobilePreviewDialog extends Dialog {
 
     _getSourceDocument() {
         return '<!DOCTYPE html><html>' +
-                    '<head>' + this.styleSheets + '</head>' +
+                    '<head>' + '<style>' + this.styleSheets + '</style>' + '</head>' +
                     '<body>' + this.props.preview + '</body>' +
                 '</html>';
     }


### PR DESCRIPTION
Currently, When the user create a new mailing record and selects a mailing template in mail body an editor opens. In that editor when user clicks on mobile preview icon the error occurs.

To reproduce the issue:
1. Install Email Marketing module.
2. Create new mailing record and select a mailing template in mail body.
3. An editor will open, click on mobile preview icon from top-right of editor.
4. The error will occur.

See this traceback:
```
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/mass_mailing/controllers/main.py", line 260, in get_mobile_preview_styling
    return request.env['ir.qweb']._render('mass_mailing.iframe_css_assets_edit')
  File "odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 582, in _render
    rendering = render_template(irQweb, values)
  File "<None>", line 5, in not_found_template
ValueError: External ID not found in the system: mass_mailing.iframe_css_assets_edit
```

The template for mobile preview styling is not there anymore but still it has been rendered.
https://github.com/odoo/odoo/blob/9d2d3911a3ac6711d3040d22e146f9eb18de2197/addons/mass_mailing/controllers/main.py#L227-L232

To solve this issue the styling is rendered from
'mass_mailing.iframe_css_assets_edit' asset bundle.

sentry-4378447913

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
