### PR TITLE
[IMP] hw_posbox_homepage: Restrict Six TID input

### DIFF
--- a/addons/hw_posbox_homepage/views/six_payment_terminal.html
+++ b/addons/hw_posbox_homepage/views/six_payment_terminal.html
@@ -38,7 +38,7 @@
         <table align="center">
             <tr>
                 <td>Terminal ID</td>
-                <td><input type="text" name="terminal_id"></td>
+                <td><input type="number" name="terminal_id"></td>
             </tr>
             <tr>
                 <td/>


### PR DESCRIPTION
It is currently to input anything in the input field in Six Terminal ID field on Iot Box homepage.
This PR modifies the input type so that the user can only input digits inside.
This allows us to avoid using input verification in Python afterwards.

task-3468616

Linked to Six to IoT task 3031744