### PR TITLE
[IMP] event_crm: add button to create leads 

### DIFF
--- a/addons/event_crm/models/event_event.py
+++ b/addons/event_crm/models/event_event.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, api
+import logging
+from odoo import _, api, fields, models
 
+_logger = logging.getLogger(__name__)
 
 class EventEvent(models.Model):
     _name = "event.event"
@@ -23,3 +25,28 @@ class EventEvent(models.Model):
         mapped_data = {event.id: count for event, count in lead_data}
         for event in self:
             event.lead_count = mapped_data.get(event.id, 0)
+
+    def action_generate_leads(self):
+        self.ensure_one()
+
+        BATCH_SIZE = 500
+        registration_batches = [
+            self.registration_ids[i: i + BATCH_SIZE] for i in range(0, len(self.registration_ids), BATCH_SIZE)
+        ]
+        total_number_of_leads = 0
+        for registration_batch in registration_batches:
+            created_leads = self.env['event.registration'].create_leads_from_event_lead_rules(registration_batch)
+            leads_len = len(created_leads)
+            if leads_len > 0:
+                _logger.info("Lead generation created a batch of %s lead(s)", leads_len)
+                total_number_of_leads += leads_len
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'info',
+                'sticky': False,
+                'message': _("Number of leads created: %s", total_number_of_leads),
+            }
+        }

--- a/addons/event_crm/views/event_event_views.xml
+++ b/addons/event_crm/views/event_event_views.xml
@@ -6,6 +6,9 @@
         <field name="inherit_id" ref="event.view_event_form"/>
         <field name="priority" eval="30"/>
         <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="action_generate_leads" class="btn btn-secondary" type="object">Generate Leads</button>
+            </xpath>
             <xpath expr="//button[@name='%(event.act_event_registration_from_event)d']" position="after">
                 <button name="%(crm_lead_action_from_event)d" class="oe_stat_button" type="action" icon="fa-star"
                     invisible="lead_count == 0" groups="sales_team.group_sale_salesman">
@@ -17,7 +20,7 @@
             </xpath>
         </field>
     </record>
-    
+
     <record id="event_view_tree" model="ir.ui.view">
         <field name="name">event.event.tree.inherit.event.crm</field>
         <field name="model">event.event</field>


### PR DESCRIPTION
New button in event form view: Generate Leads

With it, users can retroactively create leads based on lead rule generation. It
ignores leads that have already been created with the rule (this feature was
already implemented before this PR, preventing lead duplication).

Task-3461434