### PR TITLE
[REF] web: remove legacy redirect

### DIFF
--- a/addons/web/static/src/legacy/js/core/misc.js
+++ b/addons/web/static/src/legacy/js/core/misc.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { _t } from "@web/core/l10n/translation";
-import ajax from "@web/legacy/js/core/ajax";
 import Widget from "@web/legacy/js/core/widget";
 
 var messages_by_seconds = function() {
@@ -93,34 +92,6 @@ export function unblockUI() {
     return $.unblockUI.apply($, arguments);
 }
 
-/**
- * Redirect to url by replacing window.location
- * If wait is true, sleep 1s and wait for the server i.e. after a restart.
- */
-function redirect (url, wait) {
-    var load = function() {
-        var old = "" + window.location;
-        var old_no_hash = old.split("#")[0];
-        var url_no_hash = url.split("#")[0];
-        location.assign(url);
-        if (old_no_hash === url_no_hash) {
-            location.reload(true);
-        }
-    };
-
-    var wait_server = function() {
-        ajax.rpc("/web/webclient/version_info", {}).then(load).guardedCatch(function () {
-            setTimeout(wait_server, 250);
-        });
-    };
-
-    if (wait) {
-        setTimeout(wait_server, 1000);
-    } else {
-        load();
-    }
-}
-
 
 // In Internet Explorer, document doesn't have the contains method, so we make a
 // polyfill for the method in order to be compatible.
@@ -143,5 +114,4 @@ if (!document.contains) {
 export default {
     blockUI: blockUI,
     unblockUI: unblockUI,
-    redirect: redirect,
 };


### PR DESCRIPTION
This function is not used anymore.
We now call ´browser.location.assign(...)´ directly.

Related PR: https://github.com/odoo/odoo/pull/112621

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
