### PR TITLE
[FIX] account: Fix division taxes for l10n_br

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -7,6 +7,7 @@ from odoo.tools.misc import formatLang
 from odoo.tools import frozendict
 
 from collections import defaultdict
+
 import math
 import re
 
@@ -346,42 +347,176 @@ class AccountTax(models.Model):
             total_factor = sum(tax_repartition_lines.mapped('factor'))
             tax.real_amount = tax.amount * total_factor
 
-    def _compute_amount(self, base_amount, price_unit, quantity=1.0, product=None, partner=None, fixed_multiplicator=1):
-        """ Returns the amount of a single tax. base_amount is the actual amount on which the tax is applied, which is
-            price_unit * quantity eventually affected by previous taxes (if tax is include_base_amount XOR price_include)
-        """
-        self.ensure_one()
+    @api.model
+    def _prepare_taxes_batches(self, tax_values_list):
+        batches = []
 
-        if self.amount_type == 'fixed':
-            # Use copysign to take into account the sign of the base amount which includes the sign
-            # of the quantity and the sign of the price_unit
-            # Amount is the fixed price for the tax, it can be negative
-            # Base amount included the sign of the quantity and the sign of the unit price and when
-            # a product is returned, it can be done either by changing the sign of quantity or by changing the
-            # sign of the price unit.
-            # When the price unit is equal to 0, the sign of the quantity is absorbed in base_amount then
-            # a "else" case is needed.
-            if base_amount:
-                return math.copysign(quantity, base_amount) * self.amount * abs(fixed_multiplicator)
-            else:
-                return quantity * self.amount * abs(fixed_multiplicator)
+        def batch_key(tax):
+            return tax.amount_type, tax_values['price_include']
 
-        price_include = self._context.get('force_price_include', self.price_include)
+        def append_batch(batch):
+            batch['taxes'] = list(reversed(batch['taxes']))
+            batches.append(batch)
 
-        # base * (1 + tax_amount) = new_base
-        if self.amount_type == 'percent' and not price_include:
-            return base_amount * self.amount / 100
-        # <=> new_base = base / (1 + tax_amount)
-        if self.amount_type == 'percent' and price_include:
-            return base_amount - (base_amount / (1 + self.amount / 100))
-        # base / (1 - tax_amount) = new_base
-        if self.amount_type == 'division' and not price_include:
-            return base_amount / (1 - self.amount / 100) - base_amount if (1 - self.amount / 100) else 0.0
-        # <=> new_base * (1 - tax_amount) = base
-        if self.amount_type == 'division' and price_include:
-            return base_amount - (base_amount * (self.amount / 100))
-        # default value for custom amount_type
-        return 0.0
+        current_batch = None
+        is_base_affected = None
+        for tax_values in reversed(tax_values_list):
+            tax = tax_values['tax']
+
+            if current_batch is not None:
+                force_new_batch = (tax.include_base_amount and is_base_affected)
+                if current_batch['key'] != batch_key(tax) or force_new_batch:
+                    append_batch(current_batch)
+                    current_batch = None
+
+            if current_batch is None:
+                current_batch = {
+                    'key': batch_key(tax),
+                    'taxes': [],
+                    'amount_type': tax.amount_type,
+                    'include_base_amount': tax.include_base_amount,
+                    'price_include': tax_values['price_include'],
+                }
+
+            is_base_affected = tax.is_base_affected
+            current_batch['taxes'].append(tax_values)
+
+        if current_batch is not None:
+            append_batch(current_batch)
+
+        return batches
+
+    @api.model
+    def _ascending_process_fixed_taxes_batch(self, batch, base, precision_rounding, extra_computation_values, fixed_multiplicator=1):
+        if batch['amount_type'] == 'fixed':
+            batch['computed'] = True
+            quantity = abs(extra_computation_values['quantity'])
+            for tax_values in batch['taxes']:
+                tax_values['tax_amount'] = quantity * tax_values['tax'].amount * abs(fixed_multiplicator)
+                tax_values['tax_amount_factorized'] = float_round(
+                    tax_values['tax_amount'] * tax_values['factor'],
+                    precision_rounding=precision_rounding,
+                )
+
+    @api.model
+    def _descending_process_price_included_taxes_batch(self, batch, base, precision_rounding, extra_computation_values):
+        tax_values_list = batch['taxes']
+        amount_type = batch['amount_type']
+        price_include = batch['price_include']
+
+        if price_include:
+            if amount_type == 'percent':
+                batch['computed'] = True
+                total_percent = sum(
+                    tax_values['tax'].amount * tax_values['factor']
+                    for tax_values in tax_values_list
+                ) / 100.0
+                computation_base = base / (1 + total_percent)
+                for tax_values in tax_values_list:
+                    tax_values['tax_amount'] = computation_base * tax_values['tax'].amount / 100.0
+                    tax_values['tax_amount_factorized'] = float_round(
+                        tax_values['tax_amount'] * tax_values['factor'],
+                        precision_rounding=precision_rounding,
+                    )
+
+                batch_base = base - sum(tax_values['tax_amount_factorized'] for tax_values in tax_values_list)
+                for tax_values in tax_values_list:
+                    tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = batch_base
+
+            elif amount_type == 'division':
+                batch['computed'] = True
+                batch_base = base
+
+                for tax_values in tax_values_list:
+                    tax = tax_values['tax']
+                    not_factorized_base = base * (1 - (tax_values['tax'].amount * tax_values['factor'] / 100.0))
+                    tax_values['tax_amount'] = base - not_factorized_base
+                    tax_values['tax_amount_factorized'] = float_round(
+                        tax_values['tax_amount'] * tax_values['factor'],
+                        precision_rounding=precision_rounding,
+                    )
+                    tax_values['base'] = base - tax_values['tax_amount_factorized']
+                    batch_base -= tax_values['tax_amount_factorized']
+
+                grouping_key_base = defaultdict(lambda: base)
+                for tax_values in tax_values_list:
+                    grouping_key_base[tax_values['grouping_key']] -= tax_values['tax_amount_factorized']
+                for tax_values in tax_values_list:
+                    tax_values['grouping_base'] = grouping_key_base[tax_values['grouping_key']]
+                    tax_values['batch_base'] = batch_base
+
+            elif amount_type == 'fixed':
+                for tax_values in tax_values_list:
+                    tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = base
+
+    @api.model
+    def _ascending_process_taxes_batch(self, batch, base, precision_rounding, extra_computation_values):
+        tax_values_list = batch['taxes']
+        amount_type = tax_values_list[0]['tax'].amount_type
+        price_include = batch['price_include']
+
+        if not price_include:
+
+            if amount_type == 'percent':
+                batch['computed'] = True
+                for tax_values in tax_values_list:
+                    tax_values['tax_amount'] = base * tax_values['tax'].amount / 100.0
+                    tax_values['tax_amount_factorized'] = float_round(
+                        tax_values['tax_amount'] * tax_values['factor'],
+                        precision_rounding=precision_rounding,
+                    )
+                    tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = base
+
+            elif amount_type == 'division':
+                batch['computed'] = True
+                for tax_values in tax_values_list:
+                    base_tax_included = base / (1 - (tax_values['tax'].amount / 100.0))
+                    tax_values['tax_amount'] = base_tax_included - base
+                    tax_values['tax_amount_factorized'] = float_round(
+                        tax_values['tax_amount'] * tax_values['factor'],
+                        precision_rounding=precision_rounding,
+                    )
+                    tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = base
+
+            elif amount_type == 'fixed':
+                batch['computed'] = True
+                quantity = abs(extra_computation_values['quantity'])
+                for tax_values in tax_values_list:
+                    tax_values['tax_amount'] = quantity * tax_values['tax'].amount
+                    tax_values['tax_amount_factorized'] = float_round(
+                        tax_values['tax_amount'] * tax_values['factor'],
+                        precision_rounding=precision_rounding,
+                    )
+                    tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = base
+
+    @api.model
+    def _prepare_tax_repartition_line_results(self, tax_values, currency, precision_rounding):
+        repartition_line_amounts = [
+            float_round(tax_values['tax_amount'] * line.factor, precision_rounding=precision_rounding)
+            for line in tax_values['repartition_lines']
+        ]
+        total_rounding_error = float_round(
+            tax_values['tax_amount_factorized'] - sum(repartition_line_amounts),
+            precision_rounding=precision_rounding,
+        )
+        nber_rounding_steps = int(abs(total_rounding_error / currency.rounding))
+        rounding_error = float_round(
+            total_rounding_error / nber_rounding_steps if nber_rounding_steps else 0.0,
+            precision_rounding=precision_rounding,
+        )
+
+        tax_repartition_values_list = []
+        for repartition_line, line_amount in zip(tax_values['repartition_lines'], repartition_line_amounts):
+
+            if nber_rounding_steps:
+                line_amount += rounding_error
+                nber_rounding_steps -= 1
+
+            tax_repartition_values_list.append({
+                'tax_amount': line_amount,
+                'repartition_line': repartition_line,
+            })
+        return tax_repartition_values_list
 
     def json_friendly_compute_all(self, price_unit, currency_id=None, quantity=1.0, product_id=None, partner_id=None, is_refund=False, include_caba_tags=False):
         """ Called by the reconciliation to compute taxes on writeoff during bank reconciliation
@@ -429,7 +564,7 @@ class AccountTax(models.Model):
         rep_lines = self.mapped(is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids')
         return rep_lines.filtered(lambda x: x.repartition_type == repartition_type).mapped('tag_ids')
 
-    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True, include_caba_tags=False, fixed_multiplicator=1):
+    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True, include_caba_tags=False, fixed_multiplicator=1, grouping_key_generator=None):
         """Compute all information required to apply taxes (in self + their children in case of a tax group).
         We consider the sequence of the parent for group of taxes.
             Eg. considering letters as taxes and alphabetic order as sequence :
@@ -505,58 +640,10 @@ class AccountTax(models.Model):
         if not round_tax:
             prec *= 1e-5
 
-        # 3) Iterate the taxes in the reversed sequence order to retrieve the initial base of the computation.
-        #     tax  |  base  |  amount  |
-        # /\ ----------------------------
-        # || tax_1 |  XXXX  |          | <- we are looking for that, it's the total_excluded
-        # || tax_2 |   ..   |          |
-        # || tax_3 |   ..   |          |
-        # ||  ...  |   ..   |    ..    |
-        #    ----------------------------
-        def recompute_base(base_amount, fixed_amount, percent_amount, division_amount):
-            # Recompute the new base amount based on included fixed/percent amounts and the current base amount.
-            # Example:
-            #  tax  |  amount  |   type   |  price_include  |
-            # -----------------------------------------------
-            # tax_1 |   10%    | percent  |  t
-            # tax_2 |   15     |   fix    |  t
-            # tax_3 |   20%    | percent  |  t
-            # tax_4 |   10%    | division |  t
-            # -----------------------------------------------
-
-            # if base_amount = 145, the new base is computed as:
-            # (145 - 15) / (1.0 + 30%) * 90% = 130 / 1.3 * 90% = 90
-            return (base_amount - fixed_amount) / (1.0 + percent_amount / 100.0) * (100 - division_amount) / 100
-
-        # The first/last base must absolutely be rounded to work in round globally.
-        # Indeed, the sum of all taxes ('taxes' key in the result dictionary) must be strictly equals to
-        # 'price_included' - 'price_excluded' whatever the rounding method.
-        #
-        # Example using the global rounding without any decimals:
-        # Suppose two invoice lines: 27000 and 10920, both having a 19% price included tax.
-        #
-        #                   Line 1                      Line 2
-        # -----------------------------------------------------------------------
-        # total_included:   27000                       10920
-        # tax:              27000 / 1.19 = 4310.924     10920 / 1.19 = 1743.529
-        # total_excluded:   22689.076                   9176.471
-        #
-        # If the rounding of the total_excluded isn't made at the end, it could lead to some rounding issues
-        # when summing the tax amounts, e.g. on invoices.
-        # In that case:
-        #  - amount_untaxed will be 22689 + 9176 = 31865
-        #  - amount_tax will be 4310.924 + 1743.529 = 6054.453 ~ 6054
-        #  - amount_total will be 31865 + 6054 = 37919 != 37920 = 27000 + 10920
-        #
-        # By performing a rounding at the end to compute the price_excluded amount, the amount_tax will be strictly
-        # equals to 'price_included' - 'price_excluded' after rounding and then:
-        #   Line 1: sum(taxes) = 27000 - 22689 = 4311
-        #   Line 2: sum(taxes) = 10920 - 2176 = 8744
-        #   amount_tax = 4311 + 8744 = 13055
-        #   amount_total = 31865 + 13055 = 37920
+        # 3) Prepare initial values.
         base = currency.round(price_unit * quantity)
 
-        # For the computation of move lines, we could have a negative base value.
+        # We could have a negative base value.
         # In this case, compute all with positive values and negate them at the end.
         sign = 1
         if currency.is_zero(base):
@@ -565,175 +652,135 @@ class AccountTax(models.Model):
             sign = -1
             base = -base
 
-        # Store the totals to reach when using price_include taxes (only the last price included in row)
-        total_included_checkpoints = {}
-        i = len(taxes) - 1
-        store_included_tax_total = True
-        # Keep track of the accumulated included fixed/percent amount.
-        incl_fixed_amount = incl_percent_amount = incl_division_amount = 0
-        # Store the tax amounts we compute while searching for the total_excluded
-        cached_tax_amounts = {}
-        if handle_price_include:
-            for tax in reversed(taxes):
-                tax_repartition_lines = (
-                    is_refund
-                    and tax.refund_repartition_line_ids
-                    or tax.invoice_repartition_line_ids
-                ).filtered(lambda x: x.repartition_type == "tax")
-                sum_repartition_factor = sum(tax_repartition_lines.mapped("factor"))
+        if is_refund:
+            repartition_lines_field = 'refund_repartition_line_ids'
+        else:
+            repartition_lines_field = 'invoice_repartition_line_ids'
 
-                if tax.include_base_amount:
-                    base = recompute_base(base, incl_fixed_amount, incl_percent_amount, incl_division_amount)
-                    incl_fixed_amount = incl_percent_amount = incl_division_amount = 0
-                    store_included_tax_total = True
-                if tax.price_include or self._context.get('force_price_include'):
-                    if tax.amount_type == 'percent':
-                        incl_percent_amount += tax.amount * sum_repartition_factor
-                    elif tax.amount_type == 'division':
-                        incl_division_amount += tax.amount * sum_repartition_factor
-                    elif tax.amount_type == 'fixed':
-                        incl_fixed_amount += abs(quantity) * tax.amount * sum_repartition_factor * abs(fixed_multiplicator)
-                    else:
-                        # tax.amount_type == other (python)
-                        tax_amount = tax._compute_amount(base, sign * price_unit, quantity, product, partner, fixed_multiplicator) * sum_repartition_factor
-                        incl_fixed_amount += tax_amount
-                        # Avoid unecessary re-computation
-                        cached_tax_amounts[i] = tax_amount
-                    # In case of a zero tax, do not store the base amount since the tax amount will
-                    # be zero anyway. Group and Python taxes have an amount of zero, so do not take
-                    # them into account.
-                    if store_included_tax_total and (
-                        tax.amount or tax.amount_type not in ("percent", "division", "fixed")
-                    ):
-                        total_included_checkpoints[i] = base
-                        store_included_tax_total = False
-                i -= 1
+        tax_values_list = []
+        for tax in taxes:
+            tax_values = {
+                'tax': tax,
+                'price_include': handle_price_include and (tax.price_include or self._context.get('force_price_include')),
+                'repartition_lines': tax[repartition_lines_field].filtered(lambda x: x.repartition_type == "tax"),
+            }
+            tax_values['factor'] = sum(tax_values['repartition_lines'].mapped('factor'))
+            grouping_key = grouping_key_generator(tax_values) if grouping_key_generator else {}
+            tax_values['grouping_key'] = frozendict(grouping_key)
+            tax_values_list.append(tax_values)
 
-        total_excluded = currency.round(recompute_base(base, incl_fixed_amount, incl_percent_amount, incl_division_amount))
+        # 4) Process batches.
+        if product and product._name == 'product.template':
+            product = product.product_variant_id
 
-        # 4) Iterate the taxes in the sequence order to compute missing tax amounts.
-        # Start the computation of accumulated amounts at the total_excluded value.
-        base = total_included = total_void = total_excluded
+        extra_computation_values = {
+            'price_unit': price_unit,
+            'quantity': quantity,
+            'product': product,
+            'partner': partner,
+            'fixed_multiplicator': fixed_multiplicator,
+            'company': company,
+        }
 
-        # Flag indicating the checkpoint used in price_include to avoid rounding issue must be skipped since the base
-        # amount has changed because we are currently mixing price-included and price-excluded include_base_amount
-        # taxes.
-        skip_checkpoint = False
+        descending_batches = self._prepare_taxes_batches(tax_values_list)
+        ascending_batches = list(reversed(descending_batches))
 
-        # Get product tags, account.account.tag objects that need to be injected in all
-        # the tax_tag_ids of all the move lines created by the compute all for this product.
+        # First ascending computation for fixed tax.
+        # In Belgium, we could have a price-excluded tax affecting the base of a price-included tax.
+        # In that case, we need to compute the fix amount before the descending computation.
+        extra_base = 0.0
+        for batch in ascending_batches:
+            batch['extra_base'] = extra_base
+            self._ascending_process_fixed_taxes_batch(batch, base, prec, extra_computation_values, fixed_multiplicator=fixed_multiplicator)
+            if batch.get('computed'):
+                batch.pop('computed')
+                if batch['include_base_amount']:
+                    extra_base += sum(tax_values['tax_amount_factorized'] for tax_values in batch['taxes'])
+
+        # First descending computation to compute price_included values and find the total_excluded amount.
+        for batch in descending_batches:
+            self._descending_process_price_included_taxes_batch(batch, base + batch['extra_base'], prec, extra_computation_values)
+            if batch.get('computed'):
+                base -= sum(tax_values['tax_amount_factorized'] for tax_values in batch['taxes'])
+
+        # Product tags needs to be added to tax_tag_ids as well.
         product_tag_ids = product.account_tag_ids.ids if product else []
 
-        taxes_vals = []
-        i = 0
-        cumulated_tax_included_amount = 0
-        for tax in taxes:
-            price_include = self._context.get('force_price_include', tax.price_include)
+        # Second ascending computation to compute the missing values for price-excluded taxes.
+        # Split the amounts according the tax repartition lines and build the final results.
+        total_included = total_void = total_excluded = base
+        lines_results = []
+        for i, batch in enumerate(ascending_batches):
+            self._ascending_process_taxes_batch(batch, base, prec, extra_computation_values)
 
-            if price_include or tax.is_base_affected:
-                tax_base_amount = base
-            else:
-                tax_base_amount = total_excluded
-
-            tax_repartition_lines = (is_refund and tax.refund_repartition_line_ids or tax.invoice_repartition_line_ids).filtered(lambda x: x.repartition_type == 'tax')
-            sum_repartition_factor = sum(tax_repartition_lines.mapped('factor'))
-
-            #compute the tax_amount
-            if not skip_checkpoint and price_include and total_included_checkpoints.get(i) is not None and sum_repartition_factor != 0:
-                # We know the total to reach for that tax, so we make a substraction to avoid any rounding issues
-                tax_amount = total_included_checkpoints[i] - (base + cumulated_tax_included_amount)
-                cumulated_tax_included_amount = 0
-            else:
-                tax_amount = tax.with_context(force_price_include=False)._compute_amount(
-                    tax_base_amount, sign * price_unit, quantity, product, partner, fixed_multiplicator)
-
-            # Round the tax_amount multiplied by the computed repartition lines factor.
-            tax_amount = float_round(tax_amount, precision_rounding=prec)
-            factorized_tax_amount = float_round(tax_amount * sum_repartition_factor, precision_rounding=prec)
-
-            if price_include and total_included_checkpoints.get(i) is None:
-                cumulated_tax_included_amount += factorized_tax_amount
-
-            # If the tax affects the base of subsequent taxes, its tax move lines must
-            # receive the base tags and tag_ids of these taxes, so that the tax report computes
-            # the right total
             subsequent_taxes = self.env['account.tax']
             subsequent_tags = self.env['account.account.tag']
-            if tax.include_base_amount:
-                subsequent_taxes = taxes[i+1:].filtered('is_base_affected')
+            if batch['include_base_amount']:
+                base += sum(tax_values['tax_amount_factorized'] for tax_values in batch['taxes'])
+
+                for next_batch in ascending_batches[i + 1:]:
+                    for next_tax_values in next_batch['taxes']:
+                        subsequent_taxes |= next_tax_values['tax']
 
                 taxes_for_subsequent_tags = subsequent_taxes
-
                 if not include_caba_tags:
                     taxes_for_subsequent_tags = subsequent_taxes.filtered(lambda x: x.tax_exigibility != 'on_payment')
-
                 subsequent_tags = taxes_for_subsequent_tags.get_tax_tags(is_refund, 'base')
 
-            # Compute the tax line amounts by multiplying each factor with the tax amount.
-            # Then, spread the tax rounding to ensure the consistency of each line independently with the factorized
-            # amount. E.g:
-            #
-            # Suppose a tax having 4 x 50% repartition line applied on a tax amount of 0.03 with 2 decimal places.
-            # The factorized_tax_amount will be 0.06 (200% x 0.03). However, each line taken independently will compute
-            # 50% * 0.03 = 0.01 with rounding. It means there is 0.06 - 0.04 = 0.02 as total_rounding_error to dispatch
-            # in lines as 2 x 0.01.
-            repartition_line_amounts = [float_round(tax_amount * line.factor, precision_rounding=prec) for line in tax_repartition_lines]
-            total_rounding_error = float_round(factorized_tax_amount - sum(repartition_line_amounts), precision_rounding=prec)
-            nber_rounding_steps = int(abs(total_rounding_error / currency.rounding))
-            rounding_error = float_round(nber_rounding_steps and total_rounding_error / nber_rounding_steps or 0.0, precision_rounding=prec)
+            for tax_values in batch['taxes']:
+                tax = tax_values['tax']
 
-            for repartition_line, line_amount in zip(tax_repartition_lines, repartition_line_amounts):
+                tax_repartition_values_list = self._prepare_tax_repartition_line_results(
+                    tax_values,
+                    currency,
+                    prec,
+                )
+                for tax_repartition_values in tax_repartition_values_list:
+                    repartition_line = tax_repartition_values['repartition_line']
 
-                if nber_rounding_steps:
-                    line_amount += rounding_error
-                    nber_rounding_steps -= 1
+                    if not include_caba_tags and tax.tax_exigibility == 'on_payment':
+                        repartition_line_tags = self.env['account.account.tag']
+                    else:
+                        repartition_line_tags = repartition_line.tag_ids
 
-                if not include_caba_tags and tax.tax_exigibility == 'on_payment':
-                    repartition_line_tags = self.env['account.account.tag']
-                else:
-                    repartition_line_tags = repartition_line.tag_ids
+                    lines_results.append({
+                        'id': tax.id,
+                        'name': tax.with_context(lang=partner.lang).name if partner else tax.name,
+                        'amount': sign * tax_repartition_values['tax_amount'],
+                        'base': float_round(sign * tax_values['base'], precision_rounding=prec),
+                        'grouping_key': tax_values['grouping_key'],
+                        'grouping_base': float_round(sign * tax_values['grouping_base'], precision_rounding=prec),
+                        'batch_base': float_round(sign * tax_values['batch_base'], precision_rounding=prec),
+                        'sequence': tax.sequence,
+                        'account_id': repartition_line._get_aml_target_tax_account(force_caba_exigibility=include_caba_tags).id,
+                        'analytic': tax.analytic,
+                        'use_in_tax_closing': repartition_line.use_in_tax_closing,
+                        'price_include': batch['price_include'],
+                        'tax_exigibility': tax.tax_exigibility,
+                        'tax_repartition_line_id': repartition_line.id,
+                        'group': groups_map.get(tax),
+                        'tag_ids': (repartition_line_tags + subsequent_tags).ids + product_tag_ids,
+                        'tax_ids': subsequent_taxes.ids,
+                    })
 
-                taxes_vals.append({
-                    'id': tax.id,
-                    'name': partner and tax.with_context(lang=partner.lang).name or tax.name,
-                    'amount': sign * line_amount,
-                    'base': float_round(sign * tax_base_amount, precision_rounding=prec),
-                    'sequence': tax.sequence,
-                    'account_id': repartition_line._get_aml_target_tax_account(force_caba_exigibility=include_caba_tags).id,
-                    'analytic': tax.analytic,
-                    'use_in_tax_closing': repartition_line.use_in_tax_closing,
-                    'price_include': price_include,
-                    'tax_exigibility': tax.tax_exigibility,
-                    'tax_repartition_line_id': repartition_line.id,
-                    'group': groups_map.get(tax),
-                    'tag_ids': (repartition_line_tags + subsequent_tags).ids + product_tag_ids,
-                    'tax_ids': subsequent_taxes.ids,
-                })
-
-                if not repartition_line.account_id:
-                    total_void += line_amount
-
-            # Affect subsequent taxes
-            if tax.include_base_amount:
-                base += factorized_tax_amount
-                if not price_include:
-                    skip_checkpoint = True
-
-            total_included += factorized_tax_amount
-            i += 1
+                    if not repartition_line.account_id:
+                        total_void += tax_repartition_values['tax_amount']
+                    total_included += tax_repartition_values['tax_amount']
 
         base_taxes_for_tags = taxes
         if not include_caba_tags:
             base_taxes_for_tags = base_taxes_for_tags.filtered(lambda x: x.tax_exigibility != 'on_payment')
 
-        base_rep_lines = base_taxes_for_tags.mapped(is_refund and 'refund_repartition_line_ids' or 'invoice_repartition_line_ids').filtered(lambda x: x.repartition_type == 'base')
+        base_rep_lines = base_taxes_for_tags \
+            .mapped(repartition_lines_field) \
+            .filtered(lambda x: x.repartition_type == 'base')
 
         return {
             'base_tags': base_rep_lines.tag_ids.ids + product_tag_ids,
-            'taxes': taxes_vals,
-            'total_excluded': sign * total_excluded,
+            'taxes': lines_results,
+            'total_excluded': sign * currency.round(total_excluded),
             'total_included': sign * currency.round(total_included),
-            'total_void': sign * total_void,
+            'total_void': sign * currency.round(total_void),
         }
 
     @api.model
@@ -827,7 +874,15 @@ class AccountTax(models.Model):
         }
 
     @api.model
-    def _compute_taxes_for_single_line(self, base_line, handle_price_include=True, include_caba_tags=False, early_pay_discount_computation=None, early_pay_discount_percentage=None):
+    def _compute_taxes_for_single_line(
+        self,
+        base_line,
+        handle_price_include=True,
+        include_caba_tags=False,
+        early_pay_discount_computation=None,
+        early_pay_discount_percentage=None,
+        grouping_key_generator=None,
+    ):
         orig_price_unit_after_discount = base_line['price_unit'] * (1 - (base_line['discount'] / 100.0))
         price_unit_after_discount = orig_price_unit_after_discount
         taxes = base_line['taxes']._origin
@@ -848,6 +903,7 @@ class AccountTax(models.Model):
                 is_refund=base_line['is_refund'],
                 handle_price_include=base_line['handle_price_include'],
                 include_caba_tags=include_caba_tags,
+                grouping_key_generator=grouping_key_generator,
             )
 
             to_update_vals = {
@@ -883,6 +939,10 @@ class AccountTax(models.Model):
                     'tax_repartition_line': tax_rep,
                     'base_amount_currency': tax_res['base'],
                     'base_amount': currency.round(tax_res['base'] / rate),
+                    'grouping_base_amount_currency': tax_res['grouping_base'],
+                    'grouping_base_amount': currency.round(tax_res['grouping_base'] / rate),
+                    'batch_base_amount_currency': tax_res['batch_base'],
+                    'batch_base_amount': currency.round(tax_res['batch_base'] / rate),
                     'tax_amount_currency': tax_res['amount'],
                     'tax_amount': tax_amount,
                 })
@@ -900,9 +960,6 @@ class AccountTax(models.Model):
 
     @api.model
     def _aggregate_taxes(self, to_process, filter_tax_values_to_apply=None, grouping_key_generator=None):
-
-        def default_grouping_key_generator(base_line, tax_values):
-            return {'tax': tax_values['tax_repartition_line'].tax_id}
 
         global_tax_details = {
             'base_amount_currency': 0.0,
@@ -933,28 +990,6 @@ class AccountTax(models.Model):
             }),
         }
 
-        def add_tax_values(record, results, grouping_key, serialized_grouping_key, tax_values):
-            # Add to global results.
-            results['tax_amount_currency'] += tax_values['tax_amount_currency']
-            results['tax_amount'] += tax_values['tax_amount']
-
-            # Add to tax details.
-            if serialized_grouping_key not in results['tax_details']:
-                tax_details = results['tax_details'][serialized_grouping_key]
-                tax_details.update(grouping_key)
-                tax_details['base_amount_currency'] = tax_values['base_amount_currency']
-                tax_details['base_amount'] = tax_values['base_amount']
-                tax_details['records'].add(record)
-            else:
-                tax_details = results['tax_details'][serialized_grouping_key]
-                if record not in tax_details['records']:
-                    tax_details['base_amount_currency'] += tax_values['base_amount_currency']
-                    tax_details['base_amount'] += tax_values['base_amount']
-                    tax_details['records'].add(record)
-            tax_details['tax_amount_currency'] += tax_values['tax_amount_currency']
-            tax_details['tax_amount'] += tax_values['tax_amount']
-            tax_details['group_tax_details'].append(tax_values)
-
         if self.env.company.tax_calculation_rounding_method == 'round_globally':
             amount_per_tax_repartition_line_id = defaultdict(lambda: {
                 'delta_tax_amount': 0.0,
@@ -978,35 +1013,32 @@ class AccountTax(models.Model):
                     total_amounts['delta_tax_amount_currency'] = tax_amount_currency_with_delta - tax_amount_currency
                     total_amounts['delta_tax_amount'] = tax_amount_with_delta - tax_amount
 
-        grouping_key_generator = grouping_key_generator or default_grouping_key_generator
-
         for base_line, to_update_vals, tax_values_list in to_process:
             record = base_line['record']
 
-            # Add to global tax amounts.
-            global_tax_details['base_amount_currency'] += to_update_vals['price_subtotal']
-
-            currency = base_line['currency'] or self.env.company.currency_id
-            base_amount = currency.round(to_update_vals['price_subtotal'] / base_line['rate'])
-            global_tax_details['base_amount'] += base_amount
-
+            seen_grouping_keys = set()
+            base_added = False
             for tax_values in tax_values_list:
-                if filter_tax_values_to_apply and not filter_tax_values_to_apply(base_line, tax_values):
-                    continue
 
-                grouping_key = grouping_key_generator(base_line, tax_values)
-                serialized_grouping_key = frozendict(grouping_key)
+                for results in (global_tax_details, global_tax_details['tax_details_per_record'][record]):
+                    local_results = results['tax_details'][tax_values['grouping_key']]
+                    if not base_added:
+                        base_added = True
+                        results['base_amount_currency'] += tax_values['batch_base_amount_currency']
+                        results['base_amount'] += tax_values['batch_base_amount']
+                    if tax_values['grouping_key'] not in seen_grouping_keys:
+                        local_results['base_amount_currency'] += tax_values['grouping_base_amount_currency']
+                        local_results['base_amount'] += tax_values['grouping_base_amount']
+                        local_results.update(tax_values['grouping_key'])
+                        local_results['records'].add(record)
+                        local_results['group_tax_details'].append(tax_values)
 
-                # Add to invoice line global tax amounts.
-                if serialized_grouping_key not in global_tax_details['tax_details_per_record'][record]:
-                    record_global_tax_details = global_tax_details['tax_details_per_record'][record]
-                    record_global_tax_details['base_amount_currency'] = to_update_vals['price_subtotal']
-                    record_global_tax_details['base_amount'] = base_amount
-                else:
-                    record_global_tax_details = global_tax_details['tax_details_per_record'][record]
+                    results['tax_amount_currency'] += tax_values['tax_amount_currency']
+                    results['tax_amount'] += tax_values['tax_amount']
+                    local_results['tax_amount_currency'] += tax_values['tax_amount_currency']
+                    local_results['tax_amount'] += tax_values['tax_amount']
 
-                add_tax_values(record, global_tax_details, grouping_key, serialized_grouping_key, tax_values)
-                add_tax_values(record, record_global_tax_details, grouping_key, serialized_grouping_key, tax_values)
+                seen_grouping_keys.add(tax_values['grouping_key'])
 
         return global_tax_details
 
@@ -1160,14 +1192,13 @@ class AccountTax(models.Model):
 
         to_process = []
         for base_line in base_lines:
-            to_update_vals, tax_values_list = self._compute_taxes_for_single_line(base_line)
+            to_update_vals, tax_values_list = self._compute_taxes_for_single_line(
+                base_line,
+                grouping_key_generator=lambda tax_values: {'tax_group': tax_values['tax'].tax_group_id},
+            )
             to_process.append((base_line, to_update_vals, tax_values_list))
 
-        def grouping_key_generator(base_line, tax_values):
-            source_tax = tax_values['tax_repartition_line'].tax_id
-            return {'tax_group': source_tax.tax_group_id}
-
-        global_tax_details = self._aggregate_taxes(to_process, grouping_key_generator=grouping_key_generator)
+        global_tax_details = self._aggregate_taxes(to_process)
 
         tax_group_vals_list = []
         for tax_detail in global_tax_details['tax_details'].values():

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -33,6 +33,7 @@ from . import test_reconciliation_matching_rules
 from . import test_account_onboarding
 from . import test_portal_attachment
 from . import test_tax_report
+from . import test_taxes_computation
 from . import test_transfer_wizard
 from . import test_account_incoming_supplier_invoice
 from . import test_payment_term

--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -169,10 +169,6 @@ class TestTaxCommon(AccountTestInvoicingCommon):
 @tagged('post_install', '-at_install')
 class TestTax(TestTaxCommon):
 
-    @classmethod
-    def setUpClass(cls):
-        super(TestTax, cls).setUpClass()
-
     def test_tax_group_of_group_tax(self):
         self.fixed_tax.include_base_amount = True
         res = self.group_of_group_tax.compute_all(200.0)

--- a/addons/account/tests/test_taxes_computation.py
+++ b/addons/account/tests/test_taxes_computation.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestTaxesComputationCommon(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.number = 0
+
+    def _check_tax_results(self, taxes, expected_values, price_unit, quantity=1):
+        results = taxes.compute_all(price_unit, quantity=quantity)
+        self.assertAlmostEqual(results['total_included'], expected_values['total_included'])
+        self.assertAlmostEqual(results['total_excluded'], expected_values['total_excluded'])
+        self.assertEqual(len(results['taxes']), len(expected_values['taxes']))
+        for values, expected_values in zip(results['taxes'], expected_values['taxes']):
+            self.assertAlmostEqual(values['base'], expected_values[0])
+            self.assertAlmostEqual(values['amount'], expected_values[1])
+
+    def percent_tax(self, amount, **kwargs):
+        self.number += 1
+        return self.env['account.tax'].create({
+            **kwargs,
+            'name': f"percent_{amount}_({self.number})",
+            'amount_type': 'percent',
+            'amount': amount,
+        })
+
+    def division_tax(self, amount, **kwargs):
+        self.number += 1
+        return self.env['account.tax'].create({
+            **kwargs,
+            'name': f"division_{amount}_({self.number})",
+            'amount_type': 'division',
+            'amount': amount,
+        })
+
+    def fixed_tax(self, amount, **kwargs):
+        self.number += 1
+        return self.env['account.tax'].create({
+            **kwargs,
+            'name': f"fixed_{amount}_({self.number})",
+            'amount_type': 'fixed',
+            'amount': amount,
+        })
+
+    def test_percent_taxes_for_l10n_in(self):
+        tax1 = self.percent_tax(6)
+        tax2 = self.percent_tax(6)
+        tax3 = self.percent_tax(3)
+
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 115.0,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 6.0),
+                    (100.0, 6.0),
+                    (100.0, 3.0),
+                ),
+            },
+            100.0,
+        )
+
+        tax1.include_base_amount = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 115.54,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 6.0),
+                    (106.0, 6.36),
+                    (106.0, 3.18),
+                ),
+            },
+            100.0,
+        )
+
+        tax2.include_base_amount = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 115.73,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 6.0),
+                    (106.0, 6.36),
+                    (112.36, 3.37),
+                ),
+            },
+            100.0,
+        )
+
+        tax2.is_base_affected = False
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 115.36,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 6.0),
+                    (100.0, 6.0),
+                    (112.0, 3.36),
+                ),
+            },
+            100.0,
+        )
+
+        tax1.price_include = True
+        tax2.price_include = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 115.36,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 6.0),
+                    (100.0, 6.0),
+                    (112.0, 3.36),
+                ),
+            },
+            112.0,
+        )
+
+        # Ensure tax1 & tax2 give always the same result.
+        self._check_tax_results(
+            tax1 + tax2,
+            {
+                'total_included': 17.79,
+                'total_excluded': 15.89,
+                'taxes': (
+                    (15.89, 0.95),
+                    (15.89, 0.95),
+                ),
+            },
+            17.79,
+        )
+
+    def test_division_taxes_for_l10n_br(self):
+        tax1 = self.division_tax(5)
+        tax2 = self.division_tax(3)
+        tax3 = self.division_tax(0.65)
+        tax4 = self.division_tax(9)
+        tax5 = self.division_tax(15)
+
+        self._check_tax_results(
+            tax1 + tax2 + tax3 + tax4 + tax5,
+            {
+                'total_included': 44.15,
+                'total_excluded': 32.33,
+                'taxes': (
+                    (32.33, 1.7),
+                    (32.33, 1.0),
+                    (32.33, 0.21),
+                    (32.33, 3.2),
+                    (32.33, 5.71),
+                ),
+            },
+            32.33,
+        )
+
+        tax1.price_include = True
+        tax2.price_include = True
+        tax3.price_include = True
+        tax4.price_include = True
+        tax5.price_include = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3 + tax4 + tax5,
+            {
+                'total_included': 48.0,
+                'total_excluded': 32.33,
+                'taxes': (
+                    (45.6, 2.4),
+                    (46.56, 1.44),
+                    (47.69, 0.31),
+                    (43.68, 4.32),
+                    (40.8, 7.2),
+                ),
+            },
+            48.0,
+        )
+
+    def test_fixed_taxes_for_l10n_be(self):
+        tax1 = self.fixed_tax(1)
+        tax2 = self.percent_tax(21)
+        tax3 = self.fixed_tax(2)
+
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 136.0,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 5.0),
+                    (100.0, 21.0),
+                    (100.0, 10.0),
+                ),
+            },
+            20.0,
+            quantity=5,
+        )
+
+        tax1.include_base_amount = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 131.0,
+                'total_excluded': 95.0,
+                'taxes': (
+                    (95.0, 5.0),
+                    (100.0, 21.0),
+                    (100.0, 10.0),
+                ),
+            },
+            19.0,
+            quantity=5,
+        )
+
+        tax2.price_include = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 123.0,
+                'total_excluded': 99.0,
+                'taxes': (
+                    (99.0, 1.0),
+                    (100.0, 21.0),
+                    (100.0, 2.0),
+                ),
+            },
+            120.0,
+        )
+
+        tax2.include_base_amount = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 123.0,
+                'total_excluded': 99.0,
+                'taxes': (
+                    (99.0, 1.0),
+                    (100.0, 21.0),
+                    (121.0, 2.0),
+                ),
+            },
+            120.0,
+        )
+
+        tax1.include_base_amount = False
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 124.0,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 1.0),
+                    (100.0, 21.0),
+                    (121.0, 2.0),
+                ),
+            },
+            121.0,
+        )
+
+        tax1.price_include = True
+        self._check_tax_results(
+            tax1 + tax2 + tax3,
+            {
+                'total_included': 124.0,
+                'total_excluded': 100.0,
+                'taxes': (
+                    (100.0, 1.0),
+                    (100.0, 21.0),
+                    (121.0, 2.0),
+                ),
+            },
+            121.0,
+        )

--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, _
+from odoo.tools.float_utils import float_round
 from odoo.tools.safe_eval import safe_eval
 from odoo.exceptions import UserError
 
@@ -29,35 +30,47 @@ class AccountTaxPython(models.Model):
             ":param product: product.product recordset singleton or None\n"
             ":param partner: res.partner recordset singleton or None")
 
-    def _compute_amount(self, base_amount, price_unit, quantity=1.0, product=None, partner=None, fixed_multiplicator=1):
-        self.ensure_one()
-        if product and product._name == 'product.template':
-            product = product.product_variant_id
-        if self.amount_type == 'code':
-            company = self.env.company
-            localdict = {'base_amount': base_amount, 'price_unit':price_unit, 'quantity': quantity, 'product':product, 'partner':partner, 'company': company}
-            try:
-                safe_eval(self.python_compute, localdict, mode="exec", nocopy=True)
-            except Exception as e:
-                raise UserError(_("You entered invalid code %r in %r taxes\n\nError : %s") % (self.python_compute, self.name, e)) from e
-            return localdict['result']
-        return super(AccountTaxPython, self)._compute_amount(base_amount, price_unit, quantity, product, partner, fixed_multiplicator)
+    def _ascending_process_fixed_taxes_batch(self, batch, base, precision_rounding, extra_computation_values, fixed_multiplicator=1):
+        # EXTENDS 'account'
+        super()._ascending_process_fixed_taxes_batch(batch, base, precision_rounding, extra_computation_values, fixed_multiplicator=fixed_multiplicator)
 
-    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True, include_caba_tags=False, fixed_multiplicator=1):
-        taxes = self.filtered(lambda r: r.amount_type != 'code')
-        company = self.env.company
-        if product and product._name == 'product.template':
-            product = product.product_variant_id
-        for tax in self.filtered(lambda r: r.amount_type == 'code'):
-            localdict = self._context.get('tax_computation_context', {})
-            localdict.update({'price_unit': price_unit, 'quantity': quantity, 'product': product, 'partner': partner, 'company': company})
-            try:
-                safe_eval(tax.python_applicable, localdict, mode="exec", nocopy=True)
-            except Exception as e:
-                raise UserError(_("You entered invalid code %r in %r taxes\n\nError : %s") % (tax.python_applicable, tax.name, e)) from e
-            if localdict.get('result', False):
-                taxes += tax
-        return super(AccountTaxPython, taxes).compute_all(price_unit, currency, quantity, product, partner, is_refund=is_refund, handle_price_include=handle_price_include, include_caba_tags=include_caba_tags, fixed_multiplicator=fixed_multiplicator)
+        if batch['amount_type'] == 'code':
+            batch['computed'] = True
+            for tax_values in batch['taxes']:
+                localdict = {**extra_computation_values, 'base_amount': base}
+                tax = tax_values['tax']
+                try:
+                    safe_eval(tax.python_compute, localdict, mode="exec", nocopy=True)
+                except Exception as e:
+                    raise UserError(_(
+                        "You entered invalid code %r in %r taxes\n\nError : %s",
+                        tax.python_compute,
+                        tax.name,
+                        e,
+                    ))
+                tax_values['tax_amount'] = localdict['result']
+                tax_values['tax_amount_factorized'] = float_round(
+                    tax_values['tax_amount'] * tax_values['factor'],
+                    precision_rounding=precision_rounding,
+                )
+
+    def _descending_process_price_included_taxes_batch(self, batch, base, precision_rounding, extra_computation_values):
+        # EXTENDS 'account'
+        super()._descending_process_price_included_taxes_batch(batch, base, precision_rounding, extra_computation_values)
+        if batch['price_include'] and batch['amount_type'] == 'code':
+            batch['computed'] = True
+            tax_values_list = batch['taxes']
+            batch_base = base - sum(tax_values['tax_amount_factorized'] for tax_values in tax_values_list)
+            for tax_values in tax_values_list:
+                tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = batch_base
+
+    def _ascending_process_taxes_batch(self, batch, base, precision_rounding, extra_computation_values):
+        # EXTENDS 'account'
+        super()._ascending_process_taxes_batch(batch, base, precision_rounding, extra_computation_values)
+        if not batch['price_include'] and batch['amount_type'] == 'code':
+            batch['computed'] = True
+            for tax_values in batch['taxes']:
+                tax_values['base'] = tax_values['batch_base'] = tax_values['grouping_base'] = base
 
 
 class AccountTaxTemplatePython(models.Model):

--- a/addons/account_tax_python/tests/test_tax.py
+++ b/addons/account_tax_python/tests/test_tax.py
@@ -10,7 +10,7 @@ class TestTaxPython(TestTaxCommon):
     def setUpClass(cls):
         super(TestTaxPython, cls).setUpClass()
         cls.python_tax = cls.env['account.tax'].create({
-            'name': 'Python TAx',
+            'name': 'Python Tax',
             'amount_type': 'code',
             'amount': 0.0,
             'python_compute': 'result = ((price_unit * quantity) - ((price_unit * quantity) / 1.12)) * 0.5',
@@ -49,12 +49,12 @@ class TestTaxPython(TestTaxCommon):
         res = (self.python_tax + self.python_tax).compute_all(130.0)
         self._check_compute_all_results(
             130,    # 'total_included'
-            116.07, # 'total_excluded'
+            116.08, # 'total_excluded'
             [
                 # base , amount     | seq | amount | incl | incl_base
                 # ---------------------------------------------------
-                (116.07, 6.96),   # |  1  |    6%  |   t  |
-                (116.07, 6.97),   # |  1  |    6%  |   t  |
+                (116.08, 6.96),   # |  1  |    6%  |   t  |
+                (116.08, 6.96),   # |  1  |    6%  |   t  |
                 # ---------------------------------------------------
             ],
             res


### PR DESCRIPTION
The current tax engine doesn't work with division taxes because the tax amounts must be computed on the price included amount but can't be on the price excluded one. Unfortunately, the current engine is finding first the price excluded amount before computing "really" the tax amounts.

It means, 20% division price included on 100 should be computed as: 100 * 0.2 = 20
However, when trying to compute the tax amount on 100 - 20 = 80, we are not able to retrieve the original tax amount of 20.

opw: 3443703

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
