### PR TITLE
[FIX] point_of_sale,*: fix template syntax errors

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.xml
@@ -72,7 +72,7 @@
                 <t t-esc="props.title" />
             </header>
             <main>
-                <input type="text" t-model="state.payload" t-ref="input" class="value payment-input-number" inputmode="decimal">
+                <input type="text" t-model="state.payload" t-ref="input" class="value payment-input-number" inputmode="decimal"/>
             </main>
             <footer class="footer centered modal-footer">
                 <button class="button confirm highlight btn btn-lg btn-primary" t-on-mousedown.prevent="confirm">

--- a/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.xml
@@ -12,9 +12,9 @@
                             <div class="money-details-value d-flex align-items-center w-100 my-1 mx-auto" t-on-input="updateMoneyDetailsAmount">
                                 <input class="pos-input form-control w-50 text-end" t-att-id="moneyValue" type="number" t-model.number="state.moneyDetails[moneyValue]" t-on-focus="ev=>ev.target.select()"/>
                                 <label class="oe_link_icon w-25 text-end" t-att-for="moneyValue">
-                                    <t t-if="currency.position === 'before'"><t t-esc="currency.symbol"/>&nbsp;</t>
-                                    <t t-esc="moneyValue"/>
-                                    <t t-if="currency.position === 'after'">&nbsp;<t t-esc="currency.symbol"/></t>
+                                    <t t-if="currency.position === 'before'" t-esc="currency.symbol"/>
+                                    <span class="mx-1" t-esc="moneyValue"/>
+                                    <t t-if="currency.position === 'after'" t-esc="currency.symbol"/>
                                 </label>
                             </div>
                         </t>

--- a/addons/pos_loyalty/static/src/overrides/components/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/order_summary/order_summary.xml
@@ -2,37 +2,36 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_loyalty.OrderSummary" t-inherit="point_of_sale.OrderSummary" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('summary')]" position="after">
-                <t t-set="_loyaltyStats" t-value="getLoyaltyPoints()"/>
-                <t t-foreach="_loyaltyStats" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
-                    <t t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent">
-                        <div class="summary clearfix sticky-top w-100 border-top text-end fw-bolder">
-                            <div class='d-flex flex-column px-3 py-2 bg-200 text-start'>
-                                <div class="loyalty-points-title text-center mb-1">
-                                    <t t-esc="_loyaltyStat.points.name"/>
+            <t t-set="_loyaltyStats" t-value="getLoyaltyPoints()"/>
+            <t t-foreach="_loyaltyStats" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
+                <t t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent">
+                    <div class="summary clearfix sticky-top w-100 border-top text-end fw-bolder">
+                        <div class='d-flex flex-column px-3 py-2 bg-200 text-start'>
+                            <div class="loyalty-points-title text-center mb-1">
+                                <t t-esc="_loyaltyStat.points.name"/>
+                            </div>
+                            <div class="d-flex justify-content-around gap-2 mt-1">
+                                <div
+                                    t-if='_loyaltyStat.points.won'
+                                    class="loyalty-points-won d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2" >
+                                    <span class="text-muted">Points Won</span>
+                                    <span class='value text-success '>+<t t-esc='_loyaltyStat.points.won'/></span>
                                 </div>
-                                <div class="d-flex justify-content-around gap-2 mt-1">
-                                    <div 
-                                        t-if='_loyaltyStat.points.won' 
-                                        class="loyalty-points-won d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2" >
-                                        <span class="text-muted">Points Won</span>
-                                        <span class='value text-success '>+<t t-esc='_loyaltyStat.points.won'/></span>
-                                    </div>
-                                    <div 
-                                        t-if='_loyaltyStat.points.spent' 
-                                        class="loyalty-points-won d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2" >
-                                        <span class="text-muted">Points Spent</span>
-                                        <span class='value text-danger'>-<t t-esc='_loyaltyStat.points.spent'/></span>
-                                    </div>
-                                    <div class="loyalty-points-total d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2">
-                                        <span class="text-muted">New Total</span>
-                                        <span class='value text-primary'><t t-esc='_loyaltyStat.points.total'/></span>
-                                    </div>
+                                <div
+                                    t-if='_loyaltyStat.points.spent'
+                                    class="loyalty-points-won d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2" >
+                                    <span class="text-muted">Points Spent</span>
+                                    <span class='value text-danger'>-<t t-esc='_loyaltyStat.points.spent'/></span>
+                                </div>
+                                <div class="loyalty-points-total d-flex flex-column align-items-center justify-content-center flex-grow-1 rounded bg-300 px-3 py-2">
+                                    <span class="text-muted">New Total</span>
+                                    <span class='value text-primary'><t t-esc='_loyaltyStat.points.total'/></span>
                                 </div>
                             </div>
                         </div>
-                    </t>
+                    </div>
                 </t>
-            </div>
+            </t>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/control_buttons/table_guests_button/table_guests_button.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/table_guests_button/table_guests_button.xml
@@ -8,7 +8,7 @@
             </span>
             <span> </span>
             <span>Dine-in Guests</span>
-        </div>
+        </button>
     </t>
 
 </templates>

--- a/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.xml
+++ b/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.xml
@@ -45,7 +45,7 @@
                         <div class="custom-amount-form d-flex">
                             <div class="input-group input-group-lg">
                                 <span class="input-group-text bg-secondary">Tip Amount</span>
-                                <input type="text" class="item form-control fs-1" aria-label="Username" t-model="state.inputTipAmount" t-att-data-amount="state.inputTipAmount" disabled>
+                                <input type="text" class="item form-control fs-1" aria-label="Username" t-model="state.inputTipAmount" t-att-data-amount="state.inputTipAmount"/>
                                 <span class="input-group-text">
                                     <div class="currency">
                                         <t t-esc="pos.getCurrencySymbol()" />


### PR DESCRIPTION
* point_of_sale, pos_loyalty, pos_restaurant

before this commit, syntax error exist in point_of_sale, pos_loyalty and pos_restaurant modules.

* export translation of above modules
* check odoo log file

errors in the log:

* Opening and ending tag mismatch: input line
* XMLSyntaxError: Entity 'nbsp' not defined
* Opening and ending tag mismatch: button line
* Specification mandates value for attribute disabled

after this commit, no error's wont be shown in
the log


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
