### PR TITLE
[FIX] web: grouped list with aggregated value

### DIFF
--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -18,7 +18,7 @@ export class Group extends DataPoint {
         super.setup(...arguments);
         this.groupByField = this.fields[config.groupByFieldName];
         this.range = data.range;
-        this._rawValue = data[this.groupByField.name];
+        this._rawValue = data.rawValue;
         /** @type {number} */
         this.count = data.count;
         this.value = data.value;

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -426,9 +426,8 @@ export function getDisplayNameFromGroupData(field, rawValue) {
  * @param {any} rawValue
  * @returns {any}
  */
-export function getValueFromGroupData(groupData, field, rawValue) {
+export function getValueFromGroupData(groupData, field, rawValue, range) {
     if (["date", "datetime"].includes(field.type)) {
-        const range = groupData.range;
         if (!range) {
             return false;
         }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -1994,6 +1994,33 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
+    QUnit.test("group a list view with the aggregable field 'value'", async function (assert) {
+        serverData.models.foo.fields.value = {
+            string: "Value",
+            type: "integer",
+            group_operator: "sum",
+        };
+        for (const record of serverData.models.foo.records) {
+            record.value = 1;
+        }
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: `
+                    <tree>
+                        <field name="bar"/>
+                        <field name="value" sum="Sum1"/>
+                    </tree>`,
+            groupBy: ["bar"],
+        });
+        assert.containsN(target, ".o_group_header", 2);
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_group_header")].map((el) => el.textContent),
+            ["No (1) 1", "Yes (3) 3"]
+        );
+    });
+
     QUnit.test("basic grouped list rendering with groupby m2m field", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
Since the relational model (PR 114024) has been rewritten, in a grouped list
 view, if we have a field with name (value, count, aggregates or length)
and it is aggregatable, then the aggregated value of the group is false.

Why:
When loading the group list data or will process the group. As a result, values such as "value", "count", etc. are overwritten.

Solution:
We will no longer modify the group data, but only extrat what the Group DataPoint needs.

How to reproduce:
- Go to a grouped list view with the "value" field aggregateable

Before this commit:
    The value displayed on the group for the value field is wrong

After this commit:
    The value displayed on the group for the value field is correct

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
