### PR TITLE
[IMP] web: removes contains() polyfill

### DIFF
--- a/addons/web/static/src/legacy/js/core/misc.js
+++ b/addons/web/static/src/legacy/js/core/misc.js
@@ -92,25 +92,6 @@ export function unblockUI() {
     return $.unblockUI.apply($, arguments);
 }
 
-
-// In Internet Explorer, document doesn't have the contains method, so we make a
-// polyfill for the method in order to be compatible.
-if (!document.contains) {
-    document.contains = function contains (node) {
-        if (!(0 in arguments)) {
-            throw new TypeError('1 argument is required');
-        }
-
-        do {
-            if (this === node) {
-                return true;
-            }
-        } while (node = node && node.parentNode);
-
-        return false;
-    };
-}
-
 export default {
     blockUI: blockUI,
     unblockUI: unblockUI,


### PR DESCRIPTION
Mainly used for Internet Explorer support.
´contains´ is now supported by Edge.

https://caniuse.com/mdn-api_node_contains

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
