### PR TITLE
[FIX] web: put dark mode bg on field selector

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.scss
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.scss
@@ -9,8 +9,9 @@
 
 .o_model_field_selector_popover {
     width: 265px;
-    background: white;
-    --o-input-background-color: white;
+    --o-input-border-color: transparent;
+    background: $gray-100;
+    --o-input-background-color: #{$input-focus-bg};
 
     &:focus {
         outline: none;
@@ -66,15 +67,15 @@
                 font-family: Arial;
                 font-size: 13px;
                 color: #444;
-                border-bottom: 1px solid #eee;
+                border-bottom: 1px solid darken($gray-100, 10%);
                 &.active {
-                    background: #f5f5f5;
+                    background: darken($gray-100, 5%);
                 }
                 .o_model_field_selector_popover_item_title {
                     font-size: 12px;
                 }
                 .o_model_field_selector_popover_item_relation {
-                    border-left: 1px solid #eee;
+                    border-left: 1px solid darken($gray-100, 10%);
                 }
             }
         }


### PR DESCRIPTION
__Current behavior before commit:__
The field selector of the **Add Custom Filter** pop-up from the search bar has no dark mode.

__Description of the fix:__
Put scss variables instead of hard-coded value.

**Before**:
![image](https://github.com/odoo/odoo/assets/46035353/f0544575-3708-46ee-bf80-d4dd3a23c4de)

**After**:
![image](https://github.com/odoo/odoo/assets/46035353/7c8b6108-d5e8-41b1-8bb7-2849813f85fe)

opw-3439301