### PR TITLE
[IMP] mail: download all files of discuss message at once 

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -102,4 +102,13 @@ export class AttachmentList extends Component {
     get isInChatWindowAndIsAlignedLeft() {
         return this.env.inChatWindow && !this.env.alignedRight;
     }
+
+    get showDelete() {
+        return (
+            (this.attachment.isDeletable &&
+                (!this.env.message || this.env.message?.hasTextContent)) ||
+            this.env.inComposer ||
+            this.props.attachments.length > 1
+        );
+    }
 }

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -34,7 +34,7 @@
                         <i class="fa fa-spin fa-spinner"/>
                     </div>
                     <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="attachment.isDeletable"
+                        <div t-if="showDelete"
                             class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
                             tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
                             <i class="fa fa-trash"/>
@@ -76,7 +76,7 @@
                         <div t-if="!attachment.uploading and env.inComposer" class="d-flex justify-content-center align-items-center w-100 h-100 text-primary" title="Uploaded">
                             <i class="fa fa-check"/>
                         </div>
-                        <button t-if="attachment.isDeletable"
+                        <button t-if="showDelete"
                             class="o-mail-AttachmentCard-unlink btn top-0 justify-content-center align-items-center d-flex w-100 h-100 rounded-0 border-0"
                             t-attf-class="{{ env.inComposer ? 'o-inComposer position-absolute btn-primary transition-base' : 'bg-300' }}"
                             t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove"

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -113,6 +113,7 @@ export class Message extends Component {
         this.ui = useState(useService("ui"));
         this.openReactionMenu = this.openReactionMenu.bind(this);
         useChildSubEnv({
+            message: this.props.message,
             alignedRight: this.isAlignedRight,
         });
         useEffect(

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -3,8 +3,11 @@
 import { useComponent, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
+import { download } from "@web/core/network/download";
 import { registry } from "@web/core/registry";
 import { MessageReactionButton } from "./message_reaction_button";
+
+const { DateTime } = luxon;
 
 export const messageActionsRegistry = registry.category("mail.message/actions");
 
@@ -73,6 +76,20 @@ messageActionsRegistry
         title: _t("Delete"),
         onClick: (component) => component.onClickDelete(),
         sequence: 90,
+    })
+    .add("download_files", {
+        condition: (component) => component.message.attachments.length > 1,
+        icon: "fa-download",
+        title: _t("Download Files"),
+        onClick: (component) =>
+            download({
+                data: {
+                    file_ids: component.message.attachments.map((rec) => rec.id),
+                    zip_name: `attachments_${DateTime.local().toFormat("HHmmddMMyyyy")}.zip`,
+                },
+                url: "mail/attachment/zip",
+            }),
+        sequence: 55,
     });
 
 function transformAction(component, id, action) {


### PR DESCRIPTION
This commit introduces a new message action to download
all files of the message, when the message contains more
than a single attachment.

This commit also do not show the delete icon on a file
when it's linked to a message without any text content, and
there's only 1 file attached to this message.
This is because deleting message and deleting the file means
basically the same, as deleting the attachment would mean the
message is empty, and empty messages are considered deleted.
We only show "Delete" of the message for clarity.

Task-3340653