### PR TITLE
[FIX] web: sprintf named placeholders regex

### DIFF
--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -140,7 +140,7 @@ export function intersperse(str, indices, separator = "") {
 export function sprintf(s, ...values) {
     if (values.length === 1 && Object.prototype.toString.call(values[0]) === "[object Object]") {
         const valuesDict = values[0];
-        s = s.replace(/%\(?([^)]+)\)s/g, (match, value) => valuesDict[value]);
+        s = s.replace(/%\(([^)]+)\)s/g, (match, value) => valuesDict[value]);
     } else if (values.length > 0) {
         s = s.replace(/%s/g, () => values.shift());
     }


### PR DESCRIPTION
The function `sprintf` can use a dictionnary as second argument along with named placeholders with the syntax `sprintf("%(argName)s", dict)`. But the regex was wrong, making the first parenthesis optional and allowing `sprintf("%argName)s", dict)` as a valid syntax.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
