### PR TITLE
[FIX] Website_slides: make answers_ids line in quiz readonly

### DIFF
--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -167,7 +167,7 @@
                                             <tree>
                                                 <field name="sequence" widget="handle"/>
                                                 <field name="question" string="Question"/>
-                                                <field name="answer_ids" string="Answers" widget="many2many_tags"/>
+                                                <field name="answer_ids" string="Answers" widget="many2many_tags" readonly="1" force_save="1"/>
                                             </tree>
                                         </field>
                                     </group>


### PR DESCRIPTION
Answers_ids line in question_lines of quiz page is not meant to be modified, and it is not generally modifiable. However, in very niche cases where user creates more then two consecutive questions and then leave question creation modal, they may be able to modify the field, which gives us an error. With this fix we make sure that answers_ids is always readonly.

Task-3459850






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
