### PR TITLE
[IMP] hr_holidays: UX changes to increase usability

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -457,6 +457,7 @@ class HolidaysType(models.Model):
                 'closest_allocation_expire': format_date(self.env, self.closest_allocation_to_expire.date_to) if self.closest_allocation_to_expire.date_to else False,
                 'request_unit': self.request_unit,
                 'icon': self.sudo().icon_id.url,
+                'id': self.id,
                 }, self.requires_allocation, self.id)
 
     def _get_contextual_employee_id(self):

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -1,17 +1,19 @@
 /* @odoo-module */
 
 import { usePopover } from "@web/core/popover/popover_hook";
+import { useNewAllocationRequest } from '@hr_holidays/views/hooks';
 
 const { Component } = owl;
 
 export class TimeOffCardPopover extends Component {}
 
 TimeOffCardPopover.template = 'hr_holidays.TimeOffCardPopover';
-TimeOffCardPopover.props = ['allocated', 'approved', 'planned', 'left', 'close?'];
+TimeOffCardPopover.props = ['allocated', 'approved', 'planned', 'left', 'employeeId', 'holidayStatusId', 'close?', 'onClickNewAllocationRequest?'];
 
 export class TimeOffCard extends Component {
     setup() {
         this.popover = usePopover(TimeOffCardPopover, { position: "right", popoverClass: "bg-view" });
+        this.newAllocationRequest = useNewAllocationRequest();
     }
 
     onClickInfo(ev) {
@@ -21,12 +23,20 @@ export class TimeOffCard extends Component {
             approved: data.leaves_approved,
             planned: data.leaves_requested,
             left: data.virtual_remaining_leaves,
+            employeeId: this.props.employeeId,
+            holidayStatusId: this.props.holidayStatusId,
+            onClickNewAllocationRequest: this.newAllocationRequestFrom.bind(this),
         });
+    }
+
+    async newAllocationRequestFrom() {
+        this.popover.close();
+        await this.newAllocationRequest(this.props.employeeId, this.props.holidayStatusId);
     }
 }
 
 TimeOffCard.template = 'hr_holidays.TimeOffCard';
-TimeOffCard.props = ['name', 'id', 'data', 'requires_allocation'];
+TimeOffCard.props = ['name', 'data', 'requires_allocation', 'employeeId', 'holidayStatusId'];
 
 export class TimeOffCardMobile extends TimeOffCard {}
 

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -54,7 +54,7 @@
 
     <t t-name="hr_holidays.TimeOffCardPopover">
         <ul class="list-unstyled p-3 mb-0">
-            <li class="d-flex justify-content-between">Allocated: <span class="ps-1" t-esc="props.allocated"/></li>
+            <li class="d-flex justify-content-between">Allocated (<span class="btn-link p-0 cursor-pointer" t-on-click="props.onClickNewAllocationRequest">new request</span>): <span class="ps-1" t-esc="props.allocated"/></li>
             <li class="d-flex justify-content-between">Approved: <span class="ps-1" t-esc="props.approved"/></li>
             <li class="d-flex justify-content-between border-bottom">Planned: <span class="ps-1" t-esc="props.planned"/></li>
             <li class="d-flex justify-content-between">Available: <span class="ps-1" t-esc="props.left"/></li>

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { TimeOffCard } from './time_off_card';
+import { useNewAllocationRequest } from '@hr_holidays/views/hooks';
 import { useBus, useService } from "@web/core/utils/hooks";
 
 const { Component, useState, onWillStart } = owl;
@@ -8,6 +9,7 @@ const { Component, useState, onWillStart } = owl;
 export class TimeOffDashboard extends Component {
     setup() {
         this.orm = useService("orm");
+        this.newRequest = useNewAllocationRequest();
         this.state = useState({
             holidays: [],
         });
@@ -19,7 +21,7 @@ export class TimeOffDashboard extends Component {
             await this.loadDashboardData();
         });
     }
-    
+
     async loadDashboardData() {
         const context = {};
         if (this.props.employeeId !== null) {
@@ -34,6 +36,9 @@ export class TimeOffDashboard extends Component {
                 context: context
             }
         );
+    }
+    async newAllocationRequest() {
+        await this.newRequest(this.props.employeeId);
     }
 }
 

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
@@ -2,7 +2,13 @@
 <templates xml:space="preserve">
     <div t-name="hr_holidays.TimeOffDashboard" class="o_timeoff_dashboard">
         <t t-foreach="state.holidays" t-as="holiday" t-key="holiday[3]">
-            <TimeOffCard name="holiday[0]" data="holiday[1]" requires_allocation="holiday[2] == 'yes'" id="holiday[3]"/>
+            <TimeOffCard name="holiday[0]" data="holiday[1]" requires_allocation="holiday[2] == 'yes'" holidayStatusId="holiday[3]" employeeId="props.employeeId"/>
         </t>
+        <div class="o_timeoff_card py-3 text-odoo d-flex flex-grow-0 justify-content-center">
+            <button class="btn btn-link p-4" t-on-click="newAllocationRequest" type="button">
+                <t t-if="employeeId">Grant Time</t>
+                <t t-else="">New Allocation Request</t>
+            </button>
+        </div>
     </div>
 </templates>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -60,23 +60,6 @@ export class TimeOffCalendarController extends CalendarController {
         });
     }
 
-    newAllocationRequest() {
-        const context = {
-            'form_view_ref': 'hr_holidays.hr_leave_allocation_view_form_dashboard',
-        };
-        if (this.employeeId) {
-            context['default_employee_id'] = this.employeeId;
-            context['default_employee_ids'] = [this.employeeId];
-            context['form_view_ref'] = 'hr_holidays.hr_leave_allocation_view_form_manager_dashboard';
-        }
-
-        this.displayDialog(FormViewDialog, {
-            resModel: 'hr.leave.allocation',
-            title: _t('New Allocation'),
-            context: context,
-        });
-    }
-
     deleteRecord(record) {
         if (!record.data.can_cancel) {
             this.displayDialog(ConfirmationDialog, {

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -9,16 +9,11 @@
                         <button class="btn btn-primary btn-time-off " t-on-click="newTimeOffRequest" type="button">
                             New
                         </button>
-                        <Dropdown togglerClass="'btn btn-primary'" showCaret="true" class="'btn-group'">
-                                <button class="btn btn-link" t-on-click="newAllocationRequest" type="button">
-                                    <t t-if="employeeId">Grant Time</t>
-                                    <t t-else="">New Allocation Request</t>
-                                </button>
-                        </Dropdown>
                     </div>
                 </span>
             </t>
         </xpath>
+        <DatePicker position="replace"/>
     </t>
 
 </templates>

--- a/addons/hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -5,7 +5,6 @@
         <xpath expr="//t[@t-foreach='props.model.filterSections']" position="after">
             <div class="o_calendar_filter">
                 <h5>Legend</h5>
-
                 <div class="d-flex flex-column">
                     <span><img class="o_calendar_filter_plain" src="/hr/static/src/img/icons/plain.svg"/> Validated</span>
                     <span><img class="o_calendar_filter_hatched" src="/hr/static/src/img/icons/hatched.svg"/> To Approve</span>
@@ -14,7 +13,7 @@
 
                 <div class="d-flex flex-column mt-4" t-if="leaveState.mandatoryDays.length">
                     <h5>Mandatory Days</h5>
-                    <ul class="ps-2">
+                    <ul class="ps-0">
                         <li t-foreach="leaveState.mandatoryDays" t-as="mandatoryDay" t-key="mandatoryDay.id" class="mt-2 list-unstyled">
                             <strong
                                 t-esc="getFormattedDateSpan(mandatoryDay.start, mandatoryDay.end)"
@@ -26,7 +25,7 @@
 
                 <div class="d-flex flex-column mt-4" t-if="leaveState.bankHolidays.length">
                     <h5>Public Holidays</h5>
-                    <ul class="ps-2">
+                    <ul class="ps-0">
                         <li t-foreach="leaveState.bankHolidays" t-as="bankHoliday" t-key="bankHoliday.id" class="mt-2 list-unstyled">
                             <strong
                                 t-esc="getFormattedDateSpan(bankHoliday.start, bankHoliday.end)"/>

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -197,10 +197,10 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         """ Create an allocation request """
         # employee should be set to current user
         allocation_form = Form(self.env['hr.leave.allocation'].with_user(self.user_employee))
-        allocation_form.name = 'New Allocation Request'
         allocation_form.holiday_status_id = self.holidays_type_2
         allocation_form.date_from = date(2019, 5, 6)
         allocation_form.date_to = date(2019, 5, 6)
+        allocation_form.name = 'New Allocation Request'
         allocation = allocation_form.save()
 
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')


### PR DESCRIPTION
In this commit, next to UX changes, we make some changes in order to
increase time off dashboard usability.
In particular, - New Allocation Request - was moved to Time Off Card.
Now user can also ask for specific time off type allocation from
the time-off-card-popover.

Moreover, we fix the following issue:
Previously allocation name was not computed on create. We also fix the
computation of the name, in case time of type is not filled in yet.

With the later change, test_allocation_request test was failing as
first the name field was assigned, then holiday_status_id;
Which caused for the name field to be recomputed and assigned to False.
As the field is required, leave_form.save() was raising an error.

task - 3389144