### PR TITLE
[FIX] web: fix darkmode switch display

### DIFF
--- a/addons/web/static/src/webclient/user_menu/user_menu.xml
+++ b/addons/web/static/src/webclient/user_menu/user_menu.xml
@@ -23,7 +23,7 @@
                         <CheckBox
                             t-if="element.type == 'switch'"
                             value="element.isChecked"
-                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0'"
+                            className="'form-switch d-flex flex-row-reverse justify-content-between p-0 w-100'"
                             onChange="element.callback"
                         >
                             <t t-out="element.description"/>


### PR DESCRIPTION
This commit simply corrects how the darkmode switch is displayed in the user menu so that the switch won't overlap with its label.

task-3470052
