### PR TITLE
[FIX] purchase_mrp: kit bom lines cost_share

### DIFF
--- a/addons/purchase_mrp/models/mrp_bom.py
+++ b/addons/purchase_mrp/models/mrp_bom.py
@@ -31,8 +31,8 @@ class MrpBomLine(models.Model):
 
     def _get_cost_share(self):
         self.ensure_one()
-        if self.cost_share:
+        bom_lines = self.bom_id.bom_line_ids
+        lines_with_shares = bom_lines.filtered('cost_share')
+        if lines_with_shares:
             return fields.Float.round(self.cost_share / 100, 2)
-        bom = self.bom_id
-        bom_lines_without_cost_share = bom.bom_line_ids.filtered(lambda bl: not bl.cost_share)
-        return fields.Float.round(1 / len(bom_lines_without_cost_share), 2)
+        return fields.Float.round(1 / len(bom_lines), 2)


### PR DESCRIPTION
Steps to reproduce:
- Create a kit with some component that have cost share and others where it's set to 0
- All products category set to FIFO automated valuation
- Make a PO for the kit product unit price = 10$
- Products that have null cost share still have a valuation

Bug:
unit price is shared a second time amongst line that have no cost share

cost share being optional by default all bom lines have 0 cost share in that case the cost is evenly split among the lines

Fix:
if there's a non null cost share among bom lines the ones that are null should be set to cost of zero
