### PR TITLE
[FIX] web: KanbanRecord in x2m

### DIFF
--- a/addons/web/static/src/model/relational_model/datapoint.js
+++ b/addons/web/static/src/model/relational_model/datapoint.js
@@ -1,5 +1,6 @@
 /* @odoo-module */
 
+import { markRaw } from "@odoo/owl";
 import { evalDomain } from "@web/core/domain";
 import { Reactive } from "@web/core/utils/reactive";
 import { getId } from "./utils";
@@ -39,6 +40,8 @@ export class DataPoint extends Reactive {
         super(...arguments);
         this.id = getId("datapoint");
         this.model = model;
+        markRaw(config.activeFields);
+        markRaw(config.fields);
         this._config = config;
         this.setup(config, data, options);
     }

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -619,6 +619,9 @@ export class RelationalModel extends Model {
      */
     async _updateConfig(config, patch, options = {}) {
         const tmpConfig = { ...config, ...patch };
+        markRaw(tmpConfig.activeFields);
+        markRaw(tmpConfig.fields);
+
         let data;
         if (!options.noReload) {
             data = await this._loadData(tmpConfig);

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -3018,6 +3018,70 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
+        "open a record in a one2many kanban with an x2m in the form",
+        async function (assert) {
+            serverData.models.partner.records[0].p = [2];
+            serverData.models.partner.records[1].p = [4];
+
+            serverData.views = {
+                "partner,false,form": `
+                <form>
+                    <field name="display_name"/>
+                    <field name="p">
+                        <tree>
+                            <field name="display_name"/>
+                        </tree>
+                    </field>
+                </form>`,
+            };
+
+            const def = makeDeferred();
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                <form>
+                    <field name="p">
+                        <kanban>
+                            <field name="display_name"/>
+                            <templates>
+                                <t t-name="kanban-box">
+                                    <div class="oe_kanban_global_click">
+                                        <t t-esc="record.display_name.value"/>
+                                    </div>
+                                </t>
+                            </templates>
+                        </kanban>
+                    </field>
+                </form>`,
+                resId: 1,
+                async mockRPC(route, args) {
+                    if (args.method === "web_read" && args.args[0][0] === 2) {
+                        assert.step("web_read: 2");
+                        await def;
+                    }
+                },
+            });
+
+            await click(target.querySelector(".o_kanban_record"));
+            def.resolve();
+            await nextTick();
+            assert.containsOnce(target, ".modal");
+            assert.strictEqual(
+                target.querySelector(".modal [name=display_name] input").value,
+                "second record"
+            );
+            assert.deepEqual(
+                [...target.querySelectorAll(".modal .o_data_row")].map((el) => el.textContent),
+                ["aaa"]
+            );
+
+            assert.verifySteps(["web_read: 2"]);
+        }
+    );
+
+    QUnit.test(
         "one2many in kanban: add a line custom control create editable",
         async function (assert) {
             serverData.views = {


### PR DESCRIPTION
Before this commit, opening a record from an x2m in kanban mode could cause a crash. For example, if the form view of the x2m contained an x2m.

Why:
The KanbanRecord listens to changes on activeFields through fieldNames because activeFields is reactive and when the record is opened the missing fields are added to the kanban view. This will cause a recalculation of getFormattedRecord before the data has been loaded.

Solution:
ActiveFields and fields should not be reactive.

How to reproduce:
- Go to a form view with an x2m in kanban mode
- Click on a record (the form dialog must contain an x2m field)

Before this commit:
    We have a crash

After this commit:
    The form view dialog opens correctly

TaskId: 3460126

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
