### PR TITLE
[FIX] mrp: change block button to python action

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -690,6 +690,9 @@ class MrpWorkorder(models.Model):
         self.end_previous()
         return True
 
+    def button_block(self):
+        return self.env["ir.actions.actions"]._for_xml_id("mrp.act_mrp_block_workcenter_wo")
+
     def button_unblock(self):
         for order in self:
             order.workcenter_id.unblock()

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -88,13 +88,13 @@
                   attrs="{'invisible': [('production_state','=', 'draft')], 'readonly': [('is_user_working', '=', True)]}" sum="real duration"/>
                 <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-info="state not in ('progress', 'done', 'cancel')"
                   attrs="{'invisible': [('production_state', '=', 'draft')], 'column_invisible': [('parent.state', '=', 'draft')]}"/>
-                <button name="button_start" type="object" string="Start" class="btn-success"
+                <button name="button_start" type="object" string="Start" class="btn-success" context="{'from_wo_overview': True}"
                   attrs="{'invisible': ['|', '|', '|', ('production_state','in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('state', 'in', ('done', 'cancel')), ('is_user_working', '!=', False)]}"/>
                 <button name="button_pending" type="object" string="Pause" class="btn-warning"
                   attrs="{'invisible': ['|', '|', ('production_state', 'in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('is_user_working', '=', False)]}"/>
-                <button name="button_finish" type="object" string="Done" class="btn-success"
+                <button name="button_finish" type="object" string="Done" class="btn-success" context="{'from_wo_overview': True}"
                   attrs="{'invisible': ['|', '|', ('production_state', 'in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked'), ('is_user_working', '=', False)]}"/>
-                <button name="%(mrp.act_mrp_block_workcenter_wo)d" type="action" string="Block" context="{'default_workcenter_id': workcenter_id}" class="btn-danger"
+                <button name="button_block" type="object" string="Block" context="{'default_workcenter_id': workcenter_id, 'from_wo_overview': True}" class="btn-danger"
                   attrs="{'invisible': ['|', ('production_state', 'in', ('draft', 'done', 'cancel')), ('working_state', '=', 'blocked')]}"/>
                 <button name="button_unblock" type="object" string="Unblock" context="{'default_workcenter_id': workcenter_id}" class="btn-danger"
                   attrs="{'invisible': ['|', ('production_state', 'in', ('draft', 'done', 'cancel')), ('working_state', '!=', 'blocked')]}"/>


### PR DESCRIPTION
This changes the action when clicking the block button on a workorder to a python method, as opposed to a record action. This is easier to inherit/override. The method still calls the extant record action.

This is necessary to implement the changes necessary in my enterprise PR without introducing an extra record.

task-3441403

enterprise PR: https://github.com/odoo/enterprise/pull/45814