### PR TITLE
[IMP] account, web_editor, base: remove useless use strict

### DIFF
--- a/addons/account/static/tests/account_move_form_tests.js
+++ b/addons/account/static/tests/account_move_form_tests.js
@@ -1,5 +1,4 @@
 /** @odoo-module **/
-"use strict";
 
 import { start, startServer } from "@mail/../tests/helpers/test_utils";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";

--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -1,5 +1,4 @@
 /** @odoo-module */
-"use strict";
 
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1,5 +1,4 @@
 /** @odoo-module */
-'use strict';
 
 import { getAdjacentPreviousSiblings, isBlock, rgbToHex, commonParentGet } from '../editor/odoo-editor/src/utils/utils';
 

--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -1,5 +1,4 @@
 /** @odoo-module **/
-'use strict';
 
 import { renderToElement } from "@web/core/utils/render";
 import {descendants, preserveCursor} from "@web_editor/js/editor/odoo-editor/src/utils/utils";

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1,5 +1,4 @@
 /** @odoo-module **/
-'use strict';
 
 import './commands/deleteBackward.js';
 import './commands/deleteForward.js';

--- a/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
+++ b/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
@@ -1,7 +1,5 @@
 /** @odoo-module **/
 
-"use strict";
-
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 function checkLoginColumn(translation) {


### PR DESCRIPTION
According to the [ECMAScript 2023 Language Specification](https://tc39.es/ecma262/2023/#sec-strict-mode-code):
> Module code is always strict mode code.

[Odoo Modules mimic this behavior and automatically add “use strict“ at the top of the file](https://github.com/odoo/odoo/blob/9eb5ea9746cf277f09f5258dbc276162280b275b/odoo/tools/js_transpiler.py#L104), so there's no need to do it yourself.

This commit removes all the useless occurrences of use strict.

Enterprise: https://github.com/odoo/enterprise/pull/45908