### PR TITLE
[FIX] web: x2m readonly

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -197,6 +197,7 @@ export class StaticList extends DataPoint {
      * @param {Object} params.fields
      * @param {Object} [params.context]
      * @param {boolean} [params.withoutParent]
+     * @param {string} [params.mode]
      * @param {Record} [record]
      * @returns {Record}
      */
@@ -225,9 +226,8 @@ export class StaticList extends DataPoint {
                 // case 1: the record already exists
                 if (this._extendedRecords.has(record.id)) {
                     // case 1.1: the record has already been extended
-                    // -> simply switch it to edit and store a savepoint
+                    // -> simply store a savepoint
                     this.model._updateConfig(record.config, config, { noReload: true });
-                    record._switchMode("edit");
                     record._addSavePoint();
                     return record;
                 }

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -3017,6 +3017,47 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
+    QUnit.test("open a record in an one2many readonly", async function (assert) {
+        serverData.views = {
+            "turtle,false,form": `
+                <form>
+                    <field name="display_name"/>
+                </form>`,
+        };
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="turtles" readonly='1'>
+                        <tree>
+                            <field name="display_name" />
+                        </tree>
+                        <form>
+                            <field name="display_name" />
+                        </form>
+                    </field>
+                </form>`,
+            resId: 1,
+        });
+
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        assert.containsOnce(target, ".modal");
+        assert.strictEqual(
+            target.querySelector(".modal div[name=display_name] span").textContent,
+            "donatello"
+        );
+
+        await click(target, ".modal .o_form_button_cancel");
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        assert.containsOnce(target, ".modal");
+        assert.strictEqual(
+            target.querySelector(".modal div[name=display_name] span").textContent,
+            "donatello"
+        );
+    });
+
     QUnit.test(
         "one2many in kanban: add a line custom control create editable",
         async function (assert) {


### PR DESCRIPTION
Before this commit, when the same record is opened for the second time in an x2m readonly, the record is in edition.

Why:
If the record has already been extended (when first opened), it is switch in edit mode.

Solution:
The switch to "edit" mode should not be forced. The mode applied is passed to params.

How to reproduce:
- Go to a form view with an x2m readonly in list mode
- Open a record
- Close the dialo
- Open the same record

Before this commit
    The record is in ed mode

After this commit
    The record is in readonly mode

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
