### PR TITLE
[FIX] web: fieldDependencies are readonly by default

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -15,6 +15,17 @@ import { effect } from "@web/core/utils/reactive";
 import { batched } from "@web/core/utils/timing";
 import { orderByToString } from "@web/search/utils/order_by";
 
+/**
+ * @param {boolean || string} value boolean or string encoding a python expression
+ * @returns {string} string encoding a python expression
+ */
+function convertBoolToPyExpr(value) {
+    if (value === true || value === false) {
+        return value ? "True" : "False";
+    }
+    return value;
+}
+
 export function makeActiveField({
     context,
     invisible,
@@ -26,9 +37,9 @@ export function makeActiveField({
 } = {}) {
     return {
         context: context || "{}",
-        invisible: invisible || "False",
-        readonly: readonly || "False",
-        required: required || "False",
+        invisible: convertBoolToPyExpr(invisible || false),
+        readonly: convertBoolToPyExpr(readonly || false),
+        required: convertBoolToPyExpr(required || false),
         onChange: onChange || false,
         forceSave: forceSave || false,
         isHandle: isHandle || false,
@@ -39,6 +50,9 @@ const AGGREGATABLE_FIELD_TYPES = ["float", "integer", "monetary"]; // types that
 
 export function addFieldDependencies(activeFields, fields, fieldDependencies = []) {
     for (const field of fieldDependencies) {
+        if (!("readonly" in field)) {
+            field.readonly = true;
+        }
         if (field.name in activeFields) {
             patchActiveFields(activeFields[field.name], makeActiveField(field));
         } else {

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -272,7 +272,7 @@ export const dateField = {
         maxDate: options.max_date,
         minDate: options.min_date,
         placeholder: attrs.placeholder,
-        required: 'required' in attrs ? attrs.required : dynamicInfo.required,
+        required: "required" in attrs ? attrs.required : dynamicInfo.required,
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],
         warnFuture: archParseBoolean(options.warn_future),
@@ -280,14 +280,24 @@ export const dateField = {
     fieldDependencies: ({ type, attrs, options }) => {
         const deps = [];
         if (options[START_DATE_FIELD_OPTION]) {
-            deps.push({ name: options[START_DATE_FIELD_OPTION], type, attrs });
+            deps.push({
+                name: options[START_DATE_FIELD_OPTION],
+                type,
+                readonly: false,
+                ...attrs,
+            });
             if (options[END_DATE_FIELD_OPTION]) {
                 console.warn(
                     `A field cannot have both ${START_DATE_FIELD_OPTION} and ${END_DATE_FIELD_OPTION} options at the same time`
                 );
             }
         } else if (options[END_DATE_FIELD_OPTION]) {
-            deps.push({ name: options[END_DATE_FIELD_OPTION], type, attrs });
+            deps.push({
+                name: options[END_DATE_FIELD_OPTION],
+                type,
+                readonly: false,
+                ...attrs,
+            });
         }
         return deps;
     },

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -37,40 +37,6 @@ export const BUTTON_CLICK_PARAMS = [
 ];
 
 /**
- * Add dependencies to activeFields (and to fields if needed) from an "info" object,
- * which is expected to contain either a "field" or a "widget" key containing the
- * list of dependencies or a function returning it.
- *
- * @param {Record<string, any>} info
- * @param {Record<string, Object>} activeFields
- * @param {Record<string, Object>} fields
- */
-export function addFieldDependencies(info, activeFields, fields) {
-    const { fieldDependencies } = info.field || info.widget;
-    const deps =
-        typeof fieldDependencies === "function" ? fieldDependencies(info) : fieldDependencies;
-    addDependencies(deps, activeFields, fields);
-}
-
-export function addDependencies(deps, activeFields, fields) {
-    for (const dependency of deps || []) {
-        const { name } = dependency;
-        if (!(name in activeFields)) {
-            activeFields[name] = {
-                name,
-                attrs: {},
-                options: {},
-                ...dependency,
-                invisible: "True",
-            };
-        }
-        if (!(name in fields)) {
-            fields[name] = { ...dependency, name };
-        }
-    }
-}
-
-/**
  * Parse the arch to check if is true or false
  * If the string is empty, 0, False or false it's considered as false
  * The rest is considered as true
@@ -271,7 +237,11 @@ export function processButton(node) {
         display: node.getAttribute("display") || "selection",
         clickParams,
         column_invisible: node.getAttribute("column_invisible"),
-        invisible: combineModifiers(node.getAttribute("column_invisible"), node.getAttribute("invisible"), "OR"),
+        invisible: combineModifiers(
+            node.getAttribute("column_invisible"),
+            node.getAttribute("invisible"),
+            "OR"
+        ),
         readonly: node.getAttribute("readonly"),
         required: node.getAttribute("required"),
     };

--- a/addons/web/static/src/views/widgets/week_days/week_days.js
+++ b/addons/web/static/src/views/widgets/week_days/week_days.js
@@ -31,13 +31,13 @@ export class WeekDays extends Component {
 export const weekDays = {
     component: WeekDays,
     fieldDependencies: [
-        { name: "sun", type: "boolean", string: _t("Sun") },
-        { name: "mon", type: "boolean", string: _t("Mon") },
-        { name: "tue", type: "boolean", string: _t("Tue") },
-        { name: "wed", type: "boolean", string: _t("Wed") },
-        { name: "thu", type: "boolean", string: _t("Thu") },
-        { name: "fri", type: "boolean", string: _t("Fri") },
-        { name: "sat", type: "boolean", string: _t("Sat") },
+        { name: "sun", type: "boolean", string: _t("Sun"), readonly: false },
+        { name: "mon", type: "boolean", string: _t("Mon"), readonly: false },
+        { name: "tue", type: "boolean", string: _t("Tue"), readonly: false },
+        { name: "wed", type: "boolean", string: _t("Wed"), readonly: false },
+        { name: "thu", type: "boolean", string: _t("Thu"), readonly: false },
+        { name: "fri", type: "boolean", string: _t("Fri"), readonly: false },
+        { name: "sat", type: "boolean", string: _t("Sat"), readonly: false },
     ],
 };
 


### PR DESCRIPTION
The purpose of this commit is to make fieldDependencies are readonly by default. This avoids making fields unintentionally editable.

Use case:
Go to a form view with 2 fields "a" which is readonly and "b" which has "a" as fieldDependencies.

Before this commit:
    Record Datapoint thinks that field "a" is editable

After this commit:
    Record Datapoint thinks that field "a" is readonly

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
