### PR TITLE
[FIX] account: Client Traceback on Payment Terms

### DIFF
--- a/addons/account/static/src/components/account_payment_term_form/payment_term_line_ids.js
+++ b/addons/account/static/src/components/account_payment_term_form/payment_term_line_ids.js
@@ -2,25 +2,21 @@
 
 import { registry } from "@web/core/registry";
 
-import { ListRenderer } from "@web/views/list/list_renderer";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
-
-export class PaymentTermLineIdsRenderer extends ListRenderer {
-
-    /* override */
-    onGlobalClick(ev) {
-        // Prevent the discard of new records when clicking outside of the sheet.
-        // This is needed because the user is not forced to edit something on the newly
-        // created record. Therefore, there is no reason to remove this record when he
-        // attempt to save the form.
-        this.props.list.editedRecord = null;
-        super.onGlobalClick(ev);
-    }
-
-}
+import { useAddInlineRecord } from "@web/views/fields/relational_utils";
 
 export class PaymentTermLineIdsOne2Many extends X2ManyField {
-    static components = {...X2ManyField.components, ListRenderer: PaymentTermLineIdsRenderer}
+    setup() {
+        super.setup();
+        // Overloads the addInLine method to mark all new records as 'dirty' by calling update with an empty object.
+        // This prevents the records from being abandoned if the user clicks globally or on an existing record.
+        this.addInLine = useAddInlineRecord({
+            addNew: async (...args) => {
+                const newRecord = await this.list.addNewRecord(...args);
+                newRecord.update({});
+            }
+        });
+    }
 }
 
 export const PaymentTermLineIds = {

--- a/addons/account/static/tests/test_payment_term_line_widget.js
+++ b/addons/account/static/tests/test_payment_term_line_widget.js
@@ -1,0 +1,84 @@
+/** @odoo-module **/
+import { click, getFixture } from "@web/../tests/helpers/utils";
+import { makeView , setupViewRegistries } from "@web/../tests/views/helpers";
+
+let serverData;
+let target;
+
+QUnit.module('Widgets', (hooks) => {
+    QUnit.module("PaymentTermsLineWidget");
+    hooks.beforeEach(() => {
+        target = getFixture();
+        serverData = {
+            models: {
+                account_payment_term: {
+                    fields: {
+                        line_ids: {
+                            string: "Payment Term Lines",
+                            type: "one2many",
+                            relation: "account_payment_term_line",
+                        },
+                    },
+                    records: [
+                        {
+                            id: 1,
+                            line_ids: [1, 2],
+                        },
+                    ],
+                },
+                account_payment_term_line: {
+                    fields: {
+                        value_amount: { string: "Due", type: "float" },
+                    },
+                    records: [
+                        {
+                            id: 1,
+                            value_amount: 0,
+                        },
+                        {
+                            id: 2,
+                            value_amount: 50,
+                        },
+                    ],
+                },
+            }
+        };
+        setupViewRegistries();
+    });
+
+    QUnit.test("records don't get abandoned after clicking globally or on an exisiting record", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "account_payment_term",
+            resId: 1,
+            serverData,
+            arch: `
+            <form>
+                <field name="line_ids" widget="payment_term_line_ids">
+                    <tree string="Payment Terms" editable="top">
+                        <field name="value_amount"/>
+
+                    </tree>
+                </field>
+            </form>
+            `,
+        });
+        assert.containsN(target, ".o_data_row", 2);
+        // click the add button
+        await click(target.querySelector(".o_field_x2many_list_row_add > a"));
+        // make sure the new record is added
+        assert.containsN(target, ".o_data_row", 3);
+        // global click
+        await click(target.querySelector(".o_form_view"));
+        // make sure the new record is still there
+        assert.containsN(target, ".o_data_row", 3);
+        // click the add button again
+        await click(target.querySelector(".o_field_x2many_list_row_add > a"));
+        // make sure the new record is added
+        assert.containsN(target, ".o_data_row", 4);
+        // click on an existing record
+        await click(target.querySelector(".o_data_row .o_data_cell"));
+        // make sure the new record is still there
+        assert.containsN(target, ".o_data_row", 4);
+    });
+});


### PR DESCRIPTION
Removed the `ListRenderer` overload in `payment_term_line_ids.js` to fix an issue where trying to set `this.props.list.editedRecord` to null was causing a stack trace error when navigating away from a Payment Term lines.

The original intention was to prevent the discard of new records when clicking outside of the list, especially when the user is not required to edit something on the newly created record.

It has been replaced by an overload `X2ManyField` component making the `AddInLine` method mark all the new records as `dirty` by calling the `update` mehod on them with an empty object to prevent them from being discarded.

Task-3460696


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
