### PR TITLE
[FIX] web_editor: focus on the label instead of url

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2616,14 +2616,14 @@ var SnippetsMenu = Widget.extend({
                 // should avoid focusing something here while it is being
                 // rendered elsewhere.
                 if (this.options.wysiwyg.state.linkToolProps) {
-                    let inputElement = document.querySelector('#o_link_dialog_url_input');
+                    let inputElement = document.querySelector('#o_link_dialog_label_input');
                     if (!inputElement) {
                         // Wait for `linkTools` potential in-progress rendering
                         // before focusing the URL input on `snippetsMenu` (this
                         // prevents race condition for automated testing).
                         inputElement = await new Promise((resolve) => {
                             const observer = new MutationObserver(() => {
-                                const inputElement = document.querySelector('#o_link_dialog_url_input');
+                                const inputElement = document.querySelector('#o_link_dialog_label_input');
                                 if (inputElement) {
                                     observer.disconnect();
                                     resolve(inputElement);


### PR DESCRIPTION
Reproduction:
1. Install website
2. Change to edit mode and edit a link on the main page, for example, “contact us” at the bottom
3. The focus is on the url at the link tool

Fix: not really a fix but a small “improvement”, the focus is put on the link label now

Task-3444671



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
