### PR TITLE
[IMP] sale: improve sale calendar view

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -24,12 +24,13 @@
         <field name="name">sale.order.calendar</field>
         <field name="model">sale.order</field>
         <field name="arch" type="xml">
-            <calendar string="Sales Orders" date_start="date_order" color="state" hide_time="true" event_limit="5" quick_add="False">
+            <calendar string="Sales Orders" create="0" mode="month" date_start="activity_date_deadline" color="state" event_limit="5" quick_add="False">
                 <field name="currency_id" invisible="1"/>
-                <field name="partner_id" avatar_field="avatar_128"/>
+                <field name="state" filters="1" invisible="1"/>
+                <field name="activity_ids" options="{'icon': 'fa fa-clock-o'}"/>
+                <field name="partner_id" avatar_field="avatar_128" options="{'icon': 'fa fa-users'}"/>
                 <field name="amount_total" widget="monetary"/>
                 <field name="payment_term_id"/>
-                <field name="state" filters="1" invisible="1"/>
             </calendar>
         </field>
     </record>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -49,7 +49,7 @@
                     <t t-set="fieldInfo" t-value="props.model.popoverFieldNodes[fieldId]"/>
                     <t t-if="!isInvisible(fieldInfo, slot.record)">
                         <li class="list-group-item flex-shrink-0 d-flex align-items-start" t-att-class="fieldInfo.attrs.class">
-                            <strong class="me-2">
+                            <strong class="me-2" t-if="!fieldInfo.options.noLabel">
                                 <t t-if="fieldInfo.options.icon">
                                     <b>
                                         <i t-att-class="fieldInfo.options.icon" />


### PR DESCRIPTION
The goal of this task is to help user manage their sale_order by having a summary view of all their next activities.

Sale calendar view is now based on the next activity for each sale_order.

task-id: 3463325

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
