### PR TITLE
[IMP] web: scroll to 6am in calendar

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -8,8 +8,9 @@ import { useDebounced } from "@web/core/utils/timing";
 import { getColor } from "../colors";
 import { useCalendarPopover, useClickHandler, useFullCalendar } from "../hooks";
 import { CalendarCommonPopover } from "./calendar_common_popover";
+import { browser } from "@web/core/browser/browser";
 
-import { Component, useEffect } from "@odoo/owl";
+import { Component, onMounted, useEffect } from "@odoo/owl";
 
 const SCALE_TO_FC_VIEW = {
     day: "timeGridDay",
@@ -46,6 +47,15 @@ export class CalendarCommonRenderer extends Component {
         this.click = useClickHandler(this.onClick, this.onDblClick);
         this.popover = useCalendarPopover(this.constructor.components.Popover);
         this.onWindowResizeDebounced = useDebounced(this.onWindowResize, 200);
+
+        onMounted(() => {
+            if (this.props.model.scale === "day" || this.props.model.scale === "week") {
+                //Need to wait React
+                browser.setTimeout(() => {
+                    this.fc.api.scrollToTime("06:00:00");
+                }, 0);
+            }
+        });
 
         useEffect(() => {
             this.updateSize();

--- a/addons/web/static/tests/views/calendar/calendar_common_renderer_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_common_renderer_tests.js
@@ -159,4 +159,26 @@ QUnit.module("CalendarView - CommonRenderer", ({ beforeEach }) => {
             assert.strictEqual(els[i].textContent, dates[i]);
         }
     });
+
+    QUnit.test("Day: automatically scroll to 6am", async (assert) => {
+        // Make calendar scrollable
+        target.style.height = "500px";
+        await start({ model: { scale: "day" } });
+        const containerDimensions = target.querySelector(".fc-scroller").getBoundingClientRect();
+        const dayStartDimensions = target
+            .querySelector('tr[data-time="06:00:00"')
+            .getBoundingClientRect();
+        assert.ok(Math.abs(dayStartDimensions.y - containerDimensions.y) <= 2);
+    });
+
+    QUnit.test("Week: automatically scroll to 6am", async (assert) => {
+        // Make calendar scrollable
+        target.style.height = "500px";
+        await start({ model: { scale: "week" } });
+        const containerDimensions = target.querySelector(".fc-scroller").getBoundingClientRect();
+        const dayStartDimensions = target
+            .querySelector('tr[data-time="06:00:00"')
+            .getBoundingClientRect();
+        assert.ok(Math.abs(dayStartDimensions.y - containerDimensions.y) <= 2);
+    });
 });


### PR DESCRIPTION
This commit ensures that when the user opens a calendar view in day or week mode the view will be scrolled so that 6am is at the top of the view.

task-3460517
