### PR TITLE
[FIX] point_of_sale: quantity buttons moved

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -106,12 +106,6 @@
                 </main>
     
                 <footer class="footer footer-flex mobile modal-footer">
-                    <div class="button highlight confirm btn btn-lg btn-primary" t-on-click="confirm">
-                        Add
-                    </div>
-                    <div class="button cancel btn btn-lg btn-secondary" t-on-click="cancel">
-                        Cancel
-                    </div>
                     <div class="quantity-selector d-flex align-items-center justify-content-center w-100 py-2 fw-bolder">
                         <button class="btn btn-lg btn-secondary" t-on-click="removeOneQuantity">
                             <i class="fa fa-minus" aria-hidden="true"></i>
@@ -120,6 +114,12 @@
                         <button class="btn btn-lg btn-secondary" t-on-click="addOneQuantity">
                             <i class="fa fa-plus" aria-hidden="true"></i>
                         </button>
+                    </div>
+                    <div class="button highlight confirm btn btn-lg btn-primary" t-on-click="confirm">
+                        Add
+                    </div>
+                    <div class="button cancel btn btn-lg btn-secondary" t-on-click="cancel">
+                        Cancel
                     </div>
                 </footer>
             </div>


### PR DESCRIPTION
The quantity buttons of the mobile view product configurator where moved during the boostrap refactoring of the pos. This task moves them to the previous location.
before:
![2023-08-18_13-56](https://github.com/odoo/odoo/assets/33456800/66ee5e15-1e23-4bc1-ab0d-0e5508fc8586)

after:
![2023-08-18_13-55](https://github.com/odoo/odoo/assets/33456800/68b035f0-dd44-454c-a651-117dadd250a0)

task-3446503

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
