### PR TITLE
[FIX] point_of_sale: blockui should be above the closing popup

### DIFF
--- a/addons/point_of_sale/static/src/css/popups/popups.scss
+++ b/addons/point_of_sale/static/src/css/popups/popups.scss
@@ -17,7 +17,7 @@
     text-align:center;
     background-color: #fff;
     box-shadow: 0px 10px 20px rgba(0,0,0,0.4);
-    z-index:1200;
+    z-index:1060;
     border-radius: 4px;
 }
 


### PR DESCRIPTION
The z index of the closing popup div was changed to a higher index than the blockui z index. This commit sets the z index of the closing popup to a lower value then the blockui z index.

before:
![2023-08-18_13-52](https://github.com/odoo/odoo/assets/33456800/cae3f5c1-b2d6-404c-aea0-201e0dcb5269)

after:
![2023-08-18_13-50](https://github.com/odoo/odoo/assets/33456800/9d53f21e-d679-4a0a-9a8f-4ad8815d62a3)



task-3471040

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
