### PR TITLE
[IMP] sale_project: link fsm task customer to delivery address

### DIFF
--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -583,7 +583,13 @@ class ProjectTask(models.Model):
         for task in self:
             task.analytic_account_active = task.analytic_account_active or task.so_analytic_account_id.active
 
-    @api.depends('partner_id.commercial_partner_id', 'sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
+    def _inverse_partner_id(self):
+        super()._inverse_partner_id()
+        for task in self:
+            if task.allow_billable and not task.sale_line_id:
+                task.sale_line_id = task._get_last_sol_of_customer()
+
+    @api.depends('sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'allow_billable')
     def _compute_sale_line(self):
         super()._compute_sale_line()
         for task in self:

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -114,6 +114,9 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
         }
     },
 }, {
+    trigger: 'button.o_form_button_save i',
+    content: 'Manually save the records (sale order should be filled based on the partner picked for this task',
+}, {
     trigger: 'button[name="action_view_so"]',
     content: 'Click on this stat button to see the SO linked to the SOL of the task.',
 }, {


### PR DESCRIPTION
Purpose: Avoid workers ending up going to the wrong location because the delivery address changes made on the SO are not propagated to the related field service task.

When the delivery address set on the SO linked to the task is updated, it us updated on the fsm task as well.

On top of the changes made in industry_fsm, the partner_id behavior of tasks is also modified. Until now, the compute method of so and sol on tasks was triggered by changes on its partner_id field. This was done to be able to unlink task from so/sol if there was inconsistency between the partner_id set on them. However, with the changes proposed in industry_fsm_sale, this led to cycle dependencies. This implementation is therefore replaced by an inverse method on partner_id field of task.

task-3468679