### PR TITLE
[IMP] fleet: track state

### DIFF
--- a/addons/fleet/models/fleet_vehicle_log_services.py
+++ b/addons/fleet/models/fleet_vehicle_log_services.py
@@ -37,7 +37,7 @@ class FleetVehicleLogServices(models.Model):
         ('running', 'Running'),
         ('done', 'Done'),
         ('cancelled', 'Cancelled'),
-    ], default='new', string='Stage', group_expand='_expand_states')
+    ], default='new', string='Stage', group_expand='_expand_states', tracking=True)
 
     def _get_odometer(self):
         self.odometer = 0


### PR DESCRIPTION
Purpose: 
Prior state was not tracked for 'Services for vehicles' and 
it was not possible to know when service started and when it was done.

task-3469567
