### PR TITLE
[FIX] account: save on tab change

### DIFF
--- a/addons/account/static/src/components/account_move_form/account_move_form.js
+++ b/addons/account/static/src/components/account_move_form/account_move_form.js
@@ -37,7 +37,7 @@ AccountMoveFormNotebook.props = {
 }
 export class AccountMoveFormRenderer extends FormRenderer {
     async saveBeforeTabChange() {
-        if (this.props.record.mode === "edit" && await this.props.record.isDirty()) {
+        if (this.props.record.isInEdition && await this.props.record.isDirty()) {
             const contentEl = document.querySelector('.o_content');
             const scrollPos = contentEl.scrollTop;
             await this.props.record.save({


### PR DESCRIPTION
Due to the new relational model (218ad8456a06503dd508e7216edcffdc90b35cac), a new property isInEdition is available while `mode` has been removed. Due to mode always being undefined, the save method was never actually called, preventing the journal items from being available when switching tabs.

Task-3471248

