### PR TITLE
[IMP] web: add relatedFields in x2m views

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -225,6 +225,22 @@ export function extractFieldsFromArchInfo({ fieldNodes, widgetNodes }, fields) {
                         );
                         Object.assign(activeField.related.fields, formArchInfo.fields);
                     }
+
+                    if (fieldNode.viewMode !== "default" && fieldNode.views.default) {
+                        const defaultArchInfo = extractFieldsFromArchInfo(
+                            fieldNode.views.default,
+                            fieldNode.views.default.fields
+                        );
+                        activeField.related.activeFields = {
+                            ...defaultArchInfo.activeFields,
+                            ...activeField.related.activeFields,
+                        };
+                        activeField.related.fields = Object.assign(
+                            {},
+                            defaultArchInfo.fields,
+                            activeField.related.fields
+                        );
+                    }
                 }
             }
             if (fieldNode.field?.useSubView) {

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -274,7 +274,7 @@ export const many2ManyTagsField = {
     relatedFields: ({ options }) => {
         const relatedFields = [{ name: "display_name", type: "char" }];
         if (options.color_field) {
-            relatedFields.push({ name: options.color_field, type: "integer" });
+            relatedFields.push({ name: options.color_field, type: "integer", readonly: false });
         }
         return relatedFields;
     },


### PR DESCRIPTION
The goal of this commit is to allow relatedFields to be added to a one2many
field using a sub-view.

Before this commit, if an x2many custom contains a sub-view and relatedFields,
we ignore the sub-view and use only the relatedFields.

Now we're going to add the relatedFields to the fields/activeFields
defined in the sub-view.

Use case:
Created a custom x2many field dependent on the 'display_name' of
a many2one field that should not be present in the sub-view. For example,
to simulate a groupBy on this many2one field.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
