### PR TITLE
[FIX] l10n_be: create account tags while loading of demo data

### DIFF
--- a/addons/l10n_be/demo/account_demo.py
+++ b/addons/l10n_be/demo/account_demo.py
@@ -10,12 +10,22 @@ class AccountChartTemplate(models.AbstractModel):
         if company.account_fiscal_country_id.code == 'BE':
             cid = company.id
             account_data = demo_data.setdefault('account.account', {})
-            account_data.update({
-                f"account.{cid}_a100": {'tag_ids': [Command.link(self.env.ref('account.demo_capital_account').id)]},
-                f"account.{cid}_a300": {'tag_ids': [Command.link(self.env.ref('account.demo_stock_account').id)]},
-                f"account.{cid}_a7600": {'tag_ids': [Command.link(self.env.ref('account.demo_sale_of_land_account').id)]},
-                f"account.{cid}_a6201": {'tag_ids': [Command.link(self.env.ref('account.demo_ceo_wages_account').id)]},
-                f"account.{cid}_a242": {'tag_ids': [Command.link(self.env.ref('account.demo_office_furniture_account').id)]},
-            })
+            tags = {
+                'account.demo_capital_account': 'Demo Capital Account',
+                'account.demo_stock_account': 'Demo Stock Account',
+                'account.demo_sale_of_land_account': 'Demo Sale of Land Account',
+                'account.demo_ceo_wages_account': 'Demo CEO Wages Account',
+                'account.demo_office_furniture_account': 'Office Furniture',
+            }
+            tag_ids = []
+            for ref, tag_name in tags.items():
+                tag = self.env.ref(ref, raise_if_not_found=False) or self.env['account.account.tag'].create({'name': tag_name})
+                tag_ids.append(tag.id)
+
+            codes = ['a100', 'a300', 'a7600', 'a6201', 'a242']
+            for i, code in enumerate(codes):
+                account_data.update({
+                    f"account.{cid}_{code}": {'tag_ids': [Command.link(tag_ids[i])]}
+                })
 
         return demo_data


### PR DESCRIPTION
When user install 'l10n_be' and load demo data,
a traceback will appear.

Steps to reproduce the issue:
- Install 'l10n_be'.
- Settings > Developer Tools > Load demo data

Traceback:
```
KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7f5eb3622d40>, 'account.demo_capital_account')
  File "odoo/tools/cache.py", line 99, in lookup
    r = d[key]
  File "<decorator-gen-3>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: External ID not found in the system: account.demo_capital_account
  File "addons/account/models/chart_template.py", line 204, in _load
    self._load_data(self._get_demo_data(company))
  File "addons/l10n_be/demo/account_demo.py", line 14, in _get_demo_data
    f"account.{cid}_a100": {'tag_ids': [Command.link(self.env.ref('account.demo_capital_account').id)]},
  File "odoo/api.py", line 566, in ref
    res_model, res_id = self['ir.model.data']._xmlid_to_res_model_res_id(
  File "odoo/addons/base/models/ir_model.py", line 2028, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)
  File "<decorator-gen-40>", line 2, in _xmlid_lookup
  File "odoo/tools/cache.py", line 104, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 2021, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
```

https://github.com/odoo/odoo/blob/5a535d3ac90092f682ea0cb5802c7629102f53aa/addons/l10n_be/demo/account_demo.py#L14 Here, account tags is still referenced.
When demo data will load, it will not find the external_id of account tags,
So it will lead to above traceback.

sentry-4057974589

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
