### PR TITLE
[FIX] ressource: _leave_intervals_batch find public leaves

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_attendance.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance.py
@@ -10,4 +10,5 @@ class HrAttendance(models.Model):
 
     def _get_overtime_leave_domain(self):
         domain = super()._get_overtime_leave_domain()
-        return AND([domain, [('holiday_id.holiday_status_id.time_type', '=', 'leave')]])
+        # resource_id = False => Public holidays
+        return AND([domain, ['|', ('holiday_id.holiday_status_id.time_type', '=', 'leave'), ('resource_id', '=', False)]])

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -383,14 +383,14 @@ class ResourceCalendar(models.Model):
             resources_list = [resources]
         else:
             resources_list = list(resources) + [self.env['resource.resource']]
-        resource_ids = [r.id for r in resources_list]
         if domain is None:
             domain = [('time_type', '=', 'leave')]
         if not any_calendar:
             domain = domain + [('calendar_id', 'in', [False, self.id])]
         # for the computation, express all datetimes in UTC
+        # Public leave don't have a resource_id
         domain = domain + [
-            ('resource_id', 'in', resource_ids),
+            ('resource_id', 'in', [False] + [r.id for r in resources_list]),
             ('date_from', '<=', datetime_to_string(end_dt)),
             ('date_to', '>=', datetime_to_string(start_dt)),
         ]


### PR DESCRIPTION
Issue :
- When you check-in/out on a day of time off, all the time is logged as extra hours.
- When you do the same on a public holiday, it's not.

_leave_intervals_batch is used to get all leave for an employee but the domain for the search only find leaves related to given ressources. Public Holiday Leaves are not related to any specific ressources and thus where never found.

task-id: 3465686




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
