### PR TITLE
[FIX] hr_expense: set default accounting date

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1004,7 +1004,8 @@ class HrExpenseSheet(models.Model):
     @api.depends('account_move_id.date')
     def _compute_accounting_date(self):
         for sheet in self:
-            sheet.accounting_date = sheet.account_move_id.date
+            if sheet.account_move_id:
+                sheet.accounting_date = sheet.account_move_id.date
 
     @api.depends('employee_id', 'employee_id.department_id')
     def _compute_from_employee_id(self):


### PR DESCRIPTION
If we set the default value to the accounting date in expenses, it does not get applied because it's a computed field.

**Steps to reproduce:**
1. Open odoo in debug mode.
2. Create an expense and set the default expense date using the odoo debug menu button.
3. Create report and submit to the manager and approve it.
4. Set the default value for the accounting date through the same process.
5. Create a new expense and check the default dates.

**Current Behavior:**
The expense date is set correctly but the accounting date is not set as the default value because it's a computed field.

**Expected Behavior:**
The default values should be applied to both the date fields.

OPW-3441231

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
