### PR TITLE
[IMP] point_of_sale: option to print sales details from session

### DIFF
--- a/addons/point_of_sale/views/point_of_sale_report.xml
+++ b/addons/point_of_sale/views/point_of_sale_report.xml
@@ -15,6 +15,8 @@
         <field name="model">pos.session</field>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">point_of_sale.report_saledetails</field>
+        <field name="binding_model_id" ref="point_of_sale.model_pos_session"/>
+        <field name="binding_view_types">form</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
before this commit, if user need to take the sales details of a pos session, user cannot directly take from the session form in the pos backend.

if needed from the backend, user has to print from the point of sale -> reporting -> session report

after this commit, the report will be shown also in the pos session form, so that user can print the details by clicking the report from print button in the top without going to reporting menu.


![Screenshot from 2023-08-18 23-13-58](https://github.com/odoo/odoo/assets/27989791/d1e318bc-4cae-4787-b60b-31052b707dab)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
