### PR TITLE
[FIX] web_editor: selection wrong in safari

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -230,6 +230,7 @@ export class OdooEditor extends EventTarget {
 
         this.isMobile = matchMedia('(max-width: 767px)').matches;
         this.isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+        this.isSafari = navigator.userAgent.toLowerCase().indexOf('safari') > -1 && navigator.userAgent.toLowerCase().indexOf("chrome") < 0;
 
         // Keyboard type detection, happens only at the first keydown event.
         this.keyboardType = KEYBOARD_TYPES.UNKNOWN;
@@ -1440,7 +1441,9 @@ export class OdooEditor extends EventTarget {
         let next = nextLeaf(end, this.editable);
         const splitEndTd = closestElement(end, 'td') && end.nextSibling;
         const contents = range.extractContents();
-        setSelection(start, nodeSize(start));
+        if (!this.isSafari) {
+            setSelection(start, nodeSize(start));
+        }
         range = getDeepRange(this.editable, { sel });
         // Restore unremovables removed by extractContents.
         [...contents.querySelectorAll('*')].filter(isUnremovable).forEach(n => {


### PR DESCRIPTION
**Current behavior before PR:**

In Safari, pasting over selected text sometimes results in inaccuracies.

**Desired behavior after PR is merged:**

In Safari, pasting text over selected text now produces the correct result.

task-3093996




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
