### PR TITLE
[IMP] mail: rename activity type `To Do` to `To-Do`

### DIFF
--- a/addons/mail/data/mail_activity_data.xml
+++ b/addons/mail/data/mail_activity_data.xml
@@ -19,7 +19,7 @@
             <field name="sequence">9</field>
         </record>
         <record id="mail_activity_data_todo" model="mail.activity.type">
-            <field name="name">To Do</field>
+            <field name="name">To-Do</field>
             <field name="icon">fa-tasks</field>
             <field name="delay_count">5</field>
             <field name="sequence">12</field>

--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -9455,7 +9455,7 @@ msgstr ""
 
 #. module: mail
 #: model:mail.activity.type,name:mail.mail_activity_data_todo
-msgid "To Do"
+msgid "To-Do"
 msgstr ""
 
 #. module: mail


### PR DESCRIPTION
upgrade: https://github.com/odoo/upgrade/pull/5057

Renaming the activity type 'To Do' into 'To-Do' so that the naming
convention is consitent with the To-Do app.



**task-3469745**
