### PR TITLE
[FIX] point_of_sale: closing session without cash

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -82,7 +82,7 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
         }
         handleInputChange(paymentId) {
             let expectedAmount;
-            if (paymentId === this.defaultCashDetails.id) {
+            if (paymentId === this.defaultCashDetails?.id) {
                 this.manualInputCashCount = true;
                 this.state.notes = '';
                 expectedAmount = this.defaultCashDetails.amount;


### PR DESCRIPTION
The closing session popup input for bank payment methods throws an error when no cash payment method is configured.

Steps to reproduce:
 - Configure a shop without any cash payment method and with at least one bank payment method
 - Open a session for that shop
 - Click on the button to display the closing session popup
 - In the popup, change the amount of the bank payment method

An error is thrown.

The fix simply consists in correctly checking if there is a cash payment method.

task-id: 3468828

Previously merged PR from saas-16.1 to master: https://github.com/odoo/odoo/pull/132156
