### PR TITLE
[IMP] purchase: merge purchase_enterprise

### DIFF
--- a/addons/purchase/data/purchase_demo.xml
+++ b/addons/purchase/data/purchase_demo.xml
@@ -190,6 +190,74 @@
             ]"/>
         </record>
 
+        <record id="purchase_order_8" model="purchase.order">
+            <field name="partner_id" ref="base.res_partner_1"/>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="state">purchase</field>
+            <field name="create_date" eval="DateTime.today() - relativedelta(days=20)"/>
+            <field name="date_order" eval="DateTime.today() - relativedelta(days=5)"/>
+            <field name="date_approve" eval="DateTime.today() - relativedelta(days=9)"/>
+            <field name="order_line" model="purchase.order.line" eval="[(5, 0, 0),
+                (0, 0, {
+                    'product_id': ref('product.product_product_16'),
+                    'name': 'Drawer Black',
+                    'price_unit': 280.80,
+                    'product_qty': 15.0,
+                    'product_uom': ref('uom.product_uom_dozen'),
+                    'date_planned': time.strftime('%Y-%m-%d')}),
+                (0, 0, {
+                    'product_id': ref('product.product_product_20'),
+                    'name': 'Flipover',
+                    'price_unit': 450.70,
+                    'product_qty': 5.0,
+                    'product_uom': ref('uom.product_uom_dozen'),
+                    'date_planned': time.strftime('%Y-%m-%d')})
+            ]"/>
+        </record>
+
+        <record id="purchase_order_9" model="purchase.order">
+            <field name="partner_id" ref="base.res_partner_3"/>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="state">purchase</field>
+            <field name="create_date" eval="DateTime.today() - relativedelta(days=20)"/>
+            <field name="date_order" eval="DateTime.today() - relativedelta(days=15)"/>
+            <field name="date_approve" eval="DateTime.today() - relativedelta(days=5)"/>
+            <field name="order_line" model="purchase.order.line" eval="[(5, 0, 0),
+                (0, 0, {
+                    'product_id': ref('product.product_product_8'),
+                    'name': 'Large Desk',
+                    'price_unit': 500.00,
+                    'product_qty': 20.0,
+                    'product_uom': ref('uom.product_uom_dozen'),
+                    'date_planned': time.strftime('%Y-%m-%d')}),
+                (0, 0, {
+                    'product_id': ref('product.product_product_5'),
+                    'name': 'Corner Desk Right Sit',
+                    'price_unit': 500.0,
+                    'product_qty': 5.0,
+                    'product_uom': ref('uom.product_uom_dozen'),
+                    'date_planned': time.strftime('%Y-%m-%d')}),
+            ]"/>
+        </record>
+
+        <record id="purchase_order_10" model="purchase.order">
+            <field name="partner_id" ref="base.res_partner_12"/>
+            <field name="user_id" ref="base.user_admin"/>
+            <field name="state">purchase</field>
+            <field name="create_date" eval="DateTime.today() - relativedelta(days=20)"/>
+            <field name="date_order" eval="DateTime.today() - relativedelta(days=15)"/>
+            <field name="date_approve" eval="DateTime.today() - relativedelta(days=18)"/>
+            <field name="order_line" model="purchase.order.line" eval="[(5, 0, 0),
+                (0, 0, {
+                    'product_id': ref('product.product_product_12'),
+                    'name': 'Office Chair Black',
+                    'price_unit': 250.50,
+                    'product_qty': 10.0,
+                    'product_uom': ref('uom.product_uom_dozen'),
+                    'date_planned': time.strftime('%Y-%m-%d')}),
+            ]"/>
+        </record>
+
         <record id="purchase_activity_1" model="mail.activity">
             <field name="res_id" ref="purchase.purchase_order_2"/>
             <field name="res_model_id" ref="purchase.model_purchase_order"/>

--- a/addons/purchase/report/purchase_report_views.xml
+++ b/addons/purchase/report/purchase_report_views.xml
@@ -86,6 +86,9 @@
         <field name="res_model">purchase.report</field>
         <field name="view_mode">graph,pivot</field>
         <field name="view_id"></field>  <!-- force empty -->
+        <field name="context" eval="{
+                'search_default_orders': 1,
+                'search_default_filter_date_approve': 1}"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Purchase Analysis


### PR DESCRIPTION
> Originally contributed by OCA member @niyasraphy in odoo/odoo#126335

purchase_enterprise module is no longer useful since the enterprise only
dashboard view it originally had was obsoleted by the addition of the
new dashboards app. It now only provides demo data and context for an
existing action.

This PR moves the demo data and context into the community purchase app.

odoo/enterprise#45986 removes all of the obsoleted functionality.

odoo/upgrade#5064 is the associated upgrade script.

task-3452519