### PR TITLE
[FIX] account_3way_match: correct number of draft bills in dashboard

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -313,7 +313,7 @@
                                 <div class="col overflow-hidden text-start">
                                     <a type="object" name="open_action" context="{'search_default_draft': '1'}">
                                         <span t-if="journal_type == 'sale'" title="Invoices to Validate"><t t-out="dashboard.number_draft"/> Invoices to Validate</span>
-                                        <span t-if="journal_type == 'purchase'" title="Bills to Validate"><t t-out="dashboard.number_draft"/> Bills to Validate</span>
+                                        <span t-if="journal_type == 'purchase'" title="Bills to Validate" id="account_dashboard_purchase_draft"><t t-out="dashboard.number_draft"/> Bills to Validate</span>
                                     </a>
                                 </div>
                                 <div class="col-auto text-end">


### PR DESCRIPTION
The number of bills to validate in the accounting dashboard is not the same as the number of bills displayed when clicking on the button

Steps to reproduce:
1. Install Accounting and module `Vendor Bill: Release to Pay`
2. Go to Accounting > Vendors > Bills, create a new one with a due date set to yesterday and save it
3. Go to the accounting dashboard
4. In the 'Vendor Bills' journal, see that there is one bill to validate
5. Open the draft bills (by clicking on the `Bills to Validate` link), the number of bills in the view is greater than what was previously advertised

Solution:
Modify the context used in the action 'Bills to Validate'

Problem:
The module `account_3way_match` modified the query to get the number of draft bills so the action should be adapted

opw-3440854