### PR TITLE
[FIX] point_of_sale: correct taxDetails where used improperly

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -934,7 +934,7 @@ export class Orderline extends PosModel {
         const taxDetails = this.get_tax_details();
         return productTaxes
             .filter((tax) => tax.price_include)
-            .reduce((sum, tax) => sum + taxDetails[tax.id], 0);
+            .reduce((sum, tax) => sum + taxDetails[tax.id].amount, 0);
     }
     _map_tax_fiscal_position(tax, order = false) {
         return this.pos._map_tax_fiscal_position(tax, order);
@@ -2233,7 +2233,7 @@ export class Order extends PosModel {
                     if (!(taxId in groupTaxes)) {
                         groupTaxes[taxId] = 0;
                     }
-                    groupTaxes[taxId] += taxDetails[taxId];
+                    groupTaxes[taxId] += taxDetails[taxId].amount;
                 }
             });
 


### PR DESCRIPTION
The tax details was recently changed and two places were it was used were forgotten during the changes. This led to bugs in the discount button with taxes that have the options "tax included in price" and to company using round globally as rounding method.

Steps to reproduce the first bug:
    -   Set at least one tax with the attribute "tax included in price"
        to true
    -   Associate this tax to the config used
    -   Activate the global discount setting
    -   Open PoS and click on some products with the tax newly created
    -   Click the discount button in the Action pad widget

Steps to reproduct the second bug:
    -   Set the setting Rounding method of your company to
        "Round globally"
    -   Open PoS and click on products
    -   The total shown is 0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
