### PR TITLE
[IMP] mail, {crm,im}_livechat: add /bot command for livechat channels

### DIFF
--- a/addons/crm_livechat/static/tests/composer.test.js
+++ b/addons/crm_livechat/static/tests/composer.test.js
@@ -1,4 +1,6 @@
 import {
+    click,
+    contains,
     defineMailModels,
     insertText,
     openDiscuss,
@@ -21,7 +23,10 @@ test("Can execute lead command", async () => {
         return true;
     });
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "/lead great lead");
+    await insertText(".o-mail-Composer-input", "/lead");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-input", { value: "/lead " });
+    await insertText(".o-mail-Composer-input", "great lead");
     await press("Enter");
     await waitForSteps([[channelId]]);
 });

--- a/addons/crm_livechat/static/tests/message.test.js
+++ b/addons/crm_livechat/static/tests/message.test.js
@@ -28,7 +28,10 @@ test("Can open lead from internal link", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "/lead My Lead");
+    await insertText(".o-mail-Composer-input", "/lead");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-input", { value: "/lead " });
+    await insertText(".o-mail-Composer-input", "My Lead");
     await press("Enter");
     await contains(".o-mail-ChatWindow", { count: 0 });
     await click('.o_mail_notification a[data-oe-model="crm.lead"]');

--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -22,3 +22,5 @@ class WebClient(WebclientController):
             store.add(
                 request.env["im_livechat.channel"].search([]), fields=["are_you_inside", "name"]
             )
+        if kwargs.get("chatbots"):
+            store.add(request.env["chatbot.script"].search([]), fields=["title"])

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -100,6 +100,54 @@ class DiscussChannel(models.Model):
     def execute_command_history(self, **kwargs):
         self._bus_send("im_livechat.history_command", {"id": self.id})
 
+    def execute_command_bot(self, bot_id, **kwargs):
+        self.ensure_one()
+        if not self.livechat_active:
+            # To-do: remove this after livechat visitor leave has been adapted to use action_unfollow
+            return
+        chatbot_script = self.env["chatbot.script"].browse(bot_id)
+        if not chatbot_script.exists():
+            self.env.user._bus_send_transient_message(
+                self, _("Please select a chatbot")
+            )
+            return
+        if self.livechat_operator_id != chatbot_script.operator_partner_id:
+            # Checks whether the current operator is a bot or not
+            operator_partner = (
+                self.env["chatbot.script"]
+                .search(
+                    [("operator_partner_id", "=", self.livechat_operator_id.id)],
+                    limit=1,
+                )
+                .operator_partner_id
+            )
+            if operator_partner:
+                # Removes the existing operator
+                # sudo - discuss.channel: non admin operator can remove other operators
+                self.sudo()._action_unfollow(operator_partner, post_left_message=False)
+            self.add_members(
+                partner_ids=[chatbot_script.operator_partner_id.id],
+                post_joined_message=False,
+            )
+        self._chatbot_restart(chatbot_script, post_restart_message=False)
+        self.livechat_operator_id = chatbot_script.operator_partner_id
+        store = Store(
+            self,
+            {
+                "chatbot": {
+                    "script": chatbot_script.id,
+                    "currentStep": False,
+                    "steps": [],
+                },
+                "operator": Store.one(
+                    self.livechat_operator_id,
+                    fields=["user_livechat_username", "write_date"],
+                ),
+            },
+        )
+        store.add(chatbot_script)
+        self._bus_send("im_livechat.bot_command", store.get_result())
+
     def _get_visitor_leave_message(self, operator=False, cancel=False):
         return _('Visitor left the conversation.')
 
@@ -153,8 +201,9 @@ class DiscussChannel(models.Model):
         """
         Converting message body back to plaintext for correct data formatting in HTML field.
         """
+        # sudo - res.partner: public user can access internal user's name
         return Markup('').join(
-            Markup('%s: %s<br/>') % (message.author_id.name or self.anonymous_name, html2plaintext(message.body))
+            Markup('%s: %s<br/>') % (message.sudo().author_id.name or self.anonymous_name, html2plaintext(message.body))
             for message in self.message_ids.sorted('id')
         )
 
@@ -229,12 +278,15 @@ class DiscussChannel(models.Model):
             })
         return super()._message_post_after_hook(message, msg_vals)
 
-    def _chatbot_restart(self, chatbot_script):
+    def _chatbot_restart(self, chatbot_script, post_restart_message=True):
         # sudo: discuss.channel - visitor can clear current step to restart the script
         self.sudo().chatbot_current_step_id = False
         # sudo: chatbot.message - visitor can clear chatbot messages to restart the script
         self.sudo().chatbot_message_ids.unlink()
-        return self._chatbot_post_message(
+        if not post_restart_message:
+            return
+        # sudo: mail.message - chat bot can send the restart message
+        return self.sudo()._chatbot_post_message(
             chatbot_script,
             Markup('<div class="o_mail_notification">%s</div>') % _('Restarting conversation...'),
         )

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -1,5 +1,12 @@
 declare module "models" {
+    import { ChatbotScript as ChatbotScriptClass } from "@im_livechat/embed/common/chatbot/chatbot_script_model";
+
+    export interface ChatbotScript extends ChatbotScriptClass { }
     export interface Thread {
         operator: Persona,
+    }
+
+    export interface Models {
+        "chatbot.script": ChatbotScript,
     }
 }

--- a/addons/im_livechat/static/src/core/common/chatbot_script_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_script_model.js
@@ -8,7 +8,5 @@ export class ChatbotScript extends Record {
     id;
     /** @type {string} */
     title;
-    isLivechatTourRunning = false;
-    operator_partner_id = Record.one("Persona");
 }
 ChatbotScript.register();

--- a/addons/im_livechat/static/src/core/web/channel_commands_patch.js
+++ b/addons/im_livechat/static/src/core/web/channel_commands_patch.js
@@ -1,8 +1,17 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
-registry.category("discuss.channel_commands").add("history", {
-    channel_types: ["livechat"],
-    help: _t("See 15 last visited pages"),
-    methodName: "execute_command_history",
-});
+registry
+    .category("discuss.channel_commands")
+    .add("history", {
+        channel_types: ["livechat"],
+        help: _t("See 15 last visited pages"),
+        methodName: "execute_command_history",
+    })
+    .add("bot", {
+        channel_types: ["livechat"],
+        help: _t("Start a chatbot for visitor"),
+        methodName: "execute_command_bot",
+        hasSubCommand: true,
+        subCommandFields: ["bot_id"],
+    });

--- a/addons/im_livechat/static/src/core/web/composer_patch.js
+++ b/addons/im_livechat/static/src/core/web/composer_patch.js
@@ -4,6 +4,23 @@ import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(Composer.prototype, {
+    get navigableListProps() {
+        const props = super.navigableListProps;
+        switch (this.suggestion?.state.items?.type) {
+            case "Chatbot":
+                {
+                    props.options = this.suggestion.state.items.suggestions.map((item) => ({
+                        label: item.title,
+                        bot_id: item.id,
+                        classList: "o-mail-Composer-suggestion",
+                    }));
+                    props.optionTemplate = "mail.Composer.suggestionChannelCommand";
+                }
+                break;
+        }
+        return props;
+    },
+
     onKeydown(ev) {
         super.onKeydown(ev);
         if (

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -8,6 +8,7 @@ patch(Store.prototype, {
         super.setup(...arguments);
         this.livechatChannels = this.makeCachedFetchData({ livechat_channels: true });
         this.has_access_livechat = false;
+        this.chatbotData = this.makeCachedFetchData({ chatbots: true });
     },
     /**
      * @override

--- a/addons/im_livechat/static/src/core/web/suggestion_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/suggestion_service_patch.js
@@ -1,4 +1,5 @@
 import { SuggestionService } from "@mail/core/common/suggestion_service";
+import { cleanTerm } from "@mail/utils/common/format";
 
 import { patch } from "@web/core/utils/patch";
 
@@ -6,8 +7,34 @@ patch(SuggestionService.prototype, {
     /** @override */
     getSupportedDelimiters(thread) {
         const res = super.getSupportedDelimiters(...arguments);
-        return thread.channel_type === "livechat"
-            ? res.filter((delimiter) => delimiter.at(0) !== "#")
-            : res;
+        if (thread.channel_type === "livechat") {
+            if (thread.composer?.command?.hasSubCommand) {
+                res.push([" ", thread.composer.command.endPosition]);
+            }
+            return res.filter((delimiter) => delimiter.at(0) !== "#");
+        }
+        return res;
+    },
+    /** @override */
+    async fetchSuggestions({ delimiter, term }, { thread } = {}) {
+        if (delimiter === " " && thread.composer?.command?.name === "bot") {
+            return await this.store.chatbotData.fetch();
+        }
+        await super.fetchSuggestions(...arguments);
+    },
+    /** @override */
+    searchSuggestions({ delimiter, term }, { thread, sort = false } = {}) {
+        if (delimiter === " " && thread.composer?.command?.name === "bot") {
+            return this.searchChatbotSuggestions(cleanTerm(term));
+        }
+        return super.searchSuggestions(...arguments);
+    },
+    searchChatbotSuggestions(cleanedSearchTerm) {
+        return {
+            type: "Chatbot",
+            suggestions: Object.values(this.store["chatbot.script"].records).filter((chatbot) => {
+                return cleanTerm(chatbot.title).includes(cleanedSearchTerm);
+            }),
+        };
     },
 });

--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -10,11 +10,15 @@ declare module "models" {
     export interface ChatbotStep extends ChatbotStepClass { }
     export interface Chatbot extends ChatbotClass { }
     export interface ChatbotScriptStepAnswer extends ChatbotScriptStepAnswerClass { }
-    export interface ChatbotScript extends ChatbotScriptClass { }
     export interface LivechatRule extends LivechatRuleClass { }
 
-    export interface ChatWindpw {
+    export interface ChatWindow {
         hasFeedbackPanel: boolean,
+    }
+
+    export interface ChatbotScript {
+        isLivechatTourRunning: boolean,
+        operator_partner_id: Persona,
     }
 
     export interface Message {
@@ -32,7 +36,6 @@ declare module "models" {
         "ChatbotStep": ChatbotStep,
         "Chatbot": Chatbot,
         "ChatbotScriptStepAnswer": ChatbotScriptStepAnswer,
-        "chatbot.script": ChatbotScript,
         "LivechatRule": LivechatRule,
     }
 }

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -95,7 +95,7 @@ export class Chatbot extends Record {
         if (!this.thread || this.currentStep?.isLast) {
             return;
         }
-        if (this.steps.at(-1)?.eq(this.currentStep)) {
+        if (this.steps.at(-1)?.eq(this.currentStep) || !this.steps.length) {
             const storeData = await rpc("/chatbot/step/trigger", {
                 channel_id: this.thread.id,
                 chatbot_script_id: this.script.id,

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_script_model_patch.js
@@ -1,0 +1,12 @@
+import { ChatbotScript } from "@im_livechat/core/common/chatbot_script_model";
+import { Record } from "@mail/core/common/record";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(ChatbotScript.prototype, {
+    setup() {
+        super.setup();
+        this.isLivechatTourRunning = false;
+        this.operator_partner_id = Record.one("Persona");
+    },
+});

--- a/addons/im_livechat/static/tests/livechat_test_helpers.js
+++ b/addons/im_livechat/static/tests/livechat_test_helpers.js
@@ -6,6 +6,7 @@ import {
     patchWithCleanup,
     MockServer,
 } from "@web/../tests/web_test_helpers";
+import { ChatbotScript } from "./mock_server/mock_models/chatbot_script";
 import { DiscussChannel } from "./mock_server/mock_models/discuss_channel";
 import { DiscussChannelMember } from "./mock_server/mock_models/discuss_channel_member";
 import { LivechatChannel } from "./mock_server/mock_models/im_livechat_channel";
@@ -21,6 +22,7 @@ export function defineLivechatModels() {
 
 export const livechatModels = {
     ...mailModels,
+    ChatbotScript,
     DiscussChannel,
     DiscussChannelMember,
     LivechatChannel,

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -166,12 +166,15 @@ async function get_emoji_bundle(request) {
 patch(mailDataHelpers, {
     async processRequest(request) {
         const store = await super.processRequest(...arguments);
-        const { livechat_channels } = await parseRequestParams(request);
+        const { livechat_channels, chatbots } = await parseRequestParams(request);
         if (livechat_channels) {
             store.add(
                 this.env["im_livechat.channel"].search([]),
                 makeKwArgs({ fields: ["are_you_inside", "name"] })
             );
+        }
+        if (chatbots) {
+            store.add(this.env["chatbot.script"].search([]), makeKwArgs({ fields: ["title"] }));
         }
         return store;
     },

--- a/addons/im_livechat/static/tests/mock_server/mock_models/@types/mock_models.d.ts
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/@types/mock_models.d.ts
@@ -1,13 +1,16 @@
 declare module "mock_models" {
+    import { ChatbotScript as ChatbotScript2 } from "../chatbot_script";
     import { LivechatChannel as LivechatChannel2 } from "../im_livechat_channel";
     import { RatingRating as RatingRating2 } from "../rating_rating";
     import { ResLang as ResLang2 } from "../res_lang";
 
+    export interface ChatbotScript extends ChatbotScript2 {}
     export interface LivechatChannel extends LivechatChannel2 {}
     export interface RatingRating extends RatingRating2 {}
     export interface ResLang extends ResLang2 {}
 
     export interface Models {
+        "chatbot.script": ChatbotScript,
         "im_livechat.channel": LivechatChannel,
         "res.lang": ResLang,
     }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/chatbot_script.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/chatbot_script.js
@@ -1,0 +1,26 @@
+import { getKwArgs, makeKwArgs, models } from "@web/../tests/web_test_helpers";
+import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+
+export class ChatbotScript extends models.ServerModel {
+    _name = "chatbot.script";
+
+    /** @param {number[]} ids */
+    _to_store(ids, store, fields) {
+        const kwargs = getKwArgs(arguments, "ids", "store", "fields");
+        fields = kwargs.fields ?? ["title", "operator_partner_id"];
+        for (const script of this.browse(ids)) {
+            const [data] = this._read_format(
+                script.id,
+                fields.filter((field) => "operator_partner_id" !== field),
+                false
+            );
+            if (fields.includes("operator_partner_id")) {
+                data["operator_partner_id"] = mailDataHelpers.Store.one(
+                    this.env["res.partner"].browse(script.operator_partner_id),
+                    makeKwArgs({ fields: ["name"] })
+                );
+            }
+            store.add(this.browse(script.id), data);
+        }
+    }
+}

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -379,7 +379,7 @@ class DiscussChannel(models.Model):
     def action_unfollow(self):
         self._action_unfollow(self.env.user.partner_id)
 
-    def _action_unfollow(self, partner=None, guest=None):
+    def _action_unfollow(self, partner=None, guest=None, post_left_message=True):
         self.ensure_one()
         self.message_unsubscribe(partner.ids)
         custom_store = Store(self, {"is_pinned": False, "isLocallyPinned": False})
@@ -393,13 +393,14 @@ class DiscussChannel(models.Model):
             target = partner or guest
             target._bus_send_store(custom_store, notification_type="discuss.channel/leave")
             return
-        notification = Markup('<div class="o_mail_notification">%s</div>') % _(
-            "left the channel"
-        )
-        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
-        member.channel_id.sudo().message_post(
-            body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
-        )
+        if post_left_message:
+            notification = Markup('<div class="o_mail_notification">%s</div>') % _(
+                "left the channel"
+            )
+            # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
+            member.channel_id.sudo().message_post(
+                body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id
+            )
         # send custom store after message_post to avoid is_pinned reset to True
         member._bus_send_store(custom_store, notification_type="discuss.channel/leave")
         member.unlink()

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -1,5 +1,6 @@
 declare module "models" {
     import { Attachment as AttachmentClass } from "@mail/core/common/attachment_model";
+    import { ChannelCommand as ChannelCommandClass } from "@mail/core/common/channel_command_model";
     import { CannedResponse as CannedResponseClass } from "@mail/core/common/canned_response_model";
     import { ChatHub as ChatHubClass } from "@mail/core/common/chat_hub_model";
     import { ChatWindow as ChatWindowClass } from "@mail/core/common/chat_window_model";
@@ -19,7 +20,8 @@ declare module "models" {
 
     // define interfaces for jsdoc, including with patches
     export interface Attachment extends AttachmentClass {}
-    export interface CannedResponse extends CannedResponseClass {}
+    export interface CannedResponse extends CannedResponseClass { }
+    export interface ChannelCommand extends ChannelCommandClass {}
     export interface ChatHub extends ChatHubClass {}
     export interface ChatWindow extends ChatWindowClass {}
     export interface Composer extends ComposerClass {}
@@ -38,6 +40,7 @@ declare module "models" {
 
     // required to propagate types in relational fields
     export interface Models {
+        "ChannelCommand": ChannelCommand,
         "ChatHub": ChatHub,
         "ChatWindow": ChatWindow,
         "Composer": Composer,

--- a/addons/mail/static/src/core/common/channel_command_model.js
+++ b/addons/mail/static/src/core/common/channel_command_model.js
@@ -1,0 +1,38 @@
+import { Record } from "@mail/core/common/record";
+
+export class ChannelCommand extends Record {
+    static id = "name";
+    /** @type {Object.<number, import("models").ChannelCommand>} */
+    static records = {};
+    /** @returns {import("models").ChannelCommand} */
+    static get(data) {
+        return super.get(data);
+    }
+    /** @returns {import("models").ChannelCommand|import("models").ChannelCommand[]} */
+    static insert(data) {
+        return super.insert(...arguments);
+    }
+
+    /** @type {number} */
+    endPosition;
+    /** @type {string} */
+    methodName;
+    /** @type {string} */
+    name;
+    /** @type {Object} */
+    subCommandData = {};
+    /** @type {string[]} */
+    subCommandFields = [];
+    /** @type {boolean} */
+    hasSubCommand;
+
+    get params() {
+        const res = {};
+        for (const field of this.subCommandFields) {
+            res[field] = this.subCommandData[field] ?? false;
+        }
+        return res;
+    }
+}
+
+ChannelCommand.register();

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -645,6 +645,7 @@ export class Composer extends Component {
             mentionedPartners: composer.mentionedPartners || [],
             cannedResponseIds: composer.cannedResponses.map((c) => c.id),
             parentId: this.props.messageToReplyTo?.message?.id,
+            subCommand: composer.subCommand,
         };
     }
 
@@ -677,6 +678,7 @@ export class Composer extends Component {
         }
         this.suggestion?.clearRawMentions();
         this.suggestion?.clearCannedResponses();
+        this.suggestion?.clearCommand();
         this.props.messageToReplyTo?.cancel();
     }
 

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -26,6 +26,7 @@ export class Composer extends Record {
     mentionedPartners = Record.many("Persona");
     mentionedChannels = Record.many("Thread");
     cannedResponses = Record.many("mail.canned.response");
+    command = Record.one("ChannelCommand");
     text = "";
     thread = Record.one("Thread");
     /** @type {{ start: number, end: number, direction: "forward" | "backward" | "none"}}*/

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -430,7 +430,7 @@ export class Thread extends Record {
             "discuss.channel",
             command.methodName,
             [[this.id]],
-            { body }
+            { body, ...command.params }
         );
     }
 

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -4,12 +4,9 @@ import { compareDatetime, nearestGreaterThanOrEqual } from "@mail/utils/common/m
 
 import { formatList } from "@web/core/l10n/utils";
 import { rpc } from "@web/core/network/rpc";
-import { registry } from "@web/core/registry";
 import { Mutex } from "@web/core/utils/concurrency";
 import { patch } from "@web/core/utils/patch";
 import { imageUrl } from "@web/core/utils/urls";
-
-const commandRegistry = registry.category("discuss.channel_commands");
 
 /** @type {import("models").Thread} */
 const threadPatch = {
@@ -336,16 +333,9 @@ const threadPatch = {
     },
     /** @param {string} body */
     async post(body) {
-        if (this.model === "discuss.channel" && body.startsWith("/")) {
-            const [firstWord] = body.substring(1).split(/\s/);
-            const command = commandRegistry.get(firstWord, false);
-            if (
-                command &&
-                (!command.channel_types || command.channel_types.includes(this.channel_type))
-            ) {
-                await this.executeCommand(command, body);
-                return;
-            }
+        if (this.model === "discuss.channel" && this.composer.command) {
+            await this.executeCommand(this.composer.command, body);
+            return;
         }
         return super.post(...arguments);
     },

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu.test.js
@@ -114,6 +114,7 @@ test("channel preview ignores transient message", async () => {
     await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/who");
+    await click(".o-mail-Composer-suggestion");
     await press("Enter");
     await contains(".o_mail_notification", { text: "You are alone in this channel." });
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -245,6 +245,7 @@ test("Can use channel command /who", async () => {
     await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/who");
+    await click(".o-mail-Composer-suggestion");
     await press("Enter");
     await contains(".o_mail_notification", { text: "You are alone in this channel." });
 });

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -704,6 +704,7 @@ test("first unseen message should be directly preceded by the new message separa
     await contains(".o-mail-Message", { text: "not empty" });
     // send a command that leads to receiving a transient message
     await insertText(".o-mail-Composer-input", "/who");
+    await click(".o-mail-Composer-suggestion");
     await press("Enter");
     await contains(".o-mail-Message", { count: 2 });
     // composer is focused by default, we remove that focus
@@ -941,6 +942,7 @@ test("Transient messages are added at the end of the thread", async () => {
     await press("Enter");
     await contains(".o-mail-Message");
     await insertText(".o-mail-Composer-input", "/help");
+    await click(".o-mail-Composer-suggestion");
     await press("Enter");
     await contains(".o-mail-Message", { count: 2 });
     await contains(":nth-child(1 of .o-mail-Message)", { text: "Mitchell Admin" });


### PR DESCRIPTION
**PURPOSE:**

Allow operators to start chatbot conversations from the list of available chatbots with visitor.

**SPECIFICATIONS:**

- add a /bot command for operators in livechat channels.
- ENTER: open the list of existing chatbots for selection
- ENTER: select a chatbot and start chatbot conversation for visitor

task-[3373161](https://www.odoo.com/web?debug=1#id=3373161&cids=2&menu_id=4722&action=333&active_id=1519&model=project.task&view_type=form)

Related Enterprise PR: https://github.com/odoo/enterprise/pull/46637

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
