### PR TITLE
[REF] account_edi_ubl_cii,*: refactor UBL structure and add debit note

### DIFF
--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -5,6 +5,8 @@
         <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ID t-out="vals.get('id')"/>
+            <cbc:AddressTypeCode t-out="vals.get('address_type_code')"/>
             <cbc:AddressFormatCode t-att="vals.get('address_format_code_attrs', {})" t-out="vals.get('address_format_code')"/>
             <cbc:StreetName t-out="vals.get('street_name')"/>
             <cbc:BuildingNumber t-out="vals.get('building_number')"/>
@@ -31,58 +33,48 @@
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
             <t t-set="partner" t-value="vals.get('partner') or builder.env['res.partner']"/>
             <cbc:EndpointID
-                    t-att="vals.get('endpoint_id_attrs', {})"
-                    t-out="vals.get('endpoint_id')"/>
-            <t t-foreach="vals.get('party_identification_vals', [])" t-as="party_vals">
-                <cac:PartyIdentification>
-                    <cbc:ID
-                        t-att="party_vals.get('id_attrs', {})"
-                        t-out="party_vals.get('id')"/>
-                </cac:PartyIdentification>
-            </t>
-            <t t-foreach="vals.get('party_name_vals', [])" t-as="party_vals">
-                <cac:PartyName>
-                    <cbc:Name t-out="party_vals.get('name')"/>
-                </cac:PartyName>
-            </t>
+                t-att="vals.get('endpoint_id_attrs', {})"
+                t-out="vals.get('endpoint_id')"/>
+            <cac:PartyIdentification t-foreach="vals.get('party_identification_vals', [])" t-as="party_vals">
+                <cbc:ID
+                    t-att="party_vals.get('id_attrs', {})"
+                    t-out="party_vals.get('id')"/>
+            </cac:PartyIdentification>
+            <cac:PartyName t-foreach="vals.get('party_name_vals', [])" t-as="party_vals">
+                <cbc:Name t-out="party_vals.get('name')"/>
+            </cac:PartyName>
             <cac:PostalAddress>
                 <t t-call="{{AddressType_template}}">
                     <t t-set="vals" t-value="vals.get('postal_address_vals', {})"/>
                 </t>
             </cac:PostalAddress>
-            <t t-foreach="vals.get('party_tax_scheme_vals', [])" t-as="foreach_vals">
-                <cac:PartyTaxScheme>
-                    <cbc:RegistrationName t-out="foreach_vals.get('registration_name')"/>
-                    <cbc:CompanyID
-                            t-att="foreach_vals.get('company_id_attrs', {})"
-                            t-out="foreach_vals.get('company_id')"/>
-                    <cac:RegistrationAddress>
-                        <t t-call="{{AddressType_template}}">
-                            <t t-set="vals" t-value="foreach_vals.get('registration_address_vals', {})"/>
-                        </t>
-                    </cac:RegistrationAddress>
-                    <cac:TaxScheme>
-                        <cbc:ID
-                            t-att="foreach_vals.get('tax_scheme_id_attrs', {})"
-                            t-out="foreach_vals.get('tax_scheme_id')"/>
-                        <cbc:Name t-out="foreach_vals.get('tax_name')"/>
-                    </cac:TaxScheme>
-                </cac:PartyTaxScheme>
-            </t>
-
-            <t t-foreach="vals.get('party_legal_entity_vals', [])" t-as="foreach_vals">
-                <cac:PartyLegalEntity>
-                    <cbc:RegistrationName t-out="foreach_vals.get('registration_name')"/>
-                    <cbc:CompanyID
-                        t-att="foreach_vals.get('company_id_attrs', {})"
-                        t-out="foreach_vals.get('company_id')"/>
-                    <cac:RegistrationAddress>
-                        <t t-call="{{AddressType_template}}">
-                            <t t-set="vals" t-value="foreach_vals.get('registration_address_vals', {})"/>
-                        </t>
-                    </cac:RegistrationAddress>
-                </cac:PartyLegalEntity>
-            </t>
+            <cac:PartyTaxScheme t-foreach="vals.get('party_tax_scheme_vals', [])" t-as="foreach_vals">
+                <cbc:RegistrationName t-out="foreach_vals.get('registration_name')"/>
+                <cbc:CompanyID
+                    t-att="foreach_vals.get('company_id_attrs', {})"
+                    t-out="foreach_vals.get('company_id')"/>
+                <cac:RegistrationAddress>
+                    <t t-call="{{AddressType_template}}">
+                        <t t-set="vals" t-value="foreach_vals.get('registration_address_vals', {})"/>
+                    </t>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <t t-set="tax_scheme_vals" t-value="foreach_vals.get('tax_scheme_vals', {})"/>
+                    <cbc:ID t-att="tax_scheme_vals.get('id_attrs', {})" t-out="tax_scheme_vals.get('id')"/>
+                    <cbc:Name t-out="tax_scheme_vals.get('name')"/>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity t-foreach="vals.get('party_legal_entity_vals', [])" t-as="foreach_vals">
+                <cbc:RegistrationName t-out="foreach_vals.get('registration_name')"/>
+                <cbc:CompanyID
+                    t-att="foreach_vals.get('company_id_attrs', {})"
+                    t-out="foreach_vals.get('company_id')"/>
+                <cac:RegistrationAddress>
+                    <t t-call="{{AddressType_template}}">
+                        <t t-set="vals" t-value="foreach_vals.get('registration_address_vals', {})"/>
+                    </t>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
             <cac:Contact>
                 <t t-set="contact_vals" t-value="vals.get('contact_vals', {})"/>
                 <cbc:ID t-out="contact_vals.get('id')"/>
@@ -97,14 +89,13 @@
         <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ID t-out="vals.get('id')"/>
             <cbc:PaymentMeansCode
-                    t-att="vals.get('payment_means_code_attrs', {})"
-                    t-out="vals.get('payment_means_code')"/>
+                t-att="vals.get('payment_means_code_attrs', {})"
+                t-out="vals.get('payment_means_code')"/>
             <cbc:PaymentDueDate t-out="vals.get('payment_due_date')"/>
             <cbc:InstructionID t-out="vals.get('instruction_id')"/>
-            <t t-foreach="vals.get('payment_id_vals', [])" t-as="payment_id">
-                <cbc:PaymentID t-out="payment_id"/>
-            </t>
+            <cbc:PaymentID t-foreach="vals.get('payment_id_vals', [])" t-as="payment_id" t-out="payment_id"/>
             <cac:PayeeFinancialAccount>
                 <t t-set="payee_financial_account_vals" t-value="vals.get('payee_financial_account_vals', {})"/>
                 <cbc:ID
@@ -132,6 +123,18 @@
         </t>
     </template>
 
+    <template id="ubl_20_PaymentTermsType">
+        <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ID t-out="vals.get('id')"/>
+            <cbc:PaymentMeansID t-out="vals.get('payment_means_id')"/>
+            <cbc:Note t-foreach="vals.get('note_vals', [])" t-as="note" t-out="note.get('note')"/>
+            <cbc:Amount
+                t-att-currencyID="vals.get('currency_name')"
+                t-out="format_float(vals.get('amount'), vals.get('currency_dp'))"/>
+        </t>
+    </template>
+
     <template id="ubl_20_TaxCategoryType">
         <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
@@ -141,16 +144,17 @@
                 t-out="vals.get('id')"/>
             <cbc:Name t-out="vals.get('name')"/>
             <cbc:Percent t-out="vals.get('percent')"/>
-            <cbc:TaxExemptionReasonCode
-                    t-out="vals.get('tax_exemption_reason_code')"/>
-            <cbc:TaxExemptionReason
-                    t-out="vals.get('tax_exemption_reason')"/>
+            <cbc:TaxExemptionReasonCode t-out="vals.get('tax_exemption_reason_code')"/>
+            <cbc:TaxExemptionReason t-out="vals.get('tax_exemption_reason')"/>
+            <cbc:TierRange t-out="vals.get('tier_range')"/>
             <cac:TaxScheme>
+                <t t-set="tax_scheme_vals" t-value="vals.get('tax_scheme_vals', {})"/>
                 <cbc:ID
                     t-translation="off"
-                    t-att="vals.get('tax_scheme_id_attrs')"
-                    t-out="vals.get('tax_scheme_id')"/>
-                <cbc:Name t-translation="off" t-out="vals.get('tax_scheme_name')"/>
+                    t-att="tax_scheme_vals.get('id_attrs', {})"
+                    t-out="tax_scheme_vals.get('id')"/>
+                <cbc:Name t-translation="off" t-out="tax_scheme_vals.get('name')"/>
+                <cbc:TaxTypeCode t-out="tax_scheme_vals.get('tax_type_code')"/>
             </cac:TaxScheme>
         </t>
     </template>
@@ -160,24 +164,25 @@
            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
             <cbc:TaxAmount
-                    t-att-currencyID="vals['currency'].name"
-                    t-out="format_float(vals.get('tax_amount'), vals.get('currency_dp'))"/>
-            <t t-foreach="vals.get('tax_subtotal_vals', [])" t-as="foreach_vals">
-                <cac:TaxSubtotal>
-                    <cbc:TaxableAmount
-                        t-att-currencyID="foreach_vals['currency'].name"
-                        t-out="format_float(foreach_vals.get('taxable_amount'), foreach_vals.get('currency_dp'))"/>
-                    <cbc:TaxAmount
-                        t-att-currencyID="foreach_vals['currency'].name"
-                        t-out="format_float(foreach_vals.get('tax_amount'), foreach_vals.get('currency_dp'))"/>
-                    <cbc:Percent t-out="foreach_vals.get('percent')"/>
-                    <cac:TaxCategory>
-                        <t t-call="{{TaxCategoryType_template}}">
-                            <t t-set="vals" t-value="foreach_vals.get('tax_category_vals', {})"/>
-                        </t>
-                    </cac:TaxCategory>
-                </cac:TaxSubtotal>
-            </t>
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('tax_amount'), vals.get('currency_dp'))"/>
+            <cac:TaxSubtotal t-foreach="vals.get('tax_subtotal_vals', [])" t-as="foreach_vals">
+                <cbc:TaxableAmount
+                    t-att-currencyID="foreach_vals['currency'].name"
+                    t-out="format_float(foreach_vals.get('taxable_amount'), foreach_vals.get('currency_dp'))"/>
+                <cbc:TaxAmount
+                    t-att-currencyID="foreach_vals['currency'].name"
+                    t-out="format_float(foreach_vals.get('tax_amount'), foreach_vals.get('currency_dp'))"/>
+                <cbc:Percent t-out="foreach_vals.get('percent')"/>
+                <cbc:BaseUnitMeasure
+                    t-att="foreach_vals.get('base_unit_measure_attrs', {})"
+                    t-out="foreach_vals.get('base_unit_measure')"/>
+                <cac:TaxCategory>
+                    <t t-call="{{TaxCategoryType_template}}">
+                        <t t-set="vals" t-value="foreach_vals.get('tax_category_vals', {})"/>
+                    </t>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
         </t>
     </template>
 
@@ -190,56 +195,112 @@
             <cbc:AllowanceChargeReason t-out="vals.get('allowance_charge_reason')"/>
             <cbc:MultiplierFactorNumeric t-out="vals.get('multiplier_factor')"/>
             <cbc:Amount
-                    t-att-currencyID="vals.get('currency_name')"
-                    t-out="format_float(vals.get('amount'), vals.get('currency_dp'))"/>
-            <t t-foreach="vals.get('tax_category_vals', [])" t-as="foreach_vals">
-                <cac:TaxCategory>
-                    <t t-call="{{TaxCategoryType_template}}">
-                        <t t-set="vals" t-value="foreach_vals"/>
-                    </t>
-                </cac:TaxCategory>
-            </t>
+                t-att-currencyID="vals.get('currency_name')"
+                t-out="format_float(vals.get('amount'), vals.get('currency_dp'))"/>
+            <cbc:BaseAmount
+                t-att-currencyID="vals.get('currency_name')"
+                t-out="format_float(vals.get('base_amount'), vals.get('currency_dp'))"/>
+            <cac:TaxCategory t-foreach="vals.get('tax_category_vals', [])" t-as="foreach_vals">
+                <t t-call="{{TaxCategoryType_template}}">
+                    <t t-set="vals" t-value="foreach_vals"/>
+                </t>
+            </cac:TaxCategory>
         </t>
     </template>
 
-    <template id="ubl_20_InvoiceLineType">
+    <template id="ubl_20_SignatureType">
+        <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+           xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ID t-out="vals.get('id')"/>
+            <cac:SignatoryParty>
+                <t t-set="sp_vals" t-value="vals.get('signatory_party_vals', {})"/>
+                <cac:PartyIdentification>
+                    <cbc:ID t-out="sp_vals.get('party_id')"/>
+                </cac:PartyIdentification>
+                <cac:PartyName>
+                    <cbc:Name t-out="sp_vals.get('party_name')"/>
+                </cac:PartyName>
+            </cac:SignatoryParty>
+            <cac:DigitalSignatureAttachment>
+                <t t-set="dsa_vals" t-value="vals.get('digital_signature_attachment_vals', {})"/>
+                <cac:ExternalReference>
+                    <cbc:URI t-out="dsa_vals.get('external_reference_uri')"/>
+                </cac:ExternalReference>
+            </cac:DigitalSignatureAttachment>
+        </t>
+    </template>
+
+    <template id="ubl_20_ResponseType">
+        <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ResponseCode t-out="foreach_vals.get('response_code')"/>
+            <cbc:Description t-out="foreach_vals.get('description')"/>
+        </t>
+    </template>
+
+    <template id="ubl_20_DeliveryType">
+        <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+           xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ActualDeliveryDate t-out="vals.get('actual_delivery_date')"/>
+            <cac:DeliveryLocation>
+                <cac:Address>
+                    <t t-call="{{AddressType_template}}">
+                        <t t-set="vals" t-value="vals.get('delivery_location_vals', {}).get('delivery_address_vals', {})"/>
+                    </t>
+                </cac:Address>
+            </cac:DeliveryLocation>
+        </t>
+    </template>
+
+    <template id="ubl_20_MonetaryTotalType">
+        <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:LineExtensionAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('line_extension_amount'), vals.get('currency_dp'))"/>
+            <cbc:TaxExclusiveAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('tax_exclusive_amount'), vals.get('currency_dp'))"/>
+            <cbc:TaxInclusiveAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('tax_inclusive_amount'), vals.get('currency_dp'))"/>
+            <cbc:AllowanceTotalAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('allowance_total_amount'), vals.get('currency_dp'))"/>
+            <cbc:ChargeTotalAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('charge_total_amount'), vals.get('currency_dp'))"/>
+            <cbc:PrepaidAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('prepaid_amount'), vals.get('currency_dp'))"/>
+            <cbc:PayableAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('payable_amount'), vals.get('currency_dp'))"/>
+        </t>
+    </template>
+
+    <template id="ubl_20_CommonLineType">
         <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
             <cbc:ID t-out="vals.get('id')"/>
             <cbc:Note t-out="vals.get('note')"/>
-            <cbc:InvoicedQuantity
-                    t-if="invoice.move_type == 'out_invoice'"
-                    t-att="vals.get('invoiced_quantity_attrs', {})"
-                    t-out="vals.get('invoiced_quantity')"/>
-            <cbc:CreditedQuantity
-                    t-if="invoice.move_type == 'out_refund'"
-                    t-att="vals.get('invoiced_quantity_attrs', {})"
-                    t-out="vals.get('invoiced_quantity')"/>
             <cbc:LineExtensionAmount
-                    t-att-currencyID="vals['currency'].name"
-                    t-out="format_float(vals.get('line_extension_amount'), vals.get('currency_dp'))"/>
-            <!-- AllowanceCharge is only present for InvoiceLine, not for CreditNoteLine in UBL 2.0
-            (they are both present in UBL 2.1 and next)
-             http://www.datypic.com/sc/ubl20/e-cac_CreditNoteLine.html
-             http://www.datypic.com/sc/ubl20/e-cac_InvoiceLine.html
-             -->
-            <t t-if="invoice.move_type == 'out_invoice'">
-                <t t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
-                    <cac:AllowanceCharge>
-                        <t t-call="{{AllowanceChargeType_template}}">
-                            <t t-set="vals" t-value="foreach_vals"/>
-                        </t>
-                    </cac:AllowanceCharge>
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('line_extension_amount'), vals.get('currency_dp'))"/>
+            <cac:PricingReference>
+                <t t-set="pr_vals" t-value="vals.get('pricing_reference_vals', {})"/>
+                <cac:AlternativeConditionPrice t-foreach="pr_vals.get('alternative_condition_price_vals', [])" t-as="foreach_vals">
+                    <cbc:PriceAmount
+                        t-att-currencyID="foreach_vals['currency'].name"
+                        t-out="format_float(foreach_vals.get('price_amount'), foreach_vals.get('price_amount_dp'))"/>
+                    <cbc:PriceTypeCode
+                        t-out="foreach_vals.get('price_type_code')"/>
+                </cac:AlternativeConditionPrice>
+            </cac:PricingReference>
+            <cac:TaxTotal t-foreach="vals.get('tax_total_vals', [])" t-as="foreach_vals">
+                <t t-call="{{TaxTotalType_template}}">
+                    <t t-set="vals" t-value="foreach_vals"/>
                 </t>
-            </t>
-            <t t-foreach="vals.get('tax_total_vals', [])" t-as="foreach_vals">
-                <cac:TaxTotal>
-                    <t t-call="{{TaxTotalType_template}}">
-                        <t t-set="vals" t-value="foreach_vals"/>
-                    </t>
-                </cac:TaxTotal>
-            </t>
+            </cac:TaxTotal>
             <cac:Item>
                 <t t-set="item_vals" t-value="vals.get('item_vals', {})"/>
                 <cbc:Description t-out="item_vals.get('description')"/>
@@ -247,30 +308,69 @@
                 <cac:SellersItemIdentification>
                     <cbc:ID t-out="item_vals.get('sellers_item_identification_vals', {}).get('id')"/>
                 </cac:SellersItemIdentification>
-                <t t-foreach="item_vals.get('classified_tax_category_vals', [])" t-as="foreach_vals">
-                    <cac:ClassifiedTaxCategory>
-                        <t t-call="{{TaxCategoryType_template}}">
-                            <t t-set="vals" t-value="foreach_vals"/>
-                        </t>
-                    </cac:ClassifiedTaxCategory>
-                </t>
+                <cac:CommodityClassification t-foreach="item_vals.get('commodity_classification_vals', [])" t-as="foreach_vals">
+                    <cbc:ItemClassificationCode t-out="foreach_vals.get('item_classification_code')"/>
+                </cac:CommodityClassification>
+                <cac:ClassifiedTaxCategory t-foreach="item_vals.get('classified_tax_category_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{TaxCategoryType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:ClassifiedTaxCategory>
             </cac:Item>
             <cac:Price>
                 <t t-set="vals" t-value="vals.get('price_vals', {})"/>
                 <cbc:PriceAmount
-                        t-att-currencyID="vals['currency'].name"
-                        t-out="format_float(vals.get('price_amount'), vals.get('product_price_dp'))"/>
+                    t-att-currencyID="vals['currency'].name"
+                    t-out="format_float(vals.get('price_amount'), vals.get('product_price_dp'))"/>
                 <!-- nbr of item units to which the price applies), i.e.: 1 Dozen = 12 units, not mandatory -->
                 <cbc:BaseQuantity
-                        t-att="vals.get('base_quantity_attrs', {})"
-                        t-out="vals.get('base_quantity')"/>
+                    t-att="vals.get('base_quantity_attrs', {})"
+                    t-out="vals.get('base_quantity')"/>
             </cac:Price>
         </t>
     </template>
 
-    <template id="ubl_20_InvoiceType">
-        <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-           xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    <template id="ubl_20_InvoiceLineType" inherit_id="account_edi_ubl_cii.ubl_20_CommonLineType" primary="True">
+        <xpath expr="//*[local-name()='Note']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:InvoicedQuantity
+                    t-att="vals.get('line_quantity_attrs', {})"
+                    t-out="vals.get('line_quantity')"/>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="before">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{AllowanceChargeType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:AllowanceCharge>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_20_CreditNoteLineType" inherit_id="account_edi_ubl_cii.ubl_20_CommonLineType" primary="True">
+        <xpath expr="//*[local-name()='Note']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:CreditedQuantity
+                    t-att="vals.get('line_quantity_attrs', {})"
+                    t-out="vals.get('line_quantity')"/>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_20_DebitNoteLineType" inherit_id="account_edi_ubl_cii.ubl_20_CommonLineType" primary="True">
+        <xpath expr="//*[local-name()='Note']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:DebitedQuantity
+                    t-att="vals.get('line_quantity_attrs', {})"
+                    t-out="vals.get('line_quantity')"/>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_20_CommonType">
+        <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
             <cbc:UBLVersionID t-out="vals.get('ubl_version_id')"/>
             <cbc:CustomizationID t-out="vals.get('customization_id')"/>
@@ -279,38 +379,39 @@
                 t-out="vals.get('profile_id')"/>
             <cbc:ID t-out="vals.get('id')"/>
             <cbc:IssueDate t-out="vals.get('issue_date')"/>
-            <cbc:InvoiceTypeCode
-                    t-if="invoice.move_type == 'out_invoice'"
-                    t-att="vals.get('invoice_type_code_attrs', {})"
-                    t-out="vals.get('invoice_type_code')"
-            />
-            <t t-foreach="vals.get('note_vals', [])" t-as="note">
-                <cbc:Note t-out="note"/>
-            </t>
+            <cbc:Note t-foreach="vals.get('note_vals', [])" t-as="note_vals"
+                t-att="note_vals.get('note_attrs', {})"
+                t-out="note_vals.get('note')"/>
             <cbc:DocumentCurrencyCode
-                    t-att="vals.get('document_currency_code_attrs', {})"
-                    t-out="invoice.currency_id.name.upper()"/>
+                t-att="vals.get('document_currency_code_attrs', {})"
+                t-out="invoice.currency_id.name.upper()"/>
             <cbc:TaxCurrencyCode
-                    t-att="vals.get('tax_currency_code_attrs', {})"
-                    t-out="vals.get('tax_currency_code')"/>
-            <t t-foreach="vals.get('invoice_period_vals_list', [])" t-as="foreach_vals">
-                <cac:InvoicePeriod>
-                    <cbc:StartDate t-out="foreach_vals.get('start_date')"/>
-                    <cbc:EndDate t-out="foreach_vals.get('end_date')"/>
-                </cac:InvoicePeriod>
-            </t>
+                t-att="vals.get('tax_currency_code_attrs', {})"
+                t-out="vals.get('tax_currency_code')"/>
+            <cac:InvoicePeriod t-foreach="vals.get('invoice_period_vals_list', [])" t-as="foreach_vals">
+                <cbc:StartDate t-out="foreach_vals.get('start_date')"/>
+                <cbc:EndDate t-out="foreach_vals.get('end_date')"/>
+            </cac:InvoicePeriod>
             <cac:OrderReference>
-                <cbc:ID t-esc="vals.get('order_reference')"/>
-                <cbc:SalesOrderID t-esc="vals.get('sales_order_id')"/>
+                <cbc:ID t-out="vals.get('order_reference')"/>
+                <cbc:SalesOrderID t-out="vals.get('sales_order_id')"/>
             </cac:OrderReference>
-            <cac:BillingReference t-if="vals.get('billing_reference_vals')">
+            <cac:BillingReference>
+                <t t-set="billing_reference_vals" t-value="vals.get('billing_reference_vals', {})"/>
                 <cac:InvoiceDocumentReference>
-                    <cbc:ID t-out="vals['billing_reference_vals'].get('id')"/>
-                    <cbc:IssueDate t-out="vals['billing_reference_vals'].get('issue_date')"/>
+                    <cbc:ID t-out="billing_reference_vals.get('id')"/>
+                    <cbc:IssueDate t-out="billing_reference_vals.get('issue_date')"/>
+                    <cbc:DocumentTypeCode t-out="billing_reference_vals.get('document_type_code')"/>
                 </cac:InvoiceDocumentReference>
             </cac:BillingReference>
+            <cac:Signature t-foreach="vals.get('signature_vals', [])" t-as="foreach_vals">
+                <t t-call="{{SignatureType_template}}">
+                    <t t-set="vals" t-value="foreach_vals"/>
+                </t>
+            </cac:Signature>
             <cac:AccountingSupplierParty>
                 <t t-set="accounting_supplier_vals" t-value="vals.get('accounting_supplier_party_vals', {})"/>
+                <cbc:CustomerAssignedAccountID t-out="accounting_supplier_vals.get('customer_assigned_account_id')"/>
                 <cac:Party>
                     <t t-call="{{PartyType_template}}">
                         <t t-set="vals" t-value="accounting_supplier_vals.get('party_vals', {})"/>
@@ -319,112 +420,160 @@
             </cac:AccountingSupplierParty>
             <cac:AccountingCustomerParty>
                 <t t-set="accounting_customer_vals" t-value="vals.get('accounting_customer_party_vals', {})"/>
+                <cbc:AdditionalAccountID t-out="accounting_customer_vals.get('additional_account_id')"/>
                 <cac:Party>
                     <t t-call="{{PartyType_template}}">
                         <t t-set="vals" t-value="accounting_customer_vals.get('party_vals', {})"/>
                     </t>
                 </cac:Party>
             </cac:AccountingCustomerParty>
-            <t id="delivery_foreach" t-foreach="vals.get('delivery_vals_list', [])" t-as="foreach_vals">
-                <cac:Delivery>
-                    <cbc:ActualDeliveryDate t-out="foreach_vals.get('actual_delivery_date')"/>
-                    <cac:DeliveryLocation>
-                        <cac:Address>
-                            <t t-call="{{AddressType_template}}">
-                                <t t-set="vals"
-                                   t-value="foreach_vals.get('delivery_location_vals', {}).get('delivery_address_vals', {})"/>
-                            </t>
-                        </cac:Address>
-                    </cac:DeliveryLocation>
-                </cac:Delivery>
-            </t>
-            <!-- In UBL 2.0 PaymentMeans is only present for Invoice
-            while in UBL 2.1, it is present for Invoice and CreditNote
-            http://www.datypic.com/sc/ubl20/e-ns19_Invoice.html
-            http://www.datypic.com/sc/ubl20/e-ns14_CreditNote.html -->
-            <t t-if="invoice.move_type == 'out_invoice'">
-                <t t-foreach="vals.get('payment_means_vals_list', [])" t-as="foreach_vals">
-                    <cac:PaymentMeans>
-                        <t t-call="{{PaymentMeansType_template}}">
-                            <t t-set="vals" t-value="foreach_vals"/>
-                        </t>
-                    </cac:PaymentMeans>
+            <cac:TaxTotal t-foreach="vals.get('tax_total_vals', [])" t-as="foreach_vals">
+                <t t-call="{{TaxTotalType_template}}">
+                    <t t-set="vals" t-value="foreach_vals"/>
                 </t>
+            </cac:TaxTotal>
+        </t>
+    </template>
+
+    <template id="ubl_20_InvoiceType" inherit_id="account_edi_ubl_cii.ubl_20_CommonType" primary="True">
+        <xpath expr="//*[local-name()='IssueDate']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:InvoiceTypeCode
+                    t-att="vals.get('document_type_code_attrs', {})"
+                    t-out="vals.get('document_type_code')"/>
             </t>
-            <t t-foreach="vals.get('payment_terms_vals', [])" t-as="foreach_vals">
-                <cac:PaymentTerms>
-                    <t t-foreach="foreach_vals.get('note_vals', [])" t-as="note">
-                        <cbc:Note t-out="note"/>
+        </xpath>
+        <xpath expr="//*[local-name()='AccountingCustomerParty']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+               xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cac:Delivery t-foreach="vals.get('delivery_vals_list', [])" t-as="foreach_vals">
+                    <t t-call="{{DeliveryType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:Delivery>
+                <cac:PaymentMeans t-foreach="vals.get('payment_means_vals_list', [])" t-as="foreach_vals">
+                    <t t-call="{{PaymentMeansType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:PaymentMeans>
+                <cac:PaymentTerms t-foreach="vals.get('payment_terms_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{PaymentTermsType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
                     </t>
                 </cac:PaymentTerms>
             </t>
-            <t t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
-                <cac:AllowanceCharge>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="before">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
                     <t t-call="{{AllowanceChargeType_template}}">
                         <t t-set="vals" t-value="foreach_vals"/>
                     </t>
                 </cac:AllowanceCharge>
             </t>
-            <t t-foreach="vals.get('tax_total_vals', [])" t-as="foreach_vals">
-                <cac:TaxTotal>
-                    <t t-call="{{TaxTotalType_template}}">
-                        <t t-set="vals" t-value="foreach_vals"/>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:LegalMonetaryTotal>
+                    <t t-call="{{MonetaryTotalType_template}}">
+                        <t t-set="vals" t-value="vals.get('monetary_total_vals', {})"/>
                     </t>
-                </cac:TaxTotal>
-            </t>
-            <cac:LegalMonetaryTotal>
-                <t t-set="monetary_tot_vals" t-value="vals.get('legal_monetary_total_vals', {})"/>
-                <cbc:LineExtensionAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('line_extension_amount'), monetary_tot_vals.get('currency_dp'))"/>
-                <cbc:TaxExclusiveAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('tax_exclusive_amount'), monetary_tot_vals.get('currency_dp'))"/>
-                <cbc:TaxInclusiveAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('tax_inclusive_amount'), monetary_tot_vals.get('currency_dp'))"/>
-                <cbc:AllowanceTotalAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('allowance_total_amount'), monetary_tot_vals.get('currency_dp'))"/>
-                <cbc:ChargeTotalAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('charge_total_amount'), monetary_tot_vals.get('currency_dp'))"/>
-                <cbc:PrepaidAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('prepaid_amount'), monetary_tot_vals.get('currency_dp'))"/>
-                <cbc:PayableAmount
-                    t-att-currencyID="monetary_tot_vals['currency'].name"
-                    t-out="format_float(monetary_tot_vals.get('payable_amount'), monetary_tot_vals.get('currency_dp'))"/>
-            </cac:LegalMonetaryTotal>
-            <t t-foreach="vals.get('invoice_line_vals', [])" t-as="foreach_vals">
-                <cac:InvoiceLine t-if="invoice.move_type == 'out_invoice'">
+                </cac:LegalMonetaryTotal>
+                <cac:InvoiceLine t-foreach="vals.get('line_vals', [])" t-as="foreach_vals">
                     <t t-call="{{InvoiceLineType_template}}">
                         <t t-set="vals" t-value="foreach_vals"/>
                     </t>
                 </cac:InvoiceLine>
-                <cac:CreditNoteLine t-if="invoice.move_type == 'out_refund'">
-                    <t t-call="{{InvoiceLineType_template}}">
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_20_CreditNoteType" inherit_id="account_edi_ubl_cii.ubl_20_CommonType" primary="True">
+        <xpath expr="//*[local-name()='InvoicePeriod']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:DiscrepancyResponse t-foreach="vals.get('discrepancy_response_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{ResponseType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:DiscrepancyResponse>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="before">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{AllowanceChargeType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:AllowanceCharge>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:LegalMonetaryTotal>
+                    <t t-call="{{MonetaryTotalType_template}}">
+                        <t t-set="vals" t-value="vals.get('monetary_total_vals', {})"/>
+                    </t>
+                </cac:LegalMonetaryTotal>
+                <cac:CreditNoteLine t-foreach="vals.get('line_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{CreditNoteLineType_template}}">
                         <t t-set="vals" t-value="foreach_vals"/>
                     </t>
                 </cac:CreditNoteLine>
             </t>
-        </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_20_DebitNoteType" inherit_id="account_edi_ubl_cii.ubl_20_CommonType" primary="True">
+        <xpath expr="//*[local-name()='InvoicePeriod']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:DiscrepancyResponse t-foreach="vals.get('discrepancy_response_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{ResponseType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:DiscrepancyResponse>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:RequestedMonetaryTotal>
+                    <t t-call="{{MonetaryTotalType_template}}">
+                        <t t-set="vals" t-value="vals.get('monetary_total_vals', {})"/>
+                    </t>
+                </cac:RequestedMonetaryTotal>
+                <cac:DebitNoteLine t-foreach="vals.get('line_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{DebitNoteLineType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:DebitNoteLine>
+            </t>
+        </xpath>
     </template>
 
     <template id="ubl_20_Invoice">
-        <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+        <Invoice
+            xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
             <t t-call="{{InvoiceType_template}}"/>
         </Invoice>
     </template>
 
     <template id="ubl_20_CreditNote">
-        <CreditNote xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2"
-                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-            <t t-call="{{InvoiceType_template}}"/>
+        <CreditNote
+            xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <t t-call="{{CreditNoteType_template}}"/>
         </CreditNote>
+    </template>
+
+    <template id="ubl_20_DebitNote">
+        <DebitNote
+            xmlns="urn:oasis:names:specification:ubl:schema:xsd:DebitNote-2"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <t t-call="{{DebitNoteType_template}}"/>
+        </DebitNote>
     </template>
 
 </odoo>

--- a/addons/account_edi_ubl_cii/data/ubl_21_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_21_templates.xml
@@ -1,62 +1,118 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="ubl_21_InvoiceLineType" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceLineType" primary="True">
-        <xpath expr="//*[local-name()='Item']" position="before">
-            <t t-if="invoice.move_type == 'out_refund'">
-                <!-- AllowanceCharge and TaxTotal are swapped in the CreditLine
-                w.r.t InvoiceLine. see: http://www.datypic.com/sc/ubl21/e-cac_InvoiceLine.html
-                vs http://www.datypic.com/sc/ubl21/e-cac_CreditNoteLine.html-->
-                <t t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
-                    <cac:AllowanceCharge
-                        xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                        xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                        xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                        <t t-call="{{AllowanceChargeType_template}}">
-                            <t t-set="vals" t-value="foreach_vals"/>
-                        </t>
-                    </cac:AllowanceCharge>
-                </t>
+    <template id="ubl_21_PaymentTermsType" inherit_id="account_edi_ubl_cii.ubl_20_PaymentTermsType">
+        <xpath expr="//*[local-name()='Amount']" position="before">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:PaymentPercent t-out="vals.get('payment_percent')"/>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='Amount']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:PaymentDueDate t-out="vals.get('payment_due_date')"/>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_21_CreditNoteLineType" inherit_id="account_edi_ubl_cii.ubl_20_CreditNoteLineType" primary="True">
+        <xpath expr="//*[local-name()='TaxTotal']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{AllowanceChargeType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:AllowanceCharge>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_21_DebitNoteLineType" inherit_id="account_edi_ubl_cii.ubl_20_DebitNoteLineType" primary="True">
+        <xpath expr="//*[local-name()='TaxTotal']" position="after">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{AllowanceChargeType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:AllowanceCharge>
             </t>
         </xpath>
     </template>
 
     <template id="ubl_21_InvoiceType" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceType" primary="True">
         <xpath expr="//*[local-name()='IssueDate']" position="after">
-            <cbc:DueDate
-                    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                    t-if="invoice.move_type == 'out_invoice'"
-                    t-out="vals.get('due_date')"/>
-            <cbc:CreditNoteTypeCode
-                    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                    t-if="invoice.move_type == 'out_refund'"
-                    t-att="vals.get('invoice_type_code_attrs', {})"
-                    t-out="vals.get('credit_note_type_code')"
-            />
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:DueDate t-out="vals.get('due_date')"/>
+            </t>
         </xpath>
         <xpath expr="//*[local-name()='TaxCurrencyCode']" position="after">
-            <cbc:BuyerReference
-                    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                    t-out="vals.get('buyer_reference')"/>
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:BuyerReference t-out="vals.get('buyer_reference')"/>
+            </t>
         </xpath>
-        <xpath expr="//*[@id='delivery_foreach']" position="after">
-            <t t-if="invoice.move_type == 'out_refund'">
-                <t t-foreach="vals.get('payment_means_vals_list', [])" t-as="foreach_vals">
-                    <cac:PaymentMeans
-                        xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                        xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                        xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                        <t t-call="{{PaymentMeansType_template}}">
-                            <t t-set="vals" t-value="foreach_vals"/>
-                        </t>
-                    </cac:PaymentMeans>
-                </t>
+    </template>
+
+    <template id="ubl_21_CreditNoteType" inherit_id="account_edi_ubl_cii.ubl_20_CreditNoteType" primary="True">
+        <xpath expr="//*[local-name()='IssueDate']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:CreditNoteTypeCode
+                    t-att="vals.get('document_type_code_attrs', {})"
+                    t-out="vals.get('document_type_code')"/>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxCurrencyCode']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:BuyerReference t-out="vals.get('buyer_reference')"/>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="before">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:Delivery t-foreach="vals.get('delivery_vals_list', [])" t-as="foreach_vals">
+                    <t t-call="{{DeliveryType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:Delivery>
+                <cac:PaymentMeans t-foreach="vals.get('payment_means_vals_list', [])" t-as="foreach_vals">
+                    <t t-call="{{PaymentMeansType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:PaymentMeans>
+                <cac:PaymentTerms t-foreach="vals.get('payment_terms_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{PaymentTermsType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:PaymentTerms>
+            </t>
+        </xpath>
+    </template>
+
+    <template id="ubl_21_DebitNoteType" inherit_id="account_edi_ubl_cii.ubl_20_DebitNoteType" primary="True">
+        <xpath expr="//*[local-name()='TaxCurrencyCode']" position="after">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:BuyerReference t-out="vals.get('buyer_reference')"/>
+            </t>
+        </xpath>
+        <xpath expr="//*[local-name()='TaxTotal']" position="before">
+            <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                <cac:AllowanceCharge t-foreach="vals.get('allowance_charge_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{AllowanceChargeType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:AllowanceCharge>
+                <cac:Delivery t-foreach="vals.get('delivery_vals_list', [])" t-as="foreach_vals">
+                    <t t-call="{{DeliveryType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:Delivery>
+                <cac:PaymentMeans t-foreach="vals.get('payment_means_vals_list', [])" t-as="foreach_vals">
+                    <t t-call="{{PaymentMeansType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:PaymentMeans>
+                <cac:PaymentTerms t-foreach="vals.get('payment_terms_vals', [])" t-as="foreach_vals">
+                    <t t-call="{{PaymentTermsType_template}}">
+                        <t t-set="vals" t-value="foreach_vals"/>
+                    </t>
+                </cac:PaymentTerms>
             </t>
         </xpath>
     </template>

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -217,7 +217,7 @@ class AccountEdiCommon(models.AbstractModel):
                 'id': tax_unece_codes.get('tax_category_code'),
                 'percent': tax.amount if tax.amount_type == 'percent' else False,
                 'name': tax_unece_codes.get('tax_exemption_reason'),
-                'tax_scheme_id': 'VAT',
+                'tax_scheme_vals': {'id': 'VAT'},
                 **tax_unece_codes,
             })
         return res

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
@@ -25,8 +25,12 @@ class AccountEdiXmlUBL21(models.AbstractModel):
         vals = super()._export_invoice_vals(invoice)
 
         vals.update({
+            'PaymentTermsType_template': 'account_edi_ubl_cii.ubl_21_PaymentTermsType',
+            'CreditNoteLineType_template': 'account_edi_ubl_cii.ubl_21_CreditNoteLineType',
+            'DebitNoteLineType_template': 'account_edi_ubl_cii.ubl_21_DebitNoteLineType',
             'InvoiceType_template': 'account_edi_ubl_cii.ubl_21_InvoiceType',
-            'InvoiceLineType_template': 'account_edi_ubl_cii.ubl_21_InvoiceLineType',
+            'CreditNoteType_template': 'account_edi_ubl_cii.ubl_21_CreditNoteType',
+            'DebitNoteType_template': 'account_edi_ubl_cii.ubl_21_DebitNoteType',
         })
 
         vals['vals'].update({

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_a_nz.py
@@ -45,7 +45,7 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
             vals['endpoint_id'] = partner.company_registry
 
         for party_tax_scheme in vals['party_tax_scheme_vals']:
-            party_tax_scheme['tax_scheme_id'] = 'GST'
+            party_tax_scheme['tax_scheme_vals'] = {'id': 'GST'}
 
         return vals
 
@@ -70,7 +70,7 @@ class AccountEdiXmlUBLANZ(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_bis3
         vals_list = super()._get_tax_category_list(invoice, taxes)
         for vals in vals_list:
-            vals['tax_scheme_id'] = 'GST'
+            vals['tax_scheme_vals'] = {'id': 'GST'}
         return vals_list
 
     def _export_invoice_vals(self, invoice):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -70,7 +70,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         if partner.country_id.code == "NO" and role == 'supplier':
             vals_list.append({
                 'company_id': "Foretaksregisteret",
-                'tax_scheme_id': "TAX",
+                'tax_scheme_vals': {'id': 'TAX'},
             })
 
         return vals_list
@@ -236,7 +236,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             'currency_dp': 2,
             'ubl_version_id': None,
         })
-        vals['vals']['legal_monetary_total_vals']['currency_dp'] = 2
+        vals['vals']['monetary_total_vals']['currency_dp'] = 2
 
         # [NL-R-001] For suppliers in the Netherlands, if the document is a creditnote, the document MUST
         # contain an invoice reference (cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID)

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_sg.py
@@ -29,7 +29,7 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
         vals = super()._get_partner_party_vals(partner, role)
 
         for party_tax_scheme in vals['party_tax_scheme_vals']:
-            party_tax_scheme['tax_scheme_id'] = 'GST'
+            party_tax_scheme['tax_scheme_vals'] = {'id': 'GST'}
 
         return vals
 
@@ -60,7 +60,7 @@ class AccountEdiXmlUBLSG(models.AbstractModel):
             res.append({
                 'id': self._get_tax_sg_codes(invoice, tax),
                 'percent': tax.amount if tax.amount_type == 'percent' else False,
-                'tax_scheme_id': 'GST',
+                'tax_scheme_vals': {'id': 'GST'},
             })
         return res
 

--- a/addons/l10n_dk_oioubl/models/account_edi_xml_oioubl_201.py
+++ b/addons/l10n_dk_oioubl/models/account_edi_xml_oioubl_201.py
@@ -73,7 +73,7 @@ class AccountEdiXmlOIOUBL201(models.AbstractModel):
                 'schemeAgencyID': DANISH_NATIONAL_IT_AND_TELECOM_AGENCY_ID,
             }
         })
-        vals['vals'].setdefault('invoice_type_code_attrs', {}).update({
+        vals['vals'].setdefault('document_type_code_attrs', {}).update({
             'listID': 'urn:oioubl:codelist:invoicetypecode-1.2',
             'listAgencyID': DANISH_NATIONAL_IT_AND_TELECOM_AGENCY_ID,
         })
@@ -103,9 +103,11 @@ class AccountEdiXmlOIOUBL201(models.AbstractModel):
             # the doc says it could be empty but the schematron says otherwise
             # https://www.oioubl.info/Classes/en/TaxScheme.html
             party_tax_scheme.update({
-                'tax_scheme_id': 'VAT',
-                'tax_scheme_id_attrs': {'schemeID': 'urn:oioubl:id:taxschemeid-1.5'},
-                'tax_name': 'VAT',
+                'tax_scheme_vals': {
+                    'id': 'VAT',
+                    'id_attrs': {'schemeID': 'urn:oioubl:id:taxschemeid-1.5'},
+                    'name': 'VAT',
+                },
             })
         return vals
 
@@ -188,8 +190,8 @@ class AccountEdiXmlOIOUBL201(models.AbstractModel):
                 if subtotal_vals['tax_category_vals']['id'] not in TAX_POSSIBLE_VALUES:
                     subtotal_vals['tax_category_vals']['id'] = UBL_TO_OIOUBL_TAX_CATEGORY_ID_MAPPING.get(subtotal_vals['tax_category_vals']['id'])
 
-                subtotal_vals['tax_category_vals']['tax_scheme_name'] = 'VAT'
-                subtotal_vals['tax_category_vals']['tax_scheme_id_attrs'] = {'schemeID': 'urn:oioubl:id:taxschemeid-1.5'}
+                subtotal_vals['tax_category_vals']['tax_scheme_vals']['name'] = 'VAT'
+                subtotal_vals['tax_category_vals']['tax_scheme_vals']['id_attrs'] = {'schemeID': 'urn:oioubl:id:taxschemeid-1.5'}
 
                 # /Invoice[1]/cac:TaxTotal[1]/cac:TaxSubtotal[1]/cac:TaxCategory[1]
                 # [W-LIB230] Name should only be used within NES profiles
@@ -199,9 +201,9 @@ class AccountEdiXmlOIOUBL201(models.AbstractModel):
 
         return vals_list
 
-    def _get_invoice_legal_monetary_total_vals(self, invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount):
+    def _get_invoice_monetary_total_vals(self, invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount):
         # EXTENDS account.edi.xml.ubl_20
-        vals = super()._get_invoice_legal_monetary_total_vals(invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount)
+        vals = super()._get_invoice_monetary_total_vals(invoice, taxes_vals, line_extension_amount, allowance_total_amount, charge_total_amount)
         # In OIOUBL context, tax_exclusive_amount means "tax only"
         vals['tax_exclusive_amount'] = taxes_vals['tax_amount_currency']
         if invoice.currency_id.is_zero(vals['prepaid_amount']):
@@ -223,8 +225,8 @@ class AccountEdiXmlOIOUBL201(models.AbstractModel):
                 'schemeID': 'urn:oioubl:id:taxcategoryid-1.3',
                 'schemeAgencyID': DANISH_NATIONAL_IT_AND_TELECOM_AGENCY_ID,
             }
-            vals['tax_scheme_id_attrs'] = {'schemeID': 'urn:oioubl:id:taxschemeid-1.5'}
-            vals['tax_scheme_name'] = 'VAT'
+            vals['tax_scheme_vals']['id_attrs'] = {'schemeID': 'urn:oioubl:id:taxschemeid-1.5'}
+            vals['tax_scheme_vals']['name'] = 'VAT'
             # OIOUBL can't contain name for category
             # /Invoice[1]/cac:InvoiceLine[1]/cac:Item[1]/cac:ClassifiedTaxCategory[1]
             # [W-LIB230] Name should only be used within NES profiles

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
@@ -141,22 +141,6 @@
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>
-  <cac:Delivery>
-    <cac:DeliveryLocation>
-      <cac:Address>
-        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">
-          StructuredDK</cbc:AddressFormatCode>
-        <cbc:StreetName>Rue Fabricy,</cbc:StreetName>
-        <cbc:BuildingNumber>16</cbc:BuildingNumber>
-        <cbc:CityName>Lille</cbc:CityName>
-        <cbc:PostalZone>59000</cbc:PostalZone>
-        <cac:Country>
-          <cbc:IdentificationCode>FR</cbc:IdentificationCode>
-          <cbc:Name>France</cbc:Name>
-        </cac:Country>
-      </cac:Address>
-    </cac:DeliveryLocation>
-  </cac:Delivery>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
     <cac:TaxSubtotal>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -142,22 +142,6 @@
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>
-  <cac:Delivery>
-    <cac:DeliveryLocation>
-      <cac:Address>
-        <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">
-          StructuredDK</cbc:AddressFormatCode>
-        <cbc:StreetName>Paradisæblevej,</cbc:StreetName>
-        <cbc:BuildingNumber>11</cbc:BuildingNumber>
-        <cbc:CityName>Aalborg</cbc:CityName>
-        <cbc:PostalZone>9430</cbc:PostalZone>
-        <cac:Country>
-          <cbc:IdentificationCode>DK</cbc:IdentificationCode>
-          <cbc:Name>Denmark</cbc:Name>
-        </cac:Country>
-      </cac:Address>
-    </cac:DeliveryLocation>
-  </cac:Delivery>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="DKK">375.00</cbc:TaxAmount>
     <cac:TaxSubtotal>

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -44,8 +44,9 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         if not partner.vat and partner.company_registry:
             return [{
                 'company_id': partner.company_registry,
-                'TaxScheme_vals': {},
-                'tax_scheme_id': 'VAT',
+                'tax_scheme_vals': {
+                    'id': 'VAT',
+                },
             }]
 
         return vals_list

--- a/addons/l10n_sa_edi/data/ubl_21_zatca.xml
+++ b/addons/l10n_sa_edi/data/ubl_21_zatca.xml
@@ -5,8 +5,8 @@
         <template id="ubl_21_PaymentMeansType_zatca" inherit_id="account_edi_ubl_cii.ubl_20_PaymentMeansType" primary="True">
             <xpath expr="//*[local-name()='InstructionID']" position="after">
                 <cbc:InstructionNote xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                                     t-out="vals['adjustment_reason']"/>
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                    t-out="vals['adjustment_reason']"/>
             </xpath>
         </template>
 
@@ -28,9 +28,9 @@
                                 <ds:Signature Id="signature" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
                                     <ds:SignedInfo>
                                         <ds:CanonicalizationMethod
-                                                Algorithm="http://www.w3.org/2006/12/xml-c14n11"/>
+                                            Algorithm="http://www.w3.org/2006/12/xml-c14n11"/>
                                         <ds:SignatureMethod
-                                                Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+                                            Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
                                         <ds:Reference Id="invoiceSignedData" URI="">
                                             <ds:Transforms>
                                                 <ds:Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116">
@@ -73,16 +73,16 @@
                                                         <xades:Cert>
                                                             <xades:CertDigest>
                                                                 <ds:DigestMethod
-                                                                        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                                                                        Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                                                                    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                                                                    Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
                                                                 <ds:DigestValue
-                                                                        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
+                                                                    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
                                                             </xades:CertDigest>
                                                             <xades:IssuerSerial>
                                                                 <ds:X509IssuerName
-                                                                        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
+                                                                    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
                                                                 <ds:X509SerialNumber
-                                                                        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
+                                                                    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
                                                             </xades:IssuerSerial>
                                                         </xades:Cert>
                                                     </xades:SigningCertificate>
@@ -106,14 +106,14 @@
                         <xades:Cert>
                             <xades:CertDigest>
                                 <ds:DigestMethod xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                                                 Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                                    Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
                                 <ds:DigestValue xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                                                t-out="public_key_hashing"/>
+                                    t-out="public_key_hashing"/>
                             </xades:CertDigest>
                             <xades:IssuerSerial>
                                 <ds:X509IssuerName xmlns:ds="http://www.w3.org/2000/09/xmldsig#" t-out="issuer_name"/>
                                 <ds:X509SerialNumber xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                                                     t-out="serial_number"/>
+                                    t-out="serial_number"/>
                             </xades:IssuerSerial>
                         </xades:Cert>
                     </xades:SigningCertificate>
@@ -122,53 +122,83 @@
         </template>
 
         <template id="ubl_21_InvoiceLineType_zatca" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceLineType" primary="True">
-            <!-- Remove SellersItemIdentification if None -->
-            <xpath expr="//*[local-name()='SellersItemIdentification']" position="replace">
-                <cac:SellersItemIdentification t-if="item_vals['sellers_item_identification_vals']['id']"
-                                               xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                               xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                                               xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                    <cbc:ID t-out="item_vals['sellers_item_identification_vals']['id']"/>
-                </cac:SellersItemIdentification>
+            <xpath expr="//*[local-name()='PricingReference']" position="before">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cac:DocumentReference>
+                        <t t-set="prepayment_vals" t-value="vals.get('prepayment_vals', {})"/>
+                        <t t-set="issue_date" t-value="prepayment_vals.get('issue_date')"/>
+                        <cbc:ID t-out="prepayment_vals.get('prepayment_id')"/>
+                        <cbc:IssueDate t-out="issue_date and issue_date.strftime('%Y-%m-%d')"/>
+                        <cbc:IssueTime t-esc="issue_date and issue_date.strftime('%H:%M:%S')"/>
+                        <cbc:DocumentTypeCode t-out="prepayment_vals.get('document_type_code')"/>
+                    </cac:DocumentReference>
+                </t>
             </xpath>
-            <xpath expr="//*[local-name()='CreditedQuantity']" position="replace"/>
-            <xpath expr="//*[local-name()='InvoicedQuantity']" position="replace">
-                <cbc:InvoicedQuantity
-                        xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                        xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                        t-att="vals.get('invoiced_quantity_attrs', {})"
-                        t-out="vals['invoiced_quantity']"/>
+        </template>
+
+        <template id="ubl_21_CreditNoteLineType_zatca" inherit_id="account_edi_ubl_cii.ubl_21_CreditNoteLineType" primary="True">
+            <xpath expr="//*[local-name()='CreditedQuantity']" position="replace">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:InvoicedQuantity
+                        t-att="vals.get('line_quantity_attrs', {})"
+                        t-out="vals.get('line_quantity')"/>
+                </t>
             </xpath>
-            <xpath expr="//*[local-name()='LineExtensionAmount']" position="after">
-                <cac:DocumentReference
-                        t-if="vals.get('prepayment_vals', {})"
-                        xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                        xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                        xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                    <cbc:ID t-out="vals['prepayment_vals']['prepayment_id']"/>
-                    <cbc:IssueDate t-esc="vals['prepayment_vals']['issue_date'].strftime('%Y-%m-%d')"/>
-                    <cbc:IssueTime t-esc="vals['prepayment_vals']['issue_date'].strftime('%H:%M:%S')"/>
-                    <cbc:DocumentTypeCode t-out="vals['prepayment_vals']['document_type_code']"/>
-                </cac:DocumentReference>
+            <xpath expr="//*[local-name()='PricingReference']" position="before">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cac:DocumentReference>
+                        <t t-set="prepayment_vals" t-value="vals.get('prepayment_vals', {})"/>
+                        <t t-set="issue_date" t-value="prepayment_vals.get('issue_date')"/>
+                        <cbc:ID t-out="prepayment_vals.get('prepayment_id')"/>
+                        <cbc:IssueDate t-out="issue_date and issue_date.strftime('%Y-%m-%d')"/>
+                        <cbc:IssueTime t-esc="issue_date and issue_date.strftime('%H:%M:%S')"/>
+                        <cbc:DocumentTypeCode t-out="prepayment_vals.get('document_type_code')"/>
+                    </cac:DocumentReference>
+                </t>
+            </xpath>
+        </template>
+
+        <template id="ubl_21_DebitNoteLineType_zatca" inherit_id="account_edi_ubl_cii.ubl_21_DebitNoteLineType" primary="True">
+            <xpath expr="//*[local-name()='DebitedQuantity']" position="replace">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:InvoicedQuantity
+                        t-att="vals.get('line_quantity_attrs', {})"
+                        t-out="vals.get('line_quantity')"/>
+                </t>
+            </xpath>
+            <xpath expr="//*[local-name()='PricingReference']" position="before">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cac:DocumentReference>
+                        <t t-set="prepayment_vals" t-value="vals.get('prepayment_vals', {})"/>
+                        <t t-set="issue_date" t-value="prepayment_vals.get('issue_date')"/>
+                        <cbc:ID t-out="prepayment_vals.get('prepayment_id')"/>
+                        <cbc:IssueDate t-out="issue_date and issue_date.strftime('%Y-%m-%d')"/>
+                        <cbc:IssueTime t-esc="issue_date and issue_date.strftime('%H:%M:%S')"/>
+                        <cbc:DocumentTypeCode t-out="prepayment_vals.get('document_type_code')"/>
+                    </cac:DocumentReference>
+                </t>
             </xpath>
         </template>
 
         <template id="ubl_21_TaxTotalType_zatca" inherit_id="account_edi_ubl_cii.ubl_20_TaxTotalType" primary="True">
             <xpath expr="//*[local-name()='TaxAmount']" position="after">
                 <cbc:RoundingAmount xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                                    t-att-currencyID="vals['currency'].name"
-                                    t-esc="format_float(vals.get('total_amount_sa'), vals['currency_dp'])"/>
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                    t-att-currencyID="vals['currency'].name"
+                    t-esc="format_float(vals.get('total_amount_sa'), vals['currency_dp'])"/>
             </xpath>
         </template>
 
         <template id="ubl_21_PartyType_zatca" inherit_id="account_edi_ubl_cii.ubl_20_PartyType" primary="True">
             <xpath expr="//*[local-name()='PartyIdentification']" position="replace">
-                <cac:PartyIdentification t-if="party_vals.get('id')"
-                                         xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                                         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                    <cbc:ID t-att="party_vals.get('id_attrs', {})" t-out="party_vals['id']"/>
+                <cac:PartyIdentification
+                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+                    t-foreach="vals.get('party_identification_vals', [])" t-as="party_vals">
+                    <cbc:ID t-att="party_vals.get('id_attrs', {})" t-out="party_vals.get('id')"/>
                 </cac:PartyIdentification>
             </xpath>
         </template>
@@ -179,60 +209,24 @@
         </template>
 
         <template id="ubl_21_InvoiceType_zatca" inherit_id="account_edi_ubl_cii.ubl_21_InvoiceType" primary="True">
-
-            <!--    For ZATCA, we do not use CreditNoteTypeCode or DebitNoteTypeCode tags. We always use InvoiceTypeCode. -->
-            <xpath expr="//*[local-name()='CreditNoteTypeCode']" position="replace"/>
-            <xpath expr="//*[local-name()='InvoiceTypeCode']" position="replace">
-                <cbc:InvoiceTypeCode xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                     xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                                     xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                                     t-att="vals['invoice_type_code_attrs']"
-                                     t-out="vals['invoice_type_code']"/>
-            </xpath>
-
-            <!--    For ZATCA, we do not use CreditNoteLine or DebitNoteLine tags. We always use InvoiceLine. -->
-            <xpath expr="//*[local-name()='CreditNoteLine']" position="replace"/>
-            <xpath expr="//*[local-name()='InvoiceLine']" position="replace">
-                <cac:InvoiceLine xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                                 xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                    <t t-call="{{InvoiceLineType_template}}">
-                        <t t-set="vals" t-value="foreach_vals"/>
-                    </t>
-                </cac:InvoiceLine>
-            </xpath>
-
-            <!-- Remove Order Reference if None -->
-            <xpath expr="//*[local-name()='OrderReference']" position="replace">
-                <cac:OrderReference t-if="vals.get('order_reference')"
-                                    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                                    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                    <cbc:ID t-out="vals['order_reference']"/>
-                </cac:OrderReference>
-            </xpath>
-
+            <xpath expr="//*[local-name()='OrderReference']/*[local-name()='SalesOrderID']" position="replace"/>
             <!-- Add Invoice UUID in compliance with rule BR-KSA-03 -->
             <xpath expr="//*[local-name()='ID']" position="after">
-                <cbc:UUID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                          xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                          t-esc="invoice.l10n_sa_uuid"/>
-            </xpath>
-
-            <!-- Add Invoice Issue Time in compliance with rule KSA-25 -->
-            <xpath expr="//*[local-name()='IssueDate']" position="replace">
-                <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                    <cbc:IssueDate t-esc="vals['issue_date'].strftime('%Y-%m-%d')"/>
-                    <cbc:IssueTime t-esc="vals['issue_date'].strftime('%H:%M:%S')"/>
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:UUID t-out="invoice.l10n_sa_uuid"/>
                 </t>
             </xpath>
-
+            <!-- Add Invoice Issue Time in compliance with rule KSA-25 -->
+            <xpath expr="//*[local-name()='IssueDate']" position="replace">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:IssueDate t-out="vals['issue_date'].strftime('%Y-%m-%d')"/>
+                    <cbc:IssueTime t-out="vals['issue_date'].strftime('%H:%M:%S')"/>
+                </t>
+            </xpath>
             <!-- Add Previous Invoice Hash & Invoice Counter Value -->
             <xpath expr="//*[local-name()='BillingReference']" position="after">
-                <t xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
-                   xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
-                   xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
                     <!-- Add QR Code in compliance with rule BR-KSA-27 -->
                     <cac:AdditionalDocumentReference t-if="invoice._l10n_sa_is_simplified()">
                         <cbc:ID>QR</cbc:ID>
@@ -245,7 +239,141 @@
                         <cbc:ID>PIH</cbc:ID>
                         <cac:Attachment>
                             <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain"
-                                                              t-out="vals['previous_invoice_hash']"/>
+                                t-out="vals.get('previous_invoice_hash')"/>
+                        </cac:Attachment>
+                    </cac:AdditionalDocumentReference>
+                    <!-- Add Invoice Counter Value in compliance with rules BR-KSA-33 and BR-KSA-34 -->
+                    <cac:AdditionalDocumentReference>
+                        <cbc:ID>ICV</cbc:ID>
+                        <cbc:UUID t-out="invoice.l10n_sa_chain_index"/>
+                    </cac:AdditionalDocumentReference>
+                    <!-- Add Signature references in compliance with rules BR-KSA-29 and BR-KSA-30 -->
+                    <cac:Signature t-if="invoice._l10n_sa_is_simplified()">
+                        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+                        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+                    </cac:Signature>
+                </t>
+            </xpath>
+        </template>
+
+        <template id="ubl_21_CreditNoteType_zatca" inherit_id="account_edi_ubl_cii.ubl_21_CreditNoteType" primary="True">
+            <!-- For ZATCA, we do not use CreditNoteTypeCode tags. We always use InvoiceTypeCode. -->
+            <xpath expr="//*[local-name()='CreditNoteTypeCode']" position="replace">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:InvoiceTypeCode
+                        t-att="vals.get('document_type_code_attrs', {})"
+                        t-out="vals.get('document_type_code')"/>
+                </t>
+            </xpath>
+            <!-- For ZATCA, we do not use CreditNoteLine tags. We always use InvoiceLine. -->
+            <xpath expr="//*[local-name()='CreditNoteLine']" position="replace">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                    <cac:InvoiceLine t-foreach="vals.get('line_vals', [])" t-as="foreach_vals">
+                        <t t-call="{{InvoiceLineType_template}}">
+                            <t t-set="vals" t-value="foreach_vals"/>
+                        </t>
+                    </cac:InvoiceLine>
+                </t>
+            </xpath>
+            <xpath expr="//*[local-name()='OrderReference']/*[local-name()='SalesOrderID']" position="replace"/>
+            <!-- Add Invoice UUID in compliance with rule BR-KSA-03 -->
+            <xpath expr="//*[local-name()='ID']" position="after">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:UUID t-out="invoice.l10n_sa_uuid"/>
+                </t>
+            </xpath>
+            <!-- Add Invoice Issue Time in compliance with rule KSA-25 -->
+            <xpath expr="//*[local-name()='IssueDate']" position="replace">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:IssueDate t-out="vals['issue_date'].strftime('%Y-%m-%d')"/>
+                    <cbc:IssueTime t-out="vals['issue_date'].strftime('%H:%M:%S')"/>
+                </t>
+            </xpath>
+            <!-- Add Previous Invoice Hash & Invoice Counter Value -->
+            <xpath expr="//*[local-name()='BillingReference']" position="after">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <!-- Add QR Code in compliance with rule BR-KSA-27 -->
+                    <cac:AdditionalDocumentReference t-if="invoice._l10n_sa_is_simplified()">
+                        <cbc:ID>QR</cbc:ID>
+                        <cac:Attachment>
+                            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">N/A</cbc:EmbeddedDocumentBinaryObject>
+                        </cac:Attachment>
+                    </cac:AdditionalDocumentReference>
+                    <!-- Add Previous Invoice Hash in compliance with rule BR-KSA-61 -->
+                    <cac:AdditionalDocumentReference>
+                        <cbc:ID>PIH</cbc:ID>
+                        <cac:Attachment>
+                            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain"
+                                t-out="vals.get('previous_invoice_hash')"/>
+                        </cac:Attachment>
+                    </cac:AdditionalDocumentReference>
+                    <!-- Add Invoice Counter Value in compliance with rules BR-KSA-33 and BR-KSA-34 -->
+                    <cac:AdditionalDocumentReference>
+                        <cbc:ID>ICV</cbc:ID>
+                        <cbc:UUID t-out="invoice.l10n_sa_chain_index"/>
+                    </cac:AdditionalDocumentReference>
+                    <!-- Add Signature references in compliance with rules BR-KSA-29 and BR-KSA-30 -->
+                    <cac:Signature t-if="invoice._l10n_sa_is_simplified()">
+                        <cbc:ID>urn:oasis:names:specification:ubl:signature:Invoice</cbc:ID>
+                        <cbc:SignatureMethod>urn:oasis:names:specification:ubl:dsig:enveloped:xades</cbc:SignatureMethod>
+                    </cac:Signature>
+                </t>
+            </xpath>
+        </template>
+
+        <template id="ubl_21_DebitNoteType_zatca" inherit_id="account_edi_ubl_cii.ubl_21_DebitNoteType" primary="True">
+            <!-- For ZATCA, we do not use DebitNoteLine tags. We always use InvoiceLine. -->
+            <xpath expr="//*[local-name()='DebitNoteLine']" position="replace">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                    <cac:InvoiceLine t-foreach="vals.get('line_vals', [])" t-as="foreach_vals">
+                        <t t-call="{{InvoiceLineType_template}}">
+                            <t t-set="vals" t-value="foreach_vals"/>
+                        </t>
+                    </cac:InvoiceLine>
+                </t>
+            </xpath>
+            <!-- For ZATCA, we do not use RequestedMonetaryTotal tags. We always use LegalMonetaryTotal. -->
+            <xpath expr="//*[local-name()='RequestedMonetaryTotal']" position="replace">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+                    <cac:LegalMonetaryTotal>
+                        <t t-call="{{MonetaryTotalType_template}}">
+                            <t t-set="vals" t-value="vals.get('monetary_total_vals', {})"/>
+                        </t>
+                    </cac:LegalMonetaryTotal>
+                </t>
+            </xpath>
+            <xpath expr="//*[local-name()='OrderReference']/*[local-name()='SalesOrderID']" position="replace"/>
+            <!-- Add Invoice UUID in compliance with rule BR-KSA-03 -->
+            <xpath expr="//*[local-name()='ID']" position="after">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:UUID t-out="invoice.l10n_sa_uuid"/>
+                </t>
+            </xpath>
+            <!-- Add Invoice Issue Time in compliance with rule KSA-25 -->
+            <xpath expr="//*[local-name()='IssueDate']" position="replace">
+                <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <cbc:IssueDate t-out="vals['issue_date'].strftime('%Y-%m-%d')"/>
+                    <cbc:IssueTime t-out="vals['issue_date'].strftime('%H:%M:%S')"/>
+                </t>
+            </xpath>
+            <!-- Add Previous Invoice Hash & Invoice Counter Value -->
+            <xpath expr="//*[local-name()='BillingReference']" position="after">
+                <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+                    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                    <!-- Add QR Code in compliance with rule BR-KSA-27 -->
+                    <cac:AdditionalDocumentReference t-if="invoice._l10n_sa_is_simplified()">
+                        <cbc:ID>QR</cbc:ID>
+                        <cac:Attachment>
+                            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain">N/A</cbc:EmbeddedDocumentBinaryObject>
+                        </cac:Attachment>
+                    </cac:AdditionalDocumentReference>
+                    <!-- Add Previous Invoice Hash in compliance with rule BR-KSA-61 -->
+                    <cac:AdditionalDocumentReference>
+                        <cbc:ID>PIH</cbc:ID>
+                        <cac:Attachment>
+                            <cbc:EmbeddedDocumentBinaryObject mimeCode="text/plain"
+                                t-out="vals.get('previous_invoice_hash')"/>
                         </cac:Attachment>
                     </cac:AdditionalDocumentReference>
                     <!-- Add Invoice Counter Value in compliance with rules BR-KSA-33 and BR-KSA-34 -->

--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -248,7 +248,11 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
         vals.update({
             'main_template': 'account_edi_ubl_cii.ubl_20_Invoice',
             'InvoiceType_template': 'l10n_sa_edi.ubl_21_InvoiceType_zatca',
+            'CreditNoteType_template': 'l10n_sa_edi.ubl_21_CreditNoteType_zatca',
+            'DebitNoteType_template': 'l10n_sa_edi.ubl_21_DebitNoteType_zatca',
             'InvoiceLineType_template': 'l10n_sa_edi.ubl_21_InvoiceLineType_zatca',
+            'CreditNoteLineType_template': 'l10n_sa_edi.ubl_21_CreditNoteLineType_zatca',
+            'DebitNoteLineType_template': 'l10n_sa_edi.ubl_21_DebitNoteLineType_zatca',
             'AddressType_template': 'l10n_sa_edi.ubl_21_AddressType_zatca',
             'PartyType_template': 'l10n_sa_edi.ubl_21_PartyType_zatca',
             'TaxTotalType_template': 'l10n_sa_edi.ubl_21_TaxTotalType_zatca',
@@ -257,8 +261,8 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
 
         vals['vals'].update({
             'profile_id': 'reporting:1.0',
-            'invoice_type_code_attrs': {'name': self._l10n_sa_get_invoice_transaction_code(invoice)},
-            'invoice_type_code': self._l10n_sa_get_invoice_type(invoice),
+            'document_type_code_attrs': {'name': self._l10n_sa_get_invoice_transaction_code(invoice)},
+            'document_type_code': self._l10n_sa_get_invoice_type(invoice),
             'tax_currency_code': invoice.company_currency_id.name,
             'issue_date': fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'),
                                                             invoice.l10n_sa_confirmation_datetime),
@@ -269,7 +273,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             'due_date': None,
         })
 
-        vals['vals']['legal_monetary_total_vals'].update(self._l10n_sa_get_monetary_vals(invoice, vals))
+        vals['vals']['monetary_total_vals'].update(self._l10n_sa_get_monetary_vals(invoice, vals))
 
         return vals
 
@@ -348,7 +352,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             line_vals['tax_total_vals'][0]['tax_amount'] = 0
             line_vals['prepayment_vals'] = self._l10n_sa_get_line_prepayment_vals(line, taxes_vals)
         line_vals['tax_total_vals'][0]['total_amount_sa'] = total_amount_sa
-        line_vals['invoiced_quantity'] = abs(line_vals['invoiced_quantity'])
+        line_vals['line_quantity'] = abs(line_vals['line_quantity'])
         line_vals['line_extension_amount'] = extension_amount
 
         return line_vals


### PR DESCRIPTION
*l10n_account_edi_ubl_cii_tests,l10n_sa_edi

Since some localizations use the concept of debit notes (e.g. Peru), we need to support the DebitNote UBL type in order to make these localizations inherit their electronic documents from the generic `account_edi_ubl_cii` module. In order to do so, we also refactored the current UBL structure to inherit more in order to not make the templates too complex when adding the debit note type.

[task-3415758](https://www.odoo.com/web#id=3415758&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

Related to https://github.com/odoo/enterprise/pull/46014
Related to https://github.com/odoo/upgrade/pull/5131

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
