### PR TITLE
[FIX] sale: resolve optional product with warning onchange

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -671,6 +671,7 @@ class SaleOrder(models.Model):
                 'warning': {
                     'title': _("Warning for %s", partner.name),
                     'message': partner.sale_warn_msg,
+                    'allowWarning': True,
                 }
             }
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -936,6 +936,7 @@ class SaleOrderLine(models.Model):
                 'warning': {
                     'title': _("Warning for %s", product.name),
                     'message': product.sale_line_warn_msg,
+                    'allowWarning': True,
                 }
             }
 

--- a/addons/sale/tests/test_onchange.py
+++ b/addons/sale/tests/test_onchange.py
@@ -20,6 +20,7 @@ class TestSaleOnchanges(TransactionCase):
             'warning': {
                 'title': "Warning for Test",
                 'message': partner_with_warning.sale_warn_msg,
+                'allowWarning': True,
             },
         })
 
@@ -29,6 +30,7 @@ class TestSaleOnchanges(TransactionCase):
             'warning': {
                 'title': "Warning for Test2",
                 'message': partner_with_block_warning.sale_warn_msg,
+                'allowWarning': True,
             },
         })
 
@@ -54,6 +56,7 @@ class TestSaleOnchanges(TransactionCase):
             'warning': {
                 'title': "Warning for Test Product",
                 'message': product_with_warning.sale_line_warn_msg,
+                'allowWarning': True,
             },
         })
 
@@ -64,6 +67,7 @@ class TestSaleOnchanges(TransactionCase):
             'warning': {
                 'title': "Warning for Test Product (2)",
                 'message': product_with_block_warning.sale_line_warn_msg,
+                'allowWarning': True,
             },
         })
 

--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -4357,10 +4357,11 @@ var BasicModel = AbstractModel.extend({
         });
 
         await this.generateDefaultValues(record.id, {}, { fieldNames });
+        let onChange;
         try {
-            await this._performOnChange(record, [], { firstOnChange: true });
+            onChange = await this._performOnChange(record, [], { firstOnChange: true });
         } finally {
-            if (record._warning && params.allowWarning) {
+            if (record._warning && (params.allowWarning || onChange.warning.allowWarning)) {
                 delete record._warning;
             }
         }

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6214,6 +6214,7 @@ class BaseModel(metaclass=MetaModel):
                     res['warning'].get('title') or _("Warning"),
                     res['warning'].get('message') or "",
                     res['warning'].get('type') or "",
+                    res['warning'].get('allowWarning') or False,
                 ))
 
         if onchange in ("1", "true"):
@@ -6530,15 +6531,16 @@ class BaseModel(metaclass=MetaModel):
         # format warnings
         warnings = result.pop('warnings')
         if len(warnings) == 1:
-            title, message, type = warnings.pop()
-            if not type:
-                type = 'dialog'
-            result['warning'] = dict(title=title, message=message, type=type)
+            title, message, warningType, allowWarning = warnings.pop()
+            if not warningType:
+                warningType = 'dialog'
+            result['warning'] = dict(title=title, message=message, type=warningType, allowWarning=allowWarning)
         elif len(warnings) > 1:
             # concatenate warning titles and messages
             title = _("Warnings")
             message = '\n\n'.join([warn_title + '\n\n' + warn_message for warn_title, warn_message, warn_type in warnings])
-            result['warning'] = dict(title=title, message=message, type='dialog')
+            allowWarning = all(warning[3] for warning in warnings)
+            result['warning'] = dict(title=title, message=message, type='dialog', allowWarning=allowWarning)
 
         return result
 


### PR DESCRIPTION
When `_performOnChange` returns a warning during execution of the `_makeDefaultRecord` method, the resulting promise will be rejected. This can unintentionally happen when adding an optional product to a sale order that has a `sale_warn_msg` configured. Passing the `allowWarning` option avoids the rejection of the promise.

opw-3436573