### PR TITLE
[FIX] point_of_sale: Fix typo that prevents reversal on refresh

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -2973,7 +2973,7 @@ exports.Paymentline = Backbone.Model.extend({
             payment_method_id: this.payment_method.id,
             amount: this.get_amount(),
             payment_status: this.payment_status,
-            can_be_reversed: this.can_be_resersed,
+            can_be_reversed: this.can_be_reversed,
             ticket: this.ticket,
             card_type: this.card_type,
             cardholder_name: this.cardholder_name,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes a typo on point_of_sale

Current behavior before PR:
Because of this typo, you cannot reverse the only payment after a refresh.

Desired behavior after PR is merged:
Now the can_be_reversed flag will be properly saved



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
