### PR TITLE
[FIX] mail: add missing function `evaluateBooleanExpr` in activity record

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_record.js
+++ b/addons/mail/static/src/views/web/activity/activity_record.js
@@ -4,6 +4,7 @@ import { ActivityCompiler } from "@mail/views/web/activity/activity_compiler";
 
 import { Component } from "@odoo/owl";
 
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { useService } from "@web/core/utils/hooks";
 import { Field } from "@web/views/fields/field";
 import {
@@ -25,6 +26,7 @@ export class ActivityRecord extends Component {
     static template = "mail.ActivityRecord";
 
     setup() {
+        this.evaluateBooleanExpr = evaluateBooleanExpr;
         this.user = useService("user");
         this.widget = {
             deletable: false,

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -77,6 +77,18 @@ QUnit.module("test_mail", {}, function () {
                         "</div>" +
                         "</templates>" +
                         "</activity>",
+                    "mail.test.activity,1,activity": `
+                        <activity string="MailTestActivity">
+                            <div t-name="activity-box">
+                                <span t-att-title="record.name.value">
+                                    <field name="name" display="full" class="w-100 text-truncate"/>
+                                </span>
+                                <span class="invisible_node" invisible="context.get('invisible', False)">
+                                    Test invisible
+                                </span>
+                            </div>
+                        </activity>
+                    `,
                 },
             };
         },
@@ -1031,6 +1043,40 @@ QUnit.module("test_mail", {}, function () {
                     "/web/image?model=partner&field=image&id=2&unique=1659688620000"
                 ),
             "image src is the preview image given in option"
+        );
+    });
+
+    QUnit.test("test node is visible with invisible attribute on node", async function (assert) {
+        const { target, openView } = await start({
+            serverData,
+        });
+        await openView({
+            res_model: "mail.test.activity",
+            views: [[1, "activity"]],
+        });
+
+        assert.containsN(
+            target,
+            ".invisible_node",
+            2,
+            "The node with the invisible attribute should be displayed since the context does not have `invisible` key or has falsy value"
+        );
+    });
+
+    QUnit.test("test node is not displayed with invisible attribute on node", async function (assert) {
+        const { target, openView } = await start({
+            serverData,
+        });
+        await openView({
+            res_model: "mail.test.activity",
+            views: [[1, "activity"]],
+            context: { invisible: true },
+        });
+
+        assert.containsNone(
+            target,
+            ".invisible_node",
+            "The node with the invisible attribute should be displayed since `invisible` key in the context contains truly value"
         );
     });
 });


### PR DESCRIPTION
Before this commit, when the user tries to access to activity view, a traceback is occurred because `ctx.__comp__.evaluateBooleanExpr` is not a function used inside the template of `ActivityRecord`. That function is in fact used in the view compiler but the ActivityRecord component does not have that function defined.

This commit defines that function in `ActivityRecord` component to correctly compile its template.

Steps to reproduce:
------------------
1. Install Project
2. Go to Project > Tasks > My Tasks
3. Select the activity view of `project.task`

Actual behavior:
---------------
A traceback is occurred saying `ctx.__comp__.evaluateBooleanExpr` is not a function.

Expected behavior:
-----------------
The activity view should be loaded as before.
