### PR TITLE
[FIX] web : display full note when editing

### DIFF
--- a/addons/web/static/src/views/fields/text/text_field.js
+++ b/addons/web/static/src/views/fields/text/text_field.js
@@ -47,10 +47,7 @@ export class TextField extends Component {
             preventLineBreaks: !this.props.lineBreaks,
         });
         useSpellCheck({ refName: "textarea" });
-
-        if (!this.props.readonly) {
-            useAutoresize(this.textareaRef, { minimumHeight: this.minimumHeight });
-        }
+        useAutoresize(this.textareaRef, { minimumHeight: this.minimumHeight });
     }
 
     get isTranslatable() {


### PR DESCRIPTION
Issue:
======
When you create a note in a sale order for example that has multiple lines.And then you want to update it, the note will only show one line.

Steps to reproduce:
===================
- Create a sale order and add a note with multiple lines
- Save the sale order and then click again on the note to update it.
- You will be able to see only 1 line at a time.

Origin of the problem:
======================
It seems that `this.props.readonly` in text_field evaluates to `true` when we are rendering it from a list. We are able to update it because in `list_renderer` we use `column.modifiers.readonly` in `isCellReadonly` function to check if it is readonly or not. so in text_field is readonly but in reality is not.

Solution:
=========
Since useEffect works only when we have a change to the element, I removed the condition of the check on readonly since if it's readonly it will never change and in other cases like this it will work too.

opw-3446781
opw-3465679