### PR TITLE
[FIX] loyalty: ewallet program creation

### DIFF
--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -281,6 +281,7 @@ class LoyaltyProgram(models.Model):
                 'rule_ids': [(5, 0, 0), (0, 0, {
                     'reward_point_amount': '1',
                     'reward_point_mode': 'money',
+                    'reward_point_split': False,
                     'product_ids': self.env.ref('loyalty.ewallet_product_50', raise_if_not_found=False),
                 })],
                 'reward_ids': [(5, 0, 0), (0, 0, {


### PR DESCRIPTION
When installing point_of_sale and loyalty modules, then creating an eWallet program, the user gets an error that prevents him from creating the program.

Steps to reproduce:
 - Install point_of_sale and loyalty
 - Open the settings of the default POS Shop
 - Click on the "Gift cards & eWallet" link (under "Promotions, Coupons, Gift Card & Loyalty Program" setting)
 - Click on "New" to create a new program
 - Change "Program Type" to "eWallet"
 - Set a name for the program, then click on the Save button (cloud button)

The error "Split per unit is not allowed for Loyalty and eWallet programs." is raised.

This error is due to the reward_point_split hidden and not modifiable by user field of loyalty.rule that is not correctly set. The fix consists in correctly setting reward_point_split for new eWallet programs.

task-id: 3474750