### PR TITLE
[FIX] base: handle ValueError for invalid domain

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -17862,6 +17862,13 @@ msgstr ""
 
 #. module: base
 #. odoo-python
+#: code:addons/base/models/ir_model.py:0
+#, python-format
+msgid "Invalid Python code '%s' for the domain field: %s"
+msgstr ""
+
+#. module: base
+#. odoo-python
 #: code:addons/base/models/ir_ui_view.py:0
 #, python-format
 msgid "Invalid composed field %(definition)s in %(use)s"

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -606,7 +606,12 @@ class IrModelFields(models.Model):
     @api.constrains('domain')
     def _check_domain(self):
         for field in self:
-            safe_eval(field.domain or '[]')
+            try:
+                safe_eval(field.domain or '[]')
+            except Exception as e:
+                raise ValidationError(
+                    _("Invalid Python code '%s' for the domain field: %s", field.domain, e)
+                ) from None
 
     @api.constrains('name')
     def _check_name(self):


### PR DESCRIPTION
This traceback appears when user adds a new field
(`many2one`, `one2many`, `many2many`) using studio and adds a invalid 
domain in `Domain` field.

Steps to reproduce:
1) Install `stock`, `web_studio`.
2) Open `Inventory` module > `Products` > `Products`. 
3) Click on any product to open its form view > `Studio` button. 
4) Drag and drop new `many2one` field.
5) Select any model (e.g `Product`) > `Confirm`.
6) Now click on that `New Many2One` field > `MORE` under `Properties`. 
7) Now enter any invalid domain (e.g `'qty_available'>10`) under `Properties`.

See the traceback:

```
TypeError: '>' not supported between instances of 'str' and 'int'
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  ?, line 1, in <module>
ValueError: <class 'TypeError'>: "'>' not supported between instances of 'str' and 'int'" while evaluating
"['qty_available'>10]"
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/enterprise/saas-16.4/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_model.py", line 1009, in write
    res = super(IrModelFields, self).write(vals)
  File "odoo/models.py", line 4069, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1439, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_model.py", line 597, in _check_domain
    safe_eval(field.domain or '[]')
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```

When user enters this wrong domain, the ValueError is raised from `safe_eval` 
method. So to handle I have used try-except block.

sentry-4399811257

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
