### PR TITLE
[FIX] base: check compute code while save the record

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1037,6 +1037,14 @@ class IrModelFields(models.Model):
             models = self.pool.descendants(patched_models, '_inherits')
             self.pool.init_models(self._cr, models, dict(self._context, update_custom_fields=True))
 
+        if self.compute:
+            sample_data = self.env[self.model_id.model].search([], limit=1)
+            if sample_data:
+                try:
+                    sample_data._fields[self.name].compute_value(sample_data)
+                except (ValueError, SyntaxError) as e:
+                    raise ValidationError(e)
+
         return res
 
     def update_field_translations(self, field_name, translations):


### PR DESCRIPTION
Traceback appears when user makes a mistake while writing compute code for a particular field and tries to open that field's record.

sentry traceback:
```
NameError: name 'record' is not defined
  File "odoo/tools/safe_eval.py", line 362, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  ?, line 4, in <module>
ValueError: <class 'NameError'>: "name 'record' is not defined" while evaluating
"for rec in self:\r\n    today = datetime.date.today()\r\n    if rec.birthday:\r\n        age = today.year - record.birthday.year\r\n        rec['x_age'] = rec.age\r\n    else:\r\n         rec['x_age'] = 0"
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6744, in onchange
    todo = [
  File "odoo/models.py", line 6747, in <listcomp>
    if name not in done and snapshot0.has_changed(name)
  File "odoo/models.py", line 6544, in has_changed
    return self[name] != record[name]
  File "odoo/models.py", line 6171, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1156, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1366, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1339, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 396, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4524, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 103, in determine
    return needle(records, *args)
  File "odoo/addons/base/models/ir_model.py", line 38, in <lambda>
    func = lambda self: safe_eval(text, SAFE_EVAL_BASE, {'self': self}, mode="exec")
  File "odoo/tools/safe_eval.py", line 376, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```

sentry-4401185352