### PR TITLE
[FIX] sale_project: raise usererror if no service type product in SO line

### DIFF
--- a/addons/sale_project/i18n/sale_project.pot
+++ b/addons/sale_project/i18n/sale_project.pot
@@ -445,6 +445,13 @@ msgstr ""
 
 #. module: sale_project
 #. odoo-python
+#: code:addons/sale_project/models/sale_order.py:0
+#, python-format
+msgid "Order lines have at least one service type product"
+msgstr ""
+
+#. module: sale_project
+#. odoo-python
 #: code:addons/sale_project/models/project.py:0
 #, python-format
 msgid "Other Services"

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -119,7 +119,10 @@ class SaleOrder(models.Model):
             action['views'] = [(form_view_id, 'form')]
             action['res_id'] = self.tasks_ids.id
         # set default project
-        default_line = next(sol for sol in self.order_line if sol.product_id.detailed_type == 'service')
+        if self.order_line.filtered(lambda line: line.product_id.detailed_type == 'service'):
+            default_line = next(sol for sol in self.order_line if sol.product_id.detailed_type == 'service')
+        else:
+            raise UserError(_("Order lines have at least one service type product"))
         default_project_id = default_line.project_id.id or self.project_id.id or self.project_ids[:1].id
 
         action['context'] = {


### PR DESCRIPTION
This error occurs when the user changes the product type to `consumable` in a sale order and click on the `Tasks` smart button.

Here are the steps to reproduce this issue:
- Install the `sale_project` module.
- Create a new sale order.
- Select any customer > Select a product with the `service` type.
- Click `Confirm`, then proceed to click the `Create Project` button.
- Give any name to the project > Return to that sale order.
- Now a `Tasks` smart button is visible > Click on that and create a task.
- Return to that sale order > Go to the order lines, and for the previously selected product, change the product type to `consumable`.
- Once again, go to that sale order and click on the `Tasks` smart button.
- Error will be generated.

See the traceback :
```
StopIteration: null
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/sale_project/models/sale_order.py", line 122, in action_view_task
    default_line = next(sol for sol in self.order_line if sol.product_id.detailed_type == 'service') 
```

To address this issue, we have added a user error message. If there are no service-type products in the sale order line, it will prevent this error from occurring.

sentry-4385351871

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
