### PR TITLE
[IMP] models: only log "long name constraint" when the constraint is added

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2833,10 +2833,12 @@ class BaseModel(metaclass=MetaModel):
             conname = '%s_%s' % (self._table, key)
             if len(conname) > 63:
                 hashed_conname = tools.make_identifier(conname)
-                _logger.info("Constraint name %r has more than 63 characters, internal PG identifier is %r", conname, hashed_conname)
+                current_definition = tools.constraint_definition(cr, self._table, hashed_conname)
+                if not current_definition:
+                    _logger.info("Constraint name %r has more than 63 characters, internal PG identifier is %r", conname, hashed_conname)
                 conname = hashed_conname
-
-            current_definition = tools.constraint_definition(cr, self._table, conname)
+            else:
+                current_definition = tools.constraint_definition(cr, self._table, conname)
             if current_definition == definition:
                 continue
 


### PR DESCRIPTION
This way, we avoid spamming the log each time new constraints are added in the constraint's table.

**Description of the issue/feature this PR addresses:**

- Install/update module A defines a constraint with a long name -> A log is shown.
- Install/update module B introduces a different constraint in the same model.  -> Same log as before is shown again.

This commit avoids that unneeded log repetition.

**Current behavior before PR:** When a table contains a hashed "long named constraint", each time a new constraint is added (from some other module), the same log is spammed.

**Desired behavior after PR is merged:** We avoid spamming same log each time new other constraints are added.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr