### PR TITLE
[FIX] mail: only prevent odoobot new messages during onboarding

### DIFF
--- a/addons/mail/static/src/core/messaging_service.js
+++ b/addons/mail/static/src/core/messaging_service.js
@@ -124,6 +124,7 @@ export class Messaging {
         });
         this.store.hasLinkPreviewFeature = data.hasLinkPreviewFeature;
         this.store.initBusId = data.initBusId;
+        this.store.odoobotOnboarding = data.odoobotOnboarding;
         this.isReady.resolve();
         this.store.isMessagingReady = true;
     }

--- a/addons/mail/static/src/core/store_service.js
+++ b/addons/mail/static/src/core/store_service.js
@@ -83,6 +83,7 @@ export class Store {
 
     /** @type {import("@mail/core/persona_model").Persona} */
     odoobot = null;
+    odoobotOnboarding = undefined;
     /** @type {Object.<number, import("@mail/core/persona_model").Persona>} */
     personas = {};
 

--- a/addons/mail/static/src/web/messaging_service_patch.js
+++ b/addons/mail/static/src/web/messaging_service_patch.js
@@ -67,10 +67,15 @@ patch(Messaging.prototype, "mail/web", {
         const message = this.store.messages[notif.payload.message.id];
         if (
             !this.store.isSmall &&
-            channel.correspondent !== this.store.odoobot &&
+            !(channel.correspondent === this.store.odoobot && this.store.odoobotOnboarding) &&
             !message.isSelfAuthored
         ) {
             this.chatWindowService.insert({ thread: channel });
+        }
+        if (channel.correspondent === this.store.odoobot && this.store.odoobotOnboarding) {
+            // odoobot onboarding was cancelled
+            // this lets new messages of odoobot be managed as any other new messages
+            this.store.odoobotOnboarding = false;
         }
     },
 });

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -25,9 +25,13 @@ class Users(models.Model):
         return super().SELF_READABLE_FIELDS + ['odoobot_state']
 
     def _init_messaging(self):
+        odoobot_onboarding = False
         if self.odoobot_state in [False, 'not_initialized'] and self._is_internal():
+            odoobot_onboarding = True
             self._init_odoobot()
-        return super()._init_messaging()
+        res = super()._init_messaging()
+        res['odoobotOnboarding'] = odoobot_onboarding
+        return res
 
     def _init_odoobot(self):
         self.ensure_one()


### PR DESCRIPTION
Before this commit, new messages from odoobot were never opening a chat window automatically.

This is desirable only during the onboarding process of the user, when first logging-in, as to not bully the new user. It is not intended to prevent all new messages from odoobot.

This commit fixes the issue by only preventing auto-opening of chat window of odoobot for the 1st step of the onboarding process.
