### PR TITLE
[FIX] mail: only prevent odoobot new messages during onboarding

### DIFF
--- a/addons/mail/static/src/core/common/messaging_service.js
+++ b/addons/mail/static/src/core/common/messaging_service.js
@@ -98,6 +98,7 @@ export class Messaging {
         });
         this.store.hasLinkPreviewFeature = data.hasLinkPreviewFeature;
         this.store.initBusId = data.initBusId;
+        this.store.odoobotOnboarding = data.odoobotOnboarding;
         this.isReady.resolve(data);
         this.store.isMessagingReady = true;
     }

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -90,6 +90,7 @@ export class Store {
 
     /** @type {import("@mail/core/common/persona_model").Persona} */
     odoobot = null;
+    odoobotOnboarding;
     /** @type {Object.<number, import("@mail/core/common/persona_model").Persona>} */
     personas = {};
 

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -48,13 +48,15 @@ export class DiscussCoreWeb {
         this.env.bus.addEventListener(
             "discuss.channel/new_message",
             ({ detail: { channel, message } }) => {
-                if (
-                    !this.ui.isSmall &&
-                    channel.correspondent !== this.store.odoobot &&
-                    !message.isSelfAuthored
-                ) {
-                    this.chatWindowService.insert({ thread: channel });
+                if (this.ui.isSmall || message.isSelfAuthored) {
+                    return;
                 }
+                if (channel.correspondent === this.store.odoobot && this.store.odoobotOnboarding) {
+                    // this cancels odoobot onboarding auto-opening of chat window
+                    this.store.odoobotOnboarding = false;
+                    return;
+                }
+                this.chatWindowService.insert({ thread: channel });
             }
         );
         this.busService.subscribe("mail.record/insert", (payload) => {

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -25,9 +25,13 @@ class Users(models.Model):
         return super().SELF_READABLE_FIELDS + ['odoobot_state']
 
     def _init_messaging(self):
+        odoobot_onboarding = False
         if self.odoobot_state in [False, 'not_initialized'] and self._is_internal():
+            odoobot_onboarding = True
             self._init_odoobot()
-        return super()._init_messaging()
+        res = super()._init_messaging()
+        res['odoobotOnboarding'] = odoobot_onboarding
+        return res
 
     def _init_odoobot(self):
         self.ensure_one()

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -126,6 +126,7 @@ class TestDiscussFullPerformance(HttpCase):
             'hasLinkPreviewFeature': True,
             'needaction_inbox_counter': 1,
             'starred_counter': 1,
+            'odoobotOnboarding': False,
             'channels': [
                 {
                     'authorizedGroupFullName': self.group_user.full_name,


### PR DESCRIPTION
Before this commit, new messages from odoobot were never opening a chat window automatically.

This is desirable only during the onboarding process of the user, when first logging-in, as to not bully the new user. It is not intended to prevent all new messages from odoobot.

This commit fixes the issue by only preventing auto-opening of chat window of odoobot for the 1st step of the onboarding process.
