### PR TITLE
[FIX] sale_timesheet: fix hide unnecessary field

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -118,7 +118,7 @@
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
                     <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->
-                    <field name="is_so_line_edited" invisible="1" />
+                    <field name="is_so_line_edited" column_invisible="True" />
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']" position="before">
                     <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->


### PR DESCRIPTION
Steps:

Install Project ,timesheet_grid & sale_timesheet
Open project module
Click on projects card
In list view ,create a new task
Then in timesheet notebook page

Issue:

Unnecessary field in timesheet notebook page

Cause:

There was some unnecessary field issue.

Fix:

added hide optional in sale_timesheet module.
task-3474577

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
