### PR TITLE
[IMP] web: notification close delay improvement

### DIFF
--- a/addons/web/static/src/core/notifications/notification.js
+++ b/addons/web/static/src/core/notifications/notification.js
@@ -34,6 +34,8 @@ Notification.props = {
         optional: true,
     },
     close: { type: Function },
+    refresh: { type: Function },
+    freeze: { type: Function },
 };
 Notification.defaultProps = {
     buttons: [],

--- a/addons/web/static/src/core/notifications/notification.xml
+++ b/addons/web/static/src/core/notifications/notification.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.NotificationWowl">
-        <div t-attf-class="o_notification {{props.className}} border border-{{props.type}} bg-white mb-2 position-relative"
+        <div t-on-mouseenter="this.props.freeze" t-on-mouseleave="this.props.refresh" t-attf-class="o_notification {{props.className}} border border-{{props.type}} bg-white mb-2 position-relative"
          role="alert" aria-live="assertive" aria-atomic="true">
             <strong t-if="props.title" t-attf-class="o_notification_title d-block text-{{props.type}} py-2 ps-3 pe-5" t-out="props.title"/>
             <button type="button" class="o_notification_close btn" aria-label="Close" t-on-click="props.close">

--- a/addons/web/static/src/core/notifications/notification_service.js
+++ b/addons/web/static/src/core/notifications/notification_service.js
@@ -49,16 +49,43 @@ export const notificationService = {
             const sticky = props.sticky;
             delete props.sticky;
             delete props.onClose;
+            let closeTimeout;
+            const refresh = sticky
+                ? () => {}
+                : () => {
+                      closeTimeout = browser.setTimeout(closeFn, AUTOCLOSE_DELAY);
+                  };
+            const freeze = sticky
+                ? () => {}
+                : () => {
+                      browser.clearTimeout(closeTimeout);
+                  };
+            props.refresh = refreshAll;
+            props.freeze = freezeAll;
             const notification = {
                 id,
                 props,
                 onClose: options.onClose,
+                refresh,
+                freeze,
             };
             notifications[id] = notification;
             if (!sticky) {
-                browser.setTimeout(closeFn, AUTOCLOSE_DELAY);
+                closeTimeout = browser.setTimeout(closeFn, AUTOCLOSE_DELAY);
             }
             return closeFn;
+        }
+
+        function refreshAll() {
+            for (const id in notifications) {
+                notifications[id].refresh();
+            }
+        }
+
+        function freezeAll() {
+            for (const id in notifications) {
+                notifications[id].freeze();
+            }
         }
 
         function close(id) {


### PR DESCRIPTION
This commit adds the functionality to refresh notifications when the user hovers on them to reset the close delay.

task-3444667

