### PR TITLE
[FIX] models: add xmlid for inherited selection values

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1359,8 +1359,8 @@ class IrModelSelection(models.Model):
         for field in fields:
             model = self.env[field.model_name]
             for value, modules in field._selection_modules(model).items():
-                if module in modules:
-                    xml_id = selection_xmlid(module, field.model_name, field.name, value)
+                for m in modules:
+                    xml_id = selection_xmlid(m, field.model_name, field.name, value)
                     record = self.browse(selection_ids[field.model_name, field.name, value])
                     data_list.append({'xml_id': xml_id, 'record': record})
         self.env['ir.model.data']._update_xmlids(data_list)


### PR DESCRIPTION
If model A has a selection field, and is inherited by 2 modules B and C, B adds selection values to the field, and C inherits model A under a different module and model names.
Based on the order of installation of B and C, we may end up with different xmlids.
If B is installed before C, then B will add xmlids for the new selection values added for model C. But if C is installed before B, then C will have the selection values from B without xmlids. The change here ensures that the selection values introduced by B will always have correct xmlids.

Manual forward-port of https://github.com/odoo/odoo/pull/127251