### PR TITLE
[FIX] l10n_{ar,in,cl}: remove data for unprotected uoms

### DIFF
--- a/addons/l10n_ar/data/uom_uom_data.xml
+++ b/addons/l10n_ar/data/uom_uom_data.xml
@@ -13,9 +13,6 @@
     <record model='uom.uom' id='uom.product_uom_unit'>
         <field name='l10n_ar_afip_code'>07</field>
     </record>
-    <record model='uom.uom' id='uom.product_uom_dozen'>
-        <field name='l10n_ar_afip_code'>09</field>
-    </record>
     <record model='uom.uom' id='uom.product_uom_cm'>
         <field name='l10n_ar_afip_code'>20</field>
     </record>
@@ -32,9 +29,6 @@
         <field name='l10n_ar_afip_code'>14</field>
     </record>
     <record model='uom.uom' id='uom.product_uom_gal'>
-        <field name='l10n_ar_afip_code'>98</field>
-    </record>
-    <record model='uom.uom' id='uom.product_uom_hour'>
         <field name='l10n_ar_afip_code'>98</field>
     </record>
     <record model='uom.uom' id='uom.product_uom_inch'>

--- a/addons/l10n_cl/data/uom_data.xml
+++ b/addons/l10n_cl/data/uom_data.xml
@@ -12,9 +12,6 @@
         <field name="l10n_cl_sii_code">10</field>
       </record>
 
-      <record id="uom.product_uom_dozen" model="uom.uom">
-        <field name="l10n_cl_sii_code">11</field>
-      </record>
 
       <record id="uom.product_uom_meter" model="uom.uom">
         <field name="l10n_cl_sii_code">14</field>

--- a/addons/l10n_in/data/uom_data.xml
+++ b/addons/l10n_in/data/uom_data.xml
@@ -6,9 +6,6 @@
     <record id="uom.product_uom_unit" model="uom.uom">
         <field name="l10n_in_code">UNT-UNITS</field>
     </record>
-    <record id="uom.product_uom_dozen" model="uom.uom">
-        <field name="l10n_in_code">DOZ-DOZENS</field>
-    </record>
     <record id="uom.product_uom_kgm" model="uom.uom">
         <field name="l10n_in_code">KGS-KILOGRAMS</field>
     </record>
@@ -16,9 +13,6 @@
         <field name="l10n_in_code">GMS-GRAMMES</field>
     </record>
     <record id="uom.product_uom_day" model="uom.uom">
-        <field name="l10n_in_code">OTH-OTHERS</field>
-    </record>
-    <record id="uom.product_uom_hour" model="uom.uom">
         <field name="l10n_in_code">OTH-OTHERS</field>
     </record>
     <record id="uom.product_uom_ton" model="uom.uom">


### PR DESCRIPTION
When the user deletes any unprotected uom and tries to install the module(l10n_ar, l10n_in, l10n_cl (any of one)) traceback appears.

Steps to produce:
1) Sale > Configurations > Units of Measure.
2) Search for 'Dozens' or 'Hour' and delete it.
3) Apps > Install the module.

Traceback:
```
Exception: Cannot update missing record 'uom.product_uom_dozen'
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 385, in _tag_record
    raise Exception("Cannot update missing record %r" % xid)
ParseError: while parsing /home/odoo/src/enterprise/saas-16.3/product_unspsc/data/product_data.xml:12, somewhere inside
<record id="uom.product_uom_dozen" model="uom.uom">
        <field name="unspsc_code_id" ref="product_unspsc.unspsc_code_DPC"/>
    </record>
  File "odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 482, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 366, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 245, in load_module_graph
    getattr(py_module, post_init)(env)
  File "home/odoo/src/enterprise/saas-16.3/product_unspsc/hooks.py", line 13, in post_init_hook
    _assign_codes_uom(env)
  File "home/odoo/src/enterprise/saas-16.3/product_unspsc/hooks.py", line 45, in _assign_codes_uom
    tools.convert.convert_file(
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

Sentry-4268684848
