### PR TITLE
[FIX] stock: prevent to create, edit and reselect same quants

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -816,6 +816,8 @@ Please change the quantity done or the rounding precision of your unit of measur
             'res_id': self.id,
             'context': dict(
                 self.env.context,
+                use_create_lots=self.picking_type_id.use_create_lots,
+                use_existing_lots=self.picking_type_id.use_existing_lots,
                 show_owner=not quant_mode,
                 show_quant=quant_mode,
                 show_lots_m2o=not quant_mode and self.has_tracking != 'none' and (self.picking_type_id.use_existing_lots or self.state == 'done' or self.origin_returned_move_id.id),  # able to create lots, whatever the value of ` use_create_lots`.

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -83,7 +83,7 @@ class StockMoveLine(models.Model):
     tracking = fields.Selection(related='product_id.tracking', readonly=True)
     origin = fields.Char(related='move_id.origin', string='Source')
     description_picking = fields.Text(string="Description picking")
-    quant_id = fields.Many2one('stock.quant', "Pick From", store=False)  # Dummy field for the detailed operation view
+    quant_id = fields.Many2one('stock.quant', "Pick From", store=True)  # Dummy field for the detailed operation view
 
     @api.depends('product_uom_id.category_id', 'product_id.uom_id.category_id', 'move_id.product_uom', 'product_id.uom_id')
     def _compute_product_uom_id(self):

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -29,6 +29,16 @@ export class SMLX2ManyField extends X2ManyField {
     }
 
     async onAdd({ context, editable } = {}) {
+        if(!this.props.context.use_create_lots && !this.props.context.use_existing_lots)
+        {
+            return super.onAdd({
+                editable,
+                context: {
+                    ...context,
+                }
+            });
+        }
+        this.activeActions.create = this.props.context.use_create_lots;
         context = {
             ...context,
             single_product: true,

--- a/addons/stock/static/src/widgets/stock_pick_from.js
+++ b/addons/stock/static/src/widgets/stock_pick_from.js
@@ -52,7 +52,7 @@ export class StockPickFrom extends Many2OneField {
             const result = name_parts.join(" - ");
             if (result) return result;
         }
-        return "";
+        return this.props.record.data.picking_id[1];
     }
 }
 


### PR DESCRIPTION
Before this commit:
===================
- Users had the ability to change, create, and edit the Lot/Serial number in the move line.
- After confirming the move line, the same Lot/Serial number was displayed.

After this commit:
==================
- Users are restricted from creating the Lot/Serial number of existing move lines.
- Resolved the issue of displaying the same Lot/Serial number in move lines after confirmation.

task - 3389249

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
