### PR TITLE
[REM] website_event_track_quiz: remove dead code

### DIFF
--- a/addons/website_event_track_quiz/static/src/scss/event_quiz.scss
+++ b/addons/website_event_track_quiz/static/src/scss/event_quiz.scss
@@ -20,20 +20,6 @@ $o-wslides-fs-side-width: 300px;
 .o_quiz_main {
     background-color: $o-wslides-color-bg;
 
-    .o_wslides_home_nav {
-        top: -40px;
-
-        @include media-breakpoint-up(lg) {
-            font-size: 1rem;
-
-            .o_wslides_nav_navbar_right {
-                padding-left: $spacer;
-                margin-left: auto;
-                border-left: 1px solid $border-color;
-            }
-        }
-    }
-
     .o_quiz_js_quiz {
         i.o_quiz_js_quiz_icon {
             cursor: pointer;


### PR DESCRIPTION
As it is not possible to have a `.o_wslides_home_nav` in a `o_quiz_main` we can remove the scss dead code related to it.

See: https://github.com/odoo/odoo/pull/129469#discussion_r1299713550

task-3476128