### PR TITLE
[FIX] bus: keep user log in debug mode tests

### DIFF
--- a/addons/bus/static/tests/helpers/mock_python_environment.js
+++ b/addons/bus/static/tests/helpers/mock_python_environment.js
@@ -76,7 +76,6 @@ async function getModelDefinitions() {
 }
 
 let _cookie = {};
-QUnit.testDone(() => (_cookie = {}));
 export const pyEnvTarget = {
     cookie: {
         get(key) {
@@ -323,7 +322,10 @@ export async function startServer({ actions, views = {} } = {}) {
     });
     pyEnv["mockServer"] = await makeMockServer({ actions, models, views });
     pyEnv["mockServer"].pyEnv = pyEnv;
-    registerCleanup(() => (pyEnv = undefined));
+    registerCleanup(() => {
+        pyEnv = undefined;
+        _cookie = {};
+    });
     if ("res.users" in pyEnv.mockServer.models) {
         const adminUser = pyEnv["res.users"].searchRead([["id", "=", pyEnv.adminUserId]])[0];
         pyEnv.authenticate(adminUser.login, adminUser.password);


### PR DESCRIPTION
Before this commit, the current user was cleared after every test. This is an issue since we can still interract with the page after the test is done when in debug mode. This commit fixes the issue by clearing the current user at the beginning of each test instead of the end.