### PR TITLE
[FIX] Calendar: Format query only once

### DIFF
--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -27,14 +27,13 @@ class Partner(models.Model):
 
             event_id = self.env['calendar.event']._search([])  # ir.rules will be applied
             subquery_string, subquery_params = event_id.select()
-            subquery = self.env.cr.mogrify(subquery_string, subquery_params).decode()
 
             self.env.cr.execute("""
                 SELECT res_partner_id, calendar_event_id, count(1)
                   FROM calendar_event_res_partner_rel
                  WHERE res_partner_id IN %s AND calendar_event_id IN ({})
               GROUP BY res_partner_id, calendar_event_id
-            """.format(subquery), [tuple(p["id"] for p in all_partners)])
+            """.format(subquery_string), [tuple(p["id"] for p in all_partners)]  + subquery_params)
 
             meeting_data = self.env.cr.fetchall()
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the "_compute_meeting" method, a subquery is prepared and merged into the executed query by "format".
If the subquery contains a "%" sign (could be caused by a "child_of" operator), the final formatting of the query breaks.

This patch uses the raw subquery string and lets the execute method format all parameters together.

Current behavior before PR:
Invalid query

Desired behavior after PR is merged:
No error




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
