### PR TITLE
[IMP] link_tracker: allow multiple clicks

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -293,11 +293,6 @@ class LinkTrackerClick(models.Model):
         if not tracker_code:
             return None
 
-        ip = route_values.get('ip', False)
-        existing = self.search_count(['&', ('link_id', '=', tracker_code.link_id.id), ('ip', '=', ip)])
-        if existing:
-            return None
-
         route_values['link_id'] = tracker_code.link_id.id
         click_values = self._prepare_click_values_from_route(**route_values)
 

--- a/addons/test_mass_mailing/tests/test_link_tracker.py
+++ b/addons/test_mass_mailing/tests/test_link_tracker.py
@@ -34,15 +34,6 @@ class TestLinkTracker(common.TestMassMailCommon):
         self.assertEqual(click.country_id, self.env.ref('base.be'))
         self.assertEqual(self.link.count, 2)
 
-        # click from same IP (even another country) does not create a new entry
-        click = self.env['link.tracker.click'].sudo().add_click(
-            code,
-            ip='100.00.00.01',
-            country_code='FRA'
-        )
-        self.assertEqual(click, None)
-        self.assertEqual(self.link.count, 2)
-
     @users('user_marketing')
     def test_add_link_mail_stat(self):
         record = self.env['mailing.test.blacklist'].create({})


### PR DESCRIPTION
This PR removes filter on ip so that each click should count as one.
previously multiple clicks from the same device only counted as one,
but now because of the ip removal, they are being counted as many
times as you go to the link.

task-3328661



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
