### PR TITLE
[FIX] web_editor: crop buttons out of the screen

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3706,6 +3706,12 @@ const SnippetOptionWidget = Widget.extend({
             }
             el.querySelector('.o_we_collapse_toggler').classList.toggle('d-none', hasNoVisibleElInCollapseMenu);
         }
+        for(const el of this.$el.parent().children()){
+            const classNames = el.classList
+            if(classNames.contains("snippet-option-CropTools")){
+                classNames.add("d-none");
+            }
+        }
     },
 
     //--------------------------------------------------------------------------
@@ -6015,6 +6021,14 @@ registry.ImageTools = ImageHandlerOption.extend({
      * @see this.selectClass for parameters
      */
     async crop() {
+        const siblingNodes = this.$el.parent().children();
+        for(const child of siblingNodes){
+            if(child.tagName === "WE-CUSTOMIZEBLOCK-OPTION" && !child.classList.contains("snippet-option-CropTools")){
+                child.classList.add("d-none")
+            } else {
+                child.classList.remove("d-none")
+            }
+        }
         this.trigger_up('hide_overlay');
         this.trigger_up('disable_loading_effect');
         const img = this._getImg();
@@ -6027,7 +6041,10 @@ registry.ImageTools = ImageHandlerOption.extend({
             media: img,
             mimetype: this._getImageMimetype(img),
         });
-
+        await imageCropWrapper.mount(imageCropWrapperElement);
+        // Hides the floating crop button toolbar
+        const cropBtns = this.$el[0].ownerDocument.querySelectorAll('.o_we_crop_buttons');
+        cropBtns.forEach(btn => btn.classList.add('d-none'));
         await new Promise(resolve => {
             this.$target.one('image_cropper_destroyed', async () => {
                 if (isGif(this._getImageMimetype(img))) {
@@ -6039,6 +6056,11 @@ registry.ImageTools = ImageHandlerOption.extend({
         });
         imageCropWrapperElement.remove();
         imageCropWrapper.destroy();
+        for(const child of siblingNodes){
+            if(child.tagName === "WE-CUSTOMIZEBLOCK-OPTION" && !child.classList.contains("snippet-option-CropTools")){
+                child.classList.remove("d-none")
+            }
+        }
         this.trigger_up('enable_loading_effect');
     },
     /**

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -57,6 +57,15 @@ export class ImageCrop extends Component {
                 this.state.active = true;
                 await this._show(this.props);
             }
+            const cropBtns = $el[0].ownerDocument.querySelectorAll('.o_we_user_value_widget.cropBtn');
+            if (cropBtns?.length) {
+                cropBtns.forEach(btn => {
+                    btn.addEventListener('click', (ev) => {
+                        const targetButton = ev.srcElement.nodeName === 'WE-BUTTON' ? ev.srcElement : ev.srcElement.closest('.o_we_user_value_widget.cropBtn');
+                        targetButton && this._onCropOptionClick(targetButton.dataset);
+                    });
+                });
+            }
             this.mountedResolve();
         });
         onWillUpdateProps((newProps) => {
@@ -227,7 +236,7 @@ export class ImageCrop extends Component {
      * @param {MouseEvent} ev
      */
     _onCropOptionClick(ev) {
-        const {action, value, scaleDirection} = ev.currentTarget.dataset;
+        const {action, value, scaleDirection} = ev.currentTarget ? ev.currentTarget.dataset : ev;
         switch (action) {
             case 'ratio':
                 this.$cropperImage.cropper('reset');
@@ -236,6 +245,7 @@ export class ImageCrop extends Component {
                 break;
             case 'zoom':
             case 'reset':
+                this.$cropperImage.cropper('setAspectRatio',0);
                 this.$cropperImage.cropper(action, value);
                 break;
             case 'rotate':

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -602,6 +602,8 @@ img.o_we_selected_image {
     @include o-position-absolute(0, 0, 0, 0);
     /* This value must be higher than dialog z-index in bootstrap */
     z-index: 1056;
+    height: 100%;
+    overflow: auto;
 
     .o_we_cropper_wrapper {
         position: absolute;
@@ -611,7 +613,6 @@ img.o_we_selected_image {
         margin-top: 0.5rem;
         display: flex;
         flex-wrap: wrap;
-        bottom: 1rem;
 
         input[type=radio] {
             display: none;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -207,7 +207,7 @@
     @include o-input-number-no-arrows();
     @include o-position-absolute(var(--o-we-toolbar-height), 0, 0, auto);
     position: fixed;
-    z-index: $o-we-zindex;
+    z-index: 1057;
     display: flex;
     flex-flow: column nowrap;
     width: $o-we-sidebar-width;

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -302,7 +302,7 @@
        >
         <div class="o_we_cropper_wrapper">
             <img class="o_we_cropper_img"/>
-            <div class="o_we_crop_buttons text-center mt16 position-fixed o_we_no_overlay" contenteditable="false">
+            <div class="o_we_crop_buttons text-center mt16 position-absolute o_we_no_overlay" contenteditable="false">
                 <div class="btn-group btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
                     <t t-foreach="this.aspectRatios" t-as="ratio" t-key="ratio">
                         <t t-set="is_active" t-value="ratio === this.aspectRatio"/>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -776,6 +776,49 @@
             <we-colorpicker data-color="true" data-color-name="c5"/>
         </we-row>
     </div>
+
+    <div data-js="CropTools" data-selector="img">
+        <div class="o_crop_tool o_crop_aspect_ratio">
+            <we-row string="Aspect Ratio">
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="0/0">Flexible</we-button>
+            </we-row>
+            <we-row string=" ">
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="16/9">16:9</we-button>
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="4/3">4:3</we-button>
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="1/1">1:1</we-button>
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="2/3">2:3</we-button>
+            </we-row>
+        </div>
+        <div class="o_crop_tool o_crop_zoom">
+            <we-row string="Zoom">
+                <we-button class="fa fa-fw fa-search-plus cropBtn" data-action="zoom" data-no-preview="true" data-value="0.1" title="Zoom In"/>
+                <we-button class="fa fa-fw fa-search-minus cropBtn" data-action="zoom" data-no-preview="true" data-value="-0.1" title="Zoom Out"/>
+            </we-row>
+        </div>
+        <div class="o_crop_tool o_crop_rotate">
+            <we-row string="Rotate">
+                <we-button class="fa fa-fw fa-rotate-left cropBtn" data-action="rotate" data-no-preview="true" data-value="-90" title="Rotate Left"/>
+                <we-button class="fa fa-fw fa-rotate-right cropBtn" data-action="rotate" data-no-preview="true" data-value="90" title="Rotate Right"/>
+            </we-row>
+        </div>
+        <div class="o_crop_tool o_crop_flip">
+            <we-row string="Flip">
+                <we-button class="fa fa-fw fa-arrows-h cropBtn" data-action="flip" data-no-preview="true" data-scale-direction="scaleX" title="Flip-Horizontal"/>
+                <we-button class="fa fa-fw fa-arrows-v cropBtn" data-action="flip" data-no-preview="true" data-scale-direction="scaleY" title="Flip-Vertical"/>
+            </we-row>
+        </div>
+        <div class="o_crop_tool o_crop_reset">
+            <we-row string="Reset">
+                <we-button class="cropBtn" data-action="reset" data-no-preview="true" title="Reset Image">Reset Image</we-button>
+            </we-row>
+        </div>
+        <div class="o_crop_tool">
+            <we-row string=" ">
+                <we-button class="btn o_we_bg_brand_primary cropBtn" data-action="apply" data-no-preview="true">Apply</we-button>
+                <we-button class="btn o_we_bg_danger cropBtn" data-action="discard" data-no-preview="true">Discard</we-button>
+            </we-row>
+        </div>
+    </div>
 </template>
 
 <!-- default block -->


### PR DESCRIPTION
Before this commit:
The crop buttons were attached to the bottom of the screen.

After this commit:
The crop buttons will be added to the sidebar in mass-mailing, 
website making the buttons more accessible.

taskId - 3258587
