### PR TITLE
[FIX] base: prevent use of deleted record on data creation

### DIFF
--- a/odoo/addons/test_convert/models.py
+++ b/odoo/addons/test_convert/models.py
@@ -8,6 +8,7 @@ class TestModel(models.Model):
     _description = "Test Convert Model"
 
     usered_ids = fields.One2many('test_convert.usered', 'test_id')
+    parent_id = fields.Many2one('test_convert.test_model', ondelete='cascade')
 
     @api.model
     def action_test_date(self, today_date):

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -566,7 +566,8 @@ form: module.record_id""" % (xml_id,)
                     f_val = val[0] + ',' + str(val[1])
                 else:
                     f_val = self.id_get(f_ref, raise_if_not_found=nodeattr2bool(rec, 'forcecreate', True))
-                    if not f_val:
+                    # the record may not exist anymore because of a cascade deletion
+                    if not f_val or (f_model and not env[f_model].browse(f_val).exists()):
                         _logger.warning("Skipping creation of %r because %s=%r could not be resolved", xid, f_name, f_ref)
                         return None
             else:


### PR DESCRIPTION
Suppose a record deleted by PSQL: since the ORM is unaware of this
change, it can lead to an inconsistency in the DB and, worst, it
can then prevent a module from being installed

To reproduce the issue:
1. Install `documents`
2. Documents > Configuration > Workspaces, edit Internal:
   - Parent Workspace: a new folder F
3. Clean Internal's content
4. Delete F
5. Install `project`

Error: an Odoo Error appears "psycopg2.errors.ForeignKeyViolation:
insert or update on table "documents_workflow_rule" [...]"

The field `parent_folder_id` has the `ondelete` attribute set to
`cascase`:
https://github.com/odoo/enterprise/blob/d44c1530d8ece85e2e96b4e0140f4b086c596963/documents/models/folder.py#L43-L46
Therefore, PSQL side, deleting F will also delete Internal. However,
since this is done on PSQL side, the ORM is not aware of the second
deletion. As a result, the `IrModelData` related to Internal is not
deleted. There is now an inconsistency on the DB.

Step 5, the user installs `project`. This implicitly installs
`documents_project`. In this module, we create a new record that
uses a reference to Internal (see `domain_folder_id`):
https://github.com/odoo/enterprise/blob/be2342bcba961472f2961b02916297030e839ff1/documents_project/data/documents_project_data.xml#L39-L49
During the data convertion and because the `IrModelData` of Internal
still exists, the value of `domain_folder_id` is set to Internal's
ID. But the folder does not exist anymore. As a result, the record
creation leads to a `psycopg2.errors.ForeignKeyViolation`, it breaks
the installation and the DB is now in an unstable stage (the app
Project is displayed on homepage but the related models do no exist)

Note that the current diff has a negative performance impact as it
increases the number of requests by ~5% [1]. Moreover, it does not
solve the root cause (the inconsistency is still in the DB). We may
also/rather want a clean of the `IrModelData`.

sentry-3937959802

[1] Tested locally on OE with few modules (account_accountant,mrp,
sale,purchase,project,crm) and remotly (runbot) on OC only.