### PR TITLE
[FIX] web_editor: crop button at bottom of the screen and animation when resetting an image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6026,7 +6026,10 @@ registry.ImageTools = ImageHandlerOption.extend({
      */
     async resetCrop() {
         const img = this._getImg();
-        const cropper = new weWidgets.ImageCropWidget(this, img, {mimetype: this._getImageMimetype(img)});
+        const cropper = new weWidgets.ImageCropWidget(this, img, {
+            mimetype: this._getImageMimetype(img),
+            resetImage: true,
+        });
         await cropper.appendTo(this.$el[0].ownerDocument.body);
         await cropper.reset();
         await this._reapplyCurrentShape();

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
@@ -41,6 +41,7 @@ const ImageCropWidget = Widget.extend({
         this.aspectRatio = data.aspectRatio || "0/0";
         const mimetype = data.mimetype || src.endsWith('.png') ? 'image/png' : 'image/jpeg';
         this.mimetype = options.mimetype || mimetype;
+        this.resetImage = options.resetImage || false;
     },
     /**
      * @override
@@ -49,7 +50,9 @@ const ImageCropWidget = Widget.extend({
         await this._super.apply(this, arguments);
         await loadImageInfo(this.media, this._rpc.bind(this));
         const isIllustration = /^\/web_editor\/shape\/illustration\//.test(this.media.dataset.originalSrc);
-        await this._scrollToInvisibleImage();
+        if (!this.resetImage) {
+            await this._scrollToInvisibleImage();
+        }
         if (this.media.dataset.originalSrc && !isIllustration) {
             this.originalSrc = this.media.dataset.originalSrc;
             this.originalId = this.media.dataset.originalId;

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop_widget.js
@@ -74,6 +74,7 @@ const ImageCropWidget = Widget.extend({
         }
         const _super = this._super.bind(this);
         const $cropperWrapper = this.$('.o_we_cropper_wrapper');
+        const $cropButtons = this.$('.o_we_crop_buttons');
 
         // Replacing the src with the original's so that the layout is correct.
         await loadImage(this.originalSrc, this.media);
@@ -86,6 +87,8 @@ const ImageCropWidget = Widget.extend({
         offset.left += parseInt(this.$media.css('padding-left'));
         offset.top += parseInt(this.$media.css('padding-right'));
         $cropperWrapper.offset(offset);
+        offset.top += parseInt(cropperImage.style.height) + 10;
+        $cropButtons.offset(offset);
 
         await loadImage(this.originalSrc, cropperImage);
         await activateCropper(cropperImage, this.aspectRatios[this.aspectRatio].value, this.media.dataset);

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -602,7 +602,6 @@ img.o_we_selected_image {
         margin-top: 0.5rem;
         display: flex;
         flex-wrap: wrap;
-        bottom: 1rem;
 
         input[type=radio] {
             display: none;

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -342,7 +342,7 @@
     </we-customizeblock-option>
 
     <!-- ImageCropWidget controls (allows to crop images on the page) -->
-    <div t-name="wysiwyg.widgets.crop" class="o_we_crop_widget" contenteditable="false">
+    <div t-name="wysiwyg.widgets.crop" t-att-class="'o_we_crop_widget ' + ( widget.resetImage ? 'd-none' : '' ) " contenteditable="false">
         <div class="o_we_cropper_wrapper">
             <img class="o_we_cropper_img"/>
         </div>

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -345,34 +345,34 @@
     <div t-name="wysiwyg.widgets.crop" class="o_we_crop_widget" contenteditable="false">
         <div class="o_we_cropper_wrapper">
             <img class="o_we_cropper_img"/>
-            <div class="o_we_crop_buttons text-center mt16 position-fixed o_we_no_overlay" contenteditable="false">
-                <div class="btn-group btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
-                    <t t-foreach="widget.aspectRatios" t-as="ratio">
-                        <t t-set="is_active" t-value="ratio === widget.aspectRatio"/>
-                        <label t-attf-class="btn #{is_active and 'active' or ''}" data-action="ratio" t-att-data-value="ratio">
-                            <input type="radio" /><t t-esc="ratio_value.label"/>
-                        </label>
-                    </t>
-                </div>
-                <div class="btn-group" role="group">
-                    <button type="button" title="Zoom In" data-action="zoom" data-value="0.1"><i class="fa fa-fw fa-search-plus"/></button>
-                    <button type="button" title="Zoom Out" data-action="zoom" data-value="-0.1"><i class="fa fa-fw fa-search-minus"/></button>
-                </div>
-                <div class="btn-group" role="group">
-                    <button type="button" title="Rotate Left" data-action="rotate" data-value="-90"><i class="fa fa-fw fa-rotate-left"/></button>
-                    <button type="button" title="Rotate Right" data-action="rotate" data-value="90"><i class="fa fa-fw fa-rotate-right"/></button>
-                </div>
-                <div class="btn-group" role="group">
-                    <button type="button" title="Flip Horizontal" data-action="flip" data-scale-direction="scaleX"><i class="fa fa-fw fa-arrows-h"/></button>
-                    <button type="button" title="Flip Vertical" data-action="flip" data-scale-direction="scaleY"><i class="fa fa-fw fa-arrows-v"/></button>
-                </div>
-                <div class="btn-group" role="group">
-                    <button type="button" title="Reset Image" data-action="reset"><i class="fa fa-refresh"/> Reset Image</button>
-                </div>
-                <div class="btn-group" role="group">
-                    <button type="button" title="Apply" data-action="apply" class="btn btn-primary"><i class="fa fa-check"/> Apply</button>
-                    <button type="button" title="Discard" data-action="discard" class="btn btn-danger"><i class="fa fa-times"/> Discard</button>
-                </div>
+        </div>
+        <div class="o_we_crop_buttons text-center mt32 position-absolute o_we_no_overlay" contenteditable="false">
+            <div class="btn-group btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
+                <t t-foreach="widget.aspectRatios" t-as="ratio">
+                    <t t-set="is_active" t-value="ratio === widget.aspectRatio"/>
+                    <label t-attf-class="btn #{is_active and 'active' or ''}" data-action="ratio" t-att-data-value="ratio">
+                        <input type="radio" /><t t-esc="ratio_value.label"/>
+                    </label>
+                </t>
+            </div>
+            <div class="btn-group" role="group">
+                <button type="button" title="Zoom In" data-action="zoom" data-value="0.1"><i class="fa fa-fw fa-search-plus"/></button>
+                <button type="button" title="Zoom Out" data-action="zoom" data-value="-0.1"><i class="fa fa-fw fa-search-minus"/></button>
+            </div>
+            <div class="btn-group" role="group">
+                <button type="button" title="Rotate Left" data-action="rotate" data-value="-90"><i class="fa fa-fw fa-rotate-left"/></button>
+                <button type="button" title="Rotate Right" data-action="rotate" data-value="90"><i class="fa fa-fw fa-rotate-right"/></button>
+            </div>
+            <div class="btn-group" role="group">
+                <button type="button" title="Flip Horizontal" data-action="flip" data-scale-direction="scaleX"><i class="fa fa-fw fa-arrows-h"/></button>
+                <button type="button" title="Flip Vertical" data-action="flip" data-scale-direction="scaleY"><i class="fa fa-fw fa-arrows-v"/></button>
+            </div>
+            <div class="btn-group" role="group">
+                <button type="button" title="Reset Image" data-action="reset"><i class="fa fa-refresh"/> Reset Image</button>
+            </div>
+            <div class="btn-group" role="group">
+                <button type="button" title="Apply" data-action="apply" class="btn btn-primary"><i class="fa fa-check"/> Apply</button>
+                <button type="button" title="Discard" data-action="discard" class="btn btn-danger"><i class="fa fa-times"/> Discard</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### **Before this PR:**
1. When user inserts an image and cropper is activated then the crop buttons used 
to appear at the bottom of the screen irrespective with the size of the image.
2. Resetting a cropped image caused a flickering effect due to the cropper 
widget being added to the DOM, changes being undone, and then the 
widget being removed again. This was particularly noticeable with large 
images that required scrolling.

### **After this PR:**
1. Now, when the image is inserted and the cropper is activated, the crop buttons 
appears at the bottom of the image.
2. To address this issue, we modified the behavior so that the cropper widget 
remains hidden throughout the reset process, eliminating the flickering
effect. Additionally, we prevent the image from being scrolled during the 
reset operation

**task-3258587**
