### PR TITLE
[FIX] web_editor: improve url regex

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -47,12 +47,12 @@ const tldWhitelist = [
     'ug', 'uk', 'um', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi', 'vn',
     'vu', 'wf', 'ws', 'ye', 'yt', 'yu', 'za', 'zm', 'zr', 'zw', 'co\\.uk'];
 
-const urlRegexBase = `|(?:[-a-zA-Z0-9@:%._\\+~#=]{1,64}\\.))[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-zA-Z][a-zA-Z0-9]{1,62}|(?:[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.(?:${tldWhitelist.join('|')})))\\b(?:(?!\\.)[^\\s]*`;
+const urlRegexBase = `|(?:[-a-zA-Z0-9@:%._\\+~#=]{1,64}\\.))[-a-zA-Z0-9@:%._\\+~#=]{2,256}(?:\\.[a-zA-Z][a-zA-Z0-9]{1,62}|))|(?:[-a-zA-Z0-9@:%._\\+~#=]{2,256}))\\.\\b(?:${tldWhitelist.join('|')})\\b(?:(?!\\.)[^\\s]*`;
 const httpRegex = `(?:https?:\\/\\/)`;
 const httpCapturedRegex= `(https?:\\/\\/)`;
 
-export const URL_REGEX = new RegExp(`((?:(?:${httpRegex}${urlRegexBase}))`, 'gi');
-export const URL_REGEX_WITH_INFOS = new RegExp(`((?:(?:${httpCapturedRegex}${urlRegexBase}))`, 'gi');
+export const URL_REGEX = new RegExp(`((?:(?:(?:${httpRegex}${urlRegexBase}))`, 'gi');
+export const URL_REGEX_WITH_INFOS = new RegExp(`((?:(?:(?:${httpCapturedRegex}${urlRegexBase}))`, 'gi');
 export const YOUTUBE_URL_GET_VIDEO_ID =
     /^(?:(?:https?:)?\/\/)?(?:(?:www|m)\.)?(?:youtube\.com|youtu\.be)(?:\/(?:[\w-]+\?v=|embed\/|v\/)?)([^\s?&#]+)(?:\S+)?$/i;
 

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/copyPaste.test.js
@@ -1259,9 +1259,9 @@ describe('Copy and paste', () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<a href="http://existing.com">[]c</a>d</p>',
                     stepFunction: async editor => {
-                        await pasteText(editor, 'https://www.xyz.xdc');
+                        await pasteText(editor, 'https://www.xyz.c');
                     },
-                    contentAfter: '<p>a<a href="https://www.xyz.xdcc">https://www.xyz.xdc[]c</a>d</p>',
+                    contentAfter: '<p>a<a href="https://www.xyz.cc">https://www.xyz.c[]c</a>d</p>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a<a href="http://existing.com">b[].com</a>d</p>',
@@ -1477,9 +1477,9 @@ describe('Copy and paste', () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab[<a href="http://www.xyz.com">http://www.xyz.com</a>]cd</p>',
                     stepFunction: async editor => {
-                        await pasteText(editor, 'https://www.xyz.xdc ');
+                        await pasteText(editor, 'https://www.xyz.be ');
                     },
-                    contentAfter: '<p>ab<a href="https://www.xyz.xdc">https://www.xyz.xdc</a> []cd</p>',
+                    contentAfter: '<p>ab<a href="https://www.xyz.be">https://www.xyz.be</a> []cd</p>',
                 });
             });
             it('should paste plain text content over a link if all of its contents is selected', async () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -44,7 +44,7 @@ describe('Link', () => {
         testUrlRegex('https://www.google.com/');
         testNotUrlRegex('google.shop/');
         testUrlRegex('http://google.com/foo#test');
-        testUrlRegex('a.bcd.ef');
+        testNotUrlRegex('a.bcd.ef');
         testUrlRegex('a.bc.de');
         testNotUrlRegex('a.bc.d');
         testNotUrlRegex('a.b.bc');

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/urlRegex.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/urlRegex.test.js
@@ -13,20 +13,20 @@ describe('urlRegex', () => {
         const match = text.match(URL_REGEX);
         chai.expect(match).to.be.equal(null);
     });
-    it('should match abc.abc.abc', () => {
-        const url = 'abc.abc.abc';
+    it('should match abc.abc.com', () => {
+        const url = 'abc.abc.com';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX);
         chai.expect(match[0]).to.be.equal(url);
     });
-    it('should match http://abc.abc.abc', () => {
-        const url = 'http://abc.abc.abc';
+    it('should match http://abc.abc.in', () => {
+        const url = 'http://abc.abc.in';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX);
         chai.expect(match[0]).to.be.equal(url);
     });
-    it('should match https://abc.abc.abc', () => {
-        const url = 'https://abc.abc.abc';
+    it('should match https://abc.abc.be', () => {
+        const url = 'https://abc.abc.be';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX);
         chai.expect(match[0]).to.be.equal(url);
@@ -58,20 +58,20 @@ describe('urlRegex with infos', () => {
         const match = text.match(URL_REGEX_WITH_INFOS);
         chai.expect(match).to.be.equal(null);
     });
-    it('should match abc.abc.abc', () => {
-        const url = 'abc.abc.abc';
+    it('should match abc.abc.com', () => {
+        const url = 'abc.abc.com';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX_WITH_INFOS);
         chai.expect(match[0]).to.be.equal(url);
     });
-    it('should match http://abc.abc.abc', () => {
-        const url = 'http://abc.abc.abc';
+    it('should match http://abc.abc.in', () => {
+        const url = 'http://abc.abc.in';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX_WITH_INFOS);
         chai.expect(match[0]).to.be.equal(url);
     });
-    it('should match https://abc.abc.abc', () => {
-        const url = 'https://abc.abc.abc';
+    it('should match https://abc.abc.be', () => {
+        const url = 'https://abc.abc.be';
         const text = `abc ${url} abc`;
         const match = text.match(URL_REGEX_WITH_INFOS);
         chai.expect(match[0]).to.be.equal(url);


### PR DESCRIPTION
Current behavior before PR:

There were certain issues with the URL regex, wherein it failed to validate
against domain list under certain circumstances involving URLs with two dots.
for eg. this.document.anything

Desired behavior after PR is merged:

The URL regex is modified to ensure that it consistently validated against the
domain list in all scenarios.

task-3468646