### PR TITLE
[FIX] hr_work_entry_holidays: fix duration of the leave

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -767,7 +767,10 @@ class HolidaysRequest(models.Model):
             False)
 
         hours = self.env.company.resource_calendar_id.get_work_hours_count(date_from, date_to)
-        days = hours / (today_hours or HOURS_PER_DAY) if not self.request_unit_half else 0.5
+        if self.request_unit_half or hours <= (self.env.company.resource_calendar_id.hours_per_day * 3 / 4):
+            days = 0.5
+        else:
+            days = hours / (today_hours or HOURS_PER_DAY)
         return {'days': days, 'hours': hours}
 
     def _adjust_date_based_on_tz(self, leave_date, hour):

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -239,11 +239,11 @@ Contracts:
             # Use sudo otherwise base users can't compute number of days
             contracts = employee.sudo()._get_contracts(date_from, date_to, states=['open', 'close'])
             contracts |= employee.sudo()._get_incoming_contracts(date_from, date_to)
-            calendar = contracts[:1].resource_calendar_id if contracts else self.env.company.resource_calendar_id # Note: if len(contracts)>1, the leave creation will crash because of unicity constaint
+            calendar = contracts[:1].resource_calendar_id if contracts else employee.company_id.resource_calendar_id # Note: if len(contracts)>1, the leave creation will crash because of unicity constaint
             # We force the company in the domain as we are more than likely in a compute_sudo
             domain = [('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
             result = employee._get_work_days_data_batch(date_from, date_to, calendar=calendar, domain=domain)[employee.id]
-            if self.request_unit_half and result['hours'] > 0:
+            if self.request_unit_half and result['hours'] > 0 or result['hours'] <= (calendar.hours_per_day * 3 / 4):
                 result['days'] = 0.5
             return result
 

--- a/addons/hr_work_entry_holidays/models/hr_leave.py
+++ b/addons/hr_work_entry_holidays/models/hr_leave.py
@@ -239,7 +239,7 @@ Contracts:
             # Use sudo otherwise base users can't compute number of days
             contracts = employee.sudo()._get_contracts(date_from, date_to, states=['open', 'close'])
             contracts |= employee.sudo()._get_incoming_contracts(date_from, date_to)
-            calendar = contracts[:1].resource_calendar_id if contracts else None # Note: if len(contracts)>1, the leave creation will crash because of unicity constaint
+            calendar = contracts[:1].resource_calendar_id if contracts else self.env.company.resource_calendar_id # Note: if len(contracts)>1, the leave creation will crash because of unicity constaint
             # We force the company in the domain as we are more than likely in a compute_sudo
             domain = [('company_id', 'in', self.env.company.ids + self.env.context.get('allowed_company_ids', []))]
             result = employee._get_work_days_data_batch(date_from, date_to, calendar=calendar, domain=domain)[employee.id]

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -41,7 +41,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_write(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=20, admin=28):
+        with self.assertQueryCount(__system__=21, admin=29):
             leave.date_to = datetime(2018, 1, 1, 19, 0)
         leave.action_refuse()
 

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -41,7 +41,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_write(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=21, admin=29):
+        with self.assertQueryCount(__system__=22, admin=30):
             leave.date_to = datetime(2018, 1, 1, 19, 0)
         leave.action_refuse()
 
@@ -57,7 +57,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_confirm(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_draft()
-        with self.assertQueryCount(__system__=40, admin=40):
+        with self.assertQueryCount(__system__=42, admin=41):
             leave.action_confirm()
         leave.state = 'refuse'
 


### PR DESCRIPTION
1) Before these PR when we install the hr_work_entry_holiday module we find these issue if we go to the time off and if emp does not have contract and working schedule then they not able to taking time off. Fix :
After making some required changes in hr_work_entry_holiday module Emp should be able to take time off while emp working schedule removing from emp work information.
If there is no emp working schedule it will take company working hours.

2) Fix duration of the leave
When the company works for half a day and the employee takes
a day off, the leave period will appear as a half day
instead of a full day.

I got the below reference on how to calculate half a day.

https://github.com/odoo/odoo/commit/a9b804b1ad6c8fb34e6ac09d8134eacbce174760

task-3454657