### PR TITLE
[FIX] payment: prevent TypeError in checkout with one shipping method

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale/static/src/js/website_sale_delivery.js
@@ -33,7 +33,8 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
                 const payButton = document.querySelector('button[name="o_payment_submit_button"]');
                 payButton? payButton.disabled = true : null;
             } else {
-                carrierChecked[0].click();
+                // add a delay to ensure synchronization with other widgets
+                window.setTimeout(() => carrierChecked[0].click());
             }
         }
 


### PR DESCRIPTION
When utilizing the "Pickup in Store" shipping method in conjunction with the "Pay in store when picking the product" payment option (website_sale_picking), an issue arises leading to a TypeError. The error is attributed to undefined properties being assigned values. This situation is triggered because the "website_sale_delivery" module initializes before the payment form, prematurely invoking specific methods.

To solve this issue a minimal delay has been introduced. This delay allows other widgets to initialize before further actions are taken.

To Reproduce the Issue:
1. Install the "website_sale" module.
2. Install the "website_sale_picking" module.
3. Deactivate all shipping methods except "Pickup in Store."
4. Deactivate all payment methods except "Pay in store ..."
5. Create an order on the website and proceed to the checkout.

opw-3475563

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
