### PR TITLE
[FIX] mail, calendar: flicker in activity dialog

### DIFF
--- a/addons/calendar/views/mail_activity_views.xml
+++ b/addons/calendar/views/mail_activity_views.xml
@@ -27,6 +27,7 @@
             <xpath expr="//button[@name='action_close_dialog']" position="before">
                   <field name="calendar_event_id" invisible="1" />
                   <button string="Open Calendar"
+                        close="1"
                         invisible="activity_category not in ['meeting', 'phonecall'] or calendar_event_id"
                         name="action_create_calendar_event"
                         type="object"

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -134,7 +134,7 @@
                     <field name="note" class="oe-bordered-editor" placeholder="Log a note..."/>
                     <footer>
                         <field name="id" invisible="1"/>
-                        <button id="mail_activity_schedule" string="Schedule" name="action_close_dialog" type="object" class="btn-primary"
+                        <button id="mail_activity_schedule" string="Schedule" close="1" name="action_close_dialog" type="object" class="btn-primary"
                             invisible="id" data-hotkey="q"/>
                         <button id="mail_activity_save" string="Save" name="action_close_dialog" type="object" class="btn-primary"
                             invisible="not id" data-hotkey="q"/>


### PR DESCRIPTION
This commit solves a flicker in the action buttons of the activity dialog:
- open project task kanban view
- schedule an activity on a record => this open a dialog
- in that dialog, notice the Schedule button
- click on it
- the button is now, for a small amount of time, replaced by a Save button (If the network goes bad, it can be pretty obvious. Reproduced with the network dev tool)
- the dialog is closed 

When creating a meeting, the save button would be added to the buttons for a small amount of time without replacing any other button instead. By adding the close=1 attribute, the form view of the dialog will no longer reload after the create call which prevents the flicker.

task-3270301
