### PR TITLE
[FIX] Manufacturing: Fix Trace back Error when click on mrp work orders menu.

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -126,7 +126,7 @@
                 <field name="production_id" optional="hide"/>
             </field>
             <field name="state" position="attributes">
-                <attribute name="invisible">production_state == 'draft'</attribute>
+                <attribute name="column_invisible">0</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION

**Description of the issue/feature this PR addresses:**
Fix Work orders Menu Trace back form Manufacturing.

**Impacted versions:**
* master

**Steps to Reproduce :**
- Go to the Manufacturing --> Configuration --> Check Work orders and save.  
- Now system visible the Work orders menu under Manufacturing --> Operations.
- Click on Work Orders menu.

**Current behaviour before PR:**
System showing below Trace back.

UncaughtPromiseError > OwlError
Uncaught Promise > An error occured in the owl lifecycle (see this Error's "cause" property)

Caused by: EvalError: Can not evaluate python expression: (bool(parent.state == 'draft'))
Error: Name 'parent' is not defined

**Desired behaviour after PR is merged:**
After this PR merge, System will allow to open work orders without Trace back.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
