### PR TITLE
[FIX] sale_timesheet: updating view modifiers

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -118,7 +118,7 @@
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
                     <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->
-                    <field name="is_so_line_edited" invisible="1" />
+                    <field name="is_so_line_edited" column_invisible="True"/>
                 </xpath>
                 <xpath expr="//field[@name='timesheet_ids']/tree/field[@name='unit_amount']" position="before">
                     <!-- <field name="timesheet_ids"/> is already inside a block groups="hr_timesheet.group_hr_timesheet_user"  -->


### PR DESCRIPTION
**Steps:**
- Open project.task form view in Field Service
- Go to Timesheets page
- the 'is sales order item manually edited' field is visible in Field Service

**Issue:**
- The technical field is displayed to the user

**Cause:**
- The view modifier is not updated

**Fix:**
- Using column_invisible instead of invisible.

**Task:** 3461563