### PR TITLE
[IMP] web: Not use locale for float inputs parsing

### DIFF
--- a/addons/web/static/tests/views/fields/float_field_tests.js
+++ b/addons/web/static/tests/views/fields/float_field_tests.js
@@ -557,4 +557,36 @@ QUnit.module("Fields", (hooks) => {
             "should contain a number rounded to 1 decimal"
         );
     });
+
+    QUnit.test("float field try parse with wrong localization parameters", async function (assert) {
+        assert.expect(2);
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            resId: 1,
+            arch: '<form><field name="float_field"/></form>',
+        });
+
+        registry.category("services").remove("localization");
+        registry
+            .category("services")
+            .add(
+                "localization",
+                makeFakeLocalizationService({ thousandsSep: " ", decimalPoint: "." })
+            );
+
+        await editInput(target, 'div[name="float_field"] input', "108,245,193.85");
+        assert.strictEqual(
+            target.querySelector(".o_field_float input").value,
+            "108245193.85",
+            "should detect automatically that , are thousand separator and . is decimal separator"
+        );
+        await editInput(target, 'div[name="float_field"] input', "108 245 193,85");
+        assert.strictEqual(
+            target.querySelector(".o_field_float input").value,
+            "108245193.85",
+            "should detect automatically that ' ' are thousand separator and , is decimal separator"
+        );
+    });
 });

--- a/addons/web/static/tests/views/fields/parsers_tests.js
+++ b/addons/web/static/tests/views/fields/parsers_tests.js
@@ -5,6 +5,7 @@ import {
     parseFloat,
     parseFloatTime,
     parseInteger,
+    parseNumber,
     parsePercentage,
     parseMonetary,
 } from "@web/views/fields/parsers";
@@ -36,7 +37,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(parseFloat("1,000.00"), 1000);
         assert.strictEqual(parseFloat("1,000,000.00"), 1000000);
         assert.strictEqual(parseFloat("1,234.567"), 1234.567);
-        expectInvalidNumberError(assert, parseFloat, "1.000.000");
+        assert.strictEqual(parseFloat("1.000.000"), 1e6);
 
         patchWithCleanup(localization, { decimalPoint: ",", thousandsSep: "." });
         assert.strictEqual(parseFloat("1.234,567"), 1234.567);
@@ -95,6 +96,35 @@ QUnit.module("Fields", (hooks) => {
 
         patchWithCleanup(localization, { decimalPoint: ",", thousandsSep: false });
         assert.strictEqual(parseInteger("1000000"), 1000000);
+    });
+
+    QUnit.test("parseNumber", function (assert) {
+        assert.strictEqual(parseNumber("123456"), 123456);
+        assert.strictEqual(parseNumber("1 234 56"), 123456);
+        assert.strictEqual(parseNumber("1234.56"), 1234.56);
+        assert.strictEqual(parseNumber("1234.56", { decimalPoint: "," }), 1234.56);
+        assert.strictEqual(parseNumber("1234,56"), 1234.56);
+        assert.strictEqual(parseNumber("1234,56", { decimalPoint: "," }), 1234.56);
+        assert.strictEqual(parseNumber("1.234.56"), 123456);
+        assert.strictEqual(parseNumber("1.234,56"), 1234.56);
+        assert.strictEqual(parseNumber(".56"), 0.56);
+        assert.strictEqual(parseNumber(",56"), 0.56);
+        assert.strictEqual(parseNumber("1,234.56"), 1234.56);
+        assert.strictEqual(parseNumber("123.456", { thousandsSep: "." }), 123456);
+        assert.strictEqual(parseNumber("123.456"), 123.456);
+        assert.strictEqual(parseNumber("123,456", { thousandsSep: "," }), 123456);
+        assert.strictEqual(parseNumber("123,456"), 123.456);
+        assert.strictEqual(parseNumber("12,34,567.89"), 1234567.89);
+        assert.strictEqual(parseNumber("0,809"), 0.809);
+        assert.strictEqual(parseNumber("10,809", { thousandsSep: "," }), 10809);
+        assert.strictEqual(parseNumber("10,809"), 10.809);
+        assert.strictEqual(parseNumber("123,456,789"), 123456789);
+        assert.strictEqual(parseNumber("1234."), 1234);
+        assert.strictEqual(parseNumber("1234,"), 1234);
+        assert.strictEqual(parseNumber("123,456."), 123456);
+        assert.strictEqual(parseNumber("123,456.78"), 123456.78);
+        assert.strictEqual(parseNumber("10 000,45"), 10000.45);
+        assert.strictEqual(parseNumber("9 876,543"), 9876.543);
     });
 
     QUnit.test("parsePercentage", function (assert) {


### PR DESCRIPTION
Avoid faulty inputs caused by a weird parsing/detection mixup between thousand and decimal separator. We must let go of the (wrong) assumption that people will paste numbers into the format defined on their locale. We should not depend on the locale for number parsing as much as possible.

The locale format can still be used for formatting of course, so this config has its use - but parsing should be much more agnostic.

A new function has been added in this commit "lenientParseNumber(value, options)" that detects separators with regex and tries to interpret the correct value of the number taking into account the separations.

task-3092583