### PR TITLE
[FIX] mail: sending from current user

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1872,6 +1872,9 @@ class MailThread(models.AbstractModel):
         done_partners += [partner for partner in partners]
         remaining = [email for email in normalized_emails if email not in [partner.email_normalized for partner in done_partners]]
 
+        # prioritize current user if exists in list
+        done_partners.sort(key=lambda p: self.env.user.partner_id != p)
+
         # iterate and keep ordering
         partners = []
         for contact in emails:

--- a/addons/mail/tests/test_mail_tools.py
+++ b/addons/mail/tests/test_mail_tools.py
@@ -22,6 +22,12 @@ class TestMailTools(MailCommon):
             'phone': '0456334455',
         })
 
+        cls.test_user = cls.env['res.users'].create({
+            'login': 'adam',
+            'name': 'Adam',
+            'partner_id': cls.test_partner.id,
+        })
+
         cls.sources = [
             # single email
             'alfred.astaire@test.example.com',
@@ -106,6 +112,12 @@ class TestMailTools(MailCommon):
             # test with wildcard "_"
             found = Partner._mail_find_partner_from_emails(['alfred_astaire@test.example.com'])
             self.assertEqual(found, [self.env['res.partner']])
+
+        # test users with same email, priority given to current user
+        # --------------------------------------------------------------
+        self.test_user.sudo().write({'email': '"Alfred Astaire" <%s>' % self.env.user.partner_id.email_normalized})
+        found = Partner._mail_find_partner_from_emails([self.env.user.partner_id.email_formatted])
+        self.assertEqual(found, [self.env.user.partner_id])
 
     @users('employee')
     def test_tools_email_re(self):


### PR DESCRIPTION
To reproduce
============
- login as Mitchell Admin
- change the email of a portal user, ex: Joel Willis, to the same email as Mitchell Admin. Do this through the Contacts App
- always connected as Mitchell Admin, create a sale order and send it by email to client, in chatter the sender will be Joel Willis

Problem
=======
when setting the author, `_mail_find_partner_from_emails` is called, when searching for users with the given email, two results are found and the first one is taken as author

Solution
========
give the priority to the current user when it matches the given conditions

opw-3455520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
