### PR TITLE
[FIX] hr_recruitment: bypass interviewer access being officer or more

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -459,7 +459,8 @@ class Applicant(models.Model):
 
     @api.model
     def get_view(self, view_id=None, view_type='form', **options):
-        if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer'):
+        if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer')\
+            and not self.user_has_groups('hr_recruitment.group_hr_recruitment_user'):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
         return super().get_view(view_id, view_type, **options)
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- belong to the 'Officer: Manage all applicants' group or higher access;
- via settings, in groups, be a 'Recruitment Interviewer';
- go to the Recruitment app.

Issue:
------
We only have access to the records we are interviewing.

Solution:
---------
Bypass `group_hr_recruitment_interviewer` access
with `group_hr_recruitment_user`.

Note:
-----
Partial commit backport: 23c6df4683bf00578648b6af56f61d3ab01e8d20

opw-3468922