### PR TITLE
[FIX] mrp: allow access to workorder tree view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -127,6 +127,7 @@
             </field>
             <field name="state" position="attributes">
                 <attribute name="invisible">production_state == 'draft'</attribute>
+                <attribute name="column_invisible">False</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Following 332c117, the list of workorders cannot be accessed from the menu. This is due to the `parent` not being defined in this case. The `column_invisible` clause is useful when using the tree view from within a MO form.

The tree view accessed from the menu already uses a modified version, so we use this modified version to get rid of the problematic `column_invisible` that has little sense in this use-case.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
