### PR TITLE
[FIX] hr_expense: set accounting date if move exists

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1004,7 +1004,8 @@ class HrExpenseSheet(models.Model):
     @api.depends('account_move_id.date')
     def _compute_accounting_date(self):
         for sheet in self:
-            sheet.accounting_date = sheet.account_move_id.date
+            if sheet.account_move_id:
+                sheet.accounting_date = sheet.account_move_id.date
 
     @api.depends('employee_id', 'employee_id.department_id')
     def _compute_from_employee_id(self):


### PR DESCRIPTION
If there is no account_move_id for a sheet, it will not set the accounting date and will also prevent the default date from being assigned to the accounting date.

Steps to reproduce:

1. Open Odoo in debug mode.
2. Create an expense.
3. Create a report and submit it to the manager and approve it.
4. Set the default value for the accounting date through the Odoo debug menu.
5. Create a new expense and check the default date for the accounting date field.

Current Behavior:
The accounting date is not set as the default value because it's a computed field.

Expected Behavior:
The default value should be applied to the accounting date field if there does not exist a value with precedence over the default value.

OPW-3441231

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
