### PR TITLE
[FIX] account: fix the bank account onboarding

### DIFF
--- a/addons/account/static/src/components/setup_wizards/setup_wizards.js
+++ b/addons/account/static/src/components/setup_wizards/setup_wizards.js
@@ -1,0 +1,27 @@
+/** @odoo-module **/
+import { formView } from "@web/views/form/form_view";
+import { registry } from "@web/core/registry";
+import OnboardingStepFormController from "@onboarding/views/form/onboarding_step_form_controller";
+
+
+export default class SetupBankManualConfigFormController extends OnboardingStepFormController {
+    /**
+     * @override
+     */
+    get stepName() {
+        return "account.onboarding_onboarding_step_bank_account";
+    }
+    /**
+     * Reload the view to show the newly created bank account
+     */
+    get stepConfig() {
+        return { ...super.stepConfig, reloadAlways: true };
+    }
+}
+
+const SetupBankManualConfigFormView = {
+    ...formView,
+    Controller: SetupBankManualConfigFormController,
+};
+
+registry.category("views").add('setup_bank_manual_config_form', SetupBankManualConfigFormView);

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -34,7 +34,7 @@
             <field name="name">account.online.sync.res.partner.bank.setup.form</field>
             <field name="model">account.setup.bank.manual.config</field>
             <field name="arch" type="xml">
-                <form>
+                <form js_class="setup_bank_manual_config_form">
                     <field name="num_journals_without_account" invisible="1"/>
                     <field name="journal_id" invisible="1"/>
                     <field name="company_id" invisible="1"/>


### PR DESCRIPTION
If a bank account is added through the onboarding step and the user creates one instead of linking it, the dashboard is not reloaded to show the completion of the step and the new account. To make sure that the view is reloaded to show new data, we can add a `reloadAlways: true` to the `stepConfig` in the form controller.

task-3431961



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
