### PR TITLE
[IMP] sale: add menu to access product categories

### DIFF
--- a/addons/sale/views/sale_menus.xml
+++ b/addons/sale/views/sale_menus.xml
@@ -112,6 +112,10 @@
                     groups="product.group_product_variant"
                     sequence="10"/>
 
+                <menuitem id="menu_product_categories"
+                    action="product.product_category_action_form"
+                    sequence="20"/>
+
             </menuitem>
 
             <menuitem id="next_id_16"


### PR DESCRIPTION
Since the new product catalog provides filtering by product categories, and the pricelist rules have long been configurable by product categories, it makes sense to allow users to configure categories directly in the sales application.

