### PR TITLE
[IMP] im_livechat: add/move config to user_setting

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -258,11 +258,16 @@ class ImLivechatChannel(models.Model):
                     if available_user.partner_id.id == previous_operator_id
                 )
                 return previous_operator_user
-        # Try to match an operator with the same lang as the visitor
+        # Try to match an operator with the same main lang as the visitor
+        # If no operator with the same lang, try to match an operator with the addition lang
         if lang:
             same_lang_operator_ids = self.available_operator_ids.filtered(lambda operator: operator.partner_id.lang == lang)
             if same_lang_operator_ids:
                 operator = self._get_less_active_operator(operator_statuses, same_lang_operator_ids)
+            else:
+                addition_lang_operator_ids = self.available_operator_ids.filtered(lambda operator: lang in operator.res_users_settings_id.livechat_lang_ids.mapped('code'))
+                if addition_lang_operator_ids:
+                    operator = self._get_less_active_operator(operator_statuses, addition_lang_operator_ids)
         # Try to match an operator with the same country as the visitor
         if country_id and not operator:
             same_country_operator_ids = self.available_operator_ids.filtered(lambda operator: operator.partner_id.country_id.id == country_id)

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -10,12 +10,36 @@ class Users(models.Model):
     """
     _inherit = 'res.users'
 
-    livechat_username = fields.Char("Livechat Username", help="This username will be used as your name in the livechat channels.")
+    livechat_username = fields.Char(string='Livechat Username', compute='_compute_livechat_username', inverse='_inverse_livechat_username', store=False)
+    livechat_lang_ids = fields.Many2many('res.lang', string='Livechat Languages', compute='_compute_livechat_lang_ids', inverse='_inverse_livechat_lang_ids', store=False)
+    has_access_livechat = fields.Boolean(compute='_compute_has_access_livechat', string='Has access to Livechat', store=False, readonly=True)
 
     @property
     def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS + ['livechat_username']
+        return super().SELF_READABLE_FIELDS + ['livechat_username', 'livechat_lang_ids', 'has_access_livechat']
 
-    @property
-    def SELF_WRITEABLE_FIELDS(self):
-        return super().SELF_WRITEABLE_FIELDS + ['livechat_username']
+    @api.depends('res_users_settings_id.livechat_username')
+    def _compute_livechat_username(self):
+        for user in self:
+            user.livechat_username = user.res_users_settings_id.livechat_username
+
+    def _inverse_livechat_username(self):
+        for user in self:
+            if not user.res_users_settings_id:
+                self.env['res.users.settings']._find_or_create_for_user(user)
+            user.res_users_settings_id.livechat_username = user.livechat_username
+
+    @api.depends('res_users_settings_id.livechat_lang_ids')
+    def _compute_livechat_lang_ids(self):
+        for user in self:
+            user.livechat_lang_ids = user.res_users_settings_id.livechat_lang_ids
+
+    def _inverse_livechat_lang_ids(self):
+        for user in self:
+            if not user.res_users_settings_id:
+                self.env['res.users.settings']._find_or_create_for_user(user)
+            user.res_users_settings_id.livechat_lang_ids = user.livechat_lang_ids
+
+    def _compute_has_access_livechat(self):
+        for user in self:
+            user.has_access_livechat = user.has_group('im_livechat.im_livechat_group_user')

--- a/addons/im_livechat/models/res_users_settings.py
+++ b/addons/im_livechat/models/res_users_settings.py
@@ -7,4 +7,7 @@ from odoo import fields, models
 class ResUsersSettings(models.Model):
     _inherit = 'res.users.settings'
 
+    livechat_username = fields.Char("Livechat Username", help="This username will be used as your name in the livechat channels.")
+    livechat_lang_ids = fields.Many2many(comodel_name='res.lang', string='Livechat languages',
+                            help="These languages, in addition to your main language, will be used to assign you to Live Chat sessions.")
     is_discuss_sidebar_category_livechat_open = fields.Boolean("Is category livechat open", default=True)

--- a/addons/im_livechat/views/res_users_views.xml
+++ b/addons/im_livechat/views/res_users_views.xml
@@ -9,9 +9,13 @@
             <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='tz']" position="after">
+                    <field name="has_access_livechat" invisible="1"/>
                     <field name="livechat_username" string="Online Chat Name"
-                        readonly="0"
-                        invisible="share"/>
+                        invisible="not has_access_livechat"/>
+                    <field name="livechat_lang_ids" string="Online Chat Language"
+                        invisible="not has_access_livechat"
+                        options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"
+                        widget="many2many_tags"/>
                 </xpath>
             </field>
         </record>
@@ -23,9 +27,13 @@
             <field name="inherit_id" ref="base.view_users_form"/>
             <field name="arch" type="xml">
                     <xpath expr="//group[@name='messaging']" position="after">
+                        <field name="has_access_livechat" invisible="1"/>
                         <group name="livechat" string="Livechat"
-                            invisible="share">
+                            invisible="not has_access_livechat">
                             <field name="livechat_username"/>
+                            <field name="livechat_lang_ids" string="Online Chat Language"
+                                options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"
+                                widget="many2many_tags"/>
                         </group>
                     </xpath>
             </field>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -12,7 +12,7 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 @tagged('post_install', '-at_install')
 class TestDiscussFullPerformance(HttpCase):
-    _query_count = 59
+    _query_count = 72
 
     def setUp(self):
         super().setUp()
@@ -1035,6 +1035,8 @@ class TestDiscussFullPerformance(HttpCase):
                 'is_discuss_sidebar_category_livechat_open': True,
                 'push_to_talk_key': False,
                 'use_push_to_talk': False,
+                'livechat_lang_ids': [],
+                'livechat_username': False,
                 'user_id': {'id': self.users[0].id},
                 'voice_active_duration': 0,
                 'volume_settings_ids': [('ADD', [])],


### PR DESCRIPTION
Enable livechat language setting for operators
Move livechat_username into res_user_setting

Upgrade: https://github.com/odoo/upgrade/pull/5113
Enterprise: https://github.com/odoo/enterprise/pull/47382
task-3390821


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
