### PR TITLE
[wip][IMP] resource: add duration to resource_calendar_attendance

### DIFF
--- a/addons/hr_holidays/tests/test_automatic_leave_dates.py
+++ b/addons/hr_holidays/tests/test_automatic_leave_dates.py
@@ -93,6 +93,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
                                    'hour_to': 10,
                                    'day_period': 'morning',
                                    'dayofweek': '0',
+                                   'duration_days': 0.25,
                                }),
                                (0, 0, {
                                    'name': 'monday morning 2',
@@ -100,6 +101,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
                                    'hour_to': 12.25,
                                    'day_period': 'morning',
                                    'dayofweek': '0',
+                                   'duration_days': 0.25,
                                }),
                                (0, 0, {
                                    'name': 'monday lunch',
@@ -114,6 +116,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
                                    'hour_to': 17,
                                    'day_period': 'afternoon',
                                    'dayofweek': '0',
+                                   'duration_days': 0.5,
                                })]
         })
         employee = self.employee_emp
@@ -135,9 +138,6 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             self.assertEqual(leave_form.number_of_hours_text, '4 Hours')
 
     def test_attendance_on_morning(self):
-        # TODO: temporarily fixed this test. The behaviour of half-day leaves
-        #       currently not very well defined. This will be handled in an
-        #       upcoming task.
         calendar = self.env['resource.calendar'].create({
             'name': 'Morning only',
             'attendance_ids': [(5, 0, 0),
@@ -165,8 +165,8 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             # Ask for afternoon
             leave_form.request_date_from_period = 'pm'
 
-            self.assertEqual(leave_form.number_of_days_display, 1)
-            self.assertEqual(leave_form.number_of_hours_text, '8 Hours')
+            self.assertEqual(leave_form.number_of_days_display, 0)
+            self.assertEqual(leave_form.number_of_hours_text, '0 Hours')
 
     def test_attendance_next_day(self):
         self.env.user.tz = 'Europe/Brussels'
@@ -241,6 +241,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
                                    'day_period': 'morning',
                                    'dayofweek': '0',
                                    'week_type': '0',
+                                   'duration_days': 0.5,
                                }),
                                (0, 0, {
                                    'name': 'monday morning even week',
@@ -249,6 +250,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
                                    'day_period': 'morning',
                                    'dayofweek': '0',
                                    'week_type': '1',
+                                   'duration_days': 0.25
                                })]
         })
         employee = self.employee_emp
@@ -262,7 +264,7 @@ class TestAutomaticLeaveDates(TestHrHolidaysCommon):
             leave_form.request_unit_half = True
             leave_form.request_date_from_period = 'am'
 
-            self.assertEqual(leave_form.number_of_days_display, 0.5)
+            self.assertEqual(leave_form.number_of_days_display, 0.25)
             self.assertEqual(leave_form.number_of_hours_text, '2 Hours')
             self.assertEqual(leave_form.date_from, datetime(2019, 9, 2, 8, 0, 0))
             self.assertEqual(leave_form.date_to, datetime(2019, 9, 2, 10, 0, 0))

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -248,6 +248,10 @@
                             <field name="employee_ids" invisible="1" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']"/>
                             <field name="display_name" invisible="not holiday_status_id"/>
                         </div>
+                        <field name="leave_type_increases_duration" invisible="True"/>
+                        <div name="duration_warning" invisible="not leave_type_increases_duration" class="alert alert-warning mb-0" role="alert">
+                            <span >You can only take this time off in whole days, so if your schedule has half days, it won't be used efficiently.</span>
+                        </div><br />
                         <group name="col_left">
                             <field name="employee_company_id" invisible="1"/>
                             <field name="holiday_status_id" force_save="1"

--- a/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
+++ b/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
@@ -31,6 +31,7 @@ class TestFrenchLeaves(TransactionCase):
         cls.time_off_type = cls.env['hr.leave.type'].create({
             'name': 'Time Off',
             'requires_allocation': 'no',
+            'request_unit': 'half_day',
         })
         cls.company.write({
             'l10n_fr_reference_leave_type': cls.time_off_type.id,

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -104,7 +104,6 @@ class ResourceMixin(models.AbstractModel):
                 for calendar_resource in calendar_resources:
                     result[calendar_resource.id] = {'days': 0, 'hours': 0}
                 continue
-            day_total = calendar._get_resources_day_total(from_datetime, to_datetime, calendar_resources)
 
             # actual hours per day
             if compute_leaves:
@@ -113,7 +112,7 @@ class ResourceMixin(models.AbstractModel):
                 intervals = calendar._attendance_intervals_batch(from_datetime, to_datetime, calendar_resources)
 
             for calendar_resource in calendar_resources:
-                result[calendar_resource.id] = calendar._get_days_data(intervals[calendar_resource.id], day_total[calendar_resource.id])
+                result[calendar_resource.id] = calendar._get_attendance_intervals_days_data(intervals[calendar_resource.id])
 
         # convert "resource: result" into "employee: result"
         return {mapped_employees[r.id]: result[r.id] for r in resources}
@@ -142,16 +141,13 @@ class ResourceMixin(models.AbstractModel):
             mapped_resources[calendar or record.resource_calendar_id] |= record.resource_id
 
         for calendar, calendar_resources in mapped_resources.items():
-            day_total = calendar._get_resources_day_total(from_datetime, to_datetime, calendar_resources)
-
             # compute actual hours per day
             attendances = calendar._attendance_intervals_batch(from_datetime, to_datetime, calendar_resources)
             leaves = calendar._leave_intervals_batch(from_datetime, to_datetime, calendar_resources, domain)
 
             for calendar_resource in calendar_resources:
-                result[calendar_resource.id] = calendar._get_days_data(
-                    attendances[calendar_resource.id] & leaves[calendar_resource.id],
-                    day_total[calendar_resource.id]
+                result[calendar_resource.id] = calendar._get_attendance_intervals_days_data(
+                    attendances[calendar_resource.id] & leaves[calendar_resource.id]
                 )
 
         # convert "resource: result" into "employee: result"

--- a/addons/resource/views/resource_calendar_attendance_views.xml
+++ b/addons/resource/views/resource_calendar_attendance_views.xml
@@ -4,7 +4,7 @@
         <field name="name">resource.calendar.attendance.tree</field>
         <field name="model">resource.calendar.attendance</field>
         <field name="arch" type="xml">
-            <tree string="Working Time" editable="top">
+            <tree string="Working Time" editable="top" default_order="sequence, week_type, dayofweek, hour_from">
                 <field name="sequence" widget="handle"/>
                 <field name="display_type" column_invisible="True"/>
                 <field name="display_name" width="1" string=" " invisible="display_type != 'line_section'"/>
@@ -13,6 +13,7 @@
                 <field name="day_period"/>
                 <field name="hour_from" widget="float_time"/>
                 <field name="hour_to" widget="float_time"/>
+                <field name="duration_days" optional="show"/>
                 <field name="date_from" optional="hide"/>
                 <field name="date_to" optional="hide"/>
                 <field name="week_type" readonly="1" force_save="1" groups="base.group_no_one"/>
@@ -37,6 +38,7 @@
                         <field name="hour_to" widget="float_time"/>
                     </div>
                     <field name="day_period"/>
+                    <field name="duration_days"/>
                 </group>
                 </sheet>
             </form>

--- a/addons/test_resource/tests/common.py
+++ b/addons/test_resource/tests/common.py
@@ -17,6 +17,7 @@ class TestResourceCommon(TransactionCase):
                     'hour_from': att[0],
                     'hour_to': att[1],
                     'dayofweek': str(att[2]),
+                    'duration_days': att[3],
                 })
                 for index, att in enumerate(attendances)
             ],
@@ -47,18 +48,18 @@ class TestResourceCommon(TransactionCase):
         super(TestResourceCommon, cls).setUpClass()
 
         # UTC+1 winter, UTC+2 summer
-        cls.calendar_jean = cls._define_calendar('40 Hours', [(8, 16, i) for i in range(5)], 'Europe/Brussels')
+        cls.calendar_jean = cls._define_calendar('40 Hours', [(8, 16, i, 1) for i in range(5)], 'Europe/Brussels')
         # UTC+6
-        cls.calendar_patel = cls._define_calendar('38 Hours', sum([((9, 12, i), (13, 17, i)) for i in range(5)], ()), 'Etc/GMT-6')
+        cls.calendar_patel = cls._define_calendar('38 Hours', sum([((9, 12, i, 3/7), (13, 17, i, 4/7)) for i in range(5)], ()), 'Etc/GMT-6')
         # UTC-8 winter, UTC-7 summer
-        cls.calendar_john = cls._define_calendar('8+12 Hours', [(8, 16, 1), (8, 13, 4), (16, 23, 4)], 'America/Los_Angeles')
+        cls.calendar_john = cls._define_calendar('8+12 Hours', [(8, 16, 1, 1), (8, 13, 4, 5/12), (16, 23, 4, 7/12)], 'America/Los_Angeles')
         # UTC+1 winter, UTC+2 summer
         cls.calendar_jules = cls._define_calendar_2_weeks('Week 1: 30 Hours - Week 2: 16 Hours', [
             (0, 0, 0, '0', 'line_section', 0), (8, 16, 0, '0', False, 1), (9, 17, 1, '0', False, 2),
             (0, 0, 0, '1', 'line_section', 10), (8, 16, 0, '1', False, 11), (7, 15, 2, '1', False, 12),
             (8, 16, 3, '1', False, 13), (10, 16, 4, '1', False, 14)], 'Europe/Brussels')
 
-        cls.calendar_paul = cls._define_calendar('Morning and evening shifts', sum([((2, 7, i), (10, 16, i)) for i in range(5)], ()), 'Brazil/DeNoronha')
+        cls.calendar_paul = cls._define_calendar('Morning and evening shifts', sum([((2, 7, i, 0.5), (10, 16, i, 0.5)) for i in range(5)], ()), 'Brazil/DeNoronha')
 
         # Employee is linked to a resource.resource via resource.mixin
         cls.jean = cls.env['resource.test'].create({


### PR DESCRIPTION
Before this commit, conversion between worked hours and days in
resource_calendar_attendance was calculated but in reality there is no
unambigous way to do this. Eg in Belgium the morning working period is
4 hours, the one in the afternoon is 3 hours 36 minutes, while both of
them are still counted as half days.

To mediate this, the duration in days is explicitely added to
resource.calendar.attendance, with sensible default being provided
(half a day for morning and afternoon periods, 0 for lunch).

task-3131517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
