### PR TITLE
[FIX] web: tests: click helper: throw error if target is disabled

### DIFF
--- a/addons/web/static/tests/core/checkbox_tests.js
+++ b/addons/web/static/tests/core/checkbox_tests.js
@@ -69,22 +69,16 @@ QUnit.module("Components", (hooks) => {
         assert.strictEqual(value, false);
     });
 
-    QUnit.test("does not call onChange prop when disabled", async (assert) => {
+    QUnit.test("checkbox with props disabled", async (assert) => {
         const env = await makeTestEnv();
 
-        let onChangeCalled = false;
-        class Parent extends Component {
-            onChange(checked) {
-                onChangeCalled = true;
-            }
-        }
+        class Parent extends Component {}
         Parent.template = xml`<CheckBox onChange="onChange" disabled="true"/>`;
         Parent.components = { CheckBox };
 
         await mount(Parent, target, { env });
         assert.containsOnce(target, ".o-checkbox input");
-        await click(target.querySelector("input"));
-        assert.strictEqual(onChangeCalled, false);
+        assert.ok(target.querySelector(".o-checkbox input").disabled);
     });
 
     QUnit.test("can toggle value by pressing ENTER", async (assert) => {

--- a/addons/web/static/tests/core/pager_tests.js
+++ b/addons/web/static/tests/core/pager_tests.js
@@ -183,8 +183,6 @@ QUnit.module("Components", ({ beforeEach }) => {
     });
 
     QUnit.test("pager disabling", async function (assert) {
-        assert.expect(9);
-
         const reloadPromise = makeDeferred();
 
         const pager = await makePager({
@@ -203,9 +201,9 @@ QUnit.module("Components", ({ beforeEach }) => {
         });
         const pagerButtons = target.querySelectorAll("button");
 
-        // Click twice
+        // Click and check button is disabled
         await click(target.querySelector(`.o_pager button.o_pager_next`));
-        await click(target.querySelector(`.o_pager button.o_pager_next`));
+        assert.ok(target.querySelector(`.o_pager button.o_pager_next`).disabled);
         // Try to edit the pager value
         await click(target, ".o_pager_value");
 

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -446,6 +446,9 @@ export async function triggerScroll(
 }
 
 export function click(el, selector, skipVisibilityCheck = false) {
+    if (el.disabled) {
+        throw new Error("Can't click on a disabled button");
+    }
     return triggerEvents(
         el,
         selector,

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -2557,9 +2557,7 @@ QUnit.module("Fields", (hooks) => {
 
         await click(buttons[0]);
         assert.verifySteps(["action"]);
-
-        await click(buttons[1]);
-        assert.verifySteps([]); // the second button is disabled, it can't be clicked
+        assert.ok(buttons[1].disabled);
 
         def.resolve();
         await nextTick();

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -12043,7 +12043,6 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(target.querySelector(".o_data_cell").innerText, "leonardo");
 
         await click(target.querySelector(".o_field_widget[name=turtles] .o_pager_next"));
-        await click(target.querySelector(".o_field_widget[name=turtles] .o_pager_next"));
         assert.ok(target.querySelector(".o_field_widget[name=turtles] .o_pager_next").disabled);
 
         readDefs[1].resolve();

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -9688,7 +9688,8 @@ QUnit.module("Views", (hooks) => {
 
         click(target.querySelector(".modal-footer button.btn-primary"));
         await Promise.resolve();
-        await click(target.querySelector(".modal-footer button.btn-primary"));
+        assert.ok(target.querySelector(".modal-footer button.btn-primary").disabled);
+        await nextTick();
         assert.verifySteps(["create", "web_read", "execute_action"]);
     });
 
@@ -10511,7 +10512,7 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(
             target.querySelector('.o-tooltip--technical > li[data-item="invisible"]').lastChild
                 .textContent,
-            'product_id == 33',
+            "product_id == 33",
             "invisible should be properly stringified"
         );
 
@@ -11126,10 +11127,9 @@ QUnit.module("Views", (hooks) => {
                 resId: 2,
             });
 
+            assert.ok(target.querySelector(".o_form_view button.mybutton").disabled);
             await click(target.querySelector(".o_form_view .o_content button.btn-primary"));
             assert.verifySteps(["doActionButton"]);
-            await click(target.querySelector(".o_form_view button.mybutton"));
-            assert.verifySteps([]);
         }
     );
 
@@ -13734,7 +13734,9 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("containing a nested x2many list view should not overflow", async function (assert) {
         serverData.models.partner_type.records.push({
-            id: 3, display_name: 'very'.repeat(30) + '_long_name', color: 10,
+            id: 3,
+            display_name: "very".repeat(30) + "_long_name",
+            color: 10,
         });
 
         const record = serverData.models.partner.records[0];
@@ -13763,11 +13765,11 @@ QUnit.module("Views", (hooks) => {
             </form>`,
         });
 
-        const table = target.querySelector('table');
-        const group = target.querySelector('.o_inner_group:last-child');
+        const table = target.querySelector("table");
+        const group = target.querySelector(".o_inner_group:last-child");
 
         assert.equal(group.clientWidth, group.scrollWidth);
-        table.style.tableLayout = 'auto';
+        table.style.tableLayout = "auto";
         assert.ok(group.clientWidth < group.scrollWidth);
     });
 });

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -8178,7 +8178,8 @@ QUnit.module("Views", (hooks) => {
             },
         });
         click(target.querySelector("button.a1"));
-        await click(target.querySelector("button.a1"));
+        assert.ok(target.querySelector("button.a1").disabled);
+        await nextTick();
 
         assert.strictEqual(count, 1, "should have triggered an execute action only once");
         assert.verifySteps(

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -10990,9 +10990,9 @@ QUnit.module("Views", (hooks) => {
 
         assert.containsN(target, ".o_data_row", 4, "should contain 4 records");
 
-        // click on Add twice, and delay the onchange
+        // click on Add and delay the onchange (check that the button is correctly disabled)
         click($(".o_list_button_add:visible").get(0));
-        click($(".o_list_button_add:visible").get(0));
+        assert.ok($(".o_list_button_add:visible").get(0).disabled);
 
         prom.resolve();
         await nextTick();


### PR DESCRIPTION
Before chrome 116, programmatic clicks on disabled buttons weren't actually fired. With chrome 116, they are. As a consequence, some tests fail on chrome 116 because they click (on purpose) on disabled button to highlight the fact that nothing happens.

This commit improves the click helper to make it throw an error when the target is disabled. It also adapts the tests that were clicking on disabled button, in general to simply assert that the button is disabled instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
