### PR TITLE
[FIX] web: handle Error with undefined OriginalError

### DIFF
--- a/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.js
+++ b/addons/web/static/src/views/form/form_error_dialog/form_error_dialog.js
@@ -30,7 +30,7 @@ FormErrorDialog.template = "web.FormErrorDialog";
 FormErrorDialog.components = { Dialog };
 
 function formSaveErrorHandler(env, error, originalError) {
-    if (originalError.__raisedOnFormSave) {
+    if (originalError && originalError.__raisedOnFormSave) {
         const event = originalError.event;
         error.unhandledRejectionEvent.preventDefault();
         if (event.isDefaultPrevented()) {


### PR DESCRIPTION
To reproduce
============
try to upload logo in mailing, an error is raised

Problem
=======
when checking the `OriginalError`, we check if `cause` is present in the Error, but it may be present with null which is the source of the error.

opw-3383049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
