### PR TITLE
[FIX] mrp: workorder list view traceback

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -90,7 +90,7 @@
                   invisible="production_state == 'draft'"
                   readonly="is_user_working" sum="real duration"/>
                 <field name="state" widget="badge" decoration-warning="state == 'progress'" decoration-success="state == 'done'" decoration-danger="state == 'cancel'" decoration-info="state not in ('progress', 'done', 'cancel')"
-                  column_invisible="parent.state == 'draft'"
+                  column_invisible="parent and parent.state == 'draft'"
                   invisible="production_state == 'draft'"/>
                 <button name="button_start" type="object" string="Start" class="btn-success"
                   invisible="production_state in ('draft', 'done', 'cancel') or working_state == 'blocked' or state in ('done', 'cancel') or is_user_working"/>


### PR DESCRIPTION
When opening the list view of workorders, a traceback was triggered. The problem was that parent was not defined when not in a view form. Checking if parent first exists solves the problem

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
