### PR TITLE
[FIX] sale: can't open catalog with product on multiple lines

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1223,7 +1223,7 @@ class SaleOrderLine(models.Model):
             order = order_line.order_id
             return {
                 'readOnly': True,
-                'price': order.pricelist._get_product_price(
+                'price': order.pricelist_id._get_product_price(
                     product=order_line.product_id,
                     quantity=1.0,
                     currency=order.currency_id,


### PR DESCRIPTION
In 89d5d1f, changes have been made to the catalog to ease inheritance. Since this change, opening the catalog with products spread over multiple lines on the SO crashes.

Now, the catalog will open even if the SO contains products spread across multiple lines.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
