### PR TITLE
[IMP] web: Grouped kanban/list in a single RPC - refactor web_read_group

### DIFF
--- a/addons/board/static/tests/board.test.js
+++ b/addons/board/static/tests/board.test.js
@@ -168,15 +168,13 @@ describe("board_desktop", () => {
     });
 
     test("views in the dashboard do not have a control panel", async () => {
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [
-                    [4, "list"],
-                    [5, "form"],
-                ],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [
+                [4, "list"],
+                [5, "form"],
+            ],
+        }));
         await mountView({
             type: "form",
             resModel: "board",
@@ -202,15 +200,13 @@ describe("board_desktop", () => {
         // action's params (like context or domain), as the dashboard can directly
         // retrieve them from the action. Same applies for the view_type, as the
         // first view of the action can be used, by default.
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [
-                    [4, "list"],
-                    [false, "form"],
-                ],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [
+                [4, "list"],
+                [false, "form"],
+            ],
+        }));
 
         await mountView({
             type: "form",
@@ -229,12 +225,10 @@ describe("board_desktop", () => {
     });
 
     test("can sort a sub list", async () => {
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         await mountView({
             type: "form",
             resModel: "board",
@@ -271,12 +265,10 @@ describe("board_desktop", () => {
                 return true;
             },
         });
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         await mountView({
             type: "form",
             resModel: "board",
@@ -308,15 +300,13 @@ describe("board_desktop", () => {
             },
         });
 
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [
-                    [4, "list"],
-                    [5, "form"],
-                ],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [
+                [4, "list"],
+                [5, "form"],
+            ],
+        }));
 
         await mountView({
             type: "form",
@@ -335,12 +325,10 @@ describe("board_desktop", () => {
     });
 
     test("can drag and drop a view", async () => {
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         onRpc("/web/view/edit_custom", () => {
             expect.step("edit custom");
             return true;
@@ -379,15 +367,13 @@ describe("board_desktop", () => {
                     </t>
                 </templates>
             </kanban>`;
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [
-                    [4, "list"],
-                    [5, "kanban"],
-                ],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [
+                [4, "list"],
+                [5, "kanban"],
+            ],
+        }));
         onRpc("/web/view/edit_custom", () => {
             expect.step("edit custom");
             return true;
@@ -411,10 +397,12 @@ describe("board_desktop", () => {
     });
 
     test("non-existing action in a dashboard", async () => {
-        onRpc("/web/action/load", () => {
-            // server answer if the action doesn't exist anymore
-            return false;
-        });
+        onRpc(
+            "/web/action/load",
+            () =>
+                // server answer if the action doesn't exist anymore
+                false
+        );
         await mountView({
             type: "form",
             resModel: "board",
@@ -451,13 +439,11 @@ describe("board_desktop", () => {
                 expect(params.type).toBe("object");
             },
         });
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                view_mode: "kanban",
-                views: [[false, "kanban"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            view_mode: "kanban",
+            views: [[false, "kanban"]],
+        }));
         await mountView({
             type: "form",
             resModel: "board",
@@ -477,12 +463,10 @@ describe("board_desktop", () => {
     test("Views should be loaded in the user's language", async () => {
         expect.assertions(2);
         serverState.lang = "fr_FR";
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         onRpc("get_views", (args) => {
             expect(args.kwargs.context.lang).toBe("fr_FR");
         });
@@ -502,12 +486,10 @@ describe("board_desktop", () => {
 
     test("Dashboard should use correct groupby", async () => {
         expect.assertions(1);
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         onRpc("web_read_group", (args) => {
             expect(args.kwargs.groupby).toEqual(["bar"]);
         });
@@ -527,12 +509,10 @@ describe("board_desktop", () => {
 
     test("Dashboard should use correct groupby when defined as a string of one field", async () => {
         expect.assertions(1);
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         onRpc("web_read_group", ({ kwargs }) => {
             expect(kwargs.groupby).toEqual(["bar"]);
         });
@@ -562,12 +542,10 @@ describe("board_desktop", () => {
             },
         });
 
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "pivot"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "pivot"]],
+        }));
         onRpc("formatted_read_group", (args) => {
             expect(args.kwargs.groupby).toEqual([]);
         });
@@ -594,12 +572,10 @@ describe("board_desktop", () => {
 
     test("graphs in dashboard aren't squashed", async () => {
         Partner._views["graph,4"] = '<graph><field name="int_field" type="measure"/></graph>';
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "graph"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "graph"]],
+        }));
         await mountView({
             type: "form",
             resModel: "board",
@@ -671,12 +647,10 @@ describe("board_mobile", () => {
     test("can't switch views in the dashboard", async () => {
         Partner._views["list,4"] = '<list string="Partner"><field name="foo"/></list>';
 
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         await mountView({
             type: "form",
             resModel: "board",
@@ -705,12 +679,10 @@ describe("board_mobile", () => {
     test("Correctly soft switch to '1' layout on small screen", async () => {
         Partner._views["list,4"] = '<list string="Partner"><field name="foo"/></list>';
 
-        onRpc("/web/action/load", () => {
-            return {
-                res_model: "partner",
-                views: [[4, "list"]],
-            };
-        });
+        onRpc("/web/action/load", () => ({
+            res_model: "partner",
+            views: [[4, "list"]],
+        }));
         await mountView({
             type: "form",
             resModel: "board",

--- a/addons/crm/static/tests/forecast_kanban.test.js
+++ b/addons/crm/static/tests/forecast_kanban.test.js
@@ -360,8 +360,6 @@ test("Forecast drag&drop and add column", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         // drag&drop
         "web_save",
         "read_progress_bar",
@@ -369,7 +367,5 @@ test("Forecast drag&drop and add column", async () => {
         // add column
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2056,7 +2056,6 @@ class ProjectTask(models.Model):
             groupby = ['personal_stage_type_ids' if fname == 'personal_stage_type_id' else fname for fname in groupby]
             if order:
                 order = order.replace('personal_stage_type_id', 'personal_stage_type_ids')
-            return super()._read_group(domain, groupby, aggregates, having, offset, limit, order)
         return super()._read_group(domain, groupby, aggregates, having, offset, limit, order)
 
     # ---------------------------------------------------

--- a/addons/project/static/src/project_sharing/views/kanban/kanban_view.js
+++ b/addons/project/static/src/project_sharing/views/kanban/kanban_view.js
@@ -4,7 +4,7 @@ import { kanbanView } from "@web/views/kanban/kanban_view";
 import { RelationalModel } from "@web/model/relational_model/relational_model";
 
 export class ProjectSharingTaskKanbanModel extends RelationalModel {
-    async _webReadGroup(config, firstGroupByName, orderBy) {
+    async _webReadGroup(config) {
         config.context = {
             ...config.context,
             project_kanban: true,

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -40,7 +40,7 @@ export class ProjectTaskRecord extends Record {
 }
 
 export class ProjectTaskKanbanModel extends RelationalModel {
-    async _webReadGroup(config, firstGroupByName, orderBy) {
+    async _webReadGroup(config) {
         config.context = {
             ...config.context,
             project_kanban: true,

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -244,25 +244,19 @@ export class ORM {
     /**
      * @param {string} model
      * @param {import("@web/core/domain").DomainListRepr} domain
-     * @param {string[]} fields
      * @param {string[]} groupby
+     * @param {string[]} aggregates
      * @param {any} [kwargs={}]
      * @returns {Promise<any[]>}
      */
     webReadGroup(model, domain, groupby, aggregates, kwargs = {}) {
         validateArray("domain", domain);
-        validatePrimitiveList("groupby", "string", groupby);
         validatePrimitiveList("aggregates", "string", aggregates);
         return this.call(model, "web_read_group", [], {
             domain,
             groupby,
             aggregates,
             ...kwargs,
-        }).then((res) => {
-            for (const group of res.groups) {
-                group["__domain"] = Domain.and([domain, group["__extra_domain"]]).toList();
-            }
-            return res;
         });
     }
 

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -243,6 +243,8 @@ export class DynamicGroupList extends DynamicList {
             context,
             groupByFieldName: this.groupByField.name,
             isFolded: Boolean(foldField),
+            value: id,
+            extraDomain: false,
             initialDomain: domain,
             list: {
                 ...commonConfig,
@@ -250,6 +252,8 @@ export class DynamicGroupList extends DynamicList {
                 domain: domain,
                 groupBy: [],
                 orderBy: this.orderBy,
+                limit: this.model.initialLimit,
+                offset: 0,
             },
         };
         this.model._updateConfig(this.config, { groups: nextConfigGroups }, { reload: false });

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -552,12 +552,12 @@ export function getAggregateSpecifications(fields) {
  * @param {Object} fields
  * @returns {Object}
  */
-export function extractInfoFromGroupData(groupData, groupBy, fields) {
+export function extractInfoFromGroupData(groupData, groupBy, fields, domain) {
     const info = {};
     const groupByField = fields[groupBy[0].split(":")[0]];
     info.count = groupData.__count;
     info.length = info.count; // TODO: remove but still used in DynamicRecordList._updateCount
-    info.domain = groupData.__domain;
+    info.domain = Domain.and([domain, groupData.__extra_domain]).toList();
     info.rawValue = groupData[groupBy[0]];
     info.value = getValueFromGroupData(groupByField, info.rawValue);
     if (["date", "datetime"].includes(groupByField.type) && info.value) {
@@ -570,6 +570,7 @@ export function extractInfoFromGroupData(groupData, groupBy, fields) {
     info.displayName = getDisplayNameFromGroupData(groupByField, info.rawValue);
     info.serverValue = getGroupServerValue(groupByField, info.value);
     info.aggregates = getAggregatesFromGroupData(groupData, fields);
+    info.values = groupData.__values; // Extra data of the relational groupby field record
     return info;
 }
 

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -32,10 +32,10 @@ function _createFilterDomain(fieldName, bars, value) {
     return filterDomain;
 }
 
-function _groupsToAggregateValues(groups, groupBy, fields) {
+function _groupsToAggregateValues(groups, groupBy, fields, domain) {
     const groupByFieldName = groupBy[0].split(":")[0];
     return groups.map((g) => {
-        const groupInfo = extractInfoFromGroupData(g, groupBy, fields);
+        const groupInfo = extractInfoFromGroupData(g, groupBy, fields, domain);
         return Object.assign(groupInfo.aggregates, { [groupByFieldName]: groupInfo.serverValue });
     });
 }
@@ -214,7 +214,7 @@ class ProgressBarState {
             .then((groups) => {
                 if (groups.length) {
                     const groupByField = group.groupByField;
-                    const aggrValues = _groupsToAggregateValues(groups, groupBy, fields);
+                    const aggrValues = _groupsToAggregateValues(groups, groupBy, fields, domain);
                     activeBar.aggregates = _findGroup(aggrValues, groupByField, group.serverValue);
                 }
             });

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -646,8 +646,6 @@ export class MockServer {
                 return this.mockWebSave(args.model, args.args, args.kwargs);
             case "formatted_read_group":
                 return this.mockFormattedReadGroup(args.model, args.kwargs);
-            case "web_read_group":
-                return this.mockWebReadGroup(args.model, args.kwargs);
             case "web_search_read":
                 return this.mockWebSearchReadUnity(args.model, args.args, args.kwargs);
             case "read_progress_bar":
@@ -1309,19 +1307,6 @@ export class MockServer {
         }
 
         return true;
-    }
-
-    mockWebReadGroup(modelName, kwargs) {
-        const groups = this.mockFormattedReadGroup(modelName, kwargs);
-        const allGroups = this.mockFormattedReadGroup(modelName, {
-            domain: kwargs.domain,
-            groupby: kwargs.groupby,
-            aggregates: [],
-        });
-        return {
-            groups: groups,
-            length: allGroups.length,
-        };
     }
 
     mockReadProgressBar(modelName, kwargs) {

--- a/addons/web/static/tests/model/sample_server.test.js
+++ b/addons/web/static/tests/model/sample_server.test.js
@@ -219,6 +219,8 @@ describe("RPC calls", () => {
             model: "hobbit",
             groupBy: ["profession"],
             aggregates: ["__count"],
+            auto_unfold: true,
+            unfold_read_specification: { display_name: {}, age: {}, profession: {} },
         });
         expect(result).toEqual({
             groups: [
@@ -226,16 +228,23 @@ describe("RPC calls", () => {
                     __extra_domain: [],
                     profession: "adventurer",
                     __count: 5,
+                    __records: server.data.hobbit.records.filter(
+                        (r) => r.profession === "adventurer"
+                    ),
                 },
                 {
                     __extra_domain: [],
                     profession: "brewer",
                     __count: 5,
+                    __records: server.data.hobbit.records.filter((r) => r.profession === "brewer"),
                 },
                 {
                     __extra_domain: [],
                     profession: "gardener",
                     __count: 6,
+                    __records: server.data.hobbit.records.filter(
+                        (r) => r.profession === "gardener"
+                    ),
                 },
             ],
             length: 3,
@@ -254,12 +263,14 @@ describe("RPC calls", () => {
             model: "hobbit",
             groupBy: ["profession"],
             aggregates: ["__count"],
+            auto_unfold: true,
+            unfold_read_specification: { display_name: {}, age: {} },
         });
         expect(result).toHaveLength(2);
         expect(result.groups).toHaveLength(2);
         expect(result.groups.map((g) => g.profession)).toEqual(["gardener", "adventurer"]);
         expect(result.groups.reduce((acc, g) => acc + g.__count, 0)).toBe(MAIN_RECORDSET_SIZE);
-        expect(result.groups.every((g) => g.__count === g.__recordIds.length)).toBe(true);
+        expect(result.groups.every((g) => g.__count === g.__records.length)).toBe(true);
     });
 
     test("'web_read_group': all groups", async () => {
@@ -275,6 +286,8 @@ describe("RPC calls", () => {
             model: "hobbit",
             groupBy: ["profession"],
             aggregates: ["__count"],
+            auto_unfold: true,
+            unfold_read_specification: { display_name: {}, age: {} },
         });
         expect(result.length).toBe(3);
         expect(result.groups).toHaveLength(3);
@@ -284,7 +297,7 @@ describe("RPC calls", () => {
             "adventurer",
         ]);
         expect(result.groups.reduce((acc, g) => acc + g.__count, 0)).toBe(MAIN_RECORDSET_SIZE);
-        expect(result.groups.every((g) => g.__count === g.__recordIds.length)).toBe(true);
+        expect(result.groups.every((g) => g.__count === g.__records.length)).toBe(true);
     });
 
     test("'web_read_group': 'max' aggregator", async () => {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1800,8 +1800,6 @@ test("quick create record without quick_create_view", async () => {
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "onchange", // quick create
         "name_create", // should perform a name_create to create the record
         "onchange", // reopen the quick create automatically
@@ -1868,8 +1866,6 @@ test("quick create record with quick_create_view", async () => {
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "get_views", // form view in quick create
         "onchange", // quick create
         "web_save", // should perform a web_save to create the record
@@ -2109,8 +2105,6 @@ test("quick create record in grouped on m2o (no quick_create_view)", async () =>
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "onchange", // quick create
         "name_create", // should perform a name_create to create the record
         "onchange", // reopen the quick create automatically
@@ -2176,8 +2170,6 @@ test("quick create record in grouped on m2o (with quick_create_view)", async () 
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "get_views", // form view in quick create
         "onchange", // quick create
         "web_save", // should perform a web_save to create the record
@@ -2222,8 +2214,6 @@ test("quick create record in grouped on m2m (no quick_create_view)", async () =>
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "onchange", // quick create
         "name_create", // should perform a name_create to create the record
         "onchange", // reopen the quick create automatically
@@ -2270,8 +2260,6 @@ test("quick create record in grouped on m2m in the None column", async () => {
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "web_search_read", // read records when unfolding 'None'
         "onchange", // quick create
         "name_create", // should perform a name_create to create the record
@@ -2324,8 +2312,6 @@ test("quick create record in grouped on m2m (field not in template)", async () =
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "get_views", // get form view
         "onchange", // quick create
         "web_save", // should perform a web_save to create the record
@@ -2384,8 +2370,6 @@ test("quick create record in grouped on m2m (field in the form view)", async () 
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "get_views", // get form view
         "onchange", // quick create
         "web_save", // should perform a web_save to create the record
@@ -2418,8 +2402,6 @@ test("quick create record validation: stays open when invalid", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 
     await createKanbanRecord();
@@ -2488,8 +2470,6 @@ test("quick create record with default values and onchanges", async () => {
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "get_views", // form view in quick create
         "onchange", // quick create
         "onchange", // onchange due to 'foo' field change
@@ -2568,8 +2548,6 @@ test("quick create record with onchange of field marked readonly", async () => {
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
     ]);
 
     // click on 'Create' -> should open the quick create in the first column
@@ -4401,11 +4379,7 @@ test("o2m loaded in only one batch", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -4436,11 +4410,7 @@ test("kanban with many2many, load and reload", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -4475,11 +4445,7 @@ test("kanban with reference field", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
     expect(queryAllTexts(".o_kanban_record span")).toEqual(["hello", "", "xmo", ""]);
 });
@@ -5519,62 +5485,6 @@ test("create a column in grouped on m2o without sequence field on view model", a
 });
 
 test.tags("desktop");
-test("auto fold group when reach the limit", async () => {
-    for (let i = 0; i < 12; i++) {
-        Product._records.push({ id: 8 + i, name: `column ${i}` });
-        Partner._records.push({ id: 20 + i, foo: "dumb entry", product_id: 8 + i });
-    }
-    Product._records[2].fold = true;
-    Product._records[8].fold = true;
-
-    onRpc("web_search_read", ({ kwargs }) => {
-        expect.step(`web_search_read domain: ${kwargs.domain}`);
-    });
-
-    await mountView({
-        type: "kanban",
-        resModel: "partner",
-        arch: `
-            <kanban>
-                <templates>
-                    <t t-name="card">
-                        <field name="foo"/>
-                    </t>
-                </templates>
-            </kanban>`,
-        groupBy: ["product_id"],
-    });
-
-    // we look if column are folded/unfolded according to what is expected
-    expect(getKanbanColumn(1)).not.toHaveClass("o_column_folded");
-    expect(getKanbanColumn(3)).not.toHaveClass("o_column_folded");
-    expect(getKanbanColumn(9)).not.toHaveClass("o_column_folded");
-    expect(getKanbanColumn(2)).toHaveClass("o_column_folded");
-    expect(getKanbanColumn(8)).toHaveClass("o_column_folded");
-
-    // we look if columns are actually folded after we reached the limit
-    expect(getKanbanColumn(12)).toHaveClass("o_column_folded");
-    expect(getKanbanColumn(13)).toHaveClass("o_column_folded");
-
-    // we look if we have the right count of folded/unfolded column
-    expect(".o_kanban_group:not(.o_column_folded)").toHaveCount(10);
-    expect(".o_kanban_group.o_column_folded").toHaveCount(4);
-
-    expect.verifySteps([
-        "web_search_read domain: product_id,=,3",
-        "web_search_read domain: product_id,=,5",
-        "web_search_read domain: product_id,=,9",
-        "web_search_read domain: product_id,=,10",
-        "web_search_read domain: product_id,=,11",
-        "web_search_read domain: product_id,=,12",
-        "web_search_read domain: product_id,=,13",
-        "web_search_read domain: product_id,=,15",
-        "web_search_read domain: product_id,=,16",
-        "web_search_read domain: product_id,=,17",
-    ]);
-});
-
-test.tags("desktop");
 test("delete a column in grouped on m2o", async () => {
     stepAllNetworkCalls();
     let resequencedIDs = [];
@@ -5678,11 +5588,8 @@ test("delete a column in grouped on m2o", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "unlink",
         "web_read_group",
-        "web_search_read",
         "web_search_read",
     ]);
     expect(".o_kanban_group").toHaveCount(2, {
@@ -5778,6 +5685,8 @@ test("delete an empty column, then a column with records.", async () => {
                 __extra_domain: [["product_id", "=", 7]],
                 product_id: [7, "empty group"],
                 __count: 0,
+                __fold: false,
+                __records: [],
             });
             result.length = 3;
             firstLoad = false;
@@ -5887,13 +5796,13 @@ test("edit a column in grouped on m2o", async () => {
 
     expect(".modal").toHaveCount(0, { message: "the modal should be closed" });
     expect(queryText(".o_column_title", { root: getKanbanColumn(1) })).toBe("ged\n(2)");
-    expect(nbRPCs).toBe(4, {
-        message: "should have done 1 write, 1 web_read_group and 2 search_read",
+    expect(nbRPCs).toBe(2, {
+        message: "should have done 1 write, 1 web_read_group",
     });
 });
 
 test("edit a column propagates right context", async () => {
-    expect.assertions(4);
+    expect.assertions(3);
 
     Product._views["form"] = `
         <form string="Product">
@@ -5903,7 +5812,7 @@ test("edit a column propagates right context", async () => {
     serverState.lang = "nb_NO";
 
     onRpc(({ method, model, kwargs }) => {
-        if (model === "partner" && method === "web_search_read") {
+        if (model === "partner" && method === "web_read_group") {
             expect(kwargs.context.lang).toBe("nb_NO", {
                 message: "lang is present in context for partner operations",
             });
@@ -6174,6 +6083,7 @@ test("count of folded groups in empty kanban with sample data", async () => {
                 product_id: [1, "New"],
                 __count: 0,
                 __extra_domain: [],
+                __records: [],
             },
             {
                 product_id: [2, "In Progress"],
@@ -6314,6 +6224,7 @@ test("nocontent helper after adding a record (kanban with progressbar)", async (
                 __extra_domain: [["product_id", "=", 3]],
                 __count: 0,
                 product_id: [3, "hello"],
+                __records: [],
             },
         ],
     }));
@@ -6440,6 +6351,7 @@ test("no nocontent helper for grouped kanban with empty groups", async () => {
         const result = parent();
         for (const group of result.groups) {
             group.__count = 0;
+            group.__records = [];
         }
         return result;
     });
@@ -6571,6 +6483,7 @@ test("remove nocontent helper after adding a record", async () => {
                 __extra_domain: [["product_id", "=", 3]],
                 __count: 0,
                 product_id: [3, "hello"],
+                __records: [],
             },
         ],
         length: 1,
@@ -6611,6 +6524,7 @@ test("remove nocontent helper when adding a record", async () => {
                 __extra_domain: [["product_id", "=", 3]],
                 __count: 0,
                 product_id: [3, "hello"],
+                __records: [],
             },
         ],
         length: 1,
@@ -6650,6 +6564,7 @@ test("nocontent helper is displayed again after canceling quick create", async (
                 __extra_domain: [["product_id", "=", 3]],
                 __count: 0,
                 product_id: [3, "hello"],
+                __records: [],
             },
         ],
         length: 1,
@@ -6769,6 +6684,7 @@ test("empty kanban with sample data grouped by date range (fill temporal)", asyn
                         ["date", ">=", "2022-12-01"],
                         ["date", "<", "2023-01-01"],
                     ],
+                    __records: [],
                 },
             ],
             length: 1,
@@ -7136,6 +7052,7 @@ test("empty grouped kanban with sample data: add a column", async () => {
         result.groups = this.env["product"].map((r) => ({
             product_id: [r.id, r.display_name],
             __count: 0,
+            __records: [], // Open group by default
             __extra_domain: [["product_id", "=", r.id]],
         }));
         result.length = result.groups.length;
@@ -7220,6 +7137,7 @@ test("empty grouped kanban with sample data: delete a column", async () => {
             product_id: [1, "New"],
             __count: 0,
             __extra_domain: [],
+            __records: [],
         },
     ];
 
@@ -7267,6 +7185,7 @@ test("empty grouped kanban with sample data: add a column and delete it right aw
         result.groups = this.env["product"].map((r) => ({
             product_id: [r.id, r.display_name],
             __count: 0,
+            __records: [], // Open group by default
             __extra_domain: [["product_id", "=", r.id]],
         }));
         result.length = result.groups.length;
@@ -7365,6 +7284,7 @@ test("kanban with sample data grouped by m2o and existing groups", async () => {
         groups: [
             {
                 __count: 0,
+                __records: [],
                 product_id: [3, "hello"],
                 __extra_domain: [["product_id", "=", "3"]],
             },
@@ -8037,9 +7957,8 @@ test("colorpicker doesn't appear when missing access rights", async () => {
 
 test("load more records in column", async () => {
     onRpc("web_search_read", ({ kwargs }) => {
-        expect.step(`${kwargs.limit} - ${kwargs.offset}`);
+        expect.step(`web_search_read ${kwargs.limit} - ${kwargs.offset}`);
     });
-
     await mountView({
         type: "kanban",
         resModel: "partner",
@@ -8067,8 +7986,8 @@ test("load more records in column", async () => {
         message: "there should now be 3 records in the column",
     });
     // the records should be correctly fetched
-    expect.verifySteps(["2 - 0", "2 - 0", "4 - 0"]);
     expect(getKanbanRecordTexts(1)).toEqual(["1", "2", "3"]);
+    expect.verifySteps(["web_search_read 4 - 0"]);
 
     // reload
     await validateSearch();
@@ -8077,7 +7996,7 @@ test("load more records in column", async () => {
         message: "there should still be 3 records in the column after reload",
     });
     expect(getKanbanRecordTexts(1)).toEqual(["1", "2", "3"]);
-    expect.verifySteps(["2 - 0", "4 - 0"]);
+    expect.verifySteps([]); // managed by web_read_group
 });
 
 test("load more records in column with x2many", async () => {
@@ -8088,9 +8007,8 @@ test("load more records in column with x2many", async () => {
     // record [2] will be loaded after
 
     onRpc("web_search_read", ({ kwargs }) => {
-        expect.step(`web_search_read ${kwargs.limit}-${kwargs.offset}`);
+        expect.step(`web_search_read ${kwargs.limit} - ${kwargs.offset}`);
     });
-
     await mountView({
         type: "kanban",
         resModel: "partner",
@@ -8112,7 +8030,6 @@ test("load more records in column with x2many", async () => {
         "silver",
         "",
     ]);
-    expect.verifySteps(["web_search_read 2-0", "web_search_read 2-0"]);
 
     // load more
     await clickKanbanLoadMore(1);
@@ -8123,7 +8040,7 @@ test("load more records in column with x2many", async () => {
         "",
         "gold",
     ]);
-    expect.verifySteps(["web_search_read 4-0"]);
+    expect.verifySteps(["web_search_read 4 - 0"]);
 });
 
 test("update buttons after column creation", async () => {
@@ -8507,8 +8424,6 @@ test("column progressbars properly work", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -8606,8 +8521,6 @@ test('column progressbars: "false" bar is clickable', async () => {
         "web_read_group",
         "has_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "read_progress_bar",
     ]);
 });
@@ -8655,8 +8568,6 @@ test('column progressbars: "false" bar with sum_field', async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "formatted_read_group",
         "web_search_read",
         "read_progress_bar",
@@ -8728,8 +8639,6 @@ test("column progressbars: creating a new column should create a new progressbar
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "name_create",
         "web_resequence",
     ]);
@@ -8772,8 +8681,6 @@ test("column progressbars on quick create properly update counter", async () => 
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "onchange",
         "name_create",
         "onchange",
@@ -8814,7 +8721,6 @@ test("column progressbars are working with load more", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
         "web_search_read",
         "web_search_read",
     ]);
@@ -8860,7 +8766,6 @@ test("column progressbars with an active filter are working with load more", asy
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
         "web_search_read",
         "read_progress_bar",
         "web_search_read",
@@ -8917,12 +8822,9 @@ test("column progressbars on archiving records update counter", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "action_archive",
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
     ]);
 });
 
@@ -8967,12 +8869,9 @@ test("kanban with progressbars: correctly update env when archiving records", as
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "action_archive",
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
     ]);
 });
 
@@ -9004,13 +8903,9 @@ test("RPCs when (re)loading kanban view progressbars", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         // reload
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -9054,11 +8949,9 @@ test("RPCs when (de)activating kanban view progressbar filters", async () => {
         "web_read_group",
         "has_group",
         "web_read_group domain []",
-        "web_search_read",
-        "web_search_read",
         "formatted_read_group", // recomputes aggregates
         "web_search_read",
-        'formatted_read_group domain ["&",["bar","=",true],["foo","=","yop"]]', // perform web_read_group only on second column (bar=true)
+        'formatted_read_group domain ["&",["bar","=",true],["foo","=","yop"]]', // perform formatted_read_group only on second column (bar=true)
         "read_progress_bar",
         "formatted_read_group",
         "formatted_read_group",
@@ -9067,7 +8960,7 @@ test("RPCs when (de)activating kanban view progressbar filters", async () => {
         // activate filter
         "formatted_read_group", // recomputes aggregates
         "web_search_read",
-        'formatted_read_group domain ["&",["bar","=",true],["foo","=","gnap"]]', // perform web_read_group only on second column (bar=true)
+        'formatted_read_group domain ["&",["bar","=",true],["foo","=","gnap"]]', // perform formatted_read_group only on second column (bar=true)
         "read_progress_bar",
         "formatted_read_group",
         "formatted_read_group",
@@ -9129,8 +9022,6 @@ test("drag & drop records grouped by m2o with progressbar", async () => {
         "web_read_group",
         "has_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "web_save",
         "read_progress_bar",
         "web_resequence",
@@ -9191,8 +9082,6 @@ test("d&d records grouped by date with progressbar with aggregates", async () =>
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_save",
         "read_progress_bar",
         "formatted_read_group",
@@ -9230,8 +9119,6 @@ test("progress bar subgroup count recompute", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_search_read",
         "read_progress_bar",
     ]);
@@ -9273,8 +9160,6 @@ test("progress bar recompute after d&d to and from other column", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_save",
         "read_progress_bar",
         "web_resequence",
@@ -9316,8 +9201,6 @@ test("progress bar recompute after filter selection", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 
     await contains(".progress-bar.bg-success", { root: getKanbanColumn(1) }).click();
@@ -9332,7 +9215,7 @@ test("progress bar recompute after filter selection", async () => {
 
     expect(getKanbanColumnTooltips()).toEqual(["3 yop"]);
     expect(getKanbanCounters()).toEqual(["3"]);
-    expect.verifySteps(["read_progress_bar", "web_read_group", "web_search_read"]);
+    expect.verifySteps(["read_progress_bar", "web_read_group"]);
 });
 
 test("progress bar recompute after filter selection (aggregates)", async () => {
@@ -9370,8 +9253,6 @@ test("progress bar recompute after filter selection (aggregates)", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 
     await contains(".progress-bar.bg-success", { root: getKanbanColumn(1) }).click();
@@ -9392,7 +9273,7 @@ test("progress bar recompute after filter selection (aggregates)", async () => {
 
     expect(getKanbanColumnTooltips()).toEqual(["3 yop"]);
     expect(getKanbanCounters()).toEqual(["600"]);
-    expect.verifySteps(["read_progress_bar", "web_read_group", "web_search_read"]);
+    expect.verifySteps(["read_progress_bar", "web_read_group"]);
 });
 
 test("progress bar with false aggregate value", async () => {
@@ -9658,8 +9539,6 @@ test("column progressbars on quick create with quick_create_view", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "get_views",
         "onchange",
         "web_save",
@@ -9729,8 +9608,6 @@ test("progressbars and active filter with quick_create_view", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "formatted_read_group",
         "web_search_read",
         "read_progress_bar",
@@ -10688,16 +10565,11 @@ test("progressbar filter state is kept unchanged when domain is updated (records
         "web_read_group",
         "has_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "read_progress_bar",
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -10774,18 +10646,12 @@ test("progressbar filter state is kept unchanged when domain is updated (emptyin
         "web_read_group",
         "has_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "read_progress_bar",
         "read_progress_bar",
         "web_read_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "read_progress_bar",
         "web_read_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -10849,8 +10715,6 @@ test("filtered column counters when dropping in non-matching record", async () =
         "web_read_group",
         "has_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "read_progress_bar",
         "web_save",
         "read_progress_bar",
@@ -10894,8 +10758,6 @@ test("filtered column is reloaded when dragging out its last record", async () =
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 
     // Apply an active filter
@@ -11331,8 +11193,6 @@ test("basic rendering with 2 groupbys", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -11341,7 +11201,7 @@ test("basic rendering with a date groupby with a granularity", async () => {
 
     stepAllNetworkCalls();
     onRpc("web_read_group", ({ method, kwargs }) => {
-        expect(kwargs.aggregates).toEqual(["__count"]);
+        expect(kwargs.aggregates).toEqual([]);
         expect(kwargs.groupby).toEqual(["date:day"]);
     });
 
@@ -11369,8 +11229,6 @@ test("basic rendering with a date groupby with a granularity", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -11635,8 +11493,6 @@ test("Color '200' (gray) can be used twice (for false value and another value) i
         "web_read_group",
         "has_group",
         "web_search_read",
-        "web_search_read",
-        "web_search_read",
         "read_progress_bar",
         "web_search_read",
         "read_progress_bar",
@@ -11728,8 +11584,6 @@ test("update field on which progress bars are computed", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_search_read",
         "read_progress_bar",
         "web_save",
@@ -12233,8 +12087,6 @@ test("drag record to folded column, with progressbars", async () => {
         "read_progress_bar",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_save",
         "read_progress_bar",
         "formatted_read_group",
@@ -12295,8 +12147,6 @@ test("quick create record in grouped kanban in a form view dialog", async () => 
         "get_views",
         "web_read_group", // initial web_read_group
         "has_group",
-        "web_search_read", // initial search_read (first column)
-        "web_search_read", // initial search_read (second column)
         "onchange", // quick create
         "name_create", // should perform a name_create to create the record
         "get_views", // load views for form view dialog
@@ -12519,8 +12369,6 @@ test("d&d records grouped by m2o with m2o displayed in records", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
     expect(queryAllTexts(".o_kanban_record")).toEqual(["hello", "hello", "xmo", "xmo"]);
 
@@ -12639,8 +12487,6 @@ test("rerenders only once after resequencing records", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "web_save",
         "web_resequence",
         "web_save",
@@ -12664,6 +12510,7 @@ test("sample server: _mockWebReadGroup API", async () => {
         groups: [
             {
                 __count: 0,
+                __records: [],
                 state: false,
                 "date:month": ["2022-12-01", "December 2022"],
                 __extra_domain: [
@@ -12716,13 +12563,7 @@ test("scroll on group unfold and progressbar click", async () => {
         groupBy: ["product_id"],
     });
 
-    expect.verifySteps([
-        "get_views",
-        "read_progress_bar",
-        "web_read_group",
-        "has_group",
-        "web_search_read",
-    ]);
+    expect.verifySteps(["get_views", "read_progress_bar", "web_read_group", "has_group"]);
     queryOne(".o_content").style.maxHeight = "80px";
     on(".o_content", "scroll", () => expect.step("scrolled"));
 
@@ -13020,34 +12861,41 @@ test("group by properties and drag and drop", async () => {
                 "properties.my_char": "aaa",
                 __extra_domain: [["properties.my_char", "=", "aaa"]],
                 __count: 1,
+                __records: [
+                    {
+                        id: 2,
+                        properties: [
+                            {
+                                name: "my_char",
+                                string: "My Char",
+                                type: "char",
+                                value: "aaa",
+                            },
+                        ],
+                    },
+                ],
             },
             {
                 "properties.my_char": "bbb",
                 __extra_domain: [["properties.my_char", "=", "bbb"]],
                 __count: 1,
+                __records: [
+                    {
+                        id: 3,
+                        properties: [
+                            {
+                                name: "my_char",
+                                string: "My Char",
+                                type: "char",
+                                value: "bbb",
+                            },
+                        ],
+                    },
+                ],
             },
         ],
         length: 3,
     }));
-    onRpc("web_search_read", ({ kwargs }) => {
-        const value = kwargs.domain[0][2];
-        return {
-            length: 1,
-            records: [
-                {
-                    id: value === "aaa" ? 2 : 3,
-                    properties: [
-                        {
-                            name: "my_char",
-                            string: "My Char",
-                            type: "char",
-                            value: value,
-                        },
-                    ],
-                },
-            ],
-        };
-    });
     onRpc("web_resequence", () => {
         expect.step("resequence");
         return [];
@@ -13298,9 +13146,7 @@ test("Correct values for progress bar with toggling filter and slow RPC", async 
 test("group by numeric field (with aggregator)", async () => {
     onRpc("web_read_group", ({ kwargs }) => {
         expect(kwargs.groupby).toEqual(["int_field"]);
-        expect(kwargs.aggregates).toEqual(["__count", "float_field:sum"], {
-            message: "Don't aggregate int_field since it is grouped by itself",
-        });
+        expect(kwargs.aggregates).toEqual(["int_field:sum", "float_field:sum"]);
         expect.step("web_read_group");
     });
     await mountView({
@@ -13892,7 +13738,7 @@ test("click on New while kanban is loading", async () => {
 });
 
 test("click on New while kanban is loading (with quick create)", async () => {
-    onRpc("web_search_read", () => new Deferred());
+    onRpc("web_read_group", () => new Deferred());
     await mountView({
         arch: `
             <kanban on_create="quick_create">

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2435,7 +2435,6 @@ test(`enabling archive in list when groupby m2m field`, async () => {
     await contains(`.o_group_name:eq(1)`).click(); // open group "Value 2"
     // Check for the initial number of records
     expect(`.o_data_row`).toHaveCount(5, { message: "Checking initial number of records" });
-
     await clickRecordSelector(); // select first task
     await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
     // check that all the options are available
@@ -3607,10 +3606,7 @@ test("group order by count", async () => {
         if (readGroupCount < 2) {
             readGroupCount++;
         } else {
-            expect(kwargs.groupby).toHaveLength(1);
-            expect.step(`web_read_group ${kwargs.groupby[0]} order by ${kwargs.order}`);
-            // TODO: The mock server cannot handle order count
-            kwargs.order = "";
+            expect.step(`web_read_group ${kwargs.groupby} order by ${kwargs.order}`);
             return parent();
         }
     });
@@ -3627,19 +3623,13 @@ test("group order by count", async () => {
     await selectGroup("currency_id");
     expect("tr.o_group_header").toHaveCount(3, { message: "list should be grouped" });
     await contains(".o_searchview_facet_label").click();
-    expect.verifySteps(["web_read_group foo order by __count DESC, foo ASC"]);
+    expect.verifySteps(["web_read_group foo,currency_id order by __count DESC"]);
     await contains("tr.o_group_header:eq(0)").click();
-    expect.verifySteps(["web_read_group currency_id order by __count DESC, currency_id ASC"]);
+    expect.verifySteps(["web_read_group currency_id order by __count DESC"]);
     await contains(".o_searchview_facet_label").click();
-    expect.verifySteps([
-        "web_read_group foo order by __count ASC, foo ASC",
-        "web_read_group currency_id order by __count ASC, currency_id ASC",
-    ]);
+    expect.verifySteps(["web_read_group foo,currency_id order by __count ASC"]);
     await contains(".o_searchview_facet_label").click();
-    expect.verifySteps([
-        "web_read_group foo order by __count DESC, foo ASC",
-        "web_read_group currency_id order by __count DESC, currency_id ASC",
-    ]);
+    expect.verifySteps(["web_read_group foo,currency_id order by __count DESC"]);
 });
 
 test("order by count reset", async () => {
@@ -3648,10 +3638,7 @@ test("order by count reset", async () => {
         if (readGroupCount < 2) {
             readGroupCount++;
         } else {
-            expect(kwargs.groupby).toHaveLength(1);
-            expect.step(`web_read_group ${kwargs.groupby[0]} order by ${kwargs.order}`);
-            // TODO: The mock server cannot handle order count
-            kwargs.order = "";
+            expect.step(`web_read_group ${kwargs.groupby} order by ${kwargs.order}`);
             return parent();
         }
     });
@@ -3674,16 +3661,16 @@ test("order by count reset", async () => {
     await toggleMenuItem("My Filter");
     await contains(".o_searchview_facet_label").click();
     expect.verifySteps([
-        "web_read_group foo order by ",
-        "web_read_group foo order by __count DESC, foo ASC",
+        "web_read_group foo,currency_id order by ",
+        "web_read_group foo,currency_id order by __count DESC",
     ]);
     await toggleSearchBarMenu();
     await toggleMenuItem("My Filter");
-    expect.verifySteps(["web_read_group foo order by __count DESC, foo ASC"]);
+    expect.verifySteps(["web_read_group foo,currency_id order by __count DESC"]);
     await toggleMenuItem("My Filter");
-    expect.verifySteps(["web_read_group foo order by __count DESC, foo ASC"]);
+    expect.verifySteps(["web_read_group foo,currency_id order by __count DESC"]);
     await toggleMenuItem("Currency");
-    expect.verifySteps(["web_read_group foo order by __count DESC, foo ASC"]);
+    expect.verifySteps(["web_read_group foo order by __count DESC"]);
     await toggleMenuItem("Foo");
     await toggleMenuItem("Foo");
     expect.verifySteps(["web_read_group foo order by "]);
@@ -4874,24 +4861,10 @@ test(`currency_field is taken into account when formatting monetary values`, asy
     });
 });
 
-test(`groups can not be sorted on a different field than the first field of the groupBy - 1`, async () => {
-    onRpc("web_read_group", ({ kwargs }) => {
-        expect.step("web_read_group");
-        expect(kwargs.order).toBe("", { message: "order should not contains foo" });
-    });
-    await mountView({
-        resModel: "foo",
-        type: "list",
-        arch: `<list default_order="foo"><field name="foo"/><field name="bar"/></list>`,
-        groupBy: ["bar"],
-    });
-    expect.verifySteps(["web_read_group"]);
-});
-
 test(`groups can be sorted on the first field of the groupBy`, async () => {
     onRpc("web_read_group", ({ kwargs }) => {
         expect.step("web_read_group");
-        expect(kwargs.order).toBe("bar DESC", { message: "should have an order" });
+        expect(kwargs.order).toEqual("bar DESC");
     });
 
     await mountView({
@@ -4907,7 +4880,7 @@ test(`groups can be sorted on the first field of the groupBy`, async () => {
 
 test(`groups can be sorted on aggregates`, async () => {
     onRpc("web_read_group", ({ kwargs }) => {
-        expect.step(kwargs.order || "default order");
+        expect.step(kwargs.order);
     });
 
     await mountView({
@@ -4937,11 +4910,7 @@ test(`groups can be sorted on aggregates`, async () => {
         message: "initial order should be 17, 10, 5",
     });
     expect(`tfoot td:eq(-1)`).toHaveText("32", { message: "total should still be 32" });
-    expect.verifySteps([
-        "default order",
-        "int_field:sum ASC, foo ASC",
-        "int_field:sum DESC, foo ASC",
-    ]);
+    expect.verifySteps(["", "int_field ASC", "int_field DESC"]);
 });
 
 test(`groups cannot be sorted on non-aggregable fields if every group is folded`, async () => {
@@ -4951,7 +4920,7 @@ test(`groups cannot be sorted on non-aggregable fields if every group is folded`
     });
 
     onRpc("web_read_group", ({ kwargs }) => {
-        expect.step(kwargs.order || "default order");
+        expect.step(kwargs.order);
     });
 
     await mountView({
@@ -4966,7 +4935,7 @@ test(`groups cannot be sorted on non-aggregable fields if every group is folded`
             </list>
         `,
     });
-    expect.verifySteps(["default order"]);
+    expect.verifySteps([""]);
 
     // we cannot sort by sort_field since it doesn't have a aggregator
     await contains(`.o_column_sortable[data-name='sort_field']`).click();
@@ -4974,7 +4943,7 @@ test(`groups cannot be sorted on non-aggregable fields if every group is folded`
 
     // we can sort by int_field since it has a aggregator
     await contains(`.o_column_sortable[data-name='int_field']`).click();
-    expect.verifySteps(["int_field:sum ASC, foo ASC"]);
+    expect.verifySteps(["int_field ASC"]);
 
     // we keep previous order
     await contains(`.o_column_sortable[data-name='sort_field']`).click();
@@ -4982,15 +4951,16 @@ test(`groups cannot be sorted on non-aggregable fields if every group is folded`
 
     // we can sort on foo since we are groupped by foo + previous order
     await contains(`.o_column_sortable[data-name='foo']`).click();
-    expect.verifySteps(["foo ASC, int_field:sum ASC"]);
+    expect.verifySteps(["foo ASC, int_field ASC"]);
 });
 
 test(`groups can be sorted on non-aggregable fields if a group isn't folded`, async () => {
     onRpc("web_read_group", ({ kwargs }) => {
-        expect.step(`web_read_group.order: ${kwargs.order || "default order"}`);
+        const order = kwargs.order || "default order";
+        expect.step(`web_read_group: ${order}`);
     });
     onRpc("web_search_read", ({ kwargs }) => {
-        expect.step(`web_search_read.order: ${kwargs.order || "default order"}`);
+        expect.step(`web_search_read: ${kwargs.order || "default order"}`);
     });
 
     await mountView({
@@ -5001,22 +4971,17 @@ test(`groups can be sorted on non-aggregable fields if a group isn't folded`, as
     });
     await contains(`.o_group_header:eq(1)`).click();
     expect(queryAllTexts(`.o_data_cell[name='foo']`)).toEqual(["yop", "blip", "gnap"]);
-    expect.verifySteps([
-        "web_read_group.order: default order",
-        "web_search_read.order: default order",
-    ]);
+    expect.verifySteps(["web_read_group: default order", "web_search_read: default order"]);
 
     await contains(`.o_column_sortable[data-name='foo']`).click();
     expect(queryAllTexts(`.o_data_cell[name='foo']`)).toEqual(["blip", "gnap", "yop"]);
-    expect.verifySteps(["web_read_group.order: default order", "web_search_read.order: foo ASC"]);
+    expect.verifySteps(["web_read_group: foo ASC"]);
 });
 
 test(`groups can be sorted on non-aggregable fields if a group isn't folded with expand='1'`, async () => {
     onRpc("web_read_group", ({ kwargs }) => {
-        expect.step(`web_read_group.order: ${kwargs.order || "default order"}`);
-    });
-    onRpc("web_search_read", ({ kwargs }) => {
-        expect.step(`web_search_read.order: ${kwargs.order || "default order"}`);
+        const order = kwargs.order || "default order";
+        expect.step(`web_read_group: ${order}`);
     });
 
     await mountView({
@@ -5026,19 +4991,11 @@ test(`groups can be sorted on non-aggregable fields if a group isn't folded with
         groupBy: ["bar"],
     });
     expect(queryAllTexts(`.o_data_cell[name='foo']`)).toEqual(["blip", "yop", "blip", "gnap"]);
-    expect.verifySteps([
-        "web_read_group.order: default order",
-        "web_search_read.order: default order",
-        "web_search_read.order: default order",
-    ]);
+    expect.verifySteps(["web_read_group: default order"]);
 
     await contains(`.o_column_sortable[data-name='foo']`).click();
     expect(queryAllTexts(`.o_data_cell[name='foo']`)).toEqual(["blip", "blip", "gnap", "yop"]);
-    expect.verifySteps([
-        "web_read_group.order: default order",
-        "web_search_read.order: foo ASC",
-        "web_search_read.order: foo ASC",
-    ]);
+    expect.verifySteps(["web_read_group: foo ASC"]);
 });
 
 test(`properly apply onchange in simple case`, async () => {
@@ -7560,11 +7517,6 @@ test(`groupby node with a button in inner groupbys`, async () => {
 
 test(`groupby node with a button with modifiers`, async () => {
     stepAllNetworkCalls();
-    onRpc("res.currency", "web_read", ({ args, kwargs }) => {
-        expect.step("res.currency:web_read");
-        expect(args).toEqual([[1, 2]]);
-        expect(kwargs.specification).toEqual({ position: {} });
-    });
 
     await mountView({
         type: "list",
@@ -7586,8 +7538,6 @@ test(`groupby node with a button with modifiers`, async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_read",
-        "res.currency:web_read",
     ]);
     expect(`.o_group_header button`).toHaveCount(0);
     expect(`.o_data_row`).toHaveCount(0);
@@ -7631,9 +7581,6 @@ test(`groupby node with a button with modifiers using a many2one`, async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
-        "web_read",
     ]);
 });
 
@@ -8291,7 +8238,7 @@ test(`list view with nested groups`, async () => {
 
     // sort by int_field (ASC) and check that open groups are still open
     await contains(`.o_list_view thead [data-name='int_field']`).click();
-    expect.verifySteps(["web_read_group", "web_read_group", "web_search_read"]);
+    expect.verifySteps(["web_read_group"]);
     expect(`.o_group_header`).toHaveCount(5);
     expect(`.o_data_row`).toHaveCount(2);
     expect(queryAllTexts(`.o_data_row .o_data_cell`)).toEqual(["5", "-7", "4", "-4"]);
@@ -10511,8 +10458,6 @@ test(`reference field batched in grouped list`, async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
     expect(`.o_group_header`).toHaveCount(2);
     expect(queryAllTexts(`.o_data_cell`)).toEqual([
@@ -10592,8 +10537,6 @@ test(`multi edit reference field batched in grouped list`, async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
     await contains(`.o_data_row .o_list_record_selector input:eq(0)`).click();
     await contains(`.o_data_row .o_list_record_selector input:eq(1)`).click();
@@ -12291,13 +12234,9 @@ test(`list view move to previous page when all records from last page deleted`, 
 
 test.tags("desktop");
 test(`grouped list view move to previous page of group when all records from last page deleted`, async () => {
-    let checkSearchRead = false;
     onRpc("web_search_read", ({ kwargs }) => {
-        if (checkSearchRead) {
-            expect.step(`web_search_read (limit: ${kwargs.limit}, offset: ${kwargs.offset})`);
-        }
+        expect.step(`web_search_read ${kwargs.limit} - ${kwargs.offset}`);
     });
-
     await mountView({
         resModel: "foo",
         type: "list",
@@ -12315,24 +12254,21 @@ test(`grouped list view move to previous page of group when all records from las
     await contains(`.o_group_header:eq(0)`).click();
     expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([1, 2]);
     expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(3);
+    expect.verifySteps(["web_search_read 2 - 0"]);
 
     // move to next page
     await pagerNext(queryFirst(`.o_group_header`));
     expect(getPagerValue(queryFirst(`.o_group_header`))).toEqual([3, 3]);
     expect(getPagerLimit(queryFirst(`.o_group_header`))).toBe(3);
+    expect.verifySteps(["web_search_read 2 - 2"]);
 
     // delete a record
     await contains(`.o_data_row .o_list_record_selector input`).click();
-    checkSearchRead = true;
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
     await contains(`.modal .btn-primary`).click();
     expect(`th.o_group_name:eq(0) .o_pager_counter`).toHaveCount(0);
     expect(`.o_data_row`).toHaveCount(2);
-    expect.verifySteps([
-        "web_search_read (limit: 2, offset: 2)",
-        "web_search_read (limit: 2, offset: 0)",
-    ]);
 });
 
 test.tags("desktop");
@@ -12686,8 +12622,6 @@ test(`grouped list with expand attribute`, async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
     ]);
 });
 
@@ -12736,8 +12670,6 @@ test(`grouped list (two levels) with expand attribute`, async () => {
         "get_views",
         "web_read_group", // global
         "has_group",
-        "web_read_group", // first group
-        "web_read_group", // second group
     ]);
 });
 
@@ -16442,7 +16374,7 @@ test(`list view with multi-fields default_group_by`, async () => {
         expect.step(`web_read_group${readGroupCount}`);
         switch (readGroupCount) {
             case 1: {
-                expect(kwargs.groupby).toEqual(["foo"]);
+                expect(kwargs.groupby).toEqual(["foo", "bar"]);
                 break;
             }
             case 2: {

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -82,7 +82,7 @@ beforeEach(() => onRpc("has_group", () => true));
 
 test.tags("desktop");
 test("SelectCreateDialog use domain, group_by and search default on desktop", async () => {
-    expect.assertions(3);
+    expect.assertions(4);
     Partner._views["list"] = /* xml */ `
         <list string="Partner">
             <field name="name"/>
@@ -99,33 +99,14 @@ test("SelectCreateDialog use domain, group_by and search default on desktop", as
     `;
     let search = 0;
     onRpc("web_read_group", ({ kwargs }) => {
-        expect(kwargs).toEqual(
-            {
-                context: {
-                    allowed_company_ids: [1],
-                    lang: "en",
-                    read_group_expand: true,
-                    tz: "taht",
-                    uid: 7,
-                }, // not part of the test, may change
-                domain: [
-                    "&",
-                    ["name", "like", "a"],
-                    "&",
-                    ["name", "ilike", "piou"],
-                    ["foo", "ilike", "piou"],
-                ],
-                aggregates: ["__count"],
-                groupby: ["bar"],
-                order: "",
-                limit: 80,
-                offset: 0,
-            },
-            {
-                message:
-                    "should search with the complete domain (domain + search), and group by 'bar'",
-            }
-        );
+        expect(kwargs.domain).toEqual([
+            "&",
+            ["name", "like", "a"],
+            "&",
+            ["name", "ilike", "piou"],
+            ["foo", "ilike", "piou"],
+        ]);
+        expect(kwargs.groupby).toEqual(["bar"]);
     });
     onRpc("web_search_read", ({ kwargs }) => {
         if (search === 0) {
@@ -196,7 +177,7 @@ test("SelectCreateDialog use domain, group_by and search default on desktop", as
 
 test.tags("mobile");
 test("SelectCreateDialog use domain, group_by and search default on mobile", async () => {
-    expect.assertions(3);
+    expect.assertions(4);
     Partner._views["search"] = /* xml */ `
         <search>
             <field name="foo" filter_domain="[('name','ilike',self), ('foo','ilike',self)]"/>
@@ -210,32 +191,14 @@ test("SelectCreateDialog use domain, group_by and search default on mobile", asy
     ] = /* xml */ `<kanban><templates><t t-name="card"><field name="name"/><field name="foo"/></t></templates></kanban>`;
     let search = 0;
     onRpc("web_read_group", ({ kwargs }) => {
-        expect(kwargs).toEqual(
-            {
-                context: {
-                    allowed_company_ids: [1],
-                    lang: "en",
-                    tz: "taht",
-                    uid: 7,
-                    read_group_expand: true,
-                }, // not part of the test, may change
-                domain: [
-                    "&",
-                    ["name", "like", "a"],
-                    "&",
-                    ["name", "ilike", "piou"],
-                    ["foo", "ilike", "piou"],
-                ],
-                groupby: ["bar"],
-                aggregates: ["__count"],
-                offset: 0,
-                order: "",
-            },
-            {
-                message:
-                    "should search with the complete domain (domain + search), and group by 'bar'",
-            }
-        );
+        expect(kwargs.domain).toEqual([
+            "&",
+            ["name", "like", "a"],
+            "&",
+            ["name", "ilike", "piou"],
+            ["foo", "ilike", "piou"],
+        ]);
+        expect(kwargs.groupby).toEqual(["bar"]);
     });
     onRpc("web_search_read", ({ kwargs }) => {
         if (search === 0) {

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -395,8 +395,6 @@ test("switching into a view with mode=edit lands in edit mode", async () => {
         "get_views",
         "web_read_group",
         "has_group",
-        "web_search_read",
-        "web_search_read",
         "onchange",
         "name_create",
         "web_read",

--- a/odoo/addons/test_read_group/tests/test_web_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_web_read_group.py
@@ -1,74 +1,1154 @@
 from odoo.tests import common
+from unittest.mock import patch
 
 
 class TestWebReadGroup(common.TransactionCase):
-    """ Test the 'length' logic of web_read_group, groups logic
-    are tested in test_formatted_read_group """
+    """Test the 'length' logic of web_read_group, groups logic
+    are tested in test_formatted_read_group"""
 
     maxDiff = None
 
-    def test_limit_offset_performance(self):
-        Model = self.env['test_read_group.aggregate']
-        Model.create({'key': 1, 'value': 1})
-        Model.create({'key': 1, 'value': 2})
-        Model.create({'key': 1, 'value': 3})
-        Model.create({'key': 2, 'value': 4})
-        Model.create({'key': 2})
-        Model.create({'key': 2, 'value': 5})
-        Model.create({})
-        Model.create({'value': 6})
+    def test_limit_offset(self):
+        Model = self.env["test_read_group.aggregate"]
+        Model.create(
+            [
+                {"key": 1, "value": 1},
+                {"key": 1, "value": 2},
+                {"key": 1, "value": 3},
+                {"key": 2, "value": 4},
+                {"key": 2},
+                {"key": 2, "value": 5},
+                {},
+                {"value": 6},
+            ],
+        )
 
         # warmup
-        Model.web_read_group([], groupby=['key'], aggregates=['value:sum'])
+        Model.web_read_group(domain=[], groupby=["key"], aggregates=["value:sum"])
 
-        # One _read_group/query because limit is reached
+        # One query for read_group because limit is reached
         with self.assertQueryCount(1):
             self.assertEqual(
-                Model.web_read_group([], groupby=['key'], aggregates=['value:sum'], limit=4),
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    limit=4,
+                ),
                 {
-                    'groups': [
-                        {'__extra_domain': [('key', '=', 1)], 'key': 1, 'value:sum': 1 + 2 + 3},
-                        {'__extra_domain': [('key', '=', 2)], 'key': 2, 'value:sum': 4 + 5},
-                        {'__extra_domain': [('key', '=', False)], 'key': False, 'value:sum': 6},
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 1)],
+                            "key": 1,
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", False)],
+                            "key": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                        },
                     ],
-                    'length': 3,
+                    "length": 3,
                 },
             )
 
         # One _read_group with the limit and other without to get the length
         with self.assertQueryCount(2):
             self.assertEqual(
-                Model.web_read_group([], groupby=['key'], aggregates=['value:sum'], limit=2),
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    limit=2,
+                ),
                 {
-                    'groups': [
-                        {'__extra_domain': [('key', '=', 1)], 'key': 1, 'value:sum': 1 + 2 + 3},
-                        {'__extra_domain': [('key', '=', 2)], 'key': 2, 'value:sum': 4 + 5},
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 1)],
+                            "key": 1,
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                        },
                     ],
-                    'length': 3,
+                    "length": 3,
                 },
             )
 
         # One _read_group/query because limit is reached
         with self.assertQueryCount(1):
             self.assertEqual(
-                Model.web_read_group([], groupby=['key'], aggregates=['value:sum'], offset=1),
+                Model.web_read_group(
+                    domain=[], groupby=["key"], aggregates=["value:sum"], offset=1
+                ),
                 {
-                    'groups': [
-                        {'__extra_domain': [('key', '=', 2)], 'key': 2, 'value:sum': 4 + 5},
-                        {'__extra_domain': [('key', '=', False)], 'key': False, 'value:sum': 6},
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", False)],
+                            "key": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                        },
                     ],
-                    'length': 3,
+                    "length": 3,
                 },
             )
 
         with self.assertQueryCount(2):
             self.assertEqual(
-                Model.web_read_group([], groupby=['key'], aggregates=['value:sum'], offset=1, limit=2, order='key DESC'),
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    offset=1,
+                    limit=2,
+                    order="key DESC",
+                ),
                 {
-                    'groups': [
-                        {'__extra_domain': [('key', '=', 2)], 'key': 2, 'value:sum': 4 + 5},
-                        {'__extra_domain': [('key', '=', 1)], 'key': 1, 'value:sum': 1 + 2 + 3},
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", 1)],
+                            "key": 1,
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                        },
                     ],
-                    'length': 3,
+                    "length": 3,
                 },
             )
+
+    @patch("odoo.addons.web.models.models.MAX_NUMBER_OPENED_GROUPS", 2)
+    def test_auto_unfold_limit(self):
+        Model = self.env["test_read_group.aggregate"]
+        records = Model.create(
+            [
+                {"key": 1, "value": 1},
+                {"key": 1, "value": 2},
+                {"key": 1, "value": 3},
+                {"key": 2, "value": 4},
+                {"key": 2},
+                {"key": 2, "value": 5},
+                {},
+                {"value": 6},
+            ],
+        )
+
+        read_spec = {
+            "key": {},
+            "value": {},
+        }
+        key1_read_records = records[:3].web_read(read_spec)
+        key2_read_records = records[3:6].web_read(read_spec)
+
+        # Warmup ormcache
+        Model.web_read_group(
+            domain=[],
+            groupby=["key"],
+            aggregates=["value:sum"],
+            auto_unfold=True,
+            unfold_read_specification=read_spec,
+        )
+
+        self.env.invalidate_all()
+
+        # One query formatted_read_group
+        # One query get records first column
+        # One query get records second column
+        # One query to read all records
+        with self.assertQueryCount(4):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 1)],
+                            "key": 1,
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                            "__records": key1_read_records,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__records": key2_read_records,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", False)],
+                            "key": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                            # No records, since we patch MAX_NUMBER_OPENED_GROUPS to 2
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+        self.env.invalidate_all()
+
+        # One query formatted_read_group
+        # One query get records first column
+        # One query get records second column
+        # One query to read records
+        with self.assertQueryCount(4):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 1)],
+                            "key": 1,
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                            "__records": key1_read_records,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__records": key2_read_records,
+                        },
+                        {
+                            "__extra_domain": [("key", "=", False)],
+                            "key": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+        self.env.invalidate_all()
+
+        # One query formatted_read_group
+        # One query to get the number of group (because limit is reached)
+        # One query get records first column
+        # One query to read records
+        with self.assertQueryCount(4):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    offset=1,
+                    limit=1,
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("key", "=", 2)],
+                            "key": 2,
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__records": key2_read_records,
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+    def test_unfolded_specific_groups(self):
+        Model = self.env["test_read_group.aggregate"]
+        partner_1, partner_2 = self.env["res.partner"].create(
+            [
+                {"name": "P1"},
+                {"name": "P2"},
+            ],
+        )
+        records = Model.create(
+            [
+                {"partner_id": partner_1.id, "key": 1, "value": 1},
+                {"partner_id": partner_1.id, "key": 1, "value": 2},
+                {"partner_id": partner_1.id, "key": 1, "value": 3},
+                {"partner_id": partner_2.id, "key": 1, "value": 4},
+                {"partner_id": partner_2.id, "key": 2},
+                {"partner_id": partner_2.id, "value": 5},
+                {},
+                {"value": 6},
+            ],
+        )
+
+        read_spec = {
+            "key": {},
+            "value": {},
+            "partner_id": {"fields": {"display_name": {}}},
+        }
+
+        # Warmup ormcache
+        Model.web_read_group(
+            domain=[],
+            groupby=["partner_id", "key"],
+            aggregates=["value:sum"],
+        )
+
+        # Scenario: list view groupby ['partner_id', 'key'] - no group opened by default
+        self.env.invalidate_all()
+
+        # One query for the _read_group
+        # One query to read the display_name of partner_id
+        with self.assertQueryCount(2):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["partner_id", "key"],
+                    aggregates=["value:sum"],
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_1.id)],
+                            "partner_id": (partner_1.id, "P1"),
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_2.id)],
+                            "partner_id": (partner_2.id, "P2"),
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", False)],
+                            "partner_id": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+        # Scenario:
+        # Client opened manually several groups and reload the view (add a filter / change of views / ...).
+        # Simulate that DEFAULT_GROUP_LIMIT is 2.
+        opening_info = [
+            {
+                "value": partner_1.id,
+                "folded": False,  # open the partner group (partner=P1)
+                "limit": 2,
+                "offset": 0,
+                "progressbar_domain": [],
+                "groups": [
+                    {
+                        "value": 1,
+                        "folded": False,  # open the subgroup (key=1)
+                        "limit": 2,
+                        "offset": 2,  # next page of records
+                        "progressbar_domain": [],
+                    },
+                ],
+            },
+            {
+                "value": partner_2.id,
+                "folded": False,  # open the partner group (partner=P2)
+                "limit": 2,
+                "offset": 2,  # next page of subgroups
+                # Don't put progressbar_domain and it should work
+                "groups": [
+                    {
+                        "value": False,
+                        "folded": False,  # open the subgroup (key=False)
+                        "limit": 2,
+                        "offset": 0,
+                        "progressbar_domain": [],
+                    },
+                ],
+            },
+            {
+                "value": False,
+                "folded": True,
+            },
+        ]
+        read_record_2 = records[2].web_read(read_spec)
+        read_record_5 = records[5].web_read(read_spec)
+
+        self.env.invalidate_all()
+
+        # One query for the main _read_group
+        # One query for the to open subgroup partner=P1
+        # One query for the to open subgroup partner=P2
+        # One query get records first subgroup
+        # One query get records second subgroup
+        # One query to read fields of test_read_group.aggregate fields
+        # One query to read display_name of partner
+        with self.assertQueryCount(7):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["partner_id", "key"],
+                    aggregates=["value:sum"],
+                    opening_info=opening_info,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_1.id)],
+                            "partner_id": (partner_1.id, "P1"),
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                            "__groups": {
+                                "groups": [
+                                    {
+                                        "__extra_domain": [("key", "=", 1)],
+                                        "key": 1,
+                                        "__count": 3,
+                                        "value:sum": 1 + 2 + 3,
+                                        "__records": read_record_2,
+                                    },
+                                ],
+                                "length": 1,
+                            },
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_2.id)],
+                            "partner_id": (partner_2.id, "P2"),
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__groups": {
+                                "groups": [
+                                    {
+                                        "key": False,
+                                        "__extra_domain": [("key", "=", False)],
+                                        "value:sum": 5,
+                                        "__count": 1,
+                                        "__records": read_record_5,
+                                    }
+                                ],
+                                "length": 3,
+                            },
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", False)],
+                            "partner_id": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                            # Group no opened since it is an Falsy value
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+    def test_auto_unfolded(self):
+        """Test unfolded groups when no __fold exists"""
+        Model = self.env["test_read_group.aggregate"]
+        partner_1, partner_2 = self.env["res.partner"].create(
+            [
+                {"name": "P1"},
+                {"name": "P2"},
+            ],
+        )
+        records = Model.create(
+            [
+                {"partner_id": partner_1.id, "key": 1, "value": 1},
+                {"partner_id": partner_1.id, "key": 1, "value": 2},
+                {"partner_id": partner_1.id, "key": 1, "value": 3},
+                {"partner_id": partner_2.id, "key": 1, "value": 4},
+                {"partner_id": partner_2.id, "key": 2},
+                {"partner_id": partner_2.id, "value": 5},
+                {},
+                {"value": 6},
+            ],
+        )
+
+        read_spec = {
+            "key": {},
+            "value": {},
+            "partner_id": {"fields": {"display_name": {}}},
+        }
+
+        # Warmup ormcache
+        Model.web_read_group(
+            domain=[],
+            groupby=["partner_id"],
+            aggregates=["value:sum"],
+            auto_unfold=True,
+            unfold_read_specification=read_spec,
+        )
+        self.env.invalidate_all()
+
+        # Scenario: groupby many2one (no __fold informatoion) on a kanban view
+
+        # One query for the _read_group
+        # One query to read the display_name of partner_id
+        # One query get records first column
+        # One query get records second column
+        # One query to read all records opened
+        with self.assertQueryCount(5):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["partner_id"],
+                    aggregates=["value:sum"],
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_1.id)],
+                            "partner_id": (partner_1.id, "P1"),
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                            "__records": records[:3].web_read(read_spec),
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_2.id)],
+                            "partner_id": (partner_2.id, "P2"),
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__records": records[3:6].web_read(read_spec),
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", False)],
+                            "partner_id": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                            # No __records since we don't opened False relational value by default
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+        self.env.invalidate_all()
+
+        # Scenario: list view with expaned="1", auto opened the first level of groupby
+
+        # One query for the _read_group
+        # One query to read the display_name of partner_id
+        # One query to open subgroups partner_1 (not batched - hard to do)
+        # One query to open subgroups partner_2
+        with self.assertQueryCount(4):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["partner_id", "key"],
+                    aggregates=["value:sum"],
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_1.id)],
+                            "partner_id": (partner_1.id, "P1"),
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                            "__groups": {
+                                "groups": [
+                                    {
+                                        "__extra_domain": [("key", "=", 1)],
+                                        "key": 1,
+                                        "__count": 3,
+                                        "value:sum": 1 + 2 + 3,
+                                    },
+                                ],
+                                "length": 1,
+                            },
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_2.id)],
+                            "partner_id": (partner_2.id, "P2"),
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__groups": {
+                                "groups": [
+                                    {
+                                        "__extra_domain": [("key", "=", 1)],
+                                        "key": 1,
+                                        "__count": 1,
+                                        "value:sum": 4,
+                                    },
+                                    {
+                                        "__extra_domain": [("key", "=", 2)],
+                                        "key": 2,
+                                        "__count": 1,
+                                        "value:sum": False,
+                                    },
+                                    {
+                                        "__extra_domain": [("key", "=", False)],
+                                        "key": False,
+                                        "__count": 1,
+                                        "value:sum": 5,
+                                    },
+                                ],
+                                "length": 3,
+                            },
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", False)],
+                            "partner_id": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+    def test_extra_domain_records(self):
+        # Scenario: Open a kanban view, select an part of the records with the progress bar.
+
+        Model = self.env["test_read_group.aggregate"]
+        records = Model.create(
+            [
+                {"key": 1, "value": 1},
+                {"key": 1, "value": 2},
+                {"key": 1, "value": 3},
+                {"key": 2, "value": 4},
+                {"key": 2},
+                {"key": 2, "value": 5},
+                {},
+                {"value": 6},
+            ],
+        )
+
+        opening_info = [
+            {
+                "value": 1,
+                "folded": False,  # open the partner group (key=1)
+                "limit": 2,
+                "offset": 0,
+                "progressbar_domain": [  # select specific part of records with the progress_bar
+                    ["value", "=", 1],
+                ],
+            },
+            {
+                "value": 2,
+                "folded": False,  # open the partner group (key=2)
+                "limit": 2,
+                "offset": 0,
+                "progressbar_domain": [  # select specific part of records with the progress_bar
+                    ["value", "=", 5],
+                ],
+            },
+            {
+                "value": False,
+                "folded": True,
+            },
+        ]
+
+        read_spec = {"value": {}}
+
+        # warmup ormcache
+        Model.web_read_group(
+            domain=[],
+            groupby=["key"],
+            aggregates=["value:sum"],
+            auto_unfold=True,
+            opening_info=opening_info,
+            unfold_read_specification=read_spec,
+            unfold_read_default_limit=80,
+        )
+
+        self.env.invalidate_all()
+
+        # One query for the _read_group
+        # One query get records of the first column
+        # One query get records of the second column
+        # One query to read all records opened
+        with self.assertQueryCount(4):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    auto_unfold=True,
+                    opening_info=opening_info,
+                    unfold_read_specification=read_spec,
+                    unfold_read_default_limit=80,
+                ),
+                {
+                    "groups": [
+                        {
+                            "key": 1,
+                            "__extra_domain": [("key", "=", 1)],
+                            "value:sum": 6,
+                            "__count": 3,
+                            "__records": records[0].web_read(read_spec),
+                        },
+                        {
+                            "key": 2,
+                            "__extra_domain": [("key", "=", 2)],
+                            "value:sum": 9,
+                            "__count": 3,
+                            "__records": records[5].web_read(read_spec),
+                        },
+                        {
+                            "key": False,
+                            "__extra_domain": [("key", "=", False)],
+                            "value:sum": 6,
+                            "__count": 2,
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+    def test_auto_fold_info(self):
+        """Test when __fold exists in subgroup"""
+        order_1, order_2, order_3, order_4 = self.env["test_read_group.order"].create(
+            [
+                {"name": "O1", "fold": False},
+                {"name": "O2", "fold": True},
+                {"name": "O3 empty", "fold": False},
+                {"name": "O4 empty", "fold": True},
+            ]
+        )
+        Line = self.env["test_read_group.order.line"].with_context(
+            read_group_expand=True
+        )
+        records = Line.create(
+            [
+                {"order_expand_id": order_1.id, "value": 1},
+                {"order_expand_id": order_2.id, "value": 2},
+                {"order_expand_id": order_2.id, "value": 2},
+                {"order_expand_id": False, "value": 3},
+            ]
+        )
+
+        read_spec = {"value": {}}
+
+        # warmup ormcache
+        Line.web_read_group(
+            domain=[],
+            groupby=["order_expand_id"],
+            aggregates=["value:sum"],
+            auto_unfold=True,
+            unfold_read_specification=read_spec,
+        )
+
+        self.env.invalidate_all()
+
+        # Scenario: kanban view where fold information is in the comodel
+
+        # One query for the _read_group
+        # One query for the _read_group_expand_full of order_expand_id
+        # One query to read the display_name/fold of order_expand_id
+        # One query get records first column (second column empty - no query)
+        # One query to read all records opened
+        with self.assertQueryCount(5):
+            self.assertEqual(  # No group_expand limit reached directly
+                Line.web_read_group(
+                    domain=[],
+                    groupby=["order_expand_id"],
+                    aggregates=["value:sum"],
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "order_expand_id": (order_1.id, "O1"),
+                            "__extra_domain": [("order_expand_id", "=", order_1.id)],
+                            "value:sum": 1,
+                            "__count": 1,
+                            "__records": records[0].web_read(read_spec),
+                        },
+                        {
+                            "order_expand_id": (order_2.id, "O2"),
+                            "__extra_domain": [("order_expand_id", "=", order_2.id)],
+                            "value:sum": 4,
+                            "__count": 2,
+                        },
+                        {
+                            "order_expand_id": (order_3.id, "O3 empty"),
+                            "__extra_domain": [("order_expand_id", "=", order_3.id)],
+                            "value:sum": False,
+                            "__count": 0,
+                            "__records": [],
+                        },
+                        {
+                            "order_expand_id": (order_4.id, "O4 empty"),
+                            "__extra_domain": [("order_expand_id", "=", order_4.id)],
+                            "value:sum": False,
+                            "__count": 0,
+                        },
+                        {
+                            "order_expand_id": False,
+                            "__extra_domain": [("order_expand_id", "=", False)],
+                            "value:sum": 3,
+                            "__count": 1,
+                        },
+                    ],
+                    "length": 5,
+                },
+            )
+
+        # Scenario: view list where fold information is in the comodel
+
+        self.env.invalidate_all()
+
+        # One query for the _read_group
+        # One query for the _read_group_expand_full of order_expand_id
+        # One query to read the display_name/fold of order_expand_id
+        # One query to get all records
+        # One query to read all records opened
+        with self.assertQueryCount(5):
+            self.assertEqual(  # No group_expand limit reached directly
+                Line.web_read_group(
+                    domain=[],
+                    groupby=["order_expand_id", "value"],
+                    aggregates=[],
+                    auto_unfold=True,
+                    unfold_read_specification=read_spec,
+                ),
+                {
+                    "groups": [
+                        {
+                            "order_expand_id": (order_1.id, "O1"),
+                            "__extra_domain": [("order_expand_id", "=", order_1.id)],
+                            "__count": 1,
+                            "__groups": {
+                                "groups": [
+                                    {
+                                        "value": 1,
+                                        "__extra_domain": [("value", "=", 1)],
+                                        "__count": 1,
+                                        # Shouldn't be unfold
+                                    },
+                                ],
+                                "length": 1,
+                            },
+                        },
+                        {
+                            "order_expand_id": (order_2.id, "O2"),
+                            "__extra_domain": [("order_expand_id", "=", order_2.id)],
+                            "__count": 2,
+                        },
+                        {
+                            "order_expand_id": (order_3.id, "O3 empty"),
+                            "__extra_domain": [("order_expand_id", "=", order_3.id)],
+                            "__count": 0,
+                            "__groups": {
+                                "groups": [],
+                                "length": 0,
+                            },
+                        },
+                        {
+                            "order_expand_id": (order_4.id, "O4 empty"),
+                            "__extra_domain": [("order_expand_id", "=", order_4.id)],
+                            "__count": 0,
+                        },
+                        {
+                            "order_expand_id": False,
+                            "__extra_domain": [("order_expand_id", "=", False)],
+                            "__count": 1,
+                        },
+                    ],
+                    "length": 5,
+                },
+            )
+
+    def test_order(self):
+        Model = self.env["test_read_group.aggregate"]
+        records = Model.create(
+            [
+                {"key": 1, "value": 1},
+                {"key": 1, "value": 2},
+                {"key": 1, "value": 3},
+                {"key": 2, "value": 4},
+                {"key": 2, "value": 0},
+                {"key": 2, "value": 5},
+                {"value": 0},
+                {"value": 6},
+            ],
+        )
+
+        read_spec = {
+            "key": {},
+            "value": {},
+        }
+        key1_read_records = records[:3].web_read(read_spec)
+        key2_read_records = records[3:6].web_read(read_spec)
+        key_false_read_records = records[6:].web_read(read_spec)
+        # warmup
+        Model.web_read_group(
+            domain=[],
+            groupby=["key"],
+            aggregates=["value:sum"],
+            unfold_read_specification=read_spec,
+        )
+
+        # One query for the _read_group
+        # One query to get first group records
+        # One query to get second group records
+        # One query to read all records
+        with self.assertQueryCount(4):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["key"],
+                    aggregates=["value:sum"],
+                    unfold_read_specification=read_spec,
+                    auto_unfold=True,  # To check order of records too
+                    order="__count",
+                ),
+                {
+                    "groups": [
+                        {
+                            "key": False,
+                            "__extra_domain": [("key", "=", False)],
+                            "value:sum": 6,
+                            "__count": 2,
+                            "__records": key_false_read_records,
+                        },
+                        {
+                            "key": 1,
+                            "__extra_domain": [("key", "=", 1)],
+                            "value:sum": 6,
+                            "__count": 3,
+                            "__records": key1_read_records,
+                        },
+                        {
+                            "key": 2,
+                            "__extra_domain": [("key", "=", 2)],
+                            "value:sum": 9,
+                            "__count": 3,
+                            "__records": key2_read_records,
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+        self.assertEqual(
+            Model.web_read_group(
+                domain=[],
+                groupby=["key"],
+                aggregates=["value:sum"],
+                unfold_read_specification=read_spec,
+                auto_unfold=True,  # To check order of records too
+                order="__count DESC, key DESC",
+            ),
+            {
+                "groups": [
+                    {
+                        "key": 2,
+                        "__extra_domain": [("key", "=", 2)],
+                        "value:sum": 9,
+                        "__count": 3,
+                        "__records": key2_read_records,
+                    },
+                    {
+                        "key": 1,
+                        "__extra_domain": [("key", "=", 1)],
+                        "value:sum": 6,
+                        "__count": 3,
+                        "__records": key1_read_records,
+                    },
+                    {
+                        "key": False,
+                        "__extra_domain": [("key", "=", False)],
+                        "value:sum": 6,
+                        "__count": 2,
+                        "__records": key_false_read_records,
+                    },
+                ],
+                "length": 3,
+            },
+        )
+
+        self.assertEqual(
+            Model.web_read_group(
+                domain=[],
+                groupby=["key"],
+                aggregates=["value:sum"],
+                unfold_read_specification=read_spec,
+                auto_unfold=True,  # To check order of records too
+                order="value",
+            ),
+            {
+                "groups": [
+                    {
+                        "key": 1,
+                        "__extra_domain": [("key", "=", 1)],
+                        "value:sum": 6,
+                        "__count": 3,
+                        "__records": sorted(
+                            key1_read_records, key=lambda r: r["value"]
+                        ),
+                    },
+                    {
+                        "key": False,
+                        "__extra_domain": [("key", "=", False)],
+                        "value:sum": 6,
+                        "__count": 2,
+                        "__records": sorted(
+                            key_false_read_records, key=lambda r: r["value"]
+                        ),
+                    },
+                    {
+                        "key": 2,
+                        "__extra_domain": [("key", "=", 2)],
+                        "value:sum": 9,
+                        "__count": 3,
+                        "__records": sorted(
+                            key2_read_records, key=lambda r: r["value"]
+                        ),
+                    },
+                ],
+                "length": 3,
+            },
+        )
+
+        self.assertEqual(
+            Model.web_read_group(
+                domain=[],
+                groupby=["key"],
+                aggregates=["value:sum"],
+                unfold_read_specification=read_spec,
+                auto_unfold=True,  # To check order of records too
+                order="key DESC",
+            ),
+            {
+                "groups": [
+                    {
+                        "key": False,
+                        "__extra_domain": [("key", "=", False)],
+                        "value:sum": 6,
+                        "__count": 2,
+                        "__records": key_false_read_records,
+                    },
+                    {
+                        "key": 2,
+                        "__extra_domain": [("key", "=", 2)],
+                        "value:sum": 9,
+                        "__count": 3,
+                        "__records": key2_read_records,
+                    },
+                    {
+                        "key": 1,
+                        "__extra_domain": [("key", "=", 1)],
+                        "value:sum": 6,
+                        "__count": 3,
+                        "__records": key1_read_records,
+                    },
+                ],
+                "length": 3,
+            },
+        )
+
+    def test_read_extra_info_groupby_value(self):
+        Model = self.env["test_read_group.aggregate"]
+        partner_1, partner_2 = self.env["res.partner"].create(
+            [
+                {"name": "P1", "ref": "P1-REF"},
+                {"name": "P2", "ref": "P2-REF"},
+            ],
+        )
+        Model.create(
+            [
+                {"partner_id": partner_1.id, "key": 1, "value": 1},
+                {"partner_id": partner_1.id, "key": 1, "value": 2},
+                {"partner_id": partner_1.id, "key": 1, "value": 3},
+                {"partner_id": partner_2.id, "key": 1, "value": 4},
+                {"partner_id": partner_2.id, "key": 2},
+                {"partner_id": partner_2.id, "value": 5},
+                {},
+                {"value": 6},
+            ],
+        )
+
+        # Warmup ormcache
+        Model.web_read_group(
+            domain=[],
+            groupby=["partner_id"],
+            aggregates=["value:sum"],
+            groupby_read_specification={"partner_id": {"ref": {}}},
+        )
+        self.env.invalidate_all()
+
+        Partner = self.registry["res.partner"]
+        # One query for the _read_group
+        # One query to read ref/display_name of partners
+        with (
+            self.assertQueryCount(2),
+            patch.object(
+                Partner,
+                "web_read",
+                autospec=True,
+                side_effect=Partner.web_read,
+            ) as spy_web_read,
+        ):
+            self.assertEqual(
+                Model.web_read_group(
+                    domain=[],
+                    groupby=["partner_id"],
+                    aggregates=["value:sum"],
+                    groupby_read_specification={"partner_id": {"ref": {}}},
+                ),
+                {
+                    "groups": [
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_1.id)],
+                            "partner_id": (partner_1.id, "P1"),
+                            "__count": 3,
+                            "value:sum": 1 + 2 + 3,
+                            "__values": {"id": partner_1.id, "ref": "P1-REF"},
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", partner_2.id)],
+                            "partner_id": (partner_2.id, "P2"),
+                            "__count": 3,
+                            "value:sum": 4 + 5,
+                            "__values": {"id": partner_2.id, "ref": "P2-REF"},
+                        },
+                        {
+                            "__extra_domain": [("partner_id", "=", False)],
+                            "partner_id": False,
+                            "__count": 2,
+                            "value:sum": 6,
+                            "__values": {"id": False},  # Sentinel for the webclient
+                        },
+                    ],
+                    "length": 3,
+                },
+            )
+
+            self.assertEqual(spy_web_read.call_count, 1)

--- a/odoo/models/__init__.py
+++ b/odoo/models/__init__.py
@@ -17,6 +17,7 @@ from odoo.orm.models import (
     check_company_domain_parent_of,
     fix_import_export_id_paths,
     parse_read_group_spec,
+    regex_order,
     to_record_ids,
 )
 from odoo.orm.model_classes import is_model_class, is_model_definition


### PR DESCRIPTION
## Rational:

Currently, opening a grouped kanban view triggers multiple RPC calls: two initial parallel calls (`formatted_read_group` and `read_progress_bar`), followed by up to 10 parallel `web_search_read` calls for each unfolded column. In the worst case, this results in 12 RPC requests, consuming a lot of workers and CPU time. While the parallel `web_search_read` calls aimed to minimize user response time, they lead to unbatched 'read' operations across several workers for each column. Additionally, `web_search_read` generates unnecessary `search_count` queries with limits, as the group record counts are already computed via `__count` aggregates.

The objective is to minimize SQL server impact and reduce server load by decreasing worker time consumed by kanban view openings, while maintaining a good user response time. Aggressive caching of data RPC results is planned for the near future to further mitigate any potential user response degradation.

## Change:

This commit adapts `web_read_group` to return the combined results of `formatted_read_group` and the `web_search_read` data for each opened group within a single RPC. We maximizes batching to minimize the cost of this consolidated RPC.

As a result, opening a kanban view now only requires two RPC calls: `read_progress_bar` and `web_read_group`. Future work will merge `read_progress_bar` into `web_read_group`, pending the implementation of a `_read_group` version compatible with the `GROUPING SET` feature.

task-3483970

## Performance

To compare the different solutions, we'll use two key metrics: User Response Time and Worker/CPU Time. We haven't included read_progress_bar in this comparison as its behavior remains unchanged.

Comparison
- Baseline: This represents the current approach, involving parallel calls to formatted_read_group and `web_search_read`. In this setup, `web_search_read` recalculates the length based on a `count_limit` (which defaults to 10001).
- Baseline (Fixed): Similar to the standard Baseline, but with an artificial fix in `web_search_read` where the length calculation is adjusted (`count_limit`=limit). This is done because the necessary information is already available from the parent group's __count aggregates.
- New `web_read_group`: This refers to the new, consolidated single RPC `web_read_group` solution.

### Scenarios and Results
We've tested several common scenarios on both Project and CRM Kanban views. These tests were conducted on our Odoo "next" database to ensure more realistic data. Please note that these are empirical tests with a specific config/data, and various factors could influence the results.

```
CRM - Filter: default (none) - Groupby stage_id (default):
    Baseline            > User time:   2495.128 +-   57.020 ms | Worker time:   5071.780 +-   22.681 ms
    Baseline (Fixed)    > User time:   2257.154 +-   49.056 ms | Worker time:   3993.602 +-  125.464 ms
    New web_read_group  > User time:   2109.417 +-   22.845 ms | Worker time:   2105.389 +-   26.134 ms
CRM - Filter: Creation Date = 2025 - Groupby create_date:month:
    Baseline            > User time:   1489.222 +-   27.526 ms | Worker time:   4388.155 +-   47.539 ms
    Baseline (Fixed)    > User time:   1075.068 +-   31.726 ms | Worker time:   2298.392 +-   17.080 ms
    New web_read_group  > User time:    990.718 +-   36.329 ms | Worker time:    989.092 +-   36.343 ms
CRM - Filter: default (none) - Groupby lang_code (related field):
    Baseline            > User time:   4172.701 +-   15.953 ms | Worker time:  11317.637 +-   46.593 ms
    Baseline (Fixed)    > User time:   3414.296 +-   42.615 ms | Worker time:   6208.338 +-   56.249 ms
    New web_read_group  > User time:   4062.431 +-   45.224 ms | Worker time:   4037.195 +-   48.154 ms
CRM - Filter: search 'test' - Groupby stage_id (default):
    Baseline            > User time:   5059.894 +-   32.458 ms | Worker time:  12214.776 +-   66.766 ms
    Baseline (Fixed)    > User time:   4378.451 +-   18.623 ms | Worker time:   7843.374 +-   89.574 ms
    New web_read_group  > User time:   5837.071 +-   13.466 ms | Worker time:   5833.765 +-   13.061 ms
CRM - Filter: My Pipeline with (VIDH) as user - Groupby stage_id (default):
    Baseline            > User time:    354.559 +-   13.876 ms | Worker time:   1406.978 +-   50.031 ms
    Baseline (Fixed)    > User time:    376.677 +-    4.262 ms | Worker time:   1492.995 +-   30.313 ms
    New web_read_group  > User time:    224.452 +-    5.006 ms | Worker time:    223.399 +-    5.009 ms
Project, Framework Python project - Default filter - Groupby stage_id (default):
    Baseline            > User time:    370.968 +-    4.947 ms | Worker time:   1007.227 +-   24.079 ms
    Baseline (Fixed)    > User time:    374.651 +-    5.025 ms | Worker time:    991.994 +-   20.477 ms
    New web_read_group  > User time:    271.404 +-   18.166 ms | Worker time:    270.508 +-   18.144 ms
Project, Help project - No filter - Groupby stage_id (default):
    Baseline            > User time:    573.647 +-    3.087 ms | Worker time:   1693.442 +-   70.651 ms
    Baseline (Fixed)    > User time:    531.486 +-   20.436 ms | Worker time:   1569.463 +-   27.046 ms
    New web_read_group  > User time:    506.271 +-    5.747 ms | Worker time:    505.207 +-    5.708 ms
Project, Help project - Search 'bve)' on Assignees - Groupby stage_id (default):
    Baseline            > User time:    433.501 +-   15.176 ms | Worker time:   1280.144 +-    7.425 ms
    Baseline (Fixed)    > User time:    447.778 +-    5.673 ms | Worker time:   1283.168 +-    7.129 ms
    New web_read_group  > User time:    312.172 +-    3.624 ms | Worker time:    311.323 +-    3.566 ms
```

In all tested scenarios, the new `web_read_group` solution demonstrates a better performance in terms of worker time, which is an expected outcome. Additionally, in most cases, it also improves user response time.

The overall effectiveness, particularly regarding user response time, is highly dependent on how efficiently the "Multi-Search solution" finds the first X records for each group based on the model's `_order`. This is because, in the new solution, this part is executed sequentially and isn't batched. For instance, without adding a new index on the `crm.lead`.`_order` (done in https://github.com/odoo/odoo/pull/213793), the new approach did not perform as well in terms of user response time.

### Multi-Search solution

One part of web_read_group is the Multi Search operation. We've chosen a sequential search solution for its simplicity and good performance.

Other solutions we considered and discarded include:

- UNION ALL of Each `_search` query result: This method is slightly faster than the sequential search solution, primarily due to gaining the fixed cost of SQL queries. However, it's more complex to implement and bypasses the standard search mechanism.

- CTE (containing the union of group domain) + UNION ALL: This approach forces materialization, which can be significantly faster when searches don't use indexes or are otherwise slow. However, it scales poorly when efficient indexes are already present in the database.


https://github.com/odoo/enterprise/pull/83716
