### PR TITLE
[FIX] stock: make scrap name field readonly

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -15,7 +15,7 @@ class StockScrap(models.Model):
 
     name = fields.Char(
         'Reference',  default=lambda self: _('New'),
-        copy=False, required=True)
+        copy=False, readonly=True, required=True)
     company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company, required=True)
     origin = fields.Char(string='Source Document')
     product_id = fields.Many2one(


### PR DESCRIPTION
before this commit, name field for scrap was editable and user can input any value , but on validating
it will be over written by the sequence record

introduced in : https://github.com/odoo/odoo/commit/75a105f46a13f75eb56a0de80faa2a6e146730aa

after this commit, name field is readonly and user cannot input any value



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
