### PR TITLE
[FIX] mrp: add missing Enterprise widget to setting

### DIFF
--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -33,7 +33,7 @@
                                 <field name="module_mrp_subcontracting"/>
                             </setting>
                             <setting id="process_mrp_barcodes" help="Process manufacturing orders from the barcode application">
-                                <field name="module_stock_barcode" />
+                                <field name="module_stock_barcode" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="quality_control_mrp" help="Add quality checks to your work orders">
                                 <field name="module_quality_control" widget="upgrade_boolean"/>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Added Enterprise widget on the Barcode Scanner module from mrp configurations as the module is from the enterprise addons.

**Impacted versions:**
* master

**Steps to Reproduce :**
- Go to the Manufacturing --> Configuration --> Barcode Scanner.   
- Click on it and save the record, page will be reloaded as the module is from the enterprise addons.

**Current behaviour before PR:**
Not showing Enterprise widget on Barcode Scanner module.

**Desired behaviour after PR is merged:**
After this PR merge, System will show Enterprise widget on Barcode Scanner module.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
