### PR TITLE
[FIX] purchase,repair,sale,website_sale: Fixed singleton error.

### DIFF
--- a/addons/purchase/models/mail_compose_message.py
+++ b/addons/purchase/models/mail_compose_message.py
@@ -8,7 +8,7 @@ class MailComposeMessage(models.TransientModel):
     _inherit = 'mail.compose.message'
 
     def _action_send_mail(self, auto_commit=False):
-        if self.model == 'purchase.order':
+        if (len(self) == 1 and self.model == 'purchase.order') or all(wizard.model == 'purchase.order' for wizard in self):
             self = self.with_context(mailing_document_based=True)
             if self.env.context.get('mark_rfq_as_sent'):
                 self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)

--- a/addons/repair/models/mail_compose_message.py
+++ b/addons/repair/models/mail_compose_message.py
@@ -8,6 +8,6 @@ class MailComposeMessage(models.TransientModel):
     _inherit = 'mail.compose.message'
 
     def _action_send_mail(self, auto_commit=False):
-        if self.model == 'repair.order':
+        if (len(self) == 1 and self.model == 'repair.order') or all(wizard.model == 'repair.order' for wizard in self):
             self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)
         return super(MailComposeMessage, self)._action_send_mail(auto_commit=auto_commit)

--- a/addons/sale/wizard/mail_compose_message.py
+++ b/addons/sale/wizard/mail_compose_message.py
@@ -8,7 +8,7 @@ class MailComposeMessage(models.TransientModel):
     _inherit = 'mail.compose.message'
 
     def _action_send_mail(self, auto_commit=False):
-        if self.model == 'sale.order':
+        if (len(self) == 1 and self.model == 'sale.order') or all(wizard.model == 'sale.order' for wizard in self):
             self = self.with_context(mailing_document_based=True)
             if self.env.context.get('mark_so_as_sent'):
                 self = self.with_context(mail_notify_author=self.env.user.partner_id in self.partner_ids)

--- a/addons/website_sale/models/mail_compose_message.py
+++ b/addons/website_sale/models/mail_compose_message.py
@@ -10,7 +10,7 @@ class MailComposeMessage(models.TransientModel):
     def _action_send_mail(self, auto_commit=False):
         context = self._context
         # TODO TDE: clean that brole one day
-        if context.get('website_sale_send_recovery_email') and self.model == 'sale.order' and context.get('active_ids'):
+        if context.get('website_sale_send_recovery_email') and ((len(self) == 1 and self.model == 'sale.order') or all(wizard.model == 'sale.order' for wizard in self)) and context.get('active_ids'):
             self.env['sale.order'].search([
                 ('id', 'in', context.get('active_ids')),
                 ('cart_recovery_email_sent', '=', False),


### PR DESCRIPTION
Avoid singleton errors when you try to send many records by email.

The `_action_send_mail` is multi, so, could receive many records, and the methods send one by one, but this inherits compare the record model like ensure_one.

To avoid some like:
```ValueError: Expected singleton: mail.compose.message(...)```

Now ensure that the model name is found in a mapped.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
