### PR TITLE
[FIX] web: do not show total if no aggregate function

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -541,7 +541,12 @@ export class ListRenderer extends Component {
             }
             const { rawAttrs, widget } = this.props.list.activeFields[fieldName];
             let currencyId;
-            if (type === "monetary" || widget === "monetary") {
+            const func =
+                (rawAttrs.sum && "sum") ||
+                (rawAttrs.avg && "avg") ||
+                (rawAttrs.max && "max") ||
+                (rawAttrs.min && "min");
+            if (func && (type === "monetary" || widget === "monetary")) {
                 const currencyField =
                     this.props.list.activeFields[fieldName].options.currency_field ||
                     this.fields[fieldName].currency_field ||
@@ -563,11 +568,6 @@ export class ListRenderer extends Component {
                     }
                 }
             }
-            const func =
-                (rawAttrs.sum && "sum") ||
-                (rawAttrs.avg && "avg") ||
-                (rawAttrs.max && "max") ||
-                (rawAttrs.min && "min");
             if (func) {
                 let aggregateValue = 0;
                 if (func === "max") {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When using monetary fields and two items had different currencies, a total was showed in the bottom, without checking if we had an aggregation function.

With the change, we will only show it, when we have an aggregation function

Current behavior before PR:

![image](https://github.com/odoo/odoo/assets/28590170/b9a31d62-1acc-452e-b2f6-8a4472ec0cdc)

Desired behavior after PR is merged:
![image](https://github.com/odoo/odoo/assets/28590170/a6580efd-24f5-474d-9e87-cd31ff7b0259)


In order to reproduce the error, you can access the reconcilation widget with multiple currencies. The aggregation line is added in the bottom, but it disappears when we have enough filters



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
