### PR TITLE
[IMP] account: discount allocation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2316,6 +2316,13 @@ class AccountMove(models.Model):
                 stack.enter_context(self._sync_unbalanced_lines(misc_container))
                 stack.enter_context(self._sync_rounding_lines(invoice_container))
                 stack.enter_context(self._sync_dynamic_line(
+                    existing_key_fname='discount_allocation_key',
+                    needed_vals_fname='line_ids.discount_allocation_needed',
+                    needed_dirty_fname='line_ids.discount_allocation_dirty',
+                    line_type='discount',
+                    container=invoice_container,
+                ))
+                stack.enter_context(self._sync_dynamic_line(
                     existing_key_fname='tax_key',
                     needed_vals_fname='line_ids.compute_all_tax',
                     needed_dirty_fname='line_ids.compute_all_tax_dirty',
@@ -4374,6 +4381,13 @@ class AccountMove(models.Model):
         })
 
         return res
+
+    def _get_discount_allocation_account(self):
+        if self.is_sale_document(include_receipts=True) and self.company_id.account_discount_expense_allocation_id:
+            return self.company_id.account_discount_expense_allocation_id
+        if self.is_purchase_document(include_receipts=True) and self.company_id.account_discount_income_allocation_id:
+            return self.company_id.account_discount_income_allocation_id
+        return None
 
     # -------------------------------------------------------------------------
     # TOOLING

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -179,6 +179,10 @@ class ResCompany(models.Model):
             ('out_and_in_invoices', 'Customer Invoices and Vendor Bills')],
         string="Quick encoding")
 
+    # Separate account for allocation of discounts
+    account_discount_income_allocation_id = fields.Many2one(comodel_name='account.account', string='Separate account for income discount')
+    account_discount_expense_allocation_id = fields.Many2one(comodel_name='account.account', string='Separate account for expense discount')
+
     def _get_company_root_delegated_field_names(self):
         return super()._get_company_root_delegated_field_names() + [
             'fiscalyear_last_day',

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -191,6 +191,22 @@ class ResConfigSettings(models.TransientModel):
         domain="[('deprecated', '=', False), ('account_type', 'in', ('income', 'income_other', 'expense'))]",
     )
 
+    # Accounts for allocation of discounts
+    account_discount_income_allocation_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Vendor Bills Discounts Account',
+        readonly=False,
+        related='company_id.account_discount_income_allocation_id',
+        domain="[('account_type', 'in', ('income', 'expense'))]",
+    )
+    account_discount_expense_allocation_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Customer Invoices Discounts Account',
+        readonly=False,
+        related='company_id.account_discount_expense_allocation_id',
+        domain="[('account_type', 'in', ('income', 'expense'))]",
+    )
+
     def set_values(self):
         super().set_values()
         # install a chart of accounts for the given company (if required)

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -275,6 +275,19 @@
                                         </div>
                                     </div>
                                 </setting>
+                                <setting string="Separate discount accounts on invoices"
+                                         title="If empty, the discount will be discounted directly on the income/expense account. If set, discount on invoices will be realized in separate accounts.">
+                                    <div class="content-group">
+                                        <div class="row mt8">
+                                            <label for="account_discount_expense_allocation_id" class="col-lg-5 o_light_label" string="Customer Invoices"/>
+                                            <field name="account_discount_expense_allocation_id" placeholder="Same Account"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="account_discount_income_allocation_id" class="col-lg-5 o_light_label" string="Vendor Bills"/>
+                                            <field name="account_discount_income_allocation_id" placeholder="Same Account"/>
+                                        </div>
+                                    </div>
+                                </setting>
                                 <setting string="Post discounts in:">
                                     <div class="content-group">
                                         <div class="row mt8">


### PR DESCRIPTION
Provides the possibility for the user to enter defaults accounts for discounts allocation. If provided, discounts on Customer Invoices and Vendor BIlls will be allocation on the specified account instead of the product account.

Example:
Create a journal entry with one product with the following attributes: quantity: 1
price unit: 100
discount 5

We expect the following account move line:
Without an account set in the settings for discount allocation:
ACCOUNT                                             DEBIT     CREDIT
700000 Sales rendered in Belgium (marchandises)      0         95
400000 Trade debtors within one year - Customer      95        0

With discount allocation account set to "657000 Discount Given":
ACCOUNT                                             DEBIT     CREDIT
700000 Sales rendered in Belgium (marchandises)      0         95
700000 Sales rendered in Belgium (marchandises)      0         5
657000 Discounts Given                               5         0
400000 Trade debtors within one year - Customer      95        0

Note: the discount is added on another line than the one of the product even though it is the same account because it does not include taxes and analytic distributions.

task: 3278827




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
