### PR TITLE
[FIX] sale: fix downpayment refund price recalculation on sale order 

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -106,7 +106,11 @@ class SaleOrderLine(models.Model):
                     if invoice_line.move_id.move_type == 'out_invoice':
                         qty_invoiced += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
                     elif invoice_line.move_id.move_type == 'out_refund':
-                        qty_invoiced -= invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
+                        # If it's a downpayment in a credit note, we should decrease the quantity only if
+                        # the amount left to invoice on the sale order line is equal to the amount invoice line
+                        # on the credit note
+                        if not line.is_downpayment or line.untaxed_amount_to_invoice == invoice_line.price_subtotal:
+                            qty_invoiced -= invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
             line.qty_invoiced = qty_invoiced
 
     def _get_invoice_lines(self):


### PR DESCRIPTION
Steps to reproduce:

  - Install sale module
  - Create an SO with a product of 100$ validate it
  - Create a downpayment of 50% and validate it
  - Go to downpayment and create a credit note
  - Set the price of the downpayment line to 30$ on the refund invoice
  - Validate the refund invoice
  - Go back to the SO

Issue:

  Wrong price on downpayment line
  expected: 20$ (downpayment - refund => 50 - 30)
  actual: 30$

Cause:

  The downpayment line in the SO is updated each time an invoice linked
  to it (based on the invoice line linked to it) is validated .

  The downpayment line in the SO is linked to the downpayment invoice
  line but also to the refund invoice line. Therefore, when the refund
  invoice is validated, the downpayment line on the SO is recalculated
  based on the refund invoice line
  (so line price unit = invoice line price unit).

Solution:

  When computing the quantity invoice, if it's a downpayment in a
  credit note, we should decrease the quantity only if the amount left
  to invoice on the sale order line is equal to the amount invoice line
  on the credit note.

  The price unit on the sale order line should be set to the sum of the
  price unit of linked downpayment move lines - the sum of the price
  unit of linked credit note move lines.

opw-3381689