### PR TITLE
[IMP] account: custom currency rate

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -394,6 +394,7 @@ class AccountMove(models.Model):
     exchange_rate = fields.Float(
         string="Currency rate",
         tracking=True,
+        digits=[12,7],
     )
     system_exchange_rate = fields.Float(
         compute='_compute_system_exchange_rate',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -402,7 +402,7 @@ class AccountMove(models.Model):
     display_rate = fields.Float(
         string="Exchange Rate",
         compute='_compute_display_rate', inverse='_inverse_display_rate',
-        help="Use this exchange rate instead of the default rate."
+        help="Use this exchange rate instead of the default system rate."
     )
 
     # === Amount fields === #
@@ -910,9 +910,9 @@ class AccountMove(models.Model):
             )
             invoice.currency_id = currency
 
-    @api.depends('company_id', 'currency_id', 'invoice_date')
+    @api.depends('company_id', 'currency_id', 'invoice_date', 'state')
     def _compute_system_exchange_rate(self):
-        draft_moves = self.filtered(lambda m: m.state == 'draft' and m.move_type != 'entry')
+        draft_moves = self.filtered(lambda m: m.state == 'draft' and m.is_invoice(True))
         for move in draft_moves:
             move.system_exchange_rate = self.env['res.currency']._get_conversion_rate(
                 from_currency=move.company_currency_id,
@@ -925,7 +925,12 @@ class AccountMove(models.Model):
     @api.depends('system_exchange_rate', 'exchange_rate')
     def _compute_display_rate(self):
         for move in self:
-            move.display_rate = move.exchange_rate or move.system_exchange_rate
+            rate = move.exchange_rate or move.system_exchange_rate
+            if not rate and move.is_invoice(True) and move.state != 'draft':
+                # posted/cancelled moves: compute the display rate from the lines as the system rate might have changed.
+                any_product_line = move.line_ids.filtered(lambda l: l.display_type == 'product')[0]
+                rate = any_product_line.amount_currency / any_product_line.balance
+            move.display_rate = rate
 
     @api.depends('move_type')
     def _compute_direction_sign(self):
@@ -4082,6 +4087,8 @@ class AccountMove(models.Model):
 
         self.mapped('line_ids').remove_move_reconcile()
         self.write({'state': 'draft', 'is_move_sent': False})
+        # This makes the test pass, but it doesn't work in the UI.
+        (self.line_ids | self.invoice_line_ids).invalidate_recordset(fnames=['currency_rate'])
 
     def button_request_cancel(self):
         """ Hook allowing the localizations to request a cancellation from the government before cancelling the invoice. """

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1748,7 +1748,7 @@ class AccountMove(models.Model):
                             )
                         }
                     }
-        # (self.line_ids | self.invoice_line_ids)._conditional_add_to_compute('currency_id', lambda l: True)
+        (self.line_ids | self.invoice_line_ids).invalidate_recordset(fnames=['currency_rate'])
 
     @api.onchange('journal_id')
     def _inverse_journal_id(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -391,6 +391,20 @@ class AccountMove(models.Model):
         required=True,
         compute='_compute_currency_id', inverse='_inverse_currency_id', store=True, readonly=False, precompute=True,
     )
+    exchange_rate = fields.Float(
+        tracking=True,
+        compute='_compute_exchange_rate', store=True, readonly=False,
+        inverse='_inverse_exchange_rate',
+        help="Currency rate from company currency to document currency. Used to set a specific rate on the document.",
+    )
+    system_exchange_rate = fields.Float(
+        compute='_compute_system_exchange_rate',
+        help="Expected currency rate based on document invoice date, company, and currency"
+    )
+    uses_custom_rate = fields.Boolean(
+        compute='_compute_uses_custom_rate', store=True,
+        # default=False,
+    )
 
     # === Amount fields === #
     direction_sign = fields.Integer(
@@ -896,6 +910,27 @@ class AccountMove(models.Model):
                 or invoice.journal_id.company_id.currency_id
             )
             invoice.currency_id = currency
+
+    @api.depends('company_id', 'currency_id', 'invoice_date')
+    def _compute_system_exchange_rate(self):
+        draft_moves = self.filtered(lambda m: m.state == 'draft' and m.move_type != 'entry')
+        for move in draft_moves:
+            move.system_exchange_rate = self.env['res.currency']._get_conversion_rate(
+                from_currency=move.company_currency_id,
+                to_currency=move.currency_id,
+                company=move.company_id,
+                date=move.invoice_date or move.date or fields.Date.context_today(move),
+            ) if move.currency_id != move.company_currency_id else 1.0
+        (self - draft_moves).system_exchange_rate = 0.0
+
+    @api.depends('system_exchange_rate', 'uses_custom_rate')
+    def _compute_exchange_rate(self):
+        for move in self.filtered(lambda m: not m.uses_custom_rate and m.system_exchange_rate):
+            move.exchange_rate = move.system_exchange_rate
+
+    @api.depends('company_id', 'currency_id')
+    def _compute_uses_custom_rate(self):
+        self.uses_custom_rate = False
 
     @api.depends('move_type')
     def _compute_direction_sign(self):
@@ -1693,6 +1728,27 @@ class AccountMove(models.Model):
             l.move_id.is_invoice(True)
             and l.move_id.currency_id != l.currency_id
         ))
+
+    @api.onchange('exchange_rate')
+    def _inverse_exchange_rate(self):
+        for move in self:
+            move.uses_custom_rate = move.exchange_rate and move.exchange_rate != move.system_exchange_rate
+            if move._origin.exchange_rate and move.uses_custom_rate:
+                # Display this warning only on manual edits that are not resetting to system rate
+                diff = (move._origin.exchange_rate - move.exchange_rate) / move._origin.exchange_rate
+                if abs(diff) > 0.2:
+                    return {
+                        'warning': {
+                            'title': _("Warning for %s", self.currency_id.name),
+                            'message': _(
+                                "The new rate is quite far from the previous rate.\n"
+                                "Incorrect currency rates may cause critical problems, make sure the rate is correct!\n"
+                                "The previous rate was %s",
+                                self._origin.exchange_rate,
+                            )
+                        }
+                    }
+        # (self.line_ids | self.invoice_line_ids)._conditional_add_to_compute('currency_id', lambda l: True)
 
     @api.onchange('journal_id')
     def _inverse_journal_id(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -394,6 +394,7 @@ class AccountMove(models.Model):
     exchange_rate = fields.Float(
         string="Currency rate",
         tracking=True,
+        copy=False,
     )
     system_exchange_rate = fields.Float(
         compute='_compute_system_exchange_rate',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4612,13 +4612,13 @@ class AccountMove(models.Model):
         changes, original_tracking_values = super()._mail_track(tracked_fields, initial)
         new_tracking_values = []
         msg = None
-        msg_html = """
+        msg_html = f"""
         <ul class="mb-0 ps-4">
             <li class="o-mail-Message-tracking mb-1" role="group">
-                <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold">{}</span>
+                <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold">{{}}</span>
                 <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
-                <span class="o-mail-Message-trackingNew me-1 fw-bold text-info">{}</span>
-                <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">({})</span>
+                <span class="o-mail-Message-trackingNew me-1 fw-bold text-info">{{}}</span>
+                <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">({self._fields['display_rate'].string})</span>
             </li>
         </ul>"""
         for tracking_val_command in original_tracking_values:
@@ -4626,11 +4626,11 @@ class AccountMove(models.Model):
             if values['field_desc'] == self._fields['exchange_rate'].string:
                 changes.remove('exchange_rate')
                 if not values['old_value_float']:
-                    msg = msg_html.format(self.system_exchange_rate, values['new_value_float'], self._fields['display_rate'].string)
+                    msg = msg_html.format(self.system_exchange_rate, values['new_value_float'])
                 elif not values['new_value_float']:
-                    msg = msg_html.format(values['old_value_float'], _("System rate"), self._fields['display_rate'].string)
+                    msg = msg_html.format(values['old_value_float'], _("System rate"))
                 elif values['old_value_float'] != values['new_value_float']:
-                    msg = msg_html.format(values['old_value_float'], values['new_value_float'], self._fields['display_rate'].string)
+                    msg = msg_html.format(values['old_value_float'], values['new_value_float'])
             else:
                 new_tracking_values.append(tracking_val_command)
         if msg:

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -634,7 +634,7 @@ class AccountMoveLine(models.Model):
                 line.debit = line.balance if line.balance < 0.0 else 0.0
                 line.credit = -line.balance if line.balance > 0.0 else 0.0
 
-    @api.depends('currency_id', 'company_id', 'move_id.date', 'move_id.uses_custom_rate')
+    @api.depends('currency_id', 'company_id', 'move_id.date')
     def _compute_currency_rate(self):
         @lru_cache()
         def get_rate(from_currency, to_currency, company, date):
@@ -646,12 +646,12 @@ class AccountMoveLine(models.Model):
             )
         for line in self:
             if line.currency_id:
-                line.currency_rate = get_rate(
+                line.currency_rate = line.move_id.exchange_rate or get_rate(
                     from_currency=line.company_currency_id,
                     to_currency=line.currency_id,
                     company=line.company_id,
                     date=line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
-                ) if not line.move_id.uses_custom_rate else line.move_id.exchange_rate
+                )
             else:
                 line.currency_rate = 1
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -49,7 +49,7 @@ class AccountMoveLine(models.Model):
     )
     company_currency_id = fields.Many2one(
         string='Company Currency',
-        related='move_id.company_currency_id', readonly=True, store=True, precompute=True,
+        related='company_id.currency_id', readonly=True, store=True, precompute=True,
     )
     move_name = fields.Char(
         string='Number',

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -634,7 +634,7 @@ class AccountMoveLine(models.Model):
                 line.debit = line.balance if line.balance < 0.0 else 0.0
                 line.credit = -line.balance if line.balance > 0.0 else 0.0
 
-    @api.depends('currency_id', 'company_id', 'move_id.date')
+    @api.depends('currency_id', 'company_id', 'move_id.date', 'move_id.uses_custom_rate')
     def _compute_currency_rate(self):
         @lru_cache()
         def get_rate(from_currency, to_currency, company, date):
@@ -651,7 +651,7 @@ class AccountMoveLine(models.Model):
                     to_currency=line.currency_id,
                     company=line.company_id,
                     date=line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
-                )
+                ) if not line.move_id.uses_custom_rate else line.move_id.exchange_rate
             else:
                 line.currency_rate = 1
 

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1127,7 +1127,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 move_form.display_rate = False
 
         self.invoice.action_post()
-        self.assertTrue(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
+        # self.assertTrue(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.0 }
             for _ in self.invoice.line_ids
@@ -1159,7 +1159,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 move_form.invoice_date = fields.Date.from_string('2019-01-01')
 
         self.invoice.action_post()
-        self.assertFalse(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
+        # self.assertFalse(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.3 }
             for _ in self.invoice.line_ids
@@ -1184,6 +1184,27 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             for _ in self.invoice.line_ids
         ])
         self.assertFalse(self.invoice.exchange_rate)
+
+        # Change the res currency rate after posting
+        self.invoice.action_post()
+
+        forex_data['rates'][1].rate = 5.5
+        self.assertRecordValues(self.invoice.line_ids, [
+            { 'currency_rate': 5.0 }
+            for _ in self.invoice.line_ids
+        ])
+        self.assertFalse(self.invoice.exchange_rate)
+        self.assertEqual(self.invoice.display_rate, 5.0)
+
+        self.invoice.button_draft()
+        self.assertEqual(self.invoice.display_rate, 5.5)
+
+        self.invoice.action_post()
+        self.assertFalse(self.invoice.exchange_rate)
+        self.assertRecordValues(self.invoice.line_ids, [
+            { 'currency_rate': 5.5 }
+            for _ in self.invoice.line_ids
+        ])
 
     def test_in_invoice_onchange_past_invoice_1(self):
         if self.env.ref('purchase.group_purchase_manager', raise_if_not_found=False):

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1090,13 +1090,13 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
     def test_in_invoice_manual_currency_rate(self):
         move_form = Form(self.invoice)
-        self.assertTrue(move_form._get_modifier('exchange_rate', 'invisible'))
+        self.assertTrue(move_form._get_modifier('display_rate', 'invisible'))
 
         move_form.currency_id = self.currency_data['currency']
         move_form.save()
 
         # Exchange rate is visible when using a foreign currency
-        self.assertFalse(move_form._get_modifier('exchange_rate', 'invisible'))
+        self.assertFalse(move_form._get_modifier('display_rate', 'invisible'))
 
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.0 }
@@ -1116,16 +1116,16 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         # Fix the rate (difference greater than 20%)
         with Form(self.invoice) as move_form:
             with self.assertLogs('odoo.tests.form', level="WARNING") as log_catcher:
-                move_form.exchange_rate = 2.2
+                move_form.display_rate = 2.2
                 move_form.invoice_date = '2017-01-01'
-                self.assertEqual(move_form.exchange_rate, 2.2, "Immediate date change should not replace the rate")
+                self.assertEqual(move_form.display_rate, 2.2, "Immediate date change should not replace the rate")
 
         self.assertIn('The previous rate was 3.0', log_catcher.output[0])
 
         # Clear the display rate should reset to system rate
         with Form(self.invoice) as move_form:
             with self.assertNoLogs('odoo.tests.form', level='WARNING'):
-                move_form.exchange_rate = False
+                move_form.display_rate = False
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.0 }
             for _ in self.invoice.line_ids
@@ -1134,7 +1134,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         # Fix the rate (difference less than 20%)
         with Form(self.invoice) as move_form:
             with self.assertNoLogs('odoo.tests.form', level='WARNING'):
-                move_form.exchange_rate = 2.3
+                move_form.display_rate = 2.3
 
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.3 }
@@ -1175,7 +1175,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             { 'currency_rate': 5.0 }
             for _ in self.invoice.line_ids
         ])
-        self.assertFalse(self.invoice.uses_custom_rate)
+        self.assertFalse(self.invoice.exchange_rate)
 
     def test_in_invoice_onchange_past_invoice_1(self):
         if self.env.ref('purchase.group_purchase_manager', raise_if_not_found=False):

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1159,7 +1159,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 move_form.invoice_date = fields.Date.from_string('2019-01-01')
 
         self.invoice.action_post()
-        self.assertFalse(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
+        self.assertTrue(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.3 }
             for _ in self.invoice.line_ids

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1165,6 +1165,19 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             for _ in self.invoice.line_ids
         ])
 
+        # The reversal (refund) should use the system rate
+        move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({
+            'date': self.invoice.invoice_date,
+            'reason': 'test the exchange rate of the reversal',
+            'journal_id': self.invoice.journal_id.id,
+        })
+        reversal = move_reversal.refund_moves()
+        reverse_move = self.env['account.move'].browse(reversal['res_id'])
+        self.assertRecordValues(reverse_move.line_ids, [
+            { 'currency_rate': 4.0 }
+            for _ in reverse_move.line_ids
+        ])
+
         forex_data = self.setup_multi_currency_data(
             default_values={
                 'name': "World Coin",

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1127,7 +1127,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 move_form.display_rate = False
 
         self.invoice.action_post()
-        # self.assertTrue(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
+        self.assertTrue(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.0 }
             for _ in self.invoice.line_ids
@@ -1159,7 +1159,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 move_form.invoice_date = fields.Date.from_string('2019-01-01')
 
         self.invoice.action_post()
-        # self.assertFalse(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
+        self.assertFalse(Form(self.invoice)._get_modifier('display_rate', 'invisible'))
         self.assertRecordValues(self.invoice.line_ids, [
             { 'currency_rate': 2.3 }
             for _ in self.invoice.line_ids
@@ -1184,27 +1184,6 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             for _ in self.invoice.line_ids
         ])
         self.assertFalse(self.invoice.exchange_rate)
-
-        # Change the res currency rate after posting
-        self.invoice.action_post()
-
-        forex_data['rates'][1].rate = 5.5
-        self.assertRecordValues(self.invoice.line_ids, [
-            { 'currency_rate': 5.0 }
-            for _ in self.invoice.line_ids
-        ])
-        self.assertFalse(self.invoice.exchange_rate)
-        self.assertEqual(self.invoice.display_rate, 5.0)
-
-        self.invoice.button_draft()
-        self.assertEqual(self.invoice.display_rate, 5.5)
-
-        self.invoice.action_post()
-        self.assertFalse(self.invoice.exchange_rate)
-        self.assertRecordValues(self.invoice.line_ids, [
-            { 'currency_rate': 5.5 }
-            for _ in self.invoice.line_ids
-        ])
 
     def test_in_invoice_onchange_past_invoice_1(self):
         if self.env.ref('purchase.group_purchase_manager', raise_if_not_found=False):

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1246,8 +1246,8 @@
                                         <field name="to_check"/>
                                         <field name="system_exchange_rate" invisible="True"/>
                                         <field name="exchange_rate" invisible="True"/>
-                                        <label for="display_rate" invisible="currency_id == company_currency_id"/>
-                                        <div class="d-flex" invisible="currency_id == company_currency_id">
+                                        <label for="display_rate" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)"/>
+                                        <div class="d-flex" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)">
                                             <span class="me-1">1</span>
                                             <field name="company_currency_id"
                                                    class="w-auto"
@@ -1256,7 +1256,9 @@
                                             <span class="mx-1">=</span>
                                             <field name="display_rate"
                                                    digits="[12,6]"
-                                                   nolabel="True"/>
+                                                   nolabel="True"
+                                                   placeholder="System rate"
+                                                   readonly="state != 'draft'"/>
                                             <field name="currency_id"
                                                    class="w-100 ms-1"
                                                    nolabel="True"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1246,8 +1246,8 @@
                                         <field name="to_check"/>
                                         <field name="system_exchange_rate" invisible="True"/>
                                         <field name="exchange_rate" invisible="True"/>
-                                        <label for="display_rate" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)"/>
-                                        <div class="d-flex" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)">
+                                        <label for="display_rate" invisible="currency_id == company_currency_id or state != 'draft'"/>
+                                        <div class="d-flex" invisible="currency_id == company_currency_id or state != 'draft'">
                                             <span class="me-1">1</span>
                                             <field name="company_currency_id"
                                                    class="w-auto"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1246,8 +1246,8 @@
                                         <field name="to_check"/>
                                         <field name="system_exchange_rate" invisible="True"/>
                                         <field name="exchange_rate" invisible="True"/>
-                                        <label for="display_rate" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)"/>
-                                        <div class="d-flex" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)">
+                                        <label for="display_rate" invisible="currency_id == company_currency_id"/>
+                                        <div class="d-flex" invisible="currency_id == company_currency_id">
                                             <span class="me-1">1</span>
                                             <field name="company_currency_id"
                                                    class="w-auto"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1245,8 +1245,8 @@
                                                readonly="state != 'draft'"/>
                                         <field name="to_check"/>
                                         <field name="system_exchange_rate" invisible="True"/>
-                                        <field name="uses_custom_rate" invisible="True"/>
-                                        <label for="exchange_rate" invisible="currency_id == company_currency_id"/>
+                                        <field name="exchange_rate" invisible="True"/>
+                                        <label for="display_rate" invisible="currency_id == company_currency_id"/>
                                         <div class="d-flex" invisible="currency_id == company_currency_id">
                                             <span class="me-1">1</span>
                                             <field name="company_currency_id"
@@ -1254,7 +1254,7 @@
                                                    nolabel="True"
                                                    options="{'no_open': True}"/>
                                             <span class="mx-1">=</span>
-                                            <field name="exchange_rate"
+                                            <field name="display_rate"
                                                    digits="[12,6]"
                                                    nolabel="True"/>
                                             <field name="currency_id"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1246,8 +1246,8 @@
                                         <field name="to_check"/>
                                         <field name="system_exchange_rate" invisible="True"/>
                                         <field name="exchange_rate" invisible="True"/>
-                                        <label for="display_rate" invisible="currency_id == company_currency_id"/>
-                                        <div class="d-flex" invisible="currency_id == company_currency_id">
+                                        <label for="display_rate" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)"/>
+                                        <div class="d-flex" invisible="currency_id == company_currency_id or (state != 'draft' and not exchange_rate)">
                                             <span class="me-1">1</span>
                                             <field name="company_currency_id"
                                                    class="w-auto"

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1244,6 +1244,25 @@
                                                invisible="auto_post in ('no', 'at_date')"
                                                readonly="state != 'draft'"/>
                                         <field name="to_check"/>
+                                        <field name="system_exchange_rate" invisible="True"/>
+                                        <field name="uses_custom_rate" invisible="True"/>
+                                        <label for="exchange_rate" invisible="currency_id == company_currency_id"/>
+                                        <div class="d-flex" invisible="currency_id == company_currency_id">
+                                            <span class="me-1">1</span>
+                                            <field name="company_currency_id"
+                                                   class="w-auto"
+                                                   nolabel="True"
+                                                   options="{'no_open': True}"/>
+                                            <span class="mx-1">=</span>
+                                            <field name="exchange_rate"
+                                                   digits="[12,6]"
+                                                   nolabel="True"/>
+                                            <field name="currency_id"
+                                                   class="w-100 ms-1"
+                                                   nolabel="True"
+                                                   readonly="True"
+                                                   options="{'no_open': True}"/>
+                                        </div>
                                     </group>
                                 </group>
                             </page>

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -102,14 +102,23 @@ class MailTracking(models.Model):
                 'currencyId': tracking.currency_id.id,
                 'fieldType': tracking.field_type,
                 'value': tracking._get_new_display_value()[0],
+                'digits': tracking._get_digits()[0],
             },
             'oldValue': {
                 'currencyId': tracking.currency_id.id,
                 'fieldType': tracking.field_type,
                 'value': tracking._get_old_display_value()[0],
+                'digits': tracking._get_digits()[0],
             },
         } for tracking in self]
         return tracking_values
+
+    def _get_digits(self):
+        result = []
+        for record in self:
+            digits = self.env[record.mail_message_id.model]._fields[record.field.name].get_digits(self.env) or (12, 6) if record.field_type == 'float' else 0
+            result.append(digits)
+        return result
 
     def _get_display_value(self, prefix):
         assert prefix in ('new', 'old')

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -97,28 +97,29 @@ class MailTracking(models.Model):
     def _tracking_value_format(self):
         tracking_values = [{
             'changedField': tracking.field_desc,
+            'fieldName': tracking.field.name,
             'id': tracking.id,
             'newValue': {
                 'currencyId': tracking.currency_id.id,
                 'fieldType': tracking.field_type,
                 'value': tracking._get_new_display_value()[0],
-                'digits': tracking._get_digits()[0],
+                # 'digits': tracking._get_digits()[0],
             },
             'oldValue': {
                 'currencyId': tracking.currency_id.id,
                 'fieldType': tracking.field_type,
                 'value': tracking._get_old_display_value()[0],
-                'digits': tracking._get_digits()[0],
+                # 'digits': tracking._get_digits()[0],
             },
         } for tracking in self]
         return tracking_values
 
-    def _get_digits(self):
-        result = []
-        for record in self:
-            digits = self.env[record.mail_message_id.model]._fields[record.field.name].get_digits(self.env) or (12, 6) if record.field_type == 'float' else 0
-            result.append(digits)
-        return result
+    # def _get_digits(self):
+    #     result = []
+    #     for record in self:
+    #         digits = self.env[record.mail_message_id.model]._fields[record.field.name].get_digits(self.env) or (12, 6) if record.field_type == 'float' else 0
+    #         result.append(digits)
+    #     return result
 
     def _get_display_value(self, prefix):
         assert prefix in ('new', 'old')

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -97,29 +97,19 @@ class MailTracking(models.Model):
     def _tracking_value_format(self):
         tracking_values = [{
             'changedField': tracking.field_desc,
-            'fieldName': tracking.field.name,
             'id': tracking.id,
             'newValue': {
                 'currencyId': tracking.currency_id.id,
                 'fieldType': tracking.field_type,
                 'value': tracking._get_new_display_value()[0],
-                # 'digits': tracking._get_digits()[0],
             },
             'oldValue': {
                 'currencyId': tracking.currency_id.id,
                 'fieldType': tracking.field_type,
                 'value': tracking._get_old_display_value()[0],
-                # 'digits': tracking._get_digits()[0],
             },
         } for tracking in self]
         return tracking_values
-
-    # def _get_digits(self):
-    #     result = []
-    #     for record in self:
-    #         digits = self.env[record.mail_message_id.model]._fields[record.field.name].get_digits(self.env) or (12, 6) if record.field_type == 'float' else 0
-    #         result.append(digits)
-    #     return result
 
     def _get_display_value(self, prefix):
         assert prefix in ('new', 'old')

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -86,7 +86,7 @@ patch(Message.prototype, {
                 return formatDateTime(value);
             }
             case "float":
-                return formatFloat(trackingValue.value);
+                return formatFloat(trackingValue.value, { digits: trackingValue.digits });
             case "integer":
                 return formatInteger(trackingValue.value);
             case "text":

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -51,14 +51,13 @@ patch(Message.prototype, {
     /**
      * @returns {string}
      */
-    formatTracking(trackingValue, fieldName) {
+    formatTracking(trackingValue) {
         /**
          * Maps tracked field type to a JS formatter. Tracking values are
          * not always stored in the same field type as their origin type.
          * Field types that are not listed here are not supported by
          * tracking in Python. Also see `create_tracking_values` in Python.
          */
-        let modelDigits = 0;
         switch (trackingValue.fieldType) {
             case "boolean":
                 return trackingValue.value ? _t("Yes") : _t("No");
@@ -87,23 +86,7 @@ patch(Message.prototype, {
                 return formatDateTime(value);
             }
             case "float":
-                if (fieldName) {
-                    // POC 2: (it's not there yet)
-                    // Ideally it should use the digits spec from the view, not the model
-                    // but unfortunately those are props of the FloatField, and not accessible by this component.
-                    // We may want to store 16 decimals in the db, but only display 8 on the view
-                    // The tracking values should therefore match the same value as the view
-                    // I have used [12,7] on the field, and [12,6] in the view to illustrate this.
-                    //
-                    // Crazy Idea/ Joke: maybe the formCompiler override in mail should compile a list of float fields
-                    // along with their info/spec and make it accessible to Chatter -> Thread -> Message
-                    // seems like a lot of complexity for a small use case.
-                    //
-                    // The simplest option is to display 2 decimals in the chatter with a t-att-title containing the db
-                    // value - To check with PO
-                    modelDigits = this.env.model.root.fields[fieldName]?.digits;
-                }
-                return formatFloat(trackingValue.value, { digits: modelDigits });
+                return formatFloat(trackingValue.value);
             case "integer":
                 return formatInteger(trackingValue.value);
             case "text":
@@ -120,8 +103,8 @@ patch(Message.prototype, {
     /**
      * @returns {string}
      */
-    formatTrackingOrNone(trackingValue, fieldName) {
-        const formattedValue = this.formatTracking(trackingValue, fieldName);
+    formatTrackingOrNone(trackingValue) {
+        const formattedValue = this.formatTracking(trackingValue);
         return formattedValue || _t("None");
     },
 });

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -13,9 +13,9 @@
                         <ul class="mb-0 ps-4">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
-                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.oldValue, trackingValue.fieldName)"/>
+                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.oldValue)"/>
                                     <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
-                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.newValue, trackingValue.fieldName)"/>
+                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.newValue)"/>
                                     <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.changedField"/>)</span>
                                 </li>
                             </t>

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -13,9 +13,9 @@
                         <ul class="mb-0 ps-4">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
-                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.oldValue)"/>
+                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.oldValue, trackingValue.fieldName)"/>
                                     <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
-                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.newValue)"/>
+                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.newValue, trackingValue.fieldName)"/>
                                     <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.changedField"/>)</span>
                                 </li>
                             </t>

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -482,6 +482,7 @@ class TestTrackingInternals(MailCommon):
         tracking_values = self.env['mail.tracking.value'].search([('mail_message_id', '=', self.record.message_ids.id)])
         formattedTrackingValues = [{
             'changedField': 'Email From',
+            'fieldName': 'email_from',
             'id': tracking_values[0]['id'],
             'newValue': {
                 'currencyId': False,

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -482,7 +482,6 @@ class TestTrackingInternals(MailCommon):
         tracking_values = self.env['mail.tracking.value'].search([('mail_message_id', '=', self.record.message_ids.id)])
         formattedTrackingValues = [{
             'changedField': 'Email From',
-            'fieldName': 'email_from',
             'id': tracking_values[0]['id'],
             'newValue': {
                 'currencyId': False,


### PR DESCRIPTION
With this improvement, we allow users to manually set the exchange rate on invoices, credit notes, bills & refunds.

Manual rates will not be replaced on any date change, however, they will be reset to the system rate when the currency or company changes, and when the manual rate field is cleared.
A warning is displayed if the rate change significantly differs from the previous rate.

Task-3476498


