### PR TITLE
[IMP] hr_holidays: remove duplicate carry over field from milestone 

### DIFF
--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -75,7 +75,6 @@
                                 <field name="added_value_type" nolabel="1" readonly="1" force_save="1" style="width: 5rem"/>
                             </div>
                         </div>
-                        <field name="action_with_unused_accruals" class="w-25"/>
                         <field name="postpone_max_days" class="w-25" invisible="action_with_unused_accruals != 'postponed'"/>
                     </group>
                 </sheet>


### PR DESCRIPTION
Before this commit:
carry over field was two times one in radio and another in dropdown

After this commit:
dropdown carry over field is deleted from view

task-3481879