### PR TITLE
[IMP] account,account_avatax: AvaTax module auto installation for list of countries

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -33,9 +33,22 @@ def _auto_install_l10n(env):
         if module_ids:
             module_ids.sudo().button_install()
 
+def _auto_install_avatax(env):
+    """ Install the avatax module automatically if the company is in a country that uses avatax """
+    avatax_country_codes = ['US', 'BR']
+
+    country = env.company.country_id
+    country_code = country.code
+
+    if country_code in avatax_country_codes:
+        module = env['ir.module.module'].search([('name', '=', 'account_avatax')])
+        if module.state == 'uninstalled':
+            module.sudo().button_install()
+
 def _account_post_init(env):
     _auto_install_l10n(env)
     _set_fiscal_country(env)
+    _auto_install_avatax(env)
 
 # imported here to avoid dependency cycle issues
 # pylint: disable=wrong-import-position


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
~~AvaTax setting is always available for taxes, but this settings only makes sense for US. Also the module needs to be installed when the option is marked~~ AvaTax module should be auto installed for the countries that use AvaTax. Initially we should set the list of countries to ['US','BR'].

-  Currently checking if we should show AvaTax option in the settings for other countries

Task-id: 3398637

PR in enterprise-dev:
https://github.com/odoo/enterprise/pull/46416

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
