### PR TITLE
[IMP] web,*: make x2ManyCommands naming consistent

### DIFF
--- a/addons/event_booth_sale/static/src/js/sale_product_field.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_field.js
@@ -64,7 +64,7 @@ patch(SaleOrderLineProductField.prototype, {
                         this.props.record.update({
                             event_id,
                             event_booth_category_id,
-                            event_booth_pending_ids: [x2ManyCommands.replaceWith(event_booth_pending_ids)],
+                            event_booth_pending_ids: [x2ManyCommands.set(event_booth_pending_ids)],
                         });
                     }
                 }

--- a/addons/sale_product_configurator/static/src/js/sale_product_field.js
+++ b/addons/sale_product_configurator/static/src/js/sale_product_field.js
@@ -33,7 +33,7 @@ async function applyProduct(record, product) {
     await record.update({
         product_id: [product.id, product.display_name],
         product_uom_qty: product.quantity,
-        product_no_variant_attribute_value_ids: [x2ManyCommands.replaceWith(noVariantPTAVIds)],
+        product_no_variant_attribute_value_ids: [x2ManyCommands.set(noVariantPTAVIds)],
     });
 };
 

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -42,24 +42,24 @@ export const x2ManyCommands = {
         return [x2ManyCommands.DELETE, id, false];
     },
     // (3, id[, _]) removes relation, but not linked record itself
-    FORGET: 3,
-    forget(id) {
-        return [x2ManyCommands.FORGET, id, false];
+    UNLINK: 3,
+    unlink(id) {
+        return [x2ManyCommands.UNLINK, id, false];
     },
     // (4, id[, _])
-    LINK_TO: 4,
-    linkTo(id) {
-        return [x2ManyCommands.LINK_TO, id, false];
+    LINK: 4,
+    link(id) {
+        return [x2ManyCommands.LINK, id, false];
     },
     // (5[, _[, _]])
-    DELETE_ALL: 5,
-    deleteAll() {
-        return [x2ManyCommands.DELETE_ALL, false, false];
+    CLEAR: 5,
+    clear() {
+        return [x2ManyCommands.CLEAR, false, false];
     },
     // (6, _, ids) replaces all linked records with provided ids
-    REPLACE_WITH: 6,
-    replaceWith(ids) {
-        return [x2ManyCommands.REPLACE_WITH, false, ids];
+    SET: 6,
+    set(ids) {
+        return [x2ManyCommands.SET, false, ids];
     },
 };
 

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -754,7 +754,7 @@ export class Record extends DataPoint {
             const list = this.data[fieldName];
             for (const command of value) {
                 switch (command[0]) {
-                    case x2ManyCommands.REPLACE_WITH:
+                    case x2ManyCommands.SET:
                         await list._replaceWith(command[2]);
                         break;
                     default:


### PR DESCRIPTION
*: event_booth_sale, sale_product_configurator

Before this commit, the naming convention for x2m commands is not consistent with the python ORM.

After this commit, the commands use the same terminology on both side. The JavaScript side has been adapted.

See: https://www.odoo.com/documentation/16.0/developer/reference/backend/orm.html?highlight=commands#odoo.fields.Command

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
