### PR TITLE
[IMP] point_of_sale: enable combo products

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_demo.xml
+++ b/addons/point_of_sale/data/point_of_sale_demo.xml
@@ -464,6 +464,7 @@
           <field name="name">Office combo</field>
           <field name="type">combo</field>
           <field name="categ_id" ref="product.product_category_5"/>
+          <field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_desks')])]"/>
           <field name="uom_id" ref="uom.product_uom_unit"/>
           <field name="uom_po_id" ref="uom.product_uom_unit"/>
           <field name="image_1920" type="base64" file="point_of_sale/static/img/office_combo.png"/>

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -35,6 +35,13 @@ class ProductTemplate(models.Model):
         if not self.sale_ok:
             self.available_in_pos = False
 
+    @api.constrains('available_in_pos')
+    def _check_combo_inclusions(self):
+        for product in self:
+            if not product.available_in_pos:
+                combo_name = self.env['pos.combo.line'].search([('product_id', 'in', product.product_variant_ids.ids)], limit=1).combo_id.name
+                if combo_name:
+                    raise UserError(_('You must first remove this product from the %s combo') % combo_name)
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'

--- a/addons/point_of_sale/views/pos_combo_view.xml
+++ b/addons/point_of_sale/views/pos_combo_view.xml
@@ -13,7 +13,7 @@
                 </div>
                 <field name="combo_line_ids">
                     <tree editable="bottom">
-                        <field name="product_id"/>
+                        <field name="product_id" context="{'default_available_in_pos': True}"/>
                         <field name="combo_price"/>
                         <field name="lst_price"/>
                     </tree>


### PR DESCRIPTION
Products can be created directly from the `pos.combo` view.
Before this PR, such products would not be automatically available in
the POS app.

This PR makes it so products linked to combos are available in POS by
default.

We also introduce an additional check that makes it so products associated
to combos cannot be disabled in the pos.
Task: 3481899






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
