### PR TITLE
[FIX] spreadsheet*: fix o-spreadsheet dependencies

### DIFF
--- a/addons/spreadsheet/__manifest__.py
+++ b/addons/spreadsheet/__manifest__.py
@@ -13,6 +13,10 @@
         'views/public_readonly_spreadsheet_templates.xml',
     ],
     'assets': {
+        'spreadsheet.dependencies': [
+            'web/static/lib/Chart/Chart.js',
+            'web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
+        ],
         'spreadsheet.o_spreadsheet': [
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js',
             'spreadsheet/static/src/**/*.js',
@@ -54,6 +58,7 @@
             'web/static/src/core/user_service.js',
             'web/static/src/core/l10n/**/*.js',
             'web/static/src/core/network/download.js',
+            ('include', 'spreadsheet.dependencies'),
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js',
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml',
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss',
@@ -74,6 +79,7 @@
             'spreadsheet/static/src/**/*.dark.scss',
         ],
         'web.qunit_suite_tests': [
+            ('include', 'spreadsheet.dependencies'),
             'spreadsheet/static/tests/**/*',
             ('include', 'spreadsheet.o_spreadsheet'),
             'spreadsheet/static/src/public_readonly_app/**/*.xml',

--- a/addons/spreadsheet/static/src/assets_backend/helpers.js
+++ b/addons/spreadsheet/static/src/assets_backend/helpers.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import { loadJS } from "@web/core/assets";
+
+/**
+ * Load external libraries required for o-spreadsheet
+ * @returns {Promise<void>}
+ */
+export async function loadSpreadsheetDependencies() {
+    await loadJS("/web/static/lib/Chart/Chart.js");
+    await loadJS("/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js");
+}

--- a/addons/spreadsheet/static/src/assets_backend/spreadsheet_action_loader.js
+++ b/addons/spreadsheet/static/src/assets_backend/spreadsheet_action_loader.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { getBundle, loadBundle } from "@web/core/assets";
 import { sprintf } from "@web/core/utils/strings";
+import { loadSpreadsheetDependencies } from "./helpers";
 
 const actionRegistry = registry.category("actions");
 
@@ -14,6 +15,7 @@ const actionRegistry = registry.category("actions");
  * @param {function} actionLazyLoader
  */
 export async function loadSpreadsheetAction(env, actionName, actionLazyLoader) {
+    await loadSpreadsheetDependencies();
     const desc = await getBundle("spreadsheet.o_spreadsheet");
     await loadBundle(desc);
 

--- a/addons/spreadsheet/static/src/helpers/helpers.js
+++ b/addons/spreadsheet/static/src/helpers/helpers.js
@@ -1,7 +1,6 @@
 /** @odoo-module */
 
 import { serializeDate } from "@web/core/l10n/dates";
-import { loadJS } from "@web/core/assets";
 
 const { DateTime } = luxon;
 
@@ -94,13 +93,4 @@ export function isEmpty(item) {
         }
     }
     return false;
-}
-
-/**
- * Load external libraries required for o-spreadsheet
- * @returns {Promise<void>}
- */
-export async function loadSpreadsheetDependencies() {
-    await loadJS("/web/static/lib/Chart/Chart.js");
-    await loadJS("/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js");
 }

--- a/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
@@ -7,7 +7,6 @@ import { download } from "@web/core/network/download";
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { Spreadsheet, Model, registries } from "@odoo/o-spreadsheet";
 import { _t } from "@web/core/l10n/translation";
-import { loadSpreadsheetDependencies } from "../helpers/helpers";
 import { migrate } from "../o_spreadsheet/migration";
 
 registries.topbarMenuRegistry.addChild("download_public_excel", ["file"], {
@@ -35,7 +34,6 @@ export class PublicReadonlySpreadsheet extends Component {
                     data: {},
                 }),
         });
-        onWillStart(loadSpreadsheetDependencies);
         onWillStart(this.createModel.bind(this));
     }
 

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -8,7 +8,6 @@ import { useSetupAction } from "@web/webclient/actions/action_hook";
 import { DashboardMobileSearchPanel } from "./mobile_search_panel/mobile_search_panel";
 import { MobileFigureContainer } from "./mobile_figure_container/mobile_figure_container";
 import { FilterValue } from "@spreadsheet/global_filters/components/filter_value/filter_value";
-import { loadSpreadsheetDependencies } from "@spreadsheet/helpers/helpers";
 import { useService } from "@web/core/utils/hooks";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 import { SpreadsheetShareButton } from "@spreadsheet/components/share_button/share_button";
@@ -30,7 +29,6 @@ export class SpreadsheetDashboardAction extends Component {
             new DashboardLoader(this.env, this.env.services.orm, this._fetchDashboardData)
         );
         onWillStart(async () => {
-            await loadSpreadsheetDependencies();
             if (this.props.state && this.props.state.dashboardLoader) {
                 const { groups, dashboards } = this.props.state.dashboardLoader;
                 this.loader.restoreFromState(groups, dashboards);


### PR DESCRIPTION
The recent upgrade to chart.js 4.3.0 has forced us to make our own plugin to support gauge charts. The plugin was added inside the o-spreadsheet library which means that we now require chart.js to be loaded before o-spreadsheet.

Task: 3482480

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
