### PR TITLE
[IMP] sale_project: hide button on SO

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -51,7 +51,7 @@ class SaleOrder(models.Model):
         for order in self:
             order.show_project_button = order.id in show_button_ids and order.project_count
             order.show_task_button = order.show_project_button or order.tasks_count
-            order.show_create_project_button = is_project_manager and order.id in show_button_ids and not order.project_count
+            order.show_create_project_button = is_project_manager and order.id in show_button_ids and not order.project_count and order.order_line.product_template_id.filtered(lambda x: x.service_policy in ['delivered_timesheet', 'delivered_milestones'])
 
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -385,7 +385,7 @@ class TestSaleProject(TestSaleProjectCommon):
             'order_id': sale_order_2.id,
         })
         sale_order_2._compute_show_project_and_task_button()
-        self.assertTrue(sale_order_2.show_create_project_button, "There is a product service with the service_policy set on 'ordered_prepaid' on the sale order, the button should be displayed")
+        self.assertFalse(sale_order_2.show_create_project_button, "There is a product service with the service_policy set on 'ordered_prepaid' on the sale order, the button should be hidden")
         self.assertFalse(sale_order_2.show_project_button, "There is no project on the sale order, the button should be hidden")
         self.assertFalse(sale_order_2.show_task_button, "There is no project on the sale order, the button should be hidden")
         # create a new task, whose sale order item is a sol of the SO
@@ -396,7 +396,7 @@ class TestSaleProject(TestSaleProjectCommon):
         })
         sale_order_2._compute_tasks_ids()
         sale_order_2._compute_show_project_and_task_button()
-        self.assertTrue(sale_order_2.show_create_project_button, "There is a product service with the service_policy set on 'ordered_prepaid' on the sale order, the button should be displayed")
+        self.assertFalse(sale_order_2.show_create_project_button, "There is a product service with the service_policy set on 'ordered_prepaid' on the sale order, the button should be hidden")
         self.assertFalse(sale_order_2.show_project_button, "There is no project on the sale order, the button should be hidden")
         self.assertTrue(sale_order_2.show_task_button, "There is no project on the sale order and there is a task whose sale item is one of the sale_line of the SO, the button should be displayed")
 
@@ -406,7 +406,7 @@ class TestSaleProject(TestSaleProjectCommon):
             'order_id': sale_order_3.id,
         })
         sale_order_3._compute_show_project_and_task_button()
-        self.assertTrue(sale_order_3.show_create_project_button, "There is a product service with the service_policy set on 'manual' on the sale order, the button should be displayed")
+        self.assertFalse(sale_order_3.show_create_project_button, "There is a product service with the service_policy set on 'manual' on the sale order, the button should be hidden")
         self.assertFalse(sale_order_3.show_project_button, "There is no project on the sale order, the button should be hidden")
         self.assertFalse(sale_order_3.show_task_button, "There is no project on the sale order, the button should be hidden")
 


### PR DESCRIPTION
Before this PR when we confirm SO then create project button appears In this PR we have made that if product is based on timesheets or based on milestones then only create project button will appear when we confirm SO

task-3468706