### PR TITLE
[FIX] web: can create record in list view grouped by m2m

### DIFF
--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -22,6 +22,7 @@ export class Group extends DataPoint {
         /** @type {number} */
         this.count = data.count;
         this.value = data.value;
+        this.serverValue = data.serverValue;
         this.displayName = data.displayName;
         this.aggregates = data.aggregates;
         let List;
@@ -49,19 +50,6 @@ export class Group extends DataPoint {
     }
     get records() {
         return this.list.records;
-    }
-    get serverValue() {
-        const { type } = this.groupByField;
-        switch (type) {
-            case "many2one":
-                return this.value || false;
-            case "many2many": {
-                return this.value ? [this.value] : false;
-            }
-            default: {
-                return this._rawValue || false;
-            }
-        }
     }
 
     // -------------------------------------------------------------------------

--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -211,8 +211,6 @@ export class KanbanRecordQuickCreate extends Component {
     static template = "web.KanbanRecordQuickCreate";
     static props = {
         quickCreateView: { type: [String, { value: null }], optional: 1 },
-        resModel: String,
-        context: Object,
         onValidate: Function,
         onCancel: Function,
         group: Object,
@@ -241,7 +239,7 @@ export class KanbanRecordQuickCreate extends Component {
         if (props.quickCreateView) {
             const { fields, relatedModels, views } = await this.viewService.loadViews({
                 context: { ...props.context, form_view_ref: props.quickCreateView },
-                resModel: props.resModel,
+                resModel: props.group.resModel,
                 views: [[false, "form"]],
             });
             quickCreateFields = fields;
@@ -250,24 +248,22 @@ export class KanbanRecordQuickCreate extends Component {
         }
         const models = {
             ...quickCreateRelatedModels,
-            [props.resModel]: quickCreateFields,
+            [props.group.resModel]: quickCreateFields,
         };
         const archInfo = new formView.ArchParser().parse(
             quickCreateForm.arch,
             models,
-            props.resModel
+            props.group.resModel
         );
-        const context = props.context || {};
-        context[`default_${props.group.groupByField.name}`] = props.group.serverValue;
         this.quickCreateProps = {
             Model: formView.Model,
             Renderer: formView.Renderer,
             Compiler: formView.Compiler,
-            resModel: props.resModel,
+            resModel: props.group.resModel,
             onValidate: props.onValidate,
             onCancel: props.onCancel,
             fields: quickCreateFields,
-            context,
+            context: props.group.context,
             archInfo,
         };
     }

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -31,8 +31,6 @@
                         <t t-if="!group.isFolded">
                             <t t-if="group.id === props.quickCreateState.groupId">
                                 <KanbanRecordQuickCreate
-                                    context="props.list.context"
-                                    resModel="props.list.resModel"
                                     group="group"
                                     onCancel="force => this.cancelQuickCreate(force)"
                                     onValidate="(record, mode) => this.validateQuickCreate(record, mode, group)"

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -3,6 +3,8 @@
 import { onWillStart, onWillUpdateProps, reactive, useComponent } from "@odoo/owl";
 import { Domain } from "@web/core/domain";
 import { _t } from "@web/core/l10n/translation";
+import { extractInfoFromGroupData } from "@web/model/relational_model/utils";
+
 const FALSE = Symbol("False");
 
 /**
@@ -226,7 +228,7 @@ class ProgressBarState {
     }
 
     async _updateAggregates() {
-        const { context, groupBy, domain, resModel } = this.model.root;
+        const { context, fields, groupBy, domain, resModel } = this.model.root;
         const fieldsName = this._aggregateFields.map((f) => f.name);
         const firstGroupByName = groupBy[0].split(":")[0];
         const kwargs = { context };
@@ -238,7 +240,8 @@ class ProgressBarState {
             kwargs
         );
         this._aggregateValues = res.groups.map((r) => {
-            return { ...r, [firstGroupByName]: r[groupBy] };
+            const groupInfo = extractInfoFromGroupData(r, groupBy, fields);
+            return { ...groupInfo.aggregates, [firstGroupByName]: groupInfo.serverValue };
         });
     }
 


### PR DESCRIPTION
Before this commit, in an editable list view grouped by a many2many field, it crashed when the user tried to add a new record, because the default value set in the context was wrong (it was an id, but it must be a list of ids, containing a single id, the one of the group where we want to create a record).

As this is a master fix, this commit takes the shot to refactor a bit the way we extract information from groups returned by webReadGroup, s.t. everything is now computed directly (before, the serverValue was computed in the datapoint, which didn't allow us to use it in the context). We can also get rid of the context handling in kanban (where the bug wasn't present), as it is now correctly generated in the model for everyone.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
