### PR TITLE
[IMP] im_livechat: do not rely on chat history anymore

### DIFF
--- a/addons/im_livechat/controllers/__init__.py
+++ b/addons/im_livechat/controllers/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import channel
 from . import chatbot
 from . import link_preview
 from . import main

--- a/addons/im_livechat/controllers/channel.py
+++ b/addons/im_livechat/controllers/channel.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import route
+from odoo.addons.mail.controllers.discuss.channel import ChannelController
+from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
+
+
+class LivechatChannelController(ChannelController):
+    @route("/discuss/channel/messages", cors="*")
+    @add_guest_to_context
+    def discuss_channel_messages(self, channel_id, before=None, after=None, limit=30, around=None):
+        return super().discuss_channel_messages(channel_id, before, after, limit, around)

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -49,6 +49,8 @@ class DiscussChannel(models.Model):
         channel_infos = super()._channel_info()
         channel_infos_dict = dict((c['id'], c) for c in channel_infos)
         for channel in self:
+            if channel.chatbot_current_step_id:
+                channel_infos_dict[channel.id]["chatbot_script_id"] = channel.chatbot_current_step_id.chatbot_script_id.id
             channel_infos_dict[channel.id]['channel']['anonymous_name'] = channel.anonymous_name
             channel_infos_dict[channel.id]['channel']['anonymous_country'] = {
                 'code': channel.country_id.code,

--- a/addons/im_livechat/static/src/embed/chat_window/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/chat_window/chat_window_patch.xml
@@ -2,12 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ChatWindow" t-inherit-mode="extension">
         <xpath expr="//*[@name='thread content']" position="replace">
-           <FeedbackPanel
-                t-if="livechatState.hasFeedbackPanel"
-                onClickClose="() => this.close()"
-                sendFeedback="(rating, feedback) => this.livechatService.sendFeedback(thread.uuid, rating, feedback)"
-                thread="thread"
-            />
+           <FeedbackPanel t-if="livechatState.hasFeedbackPanel" onClickClose="() => this.close()" thread="thread"/>
            <t t-else="">$0</t>
         </xpath>
         <xpath expr="//*[@t-ref='needactionCounter']" position="replace">

--- a/addons/im_livechat/static/src/embed/core/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/core/autopopup_service.js
@@ -57,7 +57,7 @@ export class AutopopupService {
      * @returns {Promise<boolean>}
      */
     async shouldOpenChatWindow() {
-        const thread = await this.threadService.getLivechatThread();
+        const thread = await this.livechatService.thread;
         return this.storeService.ChatWindow.records.every((cw) => !cw.thread?.eq(thread));
     }
 

--- a/addons/im_livechat/static/src/embed/core/disabled_features.js
+++ b/addons/im_livechat/static/src/embed/core/disabled_features.js
@@ -8,6 +8,7 @@ import { Thread } from "@mail/core/common/thread_model";
 import { ThreadService } from "@mail/core/common/thread_service";
 
 import { patch } from "@web/core/utils/patch";
+import { SESSION_STATE } from "./livechat_service";
 
 patch(Composer.prototype, {
     get allowUpload() {
@@ -32,10 +33,9 @@ patch(Thread.prototype, {
 
 patch(ThreadService.prototype, {
     async fetchNewMessages(thread) {
-        return;
-    },
-    async loadAround() {
-        return;
+        if (thread.type !== "livechat" || this.livechatService.state === SESSION_STATE.PERSISTED) {
+            return super.fetchNewMessages(...arguments);
+        }
     },
 });
 

--- a/addons/im_livechat/static/src/embed/core_ui/thread_patch.xml
+++ b/addons/im_livechat/static/src/embed/core_ui/thread_patch.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[@name='content']" position="before">
-            <div t-if="livechatService.welcomeMessage" class="bg-100 py-3">
-                <Message message="livechatService.welcomeMessage" thread="props.thread"/>
+            <div t-if="props.thread?.livechatWelcomeMessage" class="bg-100 py-3">
+                <Message message="props.thread.livechatWelcomeMessage" thread="props.thread"/>
             </div>
         </xpath>
         <xpath expr="//*[@name='content']" position="after">
-            <Message t-if="chatbotService.isTyping" message="chatbotService.typingMessage" isInChatWindow="env.inChatWindow" isTypingMessage="true"  thread="props.thread"/>
+            <Message t-if="chatbotService.isTyping" message="props.thread.chatbotTypingMessage" isInChatWindow="env.inChatWindow" isTypingMessage="true"  thread="props.thread"/>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-Thread-empty')]" position="replace">
             <t t-if="props.thread.type !== 'livechat'">$0</t>

--- a/addons/im_livechat/static/src/embed/feedback_panel/feedback_panel.js
+++ b/addons/im_livechat/static/src/embed/feedback_panel/feedback_panel.js
@@ -5,18 +5,18 @@ import { TranscriptSender } from "@im_livechat/embed/feedback_panel/transcript_s
 
 import { Component, useState } from "@odoo/owl";
 
+import { useService } from "@web/core/utils/hooks";
 import { session } from "@web/session";
 
 /**
  * @typedef {Object} Props
  * @property {Function} [onClickClose]
- * @property {Function} [sendFeedback]
  * @property {import("@mail/core/common/thread_model").Thread}
  * @extends {Component<Props, Env>}
  */
 export class FeedbackPanel extends Component {
     static template = "im_livechat.FeedbackPanel";
-    static props = ["onClickClose?", "sendFeedback", "thread"];
+    static props = ["onClickClose?", "thread"];
     static components = { TranscriptSender };
 
     STEP = Object.freeze({
@@ -27,6 +27,8 @@ export class FeedbackPanel extends Component {
 
     setup() {
         this.session = session;
+        this.livechatService = useService("im_livechat.livechat");
+        this.rpc = useService("rpc");
         this.state = useState({
             step: this.STEP.RATING,
             rating: null,
@@ -41,8 +43,12 @@ export class FeedbackPanel extends Component {
         this.state.rating = rating;
     }
 
-    onClickSendFeedback() {
-        this.props.sendFeedback(this.state.rating, this.state.feedback);
+    async onClickSendFeedback() {
+        this.rpc("/im_livechat/feedback", {
+            reason: this.state.feedback,
+            rate: this.state.rating,
+            uuid: this.props.thread.uuid,
+        });
         this.state.step = this.STEP.THANKS;
     }
 }

--- a/addons/im_livechat/static/src/embed/feedback_panel/transcript_sender.js
+++ b/addons/im_livechat/static/src/embed/feedback_panel/transcript_sender.js
@@ -25,6 +25,7 @@ export class TranscriptSender extends Component {
     setup() {
         this.isValidEmail = isValidEmail;
         this.livechatService = useService("im_livechat.livechat");
+        this.rpc = useService("rpc");
         this.state = useState({
             email: "",
             status: this.STATUS.IDLE,
@@ -34,7 +35,10 @@ export class TranscriptSender extends Component {
     async onClickSend() {
         this.state.status = this.STATUS.SENDING;
         try {
-            await this.livechatService.sendTranscript(this.props.thread.uuid, this.state.email);
+            await this.rpc("/im_livechat/email_livechat_transcript", {
+                uuid: this.props.thread.uuid,
+                email: this.state.email,
+            });
             this.state.status = this.STATUS.SENT;
         } catch {
             this.state.status = this.STATUS.FAILED;

--- a/addons/website_livechat/static/tests/tours/website_livechat_common.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_common.js
@@ -1,14 +1,6 @@
 /** @odoo-module **/
 
-import { patch } from "@web/core/utils/patch";
-import { RATING, LivechatService } from "@im_livechat/embed/core/livechat_service";
-
-patch(LivechatService.prototype, {
-    sendFeedback() {
-        document.body.classList.add("feedback_sent");
-        return super.sendFeedback(...arguments);
-    },
-});
+import { RATING } from "@im_livechat/embed/core/livechat_service";
 
 /*******************************
  *         Common Steps
@@ -71,11 +63,6 @@ export const feedback = [
     {
         content: "Send the feedback",
         trigger: "button:contains(Send):not(:disabled)",
-    },
-    {
-        content: "Check if feedback has been sent",
-        trigger: "body.feedback_sent",
-        shadow_dom: false,
     },
     {
         content: "Thanks for your feedback",


### PR DESCRIPTION
Before this commit, the livechat was still using a dedicated
route to fetch messages on page load. Since [1], visitors are
actually mail guest so they can access the classic mail route
in order to do so. This commit adapt the livechat code to use
this route instead of the custom one.

At the same time, this commit simplify the livechat service.

part of task-3332628

[1]: https://github.com/odoo/odoo/pull/129770