### PR TITLE
[REM] base: remove deprecated selection field from 'ir.model.fields'

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -538,8 +538,6 @@ class IrModelFields(models.Model):
     field_description = fields.Char(string='Field Label', default='', required=True, translate=True)
     help = fields.Text(string='Field Help', translate=True)
     ttype = fields.Selection(selection=FIELD_TYPES, string='Field Type', required=True)
-    selection = fields.Char(string="Selection Options (Deprecated)",
-                            compute='_compute_selection', inverse='_inverse_selection')
     selection_ids = fields.One2many("ir.model.fields.selection", "field_id",
                                     string="Selection Options", copy=True)
     copied = fields.Boolean(string='Copied',
@@ -608,19 +606,6 @@ class IrModelFields(models.Model):
                 rec.related_field_id = rec._related_field()
             else:
                 rec.related_field_id = False
-
-    @api.depends('selection_ids')
-    def _compute_selection(self):
-        for rec in self:
-            if rec.ttype in ('selection', 'reference'):
-                rec.selection = str(self.env['ir.model.fields.selection']._get_selection(rec.id))
-            else:
-                rec.selection = False
-
-    def _inverse_selection(self):
-        for rec in self:
-            selection = literal_eval(rec.selection or "[]")
-            self.env['ir.model.fields.selection']._update_selection(rec.model, rec.name, selection)
 
     @api.depends('ttype', 'related', 'compute')
     def _compute_copied(self):

--- a/odoo/addons/test_read_group/tests/test_read_progress_bar.py
+++ b/odoo/addons/test_read_group/tests/test_read_progress_bar.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import common
+from odoo import Command
 
 
 @common.tagged('post_install', '-at_install')
@@ -78,7 +79,11 @@ class TestReadProgressBar(common.TransactionCase):
                     'field_description': 'State',
                     'name': 'x_state',
                     'ttype': 'selection',
-                    'selection': "[('foo', 'Foo'), ('bar', 'Bar'), ('baz', 'Baz')]",
+                    'selection_ids': [
+                        Command.create({'value': 'foo', 'name': 'Foo', 'sequence': 0}),
+                        Command.create({'value': 'bar', 'name': 'Bar', 'sequence': 1}),
+                        Command.create({'value': 'baz', 'name': 'Baz', 'sequence': 2}),
+                    ]
                 }),
             ],
         })
@@ -131,7 +136,11 @@ class TestReadProgressBar(common.TransactionCase):
                 'field_description': 'Related State',
                 'name': 'x_state_computed',
                 'ttype': 'selection',
-                'selection': "[('foo', 'Foo'), ('bar', 'Bar'), ('baz', 'Baz')]",
+                'selection_ids': [
+                    Command.create({'value': 'foo', 'name': 'Foo', 'sequence': 0}),
+                    Command.create({'value': 'bar', 'name': 'Bar', 'sequence': 1}),
+                    Command.create({'value': 'baz', 'name': 'Baz', 'sequence': 2}),
+                ],
                 'compute': "for rec in self: rec['x_state_computed'] = rec.x_state",
                 'depends': 'x_state',
                 'readonly': True,


### PR DESCRIPTION
The title is self-explanatory

task-3483966

https://github.com/odoo/upgrade/pull/5091
https://github.com/odoo/upgrade-util/pull/154
https://github.com/odoo/enterprise/pull/72352