### PR TITLE
[IMP] base_import: make Test button main button one until test is successful

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -53,6 +53,7 @@ export class ImportAction extends Component {
                 step: 1,
             },
             isPaused: false,
+            isTested: false,
             previewError: "",
         });
 
@@ -184,6 +185,7 @@ export class ImportAction extends Component {
             this.state.fileLength = res.file_length;
             this.state.previewError = undefined;
         }
+        this.state.isTested = false;
         this.model.unblock();
     }
 
@@ -220,11 +222,15 @@ export class ImportAction extends Component {
             this.state.isPaused = true;
         }
 
-        if (!isTest && res.ids.length) {
-            this.notification.add(_t("%s records successfully imported", res.ids.length), {
-                type: "success",
-            });
-            this.exit(res.ids);
+        if (res.ids.length) {
+            if (!isTest) {
+                this.notification.add(_t("%s records successfully imported", res.ids.length), {
+                    type: "success",
+                });
+                this.exit(res.ids);
+            } else {
+                this.state.isTested = true;
+            }
         }
     }
 

--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -5,9 +5,16 @@
             <Layout className="'o_import_action d-flex h-100 overflow-auto'" display="display">
                 <t t-set-slot="control-panel-create-button">
                     <t t-if="isPreviewing">
-                        <button t-if="!state.isPaused" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Import</button>
-                        <button t-else="" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Resume</button>
-                        <button type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(true)">Test</button>
+                        <t t-if="!state.isTested">
+                            <button type="button" class="btn btn-primary" t-on-click="() => this.handleImport(true)">Test</button>
+                            <button t-if="!state.isPaused" type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(false)">Import</button>
+                            <button t-else="" type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(false)">Resume</button>
+                        </t>
+                        <t t-else="">
+                            <button t-if="!state.isPaused" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Import</button>
+                            <button t-else="" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Resume</button>
+                            <button type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(true)">Test</button>
+                        </t>
                     </t>
                     <FileInput
                         acceptedFileExtensions="'.csv, .xls, .xlsx, .xlsm, .ods'"

--- a/addons/base_import/static/tests/import_action_tests.js
+++ b/addons/base_import/static/tests/import_action_tests.js
@@ -696,7 +696,7 @@ QUnit.module("Base Import Tests", (hooks) => {
             );
 
             await editSelectMenu(target, ".o_import_data_content .o_select_menu", "Display name");
-            await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
+            await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
             assert.verifySteps([
                 "base_import.import/execute_import",
                 "1 records successfully imported",
@@ -766,7 +766,7 @@ QUnit.module("Base Import Tests", (hooks) => {
             "prevent option is selected by default"
         );
         editSelect(target, ".o_import_field_selection select", "item_2");
-        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
         assert.strictEqual(
             target.querySelector(".o_import_data_content .alert-info").textContent,
             "Everything seems valid.",
@@ -825,7 +825,7 @@ QUnit.module("Base Import Tests", (hooks) => {
             "options are 'prevent', choose a default boolean value or 'skip'"
         );
         editSelect(target, ".o_import_field_boolean select", "false");
-        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
         assert.strictEqual(
             target.querySelector(".o_import_data_content .alert-info").textContent,
             "Everything seems valid.",
@@ -876,7 +876,7 @@ QUnit.module("Base Import Tests", (hooks) => {
         await editInput(target, ".o_control_panel_main_buttons input[type='file']", file);
         // For this test, we force the display of an error message if this field is set
         await editSelectMenu(target, ".o_import_data_content .o_select_menu", "Many2Many");
-        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
         assert.strictEqual(
             target.querySelector(".o_import_data_content .alert-danger").textContent,
             "The file contains blocking errors (see below)",
@@ -888,7 +888,7 @@ QUnit.module("Base Import Tests", (hooks) => {
             "options are 'prevent', choose a default boolean value or 'skip'"
         );
         editSelect(target, ".o_import_field_many2many select", "name_create_enabled_fields");
-        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
         assert.strictEqual(
             target.querySelector(".o_import_data_content .alert-info").textContent,
             "Everything seems valid.",
@@ -1040,7 +1040,7 @@ QUnit.module("Base Import Tests", (hooks) => {
         );
 
         await editInput(target, "input#o_import_batch_limit", 1);
-        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
         assert.strictEqual(
             target.querySelector(".o_import_data_content .alert-info").textContent,
             "Everything seems valid.",
@@ -1106,7 +1106,7 @@ QUnit.module("Base Import Tests", (hooks) => {
         const file = new File(["fake_file"], "fake_file.xls", { type: "text/plain" });
         await editInput(target, ".o_control_panel_main_buttons input[type='file']", file);
         await editInput(target, "input#o_import_batch_limit", 1);
-        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
         // Since a nextTick is added to each batch, we must wait twice before the end of the second batch
         await nextTick();
         await nextTick();
@@ -1122,7 +1122,7 @@ QUnit.module("Base Import Tests", (hooks) => {
             "a message is shown to indicate the user to resume from the third row"
         );
         assert.strictEqual(
-            target.querySelector(".o_control_panel_main_buttons button:first-child").textContent,
+            target.querySelector(".o_control_panel_main_buttons button:nth-child(2)").textContent,
             "Resume",
             "button contains the right text"
         );
@@ -1195,7 +1195,7 @@ QUnit.module("Base Import Tests", (hooks) => {
         const file = new File(["fake_file"], "fake_file.xls", { type: "text/plain" });
         await editInput(target, ".o_control_panel_main_buttons input[type='file']", file);
         await editInput(target, "input#o_import_batch_limit", 1);
-        await click(target.querySelector(".o_control_panel_main_buttons button:nth-child(2)"));
+        await click(target.querySelector(".o_control_panel_main_buttons button:first-child"));
         // Since a nextTick is added to each batch, we must wait twice before the end of the second batch
         await nextTick();
         await nextTick();


### PR DESCRIPTION
Purpose
=======

Nudge users towards safety by pushing them to test their import before importing directly.

Spec
====

In the base_import client action: set the class 'btn-secondary' on the IMPORT button and 'btn-primary' on the TEST button. Once a test has run without error, the import button becomes primary and the test secondary.

task-2865392