### PR TITLE
[IMP] stock_{delivery}: correct value in commercial invoices 

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -183,3 +183,39 @@ class SaleOrder(models.Model):
         if self:
             self.onchange_order_line()
         return price_unit
+
+    def _get_line_global_discount(self):
+        """ This method calculates the global discount for each invoicable sale order line.
+        It distributes the global discount among invoicable lines proportionally based
+        on their taxable price and quantity.
+
+        Returns:
+            dict: A dictionary with sale order lines as keys and their respective global
+            discount amount as values.
+        """
+        if not self:
+            return {}
+
+        invoicable_lines = self.order_line.filtered(lambda line: line._can_be_invoiced_alone())
+        sale_line_discount_dict = {line.id: 0 for line in invoicable_lines}
+
+        for so in self:
+            global_discount_lines = so.order_line.filtered(
+                lambda line: line.product_id == so.company_id.sale_discount_product_id
+                and not line._can_be_invoiced_alone()
+            )
+            if not global_discount_lines:
+                continue
+
+            total_global_discount_value = sum(
+                line.price_reduce_taxinc * line.product_uom_qty for line in global_discount_lines
+            )
+            total_invoicable_price = sum(invoicable_lines.mapped("price_reduce_taxinc"))
+
+            if not total_global_discount_value or not total_invoicable_price:
+                continue
+
+            for line in invoicable_lines:
+                line_price_share = (line.price_reduce_taxinc / total_invoicable_price) * total_global_discount_value
+                sale_line_discount_dict[line.id] -= line_price_share / line.product_uom_qty
+        return sale_line_discount_dict

--- a/addons/sale_loyalty_delivery/models/sale_order.py
+++ b/addons/sale_loyalty_delivery/models/sale_order.py
@@ -78,3 +78,32 @@ class SaleOrder(models.Model):
                     filtered_res[coupon] = filtered_rewards
             res = filtered_res
         return res
+
+    def _get_line_global_discount(self):
+        """ Overrides the original method to apply rewards and loyalty discounts. """
+        if not self:
+            return {}
+
+        sale_line_discount_dict = super()._get_line_global_discount()
+        for so in self:
+            invoicable_lines = so.order_line.filtered(lambda line: line._can_be_invoiced_alone())
+            reward_lines = (so.order_line - invoicable_lines).filtered(lambda line: line.is_reward_line)
+            if not invoicable_lines or sum(invoicable_lines.mapped("price_reduce_taxinc")) == 0:
+                continue
+            for line in reward_lines:
+                lines = invoicable_lines
+                reward = line.reward_id
+                reward_line_amount = line.price_total
+                if reward.reward_type == "discount":
+                    if reward.discount_applicability == "cheapest" and (cheapest_line := so._cheapest_line()):
+                        sale_line_discount_dict[cheapest_line.id] -= reward_line_amount / cheapest_line.product_uom_qty
+                        continue
+                    elif reward.discount_applicability == "specific":
+                        lines = invoicable_lines.filtered(lambda line: line.product_id in reward.discount_product_ids)
+                elif reward.reward_type == "product" and reward.reward_product_id in lines.mapped('product_id'):
+                    reward_line_amount = -(reward.reward_product_id.lst_price * line.product_uom_qty)
+                for line in lines:
+                    total_lines_price = sum(lines.mapped("price_reduce_taxinc"))
+                    line_price_share = (line.price_reduce_taxinc / total_lines_price) * reward_line_amount
+                    sale_line_discount_dict[line.id] -= line_price_share / line.product_uom_qty
+        return sale_line_discount_dict

--- a/addons/sale_mrp/models/stock_move_line.py
+++ b/addons/sale_mrp/models/stock_move_line.py
@@ -6,10 +6,39 @@ from odoo import models
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
+    def _get_kit_lines_price_ratio(self):
+        """ This method returns the ratio of the price of the kit component lines.
+        It calculates the price ratio based on either the total list price of the kit or
+        based on component quantities if the total price is unavailable. """
+        kit_lines = {}
+        boms = self.move_id.bom_line_id.bom_id
+        for bom in boms:
+            total_list_price = sum(bom.bom_line_ids.mapped("product_id.list_price"))
+            if total_list_price:
+                kit_lines.update({
+                    line: (line.product_id.list_price / total_list_price) * (
+                        1 / line.uom_id._compute_quantity(line.product_qty, line.product_id.uom_id)
+                    ) for line in bom.bom_line_ids
+                })
+            else:
+                bom_components_total_qty = sum(bom.bom_line_ids.mapped("product_qty"))
+                kit_lines.update({
+                    line: (line.product_qty / bom_components_total_qty) * (1 / line.product_qty)
+                    for line in bom.bom_line_ids
+                })
+        return kit_lines
+
     def _compute_sale_price(self):
         kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom')
-        for move_line in kit_lines:
-            unit_price = move_line.product_id.list_price
-            qty = move_line.uom_id._compute_quantity(move_line.quantity, move_line.product_id.uom_id)
-            move_line.sale_price = unit_price * qty
+        if kit_lines:
+            sale_orders = kit_lines.picking_id.sale_id
+            line_global_discounts = sale_orders._get_line_global_discount()
+            kit_line_price_ratio = kit_lines._get_kit_lines_price_ratio()
+            for move_line in kit_lines:
+                sale_line = move_line.move_id.sale_line_id
+                discount = line_global_discounts.get(sale_line.id, 0)
+                sale_unit_price = sale_line.price_reduce_taxinc - discount
+                unit_price = sale_unit_price * kit_line_price_ratio[move_line.move_id.bom_line_id]
+                qty = move_line.uom_id._compute_quantity(move_line.quantity, move_line.product_id.uom_id)
+                move_line.sale_price = unit_price * qty
         super(StockMoveLine, self - kit_lines)._compute_sale_price()

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -5,6 +5,8 @@ from unittest import skip
 from odoo.tests import Form, tagged
 
 from odoo import Command
+from odoo.tools.float_utils import float_round
+
 from odoo.addons.base.tests.common import BaseCommon
 
 
@@ -161,7 +163,10 @@ class TestSaleMrpKitBom(BaseCommon):
                 # - Components:
                 # * 1 x Component A (Price: $ 8, QTY: 10, UOM: Meter)
                 # * 1 x Component B (Price: $ 5, QTY: 2, UOM: Dozen)
-            # sale price of Kit A = (8 * 10) + (5 * 2 * 12) = $ 200
+            # sale price of Kit A = $ 1 + 15%tax = $ 1.15
+            # sale price of Component A = 1.15 * ((8 / 13) / 10) = $ 0.070769231
+            # sale price of Component B = 1.15 * ((5 / 13) / 2 * 12) = $ 0.018429487
+            # sale price of Component A + Component B = $ 0.070769231 * 10 + $ 0.018429487 * 24 = $ 1.14999998
         """
         if "sale_price" not in self.env["stock.move.line"]._fields:
             self.skipTest("This test only runs with both sale_mrp and stock_delivery installed")
@@ -218,10 +223,14 @@ class TestSaleMrpKitBom(BaseCommon):
                 })],
             'warehouse_id': self.warehouse.id,
         })
+        # Since the sale price is not explicitly set in the sale order, it defaults to 1
+        self.assertEqual(so.order_line.price_reduce_taxinc, 1.15, "The sale unit price of the kit should be 1.15")
         so.action_confirm()
         so.picking_ids._action_done()
         move_lines = so.picking_ids.move_ids.move_line_ids
-        self.assertEqual(move_lines.mapped("sale_price"), [80, 120], 'wrong shipping value')
+        # Round the sale prices to two decimal places before asserting
+        rounded_sale_prices = [float_round(price, 2) for price in move_lines.mapped("sale_price")]
+        self.assertEqual(rounded_sale_prices, [0.71, 0.44], 'wrong shipping value')
 
     def test_qty_delivered_with_bom(self):
         """Check the quantity delivered, when a bom line has a non integer quantity"""

--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -68,17 +68,23 @@ class StockMoveLine(models.Model):
 
     @api.depends('quantity', 'uom_id', 'product_id', 'move_id.sale_line_id', 'move_id.sale_line_id.price_reduce_taxinc', 'move_id.sale_line_id.product_uom_id')
     def _compute_sale_price(self):
+        sale_orders = self.picking_id.sale_id
+        line_global_discounts = sale_orders._get_line_global_discount()
         for move_line in self:
-            sale_line_id = move_line.move_id.sale_line_id
-            if sale_line_id and sale_line_id.product_id == move_line.product_id:
+            sale_line = move_line.move_id.sale_line_id
+            if sale_line and sale_line.product_id == move_line.product_id and sale_line.price_reduce_taxinc:
                 # Compute the total price (tax included) for the actually delivered quantity
                 # using the same tax logic as the sale order line and purchase order line.
-                base_line = sale_line_id._prepare_base_line_for_taxes_computation()
-                qty = move_line.uom_id._compute_quantity(move_line.quantity, sale_line_id.product_uom_id)
+                base_line = sale_line._prepare_base_line_for_taxes_computation()
+                qty = move_line.uom_id._compute_quantity(move_line.quantity, sale_line.product_uom_id)
                 base_line.update({'quantity': qty})
-                self.env['account.tax']._add_tax_details_in_base_line(base_line, sale_line_id.company_id)
+                self.env['account.tax']._add_tax_details_in_base_line(base_line, sale_line.company_id)
                 tax_results = base_line['tax_details']
-                move_line.sale_price = sale_line_id.currency_id.round(tax_results['raw_total_included_currency'])
+                raw_total = tax_results['raw_total_included_currency']
+                global_discount = line_global_discounts.get(sale_line.id, 0.0)
+                if global_discount:
+                    raw_total -= global_discount * qty
+                move_line.sale_price = sale_line.currency_id.round(raw_total)
             else:
                 # For kits, use the regular unit price
                 unit_price = move_line.product_id.list_price


### PR DESCRIPTION
Before this commit
==================
Shipping methods like FedEx generates commercial invoice - It ignores global
discounts, and the subtotal amount of commercial invoice doesn't harmonize with
the amount total of all the product line in the SO after deducting the global
discounts.

With this commit
=================
It enhances sale price accuracy for delivery items in commercial invoices,
especially for kits and orders with discounts or loyalty rewards.
It ensures kit component prices are split based on list prices and global
discounts are applied correctly to invoicable lines. The update supports
accurate invoice values for delivery pickings, aiding export documentation
and compliance. It also improves reward handling for discount and gift products,
ensuring smooth integration with loyalty programs.

Task: [3083693](https://www.odoo.com/odoo/action-4043/3083693)