### PR TITLE
[FIX] sale: keep price_reduce_taxinc with all taxes included stable 

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -612,8 +612,9 @@ class SaleOrderLine(models.Model):
 
     @api.depends('price_total', 'product_uom_qty')
     def _compute_price_reduce_taxinc(self):
+        precision_digits = self.env['decimal.precision'].precision_get('Product Unit of Measure')
         for line in self:
-            line.price_reduce_taxinc = line.price_total / line.product_uom_qty if line.product_uom_qty else 0.0
+            line.price_reduce_taxinc = float_round(line.price_total / line.product_uom_qty, precision_digits=precision_digits, rounding_method='HALF_DOWN') if line.product_uom_qty else 0.0
 
     @api.depends('product_id', 'product_uom_qty', 'product_uom')
     def _compute_product_packaging_id(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -411,6 +411,32 @@ class TestSaleOrder(SaleCommon):
         })
         self.assertEqual(sale_order.amount_total, 15.41, "")
 
+    def test_price_reduce_taxinc_rounding(self):
+        tax = self.env['account.tax'].create({
+            'name': 'Test tax',
+            'type_tax_use': 'sale',
+            'price_include': False,
+            'amount_type': 'percent',
+            'amount': 11.0,
+        })
+
+        # Test Round per Line (default)
+        self.env.company.tax_calculation_rounding_method = 'round_per_line'
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+        })
+
+        for qty in range(1, 10):
+            line = self.env['sale.order.line'].create({
+                'order_id': sale_order.id,
+                'product_id': self.product.id,
+                'product_uom_qty': qty,
+                'price_unit': 126.13,
+                'discount': 0,
+                'tax_id': tax.ids,
+            })
+            self.assertEqual(line.price_reduce_taxinc, 140.00)
+
 
 @tagged('post_install', '-at_install')
 class TestSalesTeam(SaleCommon):

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -90,7 +90,11 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
         normalized_value += sign*epsilon
         rounded_value = math.floor(abs(normalized_value)) * sign
 
-    # TIE-BREAKING: HALF-UP (for normal rounding)
+    # TIE-BREAKING: HALF-UP (for normal rounding) or HALF-DOWN
+    elif rounding_method == 'HALF_DOWN':
+        normalized_value -= math.copysign(epsilon, normalized_value)
+        rounded_value = round(normalized_value)     # round to integer
+
     # We want to apply HALF-UP tie-breaking rules, i.e. 0.5 rounds away from 0.
     else:
         normalized_value += math.copysign(epsilon, normalized_value)


### PR DESCRIPTION
The `price_reduce_taxinc` computes the unit price of an order line including all taxes, even when some taxes are configured not to be included in the unit price of the product. Generally speaking the `price_reduce_taxinc` will be equal to or higher than the `price_unit` field.

Before this commit, as the `price_reduce_taxinc` gets rounded to the same precision, the `price_reduce_taxinc` price would sometimes be different for the first few even and odd quantities. With an example, we can see that this stems from the tie-breaking rounding method used. Let's assume a product with a unit price 126.13 and an 11% tax:

```
qty  subtotal     total  price_reduce_taxinc
--------------------------------------------
  1    126.13    140.00   140.0000 -> 140.00
  2    252.26    280.01   140.0050 -> 140.01
  3    378.39    420.01   140.0033 -> 140.00
  4    504.52    560.02   140.0050 -> 140.01
  5    630.65    700.02   140.0040 -> 140.00
  6    756.78    840.03   140.0050 -> 140.01
  7    882.91    980.03   140.0042 -> 140.00
  8   1001.04   1120.03   140.0037 -> 140.00
  9   1127.17   1260.04   140.0044 -> 140.00
 10   1261.30   1400.04   140.0040 -> 140.00
```

By using a `HALF-DOWN` tie breaking strategy when rounding the values, the value of `price_reduce_taxinc` will stay stable regardless the line quantity.

Note: this behavior can be observed in the shopping cart if the shop is configured to show prices with the taxes included.

opw-3443180