### PR TITLE
[FIX] base: allow to create branches again

### DIFF
--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -60,7 +60,7 @@
                 <tree string="Companies">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
-                    <field name="partner_id"/>
+                    <field name="partner_id" required="0"/>
                     <field name="child_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 </tree>
             </field>


### PR DESCRIPTION
Since the relational model JS refactor in d4fe919db5fb4010804ca411f6e09c2747e096c5, we are unable to create new branches of companies.

The required field `partner_id` (which is created in the model's `create` method), was set as `required="0"` on the form view, but not on the list view. After the relational model refactor, when merging the modifiers of the field in both views, it is considered required. When trying to save a new branch, it thus complains that the `partner_id` field is empty.

Setting the `required="0"` modifier on the list view solves the issue, making the `partner_id` not required anymore for the JS form dialog.

[task-3461421](https://www.odoo.com/web#id=3461421&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
