### PR TITLE
[REF] web: remove LegacyAdaptedActionDialog

### DIFF
--- a/addons/web/static/src/legacy/utils.js
+++ b/addons/web/static/src/legacy/utils.js
@@ -293,26 +293,6 @@ export function makeLegacyRPCService(legacyEnv) {
     };
 }
 
-export function useLegacyRefs() {
-    const env = owl.useEnv();
-
-    let legacyRefs;
-    if (env.legacyRefs) {
-        legacyRefs = env.legacyRefs;
-    } else {
-        legacyRefs = {
-            component: null,
-            widget: null,
-        };
-    }
-
-    owl.useChildSubEnv({
-        legacyRefs,
-    });
-
-    return legacyRefs;
-}
-
 /**
  * This hook allows legacy owl Components to use services coming from the wowl env.
  * @param {string} serviceName

--- a/addons/web/static/src/webclient/actions/action_dialog.js
+++ b/addons/web/static/src/webclient/actions/action_dialog.js
@@ -3,21 +3,10 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { DebugMenu } from "@web/core/debug/debug_menu";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
-import { useLegacyRefs } from "@web/legacy/utils";
 
 import { useEffect } from "@odoo/owl";
 
-const LEGACY_SIZE_CLASSES = {
-    "extra-large": "xl",
-    large: "lg",
-    medium: "md",
-    small: "sm",
-};
-
-// -----------------------------------------------------------------------------
-// Action Dialog (Component)
-// -----------------------------------------------------------------------------
-class ActionDialog extends Dialog {
+export class ActionDialog extends Dialog {
     setup() {
         super.setup();
         useOwnDebugContext();
@@ -49,35 +38,3 @@ ActionDialog.defaultProps = {
     ...Dialog.defaultProps,
     withBodyPadding: false,
 };
-
-/**
- * This LegacyAdaptedActionDialog class will disappear when legacy code will be entirely rewritten.
- * The "ActionDialog" class should get exported from this file when the cleaning will occur, and it
- * should stop extending Dialog and use it normally instead at that point.
- */
-class LegacyAdaptedActionDialog extends ActionDialog {
-    setup() {
-        super.setup();
-        const actionProps = this.props && this.props.actionProps;
-        const actionContext = actionProps && actionProps.context;
-        const actionDialogSize = actionContext && actionContext.dialog_size;
-        this.props.size = LEGACY_SIZE_CLASSES[actionDialogSize] || Dialog.defaultProps.size;
-        const ControllerComponent = this.props && this.props.ActionComponent;
-        const Controller = ControllerComponent && ControllerComponent.Component;
-        this.isLegacy = Controller && Controller.isLegacy;
-        const legacyRefs = useLegacyRefs();
-        useEffect(
-            () => {
-                if (this.isLegacy) {
-                    // Render legacy footer buttons
-                    const footer = this.modalRef.el.querySelector("footer");
-                    legacyRefs.widget.renderButtons($(footer));
-                }
-            },
-            () => []
-        );
-    }
-}
-LegacyAdaptedActionDialog.template = "web.LegacyAdaptedActionDialog";
-
-export { LegacyAdaptedActionDialog as ActionDialog };

--- a/addons/web/static/src/webclient/actions/action_dialog.xml
+++ b/addons/web/static/src/webclient/actions/action_dialog.xml
@@ -23,14 +23,4 @@
     </xpath>
   </t>
 
-  <t t-name="web.LegacyAdaptedActionDialog" t-inherit="web.ActionDialog" t-inherit-mode="primary">
-    <xpath expr="//t[@t-slot='footer']" position="replace">
-      <t t-if="!isLegacy">
-        <t t-slot="buttons">
-          <button class="btn btn-primary o-default-button" t-on-click="() => this.data.close()">Ok</button>
-        </t>
-      </t>
-    </xpath>
-  </t>
-
 </templates>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -93,6 +93,13 @@ function parseActiveIds(ids) {
     return activeIds;
 }
 
+const DIALOG_SIZES = {
+    "extra-large": "xl",
+    large: "lg",
+    medium: "md",
+    small: "sm",
+};
+
 // -----------------------------------------------------------------------------
 // Errors
 // -----------------------------------------------------------------------------
@@ -775,13 +782,16 @@ function makeActionManager(env) {
         if (action.target === "new") {
             cleanDomFromBootstrap();
             const actionDialogProps = {
-                // TODO add size
                 ActionComponent: ControllerComponent,
                 actionProps: controller.props,
                 actionType: action.type,
             };
             if (action.name) {
                 actionDialogProps.title = action.name;
+            }
+            const size = DIALOG_SIZES[action.context.dialog_size];
+            if (size) {
+                actionDialogProps.size = size;
             }
 
             const onClose = _removeDialog();


### PR DESCRIPTION
This component was necessary during the transition phase, when all actions weren't converted to owl yet. Now, they are, so we can get rid of this small compatibility layer.

Part of task~3439226

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
