### PR TITLE
[FIX] mrp,purchase,repair,stock: cleanup of modifier refactoring

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -71,13 +71,11 @@ class MrpWorkorder(models.Model):
         'Start',
         compute='_compute_dates',
         inverse='_set_dates',
-        readonly=False,
         store=True, copy=False)
     date_finished = fields.Datetime(
         'End',
         compute='_compute_dates',
         inverse='_set_dates',
-        readonly=False,
         store=True, copy=False)
     duration_expected = fields.Float(
         'Expected Duration', digits=(16, 2), compute='_compute_duration_expected',

--- a/addons/mrp_subcontracting/views/mrp_production_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_production_views.xml
@@ -69,6 +69,7 @@
             </xpath>
             <xpath expr="//field[@name='product_qty']" position="attributes">
                 <attribute name="readonly">True</attribute>
+                <attribute name="invisible">False</attribute>
             </xpath>
             <xpath expr="//field[@name='lot_producing_id']" position="attributes">
                 <attribute name="domain">[('id', '=', False)]</attribute>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -275,6 +275,7 @@
                                                        context="{'partner_id': parent.partner_id}"
                                                        widget="many2one_barcode"
                                                        domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"
+                                                       readonly="state in ('purchase', 'to approve', 'done', 'cancel')"
                                                 />
                                                 <label for="product_qty"/>
                                                 <div class="o_row">

--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from markupsafe import Markup
-from dateutil.relativedelta import relativedelta
 
 from odoo import api, Command, fields, models, SUPERUSER_ID, _
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 from odoo.exceptions import UserError
-
-from odoo.addons.purchase.models.purchase import PurchaseOrder as Purchase
 
 
 class PurchaseOrder(models.Model):

--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -21,7 +21,6 @@ class PickingType(models.Model):
     count_repair_late = fields.Integer(
         string="Number of Repair Orders Late", compute='_compute_count_repair')
 
-    default_location_dest_id = fields.Many2one()
     default_remove_location_dest_id = fields.Many2one(
         'stock.location', 'Default Remove Destination Location',
         check_company=True, readonly=True,

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -5,6 +5,9 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
+            <field name="default_location_dest_id" position="attributes">
+                <attribute name="readonly">code == 'repair_operation'</attribute>
+            </field>
             <xpath expr="//field[@name='default_location_dest_id']" position="after">
                 <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
                 <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -48,7 +48,7 @@ class StockMove(models.Model):
         domain="[('type', 'in', ['product', 'consu'])]", index=True, required=True)
     description_picking = fields.Text('Description of Picking')
     product_qty = fields.Float(
-        'Real Quantity', compute='_compute_product_qty',
+        'Real Quantity', compute='_compute_product_qty', inverse='_set_product_qty',
         digits=0, store=True, compute_sudo=True,
         help='Quantity in the default UoM of the product')
     product_uom_qty = fields.Float(

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -347,7 +347,6 @@ class Picking(models.Model):
     scheduled_date = fields.Datetime(
         'Scheduled Date', compute='_compute_scheduled_date', inverse='_set_scheduled_date', store=True,
         index=True, default=fields.Datetime.now, tracking=True,
-        readonly=False,
         help="Scheduled time for the first part of the shipment to be processed. Setting manually a value here would set it as expected date for all the stock moves.")
     date_deadline = fields.Datetime(
         "Deadline", compute='_compute_date_deadline', store=True,

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -18,13 +18,12 @@ class StockPickingBatch(models.Model):
         string='Batch Transfer', default='New',
         copy=False, required=True, readonly=True)
     user_id = fields.Many2one(
-        'res.users', string='Responsible', tracking=True, check_company=True,
-        readonly=False)
+        'res.users', string='Responsible', tracking=True, check_company=True)
     company_id = fields.Many2one(
         'res.company', string="Company", required=True, readonly=True,
         index=True, default=lambda self: self.env.company)
     picking_ids = fields.One2many(
-        'stock.picking', 'batch_id', string='Transfers', readonly=False,
+        'stock.picking', 'batch_id', string='Transfers',
         domain="[('id', 'in', allowed_picking_ids)]", check_company=True,
         help='List of transfers associated to this batch')
     show_check_availability = fields.Boolean(
@@ -41,7 +40,7 @@ class StockPickingBatch(models.Model):
         'stock.move', string="Stock moves", compute='_compute_move_ids')
     move_line_ids = fields.One2many(
         'stock.move.line', string='Stock move lines',
-        compute='_compute_move_ids', inverse='_set_move_line_ids', readonly=False)
+        compute='_compute_move_ids', inverse='_set_move_line_ids')
     state = fields.Selection([
         ('draft', 'Draft'),
         ('in_progress', 'In progress'),


### PR DESCRIPTION
Minor cleanup after odoo/odoo#104741 thanks to edge-cases and the fun complexity of logistics code. Fixes include:

- removing some readonly=False that were added on computed/stored fields that already have an inverse func or were already not readonly (i.e. redundant => cleanup)
- fixed visibility of qty to prod in subcontractor portal view of a MO (i.e. yay they know how much they're supposed to make again)
- remove unused imports
- adding back in readonly functionality of default dest of repair operation type (and removing the now useless field override that used to add in the readonly functionality)
- adding back in the `_set_product_qty` inverse function since it was probably removed by mistake (and is still important to have)

unrelated to viewpocolypse change, also fixed:
- mobile view of PO was for some reason allowing products to be changed in already confirmed/done POs, which could lead to some inconsistent data => made this consistent with existing desktop view behavior

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
