### PR TITLE
[FIX] mrp: two MLs created for finished products when overproduce

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1520,7 +1520,10 @@ class MrpProduction(models.Model):
             # the finish move can already be completed by the workorder.
             for move in finish_moves:
                 if not move.quantity_done:
-                    move._set_quantity_done(float_round(order.qty_producing - order.qty_produced, precision_rounding=order.product_uom_id.rounding, rounding_method='HALF-UP'))
+                    done_qty = float_round(order.qty_producing - order.qty_produced, precision_rounding=order.product_uom_id.rounding, rounding_method='HALF-UP')
+                    if move.reserved_availability < done_qty and move.state not in ['done', 'cancel']:
+                        move._action_assign(force_qty=done_qty)
+                    move._set_quantity_done(done_qty)
                 if move.has_tracking != 'none' and order.lot_producing_id:
                     move.move_line_ids.lot_id = order.lot_producing_id
             # workorder duration need to be set to calculate the price of the product

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -772,6 +772,39 @@ class TestMrpOrder(TestMrpCommon):
         self.assertTrue(all(s in ['done', 'cancel'] for s in mo.move_raw_ids.mapped('state')))
         self.assertEqual(sum(mo.move_raw_ids.mapped('move_line_ids.reserved_uom_qty')), 0)
 
+    def test_product_produce_7(self):
+        """ Plan 5 finished products, reserve and produce 5. Post the current production.
+        Simulate an unlock and edit and, on the opened moves, set the consumed quantity
+        to 6, and to 4. Check produced qty is correct."""
+        self.stock_location = self.env.ref('stock.stock_location_stock')
+        mo, _, _, p1, p2 = self.generate_mo()
+        self.assertEqual(len(mo), 1, 'MO should have been created')
+
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 20)
+        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 5)
+        mo.action_assign()
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5
+        mo = mo_form.save()
+        mo.button_mark_done()
+        self.assertEqual(len(mo.move_finished_ids.move_line_ids), 1)
+        self.assertTrue(mo.is_locked)
+
+        mo.action_toggle_is_locked()
+        self.assertFalse(mo.is_locked)
+        mo_form = Form(mo)
+        mo_form.qty_producing = 6
+        mo = mo_form.save()
+        self.assertEqual(len(mo.move_finished_ids.move_line_ids), 1)
+        self.assertAlmostEqual(mo.move_finished_ids.move_line_ids.qty_done, 6)
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 4
+        mo = mo_form.save()
+        self.assertEqual(len(mo.move_finished_ids.move_line_ids), 1)
+        self.assertAlmostEqual(mo.move_finished_ids.move_line_ids.qty_done, 4)
+
     def test_consumption_strict_1(self):
         """ Checks the constraints of a strict BOM without tracking when playing around
         quantities to consume."""


### PR DESCRIPTION
Since 5a29f6995dec155147265bacb27064d9c7b4beee, finished moves of MOs now bypass reservation. When update done qty of finished move, we will create a ml with reserved qty to be the demand qty. https://github.com/odoo/odoo/blob/b3c8cc40e5c5d3061e2dcdc7ee557fb1b16d6a34/addons/stock/models/stock_move_line.py#L334-L347 If overproduce, another move line will be created for the extra qty https://github.com/odoo/odoo/blob/b3c8cc40e5c5d3061e2dcdc7ee557fb1b16d6a34/addons/stock/models/stock_move.py#L2046-L2049 This secound line is not very necessary and it will cause issue when user unlock MO and change produced qty again (both two line will be update to the new produced qty)

To fix, we can apply the same as what we did for general moves, force assign before set the qty done
https://github.com/odoo/odoo/blob/b3c8cc40e5c5d3061e2dcdc7ee557fb1b16d6a34/addons/stock/models/stock_move.py#L400-L402

Task-3468182





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
