### PR TITLE
[IMP] web, *: replace view all with search more

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -77,7 +77,7 @@ export class AnalyticDistribution extends Component {
 
         this.selectCreateIsOpen = false;
         this.addDialog = useOwnedDialogs();
-        this.onViewAll = this._onViewAll.bind(this);
+        this.onSearchMore = this._onSearchMore.bind(this);
     }
 
     // Lifecycle
@@ -247,15 +247,15 @@ export class AnalyticDistribution extends Component {
             color: result.color,
         }));
 
-        if (records.length) {
+        if (searchLimit < records.length) {
             options.push({
-                label: _t("View all"),
-                action: (editedTag) => this.onViewAll(searchTerm, editedTag),
-                classList: "o_m2o_dropdown_option o_m2o_dropdown_option_view_all",
+                label: _t("Search More..."),
+                action: (editedTag) => this.onSearchMore(searchTerm, editedTag),
+                classList: "o_m2o_dropdown_option o_m2o_dropdown_option_search_more",
             });
         }
 
-        else {
+        if (!options.length) {
             options.push({
                 label: _t("No Analytic Accounts for this plan"),
                 classList: "o_m2o_no_result",
@@ -266,7 +266,7 @@ export class AnalyticDistribution extends Component {
         return options;
     }
 
-    async _onViewAll(searchTerm, editedTag) {
+    async _onSearchMore(searchTerm, editedTag) {
         let dynamicFilters = [];
         if (searchTerm.length) {
             dynamicFilters = [

--- a/addons/analytic/static/tests/analytic_distribution_tests.js
+++ b/addons/analytic/static/tests/analytic_distribution_tests.js
@@ -250,7 +250,7 @@ QUnit.module("Analytic", (hooks) => {
 
         let incompleteCountryTag = popup.querySelector("table#plan_5 .incomplete .o_analytic_account_name input");
         await click(incompleteCountryTag);
-        await click(target.querySelector(".o_m2o_dropdown_option_view_all"));
+        await click(target.querySelector(".o_m2o_dropdown_option_search_more"));
 
         assert.containsN(target, ".modal-dialog .o_list_renderer", 1, "select create list dialog is visible");
 
@@ -282,7 +282,7 @@ QUnit.module("Analytic", (hooks) => {
         // replace the first analytic account with 4 accounts
         triggerHotkey("shift+Tab");
         await click(document.activeElement);
-        await click(target.querySelector(".o_m2o_dropdown_option_view_all"));
+        await click(target.querySelector(".o_m2o_dropdown_option_search_more"));
         accountRows = [...target.querySelectorAll(".modal-dialog .o_data_row")];
         for (const row of accountRows.slice(0,4)) {
             await click(row.querySelector(".o_list_record_selector input"));

--- a/addons/base_import/static/tests/import_records_tests.js
+++ b/addons/base_import/static/tests/import_records_tests.js
@@ -235,7 +235,7 @@ QUnit.module("Base Import Tests", (hooks) => {
                 },
             });
 
-            await selectDropdownItem(target, "m2o", "View all");
+            await selectDropdownItem(target, "m2o", "Search More...");
             const dialog = target.querySelector(".modal");
             assert.containsNone(dialog, ".o_cp_action_menus");
             assert.containsNone(dialog, ".o_import_menu");

--- a/addons/lunch/static/tests/lunch_kanban_tests.js
+++ b/addons/lunch/static/tests/lunch_kanban_tests.js
@@ -203,7 +203,7 @@ QUnit.module('LunchKanban', (hooks) => {
         await nextTick();
         assert.containsOnce(target, '.lunch_location .dropdown-item:contains(New Office)');
 
-        click(target, '.lunch_location .ui-menu-item:nth-child(2) .dropdown-item');
+        click(target, '.lunch_location li:not(.o_m2o_dropdown_option) .dropdown-item:not(.ui-state-active)');
 
         await nextTick();
         assert.containsN(target, 'div[role=article].o_kanban_record', 2);
@@ -245,7 +245,7 @@ QUnit.module('LunchKanban', (hooks) => {
         assert.containsOnce(target, '.lunch_user .dropdown-item:contains(David Elora)');
 
         expectedUserId = 2;
-        click(target, '.lunch_user .ui-menu-item:nth-child(2) .dropdown-item');
+        click(target, '.lunch_user li:not(.o_m2o_dropdown_option) .dropdown-item:not(.ui-state-active)');
 
         await nextTick();
         const wallet = target.querySelector('.o_lunch_banner .col-9 > .d-flex > span:nth-child(2)');
@@ -253,7 +253,7 @@ QUnit.module('LunchKanban', (hooks) => {
 
         click(target, '.lunch_location input');
         await nextTick();
-        click(target, '.lunch_location .ui-menu-item:nth-child(2) .dropdown-item');
+        click(target, '.lunch_location li:not(.o_m2o_dropdown_option) .dropdown-item:not(.ui-state-active)');
 
         await nextTick();
         const user = target.querySelector('.lunch_user input');

--- a/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
@@ -145,9 +145,8 @@ QUnit.module('favorite filter widget', (hooks) => {
         assert.isVisible(fixture.querySelector('.o_mass_mailing_save_filter_container'),
             "should have option to save filter if no filter is set");
         await testUtils.click(fixture.querySelector('.o_field_mailing_filter input'));
-        assert.containsN($dropdown, 'li.ui-menu-item',
-            2,
-            "there should be only one existing filter as well as the View all option");
+        assert.containsN($dropdown, 'li.ui-menu-item', 2,
+            "there should be only one existing filter and a search more btn");
         // create a new filter
         await testUtils.click(fixture, '.o_mass_mailing_add_filter');
         fixture.querySelector('.o_mass_mailing_filter_name').value = 'event promo - new users';
@@ -168,7 +167,7 @@ QUnit.module('favorite filter widget', (hooks) => {
         fixture.querySelector('.o_field_mailing_filter .o_input_dropdown input').blur();
         await testUtils.click(fixture.querySelector('.o_field_mailing_filter input'));
         assert.containsN($dropdown, 'li.ui-menu-item', 3,
-            "there should be two existing filters (and the View all option)");
+            "there should be two existing filters and a search more btn");
         await testUtils.clickSave(fixture);
     });
 
@@ -290,7 +289,7 @@ QUnit.module('favorite filter widget', (hooks) => {
         await testUtils.click(fixture.querySelector('.o_field_mailing_filter input'));
         fixture.querySelector('.o_field_mailing_filter input').autocomplete = 'widget';
         const $dropdown = fixture.querySelector('.o_field_mailing_filter .dropdown');
-        await testUtils.click($dropdown.lastElementChild.firstElementChild);
+        await testUtils.click($dropdown.lastElementChild, 'li:first-of-type');
         assert.equal(fixture.querySelector('.o_domain_show_selection_button').textContent.trim(), '1 record(s)',
             "applied filter should only display single record (only Azure)");
         await testUtils.clickSave(fixture);

--- a/addons/sale_expense/static/src/js/sale_order_many2one.js
+++ b/addons/sale_expense/static/src/js/sale_order_many2one.js
@@ -16,7 +16,7 @@ export class OrderField extends Many2OneField {
         // hide the search more option from the dropdown menu
        return {
            ...super.Many2XAutocompleteProps,
-           noViewAll: true,
+           noSearchMore: true,
        }
     }
 }

--- a/addons/sale_expense/static/tests/sale_order_many2one_tests.js
+++ b/addons/sale_expense/static/tests/sale_order_many2one_tests.js
@@ -70,6 +70,6 @@ QUnit.module('sale_expense', {
         await clickDropdown(this.target, "sale_order_id");
 
         assert.containsN(this.target, 'li.o-autocomplete--dropdown-item', 9);
-        assert.containsNone(this.target, '.o_m2o_dropdown_option_view_all', "Should not display the 'View all option'");
+        assert.containsNone(this.target, '.o_m2o_dropdown_option_search_more', "Should not display the 'Search More... option'");
     });
 });

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -66,8 +66,8 @@ export class CalendarFilterPanel extends Component {
 
         if (records.length > 7) {
             options.push({
-                label: _t("View all"),
-                action: () => this.onViewAll(section, resModel, domain, request),
+                label: _t("Search More..."),
+                action: () => this.onSearchMore(section, resModel, domain, request),
             });
         }
 
@@ -82,7 +82,7 @@ export class CalendarFilterPanel extends Component {
         return options;
     }
 
-    async onViewAll(section, resModel, domain, request) {
+    async onSearchMore(section, resModel, domain, request) {
         const dynamicFilters = [];
         if (request.length) {
             const nameGets = await this.orm.call(resModel, "name_search", [], {

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -44,7 +44,7 @@ export class Many2ManyTagsField extends Component {
         placeholder: { type: String, optional: true },
         nameCreateField: { type: String, optional: true },
         string: { type: String, optional: true },
-        noViewAll: { type: Boolean, optional: true },
+        noSearchMore: { type: Boolean, optional: true },
     };
     static defaultProps = {
         canCreate: true,

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -21,7 +21,7 @@
                     getDomain.bind="getDomain"
                     isToMany="true"
                     nameCreateField="props.nameCreateField"
-                    noViewAll="props.noViewAll"
+                    noSearchMore="props.noSearchMore"
                 />
             </div>
         </div>

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -227,7 +227,7 @@ export class PropertyValue extends Component {
                     : false;
 
             if (newValue && newValue[0] && newValue[1] === undefined) {
-                // The "View all" option in the Many2XAutocomplete component
+                // The "Search More" option in the Many2XAutocomplete component
                 // only return the record ID, and not the name. But we need to name
                 // in the component props to be able to display it.
                 // Make a RPC call to resolve the display name of the record.

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -301,11 +301,11 @@ export class Many2XAutocomplete extends Component {
             });
         }
 
-        if (!this.props.noViewAll && records.length > 0) {
+        if (!this.props.noSearchMore &&  records.length > 0) {
             options.push({
-                label: _t("View all"),
-                action: this.onViewAll.bind(this, request),
-                classList: "o_m2o_dropdown_option o_m2o_dropdown_option_view_all",
+                label: _t("Search More..."),
+                action: this.onSearchMore.bind(this, request),
+                classList: "o_m2o_dropdown_option o_m2o_dropdown_option_search_more",
             });
         }
 
@@ -343,10 +343,10 @@ export class Many2XAutocomplete extends Component {
 
     async onBarcodeSearch() {
         const autoCompleteInput = this.autoCompleteContainer.el.querySelector("input");
-        return this.onViewAll(autoCompleteInput.value);
+        return this.onSearchMore(autoCompleteInput.value);
     }
 
-    async onViewAll(request) {
+    async onSearchMore(request) {
         const { resModel, getDomain, context, fieldString } = this.props;
 
         const domain = getDomain();
@@ -356,7 +356,7 @@ export class Many2XAutocomplete extends Component {
                 name: request,
                 args: domain,
                 operator: "ilike",
-                limit: this.props.viewAllLimit,
+                limit: this.props.searchMoreLimit,
                 context,
             });
 
@@ -396,8 +396,8 @@ Many2XAutocomplete.props = {
     getDomain: Function,
     searchLimit: { type: Number, optional: true },
     quickCreate: { type: [Function, { value: null }], optional: true },
-    noViewAll: { type: Boolean, optional: true },
-    viewAllLimit: { type: Number, optional: true },
+    noSearchMore: { type: Boolean, optional: true },
+    searchMoreLimit: { type: Number, optional: true },
     fieldString: String,
     id: { type: String, optional: true },
     placeholder: { type: String, optional: true },
@@ -409,7 +409,7 @@ Many2XAutocomplete.props = {
 };
 Many2XAutocomplete.defaultProps = {
     searchLimit: 7,
-    viewAllLimit: 320,
+    searchMoreLimit: 320,
     nameCreateField: "name",
     value: "",
     setInputFloats: () => {},
@@ -633,7 +633,7 @@ X2ManyFieldDialog.props = {
     save: Function,
     title: String,
     delete: { optional: true },
-    deleteButtonLabel: { optional: true },
+    deleteButtonLabel: {optional: true},
     config: Object,
 };
 X2ManyFieldDialog.template = "web.X2ManyFieldDialog";

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -43,7 +43,7 @@
             readonly=""
             t-att-placeholder="props.placeholder"
             t-att-value="props.value"
-            t-on-click="onViewAll"
+            t-on-click="onSearchMore"
             t-on-barcode-search="onBarcodeSearch"
         />
         <AutoComplete t-else=""

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -15,7 +15,7 @@ import {
     toggleSearchBarMenu,
     toggleMenuItem,
 } from "@web/../tests/search/helpers";
-import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
+import { createWebClient, doAction }  from "@web/../tests/webclient/helpers";
 import { registry } from "@web/core/registry";
 import { SearchBarMenu } from "@web/search/search_bar_menu/search_bar_menu";
 import { SearchPanel } from "@web/search/search_panel/search_panel";
@@ -2321,7 +2321,7 @@ QUnit.module("Search", (hooks) => {
 
         await doAction(webclient, 1, { viewType: "form" });
 
-        await selectDropdownItem(target, "company_id", "View all");
+        await selectDropdownItem(target, "company_id", "Search More...");
 
         assert.containsOnce(document.body, ".modal .o_list_view");
         assert.containsNone(document.body, ".modal .o_search_panel");
@@ -3459,22 +3459,19 @@ QUnit.module("Search", (hooks) => {
         );
     });
 
-    QUnit.test(
-        "Don't display empty state message when some filters are available",
-        async (assert) => {
-            const { TestComponent } = makeTestComponent();
-            await makeWithSearch({
-                serverData,
-                Component: TestComponent,
-                resModel: "partner",
-                searchViewId: false,
-            });
+    QUnit.test("Don't display empty state message when some filters are availible", async (assert) => {
+        const { TestComponent } = makeTestComponent();
+        await makeWithSearch({
+            serverData,
+            Component: TestComponent,
+            resModel: "partner",
+            searchViewId: false,
+        });
 
-            assert.containsNone(
-                target,
-                ".o_search_panel_empty_state",
-                "Search panel does not have the empty state container"
-            );
-        }
-    );
+        assert.containsNone(
+            target,
+            ".o_search_panel_empty_state",
+            "Search panel does not have the empty state container"
+        );
+    });
 });

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -610,7 +610,7 @@ QUnit.module("Views", ({ beforeEach }) => {
                 "foo partner 8",
                 "foo partner 9",
                 "foo partner 10",
-                "View all",
+                "Search More...",
             ]
         );
 
@@ -633,7 +633,7 @@ QUnit.module("Views", ({ beforeEach }) => {
                 "foo partner 10",
                 "foo partner 11",
                 "foo partner 12",
-                "View all",
+                "Search More...",
             ]
         );
 
@@ -693,7 +693,7 @@ QUnit.module("Views", ({ beforeEach }) => {
                 "foo partner 9",
                 "foo partner 10",
                 "foo partner 11",
-                "View all",
+                "Search More...",
             ]
         );
 
@@ -715,7 +715,7 @@ QUnit.module("Views", ({ beforeEach }) => {
                 "foo partner 11",
                 "foo partner 12",
                 "foo partner 13",
-                "View all",
+                "Search More...",
             ]
         );
 
@@ -960,7 +960,12 @@ QUnit.module("Views", ({ beforeEach }) => {
         assert.containsN(target, ".fc-event-container .fc-event", 10, "should display 10 events");
         // move to next month
         await navigate(target, "next");
-        assert.containsN(target, ".fc-event-container .fc-event", 0, "should display 0 events");
+        assert.containsN(
+            target,
+            ".fc-event-container .fc-event",
+            0,
+            "should display 0 events"
+        );
         await pickDate(target, "2017-01-01");
         assert.containsN(
             target,

--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -1976,7 +1976,7 @@ QUnit.module("Fields", (hooks) => {
         });
         await click(target, ".o_field_many2many_selection input");
         checkGetViews = true;
-        await clickOpenedDropdownItem(target, "timmy", "View all");
+        await clickOpenedDropdownItem(target, "timmy", "Search More...");
         assert.verifySteps([`get_views`]);
 
         assert.containsOnce(target, ".modal");

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field_tests.js
@@ -430,7 +430,7 @@ QUnit.module("Fields", (hooks) => {
             "Should have 2 tags"
         );
         // load more
-        await click(popover.querySelector(".o_m2o_dropdown_option_view_all"));
+        await click(popover.querySelector(".o_m2o_dropdown_option_search_more"));
         // first item
         await click(document.querySelector(".o_dialog .o_list_table .o_data_row .o_data_cell"));
         assert.strictEqual(popover.querySelectorAll(".o_tag").length, 4, "Should have 4 tags");

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -166,7 +166,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(
             autocomplete.querySelectorAll("li").length,
             4,
-            "autocomplete dropdown should have 4 entries (2 values + 'View all' + 'Start typing...')"
+            "autocomplete dropdown should have 4 entries (2 values + 'Search More...' + 'Search and Edit...')"
         );
         await clickOpenedDropdownItem(target, "timmy", "gold");
         assert.containsOnce(target, "[name=timmy] .o_tag");
@@ -248,7 +248,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(
             autocompleteDropdown.querySelectorAll("li").length,
             3,
-            "autocomplete dropdown should have 3 entries"
+            "autocomplete dropdown should have 3 entry"
         );
 
         assert.strictEqual(
@@ -502,7 +502,7 @@ QUnit.module("Fields", (hooks) => {
         );
         assert.deepEqual(
             getNodesTextContent(autocompleteDropdown.querySelectorAll("li")),
-            ["silver", "View all", "Start typing..."],
+            ["silver", "Search More...", "Start typing..."],
             "should contain newly added tag 'silver'"
         );
         assert.strictEqual(
@@ -548,7 +548,7 @@ QUnit.module("Fields", (hooks) => {
             autocompleteDropdown,
             "li",
             3,
-            "autocomplete should contain 'silver', 'View all' and 'Start typing...' options"
+            "autocomplete should contain 'silver'm 'Search More...' and 'Start typing...' options"
         );
         assert.strictEqual(
             autocompleteDropdown.querySelector("li a").textContent,
@@ -567,7 +567,7 @@ QUnit.module("Fields", (hooks) => {
             autocompleteDropdown,
             "li",
             3,
-            "autocomplete should contain 'gold', 'View all' and 'Start typing...' options"
+            "autocomplete should contain 'gold'm 'Search More...' and 'Start typing...' options"
         );
         assert.strictEqual(
             autocompleteDropdown.querySelector("li a").textContent,
@@ -611,7 +611,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(
             autocomplete.querySelectorAll("li").length,
             4,
-            "autocomplete dropdown should have 4 entries (2 values + 'View all' + 'Start typing...')"
+            "autocomplete dropdown should have 4 entries (2 values + 'Search More...' + 'Search and Edit...')"
         );
         await clickOpenedDropdownItem(target, "timmy", "gold");
 
@@ -1190,7 +1190,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        await selectDropdownItem(target, "timmy", "View all");
+        await selectDropdownItem(target, "timmy", "Search More...");
 
         assert.ok(target.querySelector(".o_dialog"), "should have open the modal");
         // + 1 for the select all
@@ -1246,7 +1246,7 @@ QUnit.module("Fields", (hooks) => {
                     </form>`,
             });
 
-            await selectDropdownItem(target, "timmy", "View all");
+            await selectDropdownItem(target, "timmy", "Search More...");
 
             // -1 for the one that is already on the form & +1 for the select all,
             assert.containsN(
@@ -1448,7 +1448,7 @@ QUnit.module("Fields", (hooks) => {
             "autocomplete should contain Start typing..."
         );
 
-        await clickOpenedDropdownItem(target, "partner_ids", "View all");
+        await clickOpenedDropdownItem(target, "partner_ids", "Search More...");
 
         assert.containsN(
             target,
@@ -1498,7 +1498,7 @@ QUnit.module("Fields", (hooks) => {
         await nameSearchProm;
         await nextTick();
 
-        // only View all option should be available
+        // only Search More option should be available
         assert.containsOnce(
             $(target.querySelector(".o-autocomplete.dropdown")),
             "li.o_m2o_dropdown_option",
@@ -1506,11 +1506,11 @@ QUnit.module("Fields", (hooks) => {
         );
         assert.containsOnce(
             $(target.querySelector(".o-autocomplete.dropdown")),
-            "li.o_m2o_dropdown_option a:contains(View all)",
-            "autocomplete option should be View all"
+            "li.o_m2o_dropdown_option a:contains(Search More...)",
+            "autocomplete option should be Search More"
         );
 
-        await clickOpenedDropdownItem(target, "partner_ids", "View all");
+        await clickOpenedDropdownItem(target, "partner_ids", "Search More...");
 
         assert.containsN(
             document.body,
@@ -1538,7 +1538,7 @@ QUnit.module("Fields", (hooks) => {
         await nameSearchProm;
         await nextTick();
 
-        // only View all option should be available
+        // only Search More option should be available
         assert.containsOnce(
             $(target.querySelector(".o-autocomplete.dropdown")),
             "li.o_m2o_dropdown_option",
@@ -1546,8 +1546,8 @@ QUnit.module("Fields", (hooks) => {
         );
         assert.containsOnce(
             $(target.querySelector(".o-autocomplete.dropdown")),
-            "li.o_m2o_dropdown_option a:contains(View all)",
-            "autocomplete option should be View all"
+            "li.o_m2o_dropdown_option a:contains(Search More)",
+            "autocomplete option should be Search More"
         );
     });
 
@@ -1733,7 +1733,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(
             target.querySelector(".o_field_many2many_tags .o-autocomplete--dropdown-menu")
                 .textContent,
-            "goldsilverView all"
+            "goldsilverSearch More..."
         );
     });
 

--- a/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
@@ -395,7 +395,9 @@ QUnit.module("Fields", (hooks) => {
         );
 
         // load more
-        await click(document.querySelector(".o-overlay-container .o_m2o_dropdown_option_view_all"));
+        await click(
+            document.querySelector(".o-overlay-container .o_m2o_dropdown_option_search_more")
+        );
         await click(document.querySelector(".o_dialog .o_list_table .o_data_row .o_data_cell"));
         assert.strictEqual(
             target.querySelector(

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -601,7 +601,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        await selectDropdownItem(target, "trululu", "View all");
+        await selectDropdownItem(target, "trululu", "Search More...");
 
         assert.strictEqual($("tr.o_data_row").length, 9, "should display 9 records");
         assert.equal(target.querySelector(".o_field_widget[name=trululu] input").value, "aaa");
@@ -615,7 +615,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
-        "many2ones: Open the selection dialog several times using the 'View all' button with a context containing 'search_default_...'",
+        "many2ones: Open the selection dialog several times using the 'Search More...' button with a context containing 'search_default_...'",
         async function (assert) {
             for (let i = 5; i < 11; i++) {
                 serverData.models.partner.records.push({ id: i, display_name: `Partner ${i}` });
@@ -647,7 +647,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
             });
 
-            await selectDropdownItem(target, "trululu", "View all");
+            await selectDropdownItem(target, "trululu", "Search More...");
 
             let modal = target.querySelector(".modal");
             assert.containsOnce(modal, ".o_data_row", "should display 1 records");
@@ -656,7 +656,7 @@ QUnit.module("Fields", (hooks) => {
             await click(modal, ".btn-close");
             assert.containsNone(modal, ".modal");
 
-            await selectDropdownItem(target, "trululu", "View all");
+            await selectDropdownItem(target, "trululu", "Search More...");
             modal = target.querySelector(".modal");
             assert.containsOnce(modal, ".o_data_row", "should display 1 records");
             assert.deepEqual(getFacetTexts(modal), ["Displayed name\nPartner 10"]);
@@ -1013,7 +1013,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(
             target,
             ".dropdown-menu li.o_m2o_dropdown_option",
-            "autocomplete should contain the View all dropdown option"
+            "autocomplete should contain the Search More dropdown option"
         );
         assert.containsOnce(
             target,
@@ -1086,7 +1086,7 @@ QUnit.module("Fields", (hooks) => {
     QUnit.test("many2one in edit mode", async function (assert) {
         assert.expect(17);
 
-        // create 10 partners
+        // create 10 partners to have the 'Search More' option in the autocomplete dropdown
         for (let i = 0; i < 10; i++) {
             const id = 20 + i;
             serverData.models.partner.records.push({ id, display_name: `Partner ${id}` });
@@ -1143,7 +1143,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(
             dropdown,
             "li.o_m2o_dropdown_option",
-            'autocomplete should contain "View all"'
+            'autocomplete should contain "Search More"'
         );
         assert.containsNone(
             dropdown,
@@ -1168,11 +1168,11 @@ QUnit.module("Fields", (hooks) => {
             "value of the m2o should have been correctly updated"
         );
 
-        // change the value of the m2o with a record in the 'View allodal
+        // change the value of the m2o with a record in the 'Search More' modal
         await clickDropdown(target, "trululu");
-        // click on 'View all' (mouseenter required by ui-autocomplete)
+        // click on 'Search More' (mouseenter required by ui-autocomplete)
         dropdown = target.querySelector(".o_field_many2one[name='trululu'] .dropdown-menu");
-        await click(dropdown.querySelector(".o_m2o_dropdown_option_view_all"));
+        await click(dropdown.querySelector(".o_m2o_dropdown_option_search_more"));
         assert.containsOnce(
             target,
             ".modal .o_list_view",
@@ -1905,7 +1905,7 @@ QUnit.module("Fields", (hooks) => {
                         </field>
                     </sheet>
                 </form>`,
-            mockRPC(route, { method, args }) {
+            mockRPC(route, { method, args}) {
                 if (method === "read" && args[1].length === 1 && args[1][0] === "display_name") {
                     throw new Error("read(['display_name']) should not be called");
                 }
@@ -1945,11 +1945,7 @@ QUnit.module("Fields", (hooks) => {
                         </sheet>
                     </form>`,
                 mockRPC(route, { method, args }) {
-                    if (
-                        method === "read" &&
-                        args[1].length === 1 &&
-                        args[1][0] === "display_name"
-                    ) {
+                    if (method === "read" && args[1].length === 1 && args[1][0] === "display_name") {
                         throw new Error("read(['display_name']) should not be called");
                     }
                 },
@@ -3294,7 +3290,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsNone(target, ".ui-autocomplete a:contains(Create and Edit)");
 
         await editInput(target, ".o_field_many2one[name=product_id] input", "");
-        await clickOpenedDropdownItem(target, "product_id", "View all");
+        await clickOpenedDropdownItem(target, "product_id", "Search More...");
 
         assert.containsOnce(target, ".modal-dialog.modal-lg");
 
@@ -3749,7 +3745,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("search more in many2one: no text in input", async function (assert) {
-        // when the user clicks on 'View all' in a many2one dropdown, and there is no text
+        // when the user clicks on 'Search More...' in a many2one dropdown, and there is no text
         // in the input (i.e. no value to search on), we bypass the name_search that is meant to
         // return a list of preselected ids to filter on in the list view (opened in a dialog)
         assert.expect(7);
@@ -3787,7 +3783,7 @@ QUnit.module("Fields", (hooks) => {
         await triggerEvent(field, null, "change");
 
         await click(target, `.o_field_widget[name="trululu"] input`);
-        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_view_all`);
+        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_search_more`);
 
         assert.verifySteps([
             "get_views", // main form view
@@ -3799,7 +3795,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("search more in many2one: text in input", async function (assert) {
-        // when the user clicks on 'View all' in a many2one dropdown, and there is some
+        // when the user clicks on 'Search More...' in a many2one dropdown, and there is some
         // text in the input, we perform a name_search to get a (limited) list of preselected
         // ids and we add a dynamic filter (with those ids) to the search view in the dialog, so
         // that the user can remove this filter to bypass the limit
@@ -3834,7 +3830,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target, `.o_field_widget[name="trululu"] input`);
 
         await editInput(target, ".o_field_widget[name='trululu'] input", "test");
-        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_view_all`);
+        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_search_more`);
 
         assert.containsOnce(target, ".modal .o_list_view");
         assert.containsOnce(
@@ -3881,7 +3877,7 @@ QUnit.module("Fields", (hooks) => {
         await click(target, `.o_field_widget[name="trululu"] input`);
 
         await editInput(target, ".o_field_widget[name='trululu'] input", "test");
-        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_view_all`);
+        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_search_more`);
 
         // dropdown selector
         const searchDropdown = ".o_control_panel_actions .o-dropdown";
@@ -3954,7 +3950,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("search more in many2one: resequence inside dialog", async function (assert) {
-        // when the user clicks on 'View all' in a many2one dropdown, resequencing inside
+        // when the user clicks on 'Search More...' in a many2one dropdown, resequencing inside
         // the dialog works
         serverData.models.partner.fields.sequence = { string: "Sequence", type: "integer" };
         for (let i = 0; i < 8; i++) {
@@ -3987,7 +3983,7 @@ QUnit.module("Fields", (hooks) => {
         });
 
         await editInput(target, ".o_field_widget[name='trululu'] input", "");
-        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_view_all`);
+        await click(target, `.o_field_widget[name="trululu"] .o_m2o_dropdown_option_search_more`);
 
         assert.containsOnce(target, ".modal");
         assert.containsN(target, ".modal .ui-sortable-handle", 11);
@@ -4083,7 +4079,7 @@ QUnit.module("Fields", (hooks) => {
             arch: '<form><field name="trululu" /></form>',
         });
 
-        await selectDropdownItem(target, "trululu", "View all");
+        await selectDropdownItem(target, "trululu", "Search More...");
         const modal = target.querySelector(".modal");
         await toggleSearchBarMenu(modal);
         await toggleMenuItem(modal, "Bar");
@@ -4183,7 +4179,7 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
 
-        await selectDropdownItem(target, "trululu", "View all");
+        await selectDropdownItem(target, "trululu", "Search More...");
 
         const modal = target.querySelector(".modal");
         await click(modal, ".o_pager_next");

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -1245,7 +1245,7 @@ QUnit.module("Fields", (hooks) => {
 
         // Opening the "Search more..." modal
         await click(popover, ".o_field_property_definition_value input");
-        await click(popover, ".o_m2o_dropdown_option_view_all");
+        await click(popover, ".o_m2o_dropdown_option_search_more");
 
         // Checking the model loaded
         assert.verifySteps(["partner"]);
@@ -1259,7 +1259,7 @@ QUnit.module("Fields", (hooks) => {
 
         // Opening the "Search more..." modal
         await click(popover, ".o_field_property_definition_value input");
-        await click(popover, ".o_m2o_dropdown_option_view_all");
+        await click(popover, ".o_m2o_dropdown_option_search_more");
 
         // Checking the model loaded
         assert.verifySteps(["res.users"]);

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -5715,6 +5715,7 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("custom delete confirmation dialog", async (assert) => {
+
         const listView = registry.category("views").get("list");
         class CautiousController extends listView.Controller {
             get deleteConfirmationDialogProps() {
@@ -5754,12 +5755,7 @@ QUnit.module("Views", (hooks) => {
         );
 
         await click(document, "body .modal footer button.btn-secondary");
-        assert.containsN(
-            target,
-            "tbody td.o_list_record_selector",
-            4,
-            "nothing deleted, 4 records remain"
-        );
+        assert.containsN(target, "tbody td.o_list_record_selector", 4, "nothing deleted, 4 records remain");
     });
 
     QUnit.test(
@@ -8478,10 +8474,10 @@ QUnit.module("Views", (hooks) => {
             "the entire content should be selected on initial click"
         );
 
-        Object.assign(target.querySelector("[name=text] textarea"), {
-            selectionStart: 0,
-            selectionEnd: 1,
-        });
+        Object.assign(
+            target.querySelector("[name=text] textarea"),
+            { selectionStart: 0, selectionEnd: 1 }
+        );
 
         await click(target, "[name=text] textarea");
 
@@ -10457,7 +10453,7 @@ QUnit.module("Views", (hooks) => {
 
             await click(target.querySelector(".o_data_cell"));
             await clickOpenM2ODropdown(target, "m2o");
-            await clickOpenedDropdownItem(target, "m2o", "View all");
+            await clickOpenedDropdownItem(target, "m2o", "Search More...");
             assert.containsOnce(target, ".modal-content");
             assert.containsNone(
                 target,
@@ -11860,7 +11856,7 @@ QUnit.module("Views", (hooks) => {
         await click(rows[0], ".o_list_record_selector input");
         await click(rows[1], ".o_list_record_selector input");
         await click(rows[0].querySelector(".o_data_cell"));
-        await selectDropdownItem(target, "m2m", "View all");
+        await selectDropdownItem(target, "m2m", "Search More...");
         assert.containsOnce(document.body, ".modal", "should have open the modal");
 
         await click(target.querySelector(".modal .o_data_row .o_field_cell"));
@@ -17887,22 +17883,19 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(td2.textContent, "61%");
     });
 
-    QUnit.test(
-        "Formatted group operator with digit precision on the field definition",
-        async function (assert) {
-            serverData.models.foo.fields.qux.digits = [16, 3];
-            await makeView({
-                type: "list",
-                resModel: "foo",
-                serverData,
-                arch: '<tree><field name="qux"/></tree>',
-                groupBy: ["bar"],
-            });
-            const [td1, td2] = target.querySelectorAll("td.o_list_number");
-            assert.strictEqual(td1.textContent, "9.000");
-            assert.strictEqual(td2.textContent, "10.400");
-        }
-    );
+    QUnit.test("Formatted group operator with digit precision on the field definition", async function (assert) {
+        serverData.models.foo.fields.qux.digits = [16, 3];
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            arch: '<tree><field name="qux"/></tree>',
+            groupBy: ["bar"],
+        });
+        const [td1, td2] = target.querySelectorAll("td.o_list_number");
+        assert.strictEqual(td1.textContent, "9.000");
+        assert.strictEqual(td2.textContent, "10.400");
+    });
 
     QUnit.test("list view does not crash when clicked button cell", async function (assert) {
         await makeView({
@@ -18271,7 +18264,7 @@ QUnit.module("Views", (hooks) => {
 
         await click(target, ".o_data_row:nth-child(1) td.o_list_many2one");
         await click(target, ".o_field_many2one_selection .o-autocomplete--input");
-        await clickOpenedDropdownItem(target, "m2o", "View all");
+        await clickOpenedDropdownItem(target, "m2o", "Search More...");
 
         assert.verifySteps([]);
 
@@ -19418,7 +19411,7 @@ QUnit.module("Views", (hooks) => {
         const items = Array.from(
             target.querySelectorAll(".o_selected_row .o_field_many2many_tags .dropdown-item")
         );
-        await click(items.find((el) => el.textContent.trim() === "View all"));
+        await click(items.find((el) => el.textContent.trim() === "Search More..."));
         assert.verifySteps([
             `bar: get_views: {"lang":"en","uid":7,"tz":"taht"}`,
             `bar: unity_web_search_read: {"lang":"en","uid":7,"tz":"taht","bin_size":true}`,
@@ -19432,16 +19425,16 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("search nested many2one field with early option selection", async (assert) => {
         const deferred = makeDeferred();
-        (serverData.models.parent = {
+        serverData.models.parent = {
             fields: {
                 foo: { string: "Foo", type: "one2many", relation: "foo" },
             },
-        }),
-            await makeView({
-                type: "form",
-                resModel: "parent",
-                serverData,
-                arch: `
+        },
+        await makeView({
+            type: "form",
+            resModel: "parent",
+            serverData,
+            arch: `
             <form>
                 <field name="foo">
                     <tree editable="bottom">
@@ -19449,29 +19442,30 @@ QUnit.module("Views", (hooks) => {
                     </tree>
                 </field>
             </form>`,
-                mockRPC: async (route, { method }) => {
-                    if (method === "name_search") {
-                        await deferred;
-                    }
-                },
-            });
+            mockRPC: async (route, { method }) => {
+                if (method === "name_search") {
+                    await deferred;
+                }
+            },
+        });
 
-        await triggerEvent(document.querySelector(".o_field_x2many_list_row_add a"), null, "click");
+        await triggerEvent(document.querySelector('.o_field_x2many_list_row_add a'), null, "click");
 
         const input = document.activeElement;
-        input.value = "alu";
-        triggerEvent(document.activeElement, null, "input"), await nextTick();
-
-        input.value = "alue";
+        input.value = 'alu';
         triggerEvent(document.activeElement, null, "input"),
-            triggerHotkey("Enter"),
-            await nextTick();
+        await nextTick();
+
+        input.value = 'alue';
+        triggerEvent(document.activeElement, null, "input"),
+        triggerHotkey("Enter"),
+        await nextTick();
 
         deferred.resolve();
         await nextTick();
 
         assert.strictEqual(input, document.activeElement);
-        assert.strictEqual(input.value, "Value 1");
+        assert.strictEqual(input.value, 'Value 1');
     });
 
     QUnit.test("monetary field display for rtl languages", async function (assert) {


### PR DESCRIPTION
This partially reverts commit da50ce31ae825ef9f4b527553a2e2caec970d290.

Whilst the behavioral changes done in the task are correct, the wording is not optimal and was better understood by users before this change.

Task-3483936
