### PR TITLE
[IMP] website: theme configurator, review size/ratio

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -4,19 +4,26 @@
     $input-font-size: 40%;
 
     .o_configurator_screen {
+        // ==== Variables
+        --ConfiguratorPreview-height: MIN(70vh, 760px);
+        --ConfiguratorPreview-ratio: 1.1;
 
         // ==== Animations
+        @keyframes theme_screenshot_scroll {
+            to {
+                transform: translate3d(0, calc((100% - var(--ConfiguratorPreview-height)) * -1), 0)
+            }
+        }
+
         @keyframes configuratorFadeIn{
             from {opacity: 0}
             to {opacity: 1}
         }
 
-        @keyframes theme_screenshot_scroll {
-            to { transform: translate3d(0, -24%, 0)}
-        }
-
-        @keyframes theme_screenshot_scroll_small {
-            to { transform: translate3d(0, -31.5%, 0)}
+        @keyframes theme_screenshot_scroll-vertical {
+            to {
+                transform: translate3d(0, -74%, 0)
+            }
         }
 
         // ==== General Components
@@ -314,7 +321,7 @@
             }
 
             .theme_preview_tip {
-                @include o-position-absolute(0, 0, auto, 0);
+                @include o-position-absolute(auto, 0, 0, 0);
             }
 
             .theme_preview, .theme_svg_container svg, .theme_preview_tip {
@@ -335,37 +342,39 @@
                 cursor: pointer;
             }
 
+            .o_themes_preview_container {
+                @include media-breakpoint-up(lg) {
+                    height: var(--ConfiguratorPreview-height);
+                }
+            }
+
             .theme_preview {
-                padding-top: 65%;
+                height: 300px;
                 box-shadow: $box-shadow-sm;
 
                 @include media-breakpoint-up(lg) {
-                    padding-top: 200%;
-
-                    &:hover {
-                        transform: translate3d(0,-10px,0);
-                    }
-
-                    &.small {
-                        padding-top: 180%;
-                    }
+                    // Avoid the container size with hover ratio to be taller than the svg size;
+                    height: calc(var(--ConfiguratorPreview-height) / var(--ConfiguratorPreview-ratio));
                 }
 
                 &:hover {
                     border-color: map-get($theme-colors, primary)!important;
                     box-shadow: $box-shadow;
 
+                    @include media-breakpoint-up(lg) {
+                        height: 100%;
+                    }
+
                     .theme_preview_tip {
-                        transform: translate3d(0,-120%,0);
+                        transform: translate3d(0, 200%, 0);
                     }
 
                     .theme_svg_container svg {
-                        animation: theme_screenshot_scroll 4s cubic-bezier(0.455, 0.030, 0.515, 0.955) .1s infinite alternate;
-                    }
+                        animation: theme_screenshot_scroll 6s cubic-bezier(0.455, 0.030, 0.515, 0.955) .1s infinite alternate;
 
-                    &.small .theme_svg_container svg {
-                        animation-name: theme_screenshot_scroll_small;
-                        animation-duration: 5s;
+                        @include media-breakpoint-down(lg) {
+                            animation: theme_screenshot_scroll-vertical 8s cubic-bezier(0.455, 0.030, 0.515, 0.955) .1s infinite alternate;
+                        }
                     }
                 }
             }

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -194,37 +194,38 @@
 
 <t t-name="website.Configurator.ThemeSelectionScreen">
     <div class="o_configurator_screen h-100 d-flex flex-column o_theme_selection_screen">
-        <div class="o_configurator_odoo_logo mt-4 ms-5" style="height: 31px; width: 99px;"/>
+        <div class="o_configurator_odoo_logo position-lg-absolute my-4 mb-lg-0 ms-5" style="height: 31px; width: 99px;"/>
         <div class="o_configurator_screen_content d-flex flex-column flex-grow-1 align-items-center">
-            <div class="m-auto w-100 w-md-75 w-xl-100">
-                <div class="o_configurator_typing_text text-center mt-4 mb-lg-4">Choose your favorite <b>Theme</b>
+            <div class="d-flex flex-column align-items-center justify-content-lg-center m-auto px-lg-4 h-100 w-100 w-sm-75 w-lg-100">
+                <div class="o_configurator_typing_text mb-4">
+                    <span>Choose your favorite <b>Theme</b></span>
                 </div>
-                <div class="container">
-                    <div class="row pb-4 pt-5">
-                        <div class="col-12 col-lg-4 d-flex align-items-end mb-4 mb-lg-0">
+                <div class="o_themes_preview_container container-fluid">
+                    <div class="row h-100">
+                        <div class="col-12 col-lg-4 d-flex align-items-center mb-4 mb-lg-0">
                             <t t-if="state.getThemeName(1)">
-                                <div class="theme_preview border rounded position-relative w-100 small o_configurator_show_fast">
-                                    <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
+                                <div class="theme_preview border rounded position-relative w-100 o_configurator_show_fast">
+                                    <h6 class="theme_preview_tip d-none d-lg-block text-center">Click to select</h6>
                                     <!-- Force LTR to prevent SVG issues in RTL languages -->
                                     <div class="theme_svg_container rounded overflow-hidden" t-ref="ThemePreview2" dir="ltr"/>
                                     <div class="button_area" t-on-click="() => this.chooseTheme(state.getThemeName(1))"/>
                                 </div>
                             </t>
                         </div>
-                        <div class="col-12 col-lg-4 d-flex align-items-end mb-4 mb-lg-0">
+                        <div class="col-12 col-lg-4 d-flex align-items-center mb-4 mb-lg-0">
                             <t t-if="state.getThemeName(0)">
                                 <div class="theme_preview border rounded position-relative w-100 o_configurator_show">
-                                    <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
+                                    <h6 class="theme_preview_tip d-none d-lg-block text-center">Click to select</h6>
                                     <!-- Force LTR to prevent SVG issues in RTL languages -->
                                     <div class="theme_svg_container rounded overflow-hidden" t-ref="ThemePreview1" dir="ltr"/>
                                     <div class="button_area" t-on-click="() => this.chooseTheme(state.getThemeName(0))"/>
                                 </div>
                             </t>
                         </div>
-                        <div class="col-12 col-lg-4 d-flex align-items-end">
+                        <div class="col-12 col-lg-4 d-flex align-items-center mb-4 mb-lg-0">
                             <t t-if="state.getThemeName(2)">
-                                <div class="theme_preview border rounded position-relative w-100 small o_configurator_show_fast">
-                                    <h6 class="theme_preview_tip text-center text-muted">Click to select</h6>
+                                <div class="theme_preview border rounded position-relative w-100 o_configurator_show_fast">
+                                    <h6 class="theme_preview_tip d-none d-lg-block text-center">Click to select</h6>
                                     <!-- Force LTR to prevent SVG issues in RTL languages -->
                                     <div class="theme_svg_container rounded overflow-hidden" t-ref="ThemePreview3" dir="ltr"/>
                                     <div class="button_area" t-on-click="() => this.chooseTheme(state.getThemeName(2))"/>


### PR DESCRIPTION
The 3 proposed themes were too tall making them display an overwhelming amount of information with a vertical scroll.

This PR makes the calculation based on the viewport to ensure a responsive result and no vertical scroll on >lg screens.

An arbitrary max-height of 760px is set to make sure the animation doesn't scroll further than the size of the svg nor change direction if the container is too large.

The hover effect on theme_preview as also been emphasised with a size increase allowing to show more content.

task-2702154

| Before     | After (hover on 1st) |
| ---      | ---       |
|![image](https://github.com/odoo/odoo/assets/118886338/c02e85c7-accd-415d-8dcf-b138c5c5b22b) |![image](https://github.com/odoo/odoo/assets/118886338/60f35fb3-5731-474d-bfc6-0f4ac5218e6f) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
