### PR TITLE
[FIX] payment: enable link button in payment link wizard

### DIFF
--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -39,7 +39,7 @@
                     <field name="link"
                            string="Generate and Copy Payment Link"
                            readonly="1"
-                           disabled="[('warning_message', '!=', '')]"
+                           disabled="warning_message != ''"
                            widget="CopyClipboardButton"
                            data-hotkey="q"/>
                     <button string="Close"


### PR DESCRIPTION
before this commit, in the generate payment link wizard, the copy button is always disabled and user cannot copy the generated payment link.

* create an invoice
* validate the invoice
* click "Generate a payment link" from action button
* copy button is disabled

after this commit, when there is no warning user can copy the generated payment link from wizard

![Screenshot from 2023-08-29 20-51-52](https://github.com/odoo/odoo/assets/27989791/eebdf0ef-0148-4365-b2f7-703e59487501)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
