### PR TITLE
[IMP] base: currency symbol editing without debug mode

### DIFF
--- a/odoo/addons/base/views/res_currency_views.xml
+++ b/odoo/addons/base/views/res_currency_views.xml
@@ -148,6 +148,7 @@
                                 <field name="active" widget="boolean_toggle"/>
                             </group>
                             <group>
+                                <field name="symbol"/>
                                 <field name="currency_unit_label"/>
                                 <field name="currency_subunit_label"/>
                             </group>
@@ -160,7 +161,6 @@
                             </group>
 
                             <group string="Display">
-                                <field name="symbol"/>
                                 <field name="position"/>
                             </group>
                         </group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Prior to this, when multiple currencies with the same symbol where to appear in a same document or be sent from a country to another with the same currency symbol, the only information the recipient had was the currency symbol leading to lack of clarity.

Desired behavior after PR is merged:

This set of two PR has for objective to give the user the possibility to edit the symbol curency that is displayed everywhere so that if he feels like the documents and views are lacking clarity, he can improve it.

This was already an option before but only when the debug mode was active.

This commit has the purpose of moving the currency symbol option out of the debug mode section and put it in the right column of the currency form view.

Adding this, the "Symbol" option is moved out of the debug mode.

task-3484335

Enterprise PR :https://github.com/odoo/enterprise/pull/46527



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
