### PR TITLE
[FIX] website: remove stable fix of body line height option

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -83,17 +83,6 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         return this._super(...arguments);
     },
     /**
-     * @override
-     */
-    _patchForComputeSnippetTemplates($html) {
-        // TODO Remove in master.
-        const themeBodyLineHeightEl = $html.find(
-            "[data-selector='theme-paragraph'] we-input[data-customize-website-variable][data-variable='body-line-height']"
-        )[0];
-        delete themeBodyLineHeightEl.dataset.unit;
-        delete themeBodyLineHeightEl.dataset.saveUnit;
-    },
-    /**
      * Depending of the demand, reconfigure they gmap key or configure it
      * if not already defined.
      *


### PR DESCRIPTION
In [1] the stable patch of the body line height option was mistakenly included in the forward port to master.

This commit removes that patch.

[1]: https://github.com/odoo/odoo/commit/89c93aba75a9c4d7e304c4decd4d5d3673d4df08

task-3471117
