### PR TITLE
[IMP] hr_contract_enterprise: retain contracts menu without payroll

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -383,6 +383,14 @@
             name="Contracts"
             parent="hr.menu_human_resources_configuration"
             sequence="25"/>
+
+        <menuitem
+            id="hr_menu_contract"
+            name="Contracts"
+            action="hr_contract.action_hr_contract"
+            parent="hr.menu_hr_employee_payroll"
+            sequence="6"
+            groups="hr_contract.group_hr_contract_manager"/>
         
         <record id="hr.menu_resource_calendar_view" model="ir.ui.menu">
             <field name="parent_id" ref="menu_human_resources_configuration_contract"/>


### PR DESCRIPTION
Current behavior before PR:
Previously, without the payroll app, the menu item for contracts in the employee app was not available.

Desired behavior after PR is merged:
To improve accessibility and user experience, the contract menu item is now kept and visible when hr_contract module is installed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Task-3479237
