### PR TITLE
[IMP] pos_restaurant: re-adapt floorplan edition

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_list/control_panel/control_panel.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_list/control_panel/control_panel.xml
@@ -15,7 +15,7 @@
                 </button>
                 <t t-if="!state.isMobile || state.mobileSearchBarIsShown">
                     <div class="input-group h-100">
-                        <div class="pos-search-bar form-control d-flex align-items-center py-1 bg-view">
+                        <div class="pos-search-bar form-control d-flex align-items-center py-1 bg-view border-0 rounded-0 border-start">
                             <i class="oi oi-search me-2"/>
                             <input class="flex-grow-1 w-auto h-100 border-0 px-2 me-4" t-model="this.pos.searchProductWord" placeholder="Search Products..." type="text" autofocus="autofocus" t-on-keyup="updateSearch" />
                             <i t-if="this.pos.searchProductWord" class="fa fa-times position-absolute end-0 me-2 pe-1 cursor-pointer" t-on-click="_clearSearch"/>

--- a/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.scss
+++ b/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.scss
@@ -1,0 +1,27 @@
+.edit-bar-top {
+    .edit-button {
+        padding: 3px;
+        margin: 0 20px;
+        
+        &.last-edit-button {
+            margin: 0 2px;
+        }
+    }
+}
+
+.h-54 {
+    height: 54px;
+}
+
+.color-picker {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 54px;
+
+    .color {
+        float: left;
+        width: 54px;
+        height: 54px;
+    }
+}

--- a/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/edit_bar.xml
@@ -2,78 +2,77 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="pos_restaurant.EditBar">
-        <div class="edit-bar-top d-flex align-items-center justify-content-between px-3 py-2 border-bottom bg-view">
-            <div class="d-flex flex-grow-1 gap-1 overflow-x-auto">
-                <span class="edit-button btn btn-light btn-lg" t-on-click.stop="props.createTable">
+        <div class="edit-bar-top d-flex align-items-center justify-content-between px-3 border-bottom bg-view overflow-x-auto h-54 w-100">
+            <div class="flex-fill d-flex justify-content-center">
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-on-click.stop="props.createTable">
                     <i class="fa fa-plus icon-button" role="img" aria-label="Add" title="Add"></i>
                     <span class="text-button d-block">Table</span>
                 </span>
-                <span class="edit-button btn btn-light btn-lg" t-att-class="{ 'disabled': props.selectedTables.length == 0 }" t-on-click.stop="props.changeSeatsNum">
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-att-class="{ 'disabled': props.selectedTables.length == 0 }" t-on-click.stop="props.changeSeatsNum">
                     <i class="fa fa-user icon-button" role="img" aria-label="Seats" title="Seats"></i>
                     <span class="text-button d-block">Seats</span>
                 </span>
-                <span class="edit-button btn btn-light btn-lg" t-if="getSelectedTablesShape() == 'square'" t-att-class="{ disabled: props.selectedTables.length == 0 }" t-on-click.stop="props.changeToCircle">
-                    <span class="button-option round">
-                        <i class="fa fa-circle-o icon-button" role="img" aria-label="Round Shape" title="Round Shape"></i>
-                    </span>
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase button-option round" t-if="getSelectedTablesShape() == 'square'" t-att-class="{ disabled: props.selectedTables.length == 0 }" t-on-click.stop="props.changeToCircle">
+                    <i class="fa fa-circle-o icon-button" role="img" aria-label="Round Shape" title="Round Shape"></i>
                     <span class="text-button d-block">Shape</span>
                 </span>
-                <span class="edit-button btn btn-light btn-lg" t-else="" t-att-class="{ disabled: props.selectedTables.length == 0 }" t-on-click.stop="props.changeToSquare">
-                    <span class="button-option square">
-                        <i class="fa fa-square-o icon-button" role="img" aria-label="Square Shape" title="Square Shape"></i>
-                    </span>
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase button-option square" t-else="" t-att-class="{ disabled: props.selectedTables.length == 0 }" t-on-click.stop="props.changeToSquare">
+                    <i class="fa fa-square-o icon-button" role="img" aria-label="Square Shape" title="Square Shape"></i>
                     <span class="text-button d-block">Shape</span>
                 </span>
-                <span t-if="!props.isColorPicker" class="edit-button btn btn-light btn-lg" t-on-click.stop="props.toggleColorPicker">
+                <span t-if="!props.isColorPicker" role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-on-click.stop="props.toggleColorPicker">
                     <i class="fa fa-paint-brush icon-button" role="img" aria-label="Tint" title="Tint"></i>
                     <span class="text-button d-block">Fill</span>
                 </span>
-                <span t-else="" class="edit-button is-active btn btn-secondary btn-lg" t-on-click.stop="props.toggleColorPicker">
+                <span t-else="" role="button" class="edit-button text-center d-flex flex-column is-active btn btn-secondary text-uppercase" t-on-click.stop="props.toggleColorPicker">
                     <i class="fa fa-paint-brush icon-button" role="img" aria-label="Tint" title="Tint"></i>
                     <span class="text-button d-block">Fill</span>
                 </span>
-                <span class="edit-button btn btn-light btn-lg" t-att-class="{ disabled: props.selectedTables.length > 1 }" t-on-click.stop="props.renameTable">
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-att-class="{ disabled: props.selectedTables.length > 1 }" t-on-click.stop="props.renameTable">
                     <i class="fa fa-pencil-square-o icon-button" role="img" aria-label="Rename" title="Rename"></i>
                     <span class="text-button d-block">Rename</span>
                 </span>
-                <span class="edit-button btn btn-light btn-lg" t-on-click.stop="props.duplicateTableOrFloor">
+                <span role="button" class="edit-button text-center d-flex flex-column btn btn-light text-uppercase" t-on-click.stop="props.duplicateTableOrFloor">
                     <i class="fa fa-clone icon-button" role="img" aria-label="Copy" title="Copy"></i>
                     <span class="text-button d-block">Copy</span>
                 </span>
-                <span class="edit-button trash btn btn-light btn-lg" t-on-click.stop="props.deleteFloorOrTable">
+                <span role="button" class="edit-button text-center d-flex flex-column trash btn btn-light text-uppercase" t-on-click.stop="props.deleteFloorOrTable">
                     <i class="fa fa-trash icon-button" role="img" aria-label="Delete" title="Delete"></i>
                     <span class="text-button d-block">Delete</span>
                 </span>
             </div>
-            <span class="edit-button btn btn-secondary btn-lg ms-3" t-on-click.stop="props.toggleEditMode">
-                <div class="close-edit-button">
-                    Done
+            <span class="edit-button d-flex flex-row-reverse border-0 flex-shrink-1 text-uppercase text-end last-edit-button">
+                <div class="d-flex justify-content-end">
+                    <div role="button" class="btn btn-light d-flex flex-column align-items-center close-edit-button" t-on-click.stop="props.toggleEditMode">
+                        <i class="fa fa-times icon-button" role="img" aria-label="Close" title="Close"></i>
+                        <span class="text-button d-block">Close</span>
+                    </div>
                 </div>
             </span>
         </div>
-        <div t-if="props.isColorPicker and props.selectedTables.length > 0" class="color-picker d-flex justify-content-center border-top border-bottom p-2 bg-200">
-            <span class="color flex-grow-1 py-4 border cursor-pointer"  style="background-color:#FFFFFF" role="img" aria-label="White" title="White" t-on-click.stop="() => props.setTableColor('#FFFFFF')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#EB6D6D" role="img" aria-label="Red" title="Red" t-on-click.stop="() => props.setTableColor('#EB6D6D')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#35D374" role="img" aria-label="Green" title="Green" t-on-click.stop="() => props.setTableColor('#35D374')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#6C6DEC" role="img" aria-label="Blue" title="Blue" t-on-click.stop="() => props.setTableColor('#6C6DEC')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#EBBF6D" role="img" aria-label="Orange" title="Orange" t-on-click.stop="() => props.setTableColor('#EBBF6D')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#EBEC6D" role="img" aria-label="Yellow" title="Yellow" t-on-click.stop="() => props.setTableColor('#EBEC6D')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#AC6DAD" role="img" aria-label="Purple" title="Purple" t-on-click.stop="() => props.setTableColor('#AC6DAD')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#6C6D6D" role="img" aria-label="Grey" title="Grey" t-on-click.stop="() => props.setTableColor('#6C6D6D')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#ACADAD" role="img" aria-label="Light grey" title="Light grey" t-on-click.stop="() => props.setTableColor('#ACADAD')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:#4ED2BE" role="img" aria-label="Turquoise" title="Turquoise" t-on-click.stop="() => props.setTableColor('#4ED2BE')" />
+        <div t-if="props.isColorPicker and props.selectedTables.length > 0" class="color-picker d-flex justify-content-center align-items-center bg-200 h-54">
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#FFFFFF" role="img" aria-label="White" title="White" t-on-click.stop="() => props.setTableColor('#FFFFFF')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#EB6D6D" role="img" aria-label="Red" title="Red" t-on-click.stop="() => props.setTableColor('#EB6D6D')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#35D374" role="img" aria-label="Green" title="Green" t-on-click.stop="() => props.setTableColor('#35D374')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#6C6DEC" role="img" aria-label="Blue" title="Blue" t-on-click.stop="() => props.setTableColor('#6C6DEC')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#EBBF6D" role="img" aria-label="Orange" title="Orange" t-on-click.stop="() => props.setTableColor('#EBBF6D')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#EBEC6D" role="img" aria-label="Yellow" title="Yellow" t-on-click.stop="() => props.setTableColor('#EBEC6D')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#AC6DAD" role="img" aria-label="Purple" title="Purple" t-on-click.stop="() => props.setTableColor('#AC6DAD')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#6C6D6D" role="img" aria-label="Grey" title="Grey" t-on-click.stop="() => props.setTableColor('#6C6D6D')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#ACADAD" role="img" aria-label="Light grey" title="Light grey" t-on-click.stop="() => props.setTableColor('#ACADAD')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:#4ED2BE" role="img" aria-label="Turquoise" title="Turquoise" t-on-click.stop="() => props.setTableColor('#4ED2BE')" />
         </div>
-        <div t-if="props.isColorPicker and props.selectedTables.length == 0" class="color-picker d-flex justify-content-center border-top border-bottom p-2 bg-200">    
-            <span class="color flex-grow-1 py-4 border cursor-pointer"  style="background-color:rgb(255, 255, 255)" role="img" aria-label="White" title="White" t-on-click.stop="() => props.setFloorColor('rgb(255, 255, 255)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(244, 149, 149)" role="img" aria-label="Red" title="Red" t-on-click.stop="() => props.setFloorColor('rgb(244, 149, 149)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(130, 233, 171)" role="img" aria-label="Green" title="Green" t-on-click.stop="() => props.setFloorColor('rgb(130, 233, 171)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(136, 137, 242)" role="img" aria-label="Blue" title="Blue" t-on-click.stop="() => props.setFloorColor('rgb(136, 137, 242)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(255, 214, 136)" role="img" aria-label="Orange" title="Orange" t-on-click.stop="() => props.setFloorColor('rgb(255, 214, 136)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(254, 255, 154)" role="img" aria-label="Yellow" title="Yellow" t-on-click.stop="() => props.setFloorColor('rgb(254, 255, 154)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(209, 171, 210)" role="img" aria-label="Purple" title="Purple" t-on-click.stop="() => props.setFloorColor('rgb(209, 171, 210)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(75, 75, 75)"    role="img" aria-label="Grey" title="Grey" t-on-click.stop="() => props.setFloorColor('rgb(75, 75, 75)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(210, 210, 210)" role="img" aria-label="Light grey" title="Light grey" t-on-click.stop="() => props.setFloorColor('rgb(210, 210, 210)')" />
-            <span class="color flex-grow-1 py-4 cursor-pointer"  style="background-color:rgb(127, 221, 236)" role="img" aria-label="Turquoise" title="Turquoise" t-on-click.stop="() => props.setFloorColor('rgb(127, 221, 236)')" />
+        <div t-if="props.isColorPicker and props.selectedTables.length == 0" class="color-picker d-flex justify-content-center align-items-center bg-200 h-54">    
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(255, 255, 255)" role="img" aria-label="White" title="White" t-on-click.stop="() => props.setFloorColor('rgb(255, 255, 255)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(244, 149, 149)" role="img" aria-label="Red" title="Red" t-on-click.stop="() => props.setFloorColor('rgb(244, 149, 149)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(130, 233, 171)" role="img" aria-label="Green" title="Green" t-on-click.stop="() => props.setFloorColor('rgb(130, 233, 171)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(136, 137, 242)" role="img" aria-label="Blue" title="Blue" t-on-click.stop="() => props.setFloorColor('rgb(136, 137, 242)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(255, 214, 136)" role="img" aria-label="Orange" title="Orange" t-on-click.stop="() => props.setFloorColor('rgb(255, 214, 136)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(254, 255, 154)" role="img" aria-label="Yellow" title="Yellow" t-on-click.stop="() => props.setFloorColor('rgb(254, 255, 154)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(209, 171, 210)" role="img" aria-label="Purple" title="Purple" t-on-click.stop="() => props.setFloorColor('rgb(209, 171, 210)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(75, 75, 75)"    role="img" aria-label="Grey" title="Grey" t-on-click.stop="() => props.setFloorColor('rgb(75, 75, 75)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(210, 210, 210)" role="img" aria-label="Light grey" title="Light grey" t-on-click.stop="() => props.setFloorColor('rgb(210, 210, 210)')" />
+            <span class="color py-4 cursor-pointer float-start"  style="background-color:rgb(127, 221, 236)" role="img" aria-label="Turquoise" title="Turquoise" t-on-click.stop="() => props.setFloorColor('rgb(127, 221, 236)')" />
         </div>
     </t>
 

--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -10,9 +10,9 @@
                         setTableColor.bind="setTableColor" setFloorColor.bind="setFloorColor" deleteFloorOrTable.bind="deleteFloorOrTable"
                         toggleEditMode.bind="toggleEditMode"
             />
-            <div class="floor-selector d-flex text-center bg-100 fs-3">
+            <div class="floor-selector d-flex text-center bg-100 fs-3 w-100 h-54">
                 <t t-foreach="pos.floors" t-as="floor" t-key="floor.id">
-                    <button class="button button-floor btn p-3 rounded-0" t-attf-class="{{ floor.id === state.selectedFloorId ? 'btn-primary' : 'btn-light' }}" t-on-click="() => this.selectFloor(floor)">
+                    <button class="button button-floor btn p-3 rounded-0 flex-fill border-start shadow-none" t-attf-class="{{ floor.id === state.selectedFloorId ? 'btn-primary border-start-0' : 'btn-light' }}" t-on-click="() => this.selectFloor(floor)">
                         <t t-esc="floor.name" />
                     </button>
                 </t>

--- a/addons/pos_restaurant/static/tests/tours/helpers/FloorScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/FloorScreenTourMethods.js
@@ -22,8 +22,8 @@ class Do {
     clickEdit() {
         return [
             {
-                content: 'Click Menu button',
-                trigger: '.menu-button',
+                content: "Click Menu button",
+                trigger: ".menu-button",
             },
             {
                 content: `click edit button`,
@@ -74,16 +74,16 @@ class Do {
     closeEdit() {
         return [
             {
-                content: 'Close edit mode',
-                trigger: '.edit-button .close-edit-button',
-            }
+                content: "Close edit mode",
+                trigger: ".edit-button .close-edit-button",
+            },
         ];
     }
     changeShapeTo(shape) {
         return [
             {
                 content: `change shape to '${shape}'`,
-                trigger: `.edit-button .button-option${shape === "round" ? ".round" : ".square"}`,
+                trigger: `.edit-button.button-option${shape === "round" ? ".round" : ".square"}`,
             },
         ];
     }
@@ -94,8 +94,8 @@ class Do {
                 trigger: `.floor-map .table .label:contains("${name}")`,
                 run() {
                     const el = this.$anchor[0];
-                    el.dispatchEvent(new MouseEvent("click", {bubbles: true, ctrlKey: true}));
-                }
+                    el.dispatchEvent(new MouseEvent("click", { bubbles: true, ctrlKey: true }));
+                },
             },
         ];
     }


### PR DESCRIPTION
After the introduction of bootstrap, the floorplan edition style changed. In this PR we want to make the floorplan edition look like it was in saas-16.4.

Before:
![image](https://github.com/odoo/odoo/assets/118442417/67ecf0c0-1aec-4cec-8d36-89e973410a88)

Now:
![image](https://github.com/odoo/odoo/assets/118442417/4d3b989f-627d-4207-b0a9-3c27f2d7675e)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
