### PR TITLE
[REM] base: remove field 'groups' on ir.model.fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -525,7 +525,6 @@ class IrModelFields(models.Model):
     domain = fields.Char(default="[]", help="The optional domain to restrict possible values for relationship fields, "
                                             "specified as a Python expression defining a list of triplets. "
                                             "For example: [('color','=','red')]")
-    groups = fields.Many2many('res.groups', 'ir_model_fields_group_rel', 'field_id', 'group_id') # CLEANME unimplemented field (empty table)
     group_expand = fields.Boolean(string="Expand Groups",
                                   help="If checked, all the records of the target model will be included\n"
                                         "in a grouped result (e.g. 'Group By' filters, Kanban columns, etc.).\n"

--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -153,9 +153,6 @@
                                                 <code>self.env</code>, etc.</p>
                                             </div>
                                         </page>
-                                        <page name="groups" string="Access Rights">
-                                            <field name="groups"/>
-                                        </page>
                                         <page name="misc" string="Miscellaneous" groups="base.group_no_one">
                                             <group>
                                                 <field name="state"/>
@@ -350,9 +347,6 @@
                                     <p>Other features are accessible through <code>self</code>, like
                                     <code>self.env</code>, etc.</p>
                                 </div>
-                            </page>
-                            <page name="groups" string="Access Rights">
-                                <field name="groups"/>
                             </page>
                             <page name="misc" string="Miscellaneous" groups="base.group_no_one">
                                 <group>


### PR DESCRIPTION
The field is empty on regular fields, and is not effective on custom fields.

task-2410245

