### PR TITLE
[FIX] hr_holidays_attendance: manage overtime attendances

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -42,7 +42,7 @@ class HolidaysAllocation(models.Model):
                 if not allocation.overtime_id:
                     allocation.sudo().overtime_id = self.env['hr.attendance.overtime'].sudo().create({
                         'employee_id': allocation.employee_id.id,
-                        'date': fields.Date.today(),
+                        'date': allocation.date_from,
                         'adjustment': True,
                         'duration': -1 * duration,
                     })
@@ -72,7 +72,7 @@ class HolidaysAllocation(models.Model):
         for allocation in overtime_allocations:
             overtime = self.env['hr.attendance.overtime'].sudo().create({
                 'employee_id': allocation.employee_id.id,
-                'date': fields.Date.today(),
+                'date': allocation.date_from,
                 'adjustment': True,
                 'duration': -1 * allocation.number_of_hours_display
             })


### PR DESCRIPTION
Issue:
------
The `date` field of the `hr.attendance.overtime` model records is not the date of the related leave.

Cause:
------
We use: `fields.Date.today()` instead of the leave field `date_from`.

Solution:
---------
Use `date_from` field of `leave`.

Note:
-----
Clean code to manage `hr.overtime.attendance`.
Centralize checks and the create/write/unlink overtime with leave.

opw-3433480