### PR TITLE
[FIX] stock{,_dropshipping}: display vendor address for dropships

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -286,6 +286,9 @@ class PickingType(models.Model):
             raise UserError(_("Sequences %s already exist.",
                             ', '.join(duplicate_names)))
 
+    def _is_incoming(self):
+        return self.code == "incoming"
+
 class Picking(models.Model):
     _name = "stock.picking"
     _inherit = ['mail.thread', 'mail.activity.mixin']

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -26,7 +26,7 @@
                     <div class="row">
                         <div class="col-7" name="div_incoming_address">
                             <t t-set="show_partner" t-value="False" />
-                            <div name="vendor_address" t-if="o.picking_type_id.code=='incoming' and partner">
+                            <div name="vendor_address" t-if="o.picking_type_id._is_incoming() and partner">
                                 <span><strong>Vendor Address:</strong></span>
                                 <t t-set="show_partner" t-value="True" />
                             </div>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -27,7 +27,7 @@
                                 </div>
                                 <div class="col-5 offset-1" name="div_incoming_address">
                                     <t t-set="show_partner" t-value="False" />
-                                    <div t-if="o.picking_type_id.code=='incoming' and o.partner_id">
+                                    <div t-if="o.picking_type_id._is_incoming() and o.partner_id">
                                         <span><strong>Vendor Address:</strong></span>
                                         <t t-set="show_partner" t-value="True" />
                                     </div>

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -59,6 +59,9 @@ class StockPickingType(models.Model):
             if record.code == "dropship":
                 record.show_picking_type = True
 
+    def _is_incoming(self):
+        return super()._is_incoming() or self.code == "dropship"
+
 
 class StockLot(models.Model):
     _inherit = 'stock.lot'


### PR DESCRIPTION
The `dropship` picking type's code was added in [1], which prevents the vendor address on the delivery slip, as it's only shown for `incoming` pickings.

[1]: https://github.com/odoo/odoo/commit/1547d66585a4b57cd3b747f28b7514dbd9d7bef8

## Steps to reproduce:
1. Create a product for dropshipping
2. Make a sale for that product
3. Validate the purchase & go on the dropshipping transfer
4. Print > Delivery slip

## Before this commit:
The vendor address is not displayed on the delivery slip.

## After this commit:
Display the vendor address for both `incoming` and `dropship` pickings.

opw-3473586