### PR TITLE
[REF] web, *: replace web_search_read by unity_web_search_read

### DIFF
--- a/addons/board/static/tests/board_test.js
+++ b/addons/board/static/tests/board_test.js
@@ -109,7 +109,7 @@ QUnit.module("Board", (hooks) => {
                         views: [[4, "list"]],
                     };
                 }
-                if (route === "/web/dataset/call_kw/partner/unity_web_search_read") {
+                if (route === "/web/dataset/call_kw/partner/web_search_read") {
                     assert.deepEqual(
                         args.kwargs.domain,
                         [["foo", "!=", "False"]],

--- a/addons/board/static/tests/board_test.js
+++ b/addons/board/static/tests/board_test.js
@@ -569,9 +569,6 @@ QUnit.module("Board", (hooks) => {
                         views: [[false, "kanban"]],
                     });
                 }
-                if (route === "/web/dataset/search_read") {
-                    return Promise.resolve({ records: [{ foo: "aqualung" }] });
-                }
             },
         });
 

--- a/addons/mail/static/tests/web/activity/activity_widget_tests.js
+++ b/addons/mail/static/tests/web/activity/activity_widget_tests.js
@@ -42,7 +42,7 @@ QUnit.test("list activity widget with no activity", async (assert) => {
     });
     await contains(".o-mail-ActivityButton i.text-muted");
     await contains(".o-mail-ListActivity-summary:eq(0):contains()");
-    assert.verifySteps(["/web/dataset/call_kw/res.users/unity_web_search_read"]);
+    assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
 QUnit.test("list activity widget with activities", async (assert) => {
@@ -99,7 +99,7 @@ QUnit.test("list activity widget with activities", async (assert) => {
     );
     await contains(".o_data_row:eq(1) .o-mail-ActivityButton i.text-success.fa-clock-o");
     assert.strictEqual($(".o_data_row:eq(1) .o-mail-ListActivity-summary")[0].innerText, "Type 2");
-    assert.verifySteps(["/web/dataset/call_kw/res.users/unity_web_search_read"]);
+    assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
 QUnit.test("list activity widget with exception", async (assert) => {
@@ -142,7 +142,7 @@ QUnit.test("list activity widget with exception", async (assert) => {
     });
     await contains(".o-mail-ActivityButton i.text-warning.fa-warning");
     await contains(".o-mail-ListActivity-summary:eq(0):contains(Warning)");
-    assert.verifySteps(["/web/dataset/call_kw/res.users/unity_web_search_read"]);
+    assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
 QUnit.test("list activity widget: open dropdown", async (assert) => {
@@ -226,7 +226,7 @@ QUnit.test("list activity widget: open dropdown", async (assert) => {
     await click(".o-mail-ActivityListPopoverItem-markAsDone:eq(0)"); // mark the first activity as done
     await click(".o-mail-ActivityMarkAsDone button[aria-label='Done']"); // confirm
     await contains(".o-mail-ListActivity-summary:eq(0):contains(Meet FP)");
-    assert.verifySteps(["unity_web_search_read", "activity_format", "action_feedback", "web_read"]);
+    assert.verifySteps(["web_search_read", "activity_format", "action_feedback", "web_read"]);
 });
 
 QUnit.test("list activity exception widget with activity", async () => {

--- a/addons/mail/static/tests/web/debug_menu_tests.js
+++ b/addons/mail/static/tests/web/debug_menu_tests.js
@@ -30,7 +30,7 @@ QUnit.test("Manage Messages", async (assert) => {
         if (method === "check_access_rights") {
             return true;
         }
-        if (method === "unity_web_search_read" && model === "mail.message") {
+        if (method === "web_search_read" && model === "mail.message") {
             assert.step("message_read");
             const { context, domain } = kwargs;
             assert.strictEqual(context.default_res_id, 5);

--- a/addons/project/static/src/views/burndown_chart/burndown_chart_model.js
+++ b/addons/project/static/src/views/burndown_chart/burndown_chart_model.js
@@ -23,11 +23,12 @@ export class BurndownChartModel extends GraphModel {
             !context.active_id || !context.default_project_id
                 ? []
                 : [["project_ids", "in", context.active_id]];
-        const data = await this.orm.webSearchRead("project.task.type", searchDomain, [
-            "name",
-            "sequence",
-            "id",
-        ]);
+        const data = await this.orm.webSearchRead("project.task.type", searchDomain, {
+            specification: {
+                name: {},
+                sequence: {},
+            },
+        });
         const stageSeqAndNamePerId = {};
         for (const { id, name, sequence } of data.records) {
             stageSeqAndNamePerId[id] = { name, sequence };

--- a/addons/spreadsheet/static/tests/data_fetching/metadata_repository_test.js
+++ b/addons/spreadsheet/static/tests/data_fetching/metadata_repository_test.js
@@ -97,7 +97,7 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
         assert.verifySteps([]);
 
         await nextTick();
-        assert.verifySteps(["unity_web_search_read-A-[1,2]", "unity_web_search_read-B-[1]", "labels-fetched"]);
+        assert.verifySteps(["web_search_read-A-[1,2]", "web_search_read-B-[1]", "labels-fetched"]);
 
         assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "1");
         assert.strictEqual(metadataRepository.getRecordDisplayName("A", 2), "2");
@@ -120,11 +120,11 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
         assert.verifySteps([]);
 
         await nextTick();
-        assert.verifySteps(["unity_web_search_read-A-[1]"]);
+        assert.verifySteps(["web_search_read-A-[1]"]);
 
         assert.throws(() => metadataRepository.getRecordDisplayName("A", 2));
         await nextTick();
-        assert.verifySteps(["unity_web_search_read-A-[2]"]);
+        assert.verifySteps(["web_search_read-A-[2]"]);
     });
 
     QUnit.test(
@@ -147,7 +147,7 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
             assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "test");
 
             await nextTick();
-            assert.verifySteps(["unity_web_search_read-A-[1]"]);
+            assert.verifySteps(["web_search_read-A-[1]"]);
             assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "test");
         }
     );
@@ -178,7 +178,7 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
             assert.verifySteps([]);
 
             await nextTick();
-            assert.verifySteps(["unity_web_search_read-A-[1]", "unity_web_search_read-B-[1,2]"]);
+            assert.verifySteps(["web_search_read-A-[1]", "web_search_read-B-[1,2]"]);
 
             assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "1");
             assert.throws(

--- a/addons/spreadsheet/static/tests/data_fetching/metadata_repository_test.js
+++ b/addons/spreadsheet/static/tests/data_fetching/metadata_repository_test.js
@@ -97,7 +97,7 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
         assert.verifySteps([]);
 
         await nextTick();
-        assert.verifySteps(["web_search_read-A-[1,2]", "web_search_read-B-[1]", "labels-fetched"]);
+        assert.verifySteps(["unity_web_search_read-A-[1,2]", "unity_web_search_read-B-[1]", "labels-fetched"]);
 
         assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "1");
         assert.strictEqual(metadataRepository.getRecordDisplayName("A", 2), "2");
@@ -120,11 +120,11 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
         assert.verifySteps([]);
 
         await nextTick();
-        assert.verifySteps(["web_search_read-A-[1]"]);
+        assert.verifySteps(["unity_web_search_read-A-[1]"]);
 
         assert.throws(() => metadataRepository.getRecordDisplayName("A", 2));
         await nextTick();
-        assert.verifySteps(["web_search_read-A-[2]"]);
+        assert.verifySteps(["unity_web_search_read-A-[2]"]);
     });
 
     QUnit.test(
@@ -147,7 +147,7 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
             assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "test");
 
             await nextTick();
-            assert.verifySteps(["web_search_read-A-[1]"]);
+            assert.verifySteps(["unity_web_search_read-A-[1]"]);
             assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "test");
         }
     );
@@ -178,7 +178,7 @@ QUnit.module("spreadsheet > Metadata Repository", { beforeEach }, () => {
             assert.verifySteps([]);
 
             await nextTick();
-            assert.verifySteps(["web_search_read-A-[1]", "web_search_read-B-[1,2]"]);
+            assert.verifySteps(["unity_web_search_read-A-[1]", "unity_web_search_read-B-[1,2]"]);
 
             assert.strictEqual(metadataRepository.getRecordDisplayName("A", 1), "1");
             assert.throws(

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -350,7 +350,7 @@ QUnit.module("test_mail", {}, function () {
         const { openView } = await start({
             serverData,
             mockRPC: function (route, args) {
-                if (["get_activity_data", "unity_web_search_read"].includes(args.method)) {
+                if (["get_activity_data", "web_search_read"].includes(args.method)) {
                     assert.step(JSON.stringify(args.kwargs.domain));
                 }
             },
@@ -1023,7 +1023,7 @@ QUnit.module("test_mail", {}, function () {
         const { target, openView } = await start({
             serverData,
             mockRPC(route, { method, kwargs }, result) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.deepEqual(Object.keys(kwargs.specification), ["write_date", "id"]);
                     return Promise.resolve({
                         length: 2,

--- a/addons/web/controllers/dataset.py
+++ b/addons/web/controllers/dataset.py
@@ -15,12 +15,6 @@ _logger = logging.getLogger(__name__)
 
 class DataSet(http.Controller):
 
-    @http.route('/web/dataset/search_read', type='json', auth="user")
-    def search_read(self, model, fields=False, offset=0, limit=False, domain=None, sort=None, context=None):
-        if context:
-            request.update_context(**context)
-        return request.env[model].web_search_read(domain, fields, offset=offset, limit=limit, order=sort)
-
     def _call_kw(self, model, method, args, kwargs):
         check_method_name(method)
         return call_kw(request.env[model], method, args, kwargs)

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -42,24 +42,6 @@ class Base(models.AbstractModel):
     _inherit = 'base'
 
     @api.model
-    def web_search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, count_limit=None):
-        """
-        Performs a search_read and a search_count.
-
-        :param domain: search domain
-        :param fields: list of fields to read
-        :param limit: maximum number of records to read
-        :param offset: number of records to skip
-        :param order: columns to sort results
-        :return: {
-            'records': array of read records (result of a call to 'search_read')
-            'length': number of records matching the domain (result of a call to 'search_count')
-        }
-        """
-        values_records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
-        return self._format_web_search_read_results(domain, values_records, offset, limit, count_limit)
-
-    @api.model
     def unity_web_search_read(self, domain, specification, offset=0, limit=None, order=None, count_limit=None):
         records = self.search_fetch(domain, specification.keys(), offset=offset, limit=limit, order=order)
         values_records = records.web_read(specification)
@@ -227,8 +209,7 @@ class Base(models.AbstractModel):
     @api.model
     def web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False, lazy=True):
         """
-        Returns the result of a read_group (and optionally search for and read records inside each
-        group), and the total number of groups matching the search domain.
+        Returns the result of a read_group and the total number of groups matching the search domain.
 
         :param domain: search domain
         :param fields: list of fields to read (see ``fields``` param of ``read_group``)
@@ -263,7 +244,6 @@ class Base(models.AbstractModel):
     @api.model
     def _web_read_group(self, domain, fields, groupby, limit=None, offset=0, orderby=False, lazy=True):
         """
-        Performs a read_group and optionally a web_search_read for each group.
         See ``web_read_group`` for params description.
 
         :returns: array of groups

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -42,7 +42,7 @@ class Base(models.AbstractModel):
     _inherit = 'base'
 
     @api.model
-    def unity_web_search_read(self, domain, specification, offset=0, limit=None, order=None, count_limit=None):
+    def web_search_read(self, domain, specification, offset=0, limit=None, order=None, count_limit=None):
         records = self.search_fetch(domain, specification.keys(), offset=offset, limit=limit, order=order)
         values_records = records.web_read(specification)
         return self._format_web_search_read_results(domain, values_records, offset, limit, count_limit)

--- a/addons/web/static/src/core/name_service.js
+++ b/addons/web/static/src/core/name_service.js
@@ -74,8 +74,9 @@ export const nameService = {
                     const idsInBatch = unique(batches[resModel]);
                     delete batches[resModel];
 
+                    const specification = { display_name: {} };
                     orm.silent
-                        .webSearchRead(resModel, [["id", "in", idsInBatch]], ["display_name"])
+                        .webSearchRead(resModel, [["id", "in", idsInBatch]], { specification })
                         .then(({ records }) => {
                             const displayNames = Object.fromEntries(
                                 records.map((rec) => [rec.id, rec.display_name])

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -277,7 +277,7 @@ export class ORM {
      */
     webSearchRead(model, domain, kwargs = {}) {
         validateArray("domain", domain);
-        return this.call(model, "unity_web_search_read", [], { ...kwargs, domain });
+        return this.call(model, "web_search_read", [], { ...kwargs, domain });
     }
 
     /**

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -272,14 +272,12 @@ export class ORM {
     /**
      * @param {string} model
      * @param {import("@web/core/domain").DomainListRepr} domain
-     * @param {string[]} fields
      * @param {any} [kwargs={}]
      * @returns {Promise<any[]>}
      */
-    webSearchRead(model, domain, fields, kwargs = {}) {
+    webSearchRead(model, domain, kwargs = {}) {
         validateArray("domain", domain);
-        validatePrimitiveList("fields", "string", fields);
-        return this.call(model, "web_search_read", [], { ...kwargs, domain, fields });
+        return this.call(model, "unity_web_search_read", [], { ...kwargs, domain });
     }
 
     /**

--- a/addons/web/static/src/legacy/js/core/rpc.js
+++ b/addons/web/static/src/legacy/js/core/rpc.js
@@ -81,18 +81,6 @@ const rpc = {
             params.kwargs.order = orderBy ? rpc._serializeSort(orderBy) : orderBy;
         }
 
-        if (options.route === '/web/dataset/search_read') {
-            // specifically call the controller
-            params.model = options.model || params.model;
-            params.domain = options.domain || params.domain;
-            params.fields = options.fields || params.fields;
-            params.limit = options.limit || params.limit;
-            params.offset = options.offset || params.offset;
-            orderBy = options.orderBy || params.orderBy;
-            params.sort = orderBy ? rpc._serializeSort(orderBy) : orderBy;
-            params.context = options.context || params.context || {};
-        }
-
         return {
             route: route,
             params: JSON.parse(JSON.stringify(params)),

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -554,7 +554,6 @@ export class RelationalModel extends Model {
     async _loadUngroupedList(config) {
         const kwargs = {
             specification: getFieldsSpec(config.activeFields, config.fields, config.context),
-            domain: config.domain,
             offset: config.offset,
             order: orderByToString(config.orderBy),
             limit: config.limit,
@@ -562,7 +561,7 @@ export class RelationalModel extends Model {
             count_limit:
                 config.countLimit !== Number.MAX_SAFE_INTEGER ? config.countLimit + 1 : undefined,
         };
-        const response = await this.orm.call(config.resModel, "unity_web_search_read", [], kwargs);
+        const response = await this.orm.webSearchRead(config.resModel, config.domain, kwargs);
 
         this._applyProperties(response.records, config);
         return response;

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -125,8 +125,6 @@ export class SampleServer {
         }
         this._populateModels();
         switch (params.method || params.route) {
-            case "web_search_read":
-                return this._mockWebSearchRead(params);
             case "unity_web_search_read":
                 return this._mockWebSearchReadUnity(params);
             case "web_read_group":
@@ -577,24 +575,6 @@ export class SampleServer {
         return data;
     }
 
-    /**
-     * Mocks calls to the web_search_read method to return sample records.
-     * @private
-     * @param {Object} params
-     * @param {string} params.model
-     * @param {string[]} params.fields
-     * @returns {{ records: Object[], length: number }}
-     */
-    _mockWebSearchRead(params) {
-        const model = this.data[params.model];
-        const rawRecords = model.records.slice(0, SampleServer.SEARCH_READ_LIMIT);
-        const records = this._mockRead({
-            model: params.model,
-            args: [rawRecords.map((r) => r.id), params.fields],
-        });
-        return { records, length: records.length };
-    }
-
     _mockWebSearchReadUnity(params) {
         const fields = Object.keys(params.specification);
         let result;
@@ -606,7 +586,13 @@ export class SampleServer {
                 length: group.__data.records.length,
             };
         } else {
-            result = this._mockWebSearchRead({ ...params, fields });
+            const model = this.data[params.model];
+            const rawRecords = model.records.slice(0, SampleServer.SEARCH_READ_LIMIT);
+            const records = this._mockRead({
+                model: params.model,
+                args: [rawRecords.map((r) => r.id), fields],
+            });
+            result = { records, length: records.length };
         }
         // populate many2one and x2many values
         for (const fieldName in params.specification) {

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -125,7 +125,7 @@ export class SampleServer {
         }
         this._populateModels();
         switch (params.method || params.route) {
-            case "unity_web_search_read":
+            case "web_search_read":
                 return this._mockWebSearchReadUnity(params);
             case "web_read_group":
                 return this._mockWebReadGroup(params);

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -125,8 +125,6 @@ export class SampleServer {
         }
         this._populateModels();
         switch (params.method || params.route) {
-            case "/web/dataset/search_read":
-                return this._mockSearchReadController(params);
             case "web_search_read":
                 return this._mockWebSearchRead(params);
             case "unity_web_search_read":
@@ -139,8 +137,6 @@ export class SampleServer {
                 return this._mockReadProgressBar(params);
             case "read":
                 return this._mockRead(params);
-            case "name_get":
-                return this._mockNameGet(params);
         }
         // this rpc can't be mocked by the SampleServer itself, so check if there is an handler
         // in the registry: either specific for this model (with key 'model/method'), or
@@ -366,31 +362,6 @@ export class SampleServer {
     }
 
     /**
-     * Simulate a 'name_get' operation
-     *
-     * @private
-     * @param {Object} params
-     * @param {string} params.model
-     * @param {Array[]} params.args
-     * @returns {Array[]} a list of [id, display_name]
-     */
-    _mockNameGet(params) {
-        throw new Error("name_get is deprecated, it shouldn't be called");
-        const { model, args } = params;
-        let ids = args[0];
-        if (!args.length) {
-            throw new Error("name_get: expected one argument");
-        } else if (!ids) {
-            return [];
-        }
-        if (!Array.isArray(ids)) {
-            ids = [ids];
-        }
-        const { records } = this.data[model];
-        return ids.map((id) => [id, records.find((r) => r.id === id).display_name]);
-    }
-
-    /**
      * Mocks calls to the read method.
      * @private
      * @param {Object} params
@@ -604,19 +575,6 @@ export class SampleServer {
             }
         }
         return data;
-    }
-
-    /**
-     * Mocks calls to the /web/dataset/search_read route to return sample
-     * records.
-     * @deprecated
-     * @see _mockWebSearchRead
-     */
-    _mockSearchReadController(params) {
-        console.warn(
-            "Using deprecated route /web/dataset/search_read (call method web_search read on the model instead)"
-        );
-        return this._mockWebSearchRead(params);
     }
 
     /**

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -608,9 +608,19 @@ export class SampleServer {
         } else {
             result = this._mockWebSearchRead({ ...params, fields });
         }
-        // populate x2many values
+        // populate many2one and x2many values
         for (const fieldName in params.specification) {
             const field = this.data[params.model].fields[fieldName];
+            if (field.type === "many2one") {
+                for (const record of result.records) {
+                    record[fieldName] = record[fieldName]
+                        ? {
+                              id: record[fieldName][0],
+                              display_name: record[fieldName][1],
+                          }
+                        : false;
+                }
+            }
             if (field.type === "one2many" || field.type === "many2many") {
                 const relFields = Object.keys(params.specification[fieldName].fields || {});
                 if (relFields.length) {

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -1072,10 +1072,12 @@ export class SearchModel extends EventBus {
             domain.push(["id", "=", this.context.active_id]);
         }
 
-        const result = await this.orm.webSearchRead(definitionRecordModel, domain, [
-            "display_name",
-            definitionRecordField,
-        ]);
+        const result = await this.orm.webSearchRead(definitionRecordModel, domain, {
+            specification: {
+                display_name: {},
+                [definitionRecordField]: {},
+            },
+        });
 
         return result.records.map((values) => {
             return {

--- a/addons/web/static/src/views/fields/radio/radio_field.js
+++ b/addons/web/static/src/views/fields/radio/radio_field.js
@@ -29,7 +29,7 @@ export class RadioField extends Component {
                     specification: { display_name: 1 },
                     domain: props.domain,
                 };
-                const { records } = await orm.call(relation, "unity_web_search_read", [], kwargs);
+                const { records } = await orm.call(relation, "web_search_read", [], kwargs);
                 return records.map((record) => [record.id, record.display_name]);
             });
         }

--- a/addons/web/static/tests/core/name_service_tests.js
+++ b/addons/web/static/tests/core/name_service_tests.js
@@ -62,7 +62,7 @@ QUnit.test("single loadDisplayNames following addDisplayNames (2)", async (asser
     env.services.name.addDisplayNames("dev", { 1: "JUM" });
     const displayNames = await env.services.name.loadDisplayNames("dev", [1, 2]);
     assert.deepEqual(displayNames, { 1: "JUM", 2: "Pierre" });
-    assert.verifySteps(["unity_web_search_read", "id(s): 2"]);
+    assert.verifySteps(["web_search_read", "id(s): 2"]);
 });
 
 QUnit.test("loadDisplayNames in batch", async (assert) => {
@@ -79,7 +79,7 @@ QUnit.test("loadDisplayNames in batch", async (assert) => {
     const [displayNames1, displayNames2] = await Promise.all([prom1, prom2]);
     assert.deepEqual(displayNames1, { 1: "Julien" });
     assert.deepEqual(displayNames2, { 2: "Pierre" });
-    assert.verifySteps(["unity_web_search_read", "id(s): 1, 2"]);
+    assert.verifySteps(["web_search_read", "id(s): 1, 2"]);
 });
 
 QUnit.test("loadDisplayNames on different models", async (assert) => {
@@ -101,7 +101,7 @@ QUnit.test("loadDisplayNames on different models", async (assert) => {
     const [displayNames1, displayNames2] = await Promise.all([prom1, prom2]);
     assert.deepEqual(displayNames1, { 1: "Julien" });
     assert.deepEqual(displayNames2, { 1: "Damien" });
-    assert.verifySteps(["unity_web_search_read", "dev", "id(s): 1", "unity_web_search_read", "PO", "id(s): 1"]);
+    assert.verifySteps(["web_search_read", "dev", "id(s): 1", "web_search_read", "PO", "id(s): 1"]);
 });
 
 QUnit.test("invalid id", async (assert) => {
@@ -121,7 +121,7 @@ QUnit.test("inaccessible or missing id", async (assert) => {
     const env = await makeTestEnv({ serverData, mockRPC });
     const displayNames = await env.services.name.loadDisplayNames("dev", [3]);
     assert.deepEqual(displayNames, { 3: ERROR_INACCESSIBLE_OR_MISSING });
-    assert.verifySteps(["unity_web_search_read"]);
+    assert.verifySteps(["web_search_read"]);
 });
 
 QUnit.test("batch + inaccessible/missing", async (assert) => {
@@ -138,5 +138,5 @@ QUnit.test("batch + inaccessible/missing", async (assert) => {
     const [displayNames1, displayNames2] = await Promise.all([prom1, prom2]);
     assert.deepEqual(displayNames1, { 1: "Julien", 3: ERROR_INACCESSIBLE_OR_MISSING });
     assert.deepEqual(displayNames2, { 2: "Pierre", 4: ERROR_INACCESSIBLE_OR_MISSING });
-    assert.verifySteps(["unity_web_search_read", "id(s): 1, 3, 2, 4"]);
+    assert.verifySteps(["web_search_read", "id(s): 1, 3, 2, 4"]);
 });

--- a/addons/web/static/tests/core/name_service_tests.js
+++ b/addons/web/static/tests/core/name_service_tests.js
@@ -62,7 +62,7 @@ QUnit.test("single loadDisplayNames following addDisplayNames (2)", async (asser
     env.services.name.addDisplayNames("dev", { 1: "JUM" });
     const displayNames = await env.services.name.loadDisplayNames("dev", [1, 2]);
     assert.deepEqual(displayNames, { 1: "JUM", 2: "Pierre" });
-    assert.verifySteps(["web_search_read", "id(s): 2"]);
+    assert.verifySteps(["unity_web_search_read", "id(s): 2"]);
 });
 
 QUnit.test("loadDisplayNames in batch", async (assert) => {
@@ -79,7 +79,7 @@ QUnit.test("loadDisplayNames in batch", async (assert) => {
     const [displayNames1, displayNames2] = await Promise.all([prom1, prom2]);
     assert.deepEqual(displayNames1, { 1: "Julien" });
     assert.deepEqual(displayNames2, { 2: "Pierre" });
-    assert.verifySteps(["web_search_read", "id(s): 1, 2"]);
+    assert.verifySteps(["unity_web_search_read", "id(s): 1, 2"]);
 });
 
 QUnit.test("loadDisplayNames on different models", async (assert) => {
@@ -101,7 +101,7 @@ QUnit.test("loadDisplayNames on different models", async (assert) => {
     const [displayNames1, displayNames2] = await Promise.all([prom1, prom2]);
     assert.deepEqual(displayNames1, { 1: "Julien" });
     assert.deepEqual(displayNames2, { 1: "Damien" });
-    assert.verifySteps(["web_search_read", "dev", "id(s): 1", "web_search_read", "PO", "id(s): 1"]);
+    assert.verifySteps(["unity_web_search_read", "dev", "id(s): 1", "unity_web_search_read", "PO", "id(s): 1"]);
 });
 
 QUnit.test("invalid id", async (assert) => {
@@ -121,7 +121,7 @@ QUnit.test("inaccessible or missing id", async (assert) => {
     const env = await makeTestEnv({ serverData, mockRPC });
     const displayNames = await env.services.name.loadDisplayNames("dev", [3]);
     assert.deepEqual(displayNames, { 3: ERROR_INACCESSIBLE_OR_MISSING });
-    assert.verifySteps(["web_search_read"]);
+    assert.verifySteps(["unity_web_search_read"]);
 });
 
 QUnit.test("batch + inaccessible/missing", async (assert) => {
@@ -138,5 +138,5 @@ QUnit.test("batch + inaccessible/missing", async (assert) => {
     const [displayNames1, displayNames2] = await Promise.all([prom1, prom2]);
     assert.deepEqual(displayNames1, { 1: "Julien", 3: ERROR_INACCESSIBLE_OR_MISSING });
     assert.deepEqual(displayNames2, { 2: "Pierre", 4: ERROR_INACCESSIBLE_OR_MISSING });
-    assert.verifySteps(["web_search_read", "id(s): 1, 3, 2, 4"]);
+    assert.verifySteps(["unity_web_search_read", "id(s): 1, 3, 2, 4"]);
 });

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -369,8 +369,9 @@ QUnit.test("webSearchRead method", async (assert) => {
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
     const env = await makeTestEnv();
-    await env.services.orm.webSearchRead("sale.order", [["user_id", "=", 2]], ["amount_total"]);
-    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/web_search_read");
+    const specification = { amount_total: {} };
+    await env.services.orm.webSearchRead("sale.order", [["user_id", "=", 2]], { specification });
+    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/unity_web_search_read");
     assert.deepEqual(query.params, {
         args: [],
         kwargs: {
@@ -380,9 +381,9 @@ QUnit.test("webSearchRead method", async (assert) => {
                 uid: 7,
             },
             domain: [["user_id", "=", 2]],
-            fields: ["amount_total"],
+            specification: { amount_total: {} },
         },
-        method: "web_search_read",
+        method: "unity_web_search_read",
         model: "sale.order",
     });
 });

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -371,7 +371,7 @@ QUnit.test("webSearchRead method", async (assert) => {
     const env = await makeTestEnv();
     const specification = { amount_total: {} };
     await env.services.orm.webSearchRead("sale.order", [["user_id", "=", 2]], { specification });
-    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/unity_web_search_read");
+    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/web_search_read");
     assert.deepEqual(query.params, {
         args: [],
         kwargs: {
@@ -383,7 +383,7 @@ QUnit.test("webSearchRead method", async (assert) => {
             domain: [["user_id", "=", 2]],
             specification: { amount_total: {} },
         },
-        method: "unity_web_search_read",
+        method: "web_search_read",
         model: "sale.order",
     });
 });

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -627,8 +627,6 @@ export class MockServer {
                 return this.mockUnlink(args.model, args.args);
             case "web_read":
                 return this.mockWebRead(args.model, args.args, args.kwargs);
-            case "web_search_read":
-                return this.mockWebSearchRead(args.model, args.args, args.kwargs);
             case "read_group":
                 return this.mockReadGroup(args.model, args.kwargs);
             case "web_read_group":
@@ -1920,14 +1918,18 @@ export class MockServer {
         return records;
     }
 
-    mockWebSearchRead(modelName, args, kwargs) {
+    mockWebSearchReadUnity(modelName, args, kwargs) {
+        let _fieldNames = Object.keys(kwargs.specification);
+        if (!_fieldNames.length) {
+            _fieldNames = ["id"];
+        }
         const { fieldNames, length, records } = this.mockSearchController({
             model: modelName,
-            domain: kwargs.domain || args[0],
-            fields: kwargs.fields || args[1],
-            offset: kwargs.offset || args[2],
-            limit: kwargs.limit || args[3],
-            sort: kwargs.order || args[4],
+            fields: _fieldNames,
+            domain: kwargs.domain,
+            offset: kwargs.offset,
+            limit: kwargs.limit,
+            sort: kwargs.order,
             context: kwargs.context,
         });
         const result = {
@@ -1938,16 +1940,6 @@ export class MockServer {
         if (countLimit) {
             result.length = Math.min(result.length, countLimit);
         }
-        return result;
-    }
-
-    mockWebSearchReadUnity(modelName, args, kwargs) {
-        let fieldNames = Object.keys(kwargs.specification);
-        if (!fieldNames.length) {
-            fieldNames = ["id"];
-        }
-        const _kwargs = { ...kwargs, fields: fieldNames };
-        const result = this.mockWebSearchRead(modelName, [], _kwargs);
         this._unityReadRecords(modelName, kwargs.specification, result.records);
         return result;
     }

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -631,7 +631,7 @@ export class MockServer {
                 return this.mockReadGroup(args.model, args.kwargs);
             case "web_read_group":
                 return this.mockWebReadGroup(args.model, args.kwargs);
-            case "unity_web_search_read":
+            case "web_search_read":
                 return this.mockWebSearchReadUnity(args.model, args.args, args.kwargs);
             case "read_progress_bar":
                 return this.mockReadProgressBar(args.model, args.kwargs);

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -346,10 +346,10 @@ export class MockServer {
             if (node.nodeType === Node.TEXT_NODE) {
                 return false;
             }
-            ['required', 'readonly', 'invisible', 'column_invisible'].forEach((attr) => {
+            ["required", "readonly", "invisible", "column_invisible"].forEach((attr) => {
                 const value = node.getAttribute(attr);
-                if (value === '1' || value === 'true') {
-                    node.setAttribute(attr, 'True');
+                if (value === "1" || value === "true") {
+                    node.setAttribute(attr, "True");
                 }
             });
             const isField = node.tagName === "field";
@@ -488,7 +488,11 @@ export class MockServer {
             case "field": {
                 const fname = node.getAttribute("name");
                 const field = this.models[modelName].fields[fname];
-                return !field.readonly && node.getAttribute("readonly") !== "True" && node.getAttribute("readonly") !== "1";
+                return (
+                    !field.readonly &&
+                    node.getAttribute("readonly") !== "True" &&
+                    node.getAttribute("readonly") !== "1"
+                );
             }
             default:
                 return false;
@@ -575,8 +579,6 @@ export class MockServer {
                 return this.mockLoadMenus();
             case "/web/action/load":
                 return this.mockLoadAction(args);
-            case "/web/dataset/search_read":
-                return this.mockSearchReadController(args);
             case "/web/dataset/resequence":
                 return this.mockResequence(args);
         }
@@ -1893,7 +1895,7 @@ export class MockServer {
     }
 
     mockSearchRead(modelName, args, kwargs) {
-        const result = this.mockSearchReadController({
+        const { fieldNames, records } = this.mockSearchController({
             model: modelName,
             domain: kwargs.domain || args[0],
             fields: kwargs.fields || args[1],
@@ -1902,7 +1904,7 @@ export class MockServer {
             sort: kwargs.order || args[4],
             context: kwargs.context,
         });
-        return result.records;
+        return this.mockRead(modelName, [records.map((r) => r.id), fieldNames]);
     }
 
     mockWebRead(modelName, args, kwargs) {
@@ -1919,7 +1921,7 @@ export class MockServer {
     }
 
     mockWebSearchRead(modelName, args, kwargs) {
-        const result = this.mockSearchReadController({
+        const { fieldNames, length, records } = this.mockSearchController({
             model: modelName,
             domain: kwargs.domain || args[0],
             fields: kwargs.fields || args[1],
@@ -1928,6 +1930,10 @@ export class MockServer {
             sort: kwargs.order || args[4],
             context: kwargs.context,
         });
+        const result = {
+            length,
+            records: this.mockRead(modelName, [records.map((r) => r.id), fieldNames]),
+        };
         const countLimit = kwargs.count_limit || args[5];
         if (countLimit) {
             result.length = Math.min(result.length, countLimit);
@@ -1968,14 +1974,6 @@ export class MockServer {
             fieldNames,
             length: nbRecords,
             records,
-        };
-    }
-
-    mockSearchReadController(params) {
-        const { fieldNames, length, records } = this.mockSearchController(params);
-        return {
-            length,
-            records: this.mockRead(params.model, [records.map((r) => r.id), fieldNames]),
         };
     }
 

--- a/addons/web/static/tests/legacy/core/rpc_tests.js
+++ b/addons/web/static/tests/legacy/core/rpc_tests.js
@@ -102,28 +102,6 @@ QUnit.module('core', {}, function () {
             "should call with correct kargs");
     });
 
-    QUnit.test('search_read controller', function (assert) {
-        assert.expect(1);
-        var query = rpc.buildQuery({
-            route: '/web/dataset/search_read',
-            model: 'partner',
-            domain: ['a', '=', 1],
-            fields: ['name'],
-            limit: 32,
-            offset: 2,
-            orderBy: [{name: 'yop', asc: true}, {name: 'aa', asc: false}],
-        });
-        assert.deepEqual(query.params, {
-            context: {},
-            domain: ['a', '=', 1],
-            fields: ['name'],
-            limit: 32,
-            offset: 2,
-            model: 'partner',
-            sort: 'yop ASC, aa DESC',
-        }, "should have correct args");
-    });
-
     QUnit.test('search_read method', function (assert) {
         assert.expect(1);
         var query = rpc.buildQuery({
@@ -295,19 +273,5 @@ QUnit.module('core', {}, function () {
         assert.deepEqual(query.params.kwargs.offset, undefined, "should not enforce a default value for offset");
         assert.deepEqual(query.params.kwargs.limit, undefined, "should not enforce a default value for limit");
         assert.deepEqual(query.params.kwargs.order, undefined, "should not enforce a default value for orderby");
-    });
-
-    QUnit.test('search_read controller with no domain, nor fields', function (assert) {
-        assert.expect(5);
-        var query = rpc.buildQuery({
-            model: 'partner',
-            route: '/web/dataset/search_read',
-        });
-
-        assert.deepEqual(query.params.domain, undefined, "should not enforce a default value for domain");
-        assert.deepEqual(query.params.fields, undefined, "should not enforce a default value for fields");
-        assert.deepEqual(query.params.offset, undefined, "should not enforce a default value for groupby");
-        assert.deepEqual(query.params.limit, undefined, "should not enforce a default value for limit");
-        assert.deepEqual(query.params.sort, undefined, "should not enforce a default value for order");
     });
 });

--- a/addons/web/static/tests/model/sample_server_tests.js
+++ b/addons/web/static/tests/model/sample_server_tests.js
@@ -261,6 +261,24 @@ QUnit.module(
             );
         });
 
+        QUnit.test("Send 'search_read' RPC: many2one fields", async function (assert) {
+            const server = new DeterministicSampleServer("res.users", fields["res.users"]);
+
+            const result = await server.mockRpc({
+                method: "unity_web_search_read",
+                model: "res.users",
+                specification: {
+                    manager_id: {
+                        fields: { display_name: {} },
+                    },
+                },
+            });
+
+            assert.deepEqual(Object.keys(result.records[0]), ["id", "manager_id"]);
+            assert.ok(result.records[0].manager_id.id);
+            assert.ok(/\w+/.test(result.records[0].manager_id.display_name));
+        });
+
         QUnit.test("Send 'web_read_group' RPC: no group", async function (assert) {
             assert.expect(1);
 

--- a/addons/web/static/tests/model/sample_server_tests.js
+++ b/addons/web/static/tests/model/sample_server_tests.js
@@ -128,7 +128,7 @@ QUnit.module(
             }
             const server = new DeterministicSampleServer("res.users", fields["res.users"]);
             const { records } = await server.mockRpc({
-                method: "unity_web_search_read",
+                method: "web_search_read",
                 model: "res.users",
                 specification,
             });
@@ -209,7 +209,7 @@ QUnit.module(
 
             const server = new DeterministicSampleServer("res.country", fields["res.country"]);
             const { records } = await server.mockRpc({
-                method: "unity_web_search_read",
+                method: "web_search_read",
                 model: "res.country",
                 specification: { display_name: {} },
             });
@@ -223,7 +223,7 @@ QUnit.module(
             const server = new DeterministicSampleServer("hobbit", fields.hobbit);
 
             const { records } = await server.mockRpc({
-                method: "unity_web_search_read",
+                method: "web_search_read",
                 model: "hobbit",
                 specification: { display_name: {} },
             });
@@ -239,7 +239,7 @@ QUnit.module(
             const server = new DeterministicSampleServer("hobbit", fields.hobbit);
 
             const result = await server.mockRpc({
-                method: "unity_web_search_read",
+                method: "web_search_read",
                 model: "hobbit",
                 specification: { display_name: {} },
             });
@@ -253,7 +253,7 @@ QUnit.module(
             const server = new DeterministicSampleServer("res.users", fields["res.users"]);
 
             const result = await server.mockRpc({
-                method: "unity_web_search_read",
+                method: "web_search_read",
                 model: "res.users",
                 specification: {
                     manager_id: {

--- a/addons/web/static/tests/search/search_bar_tests.js
+++ b/addons/web/static/tests/search/search_bar_tests.js
@@ -1075,10 +1075,10 @@ QUnit.module("Search", (hooks) => {
 
         async function mockRPC(_, { method, model, kwargs }) {
             if (
-                method === "web_search_read" &&
+                method === "unity_web_search_read" &&
                 model === "partner" &&
-                kwargs.fields[0] === "display_name" &&
-                kwargs.fields[1] === "child_properties"
+                kwargs.specification.display_name &&
+                kwargs.specification.child_properties
             ) {
                 const definition1 = [
                     {
@@ -1374,10 +1374,10 @@ QUnit.module("Search", (hooks) => {
 
         async function mockRPC(route, { method, model, args, kwargs }) {
             if (
-                method === "web_search_read" &&
+                method === "unity_web_search_read" &&
                 model === "partner" &&
-                kwargs.fields[0] === "display_name" &&
-                kwargs.fields[1] === "child_properties"
+                kwargs.specification.display_name &&
+                kwargs.specification.child_properties
             ) {
                 assert.deepEqual(
                     kwargs.domain,

--- a/addons/web/static/tests/search/search_bar_tests.js
+++ b/addons/web/static/tests/search/search_bar_tests.js
@@ -1075,7 +1075,7 @@ QUnit.module("Search", (hooks) => {
 
         async function mockRPC(_, { method, model, kwargs }) {
             if (
-                method === "unity_web_search_read" &&
+                method === "web_search_read" &&
                 model === "partner" &&
                 kwargs.specification.display_name &&
                 kwargs.specification.child_properties
@@ -1374,7 +1374,7 @@ QUnit.module("Search", (hooks) => {
 
         async function mockRPC(route, { method, model, args, kwargs }) {
             if (
-                method === "unity_web_search_read" &&
+                method === "web_search_read" &&
                 model === "partner" &&
                 kwargs.specification.display_name &&
                 kwargs.specification.child_properties

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -985,11 +985,6 @@ QUnit.module("Search", (hooks) => {
         });
         await makeWithSearch({
             serverData,
-            async mockRPC(route) {
-                if (route === "/web/dataset/search_read") {
-                    await promise;
-                }
-            },
             Component: TestComponent,
             resModel: "partner",
             searchViewId: false,

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -2065,7 +2065,7 @@ QUnit.module("Search", (hooks) => {
         const webclient = await createWebClient({
             serverData,
             async mockRPC(route, { kwargs, method }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.step(JSON.stringify(kwargs.domain));
                 }
             },
@@ -2113,7 +2113,7 @@ QUnit.module("Search", (hooks) => {
         const webclient = await createWebClient({
             serverData,
             async mockRPC(route, { kwargs, method }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.step(JSON.stringify(kwargs.domain));
                 }
             },

--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -665,7 +665,7 @@ QUnit.module("Fields", (hooks) => {
                 "get_views",
                 "web_read",
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
                 "onchange",
             ]);
             modal = target.querySelector(".modal");
@@ -724,7 +724,7 @@ QUnit.module("Fields", (hooks) => {
                 "get_views",
                 "web_read",
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
                 "onchange",
             ]);
 
@@ -784,7 +784,7 @@ QUnit.module("Fields", (hooks) => {
                     </field>
                 </form>`,
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     // done by the SelectCreateDialog
                     assert.deepEqual(args.kwargs.context, {
                         abc: 2,
@@ -946,7 +946,7 @@ QUnit.module("Fields", (hooks) => {
 
         assert.verifySteps([
             "get_views", // list view in dialog
-            "unity_web_search_read", // list view in dialog
+            "web_search_read", // list view in dialog
             "web_read", // relational field (updated)
             "write", // save main record
             "web_read", // main record
@@ -1434,7 +1434,7 @@ QUnit.module("Fields", (hooks) => {
                 </field>
             </form>`,
                 mockRPC(route, args) {
-                    if (args.method === "unity_web_search_read") {
+                    if (args.method === "web_search_read") {
                         assert.deepEqual(args.kwargs.domain, [
                             "&",
                             ["id", "in", [2, 3]],
@@ -1512,9 +1512,9 @@ QUnit.module("Fields", (hooks) => {
 
         assert.verifySteps([
             "web_read on partner",
-            "unity_web_search_read on partner_type",
+            "web_search_read on partner_type",
             "web_read on partner_type",
-            "unity_web_search_read on partner_type",
+            "web_search_read on partner_type",
             "web_read on partner_type",
         ]);
     });
@@ -1635,7 +1635,7 @@ QUnit.module("Fields", (hooks) => {
             assert.verifySteps(["get_views", "web_read"]);
 
             await addRow(target);
-            assert.verifySteps(["get_views", "unity_web_search_read"]);
+            assert.verifySteps(["get_views", "web_search_read"]);
 
             await click(target, ".o_create_button");
             assert.strictEqual(

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -3587,7 +3587,7 @@ QUnit.module("Fields", (hooks) => {
             assert.containsNone(target, ".modal", "should not have any modal in DOM");
             assert.verifySteps([
                 "get_views",
-                "unity_web_search_read", // to display results in the dialog
+                "web_search_read", // to display results in the dialog
                 "name_search",
                 "onchange",
                 "write",
@@ -3637,7 +3637,7 @@ QUnit.module("Fields", (hooks) => {
             assert.containsNone(target, ".modal", "should not have any modal in DOM");
             assert.verifySteps([
                 "get_views",
-                "unity_web_search_read", // to display results in the dialog
+                "web_search_read", // to display results in the dialog
                 "name_search",
                 "onchange",
                 "write",
@@ -3772,7 +3772,7 @@ QUnit.module("Fields", (hooks) => {
             arch: '<form><field name="trululu" /></form>',
             mockRPC(route, { kwargs, method }) {
                 assert.step(method);
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.deepEqual(
                         kwargs.domain,
                         [],
@@ -3794,7 +3794,7 @@ QUnit.module("Fields", (hooks) => {
             "onchange",
             "name_search", // to display results in the dropdown
             "get_views", // list view in dialog
-            "unity_web_search_read", // to display results in the dialog
+            "web_search_read", // to display results in the dialog
         ]);
     });
 
@@ -3824,7 +3824,7 @@ QUnit.module("Fields", (hooks) => {
             arch: '<form><field name="trululu" /></form>',
             mockRPC(route, { kwargs, method }) {
                 assert.step(method || route);
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.deepEqual(kwargs.domain, expectedDomain);
                 }
             },
@@ -3854,8 +3854,8 @@ QUnit.module("Fields", (hooks) => {
             "name_search", // to display results in the dropdown
             "name_search", // to get preselected ids matching the search
             "get_views", // list view in dialog
-            "unity_web_search_read", // to display results in the dialog
-            "unity_web_search_read", // after removal of dynamic filter
+            "web_search_read", // to display results in the dialog
+            "web_search_read", // after removal of dynamic filter
         ]);
     });
 
@@ -3976,7 +3976,7 @@ QUnit.module("Fields", (hooks) => {
             arch: '<form><field name="trululu" /></form>',
             mockRPC(route, { kwargs, method }) {
                 assert.step(method || route);
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.deepEqual(
                         kwargs.domain,
                         [],
@@ -4003,7 +4003,7 @@ QUnit.module("Fields", (hooks) => {
             "onchange",
             "name_search", // to display results in the dropdown
             "get_views", // list view in dialog
-            "unity_web_search_read", // to display results in the dialog
+            "web_search_read", // to display results in the dialog
             "/web/dataset/resequence", // resequencing lines
             "read",
         ]);

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -13788,7 +13788,7 @@ QUnit.module("Fields", (hooks) => {
                     p: [[0, args.args[1].p[0][1], { display_name: "a name" }]],
                 });
             }
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 return def;
             }
         };

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -13788,7 +13788,7 @@ QUnit.module("Fields", (hooks) => {
                     p: [[0, args.args[1].p[0][1], { display_name: "a name" }]],
                 });
             }
-            if (args.method === "web_search_read") {
+            if (args.method === "unity_web_search_read") {
                 return def;
             }
         };

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -10766,10 +10766,10 @@ QUnit.module("Views", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "partner:get_views",
-            "partner:unity_web_search_read",
-            "partner:unity_web_search_read",
+            "partner:web_search_read",
+            "partner:web_search_read",
             "partner:web_read_group",
-            "partner:unity_web_search_read",
+            "partner:web_search_read",
             "partner:web_read",
         ]);
     });

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -350,7 +350,7 @@ QUnit.module("Views", (hooks) => {
                     </t></templates>
                 </kanban>`,
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.ok(
                         args.kwargs.context.bin_size,
                         "should not request direct binary payload"
@@ -1208,7 +1208,7 @@ QUnit.module("Views", (hooks) => {
                     </templates>
                 </kanban>`,
             async mockRPC(route, { method, kwargs }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.strictEqual(kwargs.limit, 40, "default limit should be 40 in Kanban");
                 }
             },
@@ -1231,7 +1231,7 @@ QUnit.module("Views", (hooks) => {
                 '<div><field name="foo"/></div>' +
                 "</t></templates></kanban>",
             async mockRPC(route, { method, kwargs }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.strictEqual(kwargs.limit, 2);
                 }
             },
@@ -1256,7 +1256,7 @@ QUnit.module("Views", (hooks) => {
                 '<div><field name="foo"/></div>' +
                 "</t></templates></kanban>",
             async mockRPC(route, { method, kwargs }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.strictEqual(kwargs.limit, 3);
                 }
             },
@@ -1290,7 +1290,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_limit"));
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
@@ -1322,13 +1322,13 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_next"));
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "3-4");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, click next (2)", async (assert) => {
@@ -1355,19 +1355,19 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_next"));
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "3-4");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4+");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         await click(target.querySelector(".o_pager_next"));
         assert.containsOnce(target, ".o_kanban_record:not(.o_kanban_ghost)");
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "5-5");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, click previous", async (assert) => {
@@ -1394,13 +1394,13 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_previous"));
         assert.containsOnce(target, ".o_kanban_record:not(.o_kanban_ghost)");
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "5-5");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5");
-        assert.verifySteps(["search_count", "unity_web_search_read"]);
+        assert.verifySteps(["search_count", "web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, edit pager", async (assert) => {
@@ -1427,21 +1427,21 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target, ".o_pager_value");
         await editInput(target, "input.o_pager_value", "2-4");
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 3);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "2-4");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4+");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         await click(target, ".o_pager_value");
         await editInput(target, "input.o_pager_value", "2-14");
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 4);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "2-5");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("count_limit attrs set in arch", async (assert) => {
@@ -1465,7 +1465,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_limit"));
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 2);
@@ -1627,9 +1627,9 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_record:not(.o_kanban_ghost)", 5);
         assert.verifySteps([
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "doAction some.action",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -1870,8 +1870,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "onchange", // quick create
             "name_create", // should perform a name_create to create the record
             "web_read", // read the created record
@@ -1948,8 +1948,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "get_views", // form view in quick create
             "onchange", // quick create
             "create", // should perform a create to create the record
@@ -2223,8 +2223,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "onchange", // quick create
             "name_create", // should perform a name_create to create the record
             "web_read", // read the created record
@@ -2292,8 +2292,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "get_views", // form view in quick create
             "onchange", // quick create
             "create", // should perform a create to create the record
@@ -2349,8 +2349,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "onchange", // quick create
             "name_create", // should perform a name_create to create the record
             "web_read", // read the created record
@@ -2406,9 +2406,9 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
-            "unity_web_search_read", // read records when unfolding 'None'
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
+            "web_search_read", // read records when unfolding 'None'
             "onchange", // quick create
             "name_create", // should perform a name_create to create the record
             "web_read", // read the created record
@@ -2474,8 +2474,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "get_views", // get form view
             "onchange", // quick create
             "create", // should perform a create to create the record
@@ -2548,8 +2548,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "get_views", // get form view
             "onchange", // quick create
             "create", // should perform a create to create the record
@@ -2576,12 +2576,7 @@ QUnit.module("Views", (hooks) => {
                 assert.step(method || route);
             },
         });
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
 
         await createRecord();
         assert.verifySteps(["onchange"]);
@@ -2651,8 +2646,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "get_views", // form view in quick create
             "onchange", // quick create
             "onchange", // onchange due to 'foo' field change
@@ -2742,8 +2737,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
         ]);
 
         // click on 'Create' -> should open the quick create in the first column
@@ -4609,7 +4604,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(getCard(0), ".o_tag.o_tag_color_2", "first tag should have color 2");
         assert.verifySteps([
             "/web/dataset/call_kw/partner/get_views",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
         ]);
 
         // Checks that second records has only one tag as one should be hidden (color 0)
@@ -4801,11 +4796,11 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -4833,11 +4828,11 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -4872,11 +4867,11 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
         const allNames = Array.from(
             target.querySelectorAll(".o_kanban_record span"),
@@ -5806,8 +5801,8 @@ QUnit.module("Views", (hooks) => {
                     result.groups[8].__fold = true;
                     return result;
                 }
-                if (args.method === "unity_web_search_read") {
-                    assert.step(`unity_web_search_read domain: ${args.kwargs.domain}`);
+                if (args.method === "web_search_read") {
+                    assert.step(`web_search_read domain: ${args.kwargs.domain}`);
                 }
             },
         });
@@ -5828,16 +5823,16 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group.o_column_folded", 4);
 
         assert.verifySteps([
-            "unity_web_search_read domain: product_id,=,3",
-            "unity_web_search_read domain: product_id,=,5",
-            "unity_web_search_read domain: product_id,=,9",
-            "unity_web_search_read domain: product_id,=,10",
-            "unity_web_search_read domain: product_id,=,11",
-            "unity_web_search_read domain: product_id,=,12",
-            "unity_web_search_read domain: product_id,=,13",
-            "unity_web_search_read domain: product_id,=,15",
-            "unity_web_search_read domain: product_id,=,16",
-            "unity_web_search_read domain: product_id,=,17",
+            "web_search_read domain: product_id,=,3",
+            "web_search_read domain: product_id,=,5",
+            "web_search_read domain: product_id,=,9",
+            "web_search_read domain: product_id,=,10",
+            "web_search_read domain: product_id,=,11",
+            "web_search_read domain: product_id,=,12",
+            "web_search_read domain: product_id,=,13",
+            "web_search_read domain: product_id,=,15",
+            "web_search_read domain: product_id,=,16",
+            "web_search_read domain: product_id,=,17",
         ]);
     });
 
@@ -5879,8 +5874,8 @@ QUnit.module("Views", (hooks) => {
                     }
                     return result;
                 }
-                if (args.method === "unity_web_search_read") {
-                    assert.step(`unity_web_search_read domain: ${args.kwargs.domain}`);
+                if (args.method === "web_search_read") {
+                    assert.step(`web_search_read domain: ${args.kwargs.domain}`);
                 }
             },
         });
@@ -5901,16 +5896,16 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group.o_column_folded", 4);
 
         assert.verifySteps([
-            "unity_web_search_read domain: product_id,=,3",
-            "unity_web_search_read domain: product_id,=,5",
-            "unity_web_search_read domain: product_id,=,9",
-            "unity_web_search_read domain: product_id,=,10",
-            "unity_web_search_read domain: product_id,=,11",
-            "unity_web_search_read domain: product_id,=,12",
-            "unity_web_search_read domain: product_id,=,13",
-            "unity_web_search_read domain: product_id,=,15",
-            "unity_web_search_read domain: product_id,=,16",
-            "unity_web_search_read domain: product_id,=,17",
+            "web_search_read domain: product_id,=,3",
+            "web_search_read domain: product_id,=,5",
+            "web_search_read domain: product_id,=,9",
+            "web_search_read domain: product_id,=,10",
+            "web_search_read domain: product_id,=,11",
+            "web_search_read domain: product_id,=,12",
+            "web_search_read domain: product_id,=,13",
+            "web_search_read domain: product_id,=,15",
+            "web_search_read domain: product_id,=,16",
+            "web_search_read domain: product_id,=,17",
         ]);
     });
 
@@ -6091,12 +6086,12 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "unlink",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
         assert.containsN(
             target,
@@ -6290,7 +6285,7 @@ QUnit.module("Views", (hooks) => {
                 "</kanban>",
             groupBy: ["product_id"],
             async mockRPC(_route, { method, model, kwargs }) {
-                if (model === "partner" && method === "unity_web_search_read") {
+                if (model === "partner" && method === "web_search_read") {
                     assert.strictEqual(
                         kwargs.context.lang,
                         "brol",
@@ -8201,7 +8196,7 @@ QUnit.module("Views", (hooks) => {
         });
         assert.verifySteps([
             "/web/dataset/call_kw/partner/get_views",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
         ]);
 
         assert.ok(
@@ -8222,7 +8217,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.strictEqual(count, 1, "should have triggered an execute action only once");
         assert.verifySteps(
-            ["/web/dataset/call_kw/partner/unity_web_search_read"],
+            ["/web/dataset/call_kw/partner/web_search_read"],
             "the records should be reloaded after executing a button action"
         );
     });
@@ -8799,7 +8794,7 @@ QUnit.module("Views", (hooks) => {
             groupBy: ["bar"],
             limit: 2,
             async mockRPC(_route, { method, kwargs }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.step(`${kwargs.limit} - ${kwargs.offset}`);
                 }
             },
@@ -8861,8 +8856,8 @@ QUnit.module("Views", (hooks) => {
             groupBy: ["bar"],
             limit: 2,
             async mockRPC(_route, { kwargs, method }) {
-                if (method === "unity_web_search_read") {
-                    assert.step(`unity_web_search_read ${kwargs.limit}-${kwargs.offset}`);
+                if (method === "web_search_read") {
+                    assert.step(`web_search_read ${kwargs.limit}-${kwargs.offset}`);
                 }
             },
         });
@@ -8872,7 +8867,7 @@ QUnit.module("Views", (hooks) => {
             [...getColumn(1).querySelectorAll("[name='category_ids']")].map((el) => el.textContent),
             ["silver", ""]
         );
-        assert.verifySteps(["unity_web_search_read 2-0", "unity_web_search_read 2-0"]);
+        assert.verifySteps(["web_search_read 2-0", "web_search_read 2-0"]);
 
         // load more
         await loadMore(1);
@@ -8882,7 +8877,7 @@ QUnit.module("Views", (hooks) => {
             [...getColumn(1).querySelectorAll("[name='category_ids']")].map((el) => el.textContent),
             ["silver", "", "gold"]
         );
-        assert.verifySteps(["unity_web_search_read 4-0"]);
+        assert.verifySteps(["web_search_read 4-0"]);
     });
 
     QUnit.test("update buttons after column creation", async (assert) => {
@@ -9336,8 +9331,8 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -9402,9 +9397,9 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -9455,10 +9450,10 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read_group",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -9485,7 +9480,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.deepEqual(getCardTexts(), ["name", "name", "name", "name"]);
         assert.verifySteps(
-            ["get_views", "unity_web_search_read"],
+            ["get_views", "web_search_read"],
             "no read on progress bar data is done"
         );
     });
@@ -9530,8 +9525,8 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "name_create",
                 "/web/dataset/resequence",
             ]);
@@ -9576,8 +9571,8 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "onchange",
             "name_create",
             "web_read",
@@ -9617,9 +9612,9 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -9662,10 +9657,10 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -9719,11 +9714,11 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "action_archive",
             "web_read_group",
-            "unity_web_search_read",
+            "web_search_read",
             "read_progress_bar",
             "web_read_group",
         ]);
@@ -9774,11 +9769,11 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "action_archive",
                 "web_read_group",
-                "unity_web_search_read",
+                "web_search_read",
                 "read_progress_bar",
                 "web_read_group",
             ]);
@@ -9814,13 +9809,13 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             // reload
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -9857,15 +9852,15 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read_group", // recomputes aggregates
-            "unity_web_search_read",
+            "web_search_read",
             // activate filter
             "web_read_group", // recomputes aggregates
-            "unity_web_search_read",
+            "web_search_read",
             // activate another filter (switching)
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -9920,9 +9915,9 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
+            "web_search_read",
             "write",
             "web_read",
             "read_progress_bar",
@@ -9992,8 +9987,8 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "write",
                 "web_read",
                 "read_progress_bar",
@@ -10032,9 +10027,9 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -10074,8 +10069,8 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "write",
                 "web_read",
                 "read_progress_bar",
@@ -10126,21 +10121,21 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
 
         await click(getColumn(1), ".progress-bar.bg-success");
 
         assert.deepEqual(getTooltips(), ["1 blip", "4 yop", "1 gnap", "1 blip"]);
         assert.deepEqual(getCounters(), ["1", "4"]);
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         // Add searchdomain to something restricting progressbars' values (records still in filtered group)
         await reload(kanban, { domain: [["qux", "=", 100]], groupBy: ["bar"] });
         assert.deepEqual(getTooltips(), ["3 yop"]);
         assert.deepEqual(getCounters(), ["3"]);
-        assert.verifySteps(["web_read_group", "read_progress_bar", "unity_web_search_read"]);
+        assert.verifySteps(["web_read_group", "read_progress_bar", "web_search_read"]);
     });
 
     QUnit.test("progress bar recompute after filter selection (aggregates)", async (assert) => {
@@ -10187,8 +10182,8 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
 
         await click(getColumn(1), ".progress-bar.bg-success");
@@ -10197,14 +10192,14 @@ QUnit.module("Views", (hooks) => {
         assert.deepEqual(getCounters(), ["-4", "610"]);
         assert.verifySteps([
             "web_read_group", // recomputes aggregates
-            "unity_web_search_read",
+            "web_search_read",
         ]);
 
         // Add searchdomain to something restricting progressbars' values (records still in filtered group)
         await reload(kanban, { domain: [["qux", "=", 100]], groupBy: ["bar"] });
         assert.deepEqual(getTooltips(), ["3 yop"]);
         assert.deepEqual(getCounters(), ["600"]);
-        assert.verifySteps(["web_read_group", "read_progress_bar", "unity_web_search_read"]);
+        assert.verifySteps(["web_read_group", "read_progress_bar", "web_search_read"]);
     });
 
     QUnit.test("load more should load correct records after drag&drop event", async (assert) => {
@@ -10290,8 +10285,8 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "get_views",
                 "onchange",
                 "create",
@@ -10363,10 +10358,10 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "web_read_group",
-                "unity_web_search_read",
+                "web_search_read",
                 "get_views",
                 "onchange",
                 "create",
@@ -10467,7 +10462,7 @@ QUnit.module("Views", (hooks) => {
                     </div></t></templates>
                 </kanban>`,
             mockRPC(route, { method, kwargs }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.deepEqual(kwargs.specification, { id: {}, write_date: {} });
                 }
             },
@@ -11353,16 +11348,16 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
+                "web_search_read",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -11449,18 +11444,18 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -11541,9 +11536,9 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "write",
                 "web_read",
                 "read_progress_bar",
@@ -11592,8 +11587,8 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
 
         // Apply an active filter
@@ -11610,7 +11605,7 @@ QUnit.module("Views", (hooks) => {
         );
         assert.containsOnce(target, ".o_kanban_group.o_kanban_group_show .o_kanban_record");
         assert.deepEqual(getCardTexts(1), ["1yop"]);
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         // Drag out its only record onto the first column
         await dragAndDrop(
@@ -11633,7 +11628,7 @@ QUnit.module("Views", (hooks) => {
             "write",
             "web_read",
             "read_progress_bar",
-            "unity_web_search_read",
+            "web_search_read",
             "/web/dataset/resequence",
             "read",
         ]);
@@ -11700,9 +11695,9 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         await click(target.querySelector(".o_kanban_record p"));
-        assert.verifySteps(["doActionButton type object name a1", "unity_web_search_read"]);
+        assert.verifySteps(["doActionButton type object name a1", "web_search_read"]);
     });
 
     QUnit.test("action/type attributes on kanban arch, type='action'", async (assert) => {
@@ -11729,9 +11724,9 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         await click(target.querySelector(".o_kanban_record p"));
-        assert.verifySteps(["doActionButton type action name a1", "unity_web_search_read"]);
+        assert.verifySteps(["doActionButton type action name a1", "web_search_read"]);
     });
 
     QUnit.test("Missing t-key is automatically filled with a warning", async (assert) => {
@@ -12057,12 +12052,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group", 2);
         assert.containsOnce(target, ".o_kanban_group:first-child .o_kanban_record");
         assert.containsN(target, ".o_kanban_group:nth-child(2) .o_kanban_record", 3);
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
     });
 
     QUnit.test("basic rendering with a date groupby with a granularity", async (assert) => {
@@ -12095,12 +12085,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group", 2);
         assert.containsN(target, ".o_kanban_group:first-child .o_kanban_record", 3);
         assert.containsOnce(target, ".o_kanban_group:nth-child(2) .o_kanban_record");
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
     });
 
     QUnit.test("quick create record and click outside (no dirty input)", async (assert) => {
@@ -12410,11 +12395,11 @@ QUnit.module("Views", (hooks) => {
                 "get_views",
                 "web_read_group",
                 "read_progress_bar",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -12494,14 +12479,14 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
+            "web_search_read",
             "write",
             "web_read",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -12527,7 +12512,7 @@ QUnit.module("Views", (hooks) => {
             groupBy: ["bar"],
             mockRPC: async (route, args) => {
                 const { method } = args;
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     await def;
                 }
             },
@@ -12582,7 +12567,7 @@ QUnit.module("Views", (hooks) => {
             domain: [["id", ">", 0]],
             mockRPC: (route, args) => {
                 const { method, kwargs } = args;
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.step(method);
                     assert.deepEqual(kwargs.domain, [
                         "&",
@@ -12610,7 +12595,7 @@ QUnit.module("Views", (hooks) => {
         await click(getProgressBars(0)[0]);
         assert.containsOnce(target, ".o_kanban_record");
 
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test(
@@ -12932,7 +12917,7 @@ QUnit.module("Views", (hooks) => {
             });
 
             assert.strictEqual(target.querySelector("[name=foo] span").innerText, "hello");
-            assert.verifySteps(["get_views", "unity_web_search_read"]);
+            assert.verifySteps(["get_views", "web_search_read"]);
         }
     );
 
@@ -13099,8 +13084,8 @@ QUnit.module("Views", (hooks) => {
             "get_views",
             "web_read_group",
             "read_progress_bar",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "write",
             "web_read",
             "read_progress_bar",
@@ -13185,8 +13170,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group", // initial read_group
-            "unity_web_search_read", // initial search_read (first column)
-            "unity_web_search_read", // initial search_read (second column)
+            "web_search_read", // initial search_read (first column)
+            "web_search_read", // initial search_read (second column)
             "onchange", // quick create
             "name_create", // should perform a name_create to create the record
             "get_views", // load views for form view dialog
@@ -13450,8 +13435,8 @@ QUnit.module("Views", (hooks) => {
             assert.verifySteps([
                 "get_views",
                 "web_read_group",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
             ]);
             assert.deepEqual(
                 [...target.querySelectorAll(".o_kanban_record")].map((el) => el.innerText),

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -1185,11 +1185,11 @@ QUnit.module("Views", (hooks) => {
 
             assert.verifySteps([
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
                 "write",
                 "web_read",
                 "toDo",
-                "unity_web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -1581,7 +1581,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
         assert.containsN(target, ".o_data_row", 4);
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click($(".o_list_button_add:visible").get(0));
         await editInput(target, "[name='int_field'] input", 1);
@@ -1608,7 +1608,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
         assert.containsN(target, ".o_data_row", 4);
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         const rows = target.querySelectorAll(".o_data_row");
         await click(rows[0], ".o_list_record_selector input");
@@ -1795,7 +1795,7 @@ QUnit.module("Views", (hooks) => {
 
             await click($(".o_list_button_add:visible").get(0));
             assert.verifySteps(
-                ["get_views", "unity_web_search_read", "onchange"],
+                ["get_views", "web_search_read", "onchange"],
                 "no nameget should be done"
             );
         }
@@ -2489,7 +2489,7 @@ QUnit.module("Views", (hooks) => {
                     <field name="date"/>
                 </tree>`,
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     if (searchReads === 0) {
                         assert.strictEqual(
                             args.kwargs.order,
@@ -2760,9 +2760,9 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         await click(target.querySelector(".o_data_cell"));
-        assert.verifySteps(["doActionButton type object name a1", "unity_web_search_read"]);
+        assert.verifySteps(["doActionButton type object name a1", "web_search_read"]);
     });
 
     QUnit.test("action/type attributes on tree arch, type='action'", async (assert) => {
@@ -2783,9 +2783,9 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         await click(target.querySelector(".o_data_cell"));
-        assert.verifySteps(["doActionButton type action name a1", "unity_web_search_read"]);
+        assert.verifySteps(["doActionButton type action name a1", "web_search_read"]);
     });
 
     QUnit.test("editable list view: readonly fields cannot be edited", async function (assert) {
@@ -4415,7 +4415,7 @@ QUnit.module("Views", (hooks) => {
                             `web_read_group.orderby: ${args.kwargs.orderby || "default order"}`
                         );
                     }
-                    if (method === "unity_web_search_read") {
+                    if (method === "web_search_read") {
                         assert.step(
                             `web_search_read.order: ${args.kwargs.order || "default order"}`
                         );
@@ -4464,7 +4464,7 @@ QUnit.module("Views", (hooks) => {
                             `web_read_group.orderby: ${args.kwargs.orderby || "default order"}`
                         );
                     }
-                    if (method === "unity_web_search_read") {
+                    if (method === "web_search_read") {
                         assert.step(
                             `web_search_read.orderby: ${args.kwargs.order || "default order"}`
                         );
@@ -5953,7 +5953,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.verifySteps([
             "/web/dataset/call_kw/foo/get_views",
-            "/web/dataset/call_kw/foo/unity_web_search_read",
+            "/web/dataset/call_kw/foo/web_search_read",
         ]);
         await toggleActionMenu(target);
         await toggleMenuItem(target, "Archive");
@@ -5982,7 +5982,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, "tbody td.o_list_record_selector", 3, "should have 3 records");
         assert.verifySteps([
             "/web/dataset/call_kw/foo/action_archive",
-            "/web/dataset/call_kw/foo/unity_web_search_read",
+            "/web/dataset/call_kw/foo/web_search_read",
         ]);
     });
 
@@ -6315,7 +6315,7 @@ QUnit.module("Views", (hooks) => {
                     <filter name="bar" string="bar" context="{'group_by': 'bar'}"/>
                 </search>`,
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.limit, 80, "default limit should be 80 in List");
                 }
             },
@@ -6339,7 +6339,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
             },
@@ -6348,7 +6348,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_limit"));
         assert.containsN(target, ".o_data_row", 2);
@@ -6358,7 +6358,7 @@ QUnit.module("Views", (hooks) => {
 
         expectedCountLimit = undefined;
         await click(target.querySelector(".o_pager_next"));
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, click next", async function (assert) {
@@ -6372,7 +6372,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
             },
@@ -6381,14 +6381,14 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         expectedCountLimit = 5;
         await click(target.querySelector(".o_pager_next"));
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "3-4");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, click next (2)", async (assert) => {
@@ -6403,7 +6403,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
             },
@@ -6412,21 +6412,21 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         expectedCountLimit = 5;
         await click(target.querySelector(".o_pager_next"));
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "3-4");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4+");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         expectedCountLimit = 7;
         await click(target.querySelector(".o_pager_next"));
         assert.containsOnce(target, ".o_data_row");
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "5-5");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, click previous", async (assert) => {
@@ -6441,7 +6441,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
             },
@@ -6450,14 +6450,14 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         expectedCountLimit = undefined;
         await click(target.querySelector(".o_pager_previous"));
         assert.containsOnce(target, ".o_data_row");
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "5-5");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5");
-        assert.verifySteps(["search_count", "unity_web_search_read"]);
+        assert.verifySteps(["search_count", "web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count limit reached, edit pager", async (assert) => {
@@ -6472,7 +6472,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
             },
@@ -6481,7 +6481,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         expectedCountLimit = 5;
         await click(target, ".o_pager_value");
@@ -6489,7 +6489,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 3);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "2-4");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4+");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         expectedCountLimit = 15;
         await click(target, ".o_pager_value");
@@ -6497,7 +6497,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 4);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "2-5");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, with count equals count limit", async function (assert) {
@@ -6516,7 +6516,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "4");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
     });
 
     QUnit.test("pager, ungrouped, reload while fetching count", async function (assert) {
@@ -6539,7 +6539,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_limit"));
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
@@ -6549,7 +6549,7 @@ QUnit.module("Views", (hooks) => {
         await reloadListView(target);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         def.resolve();
         await nextTick();
@@ -6572,7 +6572,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2"><field name="foo"/><field name="bar"/></tree>',
             async mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     await def;
                 }
             },
@@ -6581,7 +6581,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         def = makeDeferred();
         await click(target.querySelector(".o_pager_next")); // this request will be pending
@@ -6589,7 +6589,7 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "5+");
         // can't fetch count simultaneously as it is temporarily disabled while updating
         assert.hasClass(target.querySelector(".o_pager_limit"), "disabled");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         def.resolve();
         await nextTick();
@@ -6659,7 +6659,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree limit="2" count_limit="3"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
                 assert.step(args.method);
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.count_limit, expectedCountLimit);
                 }
             },
@@ -6668,7 +6668,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_data_row", 2);
         assert.strictEqual(target.querySelector(".o_pager_value").innerText, "1-2");
         assert.strictEqual(target.querySelector(".o_pager_limit").innerText, "3+");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         await click(target.querySelector(".o_pager_limit"));
         assert.containsN(target, ".o_data_row", 2);
@@ -6678,7 +6678,7 @@ QUnit.module("Views", (hooks) => {
 
         expectedCountLimit = undefined;
         await click(target.querySelector(".o_pager_next"));
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
     });
 
     QUnit.test(
@@ -6792,7 +6792,7 @@ QUnit.module("Views", (hooks) => {
 
         const offsets = [0, 1, 1];
         const mockRPC = async (route, args) => {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 assert.strictEqual(args.kwargs.offset, offsets.shift());
             }
         };
@@ -6874,7 +6874,7 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: '<tree><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     nbSearchRead++;
                 }
             },
@@ -6925,7 +6925,7 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: '<tree><field name="foo" nolabel="1"/><field name="int_field"/></tree>',
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     nbSearchRead++;
                 }
             },
@@ -6952,7 +6952,7 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: '<tree default_order="foo"><field name="foo"/><field name="bar"/></tree>',
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(
                         args.kwargs.order,
                         "foo ASC",
@@ -6984,7 +6984,7 @@ QUnit.module("Views", (hooks) => {
                 '<field name="foo"/><field name="bar"/>' +
                 "</tree>",
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(
                         args.kwargs.order,
                         "foo ASC, bar DESC, int_field ASC",
@@ -7205,7 +7205,7 @@ QUnit.module("Views", (hooks) => {
                 assert.step(args.method);
             },
         });
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), [
             "2 records",
             "3 records",
@@ -7992,7 +7992,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         assert.containsOnce(
             target,
             "thead th:not(.o_list_record_selector)",
@@ -8010,7 +8010,7 @@ QUnit.module("Views", (hooks) => {
             "there should be no button in the header"
         );
         await click(target, ".o_group_header:first-child");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
         assert.containsOnce(target, ".o_group_header button");
 
         await click(target, ".o_group_header:first-child button");
@@ -8071,12 +8071,12 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_data_row");
 
         await click(target, ".o_group_header:nth-child(2)");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
         assert.containsNone(target, ".o_group_header button");
         assert.containsN(target, ".o_data_row", 1);
 
         await click(target, ".o_group_header:first-child");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
         assert.containsOnce(target, ".o_group_header button");
         assert.containsN(target, ".o_data_row", 4);
     });
@@ -8115,8 +8115,8 @@ QUnit.module("Views", (hooks) => {
             assert.verifySteps([
                 "get_views",
                 "web_read_group",
-                "unity_web_search_read",
-                "unity_web_search_read",
+                "web_search_read",
+                "web_search_read",
                 "web_read",
             ]);
         }
@@ -8590,8 +8590,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps(
             [
                 "/web/dataset/call_kw/foo/get_views",
-                "/web/dataset/call_kw/foo/unity_web_search_read",
-                "/web/dataset/call_kw/foo/unity_web_search_read",
+                "/web/dataset/call_kw/foo/web_search_read",
+                "/web/dataset/call_kw/foo/web_search_read",
             ],
             "should have reloaded the view (after the action is complete)"
         );
@@ -8758,7 +8758,7 @@ QUnit.module("Views", (hooks) => {
                         );
                     }
                     nbRPCs.readGroup++;
-                } else if (args.method === "unity_web_search_read") {
+                } else if (args.method === "web_search_read") {
                     // called twice (once when opening the group, once when sorting)
                     assert.deepEqual(
                         args.kwargs.domain,
@@ -9351,7 +9351,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
         assert.containsN(target, "tr.o_data_row", 4);
 
         // click on 3rd line
@@ -9423,7 +9423,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.verifySteps([
             "/web/dataset/call_kw/foo/get_views",
-            "/web/dataset/call_kw/foo/unity_web_search_read",
+            "/web/dataset/call_kw/foo/web_search_read",
             "/web/dataset/call_kw/foo/write",
             "/web/dataset/call_kw/foo/web_read",
             "/web/dataset/call_kw/foo/onchange",
@@ -9486,13 +9486,7 @@ QUnit.module("Views", (hooks) => {
             "5th row should be selected"
         );
 
-        assert.verifySteps([
-            "get_views",
-            "unity_web_search_read",
-            "write",
-            "web_read",
-            "onchange",
-        ]);
+        assert.verifySteps(["get_views", "web_search_read", "write", "web_read", "onchange"]);
     });
 
     QUnit.test("display toolbar", async function (assert) {
@@ -9571,9 +9565,9 @@ QUnit.module("Views", (hooks) => {
 
         assert.verifySteps([
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             `{"action_id":44,"context":{"lang":"en","uid":7,"tz":"taht","active_id":1,"active_ids":[1,2,3,4],"active_model":"foo","active_domain":[]}}`,
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -10103,7 +10097,7 @@ QUnit.module("Views", (hooks) => {
                 1,
                 "should have the new value visible in dom"
             );
-            assert.verifySteps(["get_views", "unity_web_search_read", "write", "web_read"]);
+            assert.verifySteps(["get_views", "web_search_read", "write", "web_read"]);
         }
     );
 
@@ -11152,12 +11146,7 @@ QUnit.module("Views", (hooks) => {
                 assert.step(args.method || route);
             },
         });
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
         assert.containsN(target, ".o_group_header", 2);
         const allNames = Array.from(
             target.querySelectorAll(".o_data_cell"),
@@ -11234,12 +11223,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
         await click(target.querySelectorAll(".o_data_row .o_list_record_selector input")[0]);
         await click(target.querySelectorAll(".o_data_row .o_list_record_selector input")[1]);
         await click(target.querySelectorAll(".o_data_row .o_list_record_selector input")[2]);
@@ -11620,7 +11604,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         // select two records
         const rows = target.querySelectorAll(".o_data_row");
@@ -11768,7 +11752,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         // select and edit a single record
         const rows = target.querySelectorAll(".o_data_row");
@@ -12079,7 +12063,7 @@ QUnit.module("Views", (hooks) => {
                 "gnap",
                 "blip",
             ]);
-            assert.verifySteps(["get_views", "unity_web_search_read", "write", "web_read"]);
+            assert.verifySteps(["get_views", "web_search_read", "write", "web_read"]);
         }
     );
 
@@ -12206,7 +12190,7 @@ QUnit.module("Views", (hooks) => {
                 },
             });
 
-            assert.verifySteps(["get_views", "unity_web_search_read"]);
+            assert.verifySteps(["get_views", "web_search_read"]);
             // select two records
             const rows = target.querySelectorAll(".o_data_row");
             await click(rows[0], ".o_list_record_selector input");
@@ -12677,7 +12661,7 @@ QUnit.module("Views", (hooks) => {
             resModel: "foo",
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         // select two records
         const rows = target.querySelectorAll(".o_data_row");
@@ -13065,7 +13049,7 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: '<tree limit="2"><field name="foo"/></tree>',
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     assert.strictEqual(args.kwargs.limit, 2, "should use the correct limit value");
                 }
             },
@@ -13084,7 +13068,7 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: '<tree><field name="foo"/></tree>',
             mockRPC: async function (route, args) {
-                if (args.method === "unity_web_search_read" && blockSearchRead) {
+                if (args.method === "web_search_read" && blockSearchRead) {
                     await def;
                 }
             },
@@ -13148,7 +13132,7 @@ QUnit.module("Views", (hooks) => {
                 serverData,
                 arch: '<tree limit="3"><field name="display_name"/></tree>',
                 mockRPC(route, args) {
-                    if (checkSearchRead && args.method === "unity_web_search_read") {
+                    if (checkSearchRead && args.method === "web_search_read") {
                         assert.strictEqual(args.kwargs.limit, 3, "limit should 3");
                         assert.notOk(
                             args.kwargs.offset,
@@ -13193,7 +13177,7 @@ QUnit.module("Views", (hooks) => {
                 serverData,
                 arch: '<tree limit="2"><field name="display_name"/></tree>',
                 mockRPC(route, args) {
-                    if (checkSearchRead && args.method === "unity_web_search_read") {
+                    if (checkSearchRead && args.method === "web_search_read") {
                         assert.strictEqual(args.kwargs.limit, 2, "limit should 2");
                         assert.notOk(
                             args.kwargs.offset,
@@ -13590,12 +13574,7 @@ QUnit.module("Views", (hooks) => {
             ["blip", "yop", "blip", "gnap"]
         );
 
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
     });
 
     QUnit.test("grouped list with dynamic expand attribute (eval true)", async function (assert) {
@@ -14299,8 +14278,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "write",
             "web_read",
             "onchange",
@@ -14351,7 +14330,7 @@ QUnit.module("Views", (hooks) => {
             assert.verifySteps([
                 "get_views",
                 "web_read_group",
-                "unity_web_search_read",
+                "web_search_read",
                 "write",
                 "web_read",
             ]);
@@ -14395,8 +14374,8 @@ QUnit.module("Views", (hooks) => {
         assert.verifySteps([
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "onchange",
         ]);
     });
@@ -14434,12 +14413,7 @@ QUnit.module("Views", (hooks) => {
 
         assert.hasClass(target.querySelectorAll(".o_data_row")[2], "o_selected_row");
 
-        assert.verifySteps([
-            "get_views",
-            "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
-        ]);
+        assert.verifySteps(["get_views", "web_read_group", "web_search_read", "web_search_read"]);
     });
 
     QUnit.test(
@@ -14467,7 +14441,7 @@ QUnit.module("Views", (hooks) => {
             await click(secondGroupHeader);
             assert.containsN(target, ".o_data_row", 4);
             assert.containsNone(target, ".o_selected_row");
-            assert.verifySteps(["unity_web_search_read", "unity_web_search_read"]);
+            assert.verifySteps(["web_search_read", "web_search_read"]);
 
             // Click on first data row
             const dataRows = [...target.querySelectorAll(".o_data_row")];
@@ -17691,7 +17665,7 @@ QUnit.module("Views", (hooks) => {
             });
 
             assert.strictEqual(target.querySelector("[name=foo] span").innerText, "1");
-            assert.verifySteps(["get_views", "unity_web_search_read"]);
+            assert.verifySteps(["get_views", "web_search_read"]);
         }
     );
 
@@ -17746,7 +17720,7 @@ QUnit.module("Views", (hooks) => {
             },
         });
 
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
 
         const value = "14";
         // add a new line
@@ -19116,13 +19090,13 @@ QUnit.module("Views", (hooks) => {
 
         assert.verifySteps([
             "/web/dataset/call_kw/foo/get_views",
-            "/web/dataset/call_kw/foo/unity_web_search_read",
+            "/web/dataset/call_kw/foo/web_search_read",
         ]);
 
         await toggleSearchBarMenu(target);
         await toggleMenuItem(target, "only one");
 
-        assert.verifySteps(["/web/dataset/call_kw/foo/unity_web_search_read"]);
+        assert.verifySteps(["/web/dataset/call_kw/foo/web_search_read"]);
     });
 
     QUnit.test("do not reload properties definitions when page change", async (assert) => {
@@ -19155,12 +19129,12 @@ QUnit.module("Views", (hooks) => {
 
         assert.verifySteps([
             "/web/dataset/call_kw/foo/get_views",
-            "/web/dataset/call_kw/foo/unity_web_search_read",
+            "/web/dataset/call_kw/foo/web_search_read",
         ]);
 
         await pagerNext(target);
 
-        assert.verifySteps(["/web/dataset/call_kw/foo/unity_web_search_read"]);
+        assert.verifySteps(["/web/dataset/call_kw/foo/web_search_read"]);
     });
 
     QUnit.test("load properties definitions only once when grouped", async (assert) => {
@@ -19198,7 +19172,7 @@ QUnit.module("Views", (hooks) => {
         ]);
 
         await click(target.querySelector(".o_group_header"));
-        assert.verifySteps(["/web/dataset/call_kw/foo/unity_web_search_read"]);
+        assert.verifySteps(["/web/dataset/call_kw/foo/web_search_read"]);
     });
 
     QUnit.test("Invisible Properties", async (assert) => {
@@ -19230,7 +19204,7 @@ QUnit.module("Views", (hooks) => {
         });
 
         assert.containsNone(target, ".o_optional_columns_dropdown_toggle");
-        assert.verifySteps(["get_views", "unity_web_search_read"]);
+        assert.verifySteps(["get_views", "web_search_read"]);
     });
 
     QUnit.test("header buttons in list view", async function (assert) {
@@ -19294,7 +19268,7 @@ QUnit.module("Views", (hooks) => {
         const webclient = await createWebClient({
             serverData,
             async mockRPC(route, { kwargs, method }) {
-                if (method === "unity_web_search_read") {
+                if (method === "web_search_read") {
                     assert.step("order:" + kwargs.order);
                 }
             },
@@ -19444,7 +19418,7 @@ QUnit.module("Views", (hooks) => {
         await doAction(wc, 1);
         assert.verifySteps([
             `foo: get_views: {"lang":"en","uid":7,"tz":"taht","tree_view_ref":"foo_view_ref","search_default_bar":true}`,
-            `foo: unity_web_search_read: {"lang":"en","uid":7,"tz":"taht","bin_size":true,"tree_view_ref":"foo_view_ref"}`,
+            `foo: web_search_read: {"lang":"en","uid":7,"tz":"taht","bin_size":true,"tree_view_ref":"foo_view_ref"}`,
         ]);
 
         await click(target.querySelectorAll(".o_data_row .o_data_cell")[1]);
@@ -19461,7 +19435,7 @@ QUnit.module("Views", (hooks) => {
         await click(items.find((el) => el.textContent.trim() === "View all"));
         assert.verifySteps([
             `bar: get_views: {"lang":"en","uid":7,"tz":"taht"}`,
-            `bar: unity_web_search_read: {"lang":"en","uid":7,"tz":"taht","bin_size":true}`,
+            `bar: web_search_read: {"lang":"en","uid":7,"tz":"taht","bin_size":true}`,
         ]);
         assert.containsOnce(target, ".modal");
         assert.strictEqual(
@@ -19560,7 +19534,7 @@ QUnit.module("Views", (hooks) => {
             arch: '<tree sample="1" editable="top"><field name="int_field"/></tree>',
             noContentHelp: "click to add a record",
             mockRPC(route, args) {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     return def;
                 }
             },

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -4071,8 +4071,8 @@ QUnit.module("Views", (hooks) => {
                     }
                     readGroupCount++;
                 }
-                if (args.method === "unity_web_search_read") {
-                    assert.step("unity_web_search_read");
+                if (args.method === "web_search_read") {
+                    assert.step("web_search_read");
                     const domain = args.kwargs.domain;
                     assert.deepEqual(
                         domain,
@@ -4105,7 +4105,7 @@ QUnit.module("Views", (hooks) => {
                 "read_group",
                 "read_group",
                 "read_group",
-                "unity_web_search_read",
+                "web_search_read",
                 "read_group",
                 "read_group",
             ]);
@@ -4739,7 +4739,7 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelector(".o_control_panel .o_switch_view.o_list"));
 
         assert.containsOnce(target, ".o_list_view");
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         // switch back to pivot
         await click(target.querySelector(".o_control_panel .o_switch_view.o_pivot"));

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog_tests.js
@@ -130,7 +130,7 @@ QUnit.module("ViewDialogs", (hooks) => {
                         },
                         "should search with the complete domain (domain + search), and group by 'bar'"
                     );
-                } else if (args.method === "unity_web_search_read") {
+                } else if (args.method === "web_search_read") {
                     if (search === 0) {
                         assert.deepEqual(
                             args.kwargs,
@@ -212,7 +212,7 @@ QUnit.module("ViewDialogs", (hooks) => {
                 `,
         };
         const mockRPC = async (route, args) => {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 assert.deepEqual(
                     args.kwargs.domain,
                     [["id", "=", 2]],

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -377,8 +377,8 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("open a record while reloading the list view", async function (assert) {
         assert.expect(10);
         let def;
-        const mockRPC = async function (route) {
-            if (route === "/web/dataset/search_read") {
+        const mockRPC = async function (route, args) {
+            if (args.method === "unity_web_search_read") {
                 await def;
             }
         };

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -63,7 +63,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/action/load",
             "/web/action/load",
             "/web/dataset/call_kw/pony/get_views",
-            "/web/dataset/call_kw/pony/unity_web_search_read",
+            "/web/dataset/call_kw/pony/web_search_read",
         ]);
     });
 
@@ -73,7 +73,7 @@ QUnit.module("ActionManager", (hooks) => {
         const defs = [Promise.resolve(), def, Promise.resolve()];
         const mockRPC = async function (route, { method }) {
             assert.step(route);
-            if (method === "unity_web_search_read") {
+            if (method === "web_search_read") {
                 await defs.shift();
             }
         };
@@ -89,9 +89,9 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "/web/dataset/call_kw/partner/get_views",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
         ]);
         // we resolve def => list view is now ready (but we want to ignore it)
         def.resolve();
@@ -150,7 +150,7 @@ QUnit.module("ActionManager", (hooks) => {
             let def;
             const mockRPC = async function (route, { method, model }) {
                 assert.step(method || route);
-                if (method === "unity_web_search_read" && model === "partner") {
+                if (method === "web_search_read" && model === "partner") {
                     await def;
                 }
             };
@@ -178,10 +178,10 @@ QUnit.module("ActionManager", (hooks) => {
                 "/web/action/load",
                 "get_views",
                 "web_read",
-                "unity_web_search_read",
+                "web_search_read",
                 "/web/action/load",
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
             ]);
             // unblock the switch to Kanban in action 4
             def.resolve();
@@ -226,12 +226,12 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
             "object",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
         // unblock the call_button request
         def.resolve();
@@ -287,11 +287,11 @@ QUnit.module("ActionManager", (hooks) => {
                 "/web/webclient/load_menus",
                 "/web/action/load",
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
                 "web_read",
                 "/web/action/load",
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
             ]);
             // unblock the switch to the form view in action 3
             def.resolve();
@@ -338,7 +338,7 @@ QUnit.module("ActionManager", (hooks) => {
             "get_views",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -347,7 +347,7 @@ QUnit.module("ActionManager", (hooks) => {
         const def = makeDeferred();
         const mockRPC = async function (route, { method }) {
             assert.step(method || route);
-            if (method === "unity_web_search_read") {
+            if (method === "web_search_read") {
                 await def;
             }
         };
@@ -367,10 +367,10 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -378,7 +378,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.expect(10);
         let def;
         const mockRPC = async function (route, args) {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 await def;
             }
         };
@@ -459,10 +459,10 @@ QUnit.module("ActionManager", (hooks) => {
                 "/web/webclient/load_menus",
                 "/web/action/load",
                 "get_views",
-                "unity_web_search_read",
+                "web_search_read",
                 "web_read",
                 "/web/action/load",
-                "unity_web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -493,9 +493,9 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "/web/action/load",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -525,10 +525,10 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -538,7 +538,7 @@ QUnit.module("ActionManager", (hooks) => {
         const defs = [null, def, null];
         const mockRPC = async (route, { method }) => {
             assert.step(method || route);
-            if (method === "unity_web_search_read") {
+            if (method === "web_search_read") {
                 await Promise.resolve(defs.shift());
             }
         };
@@ -557,11 +557,11 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
         ]);
     });
 

--- a/addons/web/static/tests/webclient/actions/error_handling_tests.js
+++ b/addons/web/static/tests/webclient/actions/error_handling_tests.js
@@ -26,7 +26,7 @@ QUnit.module("ActionManager", (hooks) => {
         Boom.template = xml`<div><t t-esc="a.b.c"/></div>`;
         actionRegistry.add("Boom", Boom);
         const mockRPC = (route, args) => {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 assert.step("web_search_read");
             }
         };

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -226,7 +226,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -311,7 +311,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -346,7 +346,7 @@ QUnit.module("ActionManager", (hooks) => {
                 "/web/action/load",
                 "get_views",
                 "web_read",
-                "unity_web_search_read",
+                "web_search_read",
             ]);
         }
     );
@@ -426,8 +426,8 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read",
         ]);
     });
@@ -460,7 +460,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
             "web_read",
         ]);
@@ -531,10 +531,10 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "setItem session current_action",
             "getItem session current_action",
-            "unity_web_search_read",
+            "web_search_read",
             "setItem session current_action",
         ]);
     });
@@ -559,7 +559,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "/web/dataset/call_kw/partner/get_views",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
         ]);
     });
 
@@ -600,7 +600,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "/web/dataset/call_kw/partner/get_views",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
         ]);
     });
 

--- a/addons/web/static/tests/webclient/actions/push_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/push_state_tests.js
@@ -205,7 +205,7 @@ QUnit.module("ActionManager", (hooks) => {
     QUnit.test("push state after action is loaded, not before", async function (assert) {
         const def = makeDeferred();
         const mockRPC = async function (route, args) {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 await def;
             }
         };

--- a/addons/web/static/tests/webclient/actions/server_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/server_action_tests.js
@@ -33,7 +33,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/action/run",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -68,7 +68,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -133,11 +133,11 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
+            "web_search_read",
             "web_read",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -183,8 +183,8 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/action/load",
             "get_views",
             "web_read_group",
-            "unity_web_search_read",
-            "unity_web_search_read",
+            "web_search_read",
+            "web_search_read",
             "onchange",
             "name_create",
             "web_read",
@@ -215,7 +215,7 @@ QUnit.module("ActionManager", (hooks) => {
             ];
             let searchReadCount = 1;
             const mockRPC = async (route, args) => {
-                if (args.method === "unity_web_search_read") {
+                if (args.method === "web_search_read") {
                     args = args || {};
                     if (searchReadCount === 1) {
                         assert.strictEqual(args.model, "partner");
@@ -708,9 +708,9 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "onchange",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -764,7 +764,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
             "object",
             "web_read",
@@ -899,11 +899,11 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -913,8 +913,8 @@ QUnit.module("ActionManager", (hooks) => {
                 assert.step("web_read");
                 assert.notOk("default_partner" in kwargs.context);
             }
-            if (method === "unity_web_search_read") {
-                assert.step("unity_web_search_read");
+            if (method === "web_search_read") {
+                assert.step("web_search_read");
                 assert.strictEqual(kwargs.context.default_partner, 2);
             }
         };
@@ -927,14 +927,14 @@ QUnit.module("ActionManager", (hooks) => {
         await testUtils.dom.click(target.querySelector(".breadcrumb-item"));
         assert.containsOnce(target, ".o_form_view");
         assert.containsOnce(target, ".o_form_button_create:not([disabled]):visible");
-        assert.verifySteps(["web_read", "unity_web_search_read", "web_read"]);
+        assert.verifySteps(["web_read", "web_search_read", "web_read"]);
     });
 
     QUnit.test("execute smart button and fails", async function (assert) {
         assert.expect(13);
         const mockRPC = async (route, { method }) => {
             assert.step(method || route);
-            if (method === "unity_web_search_read") {
+            if (method === "web_search_read") {
                 return Promise.reject();
             }
         };
@@ -952,7 +952,7 @@ QUnit.module("ActionManager", (hooks) => {
             "web_read",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
         ]);
     });
@@ -1058,9 +1058,9 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
-            "unity_web_search_read",
+            "web_search_read",
             "web_read",
         ]);
     });
@@ -1191,7 +1191,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "/web/dataset/call_kw/partner/get_views",
-            "/web/dataset/call_kw/partner/unity_web_search_read",
+            "/web/dataset/call_kw/partner/web_search_read",
             "/web/dataset/call_kw/partner/web_read",
             "/web/dataset/call_kw/partner/get_formview_action",
             "/web/dataset/call_kw/partner/get_views",
@@ -1355,7 +1355,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
         ]);
     });
 
@@ -1540,7 +1540,7 @@ QUnit.module("ActionManager", (hooks) => {
             },
         ];
         const mockRPC = (route, args) => {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 assert.deepEqual(args.kwargs.domain, [["bar", "=", 1]]);
             }
         };
@@ -1662,7 +1662,7 @@ QUnit.module("ActionManager", (hooks) => {
             "/web/webclient/load_menus",
             "/web/action/load",
             "get_views",
-            "unity_web_search_read",
+            "web_search_read",
             "onchange",
             "get_formview_action",
             "create", // FIXME: to check with mcm
@@ -1895,7 +1895,7 @@ QUnit.module("ActionManager", (hooks) => {
         // because of how native events are handled in tests
         const searchPromise = testUtils.makeTestPromise();
         const mockRPC = async (route, args) => {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 assert.step("search_read " + args.kwargs.domain);
                 if (JSON.stringify(args.domain) === JSON.stringify([["foo", "ilike", "m"]])) {
                     await searchPromise;
@@ -2113,7 +2113,7 @@ QUnit.module("ActionManager", (hooks) => {
             sections: [],
         });
         const mockRPC = async (route, args) => {
-            if (args.method === "unity_web_search_read") {
+            if (args.method === "web_search_read") {
                 assert.deepEqual(args.kwargs.domain, [["id", "=", 99]]);
             }
         };
@@ -2200,18 +2200,18 @@ QUnit.module("ActionManager", (hooks) => {
 
         await doAction(webClient, 1);
         assert.containsOnce(target, ".o_kanban_view");
-        assert.verifySteps(["/web/action/load", "get_views", "unity_web_search_read"]);
+        assert.verifySteps(["/web/action/load", "get_views", "web_search_read"]);
 
         await doAction(webClient, 1);
         assert.containsOnce(target, ".o_kanban_view");
 
-        assert.verifySteps(["unity_web_search_read"]);
+        assert.verifySteps(["web_search_read"]);
 
         await webClient.env.services.orm.unlink("ir.actions.act_window", [333]);
         assert.verifySteps(["unlink"]);
         await doAction(webClient, 1);
         // cache was cleared => reload the action
-        assert.verifySteps(["/web/action/load", "unity_web_search_read"]);
+        assert.verifySteps(["/web/action/load", "web_search_read"]);
     });
 
     QUnit.test("pushState also changes the title of the tab", async (assert) => {
@@ -2477,7 +2477,7 @@ QUnit.module("ActionManager", (hooks) => {
             .add("odoo.exceptions.ValidationError", WarningDialogWait);
 
         const mockRPC = (route, args) => {
-            if (args.method === "unity_web_search_read" && args.model === "partner") {
+            if (args.method === "web_search_read" && args.model === "partner") {
                 throw makeServerError({ type: "ValidationError" });
             }
         };

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -416,7 +416,7 @@ QUnit.module("SettingsFormView", (hooks) => {
                 "create", // create the record before doing the action
                 "web_read", // read the created record
                 "get_views", // for other action in breadcrumb,
-                "unity_web_search_read", // with a searchread
+                "web_search_read", // with a searchread
                 "onchange", // when we come back, we want to restart from scratch
             ]);
         }

--- a/addons/web/tests/test_web_search_read.py
+++ b/addons/web/tests/test_web_search_read.py
@@ -12,29 +12,6 @@ class TestWebSearchRead(common.TransactionCase):
         cls.ResCurrency = cls.env['res.currency'].with_context(active_test=False)
         cls.max = cls.ResCurrency.search_count([])
 
-    def assert_web_search_read(self, expected_length, expected_records_length, expected_search_count_called=True, **kwargs):
-        original_search_count = self.ResCurrency.search_count
-        search_count_called = [False]
-
-        def search_count(obj, *method_args, **method_kwargs):
-            search_count_called[0] = True
-            return original_search_count(*method_args, **method_kwargs)
-
-        with patch('odoo.addons.base.models.res_currency.Currency.search_count', new=search_count):
-            results = self.ResCurrency.web_search_read(domain=[], fields=['id'], **kwargs)
-
-        self.assertEqual(results['length'], expected_length)
-        self.assertEqual(len(results['records']), expected_records_length)
-        self.assertEqual(search_count_called[0], expected_search_count_called)
-
-    def test_web_search_read(self):
-        self.assert_web_search_read(self.max, self.max, expected_search_count_called=False)
-        self.assert_web_search_read(self.max, 2, limit=2)
-        self.assert_web_search_read(self.max, 2, limit=2, offset=10)
-        self.assert_web_search_read(2, 2, limit=2, count_limit=2, expected_search_count_called=False)
-        self.assert_web_search_read(20, 2, limit=2, offset=10, count_limit=20)
-        self.assert_web_search_read(12, 2, limit=2, offset=10, count_limit=12, expected_search_count_called=False)
-
     def assert_unity_web_search_read(self, expected_length, expected_records_length, expected_search_count_called=True,
                                **kwargs):
         original_search_count = self.ResCurrency.search_count

--- a/addons/web/tests/test_web_search_read.py
+++ b/addons/web/tests/test_web_search_read.py
@@ -12,7 +12,7 @@ class TestWebSearchRead(common.TransactionCase):
         cls.ResCurrency = cls.env['res.currency'].with_context(active_test=False)
         cls.max = cls.ResCurrency.search_count([])
 
-    def assert_unity_web_search_read(self, expected_length, expected_records_length, expected_search_count_called=True,
+    def assert_web_search_read(self, expected_length, expected_records_length, expected_search_count_called=True,
                                **kwargs):
         original_search_count = self.ResCurrency.search_count
         search_count_called = [False]
@@ -22,16 +22,16 @@ class TestWebSearchRead(common.TransactionCase):
             return original_search_count(*method_args, **method_kwargs)
 
         with patch('odoo.addons.base.models.res_currency.Currency.search_count', new=search_count):
-            results = self.ResCurrency.unity_web_search_read(domain=[], specification={'id':{}}, **kwargs)
+            results = self.ResCurrency.web_search_read(domain=[], specification={'id':{}}, **kwargs)
 
         self.assertEqual(results['length'], expected_length)
         self.assertEqual(len(results['records']), expected_records_length)
         self.assertEqual(search_count_called[0], expected_search_count_called)
 
     def test_unity_web_search_read(self):
-        self.assert_unity_web_search_read(self.max, self.max, expected_search_count_called=False)
-        self.assert_unity_web_search_read(self.max, 2, limit=2)
-        self.assert_unity_web_search_read(self.max, 2, limit=2, offset=10)
-        self.assert_unity_web_search_read(2, 2, limit=2, count_limit=2, expected_search_count_called=False)
-        self.assert_unity_web_search_read(20, 2, limit=2, offset=10, count_limit=20)
-        self.assert_unity_web_search_read(12, 2, limit=2, offset=10, count_limit=12, expected_search_count_called=False)
+        self.assert_web_search_read(self.max, self.max, expected_search_count_called=False)
+        self.assert_web_search_read(self.max, 2, limit=2)
+        self.assert_web_search_read(self.max, 2, limit=2, offset=10)
+        self.assert_web_search_read(2, 2, limit=2, count_limit=2, expected_search_count_called=False)
+        self.assert_web_search_read(20, 2, limit=2, offset=10, count_limit=20)
+        self.assert_web_search_read(12, 2, limit=2, offset=10, count_limit=12, expected_search_count_called=False)

--- a/odoo/addons/test_new_api/tests/test_unity_read.py
+++ b/odoo/addons/test_new_api/tests/test_unity_read.py
@@ -83,8 +83,8 @@ class TestUnityRead(TransactionCase):
     def test_many2one_query_count(self):
         with self.assertQueryCount(1        # 1 query for the search of the domain and read course fields
                                    + 1):    # 1 query to read the data of the author
-            self.course.unity_web_search_read(domain=(),
-                                              specification={'display_name': {}, 'author_id': {'fields': {'write_date': {}}}})
+            self.course.web_search_read(domain=(),
+                                        specification={'display_name': {}, 'author_id': {'fields': {'write_date': {}}}})
 
     def test_read_many2one_throws_if_it_cannot_read_extra_fields(self):
         with self.assertRaises(AccessError):


### PR DESCRIPTION
This PR updates the few last occurrences of calls to the web_search_read method such that they now call unity_web_search_read, and replaces the implementation of web_search_read by the unity one.

This PR also removes the /web/dataset/search_read controller which was basically an indirection to the web_search_read method.

Part of task~3179751