### PR TITLE
[IMP] web: speedup the clickbot

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -121,7 +121,7 @@
      */
     function waitForCondition(stopCondition, tl = 30000) {
         return new Promise(function (resolve, reject) {
-            const interval = 250;
+            const interval = 25;
             let timeLimit = tl;
 
             function checkCondition() {


### PR DESCRIPTION
Reducing the interval between the condition check will increase the speed.
When the condition is fulfilled faster than 250 ms there is no need to wait longer.
