### PR TITLE
[FIX] sale_timesheet: Fix browse in _default_invoicing_timesheet_enabled

### DIFF
--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
@@ -11,7 +11,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def _default_invoicing_timesheet_enabled(self):
         if 'active_id' not in self._context and 'active_ids' not in self._context:
             return False
-        sale_orders = self.env['sale.order'].browse(self._context.get('active_id') or self._context.get('active_ids'))
+        sale_orders = self.env['sale.order'].browse(self._context.get('active_ids') or self._context.get('active_id'))
         order_lines = sale_orders.mapped('order_line').filtered(lambda sol: sol.invoice_status == 'to invoice')
         product_ids = order_lines.mapped('product_id').filtered(lambda p: p._is_delivered_timesheet())
         return bool(product_ids)


### PR DESCRIPTION
The context in the list controller sets active_id as active_ids[0] which means the default function will only check the first sale order's order lines to calculate the default

Now it checks the active_ids first to see whether there are multiple selected

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
