### PR TITLE
[FIX] fields: raise validation error when error generated from custom fields

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -41,7 +41,7 @@ from .tools import DEFAULT_SERVER_DATETIME_FORMAT as DATETIME_FORMAT
 from .tools.translate import html_translate, _
 from .tools.mimetypes import guess_mimetype
 
-from odoo.exceptions import CacheMiss
+from odoo.exceptions import CacheMiss, ValidationError
 from odoo.osv import expression
 
 DATE_LENGTH = len(date.today().strftime(DATE_FORMAT))
@@ -1387,10 +1387,12 @@ class Field(MetaField('DummyField', (object,), {})):
         try:
             with records.env.protecting(fields, records):
                 records._compute_field_value(self)
-        except Exception:
+        except Exception as e:
             for field in fields:
                 if field.store:
                     env.add_to_compute(field, records)
+                if field.name.startswith('x_'):
+                    raise ValidationError(e)
             raise
 
     def determine_inverse(self, records):


### PR DESCRIPTION
Currently, an error is generated when the user adds an import statement
in the compute method of the custom field.

Steps to produce:
- Install Employees(hr) and add a custom field 'x_age'
- add 'birthday' in dependencies and write code as below: 
````
from datetime import date
    for rec in self: today = date.today()
    if rec.birthday:
        age = today.year - rec.birthday.year
        rec['x_age'] = age 
    else: rec['x_age'] = 0 
````
- Add the new created field to the form view of employee
- Open any employee record and change the birthday
- Exception generated

Traceback on sentry:
```
ValueError: forbidden opcode(s) in "from datetime import date\r\n\r\nfor rec in self:\r\n    today = date.today()\r\n    if rec.birthday:\r\n        age = today.year - record.birthday.year\r\n        rec['x_age'] = rec.age\r\n    else:\r\n         rec['x_age'] = 0": IMPORT_NAME, IMPORT_FROM
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6744, in onchange
    todo = [
  File "odoo/models.py", line 6747, in <listcomp>
    if name not in done and snapshot0.has_changed(name)
  File "odoo/models.py", line 6544, in has_changed
    return self[name] != record[name]
  File "odoo/models.py", line 6171, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1156, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1366, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1339, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 396, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4524, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 103, in determine
    return needle(records, *args)
  File "odoo/addons/base/models/ir_model.py", line 38, in <lambda>
    func = lambda self: safe_eval(text, SAFE_EVAL_BASE, {'self': self}, mode="exec")
  File "odoo/tools/safe_eval.py", line 360, in safe_eval
    c = test_expr(expr, _SAFE_OPCODES, mode=mode, filename=filename)
  File "odoo/tools/safe_eval.py", line 218, in test_expr
    assert_valid_codeobj(allowed_codes, code_obj, expr)
  File "odoo/tools/safe_eval.py", line 191, in assert_valid_codeobj
    raise ValueError("forbidden opcode(s) in %r: %s" % (expr, ', '.join(opname[x] for x in (code_codes - allowed_codes))))
```

After this commit, it will throw the validation error to users if they write any mistaken code in the compute method with a custom field. 

sentry-4401176861

