### PR TITLE
[IMP] project_todo: add todo button in list view for open form view

### DIFF
--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -80,6 +80,7 @@
                   default_group_by="personal_stage_type_ids"
                   editable="bottom"
                   multi_edit="1"
+                  open_form_view="True"
                   js_class="todo_list">
                 <field name="state" widget="todo_done_checkmark" nolabel="1" options="{'hide_label': 1}"/>
                 <field name="name"/>


### PR DESCRIPTION
Before this commit:
in list view when click on any field it was editable and so can not see the form view of that record.

After this commit:
a view to-do button is added to the list view  to see the form view of the particular record

task-3471910