### PR TITLE
[REF] web: remove unused legacy fn from action service

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1459,9 +1459,6 @@ function makeActionManager(env) {
         get currentController() {
             return _getCurrentController();
         },
-        __legacy__isActionInStack(actionId) {
-            return controllerStack.find((c) => c.action.jsId === actionId);
-        },
     };
 }
 


### PR DESCRIPTION
This function became useless at some point, after the views and actions have been all converted to owl.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
