### PR TITLE
[IMP] web: show properties sum in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -280,6 +280,9 @@ export class ListRenderer extends Component {
                     hasLabel: true,
                     label: propertyField.string,
                     sortable: false,
+                    attrs: ["integer", "float"].includes(propertyField.type)
+                        ? { sum: propertyField.string }
+                        : {},
                 };
             });
     }

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -18736,6 +18736,11 @@ QUnit.module("Views", (hooks) => {
         await clickSave(target);
 
         assert.strictEqual(target.querySelector(".o_field_cell.o_integer_cell").textContent, "321");
+        assert.strictEqual(
+            target.querySelector(".o_list_footer .o_list_number").textContent,
+            "567",
+            "First property is 321, second is zero because it has a different parent and the 2 others are 123 so the total should be 321 + 123 * 2 = 567"
+        );
     });
 
     QUnit.test("Properties: float", async (assert) => {
@@ -18784,6 +18789,11 @@ QUnit.module("Views", (hooks) => {
         await clickSave(target);
 
         assert.strictEqual(target.querySelector(".o_field_cell.o_float_cell").textContent, "3.21");
+        assert.strictEqual(
+            target.querySelector(".o_list_footer .o_list_number").textContent,
+            "250.11",
+            "First property is 3.21, second is zero because it has a different parent and the 2 others are 123.45 so the total should be 3.21 + 123.45 * 2 = 250.11"
+        );
     });
 
     QUnit.test("Properties: date", async (assert) => {


### PR DESCRIPTION
Purpose
=======
Always show the sum of a property column if its type is integer or float.

When we group records we don't show the sum, because it will require to be able to aggregate properties (`properties.xxxxx:sum`) and the technical cost is too big for the feature it gives.

Task-3468750