### PR TITLE
[FIX] web: close dialogs on command execution from command pallet

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -103,6 +103,7 @@ export class CommandPalette extends Component {
         this.DefaultCommandItem = DefaultCommandItem;
         this.activeElement = useService("ui").activeElement;
         this.inputRef = useAutofocus();
+        this.dialogService = useService("dialog");
 
         useHotkey("Enter", () => this.executeSelectedCommand(), { bypassEditableProtection: true });
         useHotkey("Control+Enter", () => this.executeSelectedCommand(true), {
@@ -265,9 +266,13 @@ export class CommandPalette extends Component {
      */
     async executeCommand(command) {
         const config = await command.action();
+        const switchViews = ['/','?'];
         if (config) {
             this.setCommandPaletteConfig(config);
-        } else {
+        }else if(switchViews.includes(this.state.namespace)){
+            this.dialogService.closeAllDialogs();
+        }
+        else {
             this.props.close();
         }
     }

--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -71,7 +71,12 @@ export const dialogService = {
             return close;
         }
 
-        return { add };
+        function closeAllDialogs() {
+            Object.keys(dialogs).forEach((dialogId) => {
+                dialogs[dialogId].dialogData.close();
+            });
+        }
+        return { add, closeAllDialogs };
     },
 };
 


### PR DESCRIPTION
**Before this PR:**
Previously, when the command palette was opened and a command was being executed with single or multiple dialog boxes behind it, only the command palette would close. This left the dialog boxes open.

**After this PR:**
Now, when a command is being executed from the command palette, all the dialog boxes and the command palette close simultaneously.

**Task**-3441132