### PR TITLE
[FIX] point_of_sale: modify config opened session

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -52,7 +52,7 @@
                         </block>
                         <block title="Payment" id="pos_payment_section">
                             <setting id="payment_methods_new" string="Payment Methods" help="Payment methods available">
-                                <field name="pos_payment_method_ids" colspan="4" widget="many2many_tags" invisible="pos_has_active_session" required="pos_company_has_template" options="{'no_create': True}" />
+                                <field name="pos_payment_method_ids" colspan="4" widget="many2many_tags" readonly="pos_has_active_session" required="pos_company_has_template" options="{'no_create': True}" />
                                 <div>
                                     <button name="%(action_payment_methods_tree)d" icon="oi-arrow-right" type="action" string="Payment Methods" class="btn-link"/>
                                 </div>


### PR DESCRIPTION
Since 605943b5eaafe7e9224f0e7fb4fbdd020102c7a5, the modification of a POS config while a session is open with that config is prevented with the error message "Unable to modify this PoS Configuraton because you can't modify Payment Methods while a session is open".

Steps to reproduce:
 - Open a POS session
 - Open the settings page of the POS config of the opened session
 - For example, enable "Set Maximum Difference", then click on the "Save" button.

The error message "Unable to modify this PoS Configuraton because you can't modify Payment Methods while a session is open" is shown.

The fix consists in replacing the "invisible" property of the payment methods field by "readonly", as it was before the 605943b5eaafe7e9224f0e7fb4fbdd020102c7a5 commit.

task-id: 3487621