### PR TITLE
[FIX] web_editor: restore double click focusing on URL when editing link

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2609,32 +2609,6 @@ var SnippetsMenu = Widget.extend({
                 }
 
                 return editorToEnable;
-            }).then(async editor => {
-                // If a link was clicked, the linktools should be focused after
-                // the right panel is shown to the user.
-                // TODO: this should be reviewed to be done another way: we
-                // should avoid focusing something here while it is being
-                // rendered elsewhere.
-                if (this.options.wysiwyg.state.linkToolProps) {
-                    let inputElement = document.querySelector('#o_link_dialog_url_input');
-                    if (!inputElement) {
-                        // Wait for `linkTools` potential in-progress rendering
-                        // before focusing the URL input on `snippetsMenu` (this
-                        // prevents race condition for automated testing).
-                        inputElement = await new Promise((resolve) => {
-                            const observer = new MutationObserver(() => {
-                                const inputElement = document.querySelector('#o_link_dialog_url_input');
-                                if (inputElement) {
-                                    observer.disconnect();
-                                    resolve(inputElement);
-                                }
-                            });
-                            observer.observe(document.body, { childList: true, subtree: true });
-                        });
-                    }
-                    inputElement.focus();
-                }
-                return editor;
             });
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1444,6 +1444,8 @@ export class Wysiwyg extends Component {
                         }
                     };
                 }
+                // update the shouldFocusUrl prop to focus on url when double click
+                this.state.linkToolProps.shouldFocusUrl = options.shouldFocusUrl;
                 const _onClick = ev => {
                     if (
                         !ev.target.closest('#create-link') &&


### PR DESCRIPTION
Reproduction:

1. Install website
2. Change to edit mode and edit a link on the main page, for example, “contact us” at the bottom
3. The focus is on the url at the link tool

Fix: The desired behavior when clicking on links in editing mode is: one click, edit the text of the link; double click, focus on the URL in link tools. After converting to OWL, focusing on URL is handled by props, e.g . `shouldFocusUrl`. We also need to update the state of this prop in `toggleLinkTools` as we did before conversion.

Task-3444671


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
