### PR TITLE
[IMP] account: add date options for tax periods

### DIFF
--- a/addons/account/data/account_reports_data.xml
+++ b/addons/account/data/account_reports_data.xml
@@ -7,7 +7,7 @@
             <field name="name">Generic Tax report</field>
             <field name="filter_multi_company">tax_units</field>
             <field name="filter_fiscal_position" eval="1"/>
-            <field name="default_opening_date_filter">last_month</field>
+            <field name="default_opening_date_filter">last_tax_period</field>
             <field name="only_tax_exigible" eval="True"/>
             <field name="column_ids">
                 <record id="generic_tax_report_column_net" model="account.report.column">

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -62,6 +62,8 @@ class AccountReport(models.Model):
             ('last_month', "Last Month"),
             ('last_quarter', "Last Quarter"),
             ('last_year', "Last Year"),
+            ('this_tax_period', "This Tax Period"),
+            ('last_tax_period', "Last Tax Period"),
         ],
         compute=lambda x: x._compute_report_option_filter('default_opening_date_filter', 'last_month'),
         readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],


### PR DESCRIPTION
Currently the tax report always opens the previous month by default. Since tax periods are not always months, it makes much more sense to open the previous "tax period" (whatever length it has) when opening the tax report.

In order to allow that, this commit introduces a "This Tax Period" and "Previous Tax Period" option for reports and sets the default period for the tax report to "Previous Tax Period". The rest of the functionality is done in the related enterprise commit.

[task-3481913](https://www.odoo.com/web#id=3481913&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

Related to https://github.com/odoo/enterprise/pull/46601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
