### PR TITLE
[REF] mail, *: tests: use native code for most contains/text

### DIFF
--- a/addons/calendar/static/src/activity/activity_menu_patch.xml
+++ b/addons/calendar/static/src/activity/activity_menu_patch.xml
@@ -5,10 +5,8 @@
             <div t-if="group.type === 'meeting'">
                 <t t-set="is_next_meeting" t-value="true"/>
                 <t t-foreach="group.meetings" t-as="meeting" t-key="meeting.id">
-                    <div class="o-calendar-metting d-flex px-2">
-                        <span class="flex-grow-1 text-truncate" t-att-class="!meeting.allday and is_next_meeting ? 'fw-bold' : ''">
-                            <span><t t-esc="meeting.name"/></span>
-                        </span>
+                    <div class="o-calendar-meeting d-flex px-2">
+                        <span class="flex-grow-1 text-truncate" t-att-class="!meeting.allday and is_next_meeting ? 'fw-bold' : ''" t-esc="meeting.name"/>
                         <span t-if="meeting.formattedStart">
                             <t t-if="meeting.allday">All Day</t>
                             <t t-else=''>

--- a/addons/calendar/static/tests/activity_menu_tests.js
+++ b/addons/calendar/static/tests/activity_menu_tests.js
@@ -31,10 +31,10 @@ QUnit.test("activity menu widget:today meetings", async function (assert) {
             assert.step("action");
         },
     });
-    await contains(".o-mail-ActivityGroup span", 1, { text: "Today's Meetings" });
-    await contains(".o-mail-ActivityGroup .o-calendar-meeting", 2);
-    await contains(".o-calendar-meeting span.fw-bold", 1, { text: "meeting1" });
-    await contains(".o-calendar-meeting span:not(.fw-bold)", 1, { text: "meeting2" });
+    await contains(".o-mail-ActivityGroup span", { text: "Today's Meetings" });
+    await contains(".o-mail-ActivityGroup .o-calendar-meeting", { count: 2 });
+    await contains(".o-calendar-meeting span.fw-bold", { text: "meeting1" });
+    await contains(".o-calendar-meeting span:not(.fw-bold)", { text: "meeting2" });
     await click(".o-mail-ActivityMenu .o-mail-ActivityGroup");
     assert.verifySteps(["action"]);
 });

--- a/addons/calendar/static/tests/activity_menu_tests.js
+++ b/addons/calendar/static/tests/activity_menu_tests.js
@@ -2,15 +2,8 @@
 
 import { click, contains, start, startServer } from "@mail/../tests/helpers/test_utils";
 
-import { getFixture, patchDate, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { patchDate, patchWithCleanup } from "@web/../tests/helpers/utils";
 
-let target;
-
-QUnit.module("calender activity menu", {
-    async beforeEach() {
-        target = getFixture();
-    },
-});
 QUnit.test("activity menu widget:today meetings", async function (assert) {
     patchDate(2018, 3, 20, 6, 0, 0);
     const pyEnv = await startServer();
@@ -38,12 +31,10 @@ QUnit.test("activity menu widget:today meetings", async function (assert) {
             assert.step("action");
         },
     });
-    await contains(".o-mail-ActivityGroup:contains(Today's Meetings)");
-    await contains(".o-mail-ActivityGroup .o-calendar-metting", 2);
-    await contains(".o-calendar-metting:contains(meeting1)");
-    await contains(".o-calendar-metting:contains(meeting2)");
-    assert.hasClass($(target).find("span:contains(meeting1)"), "fw-bold");
-    assert.doesNotHaveClass($(target).find("span:contains(meeting2)"), "fw-bold");
+    await contains(".o-mail-ActivityGroup span", 1, { text: "Today's Meetings" });
+    await contains(".o-mail-ActivityGroup .o-calendar-meeting", 2);
+    await contains(".o-calendar-meeting span.fw-bold", 1, { text: "meeting1" });
+    await contains(".o-calendar-meeting span:not(.fw-bold)", 1, { text: "meeting2" });
     await click(".o-mail-ActivityMenu .o-mail-ActivityGroup");
     assert.verifySteps(["action"]);
 });

--- a/addons/calendar/static/tests/activity_tests.js
+++ b/addons/calendar/static/tests/activity_tests.js
@@ -28,6 +28,6 @@ QUnit.test("activity click on Reschedule", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", resPartnerId);
-    await click(".btn:contains('Reschedule')");
+    await click(".btn", { text: "Reschedule" });
     await contains(".o_calendar_view");
 });

--- a/addons/calendar/static/tests/activity_widget_tests.js
+++ b/addons/calendar/static/tests/activity_widget_tests.js
@@ -65,6 +65,6 @@ QUnit.test("list activity widget: reschedule button in dropdown", async (assert)
     assert.strictEqual($(".o-mail-ListActivity-summary")[0].innerText, "OXP");
 
     await click(".o-mail-ActivityButton"); // open the popover
-    await contains(".o-mail-ActivityListPopoverItem-editbtn .fa-pencil", 0);
+    await contains(".o-mail-ActivityListPopoverItem-editbtn .fa-pencil", { count: 0 });
     await contains(".o-mail-ActivityListPopoverItem-editbtn .fa-calendar");
 });

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -159,7 +159,7 @@ QUnit.test(
             res_id: avatarId,
             views: [[false, "form"]],
         });
-        await contains(".o_field_widget[name=employee_id] input", 1, { value: "Mario" });
+        await contains(".o_field_widget[name=employee_id] input", { value: "Mario" });
         await dom.click(document.querySelector(".o_m2o_avatar > img"));
         await contains(
             ".o_notification.border-info:contains(You can only chat with employees that have a dedicated user.)"

--- a/addons/im_livechat/static/tests/channel_invite_tests.js
+++ b/addons/im_livechat/static/tests/channel_invite_tests.js
@@ -29,12 +29,12 @@ QUnit.test("Can invite a partner to a livechat channel", async () => {
     await click("button[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable:contains(James) input");
     await click("button:contains(Invite):not(:disabled)");
-    await contains(".o-discuss-ChannelInvitation", 0);
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("button[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 1, { text: "James" });
+    await contains(".o-discuss-ChannelMember", { text: "James" });
 });
 
-QUnit.test("Available operators come first", async (assert) => {
+QUnit.test("Available operators come first", async () => {
     const pyEnv = await startServer();
     pyEnv["res.partner"].create({
         name: "Harry",
@@ -61,12 +61,12 @@ QUnit.test("Available operators come first", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await click("button[title='Add Users']");
-    const partnerSuggestions = await contains(".o-discuss-ChannelInvitation-selectable", 2);
-    assert.ok(partnerSuggestions[0].textContent.includes("Ron"));
-    assert.ok(partnerSuggestions[1].textContent.includes("Harry"));
+    await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
+    await contains(".o-discuss-ChannelInvitation-selectable:eq(0)", { text: "Ron" });
+    await contains(".o-discuss-ChannelInvitation-selectable:eq(1)", { text: "Harry" });
 });
 
-QUnit.test("Partners invited most frequently by the current user come first", async (assert) => {
+QUnit.test("Partners invited most frequently by the current user come first", async () => {
     const pyEnv = await startServer();
     pyEnv["res.partner"].create({
         name: "John",
@@ -105,7 +105,7 @@ QUnit.test("Partners invited most frequently by the current user come first", as
     await click("button:contains(Invite):not(:disabled)");
     await click(".o-mail-DiscussSidebarChannel span", { text: "Visitor #2" });
     await click("button[title='Add Users']");
-    const partnerSuggestions = await contains(".o-discuss-ChannelInvitation-selectable", 2);
-    assert.ok(partnerSuggestions[0].textContent.includes("John"));
-    assert.ok(partnerSuggestions[1].textContent.includes("Albert"));
+    await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
+    await contains(".o-discuss-ChannelInvitation-selectable:eq(0)", { text: "John" });
+    await contains(".o-discuss-ChannelInvitation-selectable:eq(1)", { text: "Albert" });
 });

--- a/addons/im_livechat/static/tests/channel_invite_tests.js
+++ b/addons/im_livechat/static/tests/channel_invite_tests.js
@@ -31,7 +31,7 @@ QUnit.test("Can invite a partner to a livechat channel", async () => {
     await click("button:contains(Invite):not(:disabled)");
     await contains(".o-discuss-ChannelInvitation", 0);
     await click("button[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember:contains(James)");
+    await contains(".o-discuss-ChannelMember", 1, { text: "James" });
 });
 
 QUnit.test("Available operators come first", async (assert) => {
@@ -99,11 +99,11 @@ QUnit.test("Partners invited most frequently by the current user come first", as
 
     const { openDiscuss } = await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel:contains(Visitor #1)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "Visitor #1" });
     await click("button[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable:contains(John) input");
     await click("button:contains(Invite):not(:disabled)");
-    await click(".o-mail-DiscussSidebarChannel:contains(Visitor #2)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "Visitor #2" });
     await click("button[title='Add Users']");
     const partnerSuggestions = await contains(".o-discuss-ChannelInvitation-selectable", 2);
     assert.ok(partnerSuggestions[0].textContent.includes("John"));

--- a/addons/im_livechat/static/tests/chat_window_patch_tests.js
+++ b/addons/im_livechat/static/tests/chat_window_patch_tests.js
@@ -19,8 +19,8 @@ QUnit.test("No call buttons", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-command i.fa-phone", 0);
-    await contains(".o-mail-ChatWindow-command i.fa-gear", 0);
+    await contains(".o-mail-ChatWindow-command i.fa-phone", { count: 0 });
+    await contains(".o-mail-ChatWindow-command i.fa-gear", { count: 0 });
 });
 
 QUnit.test("closing a chat window with no message from admin side unpins it", async (assert) => {

--- a/addons/im_livechat/static/tests/chat_window_patch_tests.js
+++ b/addons/im_livechat/static/tests/chat_window_patch_tests.js
@@ -4,7 +4,7 @@ import { click, contains, start, startServer } from "@mail/../tests/helpers/test
 
 QUnit.module("chat window (patch)");
 
-QUnit.test("No call buttons", async (assert) => {
+QUnit.test("No call buttons", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
@@ -19,8 +19,8 @@ QUnit.test("No call buttons", async (assert) => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command i.fa-phone", 0);
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command i.fa-gear", 0);
+    await contains(".o-mail-ChatWindow-command i.fa-phone", 0);
+    await contains(".o-mail-ChatWindow-command i.fa-gear", 0);
 });
 
 QUnit.test("closing a chat window with no message from admin side unpins it", async (assert) => {
@@ -45,7 +45,7 @@ QUnit.test("closing a chat window with no message from admin side unpins it", as
     const { env } = await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await click(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Close Chat Window']");
+    await click(".o-mail-ChatWindow-command[title='Close Chat Window']");
     const [channel] = await env.services.rpc(
         "/discuss/channel/info",
         { channel_id: channelId },

--- a/addons/im_livechat/static/tests/composer_patch_tests.js
+++ b/addons/im_livechat/static/tests/composer_patch_tests.js
@@ -24,7 +24,7 @@ QUnit.test("No add attachments button", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer");
-    await contains("button[title='Attach files']", 0);
+    await contains("button[title='Attach files']", { count: 0 });
 });
 
 QUnit.test("Attachment upload via drag and drop disabled", async (assert) => {
@@ -40,7 +40,7 @@ QUnit.test("Attachment upload via drag and drop disabled", async (assert) => {
     await contains(".o-mail-Composer");
     dragenterFiles($(".o-mail-Composer-input")[0]);
     await nextTick();
-    await contains(".o-mail-Dropzone", 0);
+    await contains(".o-mail-Dropzone", { count: 0 });
 });
 
 QUnit.test("Can execute help command on livechat channels", async (assert) => {
@@ -94,7 +94,7 @@ QUnit.test('Receives visitor typing status "is typing"', async (assert) => {
             })
         )
     );
-    await contains(".o-discuss-Typing", 1, { text: "Visitor 20 is typing..." });
+    await contains(".o-discuss-Typing", { text: "Visitor 20 is typing..." });
 });
 
 QUnit.test('display canned response suggestions on typing ":"', async () => {
@@ -115,7 +115,7 @@ QUnit.test('display canned response suggestions on typing ":"', async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await insertText(".o-mail-Composer-input", ":");
     await contains(".o-mail-Composer-suggestionList .o-open");
 });
@@ -138,11 +138,11 @@ QUnit.test("use a canned response", async (assert) => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", ":");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "Hello! How are you? " });
+    await contains(".o-mail-Composer-input", { value: "Hello! How are you? " });
 });
 
 QUnit.test("use a canned response some text", async (assert) => {
@@ -168,7 +168,7 @@ QUnit.test("use a canned response some text", async (assert) => {
     assert.strictEqual($(".o-mail-Composer-input").val(), "bluhbluh ");
     await insertText(".o-mail-Composer-input", ":");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "bluhbluh Hello! How are you? " });
+    await contains(".o-mail-Composer-input", { value: "bluhbluh Hello! How are you? " });
 });
 
 QUnit.test("add an emoji after a canned response", async () => {
@@ -189,11 +189,11 @@ QUnit.test("add an emoji after a canned response", async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", ":");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "Hello! How are you? " });
+    await contains(".o-mail-Composer-input", { value: "Hello! How are you? " });
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "😊" });
-    await contains(".o-mail-Composer-input", 1, { value: "Hello! How are you? 😊" });
+    await contains(".o-mail-Composer-input", { value: "Hello! How are you? 😊" });
 });

--- a/addons/im_livechat/static/tests/composer_patch_tests.js
+++ b/addons/im_livechat/static/tests/composer_patch_tests.js
@@ -94,7 +94,7 @@ QUnit.test('Receives visitor typing status "is typing"', async (assert) => {
             })
         )
     );
-    await contains(".o-discuss-Typing:contains(Visitor 20 is typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Visitor 20 is typing..." });
 });
 
 QUnit.test('display canned response suggestions on typing ":"', async () => {
@@ -194,6 +194,6 @@ QUnit.test("add an emoji after a canned response", async () => {
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", 1, { value: "Hello! How are you? " });
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(😊)");
+    await click(".o-Emoji", { text: "😊" });
     await contains(".o-mail-Composer-input", 1, { value: "Hello! How are you? 😊" });
 });

--- a/addons/im_livechat/static/tests/composer_patch_tests.js
+++ b/addons/im_livechat/static/tests/composer_patch_tests.js
@@ -83,7 +83,7 @@ QUnit.test('Receives visitor typing status "is typing"', async (assert) => {
     });
     const { env, openDiscuss } = await start();
     await openDiscuss(channelId);
-    assert.strictEqual($(".o-discuss-Typing").text(), "");
+    await contains(".o-discuss-Typing", { text: "" });
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     // simulate receive typing notification from livechat visitor "is typing"
     await afterNextRender(() =>

--- a/addons/im_livechat/static/tests/discuss_patch_tests.js
+++ b/addons/im_livechat/static/tests/discuss_patch_tests.js
@@ -190,14 +190,14 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         await openDiscuss();
-        await contains(".o-mail-DiscussSidebarChannel:eq(0)", 1, { text: "Visitor 12" });
-        await contains(".o-mail-DiscussSidebarChannel:eq(1)", 1, { text: "Visitor 11" });
+        await contains(".o-mail-DiscussSidebarChannel:eq(0)", { text: "Visitor 12" });
+        await contains(".o-mail-DiscussSidebarChannel:eq(1)", { text: "Visitor 11" });
         // post a new message on the last channel
         await click(".o-mail-DiscussSidebarChannel:eq(1)");
         await insertText(".o-mail-Composer-input", "Blabla");
         await click(".o-mail-Composer-send:not(:disabled)");
-        await contains(".o-mail-DiscussSidebarChannel", 2);
-        await contains(".o-mail-DiscussSidebarChannel:eq(0) span", 1, { text: "Visitor 11" });
-        await contains(".o-mail-DiscussSidebarChannel:eq(1) span", 1, { text: "Visitor 12" });
+        await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
+        await contains(".o-mail-DiscussSidebarChannel:eq(0) span", { text: "Visitor 11" });
+        await contains(".o-mail-DiscussSidebarChannel:eq(1) span", { text: "Visitor 12" });
     }
 );

--- a/addons/im_livechat/static/tests/discuss_patch_tests.js
+++ b/addons/im_livechat/static/tests/discuss_patch_tests.js
@@ -190,14 +190,14 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         await openDiscuss();
-        await contains(".o-mail-DiscussSidebarChannel:eq(0):contains(Visitor 12)");
-        await contains(".o-mail-DiscussSidebarChannel:eq(1):contains(Visitor 11)");
+        await contains(".o-mail-DiscussSidebarChannel:eq(0)", 1, { text: "Visitor 12" });
+        await contains(".o-mail-DiscussSidebarChannel:eq(1)", 1, { text: "Visitor 11" });
         // post a new message on the last channel
         await click(".o-mail-DiscussSidebarChannel:eq(1)");
         await insertText(".o-mail-Composer-input", "Blabla");
         await click(".o-mail-Composer-send:not(:disabled)");
         await contains(".o-mail-DiscussSidebarChannel", 2);
-        await contains(".o-mail-DiscussSidebarChannel:eq(0):contains(Visitor 11)");
-        await contains(".o-mail-DiscussSidebarChannel:eq(1):contains(Visitor 12)");
+        await contains(".o-mail-DiscussSidebarChannel:eq(0) span", 1, { text: "Visitor 11" });
+        await contains(".o-mail-DiscussSidebarChannel:eq(1) span", 1, { text: "Visitor 12" });
     }
 );

--- a/addons/im_livechat/static/tests/embed/feedback_panel_tests.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel_tests.js
@@ -18,7 +18,7 @@ QUnit.test("Do not ask feedback if empty", async () => {
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-ChatWindow");
     await click("[title='Close Chat Window']");
-    await contains(".o-livechat-LivechatButton", 0);
+    await contains(".o-livechat-LivechatButton", { count: 0 });
 });
 
 QUnit.test("Close without feedback", async (assert) => {
@@ -38,10 +38,10 @@ QUnit.test("Close without feedback", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
+    await contains(".o-mail-Message-content", { text: "Hello World!" });
     await click("[title='Close Chat Window']");
     await click("button", { text: "Close conversation" });
-    await contains(".o-livechat-LivechatButton", 0);
+    await contains(".o-livechat-LivechatButton", { count: 0 });
     assert.verifySteps(["/im_livechat/visitor_leave_session"]);
 });
 
@@ -64,13 +64,13 @@ QUnit.test("Feedback with rating and comment", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
+    await contains(".o-mail-Message-content", { text: "Hello World!" });
     await click("[title='Close Chat Window']");
     assert.verifySteps(["/im_livechat/visitor_leave_session"]);
     await click(`img[data-alt="${RATING.GOOD}"]`);
     await insertText("textarea[placeholder='Explain your note']", "Good job!");
     await click("button:contains(Send):not(:disabled)");
-    await contains("p", 1, { text: "Thank you for your feedback" });
+    await contains("p", { text: "Thank you for your feedback" });
     assert.verifySteps(["/im_livechat/feedback"]);
 });
 
@@ -81,10 +81,10 @@ QUnit.test("Closing folded chat window should open it with feedback", async () =
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
+    await contains(".o-mail-Message-content", { text: "Hello World!" });
     await click("[title='Fold']");
     await contains(".o-mail-ChatWindow.o-folded");
     await click("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow.o-folded", 0);
-    await contains(".o-mail-ChatWindow p", 1, { text: "Did we correctly answer your question?" });
+    await contains(".o-mail-ChatWindow.o-folded", { count: 0 });
+    await contains(".o-mail-ChatWindow p", { text: "Did we correctly answer your question?" });
 });

--- a/addons/im_livechat/static/tests/embed/feedback_panel_tests.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel_tests.js
@@ -38,9 +38,9 @@ QUnit.test("Close without feedback", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message:contains(Hello World!)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
     await click("[title='Close Chat Window']");
-    await click("button:contains('Close')");
+    await click("button", { text: "Close conversation" });
     await contains(".o-livechat-LivechatButton", 0);
     assert.verifySteps(["/im_livechat/visitor_leave_session"]);
 });
@@ -64,13 +64,13 @@ QUnit.test("Feedback with rating and comment", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message:contains(Hello World!)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
     await click("[title='Close Chat Window']");
     assert.verifySteps(["/im_livechat/visitor_leave_session"]);
     await click(`img[data-alt="${RATING.GOOD}"]`);
     await insertText("textarea[placeholder='Explain your note']", "Good job!");
     await click("button:contains(Send):not(:disabled)");
-    await contains("p:contains(Thank you for your feedback)");
+    await contains("p", 1, { text: "Thank you for your feedback" });
     assert.verifySteps(["/im_livechat/feedback"]);
 });
 
@@ -81,10 +81,10 @@ QUnit.test("Closing folded chat window should open it with feedback", async () =
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message:contains(Hello World!)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
     await click("[title='Fold']");
     await contains(".o-mail-ChatWindow.o-folded");
     await click("[title='Close Chat Window']");
     await contains(".o-mail-ChatWindow.o-folded", 0);
-    await contains(".o-mail-ChatWindow:contains(Did we correctly answer your question?)");
+    await contains(".o-mail-ChatWindow p", 1, { text: "Did we correctly answer your question?" });
 });

--- a/addons/im_livechat/static/tests/embed/livechat_button_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button_tests.js
@@ -14,10 +14,10 @@ QUnit.test("open/close temporary channel", async () => {
     start();
     await click(".o-livechat-LivechatButton");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-livechat-LivechatButton", 0);
+    await contains(".o-livechat-LivechatButton", { count: 0 });
     await click("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow", 0);
-    await contains(".o-livechat-LivechatButton", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-livechat-LivechatButton", { count: 0 });
 });
 
 QUnit.test("open/close persisted channel", async () => {
@@ -27,14 +27,14 @@ QUnit.test("open/close persisted channel", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "How can I help?");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", 1, { text: "How can I help?" });
+    await contains(".o-mail-Message-content", { text: "How can I help?" });
     await click("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow-content p", 1, {
+    await contains(".o-mail-ChatWindow-content p", {
         text: "Did we correctly answer your question?",
     });
     await click("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow", 0);
-    await contains(".o-livechat-LivechatButton", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-livechat-LivechatButton", { count: 0 });
 });
 
 QUnit.test("livechat not available", async () => {
@@ -48,5 +48,5 @@ QUnit.test("livechat not available", async () => {
         },
     });
     await contains(".o-mail-ChatWindowContainer");
-    await contains(".o-livechat-LivechatButton", 0);
+    await contains(".o-livechat-LivechatButton", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/embed/livechat_button_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button_tests.js
@@ -27,9 +27,11 @@ QUnit.test("open/close persisted channel", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "How can I help?");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message:contains(How can I help?)");
+    await contains(".o-mail-Message-content", 1, { text: "How can I help?" });
     await click("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow-content:contains(Did we correctly answer your question?)");
+    await contains(".o-mail-ChatWindow-content p", 1, {
+        text: "Did we correctly answer your question?",
+    });
     await click("[title='Close Chat Window']");
     await contains(".o-mail-ChatWindow", 0);
     await contains(".o-livechat-LivechatButton", 0);

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -31,7 +31,7 @@ QUnit.test("persisted session history", async () => {
         message_type: "comment",
     });
     start();
-    await contains(".o-mail-Message-content", 1, { text: "Old message in history" });
+    await contains(".o-mail-Message-content", { text: "Old message in history" });
 });
 
 QUnit.test("previous operator prioritized", async () => {
@@ -43,5 +43,5 @@ QUnit.test("previous operator prioritized", async () => {
     setCookie("im_livechat_previous_operator_pid", JSON.stringify(previousOperatorId));
     start();
     click(".o-livechat-LivechatButton");
-    await contains(".o-mail-Message-author", 1, { text: "John Doe" });
+    await contains(".o-mail-Message-author", { text: "John Doe" });
 });

--- a/addons/im_livechat/static/tests/embed/livechat_service_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service_tests.js
@@ -31,7 +31,7 @@ QUnit.test("persisted session history", async () => {
         message_type: "comment",
     });
     start();
-    await contains(".o-mail-Message:contains(Old message in history)");
+    await contains(".o-mail-Message-content", 1, { text: "Old message in history" });
 });
 
 QUnit.test("previous operator prioritized", async () => {
@@ -43,5 +43,5 @@ QUnit.test("previous operator prioritized", async () => {
     setCookie("im_livechat_previous_operator_pid", JSON.stringify(previousOperatorId));
     start();
     click(".o-livechat-LivechatButton");
-    await contains(".o-mail-Message-author:contains(John Doe)");
+    await contains(".o-mail-Message-author", 1, { text: "John Doe" });
 });

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -35,11 +35,13 @@ QUnit.test("Unsuccessful message post shows session expired", async () => {
     });
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o_notification:contains(Session expired)");
+    await contains(".o_notification_content", 1, {
+        text: "Session expired... Please refresh and try again.",
+    });
     await contains(".o-mail-ChatWindow", 0);
 });
 
-QUnit.test("Session is reset after failing to persist the channel", async (assert) => {
+QUnit.test("Session is reset after failing to persist the channel", async () => {
     await startServer();
     await loadDefaultConfig();
     const { advanceTime } = mockTimeout();
@@ -53,7 +55,9 @@ QUnit.test("Session is reset after failing to persist the channel", async (asser
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o_notification:contains(No available collaborator, please try again later.)");
+    await contains(".o_notification_content", 1, {
+        text: "No available collaborator, please try again later.",
+    });
     await contains(".o-livechat-LivechatButton");
     await advanceTime(LivechatButton.DEBOUNCE_DELAY + 10);
     await click(".o-livechat-LivechatButton");

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -35,10 +35,10 @@ QUnit.test("Unsuccessful message post shows session expired", async () => {
     });
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o_notification_content", 1, {
+    await contains(".o_notification_content", {
         text: "Session expired... Please refresh and try again.",
     });
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
 });
 
 QUnit.test("Session is reset after failing to persist the channel", async () => {
@@ -55,7 +55,7 @@ QUnit.test("Session is reset after failing to persist the channel", async () => 
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o_notification_content", 1, {
+    await contains(".o_notification_content", {
         text: "No available collaborator, please try again later.",
     });
     await contains(".o-livechat-LivechatButton");
@@ -72,7 +72,7 @@ QUnit.test("Thread state is saved on the session", async (assert) => {
     await contains(".o-mail-ChatWindow-content");
     assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
     await click(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-content", 0);
+    await contains(".o-mail-ChatWindow-content", { count: 0 });
     assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "folded");
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-ChatWindow-content");
@@ -87,7 +87,7 @@ QUnit.test("Seen message is saved on the session", async (assert) => {
     assert.notOk(env.services["im_livechat.livechat"].sessionCookie.seen_message_id);
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message", 2);
+    await contains(".o-mail-Message", { count: 2 });
     assert.strictEqual(
         env.services["im_livechat.livechat"].sessionCookie.seen_message_id,
         env.services["im_livechat.livechat"].thread.newestMessage.id

--- a/addons/im_livechat/static/tests/embed/transcript_sender_tests.js
+++ b/addons/im_livechat/static/tests/embed/transcript_sender_tests.js
@@ -23,13 +23,13 @@ QUnit.test("send", async (assert) => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
+    await contains(".o-mail-Message-content", { text: "Hello World!" });
     await click(".o-mail-ChatWindow-command[title*='Close']");
-    await contains(".form-text", 1, { text: "Receive a copy of this conversation." });
+    await contains(".form-text", { text: "Receive a copy of this conversation." });
     await contains("button[data-action='sendTranscript']:disabled");
     await insertText("input[placeholder='mail@example.com']", "odoobot@odoo.com");
     await click("button[data-action='sendTranscript']:not(:disabled)");
-    await contains(".form-text", 1, { text: "The conversation was sent." });
+    await contains(".form-text", { text: "The conversation was sent." });
     assert.verifySteps(["send_transcript - odoobot@odoo.com"]);
 });
 
@@ -46,9 +46,9 @@ QUnit.test("send failed", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
+    await contains(".o-mail-Message-content", { text: "Hello World!" });
     await click(".o-mail-ChatWindow-command[title*='Close']");
     await insertText("input[placeholder='mail@example.com']", "odoobot@odoo.com");
     await click("button[data-action='sendTranscript']:not(:disabled)");
-    await contains(".form-text", 1, { text: "An error occurred. Please try again." });
+    await contains(".form-text", { text: "An error occurred. Please try again." });
 });

--- a/addons/im_livechat/static/tests/embed/transcript_sender_tests.js
+++ b/addons/im_livechat/static/tests/embed/transcript_sender_tests.js
@@ -23,13 +23,13 @@ QUnit.test("send", async (assert) => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message:contains(Hello World!)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
     await click(".o-mail-ChatWindow-command[title*='Close']");
-    await contains(".form-text:contains(Receive a copy of this conversation)");
+    await contains(".form-text", 1, { text: "Receive a copy of this conversation." });
     await contains("button[data-action='sendTranscript']:disabled");
     await insertText("input[placeholder='mail@example.com']", "odoobot@odoo.com");
     await click("button[data-action='sendTranscript']:not(:disabled)");
-    await contains(".form-text:contains(The conversation was sent)");
+    await contains(".form-text", 1, { text: "The conversation was sent." });
     assert.verifySteps(["send_transcript - odoobot@odoo.com"]);
 });
 
@@ -46,9 +46,9 @@ QUnit.test("send failed", async () => {
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o-mail-Message:contains(Hello World!)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
     await click(".o-mail-ChatWindow-command[title*='Close']");
     await insertText("input[placeholder='mail@example.com']", "odoobot@odoo.com");
     await click("button[data-action='sendTranscript']:not(:disabled)");
-    await contains(".form-text:contains(An error occurred. Please try again.)");
+    await contains(".form-text", 1, { text: "An error occurred. Please try again." });
 });

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -9,7 +9,7 @@ import { contains } from "@mail/../tests/helpers/test_utils";
 
 QUnit.module("thread service");
 
-QUnit.test("new message from operator displays unread counter", async (assert) => {
+QUnit.test("new message from operator displays unread counter", async () => {
     const pyEnv = await startServer();
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
@@ -32,10 +32,10 @@ QUnit.test("new message from operator displays unread counter", async (assert) =
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-header:contains(1)");
+    await contains(".o-mail-ChatWindow-counter", 1, { text: "1" });
 });
 
-QUnit.test("focus on unread livechat marks it as read", async (assert) => {
+QUnit.test("focus on unread livechat marks it as read", async () => {
     const pyEnv = await startServer();
     const livechatChannelId = await loadDefaultConfig();
     const channelId = pyEnv["discuss.channel"].create({
@@ -58,7 +58,9 @@ QUnit.test("focus on unread livechat marks it as read", async (assert) => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message:contains(Are you there?)");
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", 1, {
+        text: "Are you there?",
+    });
     $(".o-mail-Composer-input").trigger("focus");
     await contains(".o-mail-Thread-newMessage", 0);
 });

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -32,7 +32,7 @@ QUnit.test("new message from operator displays unread counter", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-counter", 1, { text: "1" });
+    await contains(".o-mail-ChatWindow-counter", { text: "1" });
 });
 
 QUnit.test("focus on unread livechat marks it as read", async () => {
@@ -58,9 +58,9 @@ QUnit.test("focus on unread livechat marks it as read", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", 1, {
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", {
         text: "Are you there?",
     });
     $(".o-mail-Composer-input").trigger("focus");
-    await contains(".o-mail-Thread-newMessage", 0);
+    await contains(".o-mail-Thread-newMessage", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/go_to_oldest_unread_thread_tests.js
+++ b/addons/im_livechat/static/tests/go_to_oldest_unread_thread_tests.js
@@ -121,7 +121,7 @@ QUnit.test("switching to folded chat window unfolds it", async (assert) => {
     await start();
     assert.containsOnce(
         $,
-        ".o-mail-ChatWindow.o-folded .o-mail-ChatWindow-header:contains(Visitor 12)"
+        ".o-mail-ChatWindow.o-folded .o-mail-ChatWindow-name:contains(Visitor 12)"
     );
     await afterNextRender(() => {
         $(".o-mail-ChatWindow:contains(Visitor 11) .o-mail-Composer-input").trigger("focus");
@@ -129,7 +129,7 @@ QUnit.test("switching to folded chat window unfolds it", async (assert) => {
     });
     assert.containsOnce(
         $,
-        ".o-mail-ChatWindow:not(.o-folded) .o-mail-ChatWindow-header:contains(Visitor 12)"
+        ".o-mail-ChatWindow:not(.o-folded) .o-mail-ChatWindow-name:contains(Visitor 12)"
     );
     assert.strictEqual(
         document.activeElement,
@@ -178,7 +178,7 @@ QUnit.test("switching to hidden chat window unhides it", async (assert) => {
     await start();
     assert.containsNone(
         $,
-        ".o-mail-ChatWindow.o-folded .o-mail-ChatWindow-header:contains(Visitor 12)"
+        ".o-mail-ChatWindow.o-folded .o-mail-ChatWindow-name:contains(Visitor 12)"
     );
     await afterNextRender(() => {
         $(".o-mail-ChatWindow:contains(Visitor 11) .o-mail-Composer-input").trigger("focus");
@@ -186,7 +186,7 @@ QUnit.test("switching to hidden chat window unhides it", async (assert) => {
     });
     assert.containsOnce(
         $,
-        ".o-mail-ChatWindow:not(.o-folded) .o-mail-ChatWindow-header:contains(Visitor 12)"
+        ".o-mail-ChatWindow:not(.o-folded) .o-mail-ChatWindow-name:contains(Visitor 12)"
     );
     assert.strictEqual(
         document.activeElement,

--- a/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
@@ -19,10 +19,10 @@ QUnit.test('livechats should be in "chat" filter', async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu button:contains(All).fw-bolder");
-    await contains(".o-mail-NotificationItem:contains(Visitor 11)");
-    await click(".o-mail-MessagingMenu button:contains(Chat)");
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Visitor 11" });
+    await click(".o-mail-MessagingMenu button", { text: "Chats" });
     await contains(".o-mail-MessagingMenu button:contains(Chat).fw-bolder");
-    await contains(".o-mail-NotificationItem:contains(Visitor 11)");
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Visitor 11" });
 });
 
 QUnit.test('livechats should be in "livechat" tab in mobile', async () => {
@@ -39,8 +39,8 @@ QUnit.test('livechats should be in "livechat" tab in mobile', async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(Livechat)");
-    await contains(".o-mail-NotificationItem:contains(Visitor 11)");
-    await click("button:contains(Chat)");
-    await contains(".o-mail-NotificationItem:contains(Visitor 11)", 0);
+    await click("button", { text: "Livechat" });
+    await contains(".o-mail-NotificationItem", 1, { text: "Visitor 11" });
+    await click("button", { text: "Chat" });
+    await contains(".o-mail-NotificationItem", 0, { text: "Visitor 11" });
 });

--- a/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
@@ -19,10 +19,10 @@ QUnit.test('livechats should be in "chat" filter', async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu button:contains(All).fw-bolder");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Visitor 11" });
+    await contains(".o-mail-NotificationItem-name", { text: "Visitor 11" });
     await click(".o-mail-MessagingMenu button", { text: "Chats" });
     await contains(".o-mail-MessagingMenu button:contains(Chat).fw-bolder");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Visitor 11" });
+    await contains(".o-mail-NotificationItem-name", { text: "Visitor 11" });
 });
 
 QUnit.test('livechats should be in "livechat" tab in mobile', async () => {
@@ -40,7 +40,7 @@ QUnit.test('livechats should be in "livechat" tab in mobile', async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button", { text: "Livechat" });
-    await contains(".o-mail-NotificationItem", 1, { text: "Visitor 11" });
+    await contains(".o-mail-NotificationItem", { text: "Visitor 11" });
     await click("button", { text: "Chat" });
-    await contains(".o-mail-NotificationItem", 0, { text: "Visitor 11" });
+    await contains(".o-mail-NotificationItem", { count: 0, text: "Visitor 11" });
 });

--- a/addons/im_livechat/static/tests/messaging_service_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch_tests.js
@@ -34,5 +34,8 @@ QUnit.test("Notify message received out of focus", async () => {
             uuid: channel.uuid,
         })
     );
-    await contains(".o_notification.border-info:contains(New message):contains(Hello)");
+    await contains(".o_notification.border-info .o_notification_title", 1, {
+        text: "New message",
+    });
+    await contains(".o_notification.border-info .o_notification_content", 1, { text: "Hello" });
 });

--- a/addons/im_livechat/static/tests/messaging_service_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch_tests.js
@@ -34,8 +34,8 @@ QUnit.test("Notify message received out of focus", async () => {
             uuid: channel.uuid,
         })
     );
-    await contains(".o_notification.border-info .o_notification_title", 1, {
+    await contains(".o_notification.border-info .o_notification_title", {
         text: "New message",
     });
-    await contains(".o_notification.border-info .o_notification_content", 1, { text: "Hello" });
+    await contains(".o_notification.border-info .o_notification_content", { text: "Hello" });
 });

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
@@ -13,7 +13,7 @@ QUnit.test("Livechat button is not present when there is no livechat thread", as
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-navbar span", 0, { text: "Livechat" });
+    await contains(".o-mail-MessagingMenu-navbar span", { count: 0, text: "Livechat" });
 });
 
 QUnit.test("Livechat button is present when there is at least one livechat thread", async () => {
@@ -30,5 +30,5 @@ QUnit.test("Livechat button is present when there is at least one livechat threa
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-navbar span", 1, { text: "Livechat" });
+    await contains(".o-mail-MessagingMenu-navbar span", { text: "Livechat" });
 });

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
@@ -13,7 +13,7 @@ QUnit.test("Livechat button is not present when there is no livechat thread", as
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-navbar:contains(Livechat)", 0);
+    await contains(".o-mail-MessagingMenu-navbar span", 0, { text: "Livechat" });
 });
 
 QUnit.test("Livechat button is present when there is at least one livechat thread", async () => {
@@ -30,5 +30,5 @@ QUnit.test("Livechat button is present when there is at least one livechat threa
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-navbar:contains(Livechat)");
+    await contains(".o-mail-MessagingMenu-navbar span", 1, { text: "Livechat" });
 });

--- a/addons/im_livechat/static/tests/sidebar_patch_tests.js
+++ b/addons/im_livechat/static/tests/sidebar_patch_tests.js
@@ -20,7 +20,7 @@ QUnit.test("Unknown visitor", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebar .o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Visitor 11)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Visitor 11" });
 });
 
 QUnit.test("Known user with country", async () => {
@@ -313,7 +313,9 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge:contains(1)");
+        await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", 1, {
+            text: "1",
+        });
     }
 );
 
@@ -418,7 +420,9 @@ QUnit.test("Clicking on unpin button unpins the channel", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o_notification:contains(You unpinned your conversation with Visitor 11)");
+    await contains(".o_notification_content", 1, {
+        text: "You unpinned your conversation with Visitor 11",
+    });
 });
 
 QUnit.test("Message unread counter", async () => {
@@ -440,5 +444,5 @@ QUnit.test("Message unread counter", async () => {
             uuid: pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0].uuid,
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel .badge:contains(1)");
+    await contains(".o-mail-DiscussSidebarChannel .badge", 1, { text: "1" });
 });

--- a/addons/im_livechat/static/tests/sidebar_patch_tests.js
+++ b/addons/im_livechat/static/tests/sidebar_patch_tests.js
@@ -20,7 +20,7 @@ QUnit.test("Unknown visitor", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebar .o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Visitor 11" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Visitor 11" });
 });
 
 QUnit.test("Known user with country", async () => {
@@ -70,8 +70,8 @@ QUnit.test("Do not show channel when visitor is typing", async () => {
     });
     const { env, openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory", 2);
-    await contains(".o-mail-DiscussSidebarCategory-livechat", 0);
+    await contains(".o-mail-DiscussSidebarCategory", { count: 2 });
+    await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     // simulate livechat visitor typing
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     await pyEnv.withUser(pyEnv.publicUserId, () =>
@@ -82,7 +82,7 @@ QUnit.test("Do not show channel when visitor is typing", async () => {
     );
     // weak test, no guaranteed that we waited long enough for the livechat to potentially appear
     await nextTick();
-    await contains(".o-mail-DiscussSidebarCategory-livechat", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
 });
 
 QUnit.test("Close should update the value on the server", async (assert) => {
@@ -169,7 +169,9 @@ QUnit.test("Open from the bus", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
+        count: 0,
+    });
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.record/insert", {
         "res.users.settings": {
             id: settingsId,
@@ -203,7 +205,9 @@ QUnit.test("Close from the bus", async () => {
             is_discuss_sidebar_category_livechat_open: false,
         },
     });
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
+        count: 0,
+    });
 });
 
 QUnit.test("Smiley face avatar for an anonymous livechat item", async () => {
@@ -263,7 +267,9 @@ QUnit.test("No counter if the category is unfolded and with unread messages", as
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarCategory-livechat .o-mail-Discuss-category-counter", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat .o-mail-Discuss-category-counter", {
+        count: 0,
+    });
 });
 
 QUnit.test("No counter if category is folded and without unread messages", async () => {
@@ -284,7 +290,7 @@ QUnit.test("No counter if category is folded and without unread messages", async
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", { count: 0 });
 });
 
 QUnit.test(
@@ -313,7 +319,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", 1, {
+        await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", {
             text: "1",
         });
     }
@@ -339,7 +345,7 @@ QUnit.test("Close manually by clicking the title", async () => {
     await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
     // fold the livechat category
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });
 
 QUnit.test("Open manually by clicking the title", async () => {
@@ -360,7 +366,9 @@ QUnit.test("Open manually by clicking the title", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
+        count: 0,
+    });
     // open the livechat category
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
     await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
@@ -381,7 +389,9 @@ QUnit.test("Category item should be invisible if the category is closed", async 
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
     await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
+        count: 0,
+    });
 });
 
 QUnit.test("Active category item should be visible even if the category is closed", async () => {
@@ -420,7 +430,7 @@ QUnit.test("Clicking on unpin button unpins the channel", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o_notification_content", 1, {
+    await contains(".o_notification_content", {
         text: "You unpinned your conversation with Visitor 11",
     });
 });
@@ -444,5 +454,5 @@ QUnit.test("Message unread counter", async () => {
             uuid: pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0].uuid,
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel .badge", 1, { text: "1" });
+    await contains(".o-mail-DiscussSidebarChannel .badge", { text: "1" });
 });

--- a/addons/im_livechat/static/tests/suggestions_tests.js
+++ b/addons/im_livechat/static/tests/suggestions_tests.js
@@ -22,9 +22,9 @@ QUnit.test("Suggestions are shown after delimiter was used in text (:)", async (
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", ":");
-    await contains(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "hello" });
     await insertText(".o-mail-Composer-input", ")");
-    await contains(".o-mail-Composer-suggestion", 0);
+    await contains(".o-mail-Composer-suggestion strong", 0);
     await insertText(".o-mail-Composer-input", " :");
-    await contains(".o-mail-Composer-suggestion:contains(hello)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "hello" });
 });

--- a/addons/im_livechat/static/tests/suggestions_tests.js
+++ b/addons/im_livechat/static/tests/suggestions_tests.js
@@ -22,9 +22,9 @@ QUnit.test("Suggestions are shown after delimiter was used in text (:)", async (
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", ":");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "hello" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
     await insertText(".o-mail-Composer-input", ")");
-    await contains(".o-mail-Composer-suggestion strong", 0);
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
     await insertText(".o-mail-Composer-input", " :");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "hello" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "hello" });
 });

--- a/addons/im_livechat/static/tests/thread_model_patch_tests.js
+++ b/addons/im_livechat/static/tests/thread_model_patch_tests.js
@@ -31,6 +31,6 @@ QUnit.test("Thread name unchanged when inviting new users", async () => {
     await click("button:contains(Invite):not(:disabled)");
     await contains(".o-discuss-ChannelInvitation", 0);
     await click("button[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember:contains(James)");
+    await contains(".o-discuss-ChannelMember", 1, { text: "James" });
     await contains(".o-mail-Discuss-threadName[title='Visitor #20']");
 });

--- a/addons/im_livechat/static/tests/thread_model_patch_tests.js
+++ b/addons/im_livechat/static/tests/thread_model_patch_tests.js
@@ -29,8 +29,8 @@ QUnit.test("Thread name unchanged when inviting new users", async () => {
     await click("button[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable:contains(James) input");
     await click("button:contains(Invite):not(:disabled)");
-    await contains(".o-discuss-ChannelInvitation", 0);
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("button[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 1, { text: "James" });
+    await contains(".o-discuss-ChannelMember", { text: "James" });
     await contains(".o-mail-Discuss-threadName[title='Visitor #20']");
 });

--- a/addons/mail/static/tests/activity/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/tests/activity/activity_mark_done_popover_tests.js
@@ -26,7 +26,7 @@ QUnit.test("activity mark done popover simplest layout", async () => {
     await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done and Schedule Next']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done']");
-    await contains(".o-mail-ActivityMarkAsDone button", 1, { text: "Discard" });
+    await contains(".o-mail-ActivityMarkAsDone button", { text: "Discard" });
 });
 
 QUnit.test("activity with force next mark done popover simplest layout", async () => {
@@ -49,8 +49,8 @@ QUnit.test("activity with force next mark done popover simplest layout", async (
     await contains(".o-mail-ActivityMarkAsDone");
     await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done and Schedule Next']");
-    await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done']", 0);
-    await contains(".o-mail-ActivityMarkAsDone button", 1, { text: "Discard" });
+    await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done']", { count: 0 });
+    await contains(".o-mail-ActivityMarkAsDone button", { text: "Discard" });
 });
 
 QUnit.test("activity mark done popover mark done without feedback", async (assert) => {

--- a/addons/mail/static/tests/activity/activity_mark_done_popover_tests.js
+++ b/addons/mail/static/tests/activity/activity_mark_done_popover_tests.js
@@ -21,12 +21,12 @@ QUnit.test("activity mark done popover simplest layout", async () => {
         res_id: partnerId,
         views: [[false, "form"]],
     });
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await contains(".o-mail-ActivityMarkAsDone");
     await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done and Schedule Next']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done']");
-    await contains(".o-mail-ActivityMarkAsDone button:contains(Discard)");
+    await contains(".o-mail-ActivityMarkAsDone button", 1, { text: "Discard" });
 });
 
 QUnit.test("activity with force next mark done popover simplest layout", async () => {
@@ -45,12 +45,12 @@ QUnit.test("activity with force next mark done popover simplest layout", async (
         res_id: partnerId,
         views: [[false, "form"]],
     });
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await contains(".o-mail-ActivityMarkAsDone");
     await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done and Schedule Next']");
     await contains(".o-mail-ActivityMarkAsDone button[aria-label='Done']", 0);
-    await contains(".o-mail-ActivityMarkAsDone button:contains(Discard)");
+    await contains(".o-mail-ActivityMarkAsDone button", 1, { text: "Discard" });
 });
 
 QUnit.test("activity mark done popover mark done without feedback", async (assert) => {
@@ -87,7 +87,7 @@ QUnit.test("activity mark done popover mark done without feedback", async (asser
         res_id: partnerId,
         views: [[false, "form"]],
     });
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await click(".o-mail-ActivityMarkAsDone button[aria-label='Done']");
     assert.verifySteps(["action_feedback"]);
 });
@@ -126,7 +126,7 @@ QUnit.test("activity mark done popover mark done with feedback", async (assert) 
         res_id: partnerId,
         views: [[false, "form"]],
     });
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await insertText(
         ".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']",
         "This task is done"
@@ -175,7 +175,7 @@ QUnit.test("activity mark done popover mark done and schedule next", async (asse
             );
         },
     });
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await insertText(
         ".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']",
         "This task is done"
@@ -217,7 +217,7 @@ QUnit.test("[technical] activity mark done & schedule next with new action", asy
             );
         },
     });
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await click(".o-mail-ActivityMarkAsDone button[aria-label='Done and Schedule Next']");
     await def;
     assert.verifySteps(["activity_action"]);

--- a/addons/mail/static/tests/activity/activity_menu_tests.js
+++ b/addons/mail/static/tests/activity/activity_menu_tests.js
@@ -14,6 +14,5 @@ QUnit.test("should update activities when opening the activity menu", async (ass
         res_model: "res.partner",
     });
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter:contains(1)");
-    assert.strictEqual($(".o-mail-ActivityMenu-counter").text(), "1");
+    await contains(".o-mail-ActivityMenu-counter", 1, { text: "1" });
 });

--- a/addons/mail/static/tests/activity/activity_menu_tests.js
+++ b/addons/mail/static/tests/activity/activity_menu_tests.js
@@ -4,10 +4,11 @@ import { click, contains, start, startServer } from "@mail/../tests/helpers/test
 
 QUnit.module("activity menu");
 
-QUnit.test("should update activities when opening the activity menu", async (assert) => {
+QUnit.test("should update activities when opening the activity menu", async () => {
     const pyEnv = await startServer();
     await start();
-    assert.strictEqual($(".o-mail-ActivityMenu-counter").text(), "");
+    await contains(".o_menu_systray i[aria-label='Activities']");
+    await contains(".o-mail-ActivityMenu-counter", { count: 0 });
     const partnerId = pyEnv["res.partner"].create({});
     pyEnv["mail.activity"].create({
         res_id: partnerId,

--- a/addons/mail/static/tests/activity/activity_menu_tests.js
+++ b/addons/mail/static/tests/activity/activity_menu_tests.js
@@ -14,5 +14,5 @@ QUnit.test("should update activities when opening the activity menu", async (ass
         res_model: "res.partner",
     });
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter", 1, { text: "1" });
+    await contains(".o-mail-ActivityMenu-counter", { text: "1" });
 });

--- a/addons/mail/static/tests/activity/activity_tests.js
+++ b/addons/mail/static/tests/activity/activity_tests.js
@@ -39,7 +39,7 @@ QUnit.test("activity upload document is available", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info:contains('Upload Document')");
+    await contains(".o-mail-Activity-info span", 1, { text: "Upload Document" });
     await contains(".btn .fa-upload");
     await contains(".o-mail-Activity .o_input_file");
 });
@@ -62,10 +62,10 @@ QUnit.test("activity can upload a document", async () => {
         contentType: "text/plain",
         name: "text.txt",
     });
-    await contains(".o-mail-Activity-info:contains('Upload Document')");
+    await contains(".o-mail-Activity-info span", 1, { text: "Upload Document" });
     inputFiles($(".o-mail-Activity .o_input_file")[0], [file]);
-    await contains(".o-mail-Activity-info:contains('Upload Document')", 0);
-    await contains("button[aria-label='Attach files']:contains(1)");
+    await contains(".o-mail-Activity-info span", 0, { text: "Upload Document" });
+    await contains("button[aria-label='Attach files']", 1, { text: "1" });
 });
 
 QUnit.test("activity simplest layout", async () => {
@@ -84,10 +84,10 @@ QUnit.test("activity simplest layout", async () => {
     await contains(".o-mail-Activity-note", 0);
     await contains(".o-mail-Activity-details", 0);
     await contains(".o-mail-Activity-mailTemplates", 0);
-    await contains(".btn:contains('Edit')", 0);
-    await contains(".o-mail-Activity span:contains(Cancel)", 0);
-    await contains(".btn:contains('Mark Done')", 0);
-    await contains(".o-mail-Activity-info:contains('Upload Document')", 0);
+    await contains(".btn", 0, { text: "Edit" });
+    await contains(".o-mail-Activity span", 0, { text: "Cancel" });
+    await contains(".btn", 0, { text: "Mark Done" });
+    await contains(".o-mail-Activity-info span", 0, { text: "Upload Document" });
 });
 
 QUnit.test("activity with note layout", async (assert) => {
@@ -120,9 +120,7 @@ QUnit.test("activity info layout when planned after tomorrow", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-success");
-    await contains(".o-mail-Activity:contains('Due in 5 days:')");
+    await contains(".o-mail-Activity span.text-success", 1, { text: "Due in 5 days:" });
 });
 
 QUnit.test("activity info layout when planned tomorrow", async () => {
@@ -140,9 +138,7 @@ QUnit.test("activity info layout when planned tomorrow", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-success");
-    await contains(".o-mail-Activity:contains('Tomorrow:')");
+    await contains(".o-mail-Activity span.text-success", 1, { text: "Tomorrow:" });
 });
 
 QUnit.test("activity info layout when planned today", async () => {
@@ -157,9 +153,7 @@ QUnit.test("activity info layout when planned today", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-warning");
-    await contains(".o-mail-Activity:contains('Today:')");
+    await contains(".o-mail-Activity span.text-warning", 1, { text: "Today:" });
 });
 
 QUnit.test("activity info layout when planned yesterday", async () => {
@@ -177,9 +171,7 @@ QUnit.test("activity info layout when planned yesterday", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-danger");
-    await contains(".o-mail-Activity:contains('Yesterday:')");
+    await contains(".o-mail-Activity span.text-danger", 1, { text: "Yesterday:" });
 });
 
 QUnit.test("activity info layout when planned before yesterday", async () => {
@@ -197,9 +189,7 @@ QUnit.test("activity info layout when planned before yesterday", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-danger");
-    await contains(".o-mail-Activity:contains('5 days overdue:')");
+    await contains(".o-mail-Activity span.text-danger", 1, { text: "5 days overdue:" });
 });
 
 /**
@@ -223,15 +213,11 @@ QUnit.skip("activity info layout change at midnight", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-success");
-    await contains(".o-mail-Activity:contains('Tomorrow:')");
+    await contains(".o-mail-Activity span.text-success", 1, { text: "Tomorrow:" });
 
     patchDate(2023, 11, 8, 0, 0, 1); // OXP is coming!
     await mock.advanceTime(2000);
-    await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity .text-warning");
-    await contains(".o-mail-Activity:contains('Today:')");
+    await contains(".o-mail-Activity span.text-warning", 1, { text: "Today:" });
 });
 
 QUnit.test("activity with a summary layout", async () => {
@@ -244,7 +230,7 @@ QUnit.test("activity with a summary layout", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info:contains('test summary')");
+    await contains(".o-mail-Activity-info span", 1, { text: "“test summary”" });
 });
 
 QUnit.test("activity without summary layout", async () => {
@@ -257,7 +243,7 @@ QUnit.test("activity without summary layout", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info:contains('Email')");
+    await contains(".o-mail-Activity-info span", 1, { text: "Email" });
 });
 
 QUnit.test("activity details toggle", async () => {
@@ -304,8 +290,7 @@ QUnit.test("activity with mail template layout", async (assert) => {
     await contains(".o-mail-Activity");
     await contains(".o-mail-Activity-sidebar");
     await contains(".o-mail-Activity-mailTemplates");
-    await contains(".o-mail-ActivityMailTemplate-name:contains(Dummy mail template)");
-    assert.strictEqual($(".o-mail-ActivityMailTemplate-name").text(), "Dummy mail template");
+    await contains(".o-mail-ActivityMailTemplate-name", 1, { text: "Dummy mail template" });
     await contains(".o-mail-ActivityMailTemplate-preview");
     await contains(".o-mail-ActivityMailTemplate-send");
 });
@@ -385,18 +370,15 @@ QUnit.test("activity click on mark as done", async () => {
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
     await contains(".o-mail-Activity");
-    await contains(".btn:contains('Mark Done')");
-
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await contains(".o-mail-ActivityMarkAsDone");
-
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await contains(".o-mail-ActivityMarkAsDone", 0);
 });
 
 QUnit.test(
     "activity mark as done popover should focus feedback input on open [REQUIRE FOCUS]",
-    async (assert) => {
+    async () => {
         const pyEnv = await startServer();
         const partnerId = pyEnv["res.partner"].create({});
         const activityTypeId = pyEnv["mail.activity.type"].search([["name", "=", "Email"]])[0];
@@ -410,15 +392,8 @@ QUnit.test(
         const { openFormView } = await start();
         openFormView("res.partner", partnerId);
         await contains(".o-mail-Activity");
-        await contains(".btn:contains('Mark Done')");
-
-        await click(".btn:contains('Mark Done')");
-        assert.strictEqual(
-            (
-                await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']")
-            )[0],
-            document.activeElement
-        );
+        await click(".btn", { text: "Mark Done" });
+        await contains(".o-mail-ActivityMarkAsDone textarea[placeholder='Write Feedback']:focus");
     }
 );
 
@@ -447,7 +422,7 @@ QUnit.test("activity click on edit", async (assert) => {
             return super.doAction(...arguments);
         },
     });
-    await click(".o-mail-Activity .btn:contains('Edit')");
+    await click(".o-mail-Activity .btn", { text: "Edit" });
     assert.verifySteps(["do_action"]);
 });
 
@@ -471,7 +446,7 @@ QUnit.test("activity click on cancel", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await click(".o-mail-Activity span:contains(Cancel)");
+    await click(".o-mail-Activity span", { text: "Cancel" });
     await contains(".o-mail-Activity", 0);
     assert.verifySteps(["unlink"]);
 });
@@ -490,7 +465,7 @@ QUnit.test("activity mark done popover close on ESCAPE", async () => {
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
 
-    await click(".btn:contains('Mark Done')");
+    await click(".btn", { text: "Mark Done" });
     await contains(".o-mail-ActivityMarkAsDone");
 
     triggerHotkey("Escape");
@@ -510,9 +485,8 @@ QUnit.test("activity mark done popover click on discard", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-
-    await click(".btn:contains('Mark Done')");
-    await click(".o-mail-ActivityMarkAsDone button:contains(Discard)");
+    await click(".btn", { text: "Mark Done" });
+    await click(".o-mail-ActivityMarkAsDone button", { text: "Discard" });
     await contains(".o-mail-ActivityMarkAsDone", 0);
 });
 
@@ -545,7 +519,7 @@ QUnit.test("Activity are sorted by deadline", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity:eq(0):contains(5 days overdue:)");
-    await contains(".o-mail-Activity:eq(1):contains(Today:)");
-    await contains(".o-mail-Activity:eq(2):contains(Due in 4 days:)");
+    await contains(".o-mail-Activity:eq(0) span", 1, { text: "5 days overdue:" });
+    await contains(".o-mail-Activity:eq(1) span", 1, { text: "Today:" });
+    await contains(".o-mail-Activity:eq(2) span", 1, { text: "Due in 4 days:" });
 });

--- a/addons/mail/static/tests/activity/activity_tests.js
+++ b/addons/mail/static/tests/activity/activity_tests.js
@@ -90,7 +90,7 @@ QUnit.test("activity simplest layout", async () => {
     await contains(".o-mail-Activity-info span", { count: 0, text: "Upload Document" });
 });
 
-QUnit.test("activity with note layout", async (assert) => {
+QUnit.test("activity with note layout", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
     pyEnv["mail.activity"].create({
@@ -101,8 +101,7 @@ QUnit.test("activity with note layout", async (assert) => {
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
     await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity-note");
-    assert.strictEqual($(".o-mail-Activity-note").text(), "There is no good or bad note");
+    await contains(".o-mail-Activity-note", { text: "There is no good or bad note" });
 });
 
 QUnit.test("activity info layout when planned after tomorrow", async () => {

--- a/addons/mail/static/tests/activity/activity_tests.js
+++ b/addons/mail/static/tests/activity/activity_tests.js
@@ -39,7 +39,7 @@ QUnit.test("activity upload document is available", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info span", 1, { text: "Upload Document" });
+    await contains(".o-mail-Activity-info span", { text: "Upload Document" });
     await contains(".btn .fa-upload");
     await contains(".o-mail-Activity .o_input_file");
 });
@@ -62,10 +62,10 @@ QUnit.test("activity can upload a document", async () => {
         contentType: "text/plain",
         name: "text.txt",
     });
-    await contains(".o-mail-Activity-info span", 1, { text: "Upload Document" });
+    await contains(".o-mail-Activity-info span", { text: "Upload Document" });
     inputFiles($(".o-mail-Activity .o_input_file")[0], [file]);
-    await contains(".o-mail-Activity-info span", 0, { text: "Upload Document" });
-    await contains("button[aria-label='Attach files']", 1, { text: "1" });
+    await contains(".o-mail-Activity-info span", { count: 0, text: "Upload Document" });
+    await contains("button[aria-label='Attach files']", { text: "1" });
 });
 
 QUnit.test("activity simplest layout", async () => {
@@ -81,13 +81,13 @@ QUnit.test("activity simplest layout", async () => {
     await contains(".o-mail-Activity-sidebar");
     await contains(".o-mail-Activity-user");
     await contains(".o-mail-Activity-info");
-    await contains(".o-mail-Activity-note", 0);
-    await contains(".o-mail-Activity-details", 0);
-    await contains(".o-mail-Activity-mailTemplates", 0);
-    await contains(".btn", 0, { text: "Edit" });
-    await contains(".o-mail-Activity span", 0, { text: "Cancel" });
-    await contains(".btn", 0, { text: "Mark Done" });
-    await contains(".o-mail-Activity-info span", 0, { text: "Upload Document" });
+    await contains(".o-mail-Activity-note", { count: 0 });
+    await contains(".o-mail-Activity-details", { count: 0 });
+    await contains(".o-mail-Activity-mailTemplates", { count: 0 });
+    await contains(".btn", { count: 0, text: "Edit" });
+    await contains(".o-mail-Activity span", { count: 0, text: "Cancel" });
+    await contains(".btn", { count: 0, text: "Mark Done" });
+    await contains(".o-mail-Activity-info span", { count: 0, text: "Upload Document" });
 });
 
 QUnit.test("activity with note layout", async (assert) => {
@@ -120,7 +120,7 @@ QUnit.test("activity info layout when planned after tomorrow", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity span.text-success", 1, { text: "Due in 5 days:" });
+    await contains(".o-mail-Activity span.text-success", { text: "Due in 5 days:" });
 });
 
 QUnit.test("activity info layout when planned tomorrow", async () => {
@@ -138,7 +138,7 @@ QUnit.test("activity info layout when planned tomorrow", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity span.text-success", 1, { text: "Tomorrow:" });
+    await contains(".o-mail-Activity span.text-success", { text: "Tomorrow:" });
 });
 
 QUnit.test("activity info layout when planned today", async () => {
@@ -153,7 +153,7 @@ QUnit.test("activity info layout when planned today", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity span.text-warning", 1, { text: "Today:" });
+    await contains(".o-mail-Activity span.text-warning", { text: "Today:" });
 });
 
 QUnit.test("activity info layout when planned yesterday", async () => {
@@ -171,7 +171,7 @@ QUnit.test("activity info layout when planned yesterday", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity span.text-danger", 1, { text: "Yesterday:" });
+    await contains(".o-mail-Activity span.text-danger", { text: "Yesterday:" });
 });
 
 QUnit.test("activity info layout when planned before yesterday", async () => {
@@ -189,7 +189,7 @@ QUnit.test("activity info layout when planned before yesterday", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity span.text-danger", 1, { text: "5 days overdue:" });
+    await contains(".o-mail-Activity span.text-danger", { text: "5 days overdue:" });
 });
 
 /**
@@ -213,11 +213,11 @@ QUnit.skip("activity info layout change at midnight", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity span.text-success", 1, { text: "Tomorrow:" });
+    await contains(".o-mail-Activity span.text-success", { text: "Tomorrow:" });
 
     patchDate(2023, 11, 8, 0, 0, 1); // OXP is coming!
     await mock.advanceTime(2000);
-    await contains(".o-mail-Activity span.text-warning", 1, { text: "Today:" });
+    await contains(".o-mail-Activity span.text-warning", { text: "Today:" });
 });
 
 QUnit.test("activity with a summary layout", async () => {
@@ -230,7 +230,7 @@ QUnit.test("activity with a summary layout", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info span", 1, { text: "“test summary”" });
+    await contains(".o-mail-Activity-info span", { text: "“test summary”" });
 });
 
 QUnit.test("activity without summary layout", async () => {
@@ -243,7 +243,7 @@ QUnit.test("activity without summary layout", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info span", 1, { text: "Email" });
+    await contains(".o-mail-Activity-info span", { text: "Email" });
 });
 
 QUnit.test("activity details toggle", async () => {
@@ -264,14 +264,14 @@ QUnit.test("activity details toggle", async () => {
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
     await contains(".o-mail-Activity");
-    await contains(".o-mail-Activity-details", 0);
+    await contains(".o-mail-Activity-details", { count: 0 });
     await contains(".o-mail-Activity-info i[aria-label='Info']");
 
     await click(".o-mail-Activity-info i[aria-label='Info']");
     await contains(".o-mail-Activity-details");
 
     await click(".o-mail-Activity-info i[aria-label='Info']");
-    await contains(".o-mail-Activity-details", 0);
+    await contains(".o-mail-Activity-details", { count: 0 });
 });
 
 QUnit.test("activity with mail template layout", async (assert) => {
@@ -290,7 +290,7 @@ QUnit.test("activity with mail template layout", async (assert) => {
     await contains(".o-mail-Activity");
     await contains(".o-mail-Activity-sidebar");
     await contains(".o-mail-Activity-mailTemplates");
-    await contains(".o-mail-ActivityMailTemplate-name", 1, { text: "Dummy mail template" });
+    await contains(".o-mail-ActivityMailTemplate-name", { text: "Dummy mail template" });
     await contains(".o-mail-ActivityMailTemplate-preview");
     await contains(".o-mail-ActivityMailTemplate-send");
 });
@@ -373,7 +373,7 @@ QUnit.test("activity click on mark as done", async () => {
     await click(".btn", { text: "Mark Done" });
     await contains(".o-mail-ActivityMarkAsDone");
     await click(".btn", { text: "Mark Done" });
-    await contains(".o-mail-ActivityMarkAsDone", 0);
+    await contains(".o-mail-ActivityMarkAsDone", { count: 0 });
 });
 
 QUnit.test(
@@ -447,7 +447,7 @@ QUnit.test("activity click on cancel", async (assert) => {
     });
     openFormView("res.partner", partnerId);
     await click(".o-mail-Activity span", { text: "Cancel" });
-    await contains(".o-mail-Activity", 0);
+    await contains(".o-mail-Activity", { count: 0 });
     assert.verifySteps(["unlink"]);
 });
 
@@ -469,7 +469,7 @@ QUnit.test("activity mark done popover close on ESCAPE", async () => {
     await contains(".o-mail-ActivityMarkAsDone");
 
     triggerHotkey("Escape");
-    await contains(".o-mail-ActivityMarkAsDone", 0);
+    await contains(".o-mail-ActivityMarkAsDone", { count: 0 });
 });
 
 QUnit.test("activity mark done popover click on discard", async () => {
@@ -487,7 +487,7 @@ QUnit.test("activity mark done popover click on discard", async () => {
     openFormView("res.partner", partnerId);
     await click(".btn", { text: "Mark Done" });
     await click(".o-mail-ActivityMarkAsDone button", { text: "Discard" });
-    await contains(".o-mail-ActivityMarkAsDone", 0);
+    await contains(".o-mail-ActivityMarkAsDone", { count: 0 });
 });
 
 QUnit.test("Activity are sorted by deadline", async () => {
@@ -519,7 +519,7 @@ QUnit.test("Activity are sorted by deadline", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity:eq(0) span", 1, { text: "5 days overdue:" });
-    await contains(".o-mail-Activity:eq(1) span", 1, { text: "Today:" });
-    await contains(".o-mail-Activity:eq(2) span", 1, { text: "Due in 4 days:" });
+    await contains(".o-mail-Activity:eq(0) span", { text: "5 days overdue:" });
+    await contains(".o-mail-Activity:eq(1) span", { text: "Today:" });
+    await contains(".o-mail-Activity:eq(2) span", { text: "Due in 4 days:" });
 });

--- a/addons/mail/static/tests/chat_window/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_manager_tests.js
@@ -65,11 +65,11 @@ QUnit.test("chat window does not fetch messages if hidden", async (assert) => {
             }
         },
     });
-    await contains(".o-mail-ChatWindow", 2);
+    await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-Message-content", 1, { text: "Orange" });
-    await contains(".o-mail-Message-content", 0, { text: "Apple" });
-    await contains(".o-mail-Message-content", 1, { text: "Banana" });
+    await contains(".o-mail-Message-content", { text: "Orange" });
+    await contains(".o-mail-Message-content", { count: 0, text: "Apple" });
+    await contains(".o-mail-Message-content", { text: "Banana" });
     assert.verifySteps(["fetch_messages", "fetch_messages"]);
 });
 
@@ -127,17 +127,17 @@ QUnit.test("click on hidden chat window should fetch its messages", async (asser
             }
         },
     });
-    await contains(".o-mail-ChatWindow", 2);
+    await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-Message-content", 1, { text: "Orange" });
-    await contains(".o-mail-Message-content", 0, { text: "Apple" });
-    await contains(".o-mail-Message-content", 1, { text: "Banana" });
+    await contains(".o-mail-Message-content", { text: "Orange" });
+    await contains(".o-mail-Message-content", { count: 0, text: "Apple" });
+    await contains(".o-mail-Message-content", { text: "Banana" });
     assert.verifySteps(["fetch_messages", "fetch_messages"]);
     await click(".o-mail-ChatWindowHiddenToggler");
     await click(".o-mail-ChatWindowHiddenMenu-item .o-mail-ChatWindow-command[title='Open']");
-    await contains(".o-mail-Message-content", 1, { text: "Orange" });
-    await contains(".o-mail-Message-content", 1, { text: "Apple" });
-    await contains(".o-mail-Message", 0, { text: "Banana" });
+    await contains(".o-mail-Message-content", { text: "Orange" });
+    await contains(".o-mail-Message-content", { text: "Apple" });
+    await contains(".o-mail-Message", { count: 0, text: "Banana" });
     assert.verifySteps(["fetch_messages"]);
 });
 
@@ -168,19 +168,19 @@ QUnit.test(
         await contains(".o-mail-ChatWindow");
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem-name", { text: "channel-B" });
-        await contains(".o-mail-ChatWindow", 2);
+        await contains(".o-mail-ChatWindow", { count: 2 });
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem-name", { text: "channel-C" });
-        await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "1" });
+        await contains(".o-mail-ChatWindowHiddenToggler", { text: "1" });
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem-name", { text: "channel-D" });
-        await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "2" });
-        await contains(".o-mail-ChatWindow-name:eq(0)", 1, { text: "channel-A" });
-        await contains(".o-mail-ChatWindow-name:eq(1)", 1, { text: "channel-D" });
+        await contains(".o-mail-ChatWindowHiddenToggler", { text: "2" });
+        await contains(".o-mail-ChatWindow-name:eq(0)", { text: "channel-A" });
+        await contains(".o-mail-ChatWindow-name:eq(1)", { text: "channel-D" });
         await click(
             ".o-mail-ChatWindow-header:contains(channel-D) .o-mail-ChatWindow-command[title='Close Chat Window']"
         );
-        await contains(".o-mail-ChatWindow-name:eq(0)", 1, { text: "channel-A" });
-        await contains(".o-mail-ChatWindow-name:eq(1)", 1, { text: "channel-C" });
+        await contains(".o-mail-ChatWindow-name:eq(0)", { text: "channel-A" });
+        await contains(".o-mail-ChatWindow-name:eq(1)", { text: "channel-C" });
     }
 );

--- a/addons/mail/static/tests/chat_window/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_manager_tests.js
@@ -67,9 +67,9 @@ QUnit.test("chat window does not fetch messages if hidden", async (assert) => {
     });
     await contains(".o-mail-ChatWindow", 2);
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-Message:contains(Orange)");
-    await contains(".o-mail-Message:contains(Apple)", 0);
-    await contains(".o-mail-Message:contains(Banana)");
+    await contains(".o-mail-Message-content", 1, { text: "Orange" });
+    await contains(".o-mail-Message-content", 0, { text: "Apple" });
+    await contains(".o-mail-Message-content", 1, { text: "Banana" });
     assert.verifySteps(["fetch_messages", "fetch_messages"]);
 });
 
@@ -129,15 +129,15 @@ QUnit.test("click on hidden chat window should fetch its messages", async (asser
     });
     await contains(".o-mail-ChatWindow", 2);
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-Message:contains(Orange)");
-    await contains(".o-mail-Message:contains(Apple)", 0);
-    await contains(".o-mail-Message:contains(Banana)");
+    await contains(".o-mail-Message-content", 1, { text: "Orange" });
+    await contains(".o-mail-Message-content", 0, { text: "Apple" });
+    await contains(".o-mail-Message-content", 1, { text: "Banana" });
     assert.verifySteps(["fetch_messages", "fetch_messages"]);
     await click(".o-mail-ChatWindowHiddenToggler");
     await click(".o-mail-ChatWindowHiddenMenu-item .o-mail-ChatWindow-command[title='Open']");
-    await contains(".o-mail-Message:contains(Orange)");
-    await contains(".o-mail-Message:contains(Apple)");
-    await contains(".o-mail-Message:contains(Banana)", 0);
+    await contains(".o-mail-Message-content", 1, { text: "Orange" });
+    await contains(".o-mail-Message-content", 1, { text: "Apple" });
+    await contains(".o-mail-Message", 0, { text: "Banana" });
     assert.verifySteps(["fetch_messages"]);
 });
 
@@ -164,24 +164,23 @@ QUnit.test(
         );
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem:contains(channel-A)");
+        await click(".o-mail-NotificationItem-name", { text: "channel-A" });
+        await contains(".o-mail-ChatWindow");
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem:contains(channel-B)");
-        await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem:contains(channel-C)");
-        await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem:contains(channel-D)");
-        await contains(
-            ".o-mail-ChatWindow-header:contains(channel-D) .o-mail-ChatWindow-command[title='Close Chat Window']"
-        );
+        await click(".o-mail-NotificationItem-name", { text: "channel-B" });
         await contains(".o-mail-ChatWindow", 2);
-        await contains(".o-mail-ChatWindow:eq(0):contains(channel-A)");
-        await contains(".o-mail-ChatWindow:eq(1):contains(channel-D)");
-        await contains(".o-mail-ChatWindowHiddenToggler:contains(2)");
+        await click(".o_menu_systray i[aria-label='Messages']");
+        await click(".o-mail-NotificationItem-name", { text: "channel-C" });
+        await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "1" });
+        await click(".o_menu_systray i[aria-label='Messages']");
+        await click(".o-mail-NotificationItem-name", { text: "channel-D" });
+        await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "2" });
+        await contains(".o-mail-ChatWindow-name:eq(0)", 1, { text: "channel-A" });
+        await contains(".o-mail-ChatWindow-name:eq(1)", 1, { text: "channel-D" });
         await click(
             ".o-mail-ChatWindow-header:contains(channel-D) .o-mail-ChatWindow-command[title='Close Chat Window']"
         );
-        await contains(".o-mail-ChatWindow:eq(0):contains(channel-A)");
-        await contains(".o-mail-ChatWindow:eq(1):contains(channel-C)");
+        await contains(".o-mail-ChatWindow-name:eq(0)", 1, { text: "channel-A" });
+        await contains(".o-mail-ChatWindow-name:eq(1)", 1, { text: "channel-C" });
     }
 );

--- a/addons/mail/static/tests/chat_window/chat_window_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_tests.js
@@ -40,7 +40,7 @@ QUnit.test(
         patchUiSize({ size: SIZES.SM });
         const { env } = await start();
         await contains(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-MessagingMenu-counter", 0);
+        await contains(".o-mail-MessagingMenu-counter", { count: 0 });
         // simulate receiving a message
         pyEnv.withUser(userId, () =>
             env.services.rpc("/mail/message/post", {
@@ -49,8 +49,8 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-MessagingMenu-counter", 1, { text: "1" });
-        await contains(".o-mail-ChatWindow", 0);
+        await contains(".o-mail-MessagingMenu-counter", { text: "1" });
+        await contains(".o-mail-ChatWindow", { count: 0 });
     }
 );
 
@@ -94,7 +94,7 @@ QUnit.test("Message post in chat window of chatter should log a note", async () 
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-Message-content", 1, {
+    await contains(".o-mail-Message-content", {
         text: "A needaction message to have it in messaging menu",
     });
     await contains(
@@ -103,8 +103,8 @@ QUnit.test("Message post in chat window of chatter should log a note", async () 
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
-    await contains(".o-mail-Message-content", 1, { text: "Test" });
-    await contains(".o-mail-Message:contains(Test) .o-mail-Message-bubble.border", 0); // non-bordered bubble = "Log note" mode
+    await contains(".o-mail-Message-content", { text: "Test" });
+    await contains(".o-mail-Message:contains(Test) .o-mail-Message-bubble.border", { count: 0 }); // non-bordered bubble = "Log note" mode
 });
 
 QUnit.test("load messages from opening chat window from messaging menu", async () => {
@@ -124,7 +124,7 @@ QUnit.test("load messages from opening chat window from messaging menu", async (
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-Message", 21);
+    await contains(".o-mail-Message", { count: 21 });
 });
 
 QUnit.test("chat window: basic rendering", async () => {
@@ -136,17 +136,17 @@ QUnit.test("chat window: basic rendering", async () => {
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header");
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "General" });
-    await contains(".o-mail-ChatWindow-command", 4);
+    await contains(".o-mail-ChatWindow-name", { text: "General" });
+    await contains(".o-mail-ChatWindow-command", { count: 4 });
     await contains("[title='Start a Call']");
     await contains("[title='Open Actions Menu']");
     await contains("[title='Fold']");
     await contains("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow-content .o-mail-Thread .o-mail-Thread-empty", 1, {
+    await contains(".o-mail-ChatWindow-content .o-mail-Thread .o-mail-Thread-empty", {
         text: "There are no messages in this conversation.",
     });
     await click("[title='Open Actions Menu']");
-    await contains(".o-mail-ChatWindow-command", 10);
+    await contains(".o-mail-ChatWindow-command", { count: 10 });
     await contains("[title='Pinned Messages']");
     await contains("[title='Show Attachments']");
     await contains("[title='Add Users']");
@@ -163,14 +163,14 @@ QUnit.test("Fold state of chat window is sync among browser tabs", async () => {
     await click(".o_menu_systray i[aria-label='Messages']", { target: tab1.target });
     await click(".o-mail-NotificationItem", { target: tab1.target });
     await click(".o-mail-ChatWindow-header", { target: tab1.target }); // Fold
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", 0, { target: tab1.target });
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", 0, { target: tab2.target });
+    await contains(".o-mail-ChatWindow-content", { count: 0, target: tab1.target });
+    await contains(".o-mail-ChatWindow-content", { count: 0, target: tab2.target });
     await click(".o-mail-ChatWindow-header", { target: tab2.target }); // Unfold
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", 1, { target: tab1.target });
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", 1, { target: tab2.target });
+    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", { target: tab1.target });
+    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", { target: tab2.target });
     await click("[title='Close Chat Window']", { target: tab1.target });
-    await contains(".o-mail-ChatWindow", 0, { target: tab1.target });
-    await contains(".o-mail-ChatWindow", 0, { target: tab2.target });
+    await contains(".o-mail-ChatWindow", { count: 0, target: tab1.target });
+    await contains(".o-mail-ChatWindow", { count: 0, target: tab2.target });
 });
 
 QUnit.test(
@@ -213,7 +213,7 @@ QUnit.test("chat window: fold", async (assert) => {
 
     // Fold chat window
     await click(".o-mail-ChatWindow-command[title='Fold']");
-    await contains(".o-mail-ChatWindow .o-mail-Thread", 0);
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { count: 0 });
     assert.verifySteps(["rpc:channel_fold/folded"]);
 
     // Unfold chat window
@@ -233,13 +233,13 @@ QUnit.test("chat window: open / close", async (assert) => {
         },
     });
     await click("button i[aria-label='Messages']");
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
     assert.verifySteps(["rpc:channel_fold/open"]);
 
     await click(".o-mail-ChatWindow-command[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
     assert.verifySteps(["rpc:channel_fold/closed"]);
 
     // Reopen chat window
@@ -275,7 +275,7 @@ QUnit.test(
         await click(".o-mail-NotificationItem");
         await contains(".o-mail-ChatWindow");
         await click("[title='Close Chat Window']");
-        await contains(".o-mail-ChatWindow", 0);
+        await contains(".o-mail-ChatWindow", { count: 0 });
         const [member] = pyEnv["discuss.channel.member"].searchRead([
             ["channel_id", "=", channelId],
             ["partner_id", "=", pyEnv.currentPartnerId],
@@ -302,7 +302,7 @@ QUnit.test("chat window: close on ESCAPE", async (assert) => {
 
     $(".o-mail-Composer-input")[0].focus();
     triggerHotkey("Escape");
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
     assert.verifySteps(["rpc:channel_fold/closed"]);
 });
 
@@ -343,7 +343,7 @@ QUnit.test(
         await start();
         await click("button[aria-label='Emojis']");
         triggerHotkey("Escape");
-        await contains(".o-EmojiPicker", 0);
+        await contains(".o-EmojiPicker", { count: 0 });
         await contains(".o-mail-ChatWindow");
     }
 );
@@ -360,7 +360,7 @@ QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]",
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_1" });
+    await contains(".o-mail-ChatWindow-name", { text: "Channel_1" });
     assert.strictEqual(
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(Channel_1)")
@@ -370,9 +370,9 @@ QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]",
 
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Channel_2" });
-    await contains(".o-mail-ChatWindow", 2);
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_2" });
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_1" });
+    await contains(".o-mail-ChatWindow", { count: 2 });
+    await contains(".o-mail-ChatWindow-name", { text: "Channel_2" });
+    await contains(".o-mail-ChatWindow-name", { text: "Channel_1" });
     assert.strictEqual(
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(Channel_2)")
@@ -404,19 +404,19 @@ QUnit.test("open 3 different chat windows: not enough screen width", async (asse
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindowHiddenToggler", 0);
+    await contains(".o-mail-ChatWindowHiddenToggler", { count: 0 });
 
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Channel_2" });
-    await contains(".o-mail-ChatWindow", 2);
-    await contains(".o-mail-ChatWindowHiddenToggler", 0);
+    await contains(".o-mail-ChatWindow", { count: 2 });
+    await contains(".o-mail-ChatWindowHiddenToggler", { count: 0 });
 
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Channel_3" });
-    await contains(".o-mail-ChatWindow", 2);
+    await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_1" });
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_3" });
+    await contains(".o-mail-ChatWindow-name", { text: "Channel_1" });
+    await contains(".o-mail-ChatWindow-name", { text: "Channel_3" });
     assert.strictEqual(
         document.activeElement,
         $(".o-mail-ChatWindow-name:contains(Channel_3)")
@@ -449,30 +449,30 @@ QUnit.test("closing hidden chat window", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await click("i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
-    await contains(".o-mail-ChatWindow", 2);
+    await contains(".o-mail-ChatWindow", { count: 2 });
     await click("i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Ch_3" });
-    await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "1" });
+    await contains(".o-mail-ChatWindowHiddenToggler", { text: "1" });
     await click("i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Ch_4" });
-    await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "2" });
+    await contains(".o-mail-ChatWindowHiddenToggler", { text: "2" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_1",
     });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_2" });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_3" });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_2" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_4",
     });
     await click(".o-mail-ChatWindow:contains(Ch_2) [title='Close Chat Window']");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_1",
     });
-    await contains(".o-mail-ChatWindow-name", 0, { text: "Ch_2" });
+    await contains(".o-mail-ChatWindow-name", { count: 0, text: "Ch_2" });
 
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_3" });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_4",
     });
 });
@@ -498,23 +498,23 @@ QUnit.test("Opening hidden chat window from messaging menu", async (assert) => {
     await click("i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Ch_3" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_1",
     });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_2" });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_2" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_3",
     });
     await click("i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_1",
     });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
         text: "Ch_2",
     });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_3" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_3" });
 });
 
 QUnit.test(
@@ -558,7 +558,7 @@ QUnit.test(
             "should have enough space to open 2 chat windows simultaneously"
         );
         await start();
-        await contains(".o-mail-ChatWindow .o-mail-Composer-input", 2);
+        await contains(".o-mail-ChatWindow .o-mail-Composer-input", { count: 2 });
 
         $(".o-mail-ChatWindow-name:contains(MyTeam)")
             .closest(".o-mail-ChatWindow")
@@ -586,7 +586,7 @@ QUnit.test("chat window: switch on TAB [REQUIRE FOCUS]", async (assert) => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "channel1" });
-    await contains(".o-mail-ChatWindow", 1);
+    await contains(".o-mail-ChatWindow", { count: 1 });
     await contains(".o-mail-ChatWindow:contains(channel1) .o-mail-Composer-input:focus");
 
     triggerHotkey("Tab");
@@ -594,7 +594,7 @@ QUnit.test("chat window: switch on TAB [REQUIRE FOCUS]", async (assert) => {
 
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "channel2" });
-    await contains(".o-mail-ChatWindow", 2);
+    await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindow:contains(channel2) .o-mail-Composer-input:focus");
 
     triggerHotkey("Tab");
@@ -655,7 +655,7 @@ QUnit.test("chat window: TAB cycle with 3 open chat windows [REQUIRE FOCUS]", as
     );
     await start();
     // FIXME: assumes ordering: MyProject, MyTeam, General
-    await contains(".o-mail-ChatWindow .o-mail-Composer-input", 3);
+    await contains(".o-mail-ChatWindow .o-mail-Composer-input", { count: 3 });
     (await contains(".o-mail-ChatWindow:contains(MyProject) .o-mail-Composer-input"))[0].focus();
 
     triggerHotkey("Tab");
@@ -709,8 +709,8 @@ QUnit.test(
             })
         );
         await contains(".o-mail-ChatWindow");
-        await contains(".o-mail-Message", 2);
-        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+        await contains(".o-mail-Message", { count: 2 });
+        await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
     }
 );
 
@@ -739,7 +739,7 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+        await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
     }
 );
 
@@ -785,7 +785,7 @@ QUnit.test("chat window should not open when receiving a new DM from odoobot", a
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
 });
 
 QUnit.test(
@@ -813,11 +813,11 @@ QUnit.test(
             });
         }
         await start();
-        await contains(".o-mail-Message", 10);
+        await contains(".o-mail-Message", { count: 10 });
         await insertText(".o-mail-Composer-input", "WOLOLO");
         triggerHotkey("Enter");
-        await contains(".o-mail-Message", 11);
-        await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+        await contains(".o-mail-Message", { count: 11 });
+        await contains(".o-mail-Thread", { scroll: "bottom" });
     }
 );
 
@@ -845,7 +845,7 @@ QUnit.test("chat window should remain folded when new message is received", asyn
     });
     const { env } = await start();
     await contains(".o-mail-ChatWindow.o-folded");
-    await contains(".o-mail-ChatWindow-counter", 0);
+    await contains(".o-mail-ChatWindow-counter", { count: 0 });
     pyEnv.withUser(userId, () =>
         env.services.rpc("/mail/message/post", {
             post_data: { body: "New Message", message_type: "comment" },
@@ -853,7 +853,7 @@ QUnit.test("chat window should remain folded when new message is received", asyn
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-counter", 1, { text: "1" });
+    await contains(".o-mail-ChatWindow-counter", { text: "1" });
     await contains(".o-mail-ChatWindow.o-folded");
 });
 
@@ -891,7 +891,7 @@ QUnit.test(
         // simulate resize to go into mobile
         patchUiSize({ size: SIZES.SM });
         window.dispatchEvent(new UIEvent("resize"));
-        await contains(".o-mail-ChatWindowHiddenToggler", 0);
+        await contains(".o-mail-ChatWindowHiddenToggler", { count: 0 });
     }
 );
 
@@ -903,7 +903,9 @@ QUnit.test("chat window: composer state conservation on toggle discuss", async (
     await click(".o-mail-NotificationItem");
     // Set content of the composer of the chat window
     await insertText(".o-mail-Composer-input", "XDU for the win !");
-    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard", 0);
+    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard", {
+        count: 0,
+    });
     // Set attachments of the composer
     const files = [
         await createFile({
@@ -918,18 +920,20 @@ QUnit.test("chat window: composer state conservation on toggle discuss", async (
         }),
     ];
     inputFiles($(".o-mail-Composer-coreMain .o_input_file")[0], files);
-    await contains(".o-mail-AttachmentCard .fa-check", 2);
+    await contains(".o-mail-AttachmentCard .fa-check", { count: 2 });
 
     openDiscuss();
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
 
     openView({
         res_id: channelId,
         res_model: "discuss.channel",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard", 2);
-    await contains(".o-mail-Composer-input", 1, { value: "XDU for the win !" });
+    await contains(".o-mail-Composer-footer .o-mail-AttachmentList .o-mail-AttachmentCard", {
+        count: 2,
+    });
+    await contains(".o-mail-Composer-input", { value: "XDU for the win !" });
 });
 
 QUnit.test(
@@ -979,9 +983,9 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+        await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
         $(".o-mail-Composer-input")[0].focus();
-        await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+        await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
     }
 );
 
@@ -998,18 +1002,18 @@ QUnit.test("chat window: scroll conservation on toggle discuss", async () => {
     const { openDiscuss, openView } = await start();
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-Message", 31);
-    await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 31 });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-ChatWindow .o-mail-Thread", 142);
     openDiscuss(null, { waitUntilMessagesLoaded: false });
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
     openView({
         res_id: channelId,
         res_model: "discuss.channel",
         views: [[false, "list"]],
     });
-    await contains(".o-mail-Message", 31);
-    await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: 142 });
+    await contains(".o-mail-Message", { count: 31 });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 142 });
 });
 
 QUnit.test(
@@ -1027,17 +1031,17 @@ QUnit.test(
         await start();
         await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Message", 31);
-        await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: "bottom" });
+        await contains(".o-mail-Message", { count: 31 });
+        await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: "bottom" });
         await scroll(".o-mail-ChatWindow .o-mail-Thread", 142);
         // fold chat window
         await click(".o-mail-ChatWindow-command[title='Fold']");
-        await contains(".o-mail-Message", 0);
-        await contains(".o-mail-ChatWindow .o-mail-Thread", 0);
+        await contains(".o-mail-Message", { count: 0 });
+        await contains(".o-mail-ChatWindow .o-mail-Thread", { count: 0 });
         // unfold chat window
         await click(".o-mail-ChatWindow-command[title='Open']");
-        await contains(".o-mail-Message", 31);
-        await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: 142 });
+        await contains(".o-mail-Message", { count: 31 });
+        await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 142 });
     }
 );
 
@@ -1056,13 +1060,13 @@ QUnit.test(
         const { openDiscuss, openView } = await start();
         await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Message", 31);
-        await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: "bottom" });
+        await contains(".o-mail-Message", { count: 31 });
+        await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: "bottom" });
         await scroll(".o-mail-ChatWindow .o-mail-Thread", 142);
         // fold chat window
         await click(".o-mail-ChatWindow-command[title='Fold']");
         openDiscuss(null, { waitUntilMessagesLoaded: false });
-        await contains(".o-mail-ChatWindow", 0);
+        await contains(".o-mail-ChatWindow", { count: 0 });
         openView({
             res_id: channelId,
             res_model: "discuss.channel",
@@ -1070,8 +1074,8 @@ QUnit.test(
         });
         // unfold chat window
         await click(".o-mail-ChatWindow-command[title='Open']");
-        await contains(".o-mail-ChatWindow .o-mail-Message", 31);
-        await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: 142 });
+        await contains(".o-mail-ChatWindow .o-mail-Message", { count: 31 });
+        await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 142 });
     }
 );
 
@@ -1087,13 +1091,13 @@ QUnit.test("folded chat window should hide member-list and settings buttons", as
     await contains("[title='Show Call Settings']");
 
     await click(".o-mail-ChatWindow-header"); // click away to close the more menu
-    await contains("[title='Show Member List']", 0);
+    await contains("[title='Show Member List']", { count: 0 });
 
     // Fold chat window
     await click(".o-mail-ChatWindow-command[title='Fold']");
-    await contains("[title='Open Actions Menu']", 0);
-    await contains("[title='Show Member List']", 0);
-    await contains("[title='Show Call Settings']", 0);
+    await contains("[title='Open Actions Menu']", { count: 0 });
+    await contains("[title='Show Member List']", { count: 0 });
+    await contains("[title='Show Call Settings']", { count: 0 });
 
     // Unfold chat window
     await click(".o-mail-ChatWindow-command[title='Open']");
@@ -1113,7 +1117,7 @@ QUnit.test("Chat window in mobile are not foldable", async () => {
     await start();
     await click("button i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow-header.cursor-pointer", 0);
+    await contains(".o-mail-ChatWindow-header.cursor-pointer", { count: 0 });
     await click(".o-mail-ChatWindow-header");
     await contains(".o-mail-ChatWindow-content"); // content => non-folded
 });
@@ -1132,7 +1136,7 @@ QUnit.test("Server-synced chat windows should not open at page load on mobile", 
     patchUiSize({ size: SIZES.SM });
     await start();
     await contains(".o-mail-ChatWindowContainer");
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
 });
 
 QUnit.test("chat window of channels should not have 'Open in Discuss' (mobile)", async () => {
@@ -1145,7 +1149,7 @@ QUnit.test("chat window of channels should not have 'Open in Discuss' (mobile)",
     await contains(".o-mail-ChatWindow");
     await contains("[title='Open Actions Menu']");
     await click("[title='Open Actions Menu']");
-    await contains("[title='Open in Discuss']", 0);
+    await contains("[title='Open in Discuss']", { count: 0 });
 });
 
 QUnit.test("Open chat window of new inviter", async () => {
@@ -1158,7 +1162,7 @@ QUnit.test("Open chat window of new inviter", async () => {
         username: "Newbie",
         partnerId,
     });
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Newbie" });
+    await contains(".o-mail-ChatWindow-name", { text: "Newbie" });
     await contains(
         ".o_notification:contains(Newbie connected. This is their first connection. Wish them luck.)"
     );
@@ -1209,7 +1213,7 @@ QUnit.test(
         await contains(".o-mail-Message-moreMenu.dropdown-menu");
         document.querySelector(".o-mail-Message [title='Expand']").focus(); // necessary otherwise focus is in composer input
         triggerHotkey("Escape");
-        await contains(".o-mail-Message-moreMenu.dropdown-menu", 0);
+        await contains(".o-mail-Message-moreMenu.dropdown-menu", { count: 0 });
         await contains(".o-mail-ChatWindow");
     }
 );

--- a/addons/mail/static/tests/chat_window/chat_window_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_tests.js
@@ -49,7 +49,7 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-MessagingMenu-counter:contains(1)");
+        await contains(".o-mail-MessagingMenu-counter", 1, { text: "1" });
         await contains(".o-mail-ChatWindow", 0);
     }
 );
@@ -94,14 +94,16 @@ QUnit.test("Message post in chat window of chatter should log a note", async () 
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-Message:contains(A needaction message to have it in messaging menu)");
+    await contains(".o-mail-Message-content", 1, {
+        text: "A needaction message to have it in messaging menu",
+    });
     await contains(
         ".o-mail-Message:contains(A needaction message to have it in messaging menu) .o-mail-Message-bubble.border"
     ); // bordered bubble = "Send message" mode
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
-    await contains(".o-mail-Message:contains(Test)");
+    await contains(".o-mail-Message-content", 1, { text: "Test" });
     await contains(".o-mail-Message:contains(Test) .o-mail-Message-bubble.border", 0); // non-bordered bubble = "Log note" mode
 });
 
@@ -125,7 +127,7 @@ QUnit.test("load messages from opening chat window from messaging menu", async (
     await contains(".o-mail-Message", 21);
 });
 
-QUnit.test("chat window: basic rendering", async (assert) => {
+QUnit.test("chat window: basic rendering", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({ name: "General" });
     await start();
@@ -134,17 +136,15 @@ QUnit.test("chat window: basic rendering", async (assert) => {
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header");
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar");
-    await contains(".o-mail-ChatWindow-name:contains(General)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "General" });
     await contains(".o-mail-ChatWindow-command", 4);
     await contains("[title='Start a Call']");
     await contains("[title='Open Actions Menu']");
     await contains("[title='Fold']");
     await contains("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow-content .o-mail-Thread");
-    assert.strictEqual(
-        $(".o-mail-ChatWindow-content .o-mail-Thread").text().trim(),
-        "There are no messages in this conversation."
-    );
+    await contains(".o-mail-ChatWindow-content .o-mail-Thread .o-mail-Thread-empty", 1, {
+        text: "There are no messages in this conversation.",
+    });
     await click("[title='Open Actions Menu']");
     await contains(".o-mail-ChatWindow-command", 10);
     await contains("[title='Pinned Messages']");
@@ -358,24 +358,24 @@ QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]",
     );
     await start();
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Channel_1)");
+    await click(".o-mail-NotificationItem-name", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-header:contains(Channel_1)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_1" });
     assert.strictEqual(
         document.activeElement,
-        $(".o-mail-ChatWindow-header:contains(Channel_1)")
+        $(".o-mail-ChatWindow-name:contains(Channel_1)")
             .closest(".o-mail-ChatWindow")
             .find(".o-mail-Composer-input")[0]
     );
 
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Channel_2)");
+    await click(".o-mail-NotificationItem-name", { text: "Channel_2" });
     await contains(".o-mail-ChatWindow", 2);
-    await contains(".o-mail-ChatWindow-header:contains(Channel_2)");
-    await contains(".o-mail-ChatWindow-header:contains(Channel_1)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_2" });
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_1" });
     assert.strictEqual(
         document.activeElement,
-        $(".o-mail-ChatWindow-header:contains(Channel_2)")
+        $(".o-mail-ChatWindow-name:contains(Channel_2)")
             .closest(".o-mail-ChatWindow")
             .find(".o-mail-Composer-input")[0]
     );
@@ -402,24 +402,24 @@ QUnit.test("open 3 different chat windows: not enough screen width", async (asse
 
     // open, from systray menu, chat windows of channels with Id 1, 2, then 3
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Channel_1)");
+    await click(".o-mail-NotificationItem-name", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindowHiddenToggler", 0);
 
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Channel_2)");
+    await click(".o-mail-NotificationItem-name", { text: "Channel_2" });
     await contains(".o-mail-ChatWindow", 2);
     await contains(".o-mail-ChatWindowHiddenToggler", 0);
 
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Channel_3)");
+    await click(".o-mail-NotificationItem-name", { text: "Channel_3" });
     await contains(".o-mail-ChatWindow", 2);
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-ChatWindow-header:contains(Channel_1)");
-    await contains(".o-mail-ChatWindow-header:contains(Channel_3)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_1" });
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Channel_3" });
     assert.strictEqual(
         document.activeElement,
-        $(".o-mail-ChatWindow-header:contains(Channel_3)")
+        $(".o-mail-ChatWindow-name:contains(Channel_3)")
             .closest(".o-mail-ChatWindow")
             .find(".o-mail-Composer-input")[0]
     );
@@ -445,27 +445,36 @@ QUnit.test("closing hidden chat window", async (assert) => {
     );
     await start();
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_1)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_1" });
     await contains(".o-mail-ChatWindow");
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_2)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
     await contains(".o-mail-ChatWindow", 2);
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_3)");
-    await contains(".o-mail-ChatWindowHiddenToggler:contains(1)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_3" });
+    await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "1" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_4)");
-    await contains(".o-mail-ChatWindowHiddenToggler:contains(2)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_4" });
+    await contains(".o-mail-ChatWindowHiddenToggler", 1, { text: "2" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_1)");
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow:contains(Ch_2)");
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow:contains(Ch_3)");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_4)");
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_1",
+    });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_2" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_4",
+    });
     await click(".o-mail-ChatWindow:contains(Ch_2) [title='Close Chat Window']");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_1)");
-    await contains(".o-mail-ChatWindow:contains(Ch_2)", 0);
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow:contains(Ch_3)");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_4)");
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_1",
+    });
+    await contains(".o-mail-ChatWindow-name", 0, { text: "Ch_2" });
+
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_4",
+    });
 });
 
 QUnit.test("Opening hidden chat window from messaging menu", async (assert) => {
@@ -483,21 +492,29 @@ QUnit.test("Opening hidden chat window from messaging menu", async (assert) => {
     );
     await start();
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_1)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_1" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_2)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_3)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_3" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_1)");
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow:contains(Ch_2)");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_3)");
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_1",
+    });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_2" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_3",
+    });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(Ch_2)");
+    await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_1)");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow:contains(Ch_2)");
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow:contains(Ch_3)");
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_1",
+    });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", 1, {
+        text: "Ch_2",
+    });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", 1, { text: "Ch_3" });
 });
 
 QUnit.test(
@@ -568,7 +585,7 @@ QUnit.test("chat window: switch on TAB [REQUIRE FOCUS]", async (assert) => {
     );
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(channel1)");
+    await click(".o-mail-NotificationItem-name", { text: "channel1" });
     await contains(".o-mail-ChatWindow", 1);
     await contains(".o-mail-ChatWindow:contains(channel1) .o-mail-Composer-input:focus");
 
@@ -576,7 +593,7 @@ QUnit.test("chat window: switch on TAB [REQUIRE FOCUS]", async (assert) => {
     await contains(".o-mail-ChatWindow:contains(channel1) .o-mail-Composer-input:focus");
 
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(channel2)");
+    await click(".o-mail-NotificationItem-name", { text: "channel2" });
     await contains(".o-mail-ChatWindow", 2);
     await contains(".o-mail-ChatWindow:contains(channel2) .o-mail-Composer-input:focus");
 
@@ -693,7 +710,7 @@ QUnit.test(
         );
         await contains(".o-mail-ChatWindow");
         await contains(".o-mail-Message", 2);
-        await contains("hr + span:contains(New messages)");
+        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
     }
 );
 
@@ -722,7 +739,7 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains("hr + span:contains(New messages)");
+        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
     }
 );
 
@@ -836,7 +853,7 @@ QUnit.test("chat window should remain folded when new message is received", asyn
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-counter:contains(1)");
+    await contains(".o-mail-ChatWindow-counter", 1, { text: "1" });
     await contains(".o-mail-ChatWindow.o-folded");
 });
 
@@ -866,11 +883,11 @@ QUnit.test(
         openDiscuss();
         // open, from systray menu, chat windows of channels with id 1, 2, 3
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name:contains(Channel-1)");
+        await click(".o-mail-NotificationItem-name", { text: "Channel-1" });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name:contains(Channel-2)");
+        await click(".o-mail-NotificationItem-name", { text: "Channel-2" });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name:contains(Channel-3)");
+        await click(".o-mail-NotificationItem-name", { text: "Channel-3" });
         // simulate resize to go into mobile
         patchUiSize({ size: SIZES.SM });
         window.dispatchEvent(new UIEvent("resize"));
@@ -962,9 +979,9 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains("hr + span:contains(New messages)");
+        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
         $(".o-mail-Composer-input")[0].focus();
-        await contains("hr + span:contains(New messages)", 0);
+        await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
     }
 );
 
@@ -1141,7 +1158,7 @@ QUnit.test("Open chat window of new inviter", async () => {
         username: "Newbie",
         partnerId,
     });
-    await contains(".o-mail-ChatWindow:contains(Newbie)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Newbie" });
     await contains(
         ".o_notification:contains(Newbie connected. This is their first connection. Wish them luck.)"
     );

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -44,7 +44,7 @@ QUnit.test("composer text input: basic rendering when posting a message", async 
     const pyEnv = await startServer();
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains("textarea.o-mail-Composer-input[placeholder='Send a message to followers…']");
 });
 
@@ -52,7 +52,7 @@ QUnit.test("composer text input: basic rendering when logging note", async () =>
     const pyEnv = await startServer();
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains("textarea.o-mail-Composer-input[placeholder='Log an internal note…']");
 });
 
@@ -88,7 +88,7 @@ QUnit.test("add an emoji", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(😤)");
+    await click(".o-Emoji", { text: "😤" });
     await contains(".o-mail-Composer-input", 1, { value: "😤" });
 });
 
@@ -115,7 +115,7 @@ QUnit.test("add an emoji after some text", async () => {
     await contains(".o-mail-Composer-input", 1, { value: "Blabla" });
 
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(🤑)");
+    await click(".o-Emoji", { text: "🤑" });
     await contains(".o-mail-Composer-input", 1, { value: "Blabla🤑" });
 });
 
@@ -129,7 +129,7 @@ QUnit.test("add emoji replaces (keyboard) text selection [REQUIRE FOCUS]", async
     // simulate selection of all the content by keyboard
     textarea.setSelectionRange(0, textarea.value.length);
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(🤠)");
+    await click(".o-Emoji", { text: "🤠" });
     await contains(".o-mail-Composer-input", 1, { value: "🤠" });
 });
 
@@ -141,7 +141,7 @@ QUnit.test("Cursor is positioned after emoji after adding it", async (assert) =>
     const textarea = (await insertText(".o-mail-Composer-input", "Blabla"))[0];
     textarea.setSelectionRange(2, 2);
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(🤠)");
+    await click(".o-Emoji", { text: "🤠" });
     const expectedPos = 2 + "🤠".length;
     assert.strictEqual(textarea.selectionStart, expectedPos);
     assert.strictEqual(textarea.selectionEnd, expectedPos);
@@ -158,7 +158,7 @@ QUnit.test("selected text is not replaced after cancelling the selection", async
     textarea.setSelectionRange(0, textarea.value.length);
     await click(".o-mail-Discuss-content");
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(🤠)");
+    await click(".o-Emoji", { text: "🤠" });
     await contains(".o-mail-Composer-input", 1, { value: "Blabla🤠" });
 });
 
@@ -191,7 +191,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await click("button[aria-label='Emojis']");
-        await click(".o-Emoji:contains(👺)");
+        await click(".o-Emoji", { text: "👺" });
         await click("button[aria-label='Emojis']");
         await contains(".o-EmojiPicker");
     }
@@ -216,7 +216,7 @@ QUnit.test("reset emoji picker scroll value after an emoji is picked", async () 
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await scroll(".o-EmojiPicker-content", 150);
-    await click(".o-Emoji:contains(😎)");
+    await click(".o-Emoji", { text: "😎" });
     await click("button[aria-label='Emojis']");
     await contains(".o-EmojiPicker-content", 1, { scroll: 0 });
 });
@@ -280,7 +280,7 @@ QUnit.test('send button on discuss.channel should have "Send" as label', async (
     const channelId = pyEnv["discuss.channel"].create({ name: "minecraft-wii-u" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Composer-send:disabled:contains(Send)");
+    await contains(".o-mail-Composer-send:disabled", 1, { text: "Send" });
 });
 
 QUnit.test("Show send button in mobile", async () => {
@@ -289,8 +289,8 @@ QUnit.test("Show send button in mobile", async () => {
     pyEnv["discuss.channel"].create({ name: "minecraft-wii-u" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button:contains(Channel)");
-    await click(".o-mail-NotificationItem:contains(minecraft-wii-u)");
+    await click("button", { text: "Channel" });
+    await click(".o-mail-NotificationItem-name", { text: "minecraft-wii-u" });
     await contains(".o-mail-Composer button[aria-label='Send']");
     await contains(".o-mail-Composer button[aria-label='Send'] i.fa-paper-plane-o");
 });
@@ -306,10 +306,10 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "According to all known laws of aviation,");
-        await click("span:contains('epic-shrek-lovers')");
+        await click("span", { text: "epic-shrek-lovers" });
         await contains("textarea.o-mail-Composer-input[placeholder='Message #epic-shrek-lovers…']");
         await contains(".o-mail-Composer-input", 1, { value: "" });
-        await click("span:contains('minigolf-galaxy-iv')");
+        await click("span", { text: "minigolf-galaxy-iv" });
         await contains(
             "textarea.o-mail-Composer-input[placeholder='Message #minigolf-galaxy-iv…']",
             1,
@@ -338,7 +338,7 @@ QUnit.test("add an emoji after a partner mention", async () => {
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", 1, { value: "@TestPartner " });
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(😊)");
+    await click(".o-Emoji", { text: "😊" });
     await contains(".o-mail-Composer-input", 1, { value: "@TestPartner 😊" });
 });
 
@@ -371,7 +371,7 @@ QUnit.test("add an emoji after a channel mention", async () => {
     await click(".o-mail-Composer-suggestion");
     await contains(".o-mail-Composer-input", 1, { value: "#General " });
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(😊)");
+    await click(".o-Emoji", { text: "😊" });
     await contains(".o-mail-Composer-input", 1, { value: "#General 😊" });
 });
 
@@ -379,15 +379,15 @@ QUnit.test("pending mentions are kept when toggling composer", async () => {
     const pyEnv = await startServer();
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@");
-    await click(".o-mail-Composer-suggestion:contains(Mitchell Admin)");
+    await click(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
     await contains(".o-mail-Composer-input", 1, { value: "@Mitchell Admin " });
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Composer-input", 0);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body a.o_mail_redirect:contains(@Mitchell Admin)");
+    await contains(".o-mail-Message-body a.o_mail_redirect", 1, { text: "@Mitchell Admin" });
 });
 
 QUnit.test('do not post message on channel with "SHIFT-Enter" keyboard shortcut', async () => {
@@ -420,13 +420,14 @@ QUnit.test("leave command on channel", async () => {
     openDiscuss(channelId);
     await contains(".o-mail-DiscussSidebarChannel:contains(general).o-active");
     await insertText(".o-mail-Composer-input", "/leave");
-    await contains(".o-mail-Composer-suggestion", 1);
+    await contains(".o-mail-Composer-suggestion strong", 1);
     triggerHotkey("Enter");
     await contains(".o-mail-Composer-input", 1, { value: "/leave " });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel:contains(general)", 0);
-    await contains(".o-mail-Discuss:contains(No conversation selected.)");
-    await contains(".o_notification:contains(You unsubscribed from general)");
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "general" });
+
+    await contains(".o-mail-Discuss h4.text-muted", 1, { text: "No conversation selected." });
+    await contains(".o_notification_content", 1, { text: "You unsubscribed from general." });
 });
 
 QUnit.test("Can handle leave notification from unknown member", async () => {
@@ -446,8 +447,8 @@ QUnit.test("Can handle leave notification from unknown member", async () => {
         env.services.orm.call("discuss.channel", "action_unfollow", [channelId])
     );
     await click("button[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember:contains(Mitchell)");
-    await contains(".o-discuss-ChannelMember:contains(Dobby)", 0);
+    await contains(".o-discuss-ChannelMember", 1, { text: "Mitchell Admin" });
+    await contains(".o-discuss-ChannelMember", 0, { text: "Dobby" });
 });
 
 QUnit.test("leave command on chat", async () => {
@@ -464,13 +465,16 @@ QUnit.test("leave command on chat", async () => {
     openDiscuss(channelId);
     await contains(".o-mail-DiscussSidebarChannel:contains(Chuck Norris).o-active");
     await insertText(".o-mail-Composer-input", "/leave");
-    await contains(".o-mail-Composer-suggestion", 1);
+    await contains(".o-mail-Composer-suggestion strong", 1);
     triggerHotkey("Enter");
     await contains(".o-mail-Composer-input", 1, { value: "/leave " });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Chuck Norris)", 0);
-    await contains(".o-mail-Discuss:contains(No conversation selected.)");
-    await contains(".o_notification:contains(You unpinned your conversation with Chuck Norris)");
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "Chuck Norris" });
+
+    await contains(".o-mail-Discuss h4.text-muted", 1, { text: "No conversation selected." });
+    await contains(".o_notification_content", 1, {
+        text: "You unpinned your conversation with Chuck Norris",
+    });
 });
 
 QUnit.test("Can post suggestions", async () => {
@@ -479,7 +483,7 @@ QUnit.test("Can post suggestions", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#general");
-    await contains(".o-mail-Composer-suggestion", 1);
+    await contains(".o-mail-Composer-suggestion strong", 1);
     triggerHotkey("Enter");
     await contains(".o-mail-Composer-input", 1, { value: "#general " });
     triggerHotkey("Enter");
@@ -517,7 +521,7 @@ QUnit.test("quick edit last self-message from UP arrow", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message:contains(Test)");
+    await contains(".o-mail-Message-content", 1, { text: "Test" });
     await contains(".o-mail-Message:contains(Test) .o-mail-Composer", 0);
 
     triggerHotkey("ArrowUp");
@@ -761,8 +765,8 @@ QUnit.test("Show a thread name in the recipient status text.", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await click("button:contains(Send message)");
-    await contains(".o-mail-Chatter:contains(To: test)");
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Chatter div", 1, { text: "To: test" });
     await contains('span[title="test@odoo.com"]');
 });
 
@@ -786,16 +790,15 @@ QUnit.test("Show recipient list when there is more than 5 followers.", async () 
     }
     const { openFormView } = await start();
     openFormView("res.partner", partnerIds[0]);
-    await click("button:contains(Send message)");
-    await contains("button[title='Show all recipients']");
+    await click("button", { text: "Send message" });
     await click("button[title='Show all recipients']");
-    await contains("li:contains('test1@odoo.com')");
-    await contains("li:contains('test2@odoo.com')");
-    await contains("li:contains('test3@odoo.com')");
-    await contains("li:contains('test4@odoo.com')");
-    await contains("li:contains('test5@odoo.com')");
-    await contains("li:contains('test6@odoo.com')");
-    await contains(".o-mail-Chatter:contains('test1, test2, test3, test4, test5, …')");
+    await contains("li", 1, { text: "test1@odoo.com" });
+    await contains("li", 1, { text: "test2@odoo.com" });
+    await contains("li", 1, { text: "test3@odoo.com" });
+    await contains("li", 1, { text: "test4@odoo.com" });
+    await contains("li", 1, { text: "test5@odoo.com" });
+    await contains("li", 1, { text: "test6@odoo.com" });
+    await contains(".o-mail-Chatter div", 1, { text: "To: test1, test2, test3, test4, test5, …" });
 });
 
 QUnit.test(
@@ -824,8 +827,8 @@ QUnit.test(
             contentType: "text/plain",
         });
         inputFiles((await contains(".o-mail-Composer-coreMain .o_input_file"))[0], [file1, file2]);
-        await contains(".o-mail-AttachmentCard:contains(text1.txt)");
-        await contains(".o-mail-AttachmentCard:contains(text2.txt)");
+        await contains(".o-mail-AttachmentCard div", 1, { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard div", 1, { text: "text2.txt" });
         await contains(".o-mail-AttachmentCard-aside div[title='Uploading']", 2);
     }
 );
@@ -862,11 +865,11 @@ QUnit.test(
             }),
         ]);
         inputFiles(input[0], [file1, file2]);
-        await contains(".o-mail-AttachmentCard.o-isUploading:contains(text1.txt)");
-        await contains(".o-mail-AttachmentCard.o-isUploading:contains(text2.txt)");
+        await contains(".o-mail-AttachmentCard.o-isUploading div", 1, { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard.o-isUploading div", 1, { text: "text2.txt" });
 
         click(".o-mail-AttachmentCard-unlink:eq(1)");
-        await contains(".o-mail-AttachmentCard:contains(text2.txt)", 0);
+        await contains(".o-mail-AttachmentCard div", 0, { text: "text2.txt" });
 
         // Simulates the completion of the upload of the first attachment
         uploadPromise.resolve();
@@ -887,5 +890,5 @@ QUnit.test("Message is sent only once when pressing enter twice in a row", async
         triggerHotkey("Enter");
         triggerHotkey("Enter");
     });
-    await contains(".o-mail-Message:contains(Hello World!)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
 });

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -89,7 +89,7 @@ QUnit.test("add an emoji", async () => {
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "😤" });
-    await contains(".o-mail-Composer-input", 1, { value: "😤" });
+    await contains(".o-mail-Composer-input", { value: "😤" });
 });
 
 QUnit.test(
@@ -100,9 +100,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await click("button[aria-label='Emojis']");
-        await contains(".o-mail-Composer-input:focus", 0);
+        await contains(".o-mail-Composer-input:focus", { count: 0 });
         triggerHotkey("Escape");
-        await contains(".o-mail-Composer-input:focus", 1);
+        await contains(".o-mail-Composer-input:focus", { count: 1 });
     }
 );
 
@@ -112,11 +112,11 @@ QUnit.test("add an emoji after some text", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "Blabla");
-    await contains(".o-mail-Composer-input", 1, { value: "Blabla" });
+    await contains(".o-mail-Composer-input", { value: "Blabla" });
 
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "🤑" });
-    await contains(".o-mail-Composer-input", 1, { value: "Blabla🤑" });
+    await contains(".o-mail-Composer-input", { value: "Blabla🤑" });
 });
 
 QUnit.test("add emoji replaces (keyboard) text selection [REQUIRE FOCUS]", async () => {
@@ -125,12 +125,12 @@ QUnit.test("add emoji replaces (keyboard) text selection [REQUIRE FOCUS]", async
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "Blabla");
-    const textarea = (await contains(".o-mail-Composer-input", 1, { value: "Blabla" }))[0];
+    const textarea = (await contains(".o-mail-Composer-input", { value: "Blabla" }))[0];
     // simulate selection of all the content by keyboard
     textarea.setSelectionRange(0, textarea.value.length);
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "🤠" });
-    await contains(".o-mail-Composer-input", 1, { value: "🤠" });
+    await contains(".o-mail-Composer-input", { value: "🤠" });
 });
 
 QUnit.test("Cursor is positioned after emoji after adding it", async (assert) => {
@@ -153,13 +153,13 @@ QUnit.test("selected text is not replaced after cancelling the selection", async
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "Blabla");
-    const textarea = (await contains(".o-mail-Composer-input", 1, { value: "Blabla" }))[0];
+    const textarea = (await contains(".o-mail-Composer-input", { value: "Blabla" }))[0];
     // simulate selection of all the content by keyboard
     textarea.setSelectionRange(0, textarea.value.length);
     await click(".o-mail-Discuss-content");
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "🤠" });
-    await contains(".o-mail-Composer-input", 1, { value: "Blabla🤠" });
+    await contains(".o-mail-Composer-input", { value: "Blabla🤠" });
 });
 
 QUnit.test(
@@ -206,7 +206,7 @@ QUnit.test("keep emoji picker scroll value when re-opening it", async () => {
     await scroll(".o-EmojiPicker-content", 150);
     await click("button[aria-label='Emojis']");
     await click("button[aria-label='Emojis']");
-    await contains(".o-EmojiPicker-content", 1, { scroll: 150 });
+    await contains(".o-EmojiPicker-content", { scroll: 150 });
 });
 
 QUnit.test("reset emoji picker scroll value after an emoji is picked", async () => {
@@ -218,7 +218,7 @@ QUnit.test("reset emoji picker scroll value after an emoji is picked", async () 
     await scroll(".o-EmojiPicker-content", 150);
     await click(".o-Emoji", { text: "😎" });
     await click("button[aria-label='Emojis']");
-    await contains(".o-EmojiPicker-content", 1, { scroll: 0 });
+    await contains(".o-EmojiPicker-content", { scroll: 0 });
 });
 
 QUnit.test(
@@ -244,10 +244,10 @@ QUnit.test(
         await scroll(".o-EmojiPicker-content", 200);
         await triggerEvent(getFixture(), null, "mousedown");
         await click("button[aria-label='Emojis']");
-        await contains(".o-EmojiPicker-content", 1, { scroll: 150 });
+        await contains(".o-EmojiPicker-content", { scroll: 150 });
         await triggerEvent(getFixture(), null, "mousedown");
         await click("[title='Add a Reaction']");
-        await contains(".o-EmojiPicker-content", 1, { scroll: 200 });
+        await contains(".o-EmojiPicker-content", { scroll: 200 });
     }
 );
 
@@ -257,11 +257,11 @@ QUnit.test("composer text input cleared on message post", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "test message");
-    await contains(".o-mail-Composer-input", 1, { value: "test message" });
+    await contains(".o-mail-Composer-input", { value: "test message" });
 
     await click(".o-mail-Composer-send:not([disabled])");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
 });
 
 QUnit.test("send message only once when button send is clicked twice quickly", async () => {
@@ -280,7 +280,7 @@ QUnit.test('send button on discuss.channel should have "Send" as label', async (
     const channelId = pyEnv["discuss.channel"].create({ name: "minecraft-wii-u" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Composer-send:disabled", 1, { text: "Send" });
+    await contains(".o-mail-Composer-send:disabled", { text: "Send" });
 });
 
 QUnit.test("Show send button in mobile", async () => {
@@ -308,11 +308,10 @@ QUnit.test(
         await insertText(".o-mail-Composer-input", "According to all known laws of aviation,");
         await click("span", { text: "epic-shrek-lovers" });
         await contains("textarea.o-mail-Composer-input[placeholder='Message #epic-shrek-lovers…']");
-        await contains(".o-mail-Composer-input", 1, { value: "" });
+        await contains(".o-mail-Composer-input", { value: "" });
         await click("span", { text: "minigolf-galaxy-iv" });
         await contains(
             "textarea.o-mail-Composer-input[placeholder='Message #minigolf-galaxy-iv…']",
-            1,
             { value: "According to all known laws of aviation," }
         );
     }
@@ -333,13 +332,13 @@ QUnit.test("add an emoji after a partner mention", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "@Te");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "@TestPartner " });
+    await contains(".o-mail-Composer-input", { value: "@TestPartner " });
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "😊" });
-    await contains(".o-mail-Composer-input", 1, { value: "@TestPartner 😊" });
+    await contains(".o-mail-Composer-input", { value: "@TestPartner 😊" });
 });
 
 QUnit.test("mention a channel after some text", async () => {
@@ -350,12 +349,12 @@ QUnit.test("mention a channel after some text", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "bluhbluh ");
-    await contains(".o-mail-Composer-input", 1, { value: "bluhbluh " });
+    await contains(".o-mail-Composer-input", { value: "bluhbluh " });
     await insertText(".o-mail-Composer-input", "#");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "bluhbluh #General " });
+    await contains(".o-mail-Composer-input", { value: "bluhbluh #General " });
 });
 
 QUnit.test("add an emoji after a channel mention", async () => {
@@ -366,13 +365,13 @@ QUnit.test("add an emoji after a channel mention", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "#");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "#General " });
+    await contains(".o-mail-Composer-input", { value: "#General " });
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "😊" });
-    await contains(".o-mail-Composer-input", 1, { value: "#General 😊" });
+    await contains(".o-mail-Composer-input", { value: "#General 😊" });
 });
 
 QUnit.test("pending mentions are kept when toggling composer", async () => {
@@ -382,12 +381,12 @@ QUnit.test("pending mentions are kept when toggling composer", async () => {
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@");
     await click(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
-    await contains(".o-mail-Composer-input", 1, { value: "@Mitchell Admin " });
+    await contains(".o-mail-Composer-input", { value: "@Mitchell Admin " });
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Composer-input", 0);
+    await contains(".o-mail-Composer-input", { count: 0 });
     await click("button", { text: "Send message" });
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body a.o_mail_redirect", 1, { text: "@Mitchell Admin" });
+    await contains(".o-mail-Message-body a.o_mail_redirect", { text: "@Mitchell Admin" });
 });
 
 QUnit.test('do not post message on channel with "SHIFT-Enter" keyboard shortcut', async () => {
@@ -396,10 +395,10 @@ QUnit.test('do not post message on channel with "SHIFT-Enter" keyboard shortcut'
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "Test");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
     triggerHotkey("shift+Enter");
     await nextTick(); // weak test, no guarantee that we waited long enough for the potential message to be posted
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test('post message on channel with "Enter" keyboard shortcut', async () => {
@@ -408,7 +407,7 @@ QUnit.test('post message on channel with "Enter" keyboard shortcut', async () =>
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "Test");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
     triggerHotkey("Enter");
     await contains(".o-mail-Message");
 });
@@ -420,14 +419,14 @@ QUnit.test("leave command on channel", async () => {
     openDiscuss(channelId);
     await contains(".o-mail-DiscussSidebarChannel:contains(general).o-active");
     await insertText(".o-mail-Composer-input", "/leave");
-    await contains(".o-mail-Composer-suggestion strong", 1);
+    await contains(".o-mail-Composer-suggestion strong", { count: 1 });
     triggerHotkey("Enter");
-    await contains(".o-mail-Composer-input", 1, { value: "/leave " });
+    await contains(".o-mail-Composer-input", { value: "/leave " });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "general" });
 
-    await contains(".o-mail-Discuss h4.text-muted", 1, { text: "No conversation selected." });
-    await contains(".o_notification_content", 1, { text: "You unsubscribed from general." });
+    await contains(".o-mail-Discuss h4.text-muted", { text: "No conversation selected." });
+    await contains(".o_notification_content", { text: "You unsubscribed from general." });
 });
 
 QUnit.test("Can handle leave notification from unknown member", async () => {
@@ -447,8 +446,8 @@ QUnit.test("Can handle leave notification from unknown member", async () => {
         env.services.orm.call("discuss.channel", "action_unfollow", [channelId])
     );
     await click("button[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 1, { text: "Mitchell Admin" });
-    await contains(".o-discuss-ChannelMember", 0, { text: "Dobby" });
+    await contains(".o-discuss-ChannelMember", { text: "Mitchell Admin" });
+    await contains(".o-discuss-ChannelMember", { count: 0, text: "Dobby" });
 });
 
 QUnit.test("leave command on chat", async () => {
@@ -465,14 +464,14 @@ QUnit.test("leave command on chat", async () => {
     openDiscuss(channelId);
     await contains(".o-mail-DiscussSidebarChannel:contains(Chuck Norris).o-active");
     await insertText(".o-mail-Composer-input", "/leave");
-    await contains(".o-mail-Composer-suggestion strong", 1);
+    await contains(".o-mail-Composer-suggestion strong", { count: 1 });
     triggerHotkey("Enter");
-    await contains(".o-mail-Composer-input", 1, { value: "/leave " });
+    await contains(".o-mail-Composer-input", { value: "/leave " });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "Chuck Norris" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "Chuck Norris" });
 
-    await contains(".o-mail-Discuss h4.text-muted", 1, { text: "No conversation selected." });
-    await contains(".o_notification_content", 1, {
+    await contains(".o-mail-Discuss h4.text-muted", { text: "No conversation selected." });
+    await contains(".o_notification_content", {
         text: "You unpinned your conversation with Chuck Norris",
     });
 });
@@ -483,9 +482,9 @@ QUnit.test("Can post suggestions", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#general");
-    await contains(".o-mail-Composer-suggestion strong", 1);
+    await contains(".o-mail-Composer-suggestion strong", { count: 1 });
     triggerHotkey("Enter");
-    await contains(".o-mail-Composer-input", 1, { value: "#general " });
+    await contains(".o-mail-Composer-input", { value: "#general " });
     triggerHotkey("Enter");
     await contains(".o-mail-Message .o_channel_redirect");
 });
@@ -521,14 +520,14 @@ QUnit.test("quick edit last self-message from UP arrow", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message-content", 1, { text: "Test" });
-    await contains(".o-mail-Message:contains(Test) .o-mail-Composer", 0);
+    await contains(".o-mail-Message-content", { text: "Test" });
+    await contains(".o-mail-Message:contains(Test) .o-mail-Composer", { count: 0 });
 
     triggerHotkey("ArrowUp");
     await contains(".o-mail-Message .o-mail-Composer");
 
     triggerHotkey("Escape");
-    await contains(".o-mail-Message .o-mail-Composer", 0);
+    await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
     await contains(".o-mail-Composer-input:focus");
 
     // non-empty composer should not trigger quick edit
@@ -538,7 +537,7 @@ QUnit.test("quick edit last self-message from UP arrow", async () => {
     // Wait 2 animation frames to make sure it doesn't show quick edit
     await nextTick();
     await nextTick();
-    await contains(".o-mail-Message .o-mail-Composer", 0);
+    await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("Select composer suggestion via Enter does not send the message", async () => {
@@ -560,9 +559,9 @@ QUnit.test("Select composer suggestion via Enter does not send the message", asy
     await insertText(".o-mail-Composer-input", "@Shrek");
     await contains(".o-mail-Composer-suggestion");
     triggerHotkey("Enter");
-    await contains(".o-mail-Composer-input", 1, { value: "@Shrek " });
+    await contains(".o-mail-Composer-input", { value: "@Shrek " });
     // weak test, no guarantee that we waited long enough for the potential message to be posted
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test("composer: drop attachments", async () => {
@@ -583,14 +582,14 @@ QUnit.test("composer: drop attachments", async () => {
         }),
     ];
     await contains(".o-mail-Composer-input");
-    await contains(".o-mail-Dropzone", 0);
-    await contains(".o-mail-AttachmentCard", 0);
+    await contains(".o-mail-Dropzone", { count: 0 });
+    await contains(".o-mail-AttachmentCard", { count: 0 });
     dragenterFiles($(".o-mail-Composer-input")[0]);
     await contains(".o-mail-Dropzone");
-    await contains(".o-mail-AttachmentCard", 0);
+    await contains(".o-mail-AttachmentCard", { count: 0 });
     dropFiles((await contains(".o-mail-Dropzone"))[0], files);
-    await contains(".o-mail-Dropzone", 0);
-    await contains(".o-mail-AttachmentCard", 2);
+    await contains(".o-mail-Dropzone", { count: 0 });
+    await contains(".o-mail-AttachmentCard", { count: 2 });
     dragenterFiles($(".o-mail-Composer-input")[0]);
     dropFiles((await contains(".o-mail-Dropzone"))[0], [
         await createFile({
@@ -599,7 +598,7 @@ QUnit.test("composer: drop attachments", async () => {
             name: "text3.txt",
         }),
     ]);
-    await contains(".o-mail-AttachmentCard", 3);
+    await contains(".o-mail-AttachmentCard", { count: 3 });
 });
 
 QUnit.test("composer: add an attachment", async () => {
@@ -671,7 +670,7 @@ QUnit.test("composer: send button is disabled if attachment upload is not finish
     // simulates attachment finishes uploading
     attachmentUploadedPromise.resolve();
     await contains(".o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard.o-isUploading", 0);
+    await contains(".o-mail-AttachmentCard.o-isUploading", { count: 0 });
     await contains(".o-mail-Composer-send:not(:disabled)");
 });
 
@@ -691,7 +690,7 @@ QUnit.test("remove an attachment from composer does not need any confirmation", 
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard");
 
     await click(".o-mail-AttachmentCard-unlink");
-    await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", 0);
+    await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", { count: 0 });
 });
 
 QUnit.test("composer: paste attachments", async () => {
@@ -707,7 +706,7 @@ QUnit.test("composer: paste attachments", async () => {
         }),
     ];
     await contains(".o-mail-Composer-input");
-    await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", 0);
+    await contains(".o-mail-AttachmentList .o-mail-AttachmentCard", { count: 0 });
     pasteFiles($(".o-mail-Composer-input")[0], files);
     await contains(".o-mail-AttachmentList .o-mail-AttachmentCard");
 });
@@ -751,7 +750,7 @@ QUnit.test("remove an uploading attachment", async () => {
     await contains(".o-mail-AttachmentCard.o-isUploading");
 
     click(".o-mail-AttachmentCard-unlink");
-    await contains(".o-mail-Composer .o-mail-AttachmentCard", 0);
+    await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 0 });
 });
 
 QUnit.test("Show a thread name in the recipient status text.", async () => {
@@ -766,7 +765,7 @@ QUnit.test("Show a thread name in the recipient status text.", async () => {
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Chatter div", 1, { text: "To: test" });
+    await contains(".o-mail-Chatter div", { text: "To: test" });
     await contains('span[title="test@odoo.com"]');
 });
 
@@ -792,13 +791,13 @@ QUnit.test("Show recipient list when there is more than 5 followers.", async () 
     openFormView("res.partner", partnerIds[0]);
     await click("button", { text: "Send message" });
     await click("button[title='Show all recipients']");
-    await contains("li", 1, { text: "test1@odoo.com" });
-    await contains("li", 1, { text: "test2@odoo.com" });
-    await contains("li", 1, { text: "test3@odoo.com" });
-    await contains("li", 1, { text: "test4@odoo.com" });
-    await contains("li", 1, { text: "test5@odoo.com" });
-    await contains("li", 1, { text: "test6@odoo.com" });
-    await contains(".o-mail-Chatter div", 1, { text: "To: test1, test2, test3, test4, test5, …" });
+    await contains("li", { text: "test1@odoo.com" });
+    await contains("li", { text: "test2@odoo.com" });
+    await contains("li", { text: "test3@odoo.com" });
+    await contains("li", { text: "test4@odoo.com" });
+    await contains("li", { text: "test5@odoo.com" });
+    await contains("li", { text: "test6@odoo.com" });
+    await contains(".o-mail-Chatter div", { text: "To: test1, test2, test3, test4, test5, …" });
 });
 
 QUnit.test(
@@ -827,9 +826,9 @@ QUnit.test(
             contentType: "text/plain",
         });
         inputFiles((await contains(".o-mail-Composer-coreMain .o_input_file"))[0], [file1, file2]);
-        await contains(".o-mail-AttachmentCard div", 1, { text: "text1.txt" });
-        await contains(".o-mail-AttachmentCard div", 1, { text: "text2.txt" });
-        await contains(".o-mail-AttachmentCard-aside div[title='Uploading']", 2);
+        await contains(".o-mail-AttachmentCard div", { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard div", { text: "text2.txt" });
+        await contains(".o-mail-AttachmentCard-aside div[title='Uploading']", { count: 2 });
     }
 );
 
@@ -865,11 +864,11 @@ QUnit.test(
             }),
         ]);
         inputFiles(input[0], [file1, file2]);
-        await contains(".o-mail-AttachmentCard.o-isUploading div", 1, { text: "text1.txt" });
-        await contains(".o-mail-AttachmentCard.o-isUploading div", 1, { text: "text2.txt" });
+        await contains(".o-mail-AttachmentCard.o-isUploading div", { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard.o-isUploading div", { text: "text2.txt" });
 
         click(".o-mail-AttachmentCard-unlink:eq(1)");
-        await contains(".o-mail-AttachmentCard div", 0, { text: "text2.txt" });
+        await contains(".o-mail-AttachmentCard div", { count: 0, text: "text2.txt" });
 
         // Simulates the completion of the upload of the first attachment
         uploadPromise.resolve();
@@ -890,5 +889,5 @@ QUnit.test("Message is sent only once when pressing enter twice in a row", async
         triggerHotkey("Enter");
         triggerHotkey("Enter");
     });
-    await contains(".o-mail-Message-content", 1, { text: "Hello World!" });
+    await contains(".o-mail-Message-content", { text: "Hello World!" });
 });

--- a/addons/mail/static/tests/composer/suggested_recipients_test.js
+++ b/addons/mail/static/tests/composer/suggested_recipients_test.js
@@ -29,8 +29,8 @@ QUnit.test("with 3 or less suggested recipients: no 'show more' button", async (
     const { openFormView } = await start();
     openFormView("res.fake", fakeId);
     await click("button", { text: "Send message" });
-    await contains(".o-mail-SuggestedRecipient", 2);
-    await contains("button", 0, { text: "Show more" });
+    await contains(".o-mail-SuggestedRecipient", { count: 2 });
+    await contains("button", { count: 0, text: "Show more" });
 });
 
 QUnit.test(
@@ -66,8 +66,8 @@ QUnit.test(
             },
         });
         await click("button", { text: "Send message" });
-        await contains(".o-mail-SuggestedRecipient", 1, { text: "john@test.be (john@test.be)" });
-        await contains(".o-mail-SuggestedRecipient", 1, { text: "John Jane" });
+        await contains(".o-mail-SuggestedRecipient", { text: "john@test.be (john@test.be)" });
+        await contains(".o-mail-SuggestedRecipient", { text: "John Jane" });
         assert.ok(
             $(".o-mail-SuggestedRecipient:contains(john@test.be) input[type=checkbox]")[0].checked
         );
@@ -106,8 +106,8 @@ QUnit.test(
             },
         });
         await click("button", { text: "Send message" });
-        await contains(".o-mail-SuggestedRecipient", 1, { text: "john@test.be (john@test.be)" });
-        await contains(".o-mail-SuggestedRecipient", 1, { text: "John Jane" });
+        await contains(".o-mail-SuggestedRecipient", { text: "john@test.be (john@test.be)" });
+        await contains(".o-mail-SuggestedRecipient", { text: "John Jane" });
         assert.ok(
             $(".o-mail-SuggestedRecipient:contains(john@test.be) input[type=checkbox]")[0].checked
         );
@@ -135,7 +135,7 @@ QUnit.test("more than 3 suggested recipients: display only 3 and 'show more' but
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.fake", fakeId);
     await click("button", { text: "Send message" });
-    await contains("button", 1, { text: "Show more" });
+    await contains("button", { text: "Show more" });
 });
 
 QUnit.test(
@@ -155,7 +155,7 @@ QUnit.test(
         openFormView("res.fake", fakeId);
         await click("button", { text: "Send message" });
         await click("button", { text: "Show more" });
-        await contains(".o-mail-SuggestedRecipient", 4);
+        await contains(".o-mail-SuggestedRecipient", { count: 4 });
     }
 );
 
@@ -176,7 +176,7 @@ QUnit.test(
         openFormView("res.fake", fakeId);
         await click("button", { text: "Send message" });
         await click("button", { text: "Show more" });
-        await contains("button", 1, { text: "Show less" });
+        await contains("button", { text: "Show less" });
     }
 );
 
@@ -198,8 +198,8 @@ QUnit.test(
         await click("button", { text: "Send message" });
         await click("button", { text: "Show more" });
         await click("button", { text: "Show less" });
-        await contains(".o-mail-SuggestedRecipient", 3);
-        await contains("button", 1, { text: "Show more" });
+        await contains(".o-mail-SuggestedRecipient", { count: 3 });
+        await contains("button", { text: "Show more" });
     }
 );
 
@@ -218,7 +218,7 @@ QUnit.test(
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.fake", fakeId);
         await click("button", { text: "Send message" });
-        await contains(".o-mail-SuggestedRecipient input:checked", 2);
+        await contains(".o-mail-SuggestedRecipient input:checked", { count: 2 });
         assert.ok(
             $(".o-mail-SuggestedRecipient:not([data-partner-id]) input[type=checkbox]")[0].checked
         );

--- a/addons/mail/static/tests/composer/suggested_recipients_test.js
+++ b/addons/mail/static/tests/composer/suggested_recipients_test.js
@@ -28,9 +28,9 @@ QUnit.test("with 3 or less suggested recipients: no 'show more' button", async (
     });
     const { openFormView } = await start();
     openFormView("res.fake", fakeId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-SuggestedRecipient", 2);
-    await contains("button:contains(Show more)", 0);
+    await contains("button", 0, { text: "Show more" });
 });
 
 QUnit.test(
@@ -65,9 +65,9 @@ QUnit.test(
                 return Promise.resolve();
             },
         });
-        await click("button:contains(Send message)");
-        await contains(".o-mail-SuggestedRecipient:contains(john@test.be)");
-        await contains(".o-mail-SuggestedRecipient:contains(John Jane)");
+        await click("button", { text: "Send message" });
+        await contains(".o-mail-SuggestedRecipient", 1, { text: "john@test.be (john@test.be)" });
+        await contains(".o-mail-SuggestedRecipient", 1, { text: "John Jane" });
         assert.ok(
             $(".o-mail-SuggestedRecipient:contains(john@test.be) input[type=checkbox]")[0].checked
         );
@@ -105,16 +105,16 @@ QUnit.test(
                 return Promise.resolve();
             },
         });
-        await click("button:contains(Send message)");
-        await contains(".o-mail-SuggestedRecipient:contains(john@test.be)");
-        await contains(".o-mail-SuggestedRecipient:contains(John Jane)");
+        await click("button", { text: "Send message" });
+        await contains(".o-mail-SuggestedRecipient", 1, { text: "john@test.be (john@test.be)" });
+        await contains(".o-mail-SuggestedRecipient", 1, { text: "John Jane" });
         assert.ok(
             $(".o-mail-SuggestedRecipient:contains(john@test.be) input[type=checkbox]")[0].checked
         );
         assert.ok(
             $(".o-mail-SuggestedRecipient:contains(John Jane) input[type=checkbox]")[0].checked
         );
-        await click("button:contains(Log note)");
+        await click("button", { text: "Log note" });
         await click("button[title='Full composer']");
         await def;
         assert.verifySteps(["do-action"]);
@@ -134,8 +134,8 @@ QUnit.test("more than 3 suggested recipients: display only 3 and 'show more' but
     });
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.fake", fakeId);
-    await click("button:contains(Send message)");
-    await contains("button:contains(Show more)");
+    await click("button", { text: "Send message" });
+    await contains("button", 1, { text: "Show more" });
 });
 
 QUnit.test(
@@ -153,8 +153,8 @@ QUnit.test(
         });
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.fake", fakeId);
-        await click("button:contains(Send message)");
-        await click("button:contains(Show more)");
+        await click("button", { text: "Send message" });
+        await click("button", { text: "Show more" });
         await contains(".o-mail-SuggestedRecipient", 4);
     }
 );
@@ -174,9 +174,9 @@ QUnit.test(
         });
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.fake", fakeId);
-        await click("button:contains(Send message)");
-        await click("button:contains(Show more)");
-        await contains("button:contains(Show less)");
+        await click("button", { text: "Send message" });
+        await click("button", { text: "Show more" });
+        await contains("button", 1, { text: "Show less" });
     }
 );
 
@@ -195,11 +195,11 @@ QUnit.test(
         });
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.fake", fakeId);
-        await click("button:contains(Send message)");
-        await click("button:contains(Show more)");
-        await click("button:contains(Show less)");
+        await click("button", { text: "Send message" });
+        await click("button", { text: "Show more" });
+        await click("button", { text: "Show less" });
         await contains(".o-mail-SuggestedRecipient", 3);
-        await contains("button:contains(Show more)");
+        await contains("button", 1, { text: "Show more" });
     }
 );
 
@@ -217,7 +217,7 @@ QUnit.test(
         });
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.fake", fakeId);
-        await click("button:contains(Send message)");
+        await click("button", { text: "Send message" });
         await contains(".o-mail-SuggestedRecipient input:checked", 2);
         assert.ok(
             $(".o-mail-SuggestedRecipient:not([data-partner-id]) input[type=checkbox]")[0].checked
@@ -238,7 +238,7 @@ QUnit.test("display reason for suggested recipient on mouse over", async (assert
     const fakeId = pyEnv["res.fake"].create({ partner_ids: [partnerId] });
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.fake", fakeId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     const partnerTitle = (
         await contains(`.o-mail-SuggestedRecipient[data-partner-id="${partnerId}"]`)
     )[0].getAttribute("title");
@@ -263,7 +263,7 @@ QUnit.test(
             },
         });
         openFormView("res.fake", fakeId);
-        await click("button:contains(Log note)");
+        await click("button", { text: "Log note" });
         await insertText(".o-mail-Composer-input", "Dummy Message");
         await click(".o-mail-Composer-send:not(:disabled)");
         await contains(".o-mail-Message");
@@ -283,7 +283,7 @@ QUnit.test(
             serverData: { views },
         });
         openFormView("res.fake", fakeId);
-        await click("button:contains(Send message)");
+        await click("button", { text: "Send message" });
         await insertText(".o-mail-Composer-input", "Dummy Message");
         await click(".o-mail-Composer-send:not(:disabled)");
         await contains(".o-mail-Message");

--- a/addons/mail/static/tests/core/open_chat_test.js
+++ b/addons/mail/static/tests/core/open_chat_test.js
@@ -32,7 +32,7 @@ QUnit.test("openChat: open new chat for user", async () => {
     pyEnv["res.users"].create({ partner_id: partnerId });
     const { env } = await start();
     await contains(".o-mail-ChatWindowContainer");
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
     env.services["mail.thread"].openChat({ partnerId });
     await contains(".o-mail-ChatWindow");
 });

--- a/addons/mail/static/tests/core/out_of_focus_tests.js
+++ b/addons/mail/static/tests/core/out_of_focus_tests.js
@@ -24,7 +24,7 @@ QUnit.test("Spaces in notifications are not encoded", async () => {
             res_id: channelId,
         },
     });
-    await contains(".o_notification.border-info .o_notification_content", 1, {
+    await contains(".o_notification.border-info .o_notification_content", {
         text: "Hello world!",
     });
 });

--- a/addons/mail/static/tests/core/out_of_focus_tests.js
+++ b/addons/mail/static/tests/core/out_of_focus_tests.js
@@ -24,5 +24,7 @@ QUnit.test("Spaces in notifications are not encoded", async () => {
             res_id: channelId,
         },
     });
-    await contains(".o_notification.border-info:contains(Hello world!)");
+    await contains(".o_notification.border-info .o_notification_content", 1, {
+        text: "Hello world!",
+    });
 });

--- a/addons/mail/static/tests/crosstab/crosstab_tests.js
+++ b/addons/mail/static/tests/crosstab/crosstab_tests.js
@@ -17,8 +17,8 @@ QUnit.test("Messages are received cross-tab", async () => {
     tab2.openDiscuss(channelId);
     await tab1.insertText(".o-mail-Composer-input", "Hello World!");
     await click("button:contains(Send):not(:disabled)", { target: tab1.target });
-    await contains(".o-mail-Message-content", 1, { target: tab1.target, text: "Hello World!" });
-    await contains(".o-mail-Message-content", 1, { target: tab2.target, text: "Hello World!" });
+    await contains(".o-mail-Message-content", { target: tab1.target, text: "Hello World!" });
+    await contains(".o-mail-Message-content", { target: tab2.target, text: "Hello World!" });
 });
 
 QUnit.test("Delete starred message updates counter", async () => {
@@ -36,14 +36,14 @@ QUnit.test("Delete starred message updates counter", async () => {
     const tab2 = await start({ asTab: true });
     tab1.openDiscuss(channelId);
     tab2.openDiscuss(channelId);
-    await contains("button", 1, { target: tab2.target, text: "Starred1" });
+    await contains("button", { target: tab2.target, text: "Starred1" });
 
     tab1.env.services.rpc("/mail/message/update_content", {
         message_id: messageId,
         body: "",
         attachment_ids: [],
     });
-    await contains("button", 0, { target: tab2.target, text: "Starred1" });
+    await contains("button", { count: 0, target: tab2.target, text: "Starred1" });
 });
 
 QUnit.test("Thread rename", async () => {
@@ -58,8 +58,8 @@ QUnit.test("Thread rename", async () => {
     tab2.openDiscuss(channelId);
     await tab1.insertText(".o-mail-Discuss-threadName:not(:disabled)", "Sales", { replace: true });
     triggerHotkey("Enter");
-    await contains(".o-mail-Discuss-threadName[title='Sales']", 1, { target: tab2.target });
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { target: tab2.target, text: "Sales" });
+    await contains(".o-mail-Discuss-threadName[title='Sales']", { target: tab2.target });
+    await contains(".o-mail-DiscussSidebarChannel span", { target: tab2.target, text: "Sales" });
 });
 
 QUnit.test("Thread description update", async () => {
@@ -76,7 +76,7 @@ QUnit.test("Thread description update", async () => {
         replace: true,
     });
     triggerHotkey("Enter");
-    await contains(".o-mail-Discuss-threadDescription[title='The very best channel']", 1, {
+    await contains(".o-mail-Discuss-threadDescription[title='The very best channel']", {
         target: tab2.target,
     });
 });
@@ -98,7 +98,7 @@ QUnit.test("Channel subscription is renewed when channel is added from invite", 
     env.services.orm.call("discuss.channel", "add_members", [[channelId]], {
         partner_ids: [pyEnv.currentPartnerId],
     });
-    await contains(".o-mail-DiscussSidebarChannel", 2);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
     await new Promise((resolve) => setTimeout(resolve)); // update of channels is debounced
     assert.verifySteps(["update-channels"]);
 });
@@ -114,7 +114,7 @@ QUnit.test("Channel subscription is renewed when channel is left", async (assert
     });
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel .btn[title='Leave this channel']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await new Promise((resolve) => setTimeout(resolve)); // update of channels is debounced
     assert.verifySteps(["update-channels"]);
 });
@@ -141,7 +141,7 @@ QUnit.test("Adding attachments", async () => {
         attachment_ids: [attachmentId],
         message_id: messageId,
     });
-    await contains(".o-mail-AttachmentCard div", 1, { target: tab2.target, text: "test.txt" });
+    await contains(".o-mail-AttachmentCard div", { target: tab2.target, text: "test.txt" });
 });
 
 QUnit.test("Remove attachment from message", async () => {
@@ -162,11 +162,15 @@ QUnit.test("Remove attachment from message", async () => {
     const tab2 = await start({ asTab: true });
     tab1.openDiscuss(channelId);
     tab2.openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard div", 1, { target: tab1.target, text: "test.txt" });
+    await contains(".o-mail-AttachmentCard div", { target: tab1.target, text: "test.txt" });
 
     await click(".o-mail-AttachmentCard-unlink", { target: tab2.target });
     await click(".modal-footer .btn:contains(Ok)", { target: tab2.target });
-    await contains(".o-mail-AttachmentCard div", 0, { target: tab1.target, text: "test.txt" });
+    await contains(".o-mail-AttachmentCard div", {
+        count: 0,
+        target: tab1.target,
+        text: "test.txt",
+    });
 });
 
 QUnit.test("Message delete notification", async () => {
@@ -193,7 +197,7 @@ QUnit.test("Message delete notification", async () => {
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/delete", {
         message_ids: [messageId],
     });
-    await contains(".o-mail-Message", 0);
-    await contains("button:contains(Inbox) .badge", 0);
-    await contains("button:contains(Starred) .badge", 0);
+    await contains(".o-mail-Message", { count: 0 });
+    await contains("button:contains(Inbox) .badge", { count: 0 });
+    await contains("button:contains(Starred) .badge", { count: 0 });
 });

--- a/addons/mail/static/tests/crosstab/crosstab_tests.js
+++ b/addons/mail/static/tests/crosstab/crosstab_tests.js
@@ -17,8 +17,8 @@ QUnit.test("Messages are received cross-tab", async () => {
     tab2.openDiscuss(channelId);
     await tab1.insertText(".o-mail-Composer-input", "Hello World!");
     await click("button:contains(Send):not(:disabled)", { target: tab1.target });
-    await contains(".o-mail-Message:contains(Hello World!)", 1, { target: tab1.target });
-    await contains(".o-mail-Message:contains(Hello World!)", 1, { target: tab2.target });
+    await contains(".o-mail-Message-content", 1, { target: tab1.target, text: "Hello World!" });
+    await contains(".o-mail-Message-content", 1, { target: tab2.target, text: "Hello World!" });
 });
 
 QUnit.test("Delete starred message updates counter", async () => {
@@ -36,13 +36,14 @@ QUnit.test("Delete starred message updates counter", async () => {
     const tab2 = await start({ asTab: true });
     tab1.openDiscuss(channelId);
     tab2.openDiscuss(channelId);
-    await contains("button:contains(Starred1)", 1, { target: tab2.target });
+    await contains("button", 1, { target: tab2.target, text: "Starred1" });
+
     tab1.env.services.rpc("/mail/message/update_content", {
         message_id: messageId,
         body: "",
         attachment_ids: [],
     });
-    await contains("button:contains(Starred1)", 0, { target: tab2.target });
+    await contains("button", 0, { target: tab2.target, text: "Starred1" });
 });
 
 QUnit.test("Thread rename", async () => {
@@ -58,7 +59,7 @@ QUnit.test("Thread rename", async () => {
     await tab1.insertText(".o-mail-Discuss-threadName:not(:disabled)", "Sales", { replace: true });
     triggerHotkey("Enter");
     await contains(".o-mail-Discuss-threadName[title='Sales']", 1, { target: tab2.target });
-    await contains(".o-mail-DiscussSidebarChannel:contains(Sales)", 1, { target: tab2.target });
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { target: tab2.target, text: "Sales" });
 });
 
 QUnit.test("Thread description update", async () => {
@@ -140,7 +141,7 @@ QUnit.test("Adding attachments", async () => {
         attachment_ids: [attachmentId],
         message_id: messageId,
     });
-    await contains(".o-mail-AttachmentCard:contains(test.txt)", 1, { target: tab2.target });
+    await contains(".o-mail-AttachmentCard div", 1, { target: tab2.target, text: "test.txt" });
 });
 
 QUnit.test("Remove attachment from message", async () => {
@@ -161,10 +162,11 @@ QUnit.test("Remove attachment from message", async () => {
     const tab2 = await start({ asTab: true });
     tab1.openDiscuss(channelId);
     tab2.openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard:contains(test.txt)", 1, { target: tab1.target });
+    await contains(".o-mail-AttachmentCard div", 1, { target: tab1.target, text: "test.txt" });
+
     await click(".o-mail-AttachmentCard-unlink", { target: tab2.target });
     await click(".modal-footer .btn:contains(Ok)", { target: tab2.target });
-    await contains(".o-mail-AttachmentCard:contains(test.txt)", 0, { target: tab1.target });
+    await contains(".o-mail-AttachmentCard div", 0, { target: tab1.target, text: "test.txt" });
 });
 
 QUnit.test("Message delete notification", async () => {

--- a/addons/mail/static/tests/discuss/call/call_settings_menu_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu_tests.js
@@ -36,7 +36,7 @@ QUnit.test("Renders the call settings", async () => {
     await contains(".o-discuss-CallSettings");
     await contains("label[aria-label='Input device']");
     await contains("option[value=mockAudioDeviceId]");
-    await contains("option[value=mockVideoDeviceId]", 0);
+    await contains("option[value=mockVideoDeviceId]", { count: 0 });
     await contains("input[title='toggle push-to-talk']");
     await contains("label[aria-label='Voice detection threshold']");
     await contains("input[title='Show video participants only']");
@@ -60,7 +60,7 @@ QUnit.test("activate push to talk", async () => {
     await click("input[title='toggle push-to-talk']");
     await contains("i[aria-label='Register new key']");
     await contains("label[aria-label='Delay after releasing push-to-talk']");
-    await contains("label[aria-label='Voice detection threshold']", 0);
+    await contains("label[aria-label='Voice detection threshold']", { count: 0 });
 });
 
 QUnit.test("activate blur", async () => {
@@ -87,7 +87,7 @@ QUnit.test("Inbox should not have any call settings menu", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_inbox");
     await contains(".o-mail-Thread");
-    await contains("button[title='Show Call Settings']", 0);
+    await contains("button[title='Show Call Settings']", { count: 0 });
 });
 
 QUnit.test(
@@ -107,7 +107,7 @@ QUnit.test(
         openDiscuss(channelId);
         await click("button[title='Show Call Settings']");
         await click("button div", { text: "Inbox" });
-        await contains("button[title='Hide Call Settings']", 0);
-        await contains(".o-discuss-CallSettings", 0);
+        await contains("button[title='Hide Call Settings']", { count: 0 });
+        await contains(".o-discuss-CallSettings", { count: 0 });
     }
 );

--- a/addons/mail/static/tests/discuss/call/call_settings_menu_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu_tests.js
@@ -106,7 +106,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await click("button[title='Show Call Settings']");
-        await click("button:contains(Inbox)");
+        await click("button div", { text: "Inbox" });
         await contains("button[title='Hide Call Settings']", 0);
         await contains(".o-discuss-CallSettings", 0);
     }

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -28,7 +28,7 @@ QUnit.test("basic rendering", async () => {
     await contains(".o-discuss-CallParticipantCard[aria-label='Mitchell Admin']");
     await contains(".o-discuss-CallActionList");
     await contains(".o-discuss-CallMenu-buttonContent");
-    await contains(".o-discuss-CallActionList button", 5);
+    await contains(".o-discuss-CallActionList button", { count: 5 });
     await contains("button[aria-label='Unmute'], button[aria-label='Mute']"); // FIXME depends on current browser permission
     await contains(".o-discuss-CallActionList button[aria-label='Deafen']");
     await contains(".o-discuss-CallActionList button[aria-label='Turn camera on']");
@@ -52,7 +52,7 @@ QUnit.test("no call with odoobot", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Discuss-header");
-    await contains(".o-mail-Discuss-header button[title='Start a Call']", 0);
+    await contains(".o-mail-Discuss-header button[title='Start a Call']", { count: 0 });
 });
 
 QUnit.test("should not display call UI when no more members (self disconnect)", async () => {
@@ -64,7 +64,7 @@ QUnit.test("should not display call UI when no more members (self disconnect)", 
     await click(".o-mail-Discuss-header button[title='Start a Call']");
     await contains(".o-discuss-Call");
     await click(".o-discuss-CallActionList button[aria-label='Disconnect']");
-    await contains(".o-discuss-Call", 0);
+    await contains(".o-discuss-Call", { count: 0 });
 });
 
 QUnit.test("show call UI in chat window when in call", async () => {
@@ -75,10 +75,10 @@ QUnit.test("show call UI in chat window when in call", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name", { text: "General" });
     await contains(".o-mail-ChatWindow");
-    await contains(".o-discuss-Call", 0);
+    await contains(".o-discuss-Call", { count: 0 });
     await click(".o-mail-ChatWindow-command[title='Start a Call']");
     await contains(".o-discuss-Call");
-    await contains(".o-mail-ChatWindow-command[title='Start a Call']", 0);
+    await contains(".o-mail-ChatWindow-command[title='Start a Call']", { count: 0 });
 });
 
 QUnit.test("should disconnect when closing page while in call", async (assert) => {
@@ -149,7 +149,7 @@ QUnit.test("should display invitations", async (assert) => {
             rtcInvitingSession: [["unlink"]],
         },
     });
-    await contains(".o-discuss-CallInvitation", 0);
+    await contains(".o-discuss-CallInvitation", { count: 0 });
     assert.verifySteps(["pause_sound_effect"]);
 });
 
@@ -167,7 +167,7 @@ QUnit.test("can share screen", async () => {
     await contains(".o-discuss-CallParticipantCard video");
     await click(".o-discuss-CallActionList [title='More']");
     await click("[title='Stop Sharing Screen']");
-    await contains(".o-discuss-CallParticipantCard video", 0);
+    await contains(".o-discuss-CallParticipantCard video", { count: 0 });
 });
 
 QUnit.test("can share user camera", async () => {
@@ -182,7 +182,7 @@ QUnit.test("can share user camera", async () => {
     await click(".o-discuss-CallActionList button[title='Turn camera on']");
     await contains(".o-discuss-CallParticipantCard video");
     await click(".o-discuss-CallActionList button[title='Stop camera']");
-    await contains(".o-discuss-CallParticipantCard video", 0);
+    await contains(".o-discuss-CallParticipantCard video", { count: 0 });
 });
 
 QUnit.test("Create a direct message channel when clicking on start a meeting", async () => {
@@ -190,7 +190,7 @@ QUnit.test("Create a direct message channel when clicking on start a meeting", a
     const { openDiscuss } = await start();
     openDiscuss();
     await click("button", { text: "Start a meeting" });
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Mitchell Admin" });
     await contains(".o-discuss-Call");
     await contains(".o-discuss-ChannelInvitation");
 });

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -73,14 +73,12 @@ QUnit.test("show call UI in chat window when in call", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(General)");
+    await click(".o-mail-NotificationItem-name", { text: "General" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-discuss-Call", 0);
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Start a Call']");
-
-    await click(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Start a Call']");
+    await click(".o-mail-ChatWindow-command[title='Start a Call']");
     await contains(".o-discuss-Call");
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Start a Call']", 0);
+    await contains(".o-mail-ChatWindow-command[title='Start a Call']", 0);
 });
 
 QUnit.test("should disconnect when closing page while in call", async (assert) => {
@@ -191,8 +189,8 @@ QUnit.test("Create a direct message channel when clicking on start a meeting", a
     mockGetMedia();
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button:contains(Start a meeting)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Mitchell Admin)");
+    await click("button", { text: "Start a meeting" });
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Mitchell Admin" });
     await contains(".o-discuss-Call");
     await contains(".o-discuss-ChannelInvitation");
 });

--- a/addons/mail/static/tests/discuss/call/web/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/web/call_tests.js
@@ -13,14 +13,14 @@ QUnit.test("no default rtc after joining a chat conversation", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-Discuss-content .o-mail-Message", 0);
-    await contains(".o-discuss-Call", 0);
+    await contains(".o-mail-Discuss-content .o-mail-Message", { count: 0 });
+    await contains(".o-discuss-Call", { count: 0 });
 });
 
 QUnit.test("no default rtc after joining a group conversation", async () => {
@@ -33,13 +33,13 @@ QUnit.test("no default rtc after joining a group conversation", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion", { text: "Mario" });
     await insertText(".o-discuss-ChannelSelector input", "luigi", { replace: true });
     await click(".o-discuss-ChannelSelector-suggestion", { text: "Luigi" });
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-Discuss-content .o-mail-Message", 0);
-    await contains(".o-discuss-Call", 0);
+    await contains(".o-mail-Discuss-content .o-mail-Message", { count: 0 });
+    await contains(".o-discuss-Call", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss/call/web/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/web/call_tests.js
@@ -35,9 +35,9 @@ QUnit.test("no default rtc after joining a group conversation", async () => {
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
     await contains(".o-mail-DiscussSidebarChannel", 0);
     await insertText(".o-discuss-ChannelSelector input", "mario");
-    await click(".o-discuss-ChannelSelector-suggestion:contains(Mario)");
+    await click(".o-discuss-ChannelSelector-suggestion", { text: "Mario" });
     await insertText(".o-discuss-ChannelSelector input", "luigi", { replace: true });
-    await click(".o-discuss-ChannelSelector-suggestion:contains(Luigi)");
+    await click(".o-discuss-ChannelSelector-suggestion", { text: "Luigi" });
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-Discuss-content .o-mail-Message", 0);

--- a/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
@@ -51,7 +51,7 @@ QUnit.test("can invite users in channel from chat window", async () => {
         ".o-discuss-ChannelInvitation-selectable:contains(TestPartner) input[type='checkbox']"
     );
     await click("[title='Invite to Channel']:not(:disabled)");
-    await contains(".o-discuss-ChannelInvitation", 0);
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(
         ".o-mail-Thread .o-mail-NotificationMessage:contains(Mitchell Admin invited TestPartner to the channel)"
     );
@@ -81,7 +81,7 @@ QUnit.test("should be able to search for a new user to invite from an existing c
     openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Add Users']");
     await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
-    await contains(".o-discuss-ChannelInvitation-selectable", 1, { text: "TestPartner2" });
+    await contains(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner2" });
 });
 
 QUnit.test("Invitation form should display channel group restriction", async () => {

--- a/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation_tests.js
@@ -81,7 +81,7 @@ QUnit.test("should be able to search for a new user to invite from an existing c
     openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Add Users']");
     await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
-    await contains(".o-discuss-ChannelInvitation-selectable:contains(TestPartner2)");
+    await contains(".o-discuss-ChannelInvitation-selectable", 1, { text: "TestPartner2" });
 });
 
 QUnit.test("Invitation form should display channel group restriction", async () => {
@@ -130,7 +130,7 @@ QUnit.test("should be able to create a new group chat from an existing chat", as
     openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Add Users']");
     await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
-    await click(".o-discuss-ChannelInvitation-selectable:contains(TestPartner2)");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner2" });
     await click("button[title='Create Group Chat']:not(:disabled)");
     await contains(
         ".o-mail-DiscussSidebarChannel:contains(Mitchell Admin, TestPartner, and TestPartner2)"

--- a/addons/mail/static/tests/discuss/core/channel_member_list_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list_tests.js
@@ -63,7 +63,7 @@ QUnit.test("should have correct members in member list", async () => {
     await click("[title='Show Member List']");
     await contains(".o-discuss-ChannelMember", 2);
     await contains(`.o-discuss-ChannelMember:contains("${pyEnv.currentPartner.name}")`);
-    await contains(".o-discuss-ChannelMember:contains('Demo')");
+    await contains(".o-discuss-ChannelMember", 1, { text: "Demo" });
 });
 
 QUnit.test(
@@ -121,7 +121,7 @@ QUnit.test("should show a button to load more members if they are not all loaded
     openDiscuss(channelId);
     pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
     await click("[title='Show Member List']");
-    await contains("button:contains(Load more)");
+    await contains("button", 1, { text: "Load more" });
 });
 
 QUnit.test("Load more button should load more members", async (assert) => {
@@ -144,7 +144,7 @@ QUnit.test("Load more button should load more members", async (assert) => {
     await contains(".o-discuss-ChannelMember", 102);
 });
 
-QUnit.test("Channel member count update after user joined", async (assert) => {
+QUnit.test("Channel member count update after user joined", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const userId = pyEnv["res.users"].create({ name: "Harry" });
@@ -152,13 +152,13 @@ QUnit.test("Channel member count update after user joined", async (assert) => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMemberList:contains(Offline - 1)");
+    await contains(".o-discuss-ChannelMemberList h6", 1, { text: "Offline - 1" });
     await click("[title='Add Users']");
-    await click(".o-discuss-ChannelInvitation-selectable:contains(Harry)");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
     await click("[title='Invite to Channel']:not(:disabled)");
     await contains(".o-discuss-ChannelInvitation", 0);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMemberList:contains(Offline - 2)");
+    await contains(".o-discuss-ChannelMemberList h6", 1, { text: "Offline - 2" });
 });
 
 QUnit.test("Channel member count update after user left", async (assert) => {

--- a/addons/mail/static/tests/discuss/core/channel_member_list_tests.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list_tests.js
@@ -61,9 +61,9 @@ QUnit.test("should have correct members in member list", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 2);
+    await contains(".o-discuss-ChannelMember", { count: 2 });
     await contains(`.o-discuss-ChannelMember:contains("${pyEnv.currentPartner.name}")`);
-    await contains(".o-discuss-ChannelMember", 1, { text: "Demo" });
+    await contains(".o-discuss-ChannelMember", { text: "Demo" });
 });
 
 QUnit.test(
@@ -121,7 +121,7 @@ QUnit.test("should show a button to load more members if they are not all loaded
     openDiscuss(channelId);
     pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
     await click("[title='Show Member List']");
-    await contains("button", 1, { text: "Load more" });
+    await contains("button", { text: "Load more" });
 });
 
 QUnit.test("Load more button should load more members", async (assert) => {
@@ -141,7 +141,7 @@ QUnit.test("Load more button should load more members", async (assert) => {
     pyEnv["discuss.channel"].write([channelId], { channel_member_ids });
     await click("[title='Show Member List']");
     await click("[title='Load more']");
-    await contains(".o-discuss-ChannelMember", 102);
+    await contains(".o-discuss-ChannelMember", { count: 102 });
 });
 
 QUnit.test("Channel member count update after user joined", async () => {
@@ -152,13 +152,13 @@ QUnit.test("Channel member count update after user joined", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMemberList h6", 1, { text: "Offline - 1" });
+    await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 1" });
     await click("[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
     await click("[title='Invite to Channel']:not(:disabled)");
-    await contains(".o-discuss-ChannelInvitation", 0);
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMemberList h6", 1, { text: "Offline - 2" });
+    await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 2" });
 });
 
 QUnit.test("Channel member count update after user left", async (assert) => {

--- a/addons/mail/static/tests/discuss/core/composer_tests.js
+++ b/addons/mail/static/tests/discuss/core/composer_tests.js
@@ -46,7 +46,7 @@ QUnit.test(
         openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "/");
         await click(".o-mail-Composer-suggestion:eq(0)");
-        await contains(".o-mail-Composer-suggestion strong", 0);
+        await contains(".o-mail-Composer-suggestion strong", { count: 0 });
         await insertText(".o-mail-Composer-input", " is user?");
         assert.verifySteps([], "No rpc done");
     }
@@ -60,11 +60,11 @@ QUnit.test("add an emoji after a command", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "/");
     await click(".o-mail-Composer-suggestion:eq(0)");
-    await contains(".o-mail-Composer-input", 1, { value: "/who " });
+    await contains(".o-mail-Composer-input", { value: "/who " });
     await click("button[aria-label='Emojis']");
     await click(".o-Emoji", { text: "😊" });
-    await contains(".o-mail-Composer-input", 1, { value: "/who 😊" });
+    await contains(".o-mail-Composer-input", { value: "/who 😊" });
 });

--- a/addons/mail/static/tests/discuss/core/composer_tests.js
+++ b/addons/mail/static/tests/discuss/core/composer_tests.js
@@ -46,7 +46,7 @@ QUnit.test(
         openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "/");
         await click(".o-mail-Composer-suggestion:eq(0)");
-        await contains(".o-mail-Composer-suggestion", 0);
+        await contains(".o-mail-Composer-suggestion strong", 0);
         await insertText(".o-mail-Composer-input", " is user?");
         assert.verifySteps([], "No rpc done");
     }
@@ -65,6 +65,6 @@ QUnit.test("add an emoji after a command", async () => {
     await click(".o-mail-Composer-suggestion:eq(0)");
     await contains(".o-mail-Composer-input", 1, { value: "/who " });
     await click("button[aria-label='Emojis']");
-    await click(".o-Emoji:contains(😊)");
+    await click(".o-Emoji", { text: "😊" });
     await contains(".o-mail-Composer-input", 1, { value: "/who 😊" });
 });

--- a/addons/mail/static/tests/discuss/core/crosstab_tests.js
+++ b/addons/mail/static/tests/discuss/core/crosstab_tests.js
@@ -13,13 +13,13 @@ QUnit.test("Add member to channel", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 1, { text: "Mitchell Admin" });
+    await contains(".o-discuss-ChannelMember", { text: "Mitchell Admin" });
     await click("[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
     await click("[title='Invite to Channel']:not(:disabled)");
-    await contains(".o-discuss-ChannelInvitation", 0);
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 1, { text: "Harry" });
+    await contains(".o-discuss-ChannelMember", { text: "Harry" });
 });
 
 QUnit.test("Remove member from channel", async () => {
@@ -39,9 +39,9 @@ QUnit.test("Remove member from channel", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember", 1, { text: "Harry" });
+    await contains(".o-discuss-ChannelMember", { text: "Harry" });
     pyEnv.withUser(userId, () =>
         env.services.orm.call("discuss.channel", "action_unfollow", [channelId])
     );
-    await contains(".o-discuss-ChannelMember", 0, { text: "Harry" });
+    await contains(".o-discuss-ChannelMember", { count: 0, text: "Harry" });
 });

--- a/addons/mail/static/tests/discuss/core/crosstab_tests.js
+++ b/addons/mail/static/tests/discuss/core/crosstab_tests.js
@@ -13,13 +13,13 @@ QUnit.test("Add member to channel", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember:contains(Mitchell Admin)");
+    await contains(".o-discuss-ChannelMember", 1, { text: "Mitchell Admin" });
     await click("[title='Add Users']");
-    await click(".o-discuss-ChannelInvitation-selectable:contains(Harry)");
+    await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
     await click("[title='Invite to Channel']:not(:disabled)");
     await contains(".o-discuss-ChannelInvitation", 0);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember:contains(Harry)");
+    await contains(".o-discuss-ChannelMember", 1, { text: "Harry" });
 });
 
 QUnit.test("Remove member from channel", async () => {
@@ -39,9 +39,9 @@ QUnit.test("Remove member from channel", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Show Member List']");
-    await contains(".o-discuss-ChannelMember:contains(Harry)");
+    await contains(".o-discuss-ChannelMember", 1, { text: "Harry" });
     pyEnv.withUser(userId, () =>
         env.services.orm.call("discuss.channel", "action_unfollow", [channelId])
     );
-    await contains(".o-discuss-ChannelMember:contains(Harry)", 0);
+    await contains(".o-discuss-ChannelMember", 0, { text: "Harry" });
 });

--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -13,5 +13,5 @@ QUnit.test("Member list and settings menu are exclusive", async () => {
     await contains(".o-discuss-ChannelMemberList");
     await click("[title='Show Call Settings']");
     await contains(".o-discuss-CallSettings");
-    await contains(".o-discuss-ChannelMemberList", 0);
+    await contains(".o-discuss-ChannelMemberList", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss/core/suggestion_tests.js
+++ b/addons/mail/static/tests/discuss/core/suggestion_tests.js
@@ -62,7 +62,7 @@ QUnit.test("command suggestion should only open if command is the first characte
     await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
 });
 
-QUnit.test("Sort partner suggestions by recent chats", async (assert) => {
+QUnit.test("Sort partner suggestions by recent chats", async () => {
     const pyEnv = await startServer();
     const [partner_1, partner_2, partner_3] = pyEnv["res.partner"].create([
         { name: "User 1" },
@@ -117,9 +117,9 @@ QUnit.test("Sort partner suggestions by recent chats", async (assert) => {
     await insertText(".o-mail-Composer-input[placeholder='Message #General…']", "@");
     await insertText(".o-mail-Composer-input", "User");
     await contains(".o-mail-Composer-suggestion strong", { count: 3 });
-    assert.strictEqual($(".o-mail-Composer-suggestion").eq(0).text(), "User 2");
-    assert.strictEqual($(".o-mail-Composer-suggestion").eq(1).text(), "User 1");
-    assert.strictEqual($(".o-mail-Composer-suggestion").eq(2).text(), "User 3");
+    await contains(".o-mail-Composer-suggestion:eq(0) strong", { text: "User 2" });
+    await contains(".o-mail-Composer-suggestion:eq(1) strong", { text: "User 1" });
+    await contains(".o-mail-Composer-suggestion:eq(2) strong", { text: "User 3" });
 });
 
 QUnit.test("mention suggestion are shown after deleting a character", async () => {

--- a/addons/mail/static/tests/discuss/core/suggestion_tests.js
+++ b/addons/mail/static/tests/discuss/core/suggestion_tests.js
@@ -26,7 +26,7 @@ QUnit.test('display command suggestions on typing "/"', async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await insertText(".o-mail-Composer-input", "/");
     await contains(".o-mail-Composer-suggestionList .o-open");
 });
@@ -37,11 +37,11 @@ QUnit.test("use a command for a specific channel type", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "/");
     await click(".o-mail-Composer-suggestion strong", { text: "who" });
-    await contains(".o-mail-Composer-input", 1, { value: "/who " });
+    await contains(".o-mail-Composer-input", { value: "/who " });
 });
 
 QUnit.test("command suggestion should only open if command is the first character", async () => {
@@ -53,13 +53,13 @@ QUnit.test("command suggestion should only open if command is the first characte
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "bluhbluh ");
-    await contains(".o-mail-Composer-input", 1, { value: "bluhbluh " });
+    await contains(".o-mail-Composer-input", { value: "bluhbluh " });
     await insertText(".o-mail-Composer-input", "/");
     // weak test, no guarantee that we waited long enough for the potential list to open
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
 });
 
 QUnit.test("Sort partner suggestions by recent chats", async (assert) => {
@@ -112,11 +112,11 @@ QUnit.test("Sort partner suggestions by recent chats", async (assert) => {
     await click(".o-mail-DiscussSidebarChannel span", { text: "User 2" });
     await insertText(".o-mail-Composer-input", "This is a test");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-content", 1, { text: "This is a test" });
+    await contains(".o-mail-Message-content", { text: "This is a test" });
     await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await insertText(".o-mail-Composer-input[placeholder='Message #General…']", "@");
     await insertText(".o-mail-Composer-input", "User");
-    await contains(".o-mail-Composer-suggestion strong", 3);
+    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
     assert.strictEqual($(".o-mail-Composer-suggestion").eq(0).text(), "User 2");
     assert.strictEqual($(".o-mail-Composer-suggestion").eq(1).text(), "User 1");
     assert.strictEqual($(".o-mail-Composer-suggestion").eq(2).text(), "User 3");
@@ -136,14 +136,14 @@ QUnit.test("mention suggestion are shown after deleting a character", async () =
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@John D");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "John Doe" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "John Doe" });
     await insertText(".o-mail-Composer-input", "a");
-    await contains(".o-mail-Composer-suggestion strong", 0, { text: "John D" });
+    await contains(".o-mail-Composer-suggestion strong", { count: 0, text: "John D" });
 
     // Simulate pressing backspace
     const textarea = document.querySelector(".o-mail-Composer-input");
     textarea.value = textarea.value.slice(0, -1);
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "John Doe" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "John Doe" });
 });
 
 QUnit.test("command suggestion are shown after deleting a character", async () => {
@@ -160,12 +160,12 @@ QUnit.test("command suggestion are shown after deleting a character", async () =
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/he");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "help" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "help" });
     await insertText(".o-mail-Composer-input", "e");
-    await contains(".o-mail-Composer-suggestion strong", 0, { text: "help" });
+    await contains(".o-mail-Composer-suggestion strong", { count: 0, text: "help" });
 
     // Simulate pressing backspace
     const textarea = document.querySelector(".o-mail-Composer-input");
     textarea.value = textarea.value.slice(0, -1);
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "help" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "help" });
 });

--- a/addons/mail/static/tests/discuss/core/suggestion_tests.js
+++ b/addons/mail/static/tests/discuss/core/suggestion_tests.js
@@ -40,7 +40,7 @@ QUnit.test("use a command for a specific channel type", async () => {
     await contains(".o-mail-Composer-suggestionList .o-open", 0);
     await contains(".o-mail-Composer-input", 1, { value: "" });
     await insertText(".o-mail-Composer-input", "/");
-    await click(".o-mail-Composer-suggestion:contains(who)");
+    await click(".o-mail-Composer-suggestion strong", { text: "who" });
     await contains(".o-mail-Composer-input", 1, { value: "/who " });
 });
 
@@ -109,14 +109,14 @@ QUnit.test("Sort partner suggestions by recent chats", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel:contains('User 2')");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "User 2" });
     await insertText(".o-mail-Composer-input", "This is a test");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message:contains('This is a test')");
-    await click(".o-mail-DiscussSidebarChannel:contains('General')");
+    await contains(".o-mail-Message-content", 1, { text: "This is a test" });
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await insertText(".o-mail-Composer-input[placeholder='Message #General…']", "@");
     await insertText(".o-mail-Composer-input", "User");
-    await contains(".o-mail-Composer-suggestion", 3);
+    await contains(".o-mail-Composer-suggestion strong", 3);
     assert.strictEqual($(".o-mail-Composer-suggestion").eq(0).text(), "User 2");
     assert.strictEqual($(".o-mail-Composer-suggestion").eq(1).text(), "User 1");
     assert.strictEqual($(".o-mail-Composer-suggestion").eq(2).text(), "User 3");
@@ -136,13 +136,14 @@ QUnit.test("mention suggestion are shown after deleting a character", async () =
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@John D");
-    await contains(".o-mail-Composer-suggestion:contains(John Doe)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "John Doe" });
     await insertText(".o-mail-Composer-input", "a");
-    await contains(".o-mail-Composer-suggestion:contains(John D)", 0);
+    await contains(".o-mail-Composer-suggestion strong", 0, { text: "John D" });
+
     // Simulate pressing backspace
     const textarea = document.querySelector(".o-mail-Composer-input");
     textarea.value = textarea.value.slice(0, -1);
-    await contains(".o-mail-Composer-suggestion:contains(John Doe)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "John Doe" });
 });
 
 QUnit.test("command suggestion are shown after deleting a character", async () => {
@@ -159,11 +160,12 @@ QUnit.test("command suggestion are shown after deleting a character", async () =
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/he");
-    await contains(".o-mail-Composer-suggestion:contains(help)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "help" });
     await insertText(".o-mail-Composer-input", "e");
-    await contains(".o-mail-Composer-suggestion:contains(help)", 0);
+    await contains(".o-mail-Composer-suggestion strong", 0, { text: "help" });
+
     // Simulate pressing backspace
     const textarea = document.querySelector(".o-mail-Composer-input");
     textarea.value = textarea.value.slice(0, -1);
-    await contains(".o-mail-Composer-suggestion:contains(help)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "help" });
 });

--- a/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
@@ -23,38 +23,38 @@ QUnit.module("chat window: new message");
 QUnit.test("basic rendering", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
+    await click("button", { text: "New Message" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-name:contains(New message)");
+    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-name", 1, { text: "New message" });
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command", 2);
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Fold']");
     await contains(
         ".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Close Chat Window']"
     );
-    await contains("span:contains('To :')");
+    await contains("span", 1, { text: "To :" });
     await contains(".o-discuss-ChannelSelector");
 });
 
 QUnit.test("focused on open [REQUIRE FOCUS]", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
+    await click("button", { text: "New Message" });
     await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector input:focus");
 });
 
 QUnit.test("close", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
-    await click(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Close Chat Window']");
+    await click("button", { text: "New Message" });
+    await click(".o-mail-ChatWindow-command[title='Close Chat Window']");
     await contains(".o-mail-ChatWindow", 0);
 });
 
 QUnit.test("fold", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
+    await click("button", { text: "New Message" });
     await contains(".o-mail-ChatWindow-content");
     await contains(".o-discuss-ChannelSelector");
 
@@ -105,8 +105,8 @@ QUnit.test(
         });
         // open "new message" chat window
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click("button:contains(New Message)");
-        await contains(".o-mail-ChatWindow-header:contains(New message)");
+        await click("button", { text: "New Message" });
+        await contains(".o-mail-ChatWindow-name", 1, { text: "New message" });
         await contains(".o-mail-ChatWindow", 2);
         await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector");
         assert.ok(
@@ -117,7 +117,9 @@ QUnit.test(
 
         // open channel-2
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem .o-mail-NotificationItem-name:contains(channel-2)");
+        await click(".o-mail-NotificationItem .o-mail-NotificationItem-name", {
+            text: "channel-2",
+        });
         await contains(".o-mail-ChatWindow", 3);
         assert.ok(
             Array.from(document.querySelectorAll(".o-mail-ChatWindow"))[1].textContent.includes(
@@ -130,8 +132,9 @@ QUnit.test(
             await insertText(".o-discuss-ChannelSelector input", "131");
             await imSearchDef;
         });
-        await click(".o-discuss-ChannelSelector-suggestion a:contains(Partner 131)");
-        await contains(".o-mail-ChatWindow-header:contains(New message)", 0);
+        await click(".o-discuss-ChannelSelector-suggestion a", { text: "Partner 131" });
+        await contains(".o-mail-ChatWindow-name", 0, { text: "New message" });
+
         assert.strictEqual($(".o-mail-ChatWindow-name:eq(1)").text(), "Partner 131");
     }
 );
@@ -160,10 +163,11 @@ QUnit.test(
         });
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click("button:contains(New Message)");
+        await click("button", { text: "New Message" });
         await insertText(".o-discuss-ChannelSelector", "131");
         await click(".o-discuss-ChannelSelector-suggestion a");
-        await contains(".o-mail-ChatWindow-header:contains(New message)", 0);
+        await contains(".o-mail-ChatWindow-name", 0, { text: "New message" });
+
         await contains(".o-mail-ChatWindow");
     }
 );
@@ -174,7 +178,7 @@ QUnit.test("new message autocomplete should automatically select first result", 
     pyEnv["res.users"].create({ partner_id: partnerId });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
+    await click("button", { text: "New Message" });
     await insertText(".o-discuss-ChannelSelector", "131");
     await contains(".o-discuss-ChannelSelector-suggestion a.o-mail-NavigableList-active");
 });

--- a/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
@@ -26,13 +26,13 @@ QUnit.test("basic rendering", async () => {
     await click("button", { text: "New Message" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-name", 1, { text: "New message" });
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command", 2);
+    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-name", { text: "New message" });
+    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command", { count: 2 });
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Fold']");
     await contains(
         ".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Close Chat Window']"
     );
-    await contains("span", 1, { text: "To :" });
+    await contains("span", { text: "To :" });
     await contains(".o-discuss-ChannelSelector");
 });
 
@@ -48,7 +48,7 @@ QUnit.test("close", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button", { text: "New Message" });
     await click(".o-mail-ChatWindow-command[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-ChatWindow", { count: 0 });
 });
 
 QUnit.test("fold", async () => {
@@ -59,8 +59,8 @@ QUnit.test("fold", async () => {
     await contains(".o-discuss-ChannelSelector");
 
     await click(".o-mail-ChatWindow-command[title='Fold']");
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", 0);
-    await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector", 0);
+    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", { count: 0 });
+    await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector", { count: 0 });
 
     await click(".o-mail-ChatWindow-command[title='Open']");
     await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content");
@@ -106,8 +106,8 @@ QUnit.test(
         // open "new message" chat window
         await click(".o_menu_systray i[aria-label='Messages']");
         await click("button", { text: "New Message" });
-        await contains(".o-mail-ChatWindow-name", 1, { text: "New message" });
-        await contains(".o-mail-ChatWindow", 2);
+        await contains(".o-mail-ChatWindow-name", { text: "New message" });
+        await contains(".o-mail-ChatWindow", { count: 2 });
         await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector");
         assert.ok(
             Array.from(document.querySelectorAll(".o-mail-ChatWindow"))
@@ -117,10 +117,8 @@ QUnit.test(
 
         // open channel-2
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem .o-mail-NotificationItem-name", {
-            text: "channel-2",
-        });
-        await contains(".o-mail-ChatWindow", 3);
+        await click(".o-mail-NotificationItem-name", { text: "channel-2" });
+        await contains(".o-mail-ChatWindow", { count: 3 });
         assert.ok(
             Array.from(document.querySelectorAll(".o-mail-ChatWindow"))[1].textContent.includes(
                 "New message"
@@ -133,7 +131,7 @@ QUnit.test(
             await imSearchDef;
         });
         await click(".o-discuss-ChannelSelector-suggestion a", { text: "Partner 131" });
-        await contains(".o-mail-ChatWindow-name", 0, { text: "New message" });
+        await contains(".o-mail-ChatWindow-name", { count: 0, text: "New message" });
 
         assert.strictEqual($(".o-mail-ChatWindow-name:eq(1)").text(), "Partner 131");
     }
@@ -166,7 +164,7 @@ QUnit.test(
         await click("button", { text: "New Message" });
         await insertText(".o-discuss-ChannelSelector", "131");
         await click(".o-discuss-ChannelSelector-suggestion a");
-        await contains(".o-mail-ChatWindow-name", 0, { text: "New message" });
+        await contains(".o-mail-ChatWindow-name", { count: 0, text: "New message" });
 
         await contains(".o-mail-ChatWindow");
     }

--- a/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
@@ -7,16 +7,7 @@ import {
 } from "@mail/core/common/chat_window_service";
 import { Command } from "@mail/../tests/helpers/command";
 import { patchUiSize } from "@mail/../tests/helpers/patch_ui_size";
-import {
-    afterNextRender,
-    click,
-    contains,
-    insertText,
-    start,
-    startServer,
-} from "@mail/../tests/helpers/test_utils";
-
-import { makeDeferred } from "@web/../tests/helpers/utils";
+import { click, contains, insertText, start, startServer } from "@mail/../tests/helpers/test_utils";
 
 QUnit.module("chat window: new message");
 
@@ -87,7 +78,6 @@ QUnit.test(
                 ],
             },
         ]);
-        const imSearchDef = makeDeferred();
         patchUiSize({ width: 1920 });
         assert.ok(
             CHAT_WINDOW_END_GAP_WIDTH * 2 +
@@ -96,44 +86,23 @@ QUnit.test(
                 1920,
             "should have enough space to open 3 chat windows simultaneously"
         );
-        await start({
-            mockRPC(route, args) {
-                if (args.method === "im_search") {
-                    imSearchDef.resolve();
-                }
-            },
-        });
+        await start();
         // open "new message" chat window
         await click(".o_menu_systray i[aria-label='Messages']");
         await click("button", { text: "New Message" });
-        await contains(".o-mail-ChatWindow-name", { text: "New message" });
         await contains(".o-mail-ChatWindow", { count: 2 });
+        await contains(".o-mail-ChatWindow-name:eq(1)", { text: "New message" });
         await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector");
-        assert.ok(
-            Array.from(document.querySelectorAll(".o-mail-ChatWindow"))
-                .pop()
-                .textContent.includes("New message")
-        );
-
         // open channel-2
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem-name", { text: "channel-2" });
         await contains(".o-mail-ChatWindow", { count: 3 });
-        assert.ok(
-            Array.from(document.querySelectorAll(".o-mail-ChatWindow"))[1].textContent.includes(
-                "New message"
-            )
-        );
-
+        await contains(".o-mail-ChatWindow-name:eq(1)", { text: "New message" });
         // search for a user in "new message" autocomplete
-        await afterNextRender(async () => {
-            await insertText(".o-discuss-ChannelSelector input", "131");
-            await imSearchDef;
-        });
+        await insertText(".o-discuss-ChannelSelector input", "131");
         await click(".o-discuss-ChannelSelector-suggestion a", { text: "Partner 131" });
         await contains(".o-mail-ChatWindow-name", { count: 0, text: "New message" });
-
-        assert.strictEqual($(".o-mail-ChatWindow-name:eq(1)").text(), "Partner 131");
+        await contains(".o-mail-ChatWindow-name:eq(1)", { text: "Partner 131" });
     }
 );
 

--- a/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
@@ -43,12 +43,12 @@ QUnit.test("open the chatWindow of a channel from the command palette", async ()
     // Switch to channels
     await editSearchBar("#");
     advanceTime(commandSetupRegistry.get("#").debounceDelay);
-    await contains(".o_command:contains(general)");
-    await contains(".o_command:contains(project)");
+    await contains(".o_command", 1, { text: "general" });
+    await contains(".o_command", 1, { text: "project" });
 
     await click(".o_command.focused");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-name:contains(general)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "general" });
 });
 
 QUnit.test("Channel mentions in the command palette of Discuss app with @", async () => {
@@ -78,17 +78,19 @@ QUnit.test("Channel mentions in the command palette of Discuss app with @", asyn
     await nextTick();
     await editSearchBar("@");
     advanceTime(commandSetupRegistry.get("@").debounceDelay);
-    await contains(".o_command_palette:contains('Mentions')");
+    await contains(".o_command_palette span.fw-bold", 1, { text: "Mentions" });
     await contains(
         ".o_command_category:contains('Mentions') .o_command:contains('Mitchell Admin and Mario')"
     );
-    await contains(".o_command_category:not(:contains('Mentions')) .o_command:contains('Mario')");
+    await contains(".o_command_category:not(:contains('Mentions')) .o_command", 1, {
+        text: "Mario",
+    });
     await contains(
         ".o_command_category:not(:contains('Mentions')) .o_command:contains('Mitchell Admin')"
     );
-    await contains(".o_command.focused:contains('Mitchell Admin and Mario')");
+    await contains(".o_command.focused .o_command_name", 1, { text: "Mitchell Admin and Mario" });
     await click(".o_command.focused");
-    await contains(".o-mail-ChatWindow:contains('Mitchell Admin and Mario')");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Mitchell Admin and Mario" });
 });
 
 QUnit.test("Max 3 most recent channels in command palette of Discuss app with #", async () => {
@@ -102,6 +104,6 @@ QUnit.test("Max 3 most recent channels in command palette of Discuss app with #"
     await nextTick();
     await editSearchBar("#");
     advanceTime(commandSetupRegistry.get("#").debounceDelay);
-    await contains(".o_command_palette:contains('Recent')");
+    await contains(".o_command_palette span.fw-bold", 1, { text: "Recent" });
     await contains(".o_command_category:contains('Recent') .o_command", 3);
 });

--- a/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
@@ -43,12 +43,12 @@ QUnit.test("open the chatWindow of a channel from the command palette", async ()
     // Switch to channels
     await editSearchBar("#");
     advanceTime(commandSetupRegistry.get("#").debounceDelay);
-    await contains(".o_command", 1, { text: "general" });
-    await contains(".o_command", 1, { text: "project" });
+    await contains(".o_command", { text: "general" });
+    await contains(".o_command", { text: "project" });
 
     await click(".o_command.focused");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "general" });
+    await contains(".o-mail-ChatWindow-name", { text: "general" });
 });
 
 QUnit.test("Channel mentions in the command palette of Discuss app with @", async () => {
@@ -78,19 +78,19 @@ QUnit.test("Channel mentions in the command palette of Discuss app with @", asyn
     await nextTick();
     await editSearchBar("@");
     advanceTime(commandSetupRegistry.get("@").debounceDelay);
-    await contains(".o_command_palette span.fw-bold", 1, { text: "Mentions" });
+    await contains(".o_command_palette span.fw-bold", { text: "Mentions" });
     await contains(
         ".o_command_category:contains('Mentions') .o_command:contains('Mitchell Admin and Mario')"
     );
-    await contains(".o_command_category:not(:contains('Mentions')) .o_command", 1, {
+    await contains(".o_command_category:not(:contains('Mentions')) .o_command", {
         text: "Mario",
     });
     await contains(
         ".o_command_category:not(:contains('Mentions')) .o_command:contains('Mitchell Admin')"
     );
-    await contains(".o_command.focused .o_command_name", 1, { text: "Mitchell Admin and Mario" });
+    await contains(".o_command.focused .o_command_name", { text: "Mitchell Admin and Mario" });
     await click(".o_command.focused");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Mitchell Admin and Mario" });
+    await contains(".o-mail-ChatWindow-name", { text: "Mitchell Admin and Mario" });
 });
 
 QUnit.test("Max 3 most recent channels in command palette of Discuss app with #", async () => {
@@ -104,6 +104,6 @@ QUnit.test("Max 3 most recent channels in command palette of Discuss app with #"
     await nextTick();
     await editSearchBar("#");
     advanceTime(commandSetupRegistry.get("#").debounceDelay);
-    await contains(".o_command_palette span.fw-bold", 1, { text: "Recent" });
-    await contains(".o_command_category:contains('Recent') .o_command", 3);
+    await contains(".o_command_palette span.fw-bold", { text: "Recent" });
+    await contains(".o_command_category:contains('Recent') .o_command", { count: 3 });
 });

--- a/addons/mail/static/tests/discuss/core/web/crosstab_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab_tests.js
@@ -19,7 +19,7 @@ QUnit.test("Channel subscription is renewed when channel is manually added", asy
     await click("[title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector", "General");
     await click(".o-discuss-ChannelSelector-suggestion:eq(0)");
-    await contains(".o-mail-DiscussSidebarChannel", 1);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 1 });
     await new Promise((resolve) => setTimeout(resolve)); // update of channels is debounced
     assert.verifySteps(["update-channels"]);
 });

--- a/addons/mail/static/tests/discuss/core/web/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss_tests.js
@@ -120,7 +120,7 @@ QUnit.test("can create a group chat conversation", async () => {
     await contains(".o-mail-Message", 0);
 });
 
-QUnit.test("should create DM chat when adding self and another user", async (assert) => {
+QUnit.test("should create DM chat when adding self and another user", async () => {
     const pyEnv = await startServer();
     const partner_id = pyEnv["res.partner"].create([{ name: "Mario", im_status: "online" }]);
     pyEnv["res.users"].create({ partner_id });
@@ -135,10 +135,7 @@ QUnit.test("should create DM chat when adding self and another user", async (ass
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector-suggestion", 0);
     triggerHotkey("Enter");
-    assert.strictEqual(
-        (await contains(".o-mail-DiscussSidebarChannel:contains(Mario)")).text(),
-        "Mario"
-    );
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Mario" });
 });
 
 QUnit.test("chat search should display no result when no matches found", async () => {
@@ -146,7 +143,7 @@ QUnit.test("chat search should display no result when no matches found", async (
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
     await insertText(".o-discuss-ChannelSelector", "Rainbow Panda");
-    await contains(".o-discuss-ChannelSelector-suggestion:contains(No results found)");
+    await contains(".o-discuss-ChannelSelector-suggestion", 1, { text: "No results found" });
 });
 
 QUnit.test("chat search should not be visible when clicking outside of the field", async () => {

--- a/addons/mail/static/tests/discuss/core/web/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss_tests.js
@@ -24,11 +24,11 @@ QUnit.test("can create a new channel [REQUIRE FOCUS]", async (assert) => {
     });
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "abc");
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-Discuss-content .o-mail-Message", 0);
+    await contains(".o-mail-Discuss-content .o-mail-Message", { count: 0 });
     assert.verifySteps([
         "/mail/init_messaging",
         "/mail/load_message_failures",
@@ -51,14 +51,14 @@ QUnit.test(
         await insertText(".o-discuss-ChannelSelector input", "mario");
         await click(".o-discuss-ChannelSelector-suggestion");
         await contains(".o-discuss-ChannelSelector span[title='Mario']");
-        await contains(".o-mail-DiscussSidebarChannel", 0);
+        await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
         triggerHotkey("Backspace");
-        await contains(".o-discuss-ChannelSelector span[title='Mario']", 0);
+        await contains(".o-discuss-ChannelSelector span[title='Mario']", { count: 0 });
         await insertText(".o-discuss-ChannelSelector input", "mario");
         await contains(".o-discuss-ChannelSelector-suggestion");
         triggerHotkey("Enter");
         await contains(".o-discuss-ChannelSelector span[title='Mario']");
-        await contains(".o-mail-DiscussSidebarChannel", 0);
+        await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     }
 );
 
@@ -82,13 +82,13 @@ QUnit.test("can join a chat conversation", async (assert) => {
     });
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "mario");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
     assert.verifySteps([
         "/mail/init_messaging",
         "/mail/load_message_failures",
@@ -108,16 +108,16 @@ QUnit.test("can create a group chat conversation", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "Mario");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "Luigi");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test("should create DM chat when adding self and another user", async () => {
@@ -127,15 +127,15 @@ QUnit.test("should create DM chat when adding self and another user", async () =
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "Mi"); // Mitchell Admin
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     await insertText(".o-discuss-ChannelSelector input", "Mario");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Mario" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Mario" });
 });
 
 QUnit.test("chat search should display no result when no matches found", async () => {
@@ -143,7 +143,7 @@ QUnit.test("chat search should display no result when no matches found", async (
     openDiscuss();
     await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
     await insertText(".o-discuss-ChannelSelector", "Rainbow Panda");
-    await contains(".o-discuss-ChannelSelector-suggestion", 1, { text: "No results found" });
+    await contains(".o-discuss-ChannelSelector-suggestion", { text: "No results found" });
 });
 
 QUnit.test("chat search should not be visible when clicking outside of the field", async () => {
@@ -156,7 +156,7 @@ QUnit.test("chat search should not be visible when clicking outside of the field
     await insertText(".o-discuss-ChannelSelector", "Panda");
     await contains(".o-discuss-ChannelSelector-suggestion");
     await click(".o-mail-DiscussSidebar");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
 });
 
 QUnit.test("sidebar: add channel", async (assert) => {
@@ -187,10 +187,10 @@ QUnit.test("Chat is added to discuss on other tab that the one that joined", asy
     await tab1.insertText(".o-discuss-ChannelSelector input", "Jer");
     await click(".o-discuss-ChannelSelector-suggestion", { target: tab1.target });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Jerry Golay)", 1, {
+    await contains(".o-mail-DiscussSidebarChannel:contains(Jerry Golay)", {
         target: tab1.target,
     });
-    await contains(".o-mail-DiscussSidebarChannel:contains(Jerry Golay)", 1, {
+    await contains(".o-mail-DiscussSidebarChannel:contains(Jerry Golay)", {
         target: tab2.target,
     });
 });

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu_tests.js
@@ -14,8 +14,8 @@ QUnit.test('"Start a conversation" item selection opens chat', async () => {
     pyEnv["res.users"].create({ partner_id: partnerId });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button:contains(Chat)");
-    await click("button:contains(Start a conversation)");
+    await click("button", { text: "Chat" });
+    await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Start a conversation']", "Gandalf");
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector-suggestion", 0);
@@ -29,8 +29,8 @@ QUnit.test('"New channel" item selection opens channel (existing)', async () => 
     pyEnv["discuss.channel"].create({ name: "Gryffindors" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button:contains(Channel)");
-    await click("button:contains(New Channel)");
+    await click("button", { text: "Channel" });
+    await click("button", { text: "New Channel" });
     await insertText("input[placeholder='Add or join a channel']", "Gryff");
     await click(".o-discuss-ChannelSelector-suggestion:eq(0)");
     await contains(".o-discuss-ChannelSelector-suggestion", 0);
@@ -41,8 +41,8 @@ QUnit.test('"New channel" item selection opens channel (new)', async () => {
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button:contains(Channel)");
-    await click("button:contains(New Channel)");
+    await click("button", { text: "Channel" });
+    await click("button", { text: "New Channel" });
     await insertText("input[placeholder='Add or join a channel']", "slytherins");
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector-suggestion", 0);

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu_tests.js
@@ -18,7 +18,7 @@ QUnit.test('"Start a conversation" item selection opens chat', async () => {
     await click("button", { text: "Start a conversation" });
     await insertText("input[placeholder='Start a conversation']", "Gandalf");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
     await contains(".o-mail-ChatWindow-name[title='Gandalf']");
 });
@@ -33,7 +33,7 @@ QUnit.test('"New channel" item selection opens channel (existing)', async () => 
     await click("button", { text: "New Channel" });
     await insertText("input[placeholder='Add or join a channel']", "Gryff");
     await click(".o-discuss-ChannelSelector-suggestion:eq(0)");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     await contains(".o-mail-ChatWindow-name[title='Gryffindors']");
 });
 
@@ -45,7 +45,7 @@ QUnit.test('"New channel" item selection opens channel (new)', async () => {
     await click("button", { text: "New Channel" });
     await insertText("input[placeholder='Add or join a channel']", "slytherins");
     await click(".o-discuss-ChannelSelector-suggestion");
-    await contains(".o-discuss-ChannelSelector-suggestion", 0);
+    await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     await contains(".o-mail-ChatWindow-name[title='slytherins']");
 });
 

--- a/addons/mail/static/tests/discuss/core/web/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar_tests.js
@@ -20,9 +20,9 @@ QUnit.test("sidebar find shows channels matching search term", async () => {
     // When searching for a single existing channel, the results list will have at least 2 lines:
     // One for the existing channel itself
     // One for creating a channel with the search term
-    await contains(".o-mail-NavigableList-item", 2);
-    await contains(".o-mail-NavigableList-item", 1, { text: "test" });
-    await contains(".o-mail-NavigableList-item", 1, { text: "Create: # test" });
+    await contains(".o-mail-NavigableList-item", { count: 2 });
+    await contains(".o-mail-NavigableList-item", { text: "test" });
+    await contains(".o-mail-NavigableList-item", { text: "Create: # test" });
 });
 
 QUnit.test(
@@ -42,8 +42,8 @@ QUnit.test(
         // When searching for a single existing channel, the results list will have at least 2 lines:
         // One for the existing channel itself
         // One for creating a channel with the search term
-        await contains(".o-mail-NavigableList-item", 2);
-        await contains(".o-mail-NavigableList-item", 1, { text: "test" });
-        await contains(".o-mail-NavigableList-item", 1, { text: "Create: # test" });
+        await contains(".o-mail-NavigableList-item", { count: 2 });
+        await contains(".o-mail-NavigableList-item", { text: "test" });
+        await contains(".o-mail-NavigableList-item", { text: "Create: # test" });
     }
 );

--- a/addons/mail/static/tests/discuss/core/web/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/sidebar_tests.js
@@ -21,7 +21,8 @@ QUnit.test("sidebar find shows channels matching search term", async () => {
     // One for the existing channel itself
     // One for creating a channel with the search term
     await contains(".o-mail-NavigableList-item", 2);
-    await contains(".o-mail-NavigableList-item:contains(test)", 2);
+    await contains(".o-mail-NavigableList-item", 1, { text: "test" });
+    await contains(".o-mail-NavigableList-item", 1, { text: "Create: # test" });
 });
 
 QUnit.test(
@@ -42,6 +43,7 @@ QUnit.test(
         // One for the existing channel itself
         // One for creating a channel with the search term
         await contains(".o-mail-NavigableList-item", 2);
-        await contains(".o-mail-NavigableList-item:contains(test)", 2);
+        await contains(".o-mail-NavigableList-item", 1, { text: "test" });
+        await contains(".o-mail-NavigableList-item", 1, { text: "Create: # test" });
     }
 );

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
@@ -21,12 +21,14 @@ QUnit.test("Pin message", async () => {
         ".o-discuss-PinnedMessagesPanel:contains(This channel doesn't have any pinned messages.)"
     );
     await click(".o-mail-Message [title='Expand']");
-    await click(".dropdown-item:contains(Pin)");
-    await click(".modal-footer button:contains(pin it)");
-    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message:contains(Hello world)");
+    await click(".dropdown-item", { text: "Pin" });
+    await click(".modal-footer button", { text: "Yeah, pin it!" });
+    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message-content", 1, {
+        text: "Hello world!",
+    });
 });
 
-QUnit.test("Unpin message", async (assert) => {
+QUnit.test("Unpin message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     pyEnv["mail.message"].create({
@@ -40,12 +42,12 @@ QUnit.test("Unpin message", async (assert) => {
     await click(".o-mail-Discuss-header button[title='Pinned Messages']");
     await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
-    await click(".dropdown-item:contains(Unpin)");
-    await click(".modal-footer button:contains(Yes)");
+    await click(".dropdown-item", { text: "Unpin" });
+    await click(".modal-footer button", { text: "Yes, remove it please" });
     await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", 0);
 });
 
-QUnit.test("Deleted messages are not pinned", async (assert) => {
+QUnit.test("Deleted messages are not pinned", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     pyEnv["mail.message"].create({
@@ -60,12 +62,12 @@ QUnit.test("Deleted messages are not pinned", async (assert) => {
     await click(".o-mail-Discuss-header button[title='Pinned Messages']");
     await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
-    await click(".dropdown-item:contains(Delete)");
-    await click("button:contains(Confirm)");
+    await click(".dropdown-item", { text: "Delete" });
+    await click("button", { text: "Confirm" });
     await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", 0);
 });
 
-QUnit.test("Open pinned panel from notification", async (assert) => {
+QUnit.test("Open pinned panel from notification", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     pyEnv["mail.message"].create({
@@ -76,10 +78,10 @@ QUnit.test("Open pinned panel from notification", async (assert) => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-Message:eq(0) [title='Expand']");
-    await click(".dropdown-item:contains(Pin)");
-    await click(".modal-footer button:contains(pin it)");
+    await click(".dropdown-item", { text: "Pin" });
+    await click(".modal-footer button", { text: "Yeah, pin it!" });
     await contains(".o-discuss-PinnedMessagesPanel", 0);
-    await click(".o_mail_notification a:contains(See all pinned messages)");
+    await click(".o_mail_notification a", { text: "See all pinned messages" });
     await contains(".o-discuss-PinnedMessagesPanel");
 });
 
@@ -109,7 +111,7 @@ QUnit.test("Jump to message", async (assert) => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Pinned Messages']");
-    await click(".o-discuss-PinnedMessagesPanel button:contains(Jump)");
+    await click(".o-discuss-PinnedMessagesPanel button", { text: "Jump" });
     await nextTick();
     assert.isVisible($(".o-mail-Message:contains(Hello world!)"));
 });
@@ -139,8 +141,8 @@ QUnit.test("Jump to message from notification", async (assert) => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-Message:eq(0) [title='Expand']");
-    await click(".dropdown-item:contains(Pin)");
-    await click(".modal-footer button:contains(pin it)");
+    await click(".dropdown-item", { text: "Pin" });
+    await click(".modal-footer button", { text: "Yeah, pin it!" });
     await click(".o_mail_notification a:contains(message):eq(0)");
     await nextTick();
     assert.isVisible($(".o-mail-Message:contains(Hello world!)"));

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
@@ -23,7 +23,7 @@ QUnit.test("Pin message", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".dropdown-item", { text: "Pin" });
     await click(".modal-footer button", { text: "Yeah, pin it!" });
-    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message-content", 1, {
+    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message-content", {
         text: "Hello world!",
     });
 });
@@ -44,7 +44,7 @@ QUnit.test("Unpin message", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".dropdown-item", { text: "Unpin" });
     await click(".modal-footer button", { text: "Yes, remove it please" });
-    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", 0);
+    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", { count: 0 });
 });
 
 QUnit.test("Deleted messages are not pinned", async () => {
@@ -64,7 +64,7 @@ QUnit.test("Deleted messages are not pinned", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".dropdown-item", { text: "Delete" });
     await click("button", { text: "Confirm" });
-    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", 0);
+    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", { count: 0 });
 });
 
 QUnit.test("Open pinned panel from notification", async () => {
@@ -80,7 +80,7 @@ QUnit.test("Open pinned panel from notification", async () => {
     await click(".o-mail-Message:eq(0) [title='Expand']");
     await click(".dropdown-item", { text: "Pin" });
     await click(".modal-footer button", { text: "Yeah, pin it!" });
-    await contains(".o-discuss-PinnedMessagesPanel", 0);
+    await contains(".o-discuss-PinnedMessagesPanel", { count: 0 });
     await click(".o_mail_notification a", { text: "See all pinned messages" });
     await contains(".o-discuss-PinnedMessagesPanel");
 });

--- a/addons/mail/static/tests/discuss/typing/typing_tests.js
+++ b/addons/mail/static/tests/discuss/typing/typing_tests.js
@@ -5,8 +5,6 @@ import { OTHER_LONG_TYPING } from "@mail/discuss/typing/common/typing_service";
 import { Command } from "@mail/../tests/helpers/command";
 import { click, contains, insertText, start, startServer } from "@mail/../tests/helpers/test_utils";
 
-import { nextTick } from "@web/../tests/helpers/utils";
-
 QUnit.module("typing");
 
 QUnit.test('receive other member typing status "is typing"', async () => {
@@ -22,7 +20,8 @@ QUnit.test('receive other member typing status "is typing"', async () => {
     });
     const { env, openDiscuss } = await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
+    await contains(".o-discuss-Typing");
+    await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
     // simulate receive typing notification from demo
     pyEnv.withUser(userId, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -30,7 +29,7 @@ QUnit.test('receive other member typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing:contains(Demo is typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
 });
 
 QUnit.test(
@@ -48,8 +47,8 @@ QUnit.test(
         });
         const { env, openDiscuss } = await start();
         await openDiscuss(channelId);
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
-
+        await contains(".o-discuss-Typing");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
         // simulate receive typing notification from demo "is typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -57,7 +56,7 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await contains(".o-discuss-Typing:contains(Demo is typing...)");
+        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
         // simulate receive typing notification from demo "is no longer typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -65,7 +64,8 @@ QUnit.test(
                 is_typing: false,
             })
         );
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
+        await contains(".o-discuss-Typing");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
     }
 );
 
@@ -84,9 +84,8 @@ QUnit.test(
         });
         const { advanceTime, env, openDiscuss } = await start({ hasTimeControl: true });
         await openDiscuss(channelId);
-
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
-
+        await contains(".o-discuss-Typing");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
         // simulate receive typing notification from demo "is typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -94,9 +93,9 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await contains(".o-discuss-Typing:contains(Demo is typing...)");
+        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
         advanceTime(OTHER_LONG_TYPING);
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
     }
 );
 
@@ -115,8 +114,8 @@ QUnit.test(
         });
         const { advanceTime, env, openDiscuss } = await start({ hasTimeControl: true });
         await openDiscuss(channelId);
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
-
+        await contains(".o-discuss-Typing");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
         // simulate receive typing notification from demo "is typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -124,8 +123,7 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await contains(".o-discuss-Typing:contains(Demo is typing...)");
-
+        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
         // simulate receive typing notification from demo "is typing" again after long time.
         await advanceTime(LONG_TYPING);
         await pyEnv.withUser(userId, () =>
@@ -134,11 +132,10 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await nextTick();
         await advanceTime(LONG_TYPING);
-        await contains(".o-discuss-Typing:contains(Demo is typing...)");
+        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
         advanceTime(OTHER_LONG_TYPING - LONG_TYPING);
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
     }
 );
 
@@ -165,8 +162,8 @@ QUnit.test('receive several other members typing status "is typing"', async () =
     });
     const { env, openDiscuss } = await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
-
+    await contains(".o-discuss-Typing");
+    await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
     // simulate receive typing notification from other 10 (is typing)
     pyEnv.withUser(userId_1, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -174,7 +171,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing:contains(Other 10 is typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Other 10 is typing..." });
     // simulate receive typing notification from other 11 (is typing)
     pyEnv.withUser(userId_2, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -182,7 +179,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing:contains(Other 10 and Other 11 are typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Other 10 and Other 11 are typing..." });
     // simulate receive typing notification from other 12 (is typing)
     pyEnv.withUser(userId_3, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -190,7 +187,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing:contains(Other 10, Other 11 and more are typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Other 10, Other 11 and more are typing..." });
     // simulate receive typing notification from other 10 (no longer is typing)
     pyEnv.withUser(userId_1, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -198,7 +195,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: false,
         })
     );
-    await contains(".o-discuss-Typing:contains(Other 11 and Other 12 are typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Other 11 and Other 12 are typing..." });
     // simulate receive typing notification from other 10 (is typing again)
     pyEnv.withUser(userId_1, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -206,7 +203,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing:contains(Other 11, Other 12 and more are typing...)");
+    await contains(".o-discuss-Typing", 1, { text: "Other 11, Other 12 and more are typing..." });
 });
 
 QUnit.test("current partner notify is typing to other thread members", async (assert) => {
@@ -291,7 +288,8 @@ QUnit.test(
         await openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "a");
         assert.verifySteps(["notify_typing:true"]);
-        await contains(".o-discuss-Typing:not(:contains(Demo is typing...))");
+        await contains(".o-discuss-Typing");
+        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
     }
 );
 

--- a/addons/mail/static/tests/discuss/typing/typing_tests.js
+++ b/addons/mail/static/tests/discuss/typing/typing_tests.js
@@ -21,7 +21,7 @@ QUnit.test('receive other member typing status "is typing"', async () => {
     const { env, openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from demo
     pyEnv.withUser(userId, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -29,7 +29,7 @@ QUnit.test('receive other member typing status "is typing"', async () => {
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
+    await contains(".o-discuss-Typing", { text: "Demo is typing..." });
 });
 
 QUnit.test(
@@ -48,7 +48,7 @@ QUnit.test(
         const { env, openDiscuss } = await start();
         await openDiscuss(channelId);
         await contains(".o-discuss-Typing");
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
         // simulate receive typing notification from demo "is typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -56,7 +56,7 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
+        await contains(".o-discuss-Typing", { text: "Demo is typing..." });
         // simulate receive typing notification from demo "is no longer typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -65,7 +65,7 @@ QUnit.test(
             })
         );
         await contains(".o-discuss-Typing");
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     }
 );
 
@@ -85,7 +85,7 @@ QUnit.test(
         const { advanceTime, env, openDiscuss } = await start({ hasTimeControl: true });
         await openDiscuss(channelId);
         await contains(".o-discuss-Typing");
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
         // simulate receive typing notification from demo "is typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -93,9 +93,9 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
+        await contains(".o-discuss-Typing", { text: "Demo is typing..." });
         advanceTime(OTHER_LONG_TYPING);
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     }
 );
 
@@ -115,7 +115,7 @@ QUnit.test(
         const { advanceTime, env, openDiscuss } = await start({ hasTimeControl: true });
         await openDiscuss(channelId);
         await contains(".o-discuss-Typing");
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
         // simulate receive typing notification from demo "is typing"
         pyEnv.withUser(userId, () =>
             env.services.rpc("/discuss/channel/notify_typing", {
@@ -123,7 +123,7 @@ QUnit.test(
                 is_typing: true,
             })
         );
-        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
+        await contains(".o-discuss-Typing", { text: "Demo is typing..." });
         // simulate receive typing notification from demo "is typing" again after long time.
         await advanceTime(LONG_TYPING);
         await pyEnv.withUser(userId, () =>
@@ -133,9 +133,9 @@ QUnit.test(
             })
         );
         await advanceTime(LONG_TYPING);
-        await contains(".o-discuss-Typing", 1, { text: "Demo is typing..." });
+        await contains(".o-discuss-Typing", { text: "Demo is typing..." });
         advanceTime(OTHER_LONG_TYPING - LONG_TYPING);
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     }
 );
 
@@ -163,7 +163,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
     const { env, openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-discuss-Typing");
-    await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+    await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     // simulate receive typing notification from other 10 (is typing)
     pyEnv.withUser(userId_1, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -171,7 +171,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", 1, { text: "Other 10 is typing..." });
+    await contains(".o-discuss-Typing", { text: "Other 10 is typing..." });
     // simulate receive typing notification from other 11 (is typing)
     pyEnv.withUser(userId_2, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -179,7 +179,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", 1, { text: "Other 10 and Other 11 are typing..." });
+    await contains(".o-discuss-Typing", { text: "Other 10 and Other 11 are typing..." });
     // simulate receive typing notification from other 12 (is typing)
     pyEnv.withUser(userId_3, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -187,7 +187,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", 1, { text: "Other 10, Other 11 and more are typing..." });
+    await contains(".o-discuss-Typing", { text: "Other 10, Other 11 and more are typing..." });
     // simulate receive typing notification from other 10 (no longer is typing)
     pyEnv.withUser(userId_1, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -195,7 +195,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: false,
         })
     );
-    await contains(".o-discuss-Typing", 1, { text: "Other 11 and Other 12 are typing..." });
+    await contains(".o-discuss-Typing", { text: "Other 11 and Other 12 are typing..." });
     // simulate receive typing notification from other 10 (is typing again)
     pyEnv.withUser(userId_1, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -203,7 +203,7 @@ QUnit.test('receive several other members typing status "is typing"', async () =
             is_typing: true,
         })
     );
-    await contains(".o-discuss-Typing", 1, { text: "Other 11, Other 12 and more are typing..." });
+    await contains(".o-discuss-Typing", { text: "Other 11, Other 12 and more are typing..." });
 });
 
 QUnit.test("current partner notify is typing to other thread members", async (assert) => {
@@ -289,7 +289,7 @@ QUnit.test(
         await insertText(".o-mail-Composer-input", "a");
         assert.verifySteps(["notify_typing:true"]);
         await contains(".o-discuss-Typing");
-        await contains(".o-discuss-Typing", 0, { text: "Demo is typing...)" });
+        await contains(".o-discuss-Typing", { count: 0, text: "Demo is typing...)" });
     }
 );
 
@@ -348,7 +348,7 @@ QUnit.test("chat: correspondent is typing in chat window", async () => {
     const { env } = await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains("[title='Demo is typing...']", 0);
+    await contains("[title='Demo is typing...']", { count: 0 });
     // simulate receive typing notification from demo "is typing"
     pyEnv.withUser(userId, () =>
         env.services.rpc("/discuss/channel/notify_typing", {
@@ -364,5 +364,5 @@ QUnit.test("chat: correspondent is typing in chat window", async () => {
             is_typing: false,
         })
     );
-    await contains("[title='Demo is typing...']", 0);
+    await contains("[title='Demo is typing...']", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss/voice_message/voice_message_tests.js
+++ b/addons/mail/static/tests/discuss/voice_message/voice_message_tests.js
@@ -160,13 +160,13 @@ QUnit.test("make voice message in chat", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("button[title='Voice Message']");
-    await contains(".o-mail-VoiceRecorder:contains(00 : 00)");
+    await contains(".o-mail-VoiceRecorder", 1, { text: "00 : 00" });
     await nextAnimationFrame();
     // simulate 10 sec elapsed
     patchDate(2023, 6, 31, 13, 0, 11); // +1 so exactly 10 sec elapsed
     // simulate some microphone data
     audioProcessor.process([[new Float32Array(128)]]);
-    await contains(".o-mail-VoiceRecorder:contains(00 : 10)");
+    await contains(".o-mail-VoiceRecorder", 1, { text: "00 : 10" });
     await click("button[title='Stop Recording']");
     await contains(".o-mail-VoicePlayer");
     // wait for audio stream decode + drawing of waves
@@ -174,7 +174,7 @@ QUnit.test("make voice message in chat", async () => {
     await nextAnimationFrame();
     await contains(".o-mail-VoicePlayer button[title='Play']");
     await contains(".o-mail-VoicePlayer canvas", 2); // 1 for global waveforms, 1 for played waveforms
-    await contains(".o-mail-VoicePlayer:contains(00 : 04)"); // duration of call_02_in_.mp3
+    await contains(".o-mail-VoicePlayer", 1, { text: "00 : 04" }); // duration of call_02_in_.mp3
     await contains(".o-mail-VoiceRecorder button[title='Voice Message']:disabled");
     cleanUp();
 });

--- a/addons/mail/static/tests/discuss/voice_message/voice_message_tests.js
+++ b/addons/mail/static/tests/discuss/voice_message/voice_message_tests.js
@@ -160,21 +160,21 @@ QUnit.test("make voice message in chat", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("button[title='Voice Message']");
-    await contains(".o-mail-VoiceRecorder", 1, { text: "00 : 00" });
+    await contains(".o-mail-VoiceRecorder", { text: "00 : 00" });
     await nextAnimationFrame();
     // simulate 10 sec elapsed
     patchDate(2023, 6, 31, 13, 0, 11); // +1 so exactly 10 sec elapsed
     // simulate some microphone data
     audioProcessor.process([[new Float32Array(128)]]);
-    await contains(".o-mail-VoiceRecorder", 1, { text: "00 : 10" });
+    await contains(".o-mail-VoiceRecorder", { text: "00 : 10" });
     await click("button[title='Stop Recording']");
     await contains(".o-mail-VoicePlayer");
     // wait for audio stream decode + drawing of waves
     await voicePlayerDrawing;
     await nextAnimationFrame();
     await contains(".o-mail-VoicePlayer button[title='Play']");
-    await contains(".o-mail-VoicePlayer canvas", 2); // 1 for global waveforms, 1 for played waveforms
-    await contains(".o-mail-VoicePlayer", 1, { text: "00 : 04" }); // duration of call_02_in_.mp3
+    await contains(".o-mail-VoicePlayer canvas", { count: 2 }); // 1 for global waveforms, 1 for played waveforms
+    await contains(".o-mail-VoicePlayer", { text: "00 : 04" }); // duration of call_02_in_.mp3
     await contains(".o-mail-VoiceRecorder button[title='Voice Message']:disabled");
     cleanUp();
 });

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -31,7 +31,7 @@ QUnit.test("sanity check", async (assert) => {
     });
     openDiscuss();
     await contains(".o-mail-DiscussSidebar");
-    await contains("h4", 1, { text: "Congratulations, your inbox is empty" });
+    await contains("h4", { text: "Congratulations, your inbox is empty" });
     assert.verifySteps([
         "/mail/init_messaging",
         "/mail/load_message_failures",
@@ -55,13 +55,13 @@ QUnit.test("can change the thread name of #general [REQUIRE FOCUS]", async (asse
     });
     openDiscuss(channelId);
     await contains(".o-mail-Composer-input:focus");
-    await contains("input.o-mail-Discuss-threadName", 1, { value: "general" });
+    await contains("input.o-mail-Discuss-threadName", { value: "general" });
     await insertText("input.o-mail-Discuss-threadName:not(:disabled)", "special", {
         replace: true,
     });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "special" });
-    await contains("input.o-mail-Discuss-threadName", 1, { value: "special" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "special" });
+    await contains("input.o-mail-Discuss-threadName", { value: "special" });
     assert.verifySteps(["/web/dataset/call_kw/discuss.channel/channel_rename"]);
 });
 
@@ -82,7 +82,7 @@ QUnit.test("can change the thread description of #general [REQUIRE FOCUS]", asyn
     });
     openDiscuss(channelId);
     await contains(".o-mail-Composer-input:focus");
-    await contains("input.o-mail-Discuss-threadDescription", 1, {
+    await contains("input.o-mail-Discuss-threadDescription", {
         value: "General announcements...",
     });
     await insertText(
@@ -91,7 +91,7 @@ QUnit.test("can change the thread description of #general [REQUIRE FOCUS]", asyn
         { replace: true }
     );
     triggerHotkey("Enter");
-    await contains("input.o-mail-Discuss-threadDescription", 1, {
+    await contains("input.o-mail-Discuss-threadDescription", {
         value: "I want a burger today!",
     });
     assert.verifySteps(["/web/dataset/call_kw/discuss.channel/channel_change_description"]);
@@ -140,7 +140,7 @@ QUnit.test("Posting message should transform relevant data to emoji.", async () 
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "test :P :laughing:");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body", 1, { text: "test 😛 😆" });
+    await contains(".o-mail-Message-body", { text: "test 😛 😆" });
 });
 
 QUnit.test(
@@ -156,10 +156,10 @@ QUnit.test(
         openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "abc");
         await click(".o-mail-Composer button:contains(Send):not(:disabled)");
-        await contains(".o-mail-Message", 1);
+        await contains(".o-mail-Message", { count: 1 });
         await insertText(".o-mail-Composer-input", "def");
         await click(".o-mail-Composer button:contains(Send):not(:disabled)");
-        await contains(".o-mail-Message", 2);
+        await contains(".o-mail-Message", { count: 2 });
         await contains(".o-mail-Message-header"); // just 1, because 2nd message is squashed
     }
 );
@@ -179,7 +179,7 @@ QUnit.test("Click on avatar opens its partner chat window", async () => {
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Message-sidebar .o-mail-Message-avatarContainer img");
     await click(".o-mail-Message-sidebar .o-mail-Message-avatarContainer img");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "testPartner" });
+    await contains(".o-mail-ChatWindow-name", { text: "testPartner" });
 });
 
 QUnit.test("Can use channel command /who", async () => {
@@ -192,7 +192,7 @@ QUnit.test("Can use channel command /who", async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/who");
     await click(".o-mail-Composer button:contains(Send):not(:disabled)");
-    await contains(".o_mail_notification", 1, { text: "You are alone in this channel." });
+    await contains(".o_mail_notification", { text: "You are alone in this channel." });
 });
 
 QUnit.test("sidebar: chat im_status rendering", async () => {
@@ -227,7 +227,7 @@ QUnit.test("sidebar: chat im_status rendering", async () => {
     ]);
     const { openDiscuss } = await start({ hasTimeControl: true });
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel-threadIcon", 3);
+    await contains(".o-mail-DiscussSidebarChannel-threadIcon", { count: 3 });
     await contains(
         ".o-mail-DiscussSidebarChannel:contains(Partner1) .o-mail-ThreadIcon div[title='Offline']"
     );
@@ -259,8 +259,8 @@ QUnit.test("No load more when fetch below fetch limit of 30", async (assert) => 
         },
     });
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 29);
-    await contains("button", 0, { text: "Load More" });
+    await contains(".o-mail-Message", { count: 29 });
+    await contains("button", { count: 0, text: "Load More" });
 });
 
 QUnit.test("show date separator above mesages of similar date", async (assert) => {
@@ -283,7 +283,9 @@ QUnit.test("show date separator above mesages of similar date", async (assert) =
         await contains(".o-mail-Thread hr + span:contains(April 20, 2019) + hr")
     )[0].getBoundingClientRect().top;
     const topOfMessages = Math.min(
-        ...(await contains(".o-mail-Message", 29)).map((m) => m.getBoundingClientRect().top)
+        ...(await contains(".o-mail-Message", { count: 29 })).map(
+            (m) => m.getBoundingClientRect().top
+        )
     );
     console.log(topOfSeaparator, topOfMessages);
     assert.ok(
@@ -304,7 +306,7 @@ QUnit.test("sidebar: chat custom name", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Marc" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Marc" });
 });
 
 QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FOCUS]", async () => {
@@ -326,19 +328,19 @@ QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FO
     const { openDiscuss, openFormView } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header small", 1, { text: "on Refactoring" });
+    await contains(".o-mail-Message-header small", { text: "on Refactoring" });
     await click("[title='Reply']");
     await contains(".o-mail-Message.o-selected");
     await contains(".o-mail-Composer");
-    await contains(".o-mail-Composer-coreHeader span", 1, { text: "on: Refactoring" });
+    await contains(".o-mail-Composer-coreHeader span", { text: "on: Refactoring" });
     await insertText(".o-mail-Composer-input:focus", "Hello");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
     await contains(".o-mail-Message:not(.o-selected)");
     await contains('.o_notification.border-info:contains(Message posted on "Refactoring")');
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message-content", 1, { text: "Hello" });
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message-content", { text: "Hello" });
 });
 
 QUnit.test("Can reply to starred message", async () => {
@@ -353,13 +355,13 @@ QUnit.test("Can reply to starred message", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer-coreHeader b", 1, { text: "RandomName" });
+    await contains(".o-mail-Composer-coreHeader b", { text: "RandomName" });
     await insertText(".o-mail-Composer-input", "abc");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Composer-send", 0);
+    await contains(".o-mail-Composer-send", { count: 0 });
     await contains('.o_notification:contains(Message posted on "RandomName")');
     await click(".o-mail-DiscussSidebarChannel span", { text: "RandomName" });
-    await contains(".o-mail-Message-content", 1, { text: "abc" });
+    await contains(".o-mail-Message-content", { text: "abc" });
 });
 
 QUnit.test("Can reply to history message", async () => {
@@ -380,22 +382,22 @@ QUnit.test("Can reply to history message", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer-coreHeader b", 1, { text: "RandomName" });
+    await contains(".o-mail-Composer-coreHeader b", { text: "RandomName" });
     await insertText(".o-mail-Composer-input", "abc");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Composer-send", 0);
+    await contains(".o-mail-Composer-send", { count: 0 });
     await contains('.o_notification:contains(Message posted on "RandomName")');
     await click(".o-mail-DiscussSidebarChannel span", { text: "RandomName" });
-    await contains(".o-mail-Message-content", 1, { text: "abc" });
+    await contains(".o-mail-Message-content", { text: "abc" });
 });
 
 QUnit.test("receive new needaction messages", async () => {
     const { openDiscuss, pyEnv } = await start();
     openDiscuss();
-    await contains("button div", 1, { text: "Inbox" });
+    await contains("button div", { text: "Inbox" });
     await contains("button:contains(Inbox).o-active");
-    await contains("button:contains(Inbox) .badge", 0);
-    await contains(".o-mail-Thread .o-mail-Message", 0);
+    await contains("button:contains(Inbox) .badge", { count: 0 });
+    await contains(".o-mail-Thread .o-mail-Message", { count: 0 });
 
     // simulate receiving a new needaction message
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
@@ -406,9 +408,9 @@ QUnit.test("receive new needaction messages", async () => {
         res_id: 20,
     });
     await contains("button:contains(Inbox) .badge");
-    await contains("button:contains(Inbox) .badge", 1, { text: "1" });
+    await contains("button:contains(Inbox) .badge", { text: "1" });
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", 1, { text: "not empty 1" });
+    await contains(".o-mail-Message-content", { text: "not empty 1" });
 
     // simulate receiving another new needaction message
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
@@ -418,10 +420,10 @@ QUnit.test("receive new needaction messages", async () => {
         model: "res.partner",
         res_id: 20,
     });
-    await contains("button:contains(Inbox) .badge", 1, { text: "2" });
-    await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message-content", 1, { text: "not empty 1" });
-    await contains(".o-mail-Message-content", 1, { text: "not empty 2" });
+    await contains("button:contains(Inbox) .badge", { text: "2" });
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message-content", { text: "not empty 1" });
+    await contains(".o-mail-Message-content", { text: "not empty 2" });
 });
 
 QUnit.test("basic rendering", async () => {
@@ -435,12 +437,12 @@ QUnit.test("basic rendering", async () => {
 QUnit.test("basic rendering: sidebar", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebar button div", 1, { text: "Inbox" });
-    await contains(".o-mail-DiscussSidebar button div", 1, { text: "Starred" });
-    await contains(".o-mail-DiscussSidebar button div", 1, { text: "History" });
-    await contains(".o-mail-DiscussSidebarCategory", 2);
-    await contains(".o-mail-DiscussSidebarCategory-channel", 1, { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarCategory-chat", 1, { text: "Direct messages" });
+    await contains(".o-mail-DiscussSidebar button div", { text: "Inbox" });
+    await contains(".o-mail-DiscussSidebar button div", { text: "Starred" });
+    await contains(".o-mail-DiscussSidebar button div", { text: "History" });
+    await contains(".o-mail-DiscussSidebarCategory", { count: 2 });
+    await contains(".o-mail-DiscussSidebarCategory-channel", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarCategory-chat", { text: "Direct messages" });
 });
 
 QUnit.test("sidebar: Inbox should have icon", async () => {
@@ -470,7 +472,7 @@ QUnit.test("sidebar: basic channel rendering", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands.d-none");
     await contains(
@@ -487,7 +489,7 @@ QUnit.test("channel become active", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel.o-active", 0);
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { count: 0 });
     await click(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-DiscussSidebarChannel.o-active");
 });
@@ -517,8 +519,8 @@ QUnit.test("sidebar: channel rendering with needaction counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "general" });
-    await contains(".o-mail-DiscussSidebarChannel:contains(general) .badge", 1, { text: "1" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel:contains(general) .badge", { text: "1" });
 });
 
 QUnit.test("sidebar: chat rendering with unread counter", async () => {
@@ -531,10 +533,10 @@ QUnit.test("sidebar: chat rendering with unread counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel .badge", 1, { text: "100" });
+    await contains(".o-mail-DiscussSidebarChannel .badge", { text: "100" });
     await contains(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands:contains(Unpin Conversation)",
-        0
+        { count: 0 }
     );
 });
 
@@ -580,15 +582,15 @@ QUnit.test("basic top bar rendering", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains("button:contains(Mark all read):disabled");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "Inbox" });
+    await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
 
     await click("button", { text: "Starred" });
     await contains("button:contains(Unstar all):disabled");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "Starred" });
+    await contains(".o-mail-Discuss-threadName", { value: "Starred" });
 
     await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-Discuss-header button[title='Add Users']");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "General" });
+    await contains(".o-mail-Discuss-threadName", { value: "General" });
 });
 
 QUnit.test("rendering of inbox message", async () => {
@@ -610,14 +612,14 @@ QUnit.test("rendering of inbox message", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header small", 1, { text: "on Refactoring" });
-    await contains(".o-mail-Message-actions i", 4);
+    await contains(".o-mail-Message-header small", { text: "on Refactoring" });
+    await contains(".o-mail-Message-actions i", { count: 4 });
     await contains("[title='Reply']");
     await contains("[title='Mark as Todo']");
     await contains("[title='Mark as Read']");
     await contains("[title='Expand']");
     await click("[title='Expand']");
-    await contains(".o-mail-Message-actions i", 5);
+    await contains(".o-mail-Message-actions i", { count: 5 });
     await contains("[title='Reply']");
     await contains("[title='Mark as Todo']");
     await contains("[title='Mark as Read']");
@@ -659,7 +661,7 @@ QUnit.test("Unfollow message", async function () {
     const { openDiscuss } = await start();
     openDiscuss();
     // 2 messages about "Thread followed" with unfollow button and 1 message about "Thread not followed" without it
-    await contains(".o-mail-Message", 3);
+    await contains(".o-mail-Message", { count: 3 });
     for (const id of [0, 1]) {
         await contains(
             `.o-mail-Message:eq(${id}) .o-mail-Message-header:contains(on Thread followed)`
@@ -667,23 +669,23 @@ QUnit.test("Unfollow message", async function () {
         await click(`.o-mail-Message:eq(${id}) [title='Expand']`);
         await contains(`.o-mail-Message:eq(${id}) [title='Unfollow']`);
     }
-    await contains(".o-mail-Message:eq(2) .o-mail-Message-header small", 1, {
+    await contains(".o-mail-Message:eq(2) .o-mail-Message-header small", {
         text: "on Thread not followed",
     });
     await click(".o-mail-Message:eq(2) [title='Expand']");
     await contains(".o-mail-Message:eq(2) .o-mail-Message-moreMenu");
-    await contains(".o-mail-Message:eq(2) [title='Unfollow']", 0);
+    await contains(".o-mail-Message:eq(2) [title='Unfollow']", { count: 0 });
 
     await click(".o-mail-Message:eq(0) [title='Expand']");
     await click(".o-mail-Message:eq(0) [title='Unfollow']");
 
-    await contains(".o-mail-Message", 2); // Unfollowing message 0 marks it as read -> Message removed
-    await contains(".o-mail-Message-header small", 1, { text: "on Thread followed" });
-    await contains(".o-mail-Message-header small", 1, { text: "on Thread not followed" });
+    await contains(".o-mail-Message", { count: 2 }); // Unfollowing message 0 marks it as read -> Message removed
+    await contains(".o-mail-Message-header small", { text: "on Thread followed" });
+    await contains(".o-mail-Message-header small", { text: "on Thread not followed" });
     for (const id of [0, 1]) {
         await click(`.o-mail-Message:eq(${id}) [title='Expand']`);
         await contains(`.o-mail-Message:eq(${id}) .o-mail-Message-moreMenu`);
-        await contains(`.o-mail-Message:eq(${id}) [title='Unfollow']`, 0);
+        await contains(`.o-mail-Message:eq(${id}) [title='Unfollow']`, { count: 0 });
     }
 });
 
@@ -719,23 +721,23 @@ QUnit.test('messages marked as read move to "History" mailbox', async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await contains("button:contains(History).o-active");
-    await contains(".o-mail-Thread h4", 1, { text: "No history messages" });
+    await contains(".o-mail-Thread h4", { text: "No history messages" });
 
     await click("button div", { text: "Inbox" });
     await contains("button:contains(Inbox).o-active");
-    await contains(".o-mail-Thread h4", 0, { text: "Congratulations, your inbox is empty" });
+    await contains(".o-mail-Thread h4", { count: 0, text: "Congratulations, your inbox is empty" });
 
-    await contains(".o-mail-Thread .o-mail-Message", 2);
+    await contains(".o-mail-Thread .o-mail-Message", { count: 2 });
 
     await click("button", { text: "Mark all read" });
     await contains("button:contains(Inbox).o-active");
-    await contains(".o-mail-Thread h4", 1, { text: "Congratulations, your inbox is empty" });
+    await contains(".o-mail-Thread h4", { text: "Congratulations, your inbox is empty" });
 
     await click("button div", { text: "History" });
     await contains("button:contains(History).o-active");
-    await contains(".o-mail-Thread h4", 0, { text: "No history messages" });
+    await contains(".o-mail-Thread h4", { count: 0, text: "No history messages" });
 
-    await contains(".o-mail-Thread .o-mail-Message", 2);
+    await contains(".o-mail-Thread .o-mail-Message", { count: 2 });
 });
 
 QUnit.test(
@@ -769,20 +771,20 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_history");
         await contains("button:contains(History).o-active");
-        await contains(".o-mail-Thread h4", 1, { text: "No history messages" });
+        await contains(".o-mail-Thread h4", { text: "No history messages" });
 
         await click("button div", { text: "Inbox" });
         await contains("button:contains(Inbox).o-active");
-        await contains(".o-mail-Message", 2);
+        await contains(".o-mail-Message", { count: 2 });
 
         await click(".o-mail-Message:contains(not empty 1) [title='Mark as Read']");
         await contains(".o-mail-Message");
-        await contains(".o-mail-Message-content", 1, { text: "not empty 2" });
+        await contains(".o-mail-Message-content", { text: "not empty 2" });
 
         await click("button div", { text: "History" });
         await contains("button:contains(History).o-active");
         await contains(".o-mail-Message");
-        await contains(".o-mail-Message-content", 1, { text: "not empty 1" });
+        await contains(".o-mail-Message-content", { text: "not empty 1" });
     }
 );
 
@@ -801,14 +803,14 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
     }
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-Message", 30);
+    await contains(".o-mail-Message", { count: 30 });
     await click("button", { text: "Mark all read" });
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
     await click("button div", { text: "History" });
-    await contains(".o-mail-Message", 30);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Message", 40);
+    await contains(".o-mail-Message", { count: 40 });
 });
 
 QUnit.test("post a simple message", async (assert) => {
@@ -827,23 +829,23 @@ QUnit.test("post a simple message", async (assert) => {
         },
     });
     openDiscuss(channelId);
-    await contains(".o-mail-Thread .o-mail-Thread-empty", 1, {
+    await contains(".o-mail-Thread .o-mail-Thread-empty", {
         text: "There are no messages in this conversation.",
     });
-    await contains(".o-mail-Message", 0);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Message", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: "" });
 
     // insert some HTML in editable
     await insertText(".o-mail-Composer-input", "Test");
-    await contains(".o-mail-Composer-input", 1, { value: "Test" });
+    await contains(".o-mail-Composer-input", { value: "Test" });
 
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(".o-mail-Message");
     assert.verifySteps(["message_post"]);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-input", { value: "" });
     pyEnv["mail.message"].search([], { order: "id DESC" });
     const $message = $(".o-mail-Message");
-    await contains(".o-mail-Message-content", 1, { text: "Test" });
+    await contains(".o-mail-Message-content", { text: "Test" });
     assert.strictEqual($message.find(".o-mail-Message-author").text(), "Mitchell Admin");
     assert.strictEqual($message.find(".o-mail-Message-body").text(), "Test");
 });
@@ -856,11 +858,11 @@ QUnit.test("starred: unstar all", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
-    await contains(".o-mail-Message", 2);
+    await contains(".o-mail-Message", { count: 2 });
     assert.strictEqual($("button:contains(Starred) .badge").text(), "2");
     await click("button:contains(Unstar all):not(:disabled)");
-    await contains("button:contains(Starred) .badge", 0);
-    await contains(".o-mail-Message", 0);
+    await contains("button:contains(Starred) .badge", { count: 0 });
+    await contains(".o-mail-Message", { count: 0 });
     await contains("button:contains(Unstar all):disabled");
 });
 
@@ -879,13 +881,13 @@ QUnit.test("auto-focus composer on opening thread", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button div", 1, { text: "Inbox" });
+    await contains("button div", { text: "Inbox" });
     await contains("button:contains(Inbox).o-active");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
     assert.doesNotHaveClass($(".o-mail-DiscussSidebarChannel:contains(General)"), "o-active");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Demo User" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Demo User" });
     assert.doesNotHaveClass($(".o-mail-DiscussSidebarChannel:contains(Demo User)"), "o-active");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel:contains(General).o-active");
@@ -1065,7 +1067,7 @@ QUnit.test("should auto-pin chat when receiving a new DM", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat");
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "Demo" });
 
     // simulate receiving the first message on channel 11
     pyEnv.withUser(userId, () =>
@@ -1075,7 +1077,7 @@ QUnit.test("should auto-pin chat when receiving a new DM", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
 });
 
 QUnit.test("'Add Users' button should be displayed in the topbar of channels", async () => {
@@ -1122,8 +1124,8 @@ QUnit.test("'Add Users' button should be displayed in the topbar of groups", asy
 QUnit.test("'Add Users' button should not be displayed in the topbar of mailboxes", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
-    await contains("button", 1, { text: "Unstar all" });
-    await contains("button[title='Add Users']", 0);
+    await contains("button", { text: "Unstar all" });
+    await contains("button[title='Add Users']", { count: 0 });
 });
 
 QUnit.test(
@@ -1280,15 +1282,15 @@ QUnit.test("Channel is added to discuss after invitation", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-channel");
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
 
     pyEnv.withUser(userId, () =>
         env.services.orm.call("discuss.channel", "add_members", [[channelId]], {
             partner_ids: [pyEnv.adminPartnerId],
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
-    await contains(".o_notification.border-info .o_notification_content", 1, {
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await contains(".o_notification.border-info .o_notification_content", {
         text: "You have been invited to #General",
     });
 });
@@ -1298,20 +1300,20 @@ QUnit.test("select another mailbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Discuss");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "Inbox" });
+    await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
     await click("button", { text: "Starred" });
     await contains("button:contains(Unstar all):disabled");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "Starred" });
+    await contains(".o-mail-Discuss-threadName", { value: "Starred" });
 });
 
 QUnit.test('auto-select "Inbox nav bar" when discuss had inbox as active thread', async () => {
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-Discuss-threadName", 1, { value: "Inbox" });
+    await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
     await contains(".o-mail-MessagingMenu-navbar:contains(Mailboxes) .fw-bolder");
     await contains("button:contains(Inbox).o-active");
-    await contains("h4", 1, { text: "Congratulations, your inbox is empty" });
+    await contains("h4", { text: "Congratulations, your inbox is empty" });
 });
 
 QUnit.test(
@@ -1374,7 +1376,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId_2);
         await click("button", { text: "Bla" });
-        await contains(".o-unread", 0);
+        await contains(".o-unread", { count: 0 });
     }
 );
 
@@ -1443,9 +1445,9 @@ QUnit.test("new messages separator [REQUIRE FOCUS]", async () => {
     pyEnv["discuss.channel.member"].write([memberId], { seen_message_id: lastMessageId });
     const { env, openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 25);
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
-    await contains(".o-mail-Discuss-content .o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 25 });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
+    await contains(".o-mail-Discuss-content .o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Discuss-content .o-mail-Thread", 0);
     // composer is focused by default, we remove that focus
     $(".o-mail-Composer-input")[0].blur();
@@ -1457,12 +1459,12 @@ QUnit.test("new messages separator [REQUIRE FOCUS]", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-Message", 26);
-    await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+    await contains(".o-mail-Message", { count: 26 });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
     await scroll(".o-mail-Discuss-content .o-mail-Thread", "bottom");
-    await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
     $(".o-mail-Composer-input")[0].focus();
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 });
 
 QUnit.test("failure on loading messages should display error", async () => {
@@ -1479,7 +1481,7 @@ QUnit.test("failure on loading messages should display error", async () => {
         },
     });
     openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-    await contains(".o-mail-Thread-error", 1, {
+    await contains(".o-mail-Thread-error", {
         text: "An error occurred while fetching messages.",
     });
 });
@@ -1498,7 +1500,7 @@ QUnit.test("failure on loading messages should prompt retry button", async () =>
         },
     });
     openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-    await contains("button", 1, { text: "Click here to retry" });
+    await contains("button", { text: "Click here to retry" });
 });
 
 QUnit.test(
@@ -1530,14 +1532,14 @@ QUnit.test(
             },
         });
         openDiscuss(channelId);
-        await contains(".o-mail-Message", 30);
+        await contains(".o-mail-Message", { count: 30 });
         messageFetchShouldFail = true;
         await click("button", { text: "Load More" });
-        await contains(".o-mail-Thread-error", 1, {
+        await contains(".o-mail-Thread-error", {
             text: "An error occurred while fetching messages.",
         });
-        await contains("button", 1, { text: "Click here to retry" });
-        await contains("button", 0, { text: "Load More" });
+        await contains("button", { text: "Click here to retry" });
+        await contains("button", { count: 0, text: "Load More" });
     }
 );
 
@@ -1572,12 +1574,12 @@ QUnit.test(
             },
         });
         openDiscuss(channelId);
-        await contains(".o-mail-Message", 30);
+        await contains(".o-mail-Message", { count: 30 });
         messageFetchShouldFail = true;
         await click("button", { text: "Load More" });
         messageFetchShouldFail = false;
         await click("button", { text: "Click here to retry" });
-        await contains(".o-mail-Message", 60);
+        await contains(".o-mail-Message", { count: 60 });
     }
 );
 
@@ -1629,17 +1631,17 @@ QUnit.test("composer state: attachments save and restore", async () => {
         ".o-mail-Composer:has(textarea[placeholder='Message #Special…']) input[type=file]",
         files
     );
-    await contains(".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", 3);
+    await contains(".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", { count: 3 });
     // Switch back to #general
     await click("button", { text: "General" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard div", 1, { text: "text.txt" });
+    await contains(".o-mail-AttachmentCard div", { text: "text.txt" });
     // Switch back to #special
     await click("button", { text: "Special" });
-    await contains(".o-mail-Composer .o-mail-AttachmentCard", 3);
-    await contains(".o-mail-AttachmentCard div", 1, { text: "text2.txt" });
-    await contains(".o-mail-AttachmentCard div", 1, { text: "text3.txt" });
-    await contains(".o-mail-AttachmentCard div", 1, { text: "text4.txt" });
+    await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 3 });
+    await contains(".o-mail-AttachmentCard div", { text: "text2.txt" });
+    await contains(".o-mail-AttachmentCard div", { text: "text3.txt" });
+    await contains(".o-mail-AttachmentCard div", { text: "text4.txt" });
 });
 
 QUnit.test(
@@ -1655,8 +1657,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains("button", 1, { text: "General" });
-        await contains("div[title='Leave this channel']", 0);
+        await contains("button", { text: "General" });
+        await contains("div[title='Leave this channel']", { count: 0 });
     }
 );
 
@@ -1682,18 +1684,18 @@ QUnit.test("restore thread scroll position", async () => {
     }
     const { openDiscuss } = await start();
     openDiscuss(channelId_1);
-    await contains(".o-mail-Message", 25);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 25 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
     await click("button", { text: "Channel2" });
-    await contains(".o-mail-Message", 24);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 24 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await click("button", { text: "Channel1" });
-    await contains(".o-mail-Message", 25);
-    await contains(".o-mail-Thread", 1, { scroll: 0 });
+    await contains(".o-mail-Message", { count: 25 });
+    await contains(".o-mail-Thread", { scroll: 0 });
     await click("button", { text: "Channel2" });
-    await contains(".o-mail-Message", 24);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 24 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
 QUnit.test("Message shows up even if channel data is incomplete", async () => {
@@ -1739,7 +1741,7 @@ QUnit.test("Message shows up even if channel data is incomplete", async () => {
     await click(
         ".o-mail-DiscussSidebarCategory-chat + .o-mail-DiscussSidebarChannel:contains(Albert)"
     );
-    await contains(".o-mail-Message-content", 1, { text: "hello world" });
+    await contains(".o-mail-Message-content", { text: "hello world" });
 });
 
 QUnit.test("Correct breadcrumb when open discuss from chat window then see settings", async () => {
@@ -1751,7 +1753,7 @@ QUnit.test("Correct breadcrumb when open discuss from chat window then see setti
     await click("[title='Open Actions Menu']");
     await click("[title='Open in Discuss']");
     await click(".o-mail-DiscussSidebarChannel:contains(General) [title='Channel settings']");
-    await contains(".o_breadcrumb", 1, { text: "DiscussGeneral" });
+    await contains(".o_breadcrumb", { text: "DiscussGeneral" });
 });
 
 QUnit.test(
@@ -1777,9 +1779,9 @@ QUnit.test(
         openDiscuss();
         await click(".o_main_navbar i[aria-label='Messages']");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Discuss", 0);
+        await contains(".o-mail-Discuss", { count: 0 });
         await contains(".o_form_view .o-mail-Chatter");
-        await contains(".o_form_view .o_last_breadcrumb_item", 1, { text: "TestPartner" });
+        await contains(".o_form_view .o_last_breadcrumb_item", { text: "TestPartner" });
         await contains(
             ".o-mail-Chatter .o-mail-Message:contains(A needaction message to have it in messaging menu)"
         );
@@ -1816,15 +1818,15 @@ QUnit.test(
         openDiscuss();
         await click(".o-mail-DiscussSidebarCategory-add[title='Start a conversation']");
         await insertText(".o-discuss-ChannelSelector input", "m");
-        await contains(".o-mail-NavigableList-item", 1, { text: "Loading" });
+        await contains(".o-mail-NavigableList-item", { text: "Loading" });
         await insertText(".o-discuss-ChannelSelector input", "a");
         await insertText(".o-discuss-ChannelSelector input", "r");
         deferred1.resolve();
         await Promise.resolve();
         assert.verifySteps(["First RPC"]);
         deferred2.resolve();
-        await contains(".o-discuss-ChannelSelector-suggestion", 1, { text: "Mario" });
-        await contains(".o-discuss-ChannelSelector-suggestion", 0, { text: "Mama" });
+        await contains(".o-discuss-ChannelSelector-suggestion", { text: "Mario" });
+        await contains(".o-discuss-ChannelSelector-suggestion", { count: 0, text: "Mama" });
 
         assert.verifySteps(["Second RPC"]);
     }

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -31,7 +31,7 @@ QUnit.test("sanity check", async (assert) => {
     });
     openDiscuss();
     await contains(".o-mail-DiscussSidebar");
-    await contains("h4:contains(Congratulations, your inbox is empty)");
+    await contains("h4", 1, { text: "Congratulations, your inbox is empty" });
     assert.verifySteps([
         "/mail/init_messaging",
         "/mail/load_message_failures",
@@ -60,7 +60,7 @@ QUnit.test("can change the thread name of #general [REQUIRE FOCUS]", async (asse
         replace: true,
     });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel:contains(special)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "special" });
     await contains("input.o-mail-Discuss-threadName", 1, { value: "special" });
     assert.verifySteps(["/web/dataset/call_kw/discuss.channel/channel_rename"]);
 });
@@ -140,7 +140,7 @@ QUnit.test("Posting message should transform relevant data to emoji.", async () 
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "test :P :laughing:");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body:contains(test 😛 😆)");
+    await contains(".o-mail-Message-body", 1, { text: "test 😛 😆" });
 });
 
 QUnit.test(
@@ -179,7 +179,7 @@ QUnit.test("Click on avatar opens its partner chat window", async () => {
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Message-sidebar .o-mail-Message-avatarContainer img");
     await click(".o-mail-Message-sidebar .o-mail-Message-avatarContainer img");
-    await contains(".o-mail-ChatWindow-name:contains(testPartner)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "testPartner" });
 });
 
 QUnit.test("Can use channel command /who", async () => {
@@ -192,7 +192,7 @@ QUnit.test("Can use channel command /who", async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "/who");
     await click(".o-mail-Composer button:contains(Send):not(:disabled)");
-    await contains(".o_mail_notification:contains(You are alone in this channel.)");
+    await contains(".o_mail_notification", 1, { text: "You are alone in this channel." });
 });
 
 QUnit.test("sidebar: chat im_status rendering", async () => {
@@ -260,7 +260,7 @@ QUnit.test("No load more when fetch below fetch limit of 30", async (assert) => 
     });
     openDiscuss(channelId);
     await contains(".o-mail-Message", 29);
-    await contains("button:contains(Load More)", 0);
+    await contains("button", 0, { text: "Load More" });
 });
 
 QUnit.test("show date separator above mesages of similar date", async (assert) => {
@@ -279,9 +279,15 @@ QUnit.test("show date separator above mesages of similar date", async (assert) =
     }
     const { openDiscuss } = await start();
     openDiscuss(channelId);
+    const topOfSeaparator = (
+        await contains(".o-mail-Thread hr + span:contains(April 20, 2019) + hr")
+    )[0].getBoundingClientRect().top;
+    const topOfMessages = Math.min(
+        ...(await contains(".o-mail-Message", 29)).map((m) => m.getBoundingClientRect().top)
+    );
+    console.log(topOfSeaparator, topOfMessages);
     assert.ok(
-        (await contains("hr + span:contains(April 20, 2019) + hr")).offset().top <
-            (await contains(".o-mail-Message", 29)).offset().top,
+        topOfSeaparator < topOfMessages,
         "should have a single date separator above all the messages" // to check: may be client timezone dependent
     );
 });
@@ -298,7 +304,7 @@ QUnit.test("sidebar: chat custom name", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span:contains(Marc)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Marc" });
 });
 
 QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FOCUS]", async () => {
@@ -320,11 +326,11 @@ QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FO
     const { openDiscuss, openFormView } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header:contains(on Refactoring)");
+    await contains(".o-mail-Message-header small", 1, { text: "on Refactoring" });
     await click("[title='Reply']");
     await contains(".o-mail-Message.o-selected");
     await contains(".o-mail-Composer");
-    await contains(".o-mail-Composer-coreHeader:contains(on: Refactoring)");
+    await contains(".o-mail-Composer-coreHeader span", 1, { text: "on: Refactoring" });
     await insertText(".o-mail-Composer-input:focus", "Hello");
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(".o-mail-Composer", 0);
@@ -332,7 +338,7 @@ QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FO
     await contains('.o_notification.border-info:contains(Message posted on "Refactoring")');
     openFormView("res.partner", partnerId);
     await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message:contains(Hello)");
+    await contains(".o-mail-Message-content", 1, { text: "Hello" });
 });
 
 QUnit.test("Can reply to starred message", async () => {
@@ -347,13 +353,13 @@ QUnit.test("Can reply to starred message", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer-coreHeader:contains('RandomName')");
+    await contains(".o-mail-Composer-coreHeader b", 1, { text: "RandomName" });
     await insertText(".o-mail-Composer-input", "abc");
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(".o-mail-Composer-send", 0);
     await contains('.o_notification:contains(Message posted on "RandomName")');
-    await click(".o-mail-DiscussSidebarChannel:contains(RandomName)");
-    await contains(".o-mail-Message:contains(abc)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "RandomName" });
+    await contains(".o-mail-Message-content", 1, { text: "abc" });
 });
 
 QUnit.test("Can reply to history message", async () => {
@@ -374,52 +380,48 @@ QUnit.test("Can reply to history message", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer-coreHeader:contains('RandomName')");
+    await contains(".o-mail-Composer-coreHeader b", 1, { text: "RandomName" });
     await insertText(".o-mail-Composer-input", "abc");
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(".o-mail-Composer-send", 0);
     await contains('.o_notification:contains(Message posted on "RandomName")');
-    await click(".o-mail-DiscussSidebarChannel:contains(RandomName)");
-    await contains(".o-mail-Message:contains(abc)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "RandomName" });
+    await contains(".o-mail-Message-content", 1, { text: "abc" });
 });
 
 QUnit.test("receive new needaction messages", async () => {
     const { openDiscuss, pyEnv } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox)");
+    await contains("button div", 1, { text: "Inbox" });
     await contains("button:contains(Inbox).o-active");
     await contains("button:contains(Inbox) .badge", 0);
     await contains(".o-mail-Thread .o-mail-Message", 0);
 
     // simulate receiving a new needaction message
-    await afterNextRender(() => {
-        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
-            body: "not empty 1",
-            id: 100,
-            needaction_partner_ids: [pyEnv.currentPartnerId],
-            model: "res.partner",
-            res_id: 20,
-        });
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
+        body: "not empty 1",
+        id: 100,
+        needaction_partner_ids: [pyEnv.currentPartnerId],
+        model: "res.partner",
+        res_id: 20,
     });
     await contains("button:contains(Inbox) .badge");
-    await contains("button:contains(Inbox) .badge:contains(1)");
+    await contains("button:contains(Inbox) .badge", 1, { text: "1" });
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message:contains(not empty 1)");
+    await contains(".o-mail-Message-content", 1, { text: "not empty 1" });
 
     // simulate receiving another new needaction message
-    await afterNextRender(() => {
-        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
-            body: "not empty 2",
-            id: 101,
-            needaction_partner_ids: [pyEnv.currentPartnerId],
-            model: "res.partner",
-            res_id: 20,
-        });
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
+        body: "not empty 2",
+        id: 101,
+        needaction_partner_ids: [pyEnv.currentPartnerId],
+        model: "res.partner",
+        res_id: 20,
     });
-    await contains("button:contains(Inbox) .badge:contains(2)");
+    await contains("button:contains(Inbox) .badge", 1, { text: "2" });
     await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message:contains(not empty 1)");
-    await contains(".o-mail-Message:contains(not empty 2)");
+    await contains(".o-mail-Message-content", 1, { text: "not empty 1" });
+    await contains(".o-mail-Message-content", 1, { text: "not empty 2" });
 });
 
 QUnit.test("basic rendering", async () => {
@@ -433,12 +435,12 @@ QUnit.test("basic rendering", async () => {
 QUnit.test("basic rendering: sidebar", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebar button:contains(Inbox)");
-    await contains(".o-mail-DiscussSidebar button:contains(Starred)");
-    await contains(".o-mail-DiscussSidebar button:contains(History)");
+    await contains(".o-mail-DiscussSidebar button div", 1, { text: "Inbox" });
+    await contains(".o-mail-DiscussSidebar button div", 1, { text: "Starred" });
+    await contains(".o-mail-DiscussSidebar button div", 1, { text: "History" });
     await contains(".o-mail-DiscussSidebarCategory", 2);
-    await contains(".o-mail-DiscussSidebarCategory-channel:contains(Channels)");
-    await contains(".o-mail-DiscussSidebarCategory-chat:contains(Direct messages)");
+    await contains(".o-mail-DiscussSidebarCategory-channel", 1, { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarCategory-chat", 1, { text: "Direct messages" });
 });
 
 QUnit.test("sidebar: Inbox should have icon", async () => {
@@ -458,7 +460,7 @@ QUnit.test("sidebar: change active", async () => {
     openDiscuss();
     await contains("button:contains(Inbox).o-active");
     await contains("button:contains(Starred):not(.o-active)");
-    await click("button:contains(Starred)");
+    await click("button", { text: "Starred" });
     await contains("button:contains(Inbox):not(.o-active)");
     await contains("button:contains(Starred).o-active");
 });
@@ -468,7 +470,7 @@ QUnit.test("sidebar: basic channel rendering", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands.d-none");
     await contains(
@@ -515,8 +517,8 @@ QUnit.test("sidebar: channel rendering with needaction counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel:contains(general)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(general) .badge:contains(1)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel:contains(general) .badge", 1, { text: "1" });
 });
 
 QUnit.test("sidebar: chat rendering with unread counter", async () => {
@@ -529,7 +531,7 @@ QUnit.test("sidebar: chat rendering with unread counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel .badge:contains(100)");
+    await contains(".o-mail-DiscussSidebarChannel .badge", 1, { text: "100" });
     await contains(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands:contains(Unpin Conversation)",
         0
@@ -580,11 +582,11 @@ QUnit.test("basic top bar rendering", async () => {
     await contains("button:contains(Mark all read):disabled");
     await contains(".o-mail-Discuss-threadName", 1, { value: "Inbox" });
 
-    await click("button:contains(Starred)");
+    await click("button", { text: "Starred" });
     await contains("button:contains(Unstar all):disabled");
     await contains(".o-mail-Discuss-threadName", 1, { value: "Starred" });
 
-    await click(".o-mail-DiscussSidebarChannel:contains(General)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-Discuss-header button[title='Add Users']");
     await contains(".o-mail-Discuss-threadName", 1, { value: "General" });
 });
@@ -608,7 +610,7 @@ QUnit.test("rendering of inbox message", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header:contains(on Refactoring)");
+    await contains(".o-mail-Message-header small", 1, { text: "on Refactoring" });
     await contains(".o-mail-Message-actions i", 4);
     await contains("[title='Reply']");
     await contains("[title='Mark as Todo']");
@@ -665,7 +667,9 @@ QUnit.test("Unfollow message", async function () {
         await click(`.o-mail-Message:eq(${id}) [title='Expand']`);
         await contains(`.o-mail-Message:eq(${id}) [title='Unfollow']`);
     }
-    await contains(".o-mail-Message:eq(2) .o-mail-Message-header:contains(on Thread not followed)");
+    await contains(".o-mail-Message:eq(2) .o-mail-Message-header small", 1, {
+        text: "on Thread not followed",
+    });
     await click(".o-mail-Message:eq(2) [title='Expand']");
     await contains(".o-mail-Message:eq(2) .o-mail-Message-moreMenu");
     await contains(".o-mail-Message:eq(2) [title='Unfollow']", 0);
@@ -674,8 +678,8 @@ QUnit.test("Unfollow message", async function () {
     await click(".o-mail-Message:eq(0) [title='Unfollow']");
 
     await contains(".o-mail-Message", 2); // Unfollowing message 0 marks it as read -> Message removed
-    await contains(".o-mail-Message-header:contains(on Thread followed)");
-    await contains(".o-mail-Message-header:contains(on Thread not followed)");
+    await contains(".o-mail-Message-header small", 1, { text: "on Thread followed" });
+    await contains(".o-mail-Message-header small", 1, { text: "on Thread not followed" });
     for (const id of [0, 1]) {
         await click(`.o-mail-Message:eq(${id}) [title='Expand']`);
         await contains(`.o-mail-Message:eq(${id}) .o-mail-Message-moreMenu`);
@@ -715,20 +719,22 @@ QUnit.test('messages marked as read move to "History" mailbox', async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await contains("button:contains(History).o-active");
-    await contains(".o-mail-Thread:contains(No history messages)");
+    await contains(".o-mail-Thread h4", 1, { text: "No history messages" });
 
-    await click("button:contains(Inbox)");
+    await click("button div", { text: "Inbox" });
     await contains("button:contains(Inbox).o-active");
-    await contains(".o-mail-Thread:contains(Congratulations, your inbox is empty)", 0);
+    await contains(".o-mail-Thread h4", 0, { text: "Congratulations, your inbox is empty" });
+
     await contains(".o-mail-Thread .o-mail-Message", 2);
 
-    await click("button:contains(Mark all read)");
+    await click("button", { text: "Mark all read" });
     await contains("button:contains(Inbox).o-active");
-    await contains(".o-mail-Thread:contains(Congratulations, your inbox is empty)");
+    await contains(".o-mail-Thread h4", 1, { text: "Congratulations, your inbox is empty" });
 
-    await click("button:contains(History)");
+    await click("button div", { text: "History" });
     await contains("button:contains(History).o-active");
-    await contains(".o-mail-Thread:contains(No history messages)", 0);
+    await contains(".o-mail-Thread h4", 0, { text: "No history messages" });
+
     await contains(".o-mail-Thread .o-mail-Message", 2);
 });
 
@@ -763,20 +769,20 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_history");
         await contains("button:contains(History).o-active");
-        await contains(".o-mail-Thread:contains(No history messages)");
+        await contains(".o-mail-Thread h4", 1, { text: "No history messages" });
 
-        await click("button:contains(Inbox)");
+        await click("button div", { text: "Inbox" });
         await contains("button:contains(Inbox).o-active");
         await contains(".o-mail-Message", 2);
 
         await click(".o-mail-Message:contains(not empty 1) [title='Mark as Read']");
         await contains(".o-mail-Message");
-        await contains(".o-mail-Message:contains(not empty 2)");
+        await contains(".o-mail-Message-content", 1, { text: "not empty 2" });
 
-        await click("button:contains(History)");
+        await click("button div", { text: "History" });
         await contains("button:contains(History).o-active");
         await contains(".o-mail-Message");
-        await contains(".o-mail-Message:contains(not empty 1)");
+        await contains(".o-mail-Message-content", 1, { text: "not empty 1" });
     }
 );
 
@@ -796,9 +802,9 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message", 30);
-    await click("button:contains(Mark all read)");
+    await click("button", { text: "Mark all read" });
     await contains(".o-mail-Message", 0);
-    await click("button:contains(History)");
+    await click("button div", { text: "History" });
     await contains(".o-mail-Message", 30);
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
@@ -821,7 +827,9 @@ QUnit.test("post a simple message", async (assert) => {
         },
     });
     openDiscuss(channelId);
-    await contains(".o-mail-Thread:contains(There are no messages in this conversation.)");
+    await contains(".o-mail-Thread .o-mail-Thread-empty", 1, {
+        text: "There are no messages in this conversation.",
+    });
     await contains(".o-mail-Message", 0);
     await contains(".o-mail-Composer-input", 1, { value: "" });
 
@@ -835,7 +843,7 @@ QUnit.test("post a simple message", async (assert) => {
     await contains(".o-mail-Composer-input", 1, { value: "" });
     pyEnv["mail.message"].search([], { order: "id DESC" });
     const $message = $(".o-mail-Message");
-    await contains(".o-mail-Message:contains(Test)");
+    await contains(".o-mail-Message-content", 1, { text: "Test" });
     assert.strictEqual($message.find(".o-mail-Message-author").text(), "Mitchell Admin");
     assert.strictEqual($message.find(".o-mail-Message-body").text(), "Test");
 });
@@ -871,20 +879,20 @@ QUnit.test("auto-focus composer on opening thread", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox)");
+    await contains("button div", 1, { text: "Inbox" });
     await contains("button:contains(Inbox).o-active");
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
     assert.doesNotHaveClass($(".o-mail-DiscussSidebarChannel:contains(General)"), "o-active");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Demo User)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Demo User" });
     assert.doesNotHaveClass($(".o-mail-DiscussSidebarChannel:contains(Demo User)"), "o-active");
     await contains(".o-mail-Composer", 0);
 
-    await click(".o-mail-DiscussSidebarChannel:contains(General)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel:contains(General).o-active");
     await contains(".o-mail-Composer");
     assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
 
-    await click(".o-mail-DiscussSidebarChannel:contains(Demo User)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "Demo User" });
     await contains(".o-mail-DiscussSidebarChannel:contains(Demo User).o-active");
     await contains(".o-mail-Composer");
     assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
@@ -1057,7 +1065,7 @@ QUnit.test("should auto-pin chat when receiving a new DM", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Demo)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "Demo" });
 
     // simulate receiving the first message on channel 11
     pyEnv.withUser(userId, () =>
@@ -1067,7 +1075,7 @@ QUnit.test("should auto-pin chat when receiving a new DM", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel:contains(Demo)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Demo" });
 });
 
 QUnit.test("'Add Users' button should be displayed in the topbar of channels", async () => {
@@ -1114,7 +1122,7 @@ QUnit.test("'Add Users' button should be displayed in the topbar of groups", asy
 QUnit.test("'Add Users' button should not be displayed in the topbar of mailboxes", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
-    await contains("button:contains(Unstar all)");
+    await contains("button", 1, { text: "Unstar all" });
     await contains("button[title='Add Users']", 0);
 });
 
@@ -1198,15 +1206,15 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         openDiscuss();
-        await click(".o-mail-DiscussSidebarChannel:contains('Michel Online')");
+        await click(".o-mail-DiscussSidebarChannel span", { text: "Michel Online" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Online']");
-        await click(".o-mail-DiscussSidebarChannel:contains('Jacqueline Offline')");
+        await click(".o-mail-DiscussSidebarChannel span", { text: "Jacqueline Offline" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Offline']");
-        await click(".o-mail-DiscussSidebarChannel:contains('Nabuchodonosor Idle')");
+        await click(".o-mail-DiscussSidebarChannel span", { text: "Nabuchodonosor Idle" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Idle']");
-        await click(".o-mail-DiscussSidebarChannel:contains('Robert Fired')");
+        await click(".o-mail-DiscussSidebarChannel span", { text: "Robert Fired" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='No IM status available']");
-        await click(".o-mail-DiscussSidebarChannel:contains('OdooBot')");
+        await click(".o-mail-DiscussSidebarChannel span", { text: "OdooBot" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Bot']");
     }
 );
@@ -1272,14 +1280,17 @@ QUnit.test("Channel is added to discuss after invitation", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-channel");
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+
     pyEnv.withUser(userId, () =>
         env.services.orm.call("discuss.channel", "add_members", [[channelId]], {
             partner_ids: [pyEnv.adminPartnerId],
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
-    await contains(".o_notification.border-info:contains(You have been invited to #General)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains(".o_notification.border-info .o_notification_content", 1, {
+        text: "You have been invited to #General",
+    });
 });
 
 QUnit.test("select another mailbox", async () => {
@@ -1288,7 +1299,7 @@ QUnit.test("select another mailbox", async () => {
     openDiscuss();
     await contains(".o-mail-Discuss");
     await contains(".o-mail-Discuss-threadName", 1, { value: "Inbox" });
-    await click("button:contains(Starred)");
+    await click("button", { text: "Starred" });
     await contains("button:contains(Unstar all):disabled");
     await contains(".o-mail-Discuss-threadName", 1, { value: "Starred" });
 });
@@ -1300,7 +1311,7 @@ QUnit.test('auto-select "Inbox nav bar" when discuss had inbox as active thread'
     await contains(".o-mail-Discuss-threadName", 1, { value: "Inbox" });
     await contains(".o-mail-MessagingMenu-navbar:contains(Mailboxes) .fw-bolder");
     await contains("button:contains(Inbox).o-active");
-    await contains("h4:contains(Congratulations, your inbox is empty)");
+    await contains("h4", 1, { text: "Congratulations, your inbox is empty" });
 });
 
 QUnit.test(
@@ -1362,7 +1373,7 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         openDiscuss(channelId_2);
-        await click("button:contains(Bla)");
+        await click("button", { text: "Bla" });
         await contains(".o-unread", 0);
     }
 );
@@ -1433,7 +1444,7 @@ QUnit.test("new messages separator [REQUIRE FOCUS]", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message", 25);
-    await contains("hr + span:contains(New messages)", 0);
+    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
     await contains(".o-mail-Discuss-content .o-mail-Thread", 1, { scroll: "bottom" });
     await scroll(".o-mail-Discuss-content .o-mail-Thread", 0);
     // composer is focused by default, we remove that focus
@@ -1447,11 +1458,11 @@ QUnit.test("new messages separator [REQUIRE FOCUS]", async () => {
         })
     );
     await contains(".o-mail-Message", 26);
-    await contains("hr + span:contains(New messages)");
+    await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
     await scroll(".o-mail-Discuss-content .o-mail-Thread", "bottom");
-    await contains("hr + span:contains(New messages)");
+    await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
     $(".o-mail-Composer-input")[0].focus();
-    await contains("hr + span:contains(New messages)", 0);
+    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
 });
 
 QUnit.test("failure on loading messages should display error", async () => {
@@ -1468,7 +1479,9 @@ QUnit.test("failure on loading messages should display error", async () => {
         },
     });
     openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-    await contains(".o-mail-Thread-error:contains(An error occurred while fetching messages.)");
+    await contains(".o-mail-Thread-error", 1, {
+        text: "An error occurred while fetching messages.",
+    });
 });
 
 QUnit.test("failure on loading messages should prompt retry button", async () => {
@@ -1485,7 +1498,7 @@ QUnit.test("failure on loading messages should prompt retry button", async () =>
         },
     });
     openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-    await contains("button:contains(Click here to retry)");
+    await contains("button", 1, { text: "Click here to retry" });
 });
 
 QUnit.test(
@@ -1519,10 +1532,12 @@ QUnit.test(
         openDiscuss(channelId);
         await contains(".o-mail-Message", 30);
         messageFetchShouldFail = true;
-        await click("button:contains(Load More)");
-        await contains(".o-mail-Thread-error:contains(An error occurred while fetching messages.)");
-        await contains("button:contains(Click here to retry)");
-        await contains("button:contains(Load More)", 0);
+        await click("button", { text: "Load More" });
+        await contains(".o-mail-Thread-error", 1, {
+            text: "An error occurred while fetching messages.",
+        });
+        await contains("button", 1, { text: "Click here to retry" });
+        await contains("button", 0, { text: "Load More" });
     }
 );
 
@@ -1559,9 +1574,9 @@ QUnit.test(
         openDiscuss(channelId);
         await contains(".o-mail-Message", 30);
         messageFetchShouldFail = true;
-        await click("button:contains(Load More)");
+        await click("button", { text: "Load More" });
         messageFetchShouldFail = false;
-        await click("button:contains(Click here to retry)");
+        await click("button", { text: "Click here to retry" });
         await contains(".o-mail-Message", 60);
     }
 );
@@ -1587,7 +1602,7 @@ QUnit.test("composer state: attachments save and restore", async () => {
     );
     await contains(".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)");
     // Switch to #special
-    await click("button:contains(Special)");
+    await click("button", { text: "Special" });
     // Attach files in a message for #special
     const files = await Promise.all([
         createFile({
@@ -1616,15 +1631,15 @@ QUnit.test("composer state: attachments save and restore", async () => {
     );
     await contains(".o-mail-Composer .o-mail-AttachmentCard:not(.o-isUploading)", 3);
     // Switch back to #general
-    await click("button:contains(General)");
+    await click("button", { text: "General" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard:contains(text.txt)");
+    await contains(".o-mail-AttachmentCard div", 1, { text: "text.txt" });
     // Switch back to #special
-    await click("button:contains(Special)");
+    await click("button", { text: "Special" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard", 3);
-    await contains(".o-mail-AttachmentCard:contains(text2.txt)");
-    await contains(".o-mail-AttachmentCard:contains(text3.txt)");
-    await contains(".o-mail-AttachmentCard:contains(text4.txt)");
+    await contains(".o-mail-AttachmentCard div", 1, { text: "text2.txt" });
+    await contains(".o-mail-AttachmentCard div", 1, { text: "text3.txt" });
+    await contains(".o-mail-AttachmentCard div", 1, { text: "text4.txt" });
 });
 
 QUnit.test(
@@ -1640,7 +1655,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains("button:contains(General)");
+        await contains("button", 1, { text: "General" });
         await contains("div[title='Leave this channel']", 0);
     }
 );
@@ -1670,13 +1685,13 @@ QUnit.test("restore thread scroll position", async () => {
     await contains(".o-mail-Message", 25);
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
-    await click("button:contains(Channel2)");
+    await click("button", { text: "Channel2" });
     await contains(".o-mail-Message", 24);
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
-    await click("button:contains(Channel1)");
+    await click("button", { text: "Channel1" });
     await contains(".o-mail-Message", 25);
     await contains(".o-mail-Thread", 1, { scroll: 0 });
-    await click("button:contains(Channel2)");
+    await click("button", { text: "Channel2" });
     await contains(".o-mail-Message", 24);
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
 });
@@ -1724,7 +1739,7 @@ QUnit.test("Message shows up even if channel data is incomplete", async () => {
     await click(
         ".o-mail-DiscussSidebarCategory-chat + .o-mail-DiscussSidebarChannel:contains(Albert)"
     );
-    await contains(".o-mail-Message:contains(hello world)");
+    await contains(".o-mail-Message-content", 1, { text: "hello world" });
 });
 
 QUnit.test("Correct breadcrumb when open discuss from chat window then see settings", async () => {
@@ -1732,11 +1747,11 @@ QUnit.test("Correct breadcrumb when open discuss from chat window then see setti
     pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await click(".o_main_navbar i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem:contains(General)");
+    await click(".o-mail-NotificationItem-name", { text: "General" });
     await click("[title='Open Actions Menu']");
     await click("[title='Open in Discuss']");
     await click(".o-mail-DiscussSidebarChannel:contains(General) [title='Channel settings']");
-    await contains(".o_breadcrumb:contains(DiscussGeneral)");
+    await contains(".o_breadcrumb", 1, { text: "DiscussGeneral" });
 });
 
 QUnit.test(
@@ -1764,7 +1779,7 @@ QUnit.test(
         await click(".o-mail-NotificationItem");
         await contains(".o-mail-Discuss", 0);
         await contains(".o_form_view .o-mail-Chatter");
-        await contains(".o_form_view .o_breadcrumb:contains(TestPartner)");
+        await contains(".o_form_view .o_last_breadcrumb_item", 1, { text: "TestPartner" });
         await contains(
             ".o-mail-Chatter .o-mail-Message:contains(A needaction message to have it in messaging menu)"
         );
@@ -1801,15 +1816,16 @@ QUnit.test(
         openDiscuss();
         await click(".o-mail-DiscussSidebarCategory-add[title='Start a conversation']");
         await insertText(".o-discuss-ChannelSelector input", "m");
-        await contains(".o-mail-NavigableList-item:contains(Loading)");
+        await contains(".o-mail-NavigableList-item", 1, { text: "Loading" });
         await insertText(".o-discuss-ChannelSelector input", "a");
         await insertText(".o-discuss-ChannelSelector input", "r");
         deferred1.resolve();
         await Promise.resolve();
         assert.verifySteps(["First RPC"]);
         deferred2.resolve();
-        await contains(".o-discuss-ChannelSelector-suggestion:contains(Mario)");
-        await contains(".o-discuss-ChannelSelector-suggestion:contains(Mama)", 0);
+        await contains(".o-discuss-ChannelSelector-suggestion", 1, { text: "Mario" });
+        await contains(".o-discuss-ChannelSelector-suggestion", 0, { text: "Mama" });
+
         assert.verifySteps(["Second RPC"]);
     }
 );

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -833,24 +833,15 @@ QUnit.test("post a simple message", async (assert) => {
         text: "There are no messages in this conversation.",
     });
     await contains(".o-mail-Message", { count: 0 });
-    await contains(".o-mail-Composer-input", { value: "" });
-
-    // insert some HTML in editable
     await insertText(".o-mail-Composer-input", "Test");
-    await contains(".o-mail-Composer-input", { value: "Test" });
-
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message");
-    assert.verifySteps(["message_post"]);
     await contains(".o-mail-Composer-input", { value: "" });
-    pyEnv["mail.message"].search([], { order: "id DESC" });
-    const $message = $(".o-mail-Message");
+    await contains(".o-mail-Message-author", { text: "Mitchell Admin" });
     await contains(".o-mail-Message-content", { text: "Test" });
-    assert.strictEqual($message.find(".o-mail-Message-author").text(), "Mitchell Admin");
-    assert.strictEqual($message.find(".o-mail-Message-body").text(), "Test");
+    assert.verifySteps(["message_post"]);
 });
 
-QUnit.test("starred: unstar all", async (assert) => {
+QUnit.test("starred: unstar all", async () => {
     const pyEnv = await startServer();
     pyEnv["mail.message"].create([
         { body: "not empty", starred_partner_ids: [pyEnv.currentPartnerId] },
@@ -859,7 +850,7 @@ QUnit.test("starred: unstar all", async (assert) => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
     await contains(".o-mail-Message", { count: 2 });
-    assert.strictEqual($("button:contains(Starred) .badge").text(), "2");
+    await contains("button:contains(Starred) .badge", { text: "2" });
     await click("button:contains(Unstar all):not(:disabled)");
     await contains("button:contains(Starred) .badge", { count: 0 });
     await contains(".o-mail-Message", { count: 0 });

--- a/addons/mail/static/tests/discuss_app/inbox_tests.js
+++ b/addons/mail/static/tests/discuss_app/inbox_tests.js
@@ -41,7 +41,7 @@ QUnit.test("reply: discard on reply button toggle", async (assert) => {
     await click("[title='Reply']");
     await contains(".o-mail-Composer");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("reply: discard on pressing escape", async () => {
@@ -74,19 +74,19 @@ QUnit.test("reply: discard on pressing escape", async () => {
     await click(".o-mail-Composer button[aria-label='Emojis']");
     await contains(".o-EmojiPicker");
     triggerHotkey("Escape");
-    await contains(".o-EmojiPicker", 0);
+    await contains(".o-EmojiPicker", { count: 0 });
     await contains(".o-mail-Composer");
 
     // Escape on suggestion prompt does not stop replying
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-Composer-suggestionList .o-open");
     triggerHotkey("Escape");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await contains(".o-mail-Composer");
 
     click(".o-mail-Composer-input").catch(() => {});
     triggerHotkey("Escape");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 });
 
 QUnit.test(
@@ -123,7 +123,7 @@ QUnit.test(
         await contains(".o-mail-Composer [placeholder='Log an internal note…']");
         await insertText(".o-mail-Composer-input", "Test");
         await click(".o-mail-Composer-send:not(:disabled)", { text: "Log" });
-        await contains(".o-mail-Composer", 0);
+        await contains(".o-mail-Composer", { count: 0 });
         assert.verifySteps(["/mail/message/post"]);
     }
 );
@@ -162,7 +162,7 @@ QUnit.test(
         await contains(".o-mail-Composer [placeholder='Send a message to followers…']");
         await insertText(".o-mail-Composer-input", "Test");
         await click(".o-mail-Composer-send:not(:disabled)", { text: "Send" });
-        await contains(".o-mail-Composer-send", 0);
+        await contains(".o-mail-Composer-send", { count: 0 });
         assert.verifySteps(["/mail/message/post"]);
     }
 );
@@ -185,7 +185,7 @@ QUnit.test("show subject of message in Inbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", 1, {
+    await contains(".o-mail-Message-content", {
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -208,7 +208,7 @@ QUnit.test("show subject of message in history", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", 1, {
+    await contains(".o-mail-Message-content", {
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -232,7 +232,8 @@ QUnit.test("subject should not be shown when subject is the same as the thread n
     const { openDiscuss } = await start();
     openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message-content");
-    await contains(".o-mail-Message-content", 0, {
+    await contains(".o-mail-Message-content", {
+        count: 0,
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -258,7 +259,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", 0, {
+        await contains(".o-mail-Message-content", {
+            count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
     }
@@ -285,7 +287,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", 0, {
+        await contains(".o-mail-Message-content", {
+            count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
     }
@@ -312,7 +315,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", 0, {
+        await contains(".o-mail-Message-content", {
+            count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
     }
@@ -339,7 +343,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", 0, {
+        await contains(".o-mail-Message-content", {
+            count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
     }
@@ -366,7 +371,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", 0, {
+        await contains(".o-mail-Message-content", {
+            count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
     }
@@ -393,7 +399,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", 0, {
+        await contains(".o-mail-Message-content", {
+            count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
     }
@@ -430,15 +437,15 @@ QUnit.test("inbox: mark all messages as read", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox) .badge", 1, { text: "2" });
-    await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge", 1, { text: "2" });
-    await contains(".o-mail-Discuss-content .o-mail-Message", 2);
+    await contains("button:contains(Inbox) .badge", { text: "2" });
+    await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge", { text: "2" });
+    await contains(".o-mail-Discuss-content .o-mail-Message", { count: 2 });
     assert.notOk($("button:contains(Mark all read)")[0].disabled);
 
     await click(".o-mail-Discuss-header button", { text: "Mark all read" });
-    await contains("button:contains(Inbox) .badge", 0);
-    await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge", 0);
-    await contains(".o-mail-Message", 0);
+    await contains("button:contains(Inbox) .badge", { count: 0 });
+    await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge", { count: 0 });
+    await contains(".o-mail-Message", { count: 0 });
     assert.ok($("button:contains(Mark all read)")[0].disabled);
 });
 
@@ -526,15 +533,15 @@ QUnit.test("inbox messages are never squashed", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", {
         text: "body1",
     });
-    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", {
         text: "body2",
     });
     await click(".o-mail-DiscussSidebarChannel span", { text: "test" });
-    await contains(".o-mail-Message.o-squashed .o-mail-Message-content", 1, { text: "body2" });
+    await contains(".o-mail-Message.o-squashed .o-mail-Message-content", { text: "body2" });
 });
 
 QUnit.test("reply: stop replying button click", async () => {
@@ -562,7 +569,7 @@ QUnit.test("reply: stop replying button click", async () => {
     await contains("i[title='Stop replying']");
 
     await click("i[title='Stop replying']");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("error notifications should not be shown in Inbox", async () => {
@@ -584,11 +591,11 @@ QUnit.test("error notifications should not be shown in Inbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header small", 1, { text: "on Demo User" });
+    await contains(".o-mail-Message-header small", { text: "on Demo User" });
     await contains(
         `.o-mail-Message-header a:contains(Demo User)[href*='/web#model=res.partner&id=${partnerId}']`
     );
-    await contains(".o-mail-Message-notification", 0);
+    await contains(".o-mail-Message-notification", { count: 0 });
 });
 
 QUnit.test("emptying inbox displays rainbow man in inbox", async () => {
@@ -635,12 +642,12 @@ QUnit.test("emptying inbox doesn't display rainbow man in another thread", async
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains("button:contains(Inbox) .badge", 1, { text: "1" });
+    await contains("button:contains(Inbox) .badge", { text: "1" });
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/mark_as_read", {
         message_ids: [messageId],
         needaction_inbox_counter: 0,
     });
     await afterNextRender(() => mockTimeout().execRegisteredTimeouts);
-    await contains("button:contains(Inbox) .badge", 0);
-    await contains(".o_reward_rainbow", 0);
+    await contains("button:contains(Inbox) .badge", { count: 0 });
+    await contains(".o_reward_rainbow", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss_app/inbox_tests.js
+++ b/addons/mail/static/tests/discuss_app/inbox_tests.js
@@ -122,7 +122,7 @@ QUnit.test(
         await click("[title='Reply']");
         await contains(".o-mail-Composer [placeholder='Log an internal note…']");
         await insertText(".o-mail-Composer-input", "Test");
-        await click(".o-mail-Composer-send:not(:disabled):contains(Log)");
+        await click(".o-mail-Composer-send:not(:disabled)", { text: "Log" });
         await contains(".o-mail-Composer", 0);
         assert.verifySteps(["/mail/message/post"]);
     }
@@ -161,7 +161,7 @@ QUnit.test(
         await click("[title='Reply']");
         await contains(".o-mail-Composer [placeholder='Send a message to followers…']");
         await insertText(".o-mail-Composer-input", "Test");
-        await click(".o-mail-Composer-send:not(:disabled):contains(Send)");
+        await click(".o-mail-Composer-send:not(:disabled)", { text: "Send" });
         await contains(".o-mail-Composer-send", 0);
         assert.verifySteps(["/mail/message/post"]);
     }
@@ -185,7 +185,9 @@ QUnit.test("show subject of message in Inbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message:contains(Subject: Salutations, voyageur)");
+    await contains(".o-mail-Message-content", 1, {
+        text: "Subject: Salutations, voyageurnot empty",
+    });
 });
 
 QUnit.test("show subject of message in history", async () => {
@@ -206,7 +208,9 @@ QUnit.test("show subject of message in history", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message:contains(Subject: Salutations, voyageur)");
+    await contains(".o-mail-Message-content", 1, {
+        text: "Subject: Salutations, voyageurnot empty",
+    });
 });
 
 QUnit.test("subject should not be shown when subject is the same as the thread name", async () => {
@@ -228,7 +232,9 @@ QUnit.test("subject should not be shown when subject is the same as the thread n
     const { openDiscuss } = await start();
     openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message-content");
-    await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+    await contains(".o-mail-Message-content", 0, {
+        text: "Subject: Salutations, voyageurnot empty",
+    });
 });
 
 QUnit.test(
@@ -252,7 +258,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+        await contains(".o-mail-Message-content", 0, {
+            text: "Subject: Salutations, voyageurnot empty",
+        });
     }
 );
 
@@ -277,7 +285,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+        await contains(".o-mail-Message-content", 0, {
+            text: "Subject: Salutations, voyageurnot empty",
+        });
     }
 );
 
@@ -302,7 +312,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+        await contains(".o-mail-Message-content", 0, {
+            text: "Subject: Salutations, voyageurnot empty",
+        });
     }
 );
 
@@ -327,7 +339,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+        await contains(".o-mail-Message-content", 0, {
+            text: "Subject: Salutations, voyageurnot empty",
+        });
     }
 );
 
@@ -352,7 +366,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+        await contains(".o-mail-Message-content", 0, {
+            text: "Subject: Salutations, voyageurnot empty",
+        });
     }
 );
 
@@ -377,7 +393,9 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
         await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content:contains(Salutations, voyageur)", 0);
+        await contains(".o-mail-Message-content", 0, {
+            text: "Subject: Salutations, voyageurnot empty",
+        });
     }
 );
 
@@ -412,12 +430,12 @@ QUnit.test("inbox: mark all messages as read", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox) .badge:contains(2)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge:contains(2)");
+    await contains("button:contains(Inbox) .badge", 1, { text: "2" });
+    await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge", 1, { text: "2" });
     await contains(".o-mail-Discuss-content .o-mail-Message", 2);
     assert.notOk($("button:contains(Mark all read)")[0].disabled);
 
-    await click(".o-mail-Discuss-header button:contains(Mark all read)");
+    await click(".o-mail-Discuss-header button", { text: "Mark all read" });
     await contains("button:contains(Inbox) .badge", 0);
     await contains(".o-mail-DiscussSidebarChannel:contains(General) .badge", 0);
     await contains(".o-mail-Message", 0);
@@ -460,7 +478,7 @@ QUnit.test(
             },
         });
         await contains(".o-mail-Message");
-        await click(".o-mail-Message-header a:contains(Some record)");
+        await click(".o-mail-Message-header a", { text: "Some record" });
         await def;
         assert.verifySteps(["do-action"]);
     }
@@ -509,10 +527,14 @@ QUnit.test("inbox messages are never squashed", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message:contains(body1):not(.o-squashed)");
-    await contains(".o-mail-Message:contains(body2):not(.o-squashed)");
-    await click(".o-mail-DiscussSidebarChannel:contains(test)");
-    await contains(".o-mail-Message:contains(body2).o-squashed");
+    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", 1, {
+        text: "body1",
+    });
+    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", 1, {
+        text: "body2",
+    });
+    await click(".o-mail-DiscussSidebarChannel span", { text: "test" });
+    await contains(".o-mail-Message.o-squashed .o-mail-Message-content", 1, { text: "body2" });
 });
 
 QUnit.test("reply: stop replying button click", async () => {
@@ -562,7 +584,7 @@ QUnit.test("error notifications should not be shown in Inbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header:contains(on Demo User)");
+    await contains(".o-mail-Message-header small", 1, { text: "on Demo User" });
     await contains(
         `.o-mail-Message-header a:contains(Demo User)[href*='/web#model=res.partner&id=${partnerId}']`
     );
@@ -589,7 +611,7 @@ QUnit.test("emptying inbox displays rainbow man in inbox", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button:contains(Mark all read)");
+    await click("button", { text: "Mark all read" });
     await contains(".o_reward_rainbow");
 });
 
@@ -613,7 +635,7 @@ QUnit.test("emptying inbox doesn't display rainbow man in another thread", async
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains("button:contains(Inbox) .badge:contains(1)");
+    await contains("button:contains(Inbox) .badge", 1, { text: "1" });
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/mark_as_read", {
         message_ids: [messageId],
         needaction_inbox_counter: 0,

--- a/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
@@ -26,21 +26,22 @@ QUnit.test("Basic jump to present when scrolling to outdated messages", async (a
     }
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 20);
+    await contains(".o-mail-Message", { count: 20 });
     assert.ok(
         (await contains(".o-mail-Thread"))[0].scrollHeight > PRESENT_THRESHOLD,
         "should have enough scroll height to trigger jump to present"
     );
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Thread-jumpPresent", 1, {
+    await contains(".o-mail-Thread-jumpPresent", {
         text: "You're viewing older messagesJump to Present",
     });
     await click(".o-mail-Thread-jumpPresent");
-    await contains(".o-mail-Thread-jumpPresent", 0, {
+    await contains(".o-mail-Thread-jumpPresent", {
+        count: 0,
         text: "You're viewing older messagesJump to Present",
     });
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
 QUnit.test("Jump to old reply should prompt jump to presence", async (assert) => {
@@ -80,23 +81,24 @@ QUnit.test("Jump to old reply should prompt jump to presence", async (assert) =>
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 30);
+    await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
-    await contains(".o-mail-Message", 46);
+    await contains(".o-mail-Message", { count: 46 });
     assert.isVisible((await contains(".o-mail-Message:contains(Hello world!):eq(0)"))[0]);
     assert.strictEqual(
         $(".o-mail-Message-body:contains(Hello world!):eq(0)").text(),
         "Hello world!",
         "should correctly execute HTML tags in parent message when using 'load around' feature"
     );
-    await contains(".o-mail-Thread-jumpPresent", 1, {
+    await contains(".o-mail-Thread-jumpPresent", {
         text: "You're viewing older messagesJump to Present",
     });
     await click(".o-mail-Thread-jumpPresent");
-    await contains(".o-mail-Thread-jumpPresent", 0, {
+    await contains(".o-mail-Thread-jumpPresent", {
+        count: 0,
         text: "You're viewing older messagesJump to Present",
     });
 
-    await contains(".o-mail-Message", 30);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
 });

--- a/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
@@ -44,7 +44,7 @@ QUnit.test("Basic jump to present when scrolling to outdated messages", async (a
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
-QUnit.test("Jump to old reply should prompt jump to presence", async (assert) => {
+QUnit.test("Jump to old reply should prompt jump to presence", async () => {
     // make scroll behavior instantaneous.
     patchWithCleanup(Element.prototype, {
         scrollIntoView() {
@@ -84,21 +84,12 @@ QUnit.test("Jump to old reply should prompt jump to presence", async (assert) =>
     await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
     await contains(".o-mail-Message", { count: 46 });
-    assert.isVisible((await contains(".o-mail-Message:contains(Hello world!):eq(0)"))[0]);
-    assert.strictEqual(
-        $(".o-mail-Message-body:contains(Hello world!):eq(0)").text(),
-        "Hello world!",
-        "should correctly execute HTML tags in parent message when using 'load around' feature"
-    );
+    await contains(".o-mail-Message-content:eq(0)", { text: "Hello world!" });
     await contains(".o-mail-Thread-jumpPresent", {
         text: "You're viewing older messagesJump to Present",
     });
     await click(".o-mail-Thread-jumpPresent");
-    await contains(".o-mail-Thread-jumpPresent", {
-        count: 0,
-        text: "You're viewing older messagesJump to Present",
-    });
-
+    await contains(".o-mail-Thread-jumpPresent", { count: 0 });
     await contains(".o-mail-Message", { count: 30 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
 });

--- a/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
@@ -33,9 +33,13 @@ QUnit.test("Basic jump to present when scrolling to outdated messages", async (a
     );
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Thread:contains(You're viewing older messagesJump to Present)");
+    await contains(".o-mail-Thread-jumpPresent", 1, {
+        text: "You're viewing older messagesJump to Present",
+    });
     await click(".o-mail-Thread-jumpPresent");
-    await contains(".o-mail-Thread:contains(You're viewing older messagesJump to Present)", 0);
+    await contains(".o-mail-Thread-jumpPresent", 0, {
+        text: "You're viewing older messagesJump to Present",
+    });
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
 });
 
@@ -85,9 +89,14 @@ QUnit.test("Jump to old reply should prompt jump to presence", async (assert) =>
         "Hello world!",
         "should correctly execute HTML tags in parent message when using 'load around' feature"
     );
-    await contains(".o-mail-Thread:contains(You're viewing older messagesJump to Present)");
+    await contains(".o-mail-Thread-jumpPresent", 1, {
+        text: "You're viewing older messagesJump to Present",
+    });
     await click(".o-mail-Thread-jumpPresent");
-    await contains(".o-mail-Thread:contains(You're viewing older messagesJump to Present)", 0);
+    await contains(".o-mail-Thread-jumpPresent", 0, {
+        text: "You're viewing older messagesJump to Present",
+    });
+
     await contains(".o-mail-Message", 30);
     await contains(".o-mail-Thread", 1, { scroll: "bottom" });
 });

--- a/addons/mail/static/tests/discuss_app/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss_app/sidebar_tests.js
@@ -23,7 +23,7 @@ QUnit.test("toggling category button hide category items", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button.o-active:contains('Inbox')");
+    await contains("button.o-active", 1, { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel");
 
     await click(".o-mail-DiscussSidebarCategory-icon:eq(0)");
@@ -99,7 +99,7 @@ QUnit.test("channel - command: should have view command when category is folded"
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarCategory-channel span:contains(Channels)");
+    await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
     await contains("i[title='View or join channels']");
 });
 
@@ -117,7 +117,7 @@ QUnit.test("channel - command: should not have add command when category is fold
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory:contains(Channels)");
+    await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
     await contains("i[title='Add or join a channel']", 0);
 });
 
@@ -130,9 +130,9 @@ QUnit.test("channel - states: close manually by clicking the title", async () =>
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel:contains(general)");
-    await click(".o-mail-DiscussSidebarCategory-channel span:contains(Channels)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(general)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "general" });
+    await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "general" });
 });
 
 QUnit.test("channel - states: open manually by clicking the title", async () => {
@@ -144,10 +144,11 @@ QUnit.test("channel - states: open manually by clicking the title", async () => 
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-channel span:contains(Channels)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(general)", 0);
-    await click(".o-mail-DiscussSidebarCategory-channel span:contains(Channels)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(general)");
+    await contains(".o-mail-DiscussSidebarCategory-channel span", 1, { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "general" });
+
+    await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "general" });
 });
 
 QUnit.test("sidebar: inbox with counter", async () => {
@@ -158,7 +159,7 @@ QUnit.test("sidebar: inbox with counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox) .badge:contains(1)");
+    await contains("button:contains(Inbox) .badge", 1, { text: "1" });
 });
 
 QUnit.test("default thread rendering", async () => {
@@ -166,30 +167,32 @@ QUnit.test("default thread rendering", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox)");
-    await contains("button:contains(Starred)");
-    await contains("button:contains(History)");
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
+    await contains("button div", 1, { text: "Inbox" });
+    await contains("button div", 1, { text: "Starred" });
+    await contains("button div", 1, { text: "History" });
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
     await contains("button:contains(Inbox).o-active");
     await contains(
         ".o-mail-Thread:contains(Congratulations, your inbox is empty  New messages appear here.)"
     );
 
-    await click("button:contains(Starred)");
+    await click("button", { text: "Starred" });
     await contains("button:contains(Starred).o-active");
     await contains(
         ".o-mail-Thread:contains(No starred messages  You can mark any message as 'starred', and it shows up in this mailbox.)"
     );
 
-    await click("button:contains(History)");
+    await click("button div", { text: "History" });
     await contains("button:contains(History).o-active");
     await contains(
         ".o-mail-Thread:contains(No history messages  Messages marked as read will appear in the history.)"
     );
 
-    await click(".o-mail-DiscussSidebarChannel:contains(General)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel:contains(General).o-active");
-    await contains(".o-mail-Thread:contains(There are no messages in this conversation.)");
+    await contains(".o-mail-Thread .o-mail-Thread-empty", 1, {
+        text: "There are no messages in this conversation.",
+    });
 });
 
 QUnit.test("sidebar quick search at 20 or more pinned channels", async () => {
@@ -199,22 +202,22 @@ QUnit.test("sidebar quick search at 20 or more pinned channels", async () => {
     }
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel", 20);
+    await contains(".o-mail-DiscussSidebarChannel span", 20);
     await contains(".o-mail-DiscussSidebar input[placeholder='Quick search...']");
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "1");
-    await contains(".o-mail-DiscussSidebarChannel", 11);
+    await contains(".o-mail-DiscussSidebarChannel span", 11);
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "12", {
         replace: true,
     });
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel:contains(channel12)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "channel12" });
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "123", {
         replace: true,
     });
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0);
 });
 
 QUnit.test("sidebar: basic chat rendering", async () => {
@@ -230,7 +233,7 @@ QUnit.test("sidebar: basic chat rendering", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel span:contains(Demo)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Demo" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands div[title='Unpin Conversation']"
@@ -243,7 +246,7 @@ QUnit.test("sidebar: show pinned channel", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
 });
 
 QUnit.test("sidebar: open pinned channel", async () => {
@@ -251,7 +254,7 @@ QUnit.test("sidebar: open pinned channel", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel:contains(General)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-Composer-input[placeholder='Message #General…']");
     await contains(".o-mail-Discuss-threadName", 1, { value: "General" });
 });
@@ -277,12 +280,13 @@ QUnit.test("sidebar: open channel and leave it", async (assert) => {
         },
     });
     openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel:contains(General)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     assert.verifySteps([]);
 
     await click(".o-mail-DiscussSidebarChannel:contains(General) .btn[title='Leave this channel']");
     assert.verifySteps(["action_unfollow"]);
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+
     await contains(".o-mail-Discuss-threadName", 0, { value: "General" });
 });
 
@@ -291,16 +295,17 @@ QUnit.test("sidebar: unpin channel from bus", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
 
-    await click(".o-mail-DiscussSidebarChannel:contains(General)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-Composer-input[placeholder='Message #General…']");
     await contains(".o-mail-Discuss-threadName", 1, { value: "General" });
 
     // Simulate receiving a leave channel notification
     // (e.g. from user interaction from another device or browser tab)
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "discuss.channel/unpin", { id: channelId });
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+
     await contains(".o-mail-Discuss-threadName", 0, { value: "General" });
 });
 
@@ -328,7 +333,7 @@ QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async (
     await contains(".o-discuss-badge");
     assert.strictEqual($(".o-discuss-badge").text(), "1");
 
-    await click(".o-mail-DiscussSidebarChannel:contains(Demo)");
+    await click(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
     await contains(".o-discuss-badge", 0);
 });
 
@@ -362,7 +367,7 @@ QUnit.test(
         pyEnv["discuss.channel"].create({ name: "general" });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels)");
+        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
         await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 0);
     }
 );
@@ -405,7 +410,7 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels)");
+        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
         await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 0);
     }
 );
@@ -421,7 +426,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels)");
+        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
         await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 0);
     }
 );
@@ -464,7 +469,9 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge:contains(2)");
+        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 1, {
+            text: "2",
+        });
     }
 );
 
@@ -484,7 +491,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages)");
+        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", 0);
     }
 );
@@ -508,7 +515,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages)");
+        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", 0);
     }
 );
@@ -529,7 +536,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages)");
+        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", 0);
     }
 );
@@ -586,7 +593,7 @@ QUnit.test("chat - command: should not have add command when category is folded"
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages)");
+    await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
     await contains(
         ".o-mail-DiscussSidebarCategory:contains(Direct messages) i[title='Start a conversation']",
         0
@@ -631,7 +638,7 @@ QUnit.test("sidebar: public channel rendering", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(channel1)");
+    await contains("button", 1, { text: "channel1" });
     await contains("button:contains(channel1) .fa-globe");
 });
 
@@ -688,7 +695,7 @@ QUnit.test("channel - states: close should update the value on the server", asyn
         [[currentUserId]]
     );
     assert.ok(initalSettings.is_discuss_sidebar_category_channel_open);
-    await click(".o-mail-DiscussSidebarCategory span:contains(Channels)");
+    await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -714,7 +721,7 @@ QUnit.test("channel - states: open should update the value on the server", async
     );
     assert.notOk(initalSettings.is_discuss_sidebar_category_channel_open);
 
-    await click(".o-mail-DiscussSidebarCategory span:contains(Channels)");
+    await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -741,7 +748,7 @@ QUnit.test("channel - states: close from the bus", async () => {
         });
     });
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
-    await contains("button:contains(channel1)", 0);
+    await contains("button", 0, { text: "channel1" });
 });
 
 QUnit.test("channel - states: open from the bus", async () => {
@@ -762,7 +769,7 @@ QUnit.test("channel - states: open from the bus", async () => {
         });
     });
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-down");
-    await contains("button:contains(channel1)");
+    await contains("button", 1, { text: "channel1" });
 });
 
 QUnit.test(
@@ -772,15 +779,15 @@ QUnit.test(
         pyEnv["discuss.channel"].create({ name: "channel1" });
         const { openDiscuss } = await start();
         openDiscuss();
-        await click(".o-mail-DiscussSidebarChannel:contains(channel1)");
+        await click(".o-mail-DiscussSidebarChannel span", { text: "channel1" });
         await contains("button:contains(channel1).o-active");
 
-        await click(".o-mail-DiscussSidebarCategory span:contains(Channels)");
+        await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
         await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
-        await contains("button:contains(channel1)");
+        await contains("button", 1, { text: "channel1" });
 
-        await click("button:contains(Inbox)");
-        await contains("button:contains(channel1)", 0);
+        await click("button div", { text: "Inbox" });
+        await contains("button", 0, { text: "channel1" });
     }
 );
 
@@ -795,8 +802,8 @@ QUnit.test("chat - states: open manually by clicking the title", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarCategory-chat span:contains(Direct messages)");
-    await contains("button:contains(Mitchell Admin)");
+    await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
+    await contains("button", 1, { text: "Mitchell Admin" });
 });
 
 QUnit.test("chat - states: close should call update server data", async (assert) => {
@@ -816,7 +823,7 @@ QUnit.test("chat - states: close should call update server data", async (assert)
     );
     assert.ok(initalSettings.is_discuss_sidebar_category_chat_open);
 
-    await click(".o-mail-DiscussSidebarCategory-chat span:contains(Direct messages)");
+    await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -842,7 +849,7 @@ QUnit.test("chat - states: open should call update server data", async (assert) 
     );
     assert.notOk(initalSettings.is_discuss_sidebar_category_chat_open);
 
-    await click(".o-mail-DiscussSidebarCategory-chat span:contains(Direct messages)");
+    await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -867,7 +874,7 @@ QUnit.test("chat - states: close from the bus", async () => {
         },
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains("button:contains(Mitchell Admin)", 0);
+    await contains("button", 0, { text: "Mitchell Admin" });
 });
 
 QUnit.test("chat - states: open from the bus", async () => {
@@ -888,7 +895,7 @@ QUnit.test("chat - states: open from the bus", async () => {
         });
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains("button:contains(Mitchell Admin)");
+    await contains("button", 1, { text: "Mitchell Admin" });
 });
 
 QUnit.test(
@@ -899,18 +906,18 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss();
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-        await contains("button:contains(Mitchell Admin)");
+        await contains("button", 1, { text: "Mitchell Admin" });
 
-        await click("button:contains(Mitchell Admin)");
+        await click("button", { text: "Mitchell Admin" });
         await contains("button:contains(Mitchell Admin).o-active");
 
-        await click(".o-mail-DiscussSidebarCategory-chat span:contains(Direct messages)");
+        await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-        await contains("button:contains(Mitchell Admin)");
+        await contains("button", 1, { text: "Mitchell Admin" });
 
-        await click("button:contains(Inbox)");
+        await click("button div", { text: "Inbox" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-        await contains("button:contains(Mitchell Admin)", 0);
+        await contains("button", 0, { text: "Mitchell Admin" });
     }
 );
 
@@ -986,9 +993,9 @@ QUnit.test("Can unpin chat channel", async () => {
     pyEnv["discuss.channel"].create({ channel_type: "chat" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel:contains(Mitchell Admin)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o-mail-DiscussSidebarChannel:contains(Mitchell Admin)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "Mitchell Admin" });
 });
 
 QUnit.test("Unpinning chat should display notification", async () => {
@@ -997,7 +1004,7 @@ QUnit.test("Unpinning chat should display notification", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0);
     await contains(
         ".o_notification.border-info:contains(You unpinned your conversation with Mitchell Admin)"
     );
@@ -1008,9 +1015,9 @@ QUnit.test("Can leave channel", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)");
+    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
     await click("[title='Leave this channel']");
-    await contains(".o-mail-DiscussSidebarChannel:contains(General)", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
 });
 
 QUnit.test("Do no channel_info after unpin", async (assert) => {
@@ -1078,9 +1085,9 @@ QUnit.test("Unpinning channel closes its chat window", async () => {
     await openFormView("discuss.channel");
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow:contains(Sales)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Sales" });
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel:contains(Sales) [title='Leave this channel']");
     await openFormView("discuss.channel");
-    await contains(".o-mail-ChatWindow:contains(Sales)", 0);
+    await contains(".o-mail-ChatWindow", 0, { text: "Sales" });
 });

--- a/addons/mail/static/tests/discuss_app/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss_app/sidebar_tests.js
@@ -23,11 +23,11 @@ QUnit.test("toggling category button hide category items", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button.o-active", 1, { text: "Inbox" });
+    await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-DiscussSidebarChannel");
 
     await click(".o-mail-DiscussSidebarCategory-icon:eq(0)");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });
 
 QUnit.test("toggling category button does not hide active category items", async () => {
@@ -38,7 +38,7 @@ QUnit.test("toggling category button does not hide active category items", async
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-DiscussSidebarChannel", 2);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
     await contains(".o-mail-DiscussSidebarChannel.o-active");
 
     await click(".o-mail-DiscussSidebarCategory-icon:eq(0)");
@@ -117,8 +117,8 @@ QUnit.test("channel - command: should not have add command when category is fold
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
-    await contains("i[title='Add or join a channel']", 0);
+    await contains(".o-mail-DiscussSidebarCategory", { text: "Channels" });
+    await contains("i[title='Add or join a channel']", { count: 0 });
 });
 
 QUnit.test("channel - states: close manually by clicking the title", async () => {
@@ -130,9 +130,9 @@ QUnit.test("channel - states: close manually by clicking the title", async () =>
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "general" });
     await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "general" });
 });
 
 QUnit.test("channel - states: open manually by clicking the title", async () => {
@@ -144,11 +144,11 @@ QUnit.test("channel - states: open manually by clicking the title", async () => 
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-channel span", 1, { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "general" });
+    await contains(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "general" });
 
     await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "general" });
 });
 
 QUnit.test("sidebar: inbox with counter", async () => {
@@ -159,7 +159,7 @@ QUnit.test("sidebar: inbox with counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button:contains(Inbox) .badge", 1, { text: "1" });
+    await contains("button:contains(Inbox) .badge", { text: "1" });
 });
 
 QUnit.test("default thread rendering", async () => {
@@ -167,10 +167,10 @@ QUnit.test("default thread rendering", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button div", 1, { text: "Inbox" });
-    await contains("button div", 1, { text: "Starred" });
-    await contains("button div", 1, { text: "History" });
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains("button div", { text: "Inbox" });
+    await contains("button div", { text: "Starred" });
+    await contains("button div", { text: "History" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains("button:contains(Inbox).o-active");
     await contains(
         ".o-mail-Thread:contains(Congratulations, your inbox is empty  New messages appear here.)"
@@ -190,7 +190,7 @@ QUnit.test("default thread rendering", async () => {
 
     await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel:contains(General).o-active");
-    await contains(".o-mail-Thread .o-mail-Thread-empty", 1, {
+    await contains(".o-mail-Thread .o-mail-Thread-empty", {
         text: "There are no messages in this conversation.",
     });
 });
@@ -202,22 +202,22 @@ QUnit.test("sidebar quick search at 20 or more pinned channels", async () => {
     }
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 20);
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 20 });
     await contains(".o-mail-DiscussSidebar input[placeholder='Quick search...']");
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "1");
-    await contains(".o-mail-DiscussSidebarChannel span", 11);
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 11 });
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "12", {
         replace: true,
     });
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "channel12" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "channel12" });
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "123", {
         replace: true,
     });
-    await contains(".o-mail-DiscussSidebarChannel span", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0 });
 });
 
 QUnit.test("sidebar: basic chat rendering", async () => {
@@ -233,12 +233,12 @@ QUnit.test("sidebar: basic chat rendering", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands div[title='Unpin Conversation']"
     );
-    await contains(".o-mail-DiscussSidebarChannel .badge", 0);
+    await contains(".o-mail-DiscussSidebarChannel .badge", { count: 0 });
 });
 
 QUnit.test("sidebar: show pinned channel", async () => {
@@ -246,7 +246,7 @@ QUnit.test("sidebar: show pinned channel", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
 });
 
 QUnit.test("sidebar: open pinned channel", async () => {
@@ -256,7 +256,7 @@ QUnit.test("sidebar: open pinned channel", async () => {
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-Composer-input[placeholder='Message #General…']");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "General" });
+    await contains(".o-mail-Discuss-threadName", { value: "General" });
 });
 
 QUnit.test("sidebar: open channel and leave it", async (assert) => {
@@ -285,9 +285,9 @@ QUnit.test("sidebar: open channel and leave it", async (assert) => {
 
     await click(".o-mail-DiscussSidebarChannel:contains(General) .btn[title='Leave this channel']");
     assert.verifySteps(["action_unfollow"]);
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
 
-    await contains(".o-mail-Discuss-threadName", 0, { value: "General" });
+    await contains(".o-mail-Discuss-threadName", { count: 0, value: "General" });
 });
 
 QUnit.test("sidebar: unpin channel from bus", async () => {
@@ -295,18 +295,18 @@ QUnit.test("sidebar: unpin channel from bus", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
 
     await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await contains(".o-mail-Composer-input[placeholder='Message #General…']");
-    await contains(".o-mail-Discuss-threadName", 1, { value: "General" });
+    await contains(".o-mail-Discuss-threadName", { value: "General" });
 
     // Simulate receiving a leave channel notification
     // (e.g. from user interaction from another device or browser tab)
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "discuss.channel/unpin", { id: channelId });
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
 
-    await contains(".o-mail-Discuss-threadName", 0, { value: "General" });
+    await contains(".o-mail-Discuss-threadName", { count: 0, value: "General" });
 });
 
 QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async (assert) => {
@@ -334,7 +334,7 @@ QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async (
     assert.strictEqual($(".o-discuss-badge").text(), "1");
 
     await click(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
-    await contains(".o-discuss-badge", 0);
+    await contains(".o-discuss-badge", { count: 0 });
 });
 
 QUnit.test("mark channel as seen on last message visible [REQUIRE FOCUS]", async () => {
@@ -367,8 +367,8 @@ QUnit.test(
         pyEnv["discuss.channel"].create({ name: "general" });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 0);
+        await contains(".o-mail-DiscussSidebarCategory", { text: "Channels" });
+        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", { count: 0 });
     }
 );
 
@@ -410,8 +410,8 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 0);
+        await contains(".o-mail-DiscussSidebarCategory", { text: "Channels" });
+        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", { count: 0 });
     }
 );
 
@@ -426,8 +426,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Channels" });
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 0);
+        await contains(".o-mail-DiscussSidebarCategory", { text: "Channels" });
+        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", { count: 0 });
     }
 );
 
@@ -469,7 +469,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", 1, {
+        await contains(".o-mail-DiscussSidebarCategory:contains(Channels) .badge", {
             text: "2",
         });
     }
@@ -491,8 +491,10 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
-        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", 0);
+        await contains(".o-mail-DiscussSidebarCategory", { text: "Direct messages" });
+        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", {
+            count: 0,
+        });
     }
 );
 
@@ -515,8 +517,10 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
-        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", 0);
+        await contains(".o-mail-DiscussSidebarCategory", { text: "Direct messages" });
+        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", {
+            count: 0,
+        });
     }
 );
 
@@ -536,8 +540,10 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
-        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", 0);
+        await contains(".o-mail-DiscussSidebarCategory", { text: "Direct messages" });
+        await contains(".o-mail-DiscussSidebarCategory:contains(Direct messages) .badge", {
+            count: 0,
+        });
     }
 );
 
@@ -593,10 +599,10 @@ QUnit.test("chat - command: should not have add command when category is folded"
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory", 1, { text: "Direct messages" });
+    await contains(".o-mail-DiscussSidebarCategory", { text: "Direct messages" });
     await contains(
         ".o-mail-DiscussSidebarCategory:contains(Direct messages) i[title='Start a conversation']",
-        0
+        { count: 0 }
     );
 });
 
@@ -611,7 +617,7 @@ QUnit.test("chat - states: close manually by clicking the title", async () => {
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
     await click(".o-mail-DiscussSidebarCategory:contains(Direct messages) div:eq(0)");
-    await contains(".o-mail-DiscussSidebarChannel", 0);
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });
 
 QUnit.test("sidebar channels should be ordered case insensitive alphabetically", async () => {
@@ -638,7 +644,7 @@ QUnit.test("sidebar: public channel rendering", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button", 1, { text: "channel1" });
+    await contains("button", { text: "channel1" });
     await contains("button:contains(channel1) .fa-globe");
 });
 
@@ -663,7 +669,7 @@ QUnit.test("channel - avatar: should update avatar url from bus", async (assert)
     openDiscuss(channelId);
     await contains(
         `img[data-src='${getOrigin()}/discuss/channel/${channelId}/avatar_128?unique=101010']`,
-        2
+        { count: 2 }
     );
     await afterNextRender(() => {
         env.services.orm.call("discuss.channel", "write", [
@@ -675,7 +681,7 @@ QUnit.test("channel - avatar: should update avatar url from bus", async (assert)
     const newCacheKey = result[0]["avatarCacheKey"];
     await contains(
         `img[data-src='${getOrigin()}/discuss/channel/${channelId}/avatar_128?unique=${newCacheKey}']`,
-        2
+        { count: 2 }
     );
 });
 
@@ -748,7 +754,7 @@ QUnit.test("channel - states: close from the bus", async () => {
         });
     });
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
-    await contains("button", 0, { text: "channel1" });
+    await contains("button", { count: 0, text: "channel1" });
 });
 
 QUnit.test("channel - states: open from the bus", async () => {
@@ -769,7 +775,7 @@ QUnit.test("channel - states: open from the bus", async () => {
         });
     });
     await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-down");
-    await contains("button", 1, { text: "channel1" });
+    await contains("button", { text: "channel1" });
 });
 
 QUnit.test(
@@ -784,10 +790,10 @@ QUnit.test(
 
         await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
         await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
-        await contains("button", 1, { text: "channel1" });
+        await contains("button", { text: "channel1" });
 
         await click("button div", { text: "Inbox" });
-        await contains("button", 0, { text: "channel1" });
+        await contains("button", { count: 0, text: "channel1" });
     }
 );
 
@@ -803,7 +809,7 @@ QUnit.test("chat - states: open manually by clicking the title", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
-    await contains("button", 1, { text: "Mitchell Admin" });
+    await contains("button", { text: "Mitchell Admin" });
 });
 
 QUnit.test("chat - states: close should call update server data", async (assert) => {
@@ -874,7 +880,7 @@ QUnit.test("chat - states: close from the bus", async () => {
         },
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-    await contains("button", 0, { text: "Mitchell Admin" });
+    await contains("button", { count: 0, text: "Mitchell Admin" });
 });
 
 QUnit.test("chat - states: open from the bus", async () => {
@@ -895,7 +901,7 @@ QUnit.test("chat - states: open from the bus", async () => {
         });
     });
     await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-    await contains("button", 1, { text: "Mitchell Admin" });
+    await contains("button", { text: "Mitchell Admin" });
 });
 
 QUnit.test(
@@ -906,18 +912,18 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss();
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-down");
-        await contains("button", 1, { text: "Mitchell Admin" });
+        await contains("button", { text: "Mitchell Admin" });
 
         await click("button", { text: "Mitchell Admin" });
         await contains("button:contains(Mitchell Admin).o-active");
 
         await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-        await contains("button", 1, { text: "Mitchell Admin" });
+        await contains("button", { text: "Mitchell Admin" });
 
         await click("button div", { text: "Inbox" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
-        await contains("button", 0, { text: "Mitchell Admin" });
+        await contains("button", { count: 0, text: "Mitchell Admin" });
     }
 );
 
@@ -993,9 +999,9 @@ QUnit.test("Can unpin chat channel", async () => {
     pyEnv["discuss.channel"].create({ channel_type: "chat" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "Mitchell Admin" });
 });
 
 QUnit.test("Unpinning chat should display notification", async () => {
@@ -1004,7 +1010,7 @@ QUnit.test("Unpinning chat should display notification", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o-mail-DiscussSidebarChannel span", 0);
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0 });
     await contains(
         ".o_notification.border-info:contains(You unpinned your conversation with Mitchell Admin)"
     );
@@ -1015,9 +1021,9 @@ QUnit.test("Can leave channel", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-DiscussSidebarChannel span", 1, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
     await click("[title='Leave this channel']");
-    await contains(".o-mail-DiscussSidebarChannel span", 0, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
 });
 
 QUnit.test("Do no channel_info after unpin", async (assert) => {
@@ -1075,7 +1081,7 @@ QUnit.test("Group unread counter up to date after mention is marked as seen", as
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel .o-discuss-badge");
     click(".o-mail-DiscussSidebarChannel");
-    await contains(".o-discuss-badge", 0);
+    await contains(".o-discuss-badge", { count: 0 });
 });
 
 QUnit.test("Unpinning channel closes its chat window", async () => {
@@ -1085,9 +1091,9 @@ QUnit.test("Unpinning channel closes its chat window", async () => {
     await openFormView("discuss.channel");
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Sales" });
+    await contains(".o-mail-ChatWindow-name", { text: "Sales" });
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel:contains(Sales) [title='Leave this channel']");
     await openFormView("discuss.channel");
-    await contains(".o-mail-ChatWindow", 0, { text: "Sales" });
+    await contains(".o-mail-ChatWindow", { count: 0, text: "Sales" });
 });

--- a/addons/mail/static/tests/discuss_app/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss_app/sidebar_tests.js
@@ -309,7 +309,7 @@ QUnit.test("sidebar: unpin channel from bus", async () => {
     await contains(".o-mail-Discuss-threadName", { count: 0, value: "General" });
 });
 
-QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async (assert) => {
+QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         name: "Demo",
@@ -330,9 +330,7 @@ QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async (
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-discuss-badge");
-    assert.strictEqual($(".o-discuss-badge").text(), "1");
-
+    await contains(".o-discuss-badge", { text: "1" });
     await click(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
     await contains(".o-discuss-badge", { count: 0 });
 });

--- a/addons/mail/static/tests/emoji/emoji_tests.js
+++ b/addons/mail/static/tests/emoji/emoji_tests.js
@@ -14,7 +14,7 @@ QUnit.test("search emoji from keywords", async () => {
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "mexican");
-    await contains(".o-Emoji:contains(🌮)");
+    await contains(".o-Emoji", 1, { text: "🌮" });
 });
 
 QUnit.test("search emoji from keywords should be case insensitive", async () => {
@@ -24,7 +24,7 @@ QUnit.test("search emoji from keywords should be case insensitive", async () => 
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "ok");
-    await contains(".o-Emoji:contains(🆗)"); // all search terms are uppercase OK
+    await contains(".o-Emoji", 1, { text: "🆗" }); // all search terms are uppercase OK
 });
 
 QUnit.test("search emoji from keywords with special regex character", async () => {
@@ -34,7 +34,7 @@ QUnit.test("search emoji from keywords with special regex character", async () =
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "(blood");
-    await contains(".o-Emoji:contains(🆎)");
+    await contains(".o-Emoji", 1, { text: "🆎" });
 });
 
 QUnit.test("Press Escape in emoji picker closes the emoji picker", async () => {
@@ -75,7 +75,7 @@ QUnit.test("recent category (basic)", async () => {
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await contains(".o-EmojiPicker-navbar [title='Frequently used']", 0);
-    await click(".o-EmojiPicker-content .o-Emoji:contains(😀)");
+    await click(".o-EmojiPicker-content .o-Emoji", { text: "😀" });
     await click("button[aria-label='Emojis']");
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
     await contains(
@@ -89,11 +89,11 @@ QUnit.test("emoji usage amount orders frequent emojis", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
-    await click(".o-EmojiPicker-content .o-Emoji:contains(😀)");
+    await click(".o-EmojiPicker-content .o-Emoji", { text: "😀" });
     await click("button[aria-label='Emojis']");
-    await click(".o-EmojiPicker-content .o-Emoji:contains(👽)");
+    await click(".o-EmojiPicker-content .o-Emoji", { text: "👽" });
     await click("button[aria-label='Emojis']");
-    await click(".o-EmojiPicker-content .o-Emoji:contains(👽)");
+    await click(".o-EmojiPicker-content .o-Emoji", { text: "👽" });
     await click("button[aria-label='Emojis']");
     await contains(
         "span:contains(Frequently used) ~ .o-Emoji:contains(😀) ~ span:contains(Smileys & Emotion)"

--- a/addons/mail/static/tests/emoji/emoji_tests.js
+++ b/addons/mail/static/tests/emoji/emoji_tests.js
@@ -14,7 +14,7 @@ QUnit.test("search emoji from keywords", async () => {
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "mexican");
-    await contains(".o-Emoji", 1, { text: "🌮" });
+    await contains(".o-Emoji", { text: "🌮" });
 });
 
 QUnit.test("search emoji from keywords should be case insensitive", async () => {
@@ -24,7 +24,7 @@ QUnit.test("search emoji from keywords should be case insensitive", async () => 
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "ok");
-    await contains(".o-Emoji", 1, { text: "🆗" }); // all search terms are uppercase OK
+    await contains(".o-Emoji", { text: "🆗" }); // all search terms are uppercase OK
 });
 
 QUnit.test("search emoji from keywords with special regex character", async () => {
@@ -34,7 +34,7 @@ QUnit.test("search emoji from keywords with special regex character", async () =
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     await insertText("input[placeholder='Search for an emoji']", "(blood");
-    await contains(".o-Emoji", 1, { text: "🆎" });
+    await contains(".o-Emoji", { text: "🆎" });
 });
 
 QUnit.test("Press Escape in emoji picker closes the emoji picker", async () => {
@@ -44,7 +44,7 @@ QUnit.test("Press Escape in emoji picker closes the emoji picker", async () => {
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
     triggerHotkey("Escape");
-    await contains(".o-EmojiPicker", 0);
+    await contains(".o-EmojiPicker", { count: 0 });
 });
 
 QUnit.test("Basic keyboard navigation", async () => {
@@ -64,8 +64,8 @@ QUnit.test("Basic keyboard navigation", async () => {
     await contains(".o-EmojiPicker-content .o-Emoji[data-index=0].bg-200");
     const codepoints = $(".o-EmojiPicker-content .o-Emoji[data-index=0].bg-200").data("codepoints");
     triggerHotkey("Enter");
-    await contains(".o-EmojiPicker", 0);
-    await contains(".o-mail-Composer-input", 1, { value: codepoints });
+    await contains(".o-EmojiPicker", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: codepoints });
 });
 
 QUnit.test("recent category (basic)", async () => {
@@ -74,7 +74,7 @@ QUnit.test("recent category (basic)", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("button[aria-label='Emojis']");
-    await contains(".o-EmojiPicker-navbar [title='Frequently used']", 0);
+    await contains(".o-EmojiPicker-navbar [title='Frequently used']", { count: 0 });
     await click(".o-EmojiPicker-content .o-Emoji", { text: "😀" });
     await click("button[aria-label='Emojis']");
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
@@ -155,6 +155,6 @@ QUnit.test(
         );
         await contains(".o-EmojiPicker-navbar [title='Frequently used']");
         await contains(".o-EmojiPicker");
-        await contains(".o-mail-Composer-input", 1, { value: "👺" });
+        await contains(".o-mail-Composer-input", { value: "👺" });
     }
 );

--- a/addons/mail/static/tests/gif_picker/gif_picker_test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker_test.js
@@ -113,7 +113,7 @@ QUnit.test("Searching for a GIF", async () => {
     await click("button[aria-label='GIFs']");
     insertText((await contains("input[placeholder='Search for a gif']"))[0], "search");
     await contains("i[aria-label='back']");
-    await contains(".o-discuss-Gif", 2);
+    await contains(".o-discuss-Gif", { count: 2 });
 });
 
 QUnit.test("Open a GIF category trigger the search for the category", async () => {
@@ -132,8 +132,8 @@ QUnit.test("Open a GIF category trigger the search for the category", async () =
     openDiscuss(channelId);
     await click("button[aria-label='GIFs']");
     await click("img[data-src='https://media.tenor.com/6uIlQAHIkNoAAAAM/cry.gif']");
-    await contains(".o-discuss-Gif", 2);
-    await contains("input[placeholder='Search for a gif']", 1, { value: "cry" });
+    await contains(".o-discuss-Gif", { count: 2 });
+    await contains("input[placeholder='Search for a gif']", { value: "cry" });
 });
 
 QUnit.test("Reopen GIF category list when going back", async () => {
@@ -184,7 +184,7 @@ QUnit.test("Chatter should not have the GIF button", async () => {
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     openFormView("res.partner", partnerId);
     await click("button", { text: "Log note" });
-    await contains("button[aria-label='GIFs']", 0);
+    await contains("button[aria-label='GIFs']", { count: 0 });
 });
 
 QUnit.test(
@@ -197,7 +197,7 @@ QUnit.test(
         openDiscuss(channelId, { waitUntilMessagesLoaded: false });
         await click("span", { text: "General" });
         await click("button[aria-label='GIFs']");
-        await contains(".popover .o-discuss-GifPicker", 0);
+        await contains(".popover .o-discuss-GifPicker", { count: 0 });
         await contains(".o-mail-Composer-footer .o-discuss-GifPicker");
     }
 );

--- a/addons/mail/static/tests/gif_picker/gif_picker_test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker_test.js
@@ -175,7 +175,7 @@ QUnit.test("Add GIF to favorite", async () => {
     await click(".o-discuss-Gif .fa-star-o:eq(0)");
     await contains(".o-discuss-Gif .fa-star");
     await click("i[aria-label='back']");
-    await click(".o-discuss-GifPicker div[aria-label='list-item']:contains(Favorites)");
+    await click(".o-discuss-GifPicker div[aria-label='list-item']", { text: "Favorites" });
     await contains(".o-discuss-Gif");
 });
 
@@ -183,7 +183,7 @@ QUnit.test("Chatter should not have the GIF button", async () => {
     const { openFormView, pyEnv } = await start();
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     openFormView("res.partner", partnerId);
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains("button[aria-label='GIFs']", 0);
 });
 
@@ -195,7 +195,7 @@ QUnit.test(
         patchUiSize({ size: SIZES.SM });
         const { openDiscuss } = await start();
         openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-        await click("span:contains(General)");
+        await click("span", { text: "General" });
         await click("button[aria-label='GIFs']");
         await contains(".popover .o-discuss-GifPicker", 0);
         await contains(".o-mail-Composer-footer .o-discuss-GifPicker");

--- a/addons/mail/static/tests/helpers/test_utils.js
+++ b/addons/mail/static/tests/helpers/test_utils.js
@@ -614,7 +614,7 @@ export {
  * @param {Object} [options={}] forwarded to `contains`
  */
 export async function click(selector, options) {
-    await contains(selector, 1, { click: true, ...options });
+    await contains(selector, { click: true, ...options });
 }
 
 /**
@@ -626,7 +626,7 @@ export async function click(selector, options) {
  * @param {Object} [options={}] forwarded to `contains`
  */
 export async function scroll(selector, scrollTop, options) {
-    await contains(selector, 1, { setScroll: scrollTop, ...options });
+    await contains(selector, { setScroll: scrollTop, ...options });
 }
 
 let hasUsedContainsPositively = false;
@@ -636,9 +636,9 @@ QUnit.testStart(() => (hasUsedContainsPositively = false));
  * `options.target`.
  *
  * @param {string} selector
- * @param {number} [count=1]
  * @param {Object} [options={}]
  * @param {boolean} [options.click] if provided, clicks on the found element
+ * @param {number} [count=1]
  * @param {number|"bottom"} [options.scroll] if provided, the scrollTop of the found element(s)
  *  must match.
  *  Note: when using one of the scrollTop options, it is advised to ensure the height is not going
@@ -652,8 +652,7 @@ QUnit.testStart(() => (hasUsedContainsPositively = false));
  */
 export function contains(
     selector,
-    count = 1,
-    { click, scroll, setScroll, target = getFixture(), text, value } = {}
+    { click, count = 1, scroll, setScroll, target = getFixture(), text, value } = {}
 ) {
     if (count) {
         hasUsedContainsPositively = true;

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -107,8 +107,8 @@ QUnit.test("url", async () => {
     // see: https://www.ietf.org/rfc/rfc1738.txt
     const messageBody = "https://odoo.com?test=~^|`{}[]#";
     await insertText(".o-mail-Composer-input", messageBody);
-    await click("button:contains(Send):not(:disabled)");
-    await contains(`.o-mail-Message a:contains(${messageBody})`);
+    await click("button:not(:disabled)", { text: "Send" });
+    await contains(".o-mail-Message a", 1, { text: messageBody });
 });
 
 QUnit.test("url with comma at the end", async () => {
@@ -118,9 +118,9 @@ QUnit.test("url with comma at the end", async () => {
     await openDiscuss(channelId);
     const messageBody = "Go to https://odoo.com, it's great!";
     await insertText(".o-mail-Composer-input", messageBody);
-    await click("button:contains(Send):not(:disabled)");
-    await contains(`.o-mail-Message a:contains(https://odoo.com)`);
-    await contains(`.o-mail-Message:contains(${messageBody})`);
+    await click("button:not(:disabled)", { text: "Send" });
+    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", 1, { text: messageBody });
 });
 
 QUnit.test("url with dot at the end", async () => {
@@ -130,9 +130,9 @@ QUnit.test("url with dot at the end", async () => {
     await openDiscuss(channelId);
     const messageBody = "Go to https://odoo.com. It's great!";
     await insertText(".o-mail-Composer-input", messageBody);
-    await click("button:contains(Send):not(:disabled)");
-    await contains(`.o-mail-Message a:contains(https://odoo.com)`);
-    await contains(`.o-mail-Message:contains(${messageBody})`);
+    await click("button:not(:disabled)", { text: "Send" });
+    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", 1, { text: messageBody });
 });
 
 QUnit.test("url with semicolon at the end", async () => {
@@ -142,9 +142,9 @@ QUnit.test("url with semicolon at the end", async () => {
     await openDiscuss(channelId);
     const messageBody = "Go to https://odoo.com; it's great!";
     await insertText(".o-mail-Composer-input", messageBody);
-    await click("button:contains(Send):not(:disabled)");
-    await contains(`.o-mail-Message a:contains(https://odoo.com)`);
-    await contains(`.o-mail-Message:contains(${messageBody})`);
+    await click("button:not(:disabled)", { text: "Send" });
+    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", 1, { text: messageBody });
 });
 
 QUnit.test("url with ellipsis at the end", async () => {
@@ -154,9 +154,9 @@ QUnit.test("url with ellipsis at the end", async () => {
     await openDiscuss(channelId);
     const messageBody = "Go to https://odoo.com... it's great!";
     await insertText(".o-mail-Composer-input", messageBody);
-    await click("button:contains(Send):not(:disabled)");
-    await contains(`.o-mail-Message a:contains(https://odoo.com)`);
-    await contains(`.o-mail-Message:contains(${messageBody})`);
+    await click("button:not(:disabled)", { text: "Send" });
+    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", 1, { text: messageBody });
 });
 
 QUnit.test("url with number in subdomain", async () => {
@@ -166,8 +166,8 @@ QUnit.test("url with number in subdomain", async () => {
     await openDiscuss(channelId);
     const messageBody = "https://www.45017478-master-all.runbot134.odoo.com/web";
     await insertText(".o-mail-Composer-input", messageBody);
-    await click("button:contains(Send):not(:disabled)");
-    await contains(
-        `.o-mail-Message a:contains(https://www.45017478-master-all.runbot134.odoo.com/web)`
-    );
+    await click("button:not(:disabled)", { text: "Send" });
+    await contains(".o-mail-Message a", 1, {
+        text: "https://www.45017478-master-all.runbot134.odoo.com/web",
+    });
 });

--- a/addons/mail/static/tests/mail_utils_tests.js
+++ b/addons/mail/static/tests/mail_utils_tests.js
@@ -76,7 +76,7 @@ QUnit.test("addLink: linkify inside text node (1 occurrence)", async (assert) =>
     fragment.appendChild(div);
     div.innerHTML = linkified;
     assert.strictEqual(div.textContent, "some text https://somelink.com");
-    await contains("a", 1, { target: div });
+    await contains("a", { target: div });
     assert.strictEqual(div.querySelector(":scope a").textContent, "https://somelink.com");
 });
 
@@ -108,7 +108,7 @@ QUnit.test("url", async () => {
     const messageBody = "https://odoo.com?test=~^|`{}[]#";
     await insertText(".o-mail-Composer-input", messageBody);
     await click("button:not(:disabled)", { text: "Send" });
-    await contains(".o-mail-Message a", 1, { text: messageBody });
+    await contains(".o-mail-Message a", { text: messageBody });
 });
 
 QUnit.test("url with comma at the end", async () => {
@@ -119,8 +119,8 @@ QUnit.test("url with comma at the end", async () => {
     const messageBody = "Go to https://odoo.com, it's great!";
     await insertText(".o-mail-Composer-input", messageBody);
     await click("button:not(:disabled)", { text: "Send" });
-    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
-    await contains(".o-mail-Message-content", 1, { text: messageBody });
+    await contains(".o-mail-Message a", { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", { text: messageBody });
 });
 
 QUnit.test("url with dot at the end", async () => {
@@ -131,8 +131,8 @@ QUnit.test("url with dot at the end", async () => {
     const messageBody = "Go to https://odoo.com. It's great!";
     await insertText(".o-mail-Composer-input", messageBody);
     await click("button:not(:disabled)", { text: "Send" });
-    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
-    await contains(".o-mail-Message-content", 1, { text: messageBody });
+    await contains(".o-mail-Message a", { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", { text: messageBody });
 });
 
 QUnit.test("url with semicolon at the end", async () => {
@@ -143,8 +143,8 @@ QUnit.test("url with semicolon at the end", async () => {
     const messageBody = "Go to https://odoo.com; it's great!";
     await insertText(".o-mail-Composer-input", messageBody);
     await click("button:not(:disabled)", { text: "Send" });
-    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
-    await contains(".o-mail-Message-content", 1, { text: messageBody });
+    await contains(".o-mail-Message a", { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", { text: messageBody });
 });
 
 QUnit.test("url with ellipsis at the end", async () => {
@@ -155,8 +155,8 @@ QUnit.test("url with ellipsis at the end", async () => {
     const messageBody = "Go to https://odoo.com... it's great!";
     await insertText(".o-mail-Composer-input", messageBody);
     await click("button:not(:disabled)", { text: "Send" });
-    await contains(".o-mail-Message a", 1, { text: "https://odoo.com" });
-    await contains(".o-mail-Message-content", 1, { text: messageBody });
+    await contains(".o-mail-Message a", { text: "https://odoo.com" });
+    await contains(".o-mail-Message-content", { text: messageBody });
 });
 
 QUnit.test("url with number in subdomain", async () => {
@@ -167,7 +167,7 @@ QUnit.test("url with number in subdomain", async () => {
     const messageBody = "https://www.45017478-master-all.runbot134.odoo.com/web";
     await insertText(".o-mail-Composer-input", messageBody);
     await click("button:not(:disabled)", { text: "Send" });
-    await contains(".o-mail-Message a", 1, {
+    await contains(".o-mail-Message a", {
         text: "https://www.45017478-master-all.runbot134.odoo.com/web",
     });
 });

--- a/addons/mail/static/tests/message/link_preview_test.js
+++ b/addons/mail/static/tests/message/link_preview_test.js
@@ -75,8 +75,8 @@ QUnit.test("simplest card layout", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewCard");
-    await contains(".o-mail-LinkPreviewCard h6", 1, { text: "Article title" });
-    await contains(".o-mail-LinkPreviewCard p", 1, { text: "Description" });
+    await contains(".o-mail-LinkPreviewCard h6", { text: "Article title" });
+    await contains(".o-mail-LinkPreviewCard p", { text: "Description" });
 });
 
 QUnit.test("simplest card layout with image", async () => {
@@ -99,8 +99,8 @@ QUnit.test("simplest card layout with image", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewCard");
-    await contains(".o-mail-LinkPreviewCard h6", 1, { text: "Article title" });
-    await contains(".o-mail-LinkPreviewCard p", 1, { text: "Description" });
+    await contains(".o-mail-LinkPreviewCard h6", { text: "Article title" });
+    await contains(".o-mail-LinkPreviewCard p", { text: "Description" });
     await contains(".o-mail-LinkPreviewCard img");
 });
 
@@ -124,8 +124,8 @@ QUnit.test("Link preview video layout", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewVideo");
-    await contains(".o-mail-LinkPreviewVideo h6", 1, { text: "video title" });
-    await contains(".o-mail-LinkPreviewVideo p", 1, { text: "Description" });
+    await contains(".o-mail-LinkPreviewVideo h6", { text: "video title" });
+    await contains(".o-mail-LinkPreviewVideo p", { text: "Description" });
     await contains(".o-mail-LinkPreviewVideo-overlay");
 });
 
@@ -170,9 +170,9 @@ QUnit.test("Remove link preview Gif", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
-    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await contains("p", { text: "Do you really want to delete this preview?" });
     await click(".modal-footer button", { text: "Ok" });
-    await contains(".o-mail-LinkPreviewImage", 0);
+    await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });
 
 QUnit.test("Remove link preview card", async () => {
@@ -194,9 +194,9 @@ QUnit.test("Remove link preview card", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewCard button[aria-label='Remove']");
-    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await contains("p", { text: "Do you really want to delete this preview?" });
     await click(".modal-footer button", { text: "Ok" });
-    await contains(".o-mail-LinkPreviewCard", 0);
+    await contains(".o-mail-LinkPreviewCard", { count: 0 });
 });
 
 QUnit.test("Remove link preview video", async () => {
@@ -219,9 +219,9 @@ QUnit.test("Remove link preview video", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewVideo button[aria-label='Remove']");
-    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await contains("p", { text: "Do you really want to delete this preview?" });
     await click(".modal-footer button", { text: "Ok" });
-    await contains(".o-mail-LinkPreviewVideo", 0);
+    await contains(".o-mail-LinkPreviewVideo", { count: 0 });
 });
 
 QUnit.test("Remove link preview image", async () => {
@@ -242,9 +242,9 @@ QUnit.test("Remove link preview image", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
-    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await contains("p", { text: "Do you really want to delete this preview?" });
     await click(".modal-footer button", { text: "Ok" });
-    await contains(".o-mail-LinkPreviewImage", 0);
+    await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });
 
 QUnit.test("No crash on receiving link preview of non-known message", async (assert) => {
@@ -292,7 +292,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await contains(".o-mail-LinkPreviewImage");
-        await contains(".o-mail-Message-bubble", 0);
+        await contains(".o-mail-Message-bubble", { count: 0 });
     }
 );
 

--- a/addons/mail/static/tests/message/link_preview_test.js
+++ b/addons/mail/static/tests/message/link_preview_test.js
@@ -75,8 +75,8 @@ QUnit.test("simplest card layout", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewCard");
-    await contains(".o-mail-LinkPreviewCard:contains(Article title)");
-    await contains(".o-mail-LinkPreviewCard:contains(Description)");
+    await contains(".o-mail-LinkPreviewCard h6", 1, { text: "Article title" });
+    await contains(".o-mail-LinkPreviewCard p", 1, { text: "Description" });
 });
 
 QUnit.test("simplest card layout with image", async () => {
@@ -99,8 +99,8 @@ QUnit.test("simplest card layout with image", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewCard");
-    await contains(".o-mail-LinkPreviewCard:contains(Article title)");
-    await contains(".o-mail-LinkPreviewCard:contains(Description)");
+    await contains(".o-mail-LinkPreviewCard h6", 1, { text: "Article title" });
+    await contains(".o-mail-LinkPreviewCard p", 1, { text: "Description" });
     await contains(".o-mail-LinkPreviewCard img");
 });
 
@@ -124,8 +124,8 @@ QUnit.test("Link preview video layout", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-LinkPreviewVideo");
-    await contains(".o-mail-LinkPreviewVideo:contains(video title)");
-    await contains(".o-mail-LinkPreviewVideo:contains(Description)");
+    await contains(".o-mail-LinkPreviewVideo h6", 1, { text: "video title" });
+    await contains(".o-mail-LinkPreviewVideo p", 1, { text: "Description" });
     await contains(".o-mail-LinkPreviewVideo-overlay");
 });
 
@@ -170,8 +170,8 @@ QUnit.test("Remove link preview Gif", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
-    await contains("p:contains(Do you really want to delete this preview?)");
-    await click(".modal-footer button:contains(Ok)");
+    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await click(".modal-footer button", { text: "Ok" });
     await contains(".o-mail-LinkPreviewImage", 0);
 });
 
@@ -194,8 +194,8 @@ QUnit.test("Remove link preview card", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewCard button[aria-label='Remove']");
-    await contains("p:contains(Do you really want to delete this preview?)");
-    await click(".modal-footer button:contains(Ok)");
+    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await click(".modal-footer button", { text: "Ok" });
     await contains(".o-mail-LinkPreviewCard", 0);
 });
 
@@ -219,8 +219,8 @@ QUnit.test("Remove link preview video", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewVideo button[aria-label='Remove']");
-    await contains("p:contains(Do you really want to delete this preview?)");
-    await click(".modal-footer button:contains(Ok)");
+    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await click(".modal-footer button", { text: "Ok" });
     await contains(".o-mail-LinkPreviewVideo", 0);
 });
 
@@ -242,8 +242,8 @@ QUnit.test("Remove link preview image", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
-    await contains("p:contains(Do you really want to delete this preview?)");
-    await click(".modal-footer button:contains(Ok)");
+    await contains("p", 1, { text: "Do you really want to delete this preview?" });
+    await click(".modal-footer button", { text: "Ok" });
     await contains(".o-mail-LinkPreviewImage", 0);
 });
 

--- a/addons/mail/static/tests/message/message_seen_indicator_tests.js
+++ b/addons/mail/static/tests/message/message_seen_indicator_tests.js
@@ -105,7 +105,7 @@ QUnit.test("rendering when just one has seen the message", async (assert) => {
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
     assert.doesNotHaveClass($(".o-mail-MessageSeenIndicator"), "o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i", 2);
+    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 
 QUnit.test("rendering when just one has seen & received the message", async (assert) => {
@@ -139,7 +139,7 @@ QUnit.test("rendering when just one has seen & received the message", async (ass
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
     assert.doesNotHaveClass($(".o-mail-MessageSeenIndicator"), "o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i", 2);
+    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 
 QUnit.test("rendering when just everyone has seen the message", async (assert) => {
@@ -170,7 +170,7 @@ QUnit.test("rendering when just everyone has seen the message", async (assert) =
     await openDiscuss(channelId);
     await contains(".o-mail-MessageSeenIndicator");
     assert.hasClass($(".o-mail-MessageSeenIndicator"), "o-all-seen");
-    await contains(".o-mail-MessageSeenIndicator i", 2);
+    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 
 QUnit.test("'channel_fetch' notification received is correctly handled", async () => {
@@ -193,7 +193,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async (
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-MessageSeenIndicator i", 0);
+    await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
 
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     // Simulate received channel fetched notification
@@ -227,7 +227,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async ()
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-MessageSeenIndicator i", 0);
+    await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
 
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     // Simulate received channel seen notification
@@ -238,7 +238,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async ()
             partner_id: partnerId,
         });
     });
-    await contains(".o-mail-MessageSeenIndicator i", 2);
+    await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 
 QUnit.test(
@@ -263,7 +263,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
         await contains(".o-mail-Message");
-        await contains(".o-mail-MessageSeenIndicator i", 0);
+        await contains(".o-mail-MessageSeenIndicator i", { count: 0 });
 
         const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
         // Simulate received channel fetched notification
@@ -284,7 +284,7 @@ QUnit.test(
                 partner_id: partnerId,
             });
         });
-        await contains(".o-mail-MessageSeenIndicator i", 2);
+        await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
     }
 );
 
@@ -312,7 +312,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
         await contains(".o-mail-Message");
-        await contains(".o-mail-MessageSeenIndicator", 0);
+        await contains(".o-mail-MessageSeenIndicator", { count: 0 });
     }
 );
 
@@ -347,13 +347,13 @@ QUnit.test(
         pyEnv["discuss.channel.member"].write(memberIds, { seen_message_id: messageId_2 });
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
-        await contains(".o-mail-Message-content", 1, { text: "Message before last seen" });
+        await contains(".o-mail-Message-content", { text: "Message before last seen" });
         await contains(
             ".o-mail-Message:contains(Message before last seen) .o-mail-MessageSeenIndicator"
         );
         await contains(
             ".o-mail-Message:contains(Message before last seen) .o-mail-MessageSeenIndicator i",
-            0
+            { count: 0 }
         );
     }
 );

--- a/addons/mail/static/tests/message/message_seen_indicator_tests.js
+++ b/addons/mail/static/tests/message/message_seen_indicator_tests.js
@@ -347,7 +347,7 @@ QUnit.test(
         pyEnv["discuss.channel.member"].write(memberIds, { seen_message_id: messageId_2 });
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
-        await contains(".o-mail-Message:contains(Message before last seen)");
+        await contains(".o-mail-Message-content", 1, { text: "Message before last seen" });
         await contains(
             ".o-mail-Message:contains(Message before last seen) .o-mail-MessageSeenIndicator"
         );

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -40,7 +40,7 @@ QUnit.test("Start edition on click edit", async () => {
     openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message-editable .o-mail-Composer-input", 1, { value: "Hello world" });
+    await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
 });
 
 QUnit.test("Can edit message comment in chatter", async () => {
@@ -59,7 +59,7 @@ QUnit.test("Can edit message comment in chatter", async () => {
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-content", 1, { text: "edited message" });
+    await contains(".o-mail-Message-content", { text: "edited message" });
 });
 
 QUnit.test("Cursor is at end of composer input on edit", async (assert) => {
@@ -102,7 +102,7 @@ QUnit.test("Stop edition on click cancel", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message a", { text: "cancel" });
-    await contains(".o-mail-Message-editable .o-mail-Composer", 0);
+    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("Stop edition on press escape", async () => {
@@ -123,7 +123,7 @@ QUnit.test("Stop edition on press escape", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
     triggerHotkey("Escape", false);
-    await contains(".o-mail-Message-editable .o-mail-Composer", 0);
+    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("Stop edition on click save", async () => {
@@ -144,7 +144,7 @@ QUnit.test("Stop edition on click save", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-editable .o-mail-Composer", 0);
+    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("Stop edition on press enter", async () => {
@@ -165,7 +165,7 @@ QUnit.test("Stop edition on press enter", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
     triggerHotkey("Enter", false);
-    await contains(".o-mail-Message-editable .o-mail-Composer", 0);
+    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("Do not stop edition on click away when clicking on emoji", async () => {
@@ -209,7 +209,7 @@ QUnit.test("Edit and click save", async () => {
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-body", 1, { text: "Goodbye World" });
+    await contains(".o-mail-Message-body", { text: "Goodbye World" });
 });
 
 QUnit.test("Do not call server on save if no changes", async (assert) => {
@@ -264,7 +264,7 @@ QUnit.test("Update the link previews when a message is edited", async (assert) =
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-body", 1, { text: "Goodbye World" });
+    await contains(".o-mail-Message-body", { text: "Goodbye World" });
     assert.verifySteps(["link_preview"]);
 });
 
@@ -287,7 +287,7 @@ QUnit.test("Scroll bar to the top when edit starts", async (assert) => {
     await click(".o-mail-Message [title='Edit']");
     const $textarea = await contains(".o-mail-Message .o-mail-Composer-input");
     assert.ok($textarea[0].scrollHeight > $textarea[0].clientHeight);
-    await contains(".o-mail-Message .o-mail-Composer-input", 1, { scroll: 0 });
+    await contains(".o-mail-Message .o-mail-Composer-input", { scroll: 0 });
 });
 
 QUnit.test("mentions are kept when editing message", async () => {
@@ -343,7 +343,7 @@ QUnit.test("can add new mentions when editing message", async () => {
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", " @");
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
-    await contains(".o-mail-Composer-input", 1, { value: "Hello @TestPartner " });
+    await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
     await click(".o-mail-Message a", { text: "save" });
     await contains(
         ".o-mail-Message-body:contains(Hello @TestPartner) a.o_mail_redirect:contains(@TestPartner)"
@@ -362,12 +362,12 @@ QUnit.test("Other messages are grayed out when replying to another one", async (
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 2);
+    await contains(".o-mail-Message", { count: 2 });
     await click(".o-mail-Message:contains(Hello world) [title='Reply']");
-    await contains(".o-mail-Message.opacity-50 .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message.opacity-50 .o-mail-Message-content", {
         text: "Goodbye world",
     });
-    await contains(".o-mail-Message:not(.opacity_50) .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message:not(.opacity_50) .o-mail-Message-content", {
         text: "Hello world",
     });
 });
@@ -420,7 +420,7 @@ QUnit.test(
         const input = (await contains(".o-mail-Message .o-mail-Composer-input"))[0];
         insertText(input, "Goodbye World", { replace: true });
         triggerHotkey("Enter", false);
-        await contains(".o-mail-MessageInReply-message", 1, { text: "Goodbye World" });
+        await contains(".o-mail-MessageInReply-message", { text: "Goodbye World" });
         assert.strictEqual($(".o-mail-MessageInReply-message")[0].innerText, "Goodbye World");
     }
 );
@@ -445,7 +445,7 @@ QUnit.test("Deleting parent message of a reply should adapt reply visual", async
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Delete']");
     await click("button", { text: "Confirm" });
-    await contains(".o-mail-MessageInReply", 1, { text: "Original message was deleted" });
+    await contains(".o-mail-MessageInReply", { text: "Original message was deleted" });
 });
 
 QUnit.test("Can open emoji picker after edit mode", async () => {
@@ -485,7 +485,7 @@ QUnit.test("Can add a reaction", async () => {
     openDiscuss(channelId);
     await click("[title='Add a Reaction']");
     await click(".o-Emoji", { text: "😅" });
-    await contains(".o-mail-MessageReaction", 1, { text: "😅1" });
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
 });
 
 QUnit.test("Can remove a reaction", async () => {
@@ -505,7 +505,7 @@ QUnit.test("Can remove a reaction", async () => {
     await click("[title='Add a Reaction']");
     await click(".o-Emoji", { text: "😅" });
     await click(".o-mail-MessageReaction");
-    await contains(".o-mail-MessageReaction", 0);
+    await contains(".o-mail-MessageReaction", { count: 0 });
 });
 
 QUnit.test("Two users reacting with the same emoji", async () => {
@@ -535,9 +535,9 @@ QUnit.test("Two users reacting with the same emoji", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-MessageReaction", 1, { text: "😅2" });
+    await contains(".o-mail-MessageReaction", { text: "😅2" });
     await click(".o-mail-MessageReaction");
-    await contains(".o-mail-MessageReaction", 1, { text: "😅1" });
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
 });
 
 QUnit.test("Reaction summary", async () => {
@@ -590,7 +590,7 @@ QUnit.test("Add the same reaction twice from the emoji picker", async () => {
     await click(".o-Emoji", { text: "😅" });
     await click("[title='Add a Reaction']");
     await click(".o-Emoji", { text: "😅" });
-    await contains(".o-mail-MessageReaction", 1, { text: "😅1" });
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
 });
 
 QUnit.test("basic rendering of message", async () => {
@@ -607,11 +607,11 @@ QUnit.test("basic rendering of message", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message .o-mail-Message-content", 1, { text: "body" });
+    await contains(".o-mail-Message .o-mail-Message-content", { text: "body" });
     await contains(
         `.o-mail-Message .o-mail-Message-sidebar .o-mail-Message-avatarContainer img[data-src='${getOrigin()}/discuss/channel/${channelId}/partner/${partnerId}/avatar_128']`
     );
-    await contains(".o-mail-Message .o-mail-Message-header .o-mail-Message-author", 1, {
+    await contains(".o-mail-Message .o-mail-Message-header .o-mail-Message-author", {
         text: "Demo",
     });
     await contains(
@@ -629,7 +629,7 @@ QUnit.test("should not be able to reply to temporary/transient messages", async 
     // these user interactions is to forge a transient message response from channel command "/who"
     await insertText(".o-mail-Composer-input", "/who");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message [title='Reply']", 0);
+    await contains(".o-mail-Message [title='Reply']", { count: 0 });
 });
 
 QUnit.test("message comment of same author within 1min. should be squashed", async () => {
@@ -659,19 +659,17 @@ QUnit.test("message comment of same author within 1min. should be squashed", asy
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message-content", 1, { text: "body1" });
-    await contains(".o-mail-Message-content", 1, { text: "body2" });
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message-content", { text: "body1" });
+    await contains(".o-mail-Message-content", { text: "body2" });
     await contains(".o-mail-Message:contains(body1) .o-mail-Message-header");
-    await contains(".o-mail-Message:contains(body2) .o-mail-Message-header", 0);
-    await contains(
-        ".o-mail-Message:contains(body1) .o-mail-Message-sidebar .o-mail-Message-date",
-        0
-    );
-    await contains(
-        ".o-mail-Message:contains(body2) .o-mail-Message-sidebar .o-mail-Message-date",
-        0
-    );
+    await contains(".o-mail-Message:contains(body2) .o-mail-Message-header", { count: 0 });
+    await contains(".o-mail-Message:contains(body1) .o-mail-Message-sidebar .o-mail-Message-date", {
+        count: 0,
+    });
+    await contains(".o-mail-Message:contains(body2) .o-mail-Message-sidebar .o-mail-Message-date", {
+        count: 0,
+    });
     await click(".o-mail-Message", { text: "body2" });
     await contains(".o-mail-Message:contains(body2) .o-mail-Message-sidebar .o-mail-Message-date");
 });
@@ -698,11 +696,11 @@ QUnit.test("redirect to author (open chat)", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId_1);
-    await contains(".o-mail-DiscussSidebarChannel.o-active", 1, { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });
     await contains(".o-mail-Discuss-content .o-mail-Message-avatarContainer img");
 
     await click(".o-mail-Discuss-content .o-mail-Message-avatarContainer img");
-    await contains(".o-mail-DiscussSidebarChannel.o-active", 1, { text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "Demo" });
 });
 
 QUnit.test("open chat from avatar should not work on self-authored messages", async () => {
@@ -726,8 +724,8 @@ QUnit.test("open chat from avatar should not work on self-authored messages", as
     await contains(".o-mail-Message-author:not(.cursor-pointer)");
     await click(".o-mail-Message-avatar");
     // weak test, no guarantee that we waited long enough to open the chat/view
-    await contains(".o-mail-DiscussSidebarChannel.o-active", 0, { text: "Mitchell Admin" });
-    await contains(".breadcrumb", 0, { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { count: 0, text: "Mitchell Admin" });
+    await contains(".breadcrumb", { count: 0, text: "Mitchell Admin" });
 });
 
 QUnit.test("toggle_star message", async (assert) => {
@@ -750,16 +748,16 @@ QUnit.test("toggle_star message", async (assert) => {
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo']");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star-o");
-    await contains("button:contains(Starred) .badge", 0);
+    await contains("button:contains(Starred) .badge", { count: 0 });
 
     await click("[title='Mark as Todo']");
-    await contains("button:contains(Starred) .badge", 1, { text: "1" });
+    await contains("button:contains(Starred) .badge", { text: "1" });
     assert.verifySteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star");
 
     await click("[title='Mark as Todo']");
-    await contains("button:contains(Starred) .badge", 0);
+    await contains("button:contains(Starred) .badge", { count: 0 });
     assert.verifySteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star-o");
@@ -814,7 +812,7 @@ QUnit.test(
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Message-author", 0);
+        await contains(".o-mail-Message-author", { count: 0 });
     }
 );
 
@@ -867,7 +865,7 @@ QUnit.test("Notification Sent", async (assert) => {
     await contains(".o-mail-MessageNotificationPopover");
     await contains(".o-mail-MessageNotificationPopover i");
     assert.hasClass($(".o-mail-MessageNotificationPopover i"), "fa-check");
-    await contains(".o-mail-MessageNotificationPopover", 1, { text: "Someone" });
+    await contains(".o-mail-MessageNotificationPopover", { text: "Someone" });
 });
 
 QUnit.test("Notification Error", async (assert) => {
@@ -939,7 +937,7 @@ QUnit.test(
         await contains(".o-mail-Message");
         triggerHotkey("ArrowUp");
         await contains(".o-mail-Message .o-mail-Message-editable");
-        await contains(".o-mail-Message .o-mail-Composer-input", 1, { value: "not empty" });
+        await contains(".o-mail-Message .o-mail-Composer-input", { value: "not empty" });
     }
 );
 
@@ -966,7 +964,7 @@ QUnit.test("Editing a message to clear its composer opens message delete dialog.
         ""
     );
     triggerHotkey("Enter");
-    await contains(".modal-body p", 1, { text: "Are you sure you want to delete this message?" });
+    await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
 });
 
 QUnit.test(
@@ -997,10 +995,9 @@ QUnit.test(
             ""
         );
         triggerHotkey("Enter");
-        await contains(
-            ".modal-body p:contains('Are you sure you want to delete this message?')",
-            0
-        );
+        await contains(".modal-body p:contains('Are you sure you want to delete this message?')", {
+            count: 0,
+        });
     }
 );
 
@@ -1082,7 +1079,7 @@ QUnit.test("allow attachment delete on authored message", async (assert) => {
     assert.strictEqual($(".modal-body").text(), 'Do you really want to delete "BLAH"?');
 
     await click(".modal-footer .btn-primary");
-    await contains(".o-mail-AttachmentCard", 0);
+    await contains(".o-mail-AttachmentCard", { count: 0 });
 });
 
 QUnit.test("prevent attachment delete on non-authored message in channels", async () => {
@@ -1110,7 +1107,7 @@ QUnit.test("prevent attachment delete on non-authored message in channels", asyn
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-AttachmentImage");
-    await contains(".o-mail-AttachmentImage div[title='Remove']", 0);
+    await contains(".o-mail-AttachmentImage div[title='Remove']", { count: 0 });
 });
 
 QUnit.test("Toggle star should update starred counter on all tabs", async () => {
@@ -1131,7 +1128,7 @@ QUnit.test("Toggle star should update starred counter on all tabs", async () => 
     await tab1.openDiscuss(channelId);
     await tab2.openDiscuss();
     await click(".o-mail-Message [title='Mark as Todo']", { target: tab1.target });
-    await contains("button:contains(Starred) .badge", 1, { target: tab2.target, text: "1" });
+    await contains("button:contains(Starred) .badge", { target: tab2.target, text: "1" });
 });
 
 QUnit.test("allow attachment image download on message", async () => {
@@ -1171,7 +1168,7 @@ QUnit.test("chat with author should be opened after clicking on their avatar", a
     assert.hasClass($(".o-mail-Message-avatarContainer"), "cursor-pointer");
     await click(".o-mail-Message-avatar");
     await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Partner_2" });
+    await contains(".o-mail-ChatWindow-name", { text: "Partner_2" });
 });
 
 QUnit.test("chat with author should be opened after clicking on their name", async () => {
@@ -1186,11 +1183,11 @@ QUnit.test("chat with author should be opened after clicking on their name", asy
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message span", 1, { text: "Demo User" });
+    await contains(".o-mail-Message span", { text: "Demo User" });
 
     await click(".o-mail-Message span", { text: "Demo User" });
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Demo User" });
+    await contains(".o-mail-ChatWindow-name", { text: "Demo User" });
 });
 
 QUnit.test("subtype description should be displayed if it is different than body", async () => {
@@ -1205,7 +1202,7 @@ QUnit.test("subtype description should be displayed if it is different than body
     });
     const { openFormView } = await start();
     openFormView("res.partner", threadId);
-    await contains(".o-mail-Message-body", 1, { text: "HelloBonjour" });
+    await contains(".o-mail-Message-body", { text: "HelloBonjour" });
 });
 
 QUnit.test("subtype description should not be displayed if it is similar to body", async () => {
@@ -1220,7 +1217,7 @@ QUnit.test("subtype description should not be displayed if it is similar to body
     });
     const { openFormView } = await start();
     openFormView("res.partner", threadId);
-    await contains(".o-mail-Message-body", 1, { text: "Hello" });
+    await contains(".o-mail-Message-body", { text: "Hello" });
 });
 
 QUnit.test("data-oe-id & data-oe-model link redirection on click", async (assert) => {
@@ -1257,11 +1254,11 @@ QUnit.test("Chat with partner should be opened after clicking on their mention",
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@Te");
     await click(".o-mail-Composer-suggestion strong", { text: "Test Partner" });
-    await contains(".o-mail-Composer-input", 1, { value: "@Test Partner " });
+    await contains(".o-mail-Composer-input", { value: "@Test Partner " });
     await click(".o-mail-Composer-send:not(:disabled)");
     await click(".o_mail_redirect");
     await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Test Partner" });
+    await contains(".o-mail-ChatWindow-name", { text: "Test Partner" });
 });
 
 QUnit.test(
@@ -1291,7 +1288,7 @@ QUnit.test(
 
         click(".o-mail-Message-avatar").catch(() => {});
         await nextAnimationFrame();
-        await contains(".o-mail-ChatWindow", 0);
+        await contains(".o-mail-ChatWindow", { count: 0 });
     }
 );
 
@@ -1307,7 +1304,7 @@ QUnit.test("Channel should be opened after clicking on its mention", async () =>
     await click(".o-mail-Composer-send:not(:disabled)");
     await click(".o_channel_redirect");
     await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-name", 1, { text: "my-channel" });
+    await contains(".o-mail-ChatWindow-name", { text: "my-channel" });
 });
 
 QUnit.test(
@@ -1331,7 +1328,7 @@ QUnit.test(
 
         await click(".o-mail-AttachmentCard button[title='Remove']");
         await click(".modal button", { text: "Ok" });
-        await contains(".o-mail-Message", 0);
+        await contains(".o-mail-Message", { count: 0 });
     }
 );
 
@@ -1373,7 +1370,7 @@ QUnit.test("message with subtype should be displayed (and not considered as empt
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", 1, { text: "Task created" });
+    await contains(".o-mail-Message-content", { text: "Task created" });
 });
 
 QUnit.test("message considered empty", async () => {
@@ -1423,7 +1420,7 @@ QUnit.test("message considered empty", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Thread-empty");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test("message with html not to be considered empty", async () => {
@@ -1496,7 +1493,7 @@ QUnit.test("Mark as unread", async () => {
     await click("[title='Expand']");
     await click("[title='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage");
-    await contains(".o-mail-DiscussSidebarChannel .badge", 1, { text: "1" });
+    await contains(".o-mail-DiscussSidebarChannel .badge", { text: "1" });
 });
 
 QUnit.test("Avatar of unknown author", async () => {
@@ -1528,7 +1525,7 @@ QUnit.test("Show email_from of message without author", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await contains(".o-mail-Message-author", 1, { text: "md@oilcompany.fr" });
+    await contains(".o-mail-Message-author", { text: "md@oilcompany.fr" });
 });
 
 QUnit.test("Message should display attachments in order", async () => {
@@ -1551,7 +1548,7 @@ QUnit.test("Message should display attachments in order", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard:eq(0) div", 1, { text: "A.txt" });
-    await contains(".o-mail-AttachmentCard:eq(1) div", 1, { text: "B.txt" });
-    await contains(".o-mail-AttachmentCard:eq(2) div", 1, { text: "C.txt" });
+    await contains(".o-mail-AttachmentCard:eq(0) div", { text: "A.txt" });
+    await contains(".o-mail-AttachmentCard:eq(1) div", { text: "B.txt" });
+    await contains(".o-mail-AttachmentCard:eq(2) div", { text: "C.txt" });
 });

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -372,7 +372,7 @@ QUnit.test("Other messages are grayed out when replying to another one", async (
     });
 });
 
-QUnit.test("Parent message body is displayed on replies", async (assert) => {
+QUnit.test("Parent message body is displayed on replies", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         channel_type: "channel",
@@ -388,13 +388,12 @@ QUnit.test("Parent message body is displayed on replies", async (assert) => {
     await click(".o-mail-Message [title='Reply']");
     await insertText(".o-mail-Composer-input", "FooBarFoo");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-MessageInReply-message");
-    assert.ok($(".o-mail-MessageInReply-message")[0].innerText, "Hello world");
+    await contains(".o-mail-MessageInReply-message", { text: "Hello world" });
 });
 
 QUnit.test(
     "Updating the parent message of a reply also updates the visual of the reply",
-    async (assert) => {
+    async () => {
         const pyEnv = await startServer();
         const channelId = pyEnv["discuss.channel"].create({
             channel_type: "channel",
@@ -421,7 +420,6 @@ QUnit.test(
         insertText(input, "Goodbye World", { replace: true });
         triggerHotkey("Enter", false);
         await contains(".o-mail-MessageInReply-message", { text: "Goodbye World" });
-        assert.strictEqual($(".o-mail-MessageInReply-message")[0].innerText, "Goodbye World");
     }
 );
 
@@ -765,7 +763,7 @@ QUnit.test("toggle_star message", async (assert) => {
 
 QUnit.test(
     "Name of message author is only displayed in chat window for partners others than the current user",
-    async (assert) => {
+    async () => {
         const pyEnv = await startServer();
         const channelId = pyEnv["discuss.channel"].create({ channel_type: "channel" });
         const partnerId = pyEnv["res.partner"].create({ name: "Not the current user" });
@@ -785,8 +783,7 @@ QUnit.test(
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Message-author");
-        assert.equal($(".o-mail-Message-author").text(), "Not the current user");
+        await contains(".o-mail-Message-author", { text: "Not the current user" });
     }
 );
 
@@ -1047,7 +1044,7 @@ QUnit.test(
     }
 );
 
-QUnit.test("allow attachment delete on authored message", async (assert) => {
+QUnit.test("allow attachment delete on authored message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "test" });
     pyEnv["mail.message"].create({
@@ -1071,13 +1068,8 @@ QUnit.test("allow attachment delete on authored message", async (assert) => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-AttachmentImage");
-    await contains(".o-mail-AttachmentImage div[title='Remove']");
-
     await click(".o-mail-AttachmentImage div[title='Remove']");
-    await contains(".modal-dialog");
-    assert.strictEqual($(".modal-body").text(), 'Do you really want to delete "BLAH"?');
-
+    await contains(".modal-dialog .modal-body", { text: 'Do you really want to delete "BLAH"?' });
     await click(".modal-footer .btn-primary");
     await contains(".o-mail-AttachmentCard", { count: 0 });
 });

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -57,9 +57,9 @@ QUnit.test("Can edit message comment in chatter", async () => {
     openFormView("res.partner", partnerId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message");
-    await click(".o-mail-Message a:contains('save')");
-    await contains(".o-mail-Message:contains(edited message)");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-content", 1, { text: "edited message" });
 });
 
 QUnit.test("Cursor is at end of composer input on edit", async (assert) => {
@@ -101,7 +101,7 @@ QUnit.test("Stop edition on click cancel", async () => {
     openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a:contains('cancel')");
+    await click(".o-mail-Message a", { text: "cancel" });
     await contains(".o-mail-Message-editable .o-mail-Composer", 0);
 });
 
@@ -143,7 +143,7 @@ QUnit.test("Stop edition on click save", async () => {
     openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a:contains('save')");
+    await click(".o-mail-Message a", { text: "save" });
     await contains(".o-mail-Message-editable .o-mail-Composer", 0);
 });
 
@@ -207,9 +207,9 @@ QUnit.test("Edit and click save", async () => {
     openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World");
-    await click(".o-mail-Message a:contains('save')");
-    await contains(".o-mail-Message-body:contains(Goodbye World)");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-body", 1, { text: "Goodbye World" });
 });
 
 QUnit.test("Do not call server on save if no changes", async (assert) => {
@@ -235,7 +235,7 @@ QUnit.test("Do not call server on save if no changes", async (assert) => {
     openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await click(".o-mail-Message a:contains('save')");
+    await click(".o-mail-Message a", { text: "save" });
     assert.verifySteps([]);
 });
 
@@ -262,9 +262,9 @@ QUnit.test("Update the link previews when a message is edited", async (assert) =
     openDiscuss(channelId);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World");
-    await click(".o-mail-Message a:contains('save')");
-    await contains(".o-mail-Message-body:contains(Goodbye World)");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "Goodbye World", { replace: true });
+    await click(".o-mail-Message a", { text: "save" });
+    await contains(".o-mail-Message-body", 1, { text: "Goodbye World" });
     assert.verifySteps(["link_preview"]);
 });
 
@@ -309,7 +309,7 @@ QUnit.test("mentions are kept when editing message", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", "Hi @Mitchell Admin");
-    await click(".o-mail-Message a:contains('save')");
+    await click(".o-mail-Message a", { text: "save" });
     await contains(
         ".o-mail-Message-body:contains(Hi @Mitchell Admin) a.o_mail_redirect:contains(@Mitchell Admin)"
     );
@@ -342,9 +342,9 @@ QUnit.test("can add new mentions when editing message", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Edit']");
     await insertText(".o-mail-Message .o-mail-Composer-input", " @");
-    await click(".o-mail-Composer-suggestion:contains(TestPartner)");
+    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", 1, { value: "Hello @TestPartner " });
-    await click(".o-mail-Message a:contains('save')");
+    await click(".o-mail-Message a", { text: "save" });
     await contains(
         ".o-mail-Message-body:contains(Hello @TestPartner) a.o_mail_redirect:contains(@TestPartner)"
     );
@@ -364,8 +364,12 @@ QUnit.test("Other messages are grayed out when replying to another one", async (
     openDiscuss(channelId);
     await contains(".o-mail-Message", 2);
     await click(".o-mail-Message:contains(Hello world) [title='Reply']");
-    await contains(".o-mail-Message:contains(Goodbye world).opacity-50");
-    await contains(".o-mail-Message:contains(Hello world):not(.opacity_50)");
+    await contains(".o-mail-Message.opacity-50 .o-mail-Message-content", 1, {
+        text: "Goodbye world",
+    });
+    await contains(".o-mail-Message:not(.opacity_50) .o-mail-Message-content", 1, {
+        text: "Hello world",
+    });
 });
 
 QUnit.test("Parent message body is displayed on replies", async (assert) => {
@@ -416,7 +420,7 @@ QUnit.test(
         const input = (await contains(".o-mail-Message .o-mail-Composer-input"))[0];
         insertText(input, "Goodbye World", { replace: true });
         triggerHotkey("Enter", false);
-        await contains(".o-mail-MessageInReply-message:contains(Goodbye World)");
+        await contains(".o-mail-MessageInReply-message", 1, { text: "Goodbye World" });
         assert.strictEqual($(".o-mail-MessageInReply-message")[0].innerText, "Goodbye World");
     }
 );
@@ -440,8 +444,8 @@ QUnit.test("Deleting parent message of a reply should adapt reply visual", async
     triggerHotkey("Enter", false);
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message [title='Delete']");
-    await click("button:contains(Confirm)");
-    await contains(".o-mail-MessageInReply:contains(Original message was deleted)");
+    await click("button", { text: "Confirm" });
+    await contains(".o-mail-MessageInReply", 1, { text: "Original message was deleted" });
 });
 
 QUnit.test("Can open emoji picker after edit mode", async () => {
@@ -480,8 +484,8 @@ QUnit.test("Can add a reaction", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Add a Reaction']");
-    await click(".o-Emoji:contains(😅)");
-    await contains(".o-mail-MessageReaction:contains('😅')");
+    await click(".o-Emoji", { text: "😅" });
+    await contains(".o-mail-MessageReaction", 1, { text: "😅1" });
 });
 
 QUnit.test("Can remove a reaction", async () => {
@@ -499,9 +503,9 @@ QUnit.test("Can remove a reaction", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Add a Reaction']");
-    await click(".o-Emoji:contains(😅)");
+    await click(".o-Emoji", { text: "😅" });
     await click(".o-mail-MessageReaction");
-    await contains(".o-mail-MessageReaction:contains('😅')", 0);
+    await contains(".o-mail-MessageReaction", 0);
 });
 
 QUnit.test("Two users reacting with the same emoji", async () => {
@@ -531,11 +535,9 @@ QUnit.test("Two users reacting with the same emoji", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-MessageReaction:contains(2)");
-
+    await contains(".o-mail-MessageReaction", 1, { text: "😅2" });
     await click(".o-mail-MessageReaction");
-    await contains(".o-mail-MessageReaction:contains('😅')");
-    await contains(".o-mail-MessageReaction:contains(1)");
+    await contains(".o-mail-MessageReaction", 1, { text: "😅1" });
 });
 
 QUnit.test("Reaction summary", async () => {
@@ -585,10 +587,10 @@ QUnit.test("Add the same reaction twice from the emoji picker", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click("[title='Add a Reaction']");
-    await click(".o-Emoji:contains(😅)");
+    await click(".o-Emoji", { text: "😅" });
     await click("[title='Add a Reaction']");
-    await click(".o-Emoji:contains(😅)");
-    await contains(".o-mail-MessageReaction:contains('😅')");
+    await click(".o-Emoji", { text: "😅" });
+    await contains(".o-mail-MessageReaction", 1, { text: "😅1" });
 });
 
 QUnit.test("basic rendering of message", async () => {
@@ -605,11 +607,13 @@ QUnit.test("basic rendering of message", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message .o-mail-Message-content:contains(body)");
+    await contains(".o-mail-Message .o-mail-Message-content", 1, { text: "body" });
     await contains(
         `.o-mail-Message .o-mail-Message-sidebar .o-mail-Message-avatarContainer img[data-src='${getOrigin()}/discuss/channel/${channelId}/partner/${partnerId}/avatar_128']`
     );
-    await contains(".o-mail-Message .o-mail-Message-header .o-mail-Message-author:contains(Demo)");
+    await contains(".o-mail-Message .o-mail-Message-header .o-mail-Message-author", 1, {
+        text: "Demo",
+    });
     await contains(
         `.o-mail-Message .o-mail-Message-header .o-mail-Message-date[title='${deserializeDateTime(
             "2019-04-20 10:00:00"
@@ -656,8 +660,8 @@ QUnit.test("message comment of same author within 1min. should be squashed", asy
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Message:contains(body1)");
-    await contains(".o-mail-Message:contains(body2)");
+    await contains(".o-mail-Message-content", 1, { text: "body1" });
+    await contains(".o-mail-Message-content", 1, { text: "body2" });
     await contains(".o-mail-Message:contains(body1) .o-mail-Message-header");
     await contains(".o-mail-Message:contains(body2) .o-mail-Message-header", 0);
     await contains(
@@ -668,7 +672,7 @@ QUnit.test("message comment of same author within 1min. should be squashed", asy
         ".o-mail-Message:contains(body2) .o-mail-Message-sidebar .o-mail-Message-date",
         0
     );
-    await click(".o-mail-Message:contains(body2)");
+    await click(".o-mail-Message", { text: "body2" });
     await contains(".o-mail-Message:contains(body2) .o-mail-Message-sidebar .o-mail-Message-date");
 });
 
@@ -694,11 +698,11 @@ QUnit.test("redirect to author (open chat)", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId_1);
-    await contains(".o-mail-DiscussSidebarChannel.o-active:contains(General)");
+    await contains(".o-mail-DiscussSidebarChannel.o-active", 1, { text: "General" });
     await contains(".o-mail-Discuss-content .o-mail-Message-avatarContainer img");
 
     await click(".o-mail-Discuss-content .o-mail-Message-avatarContainer img");
-    await contains(".o-mail-DiscussSidebarChannel.o-active:contains(Demo)");
+    await contains(".o-mail-DiscussSidebarChannel.o-active", 1, { text: "Demo" });
 });
 
 QUnit.test("open chat from avatar should not work on self-authored messages", async () => {
@@ -722,8 +726,8 @@ QUnit.test("open chat from avatar should not work on self-authored messages", as
     await contains(".o-mail-Message-author:not(.cursor-pointer)");
     await click(".o-mail-Message-avatar");
     // weak test, no guarantee that we waited long enough to open the chat/view
-    await contains(".o-mail-DiscussSidebarChannel.o-active:contains(Mitchell Admin)", 0);
-    await contains(".breadcrumb:contains(Mitchell Admin)", 0); // should not open form view neith, 0er
+    await contains(".o-mail-DiscussSidebarChannel.o-active", 0, { text: "Mitchell Admin" });
+    await contains(".breadcrumb", 0, { text: "Mitchell Admin" });
 });
 
 QUnit.test("toggle_star message", async (assert) => {
@@ -749,7 +753,7 @@ QUnit.test("toggle_star message", async (assert) => {
     await contains("button:contains(Starred) .badge", 0);
 
     await click("[title='Mark as Todo']");
-    await contains("button:contains(Starred) .badge:contains(1)");
+    await contains("button:contains(Starred) .badge", 1, { text: "1" });
     assert.verifySteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star");
@@ -863,7 +867,7 @@ QUnit.test("Notification Sent", async (assert) => {
     await contains(".o-mail-MessageNotificationPopover");
     await contains(".o-mail-MessageNotificationPopover i");
     assert.hasClass($(".o-mail-MessageNotificationPopover i"), "fa-check");
-    await contains(".o-mail-MessageNotificationPopover:contains(Someone)");
+    await contains(".o-mail-MessageNotificationPopover", 1, { text: "Someone" });
 });
 
 QUnit.test("Notification Error", async (assert) => {
@@ -962,7 +966,7 @@ QUnit.test("Editing a message to clear its composer opens message delete dialog.
         ""
     );
     triggerHotkey("Enter");
-    await contains(".modal-body p:contains('Are you sure you want to delete this message?')");
+    await contains(".modal-body p", 1, { text: "Are you sure you want to delete this message?" });
 });
 
 QUnit.test(
@@ -1127,7 +1131,7 @@ QUnit.test("Toggle star should update starred counter on all tabs", async () => 
     await tab1.openDiscuss(channelId);
     await tab2.openDiscuss();
     await click(".o-mail-Message [title='Mark as Todo']", { target: tab1.target });
-    await contains("button:contains(Starred) .badge:contains(1)", 1, { target: tab2.target });
+    await contains("button:contains(Starred) .badge", 1, { target: tab2.target, text: "1" });
 });
 
 QUnit.test("allow attachment image download on message", async () => {
@@ -1167,7 +1171,7 @@ QUnit.test("chat with author should be opened after clicking on their avatar", a
     assert.hasClass($(".o-mail-Message-avatarContainer"), "cursor-pointer");
     await click(".o-mail-Message-avatar");
     await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-header:contains(Partner_2)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Partner_2" });
 });
 
 QUnit.test("chat with author should be opened after clicking on their name", async () => {
@@ -1182,11 +1186,11 @@ QUnit.test("chat with author should be opened after clicking on their name", asy
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message span:contains(Demo User)");
+    await contains(".o-mail-Message span", 1, { text: "Demo User" });
 
-    await click(".o-mail-Message span:contains(Demo User)");
+    await click(".o-mail-Message span", { text: "Demo User" });
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-header:contains(Demo User)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Demo User" });
 });
 
 QUnit.test("subtype description should be displayed if it is different than body", async () => {
@@ -1201,7 +1205,7 @@ QUnit.test("subtype description should be displayed if it is different than body
     });
     const { openFormView } = await start();
     openFormView("res.partner", threadId);
-    await contains(".o-mail-Message-body:contains(HelloBonjour)");
+    await contains(".o-mail-Message-body", 1, { text: "HelloBonjour" });
 });
 
 QUnit.test("subtype description should not be displayed if it is similar to body", async () => {
@@ -1216,7 +1220,7 @@ QUnit.test("subtype description should not be displayed if it is similar to body
     });
     const { openFormView } = await start();
     openFormView("res.partner", threadId);
-    await contains(".o-mail-Message-body:contains(Hello)");
+    await contains(".o-mail-Message-body", 1, { text: "Hello" });
 });
 
 QUnit.test("data-oe-id & data-oe-model link redirection on click", async (assert) => {
@@ -1250,14 +1254,14 @@ QUnit.test("Chat with partner should be opened after clicking on their mention",
     pyEnv["res.users"].create({ partner_id: partnerId });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@Te");
-    await click(".o-mail-Composer-suggestion:contains(Test Partner)");
+    await click(".o-mail-Composer-suggestion strong", { text: "Test Partner" });
     await contains(".o-mail-Composer-input", 1, { value: "@Test Partner " });
     await click(".o-mail-Composer-send:not(:disabled)");
     await click(".o_mail_redirect");
     await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-header:contains(Test Partner)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Test Partner" });
 });
 
 QUnit.test(
@@ -1297,13 +1301,13 @@ QUnit.test("Channel should be opened after clicking on its mention", async () =>
     pyEnv["discuss.channel"].create({ name: "my-channel" });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "#");
-    await click(".o-mail-Composer-suggestion:contains(my-channel)");
+    await click(".o-mail-Composer-suggestion strong", { text: "#my-channel" });
     await click(".o-mail-Composer-send:not(:disabled)");
     await click(".o_channel_redirect");
     await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-header:contains(my-channel)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "my-channel" });
 });
 
 QUnit.test(
@@ -1326,7 +1330,7 @@ QUnit.test(
         await contains(".o-mail-Message");
 
         await click(".o-mail-AttachmentCard button[title='Remove']");
-        await click(".modal button:contains(Ok)");
+        await click(".modal button", { text: "Ok" });
         await contains(".o-mail-Message", 0);
     }
 );
@@ -1352,7 +1356,7 @@ QUnit.test(
         await contains(".o-mail-Message");
 
         await click(".o-mail-AttachmentCard button[title='Remove']");
-        await click(".modal button:contains(Ok)");
+        await click(".modal button", { text: "Ok" });
         await contains(".o-mail-Message");
     }
 );
@@ -1369,7 +1373,7 @@ QUnit.test("message with subtype should be displayed (and not considered as empt
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message:contains(Task created)");
+    await contains(".o-mail-Message-content", 1, { text: "Task created" });
 });
 
 QUnit.test("message considered empty", async () => {
@@ -1492,7 +1496,7 @@ QUnit.test("Mark as unread", async () => {
     await click("[title='Expand']");
     await click("[title='Mark as Unread']");
     await contains(".o-mail-Thread-newMessage");
-    await contains(".o-mail-DiscussSidebarChannel .badge:contains(1)");
+    await contains(".o-mail-DiscussSidebarChannel .badge", 1, { text: "1" });
 });
 
 QUnit.test("Avatar of unknown author", async () => {
@@ -1524,7 +1528,7 @@ QUnit.test("Show email_from of message without author", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await contains(".o-mail-Message-header:contains(md@oilcompany.fr)");
+    await contains(".o-mail-Message-author", 1, { text: "md@oilcompany.fr" });
 });
 
 QUnit.test("Message should display attachments in order", async () => {
@@ -1547,7 +1551,7 @@ QUnit.test("Message should display attachments in order", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard:eq(0):contains(A.txt)");
-    await contains(".o-mail-AttachmentCard:eq(1):contains(B.txt)");
-    await contains(".o-mail-AttachmentCard:eq(2):contains(C.txt)");
+    await contains(".o-mail-AttachmentCard:eq(0) div", 1, { text: "A.txt" });
+    await contains(".o-mail-AttachmentCard:eq(1) div", 1, { text: "B.txt" });
+    await contains(".o-mail-AttachmentCard:eq(2) div", 1, { text: "C.txt" });
 });

--- a/addons/mail/static/tests/messaging/messaging_tests.js
+++ b/addons/mail/static/tests/messaging/messaging_tests.js
@@ -25,7 +25,7 @@ QUnit.test("Receiving a new message out of discuss app should open a chat window
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-header:contains(Dumbledore)");
+    await contains(".o-mail-ChatWindow-name", 1, { text: "Dumbledore" });
 });
 
 QUnit.test(
@@ -53,7 +53,7 @@ QUnit.test(
         );
         // leaving discuss.
         await openFormView("res.partner", partnerId);
-        await contains(".o-mail-ChatWindow-header:contains(Dumbledore)");
+        await contains(".o-mail-ChatWindow-name", 1, { text: "Dumbledore" });
     }
 );
 
@@ -76,6 +76,6 @@ QUnit.test(
         // leaving discuss.
         await openFormView("res.partner", partnerId);
         // weak test, no guarantee that we waited long enough for the potential chat window to open
-        await contains(".o-mail-ChatWindow-header:contains(Dumbledore)", 0);
+        await contains(".o-mail-ChatWindow-name", 0, { text: "Dumbledore" });
     }
 );

--- a/addons/mail/static/tests/messaging/messaging_tests.js
+++ b/addons/mail/static/tests/messaging/messaging_tests.js
@@ -25,7 +25,7 @@ QUnit.test("Receiving a new message out of discuss app should open a chat window
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-name", 1, { text: "Dumbledore" });
+    await contains(".o-mail-ChatWindow-name", { text: "Dumbledore" });
 });
 
 QUnit.test(
@@ -53,7 +53,7 @@ QUnit.test(
         );
         // leaving discuss.
         await openFormView("res.partner", partnerId);
-        await contains(".o-mail-ChatWindow-name", 1, { text: "Dumbledore" });
+        await contains(".o-mail-ChatWindow-name", { text: "Dumbledore" });
     }
 );
 
@@ -76,6 +76,6 @@ QUnit.test(
         // leaving discuss.
         await openFormView("res.partner", partnerId);
         // weak test, no guarantee that we waited long enough for the potential chat window to open
-        await contains(".o-mail-ChatWindow-name", 0, { text: "Dumbledore" });
+        await contains(".o-mail-ChatWindow-name", { count: 0, text: "Dumbledore" });
     }
 );

--- a/addons/mail/static/tests/messaging_menu/messaging_menu_tests.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu_tests.js
@@ -19,7 +19,7 @@ QUnit.module("messaging menu");
 QUnit.test("should have messaging menu button in systray", async () => {
     await start();
     await contains(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-MessagingMenu", 0);
+    await contains(".o-mail-MessagingMenu", { count: 0 });
     await contains(".o_menu_systray i[aria-label='Messages'].fa-comments");
 });
 
@@ -27,14 +27,14 @@ QUnit.test("messaging menu should have topbar buttons", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-header button", 4);
-    await contains("button", 1, { text: "All" });
-    await contains("button", 1, { text: "Chats" });
-    await contains("button", 1, { text: "Channels" });
-    await contains("button", 1, { text: "New Message" });
+    await contains(".o-mail-MessagingMenu-header button", { count: 4 });
+    await contains("button", { text: "All" });
+    await contains("button", { text: "Chats" });
+    await contains("button", { text: "Channels" });
+    await contains("button", { text: "New Message" });
     await contains("button:contains(All).fw-bolder");
-    await contains("button:contains(Chats).fw-bolder", 0);
-    await contains("button:contains(Channels).fw-bolder", 0);
+    await contains("button:contains(Chats).fw-bolder", { count: 0 });
+    await contains("button:contains(Channels).fw-bolder", { count: 0 });
 });
 
 QUnit.test("counter is taking into account failure notification", async (assert) => {
@@ -74,23 +74,23 @@ QUnit.test("rendering with OdooBot has a request (default)", async (assert) => {
             .data("src")
             .includes("/web/image?field=avatar_128&id=2&model=res.partner")
     );
-    await contains(".o-mail-NotificationItem-name", 1, { text: "OdooBot has a request" });
+    await contains(".o-mail-NotificationItem-name", { text: "OdooBot has a request" });
 });
 
 QUnit.test("rendering without OdooBot has a request (denied)", async () => {
     patchBrowserNotification("denied");
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-MessagingMenu-counter", 0);
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-MessagingMenu-counter", { count: 0 });
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("rendering without OdooBot has a request (accepted)", async () => {
     patchBrowserNotification("granted");
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-MessagingMenu-counter", 0);
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-MessagingMenu-counter", { count: 0 });
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("respond to notification prompt (denied)", async () => {
@@ -101,9 +101,9 @@ QUnit.test("respond to notification prompt (denied)", async () => {
     await contains(
         ".o_notification.border-warning:contains(Odoo will not send notifications on this device.)"
     );
-    await contains(".o-mail-MessagingMenu-counter", 0);
+    await contains(".o-mail-MessagingMenu-counter", { count: 0 });
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("respond to notification prompt (granted)", async () => {
@@ -124,33 +124,33 @@ QUnit.test("no 'OdooBot has a request' in mobile app", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-MessagingMenu-counter", 0);
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-MessagingMenu-counter", { count: 0 });
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("Is closed after clicking on new message", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button", { text: "New Message" });
-    await contains(".o-mail-MessagingMenu", 0);
+    await contains(".o-mail-MessagingMenu", { count: 0 });
 });
 
 QUnit.test("no 'New Message' button when discuss is open", async () => {
     const { openDiscuss, openView } = await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains("button", 1, { text: "New Message" });
+    await contains("button", { text: "New Message" });
 
     await openDiscuss();
-    await contains("button", 0, { text: "New Message" });
+    await contains("button", { count: 0, text: "New Message" });
 
     await openView({
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button", 1, { text: "New Message" });
+    await contains("button", { text: "New Message" });
 
     await openDiscuss();
-    await contains("button", 0, { text: "New Message" });
+    await contains("button", { count: 0, text: "New Message" });
 });
 
 QUnit.test("grouped notifications by document", async () => {
@@ -184,8 +184,8 @@ QUnit.test("grouped notifications by document", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem:contains(Partner) .badge", 1, { text: "2" });
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-NotificationItem:contains(Partner) .badge", { text: "2" });
+    await contains(".o-mail-ChatWindow", { count: 0 });
 
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
@@ -243,7 +243,7 @@ QUnit.test("grouped notifications by document model", async (assert) => {
         },
     });
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(Partner) .badge", 1, { text: "2" });
+    await contains(".o-mail-NotificationItem:contains(Partner) .badge", { text: "2" });
 
     $(".o-mail-NotificationItem")[0].click();
     assert.verifySteps(["do_action"]);
@@ -291,7 +291,7 @@ QUnit.test(
         ]);
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-NotificationItem", 2);
+        await contains(".o-mail-NotificationItem", { count: 2 });
         assert.ok($(".o-mail-NotificationItem:eq(0)").text().includes("Company"));
         assert.ok($(".o-mail-NotificationItem:eq(1)").text().includes("Partner"));
     }
@@ -312,7 +312,7 @@ QUnit.test("non-failure notifications are ignored", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("mark unread channel as read", async (assert) => {
@@ -348,8 +348,8 @@ QUnit.test("mark unread channel as read", async (assert) => {
     assert.verifySteps(["set_last_seen_message"]);
     await contains(".o-mail-NotificationItem.o-muted");
     await triggerEvent($(".o-mail-NotificationItem")[0], null, "mouseenter");
-    await contains(".o-mail-NotificationItem [title='Mark As Read']", 0);
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-NotificationItem [title='Mark As Read']", { count: 0 });
+    await contains(".o-mail-ChatWindow", { count: 0 });
 });
 
 QUnit.test("mark failure as read", async () => {
@@ -371,17 +371,18 @@ QUnit.test("mark failure as read", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Channel" });
-    await contains(".o-mail-NotificationItem-text", 1, {
+    await contains(".o-mail-NotificationItem-name", { text: "Channel" });
+    await contains(".o-mail-NotificationItem-text", {
         text: "An error occurred when sending an email",
     });
     await triggerEvent($(".o-mail-NotificationItem:contains(Channel)")[0], null, "mouseenter");
     await contains(".o-mail-NotificationItem:contains(Channel) [title='Mark As Read']");
 
     await click(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem-name", 0, { text: "Channel" });
+    await contains(".o-mail-NotificationItem-name", { count: 0, text: "Channel" });
 
-    await contains("o-mail-NotificationItem-text", 0, {
+    await contains("o-mail-NotificationItem-text", {
+        count: 0,
         text: "An error occurred when sending an email",
     });
 });
@@ -430,7 +431,7 @@ QUnit.test("different discuss.channel are not grouped", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 4);
+    await contains(".o-mail-NotificationItem", { count: 4 });
     await click(".o-mail-NotificationItem:contains(Channel):first");
     await contains(".o-mail-ChatWindow");
 });
@@ -457,34 +458,34 @@ QUnit.test('"Start a conversation" in mobile shows channel selector (+ click awa
     const { openDiscuss } = await start();
     await openDiscuss();
     await click("button", { text: "Chat" });
-    await contains("button", 1, { text: "Start a conversation" });
-    await contains("input[placeholder='Start a conversation']", 0);
+    await contains("button", { text: "Start a conversation" });
+    await contains("input[placeholder='Start a conversation']", { count: 0 });
 
     await click("button", { text: "Start a conversation" });
-    await contains("button", 0, { text: "Start a conversation" });
+    await contains("button", { count: 0, text: "Start a conversation" });
 
     await contains("input[placeholder='Start a conversation']");
 
     await click(".o-mail-MessagingMenu");
-    await contains("button", 1, { text: "Start a conversation" });
-    await contains("input[placeholder='Start a conversation']", 0);
+    await contains("button", { text: "Start a conversation" });
+    await contains("input[placeholder='Start a conversation']", { count: 0 });
 });
 QUnit.test('"New Channel" in mobile shows channel selector (+ click away)', async () => {
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     await openDiscuss();
     await click("button", { text: "Channel" });
-    await contains("button", 1, { text: "New Channel" });
-    await contains("input[placeholder='Add or join a channel']", 0);
+    await contains("button", { text: "New Channel" });
+    await contains("input[placeholder='Add or join a channel']", { count: 0 });
 
     await click("button", { text: "New Channel" });
-    await contains("button", 0, { text: "New Channel" });
+    await contains("button", { count: 0, text: "New Channel" });
 
     await contains("input[placeholder='Add or join a channel']");
 
     await click(".o-mail-MessagingMenu");
-    await contains("button", 1, { text: "New Channel" });
-    await contains("input[placeholder='Add or join a channel']", 0);
+    await contains("button", { text: "New Channel" });
+    await contains("input[placeholder='Add or join a channel']", { count: 0 });
 });
 
 QUnit.test("'New Message' button should open a chat window in mobile", async () => {
@@ -523,7 +524,7 @@ QUnit.test("Counter is updated when receiving new message", async () => {
             })
         )
     );
-    await contains(".o-mail-MessagingMenu-counter", 1, { text: "1" });
+    await contains(".o-mail-MessagingMenu-counter", { text: "1" });
 });
 
 QUnit.test("basic rendering", async (assert) => {
@@ -541,19 +542,19 @@ QUnit.test("basic rendering", async (assert) => {
     );
     await contains(".o_menu_systray i[aria-label='Messages']");
     await contains('.o_menu_systray i[aria-label="Messages"].fa-comments');
-    await contains(".o-mail-MessagingMenu", 0);
+    await contains(".o-mail-MessagingMenu", { count: 0 });
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await contains('.o_menu_systray .dropdown:has(i[aria-label="Messages"]).show');
     await contains(".o-mail-MessagingMenu");
     await contains(".o-mail-MessagingMenu-header");
-    await contains(".o-mail-MessagingMenu-header button", 4);
+    await contains(".o-mail-MessagingMenu-header button", { count: 4 });
     await contains('.o-mail-MessagingMenu button:contains("All")');
     await contains('.o-mail-MessagingMenu button:contains("Chats")');
     await contains('.o-mail-MessagingMenu button:contains("Channels")');
     await contains('.o-mail-MessagingMenu button:contains("All").fw-bolder');
     await contains('.o-mail-MessagingMenu button:contains("Chats"):not(.fw-bolder)');
     await contains('.o-mail-MessagingMenu button:contains("Channels"):not(.fw-bolder)');
-    await contains("button", 1, { text: "New Message" });
+    await contains("button", { text: "New Message" });
     await contains('.o-mail-MessagingMenu:contains("No conversation yet...")');
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     assert.doesNotHaveClass(
@@ -623,7 +624,7 @@ QUnit.test("filtered previews", async () => {
     ]);
     await start();
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await contains(".o-mail-NotificationItem", 2);
+    await contains(".o-mail-NotificationItem", { count: 2 });
     await contains('.o-mail-NotificationItem:contains("Mitchell Admin")');
     await contains('.o-mail-NotificationItem:contains("channel1")');
     await click('.o-mail-MessagingMenu button:contains("Chats")');
@@ -631,7 +632,7 @@ QUnit.test("filtered previews", async () => {
     await click('.o-mail-MessagingMenu button:contains("Channels")');
     await contains('.o-mail-NotificationItem:contains("channel1")');
     await click('.o-mail-MessagingMenu button:contains("All")');
-    await contains(".o-mail-NotificationItem", 2);
+    await contains(".o-mail-NotificationItem", { count: 2 });
     await contains('.o-mail-NotificationItem:contains("Mitchell Admin")');
     await click('.o-mail-MessagingMenu button:contains("Channels")');
     await contains('.o-mail-NotificationItem:contains("channel1")');
@@ -650,7 +651,7 @@ QUnit.test("no code injection in message body preview", async () => {
     await contains(
         ".o-mail-NotificationItem-text:contains(You: &shoulnotberaisedthrow new Error('CodeInjectionError');)"
     );
-    await contains(".o-mail-NotificationItem-text script", 0);
+    await contains(".o-mail-NotificationItem-text script", { count: 0 });
 });
 
 QUnit.test("no code injection in message body preview from sanitized message", async () => {
@@ -666,7 +667,7 @@ QUnit.test("no code injection in message body preview from sanitized message", a
     await contains(
         ".o-mail-NotificationItem-text:contains(You: <em>&shoulnotberaised</em><script>throw new Error('CodeInjectionError');</script>)"
     );
-    await contains(".o-mail-NotificationItem-text script", 0);
+    await contains(".o-mail-NotificationItem-text script", { count: 0 });
 });
 
 QUnit.test("<br/> tags in message body preview are transformed in spaces", async () => {
@@ -679,7 +680,7 @@ QUnit.test("<br/> tags in message body preview are transformed in spaces", async
     });
     await start();
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await contains(".o-mail-NotificationItem-text", 1, { text: "You: a b c d" });
+    await contains(".o-mail-NotificationItem-text", { text: "You: a b c d" });
 });
 
 QUnit.test(
@@ -741,12 +742,12 @@ QUnit.test("click on preview should mark as read and open the thread", async () 
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Frodo Baggins" });
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
+    await contains(".o-mail-ChatWindow", { count: 0 });
     await click(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
     await contains(".o-mail-ChatWindow");
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", 0, { text: "Frodo Baggins" });
+    await contains(".o-mail-NotificationItem-name", { count: 0, text: "Frodo Baggins" });
 });
 
 QUnit.test(
@@ -779,7 +780,7 @@ QUnit.test(
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
         await click(".o-mail-ChatWindow-command i.fa-expand");
-        await contains(".o-mail-ChatWindow", 0);
+        await contains(".o-mail-ChatWindow", { count: 0 });
         assert.verifySteps(["do_action"], "should have done an action to open the form view");
     }
 );
@@ -811,7 +812,7 @@ QUnit.test(
         });
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-NotificationItem-text", 1, {
+        await contains(".o-mail-NotificationItem-text", {
             text: "Stranger: I am the oldest but needaction",
         });
     }
@@ -874,8 +875,8 @@ QUnit.test("chat should show unread counter on receiving new messages", async ()
     await start();
     click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Partner1" });
-    await contains(".o-mail-NotificationItem .badge", 0, { text: "1" });
+    await contains(".o-mail-NotificationItem-name", { text: "Partner1" });
+    await contains(".o-mail-NotificationItem .badge", { count: 0, text: "1" });
 
     // simulate receiving a new message
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
@@ -889,7 +890,7 @@ QUnit.test("chat should show unread counter on receiving new messages", async ()
             res_id: channelId,
         },
     });
-    await contains(".o-mail-NotificationItem .badge", 1, { text: "1" });
+    await contains(".o-mail-NotificationItem .badge", { text: "1" });
 });
 
 QUnit.test("preview for channel should show latest non-deleted message", async () => {
@@ -912,7 +913,7 @@ QUnit.test("preview for channel should show latest non-deleted message", async (
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-text", 1, { text: "Partner1: message-2" });
+    await contains(".o-mail-NotificationItem-text", { text: "Partner1: message-2" });
     // Simulate deletion of message-2
     await afterNextRender(() =>
         env.services.rpc("/mail/message/update_content", {
@@ -921,7 +922,7 @@ QUnit.test("preview for channel should show latest non-deleted message", async (
             attachment_ids: [],
         })
     );
-    await contains(".o-mail-NotificationItem-text", 1, { text: "Partner1: message-1" });
+    await contains(".o-mail-NotificationItem-text", { text: "Partner1: message-1" });
 });
 
 QUnit.test("failure notifications are shown before channel preview", async () => {
@@ -951,10 +952,10 @@ QUnit.test("failure notifications are shown before channel preview", async () =>
     pyEnv["discuss.channel.member"].write([memberId], { seen_message_id: messageId });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-text", 1, {
+    await contains(".o-mail-NotificationItem-text", {
         text: "An error occurred when sending an email",
     });
-    await contains(".o-mail-NotificationItem-text", 1, { text: "Partner1: message" });
+    await contains(".o-mail-NotificationItem-text", { text: "Partner1: message" });
     await contains(
         ".o-mail-NotificationItem:contains(An error occurred when sending an email) ~ .o-mail-NotificationItem:contains(message)"
     );
@@ -965,7 +966,7 @@ QUnit.test("messaging menu should show new needaction messages from chatter", as
     const partnerId = pyEnv["res.partner"].create({ name: "Frodo Baggins" });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-text", 0, { text: "@Mitchell Admin" });
+    await contains(".o-mail-NotificationItem-text", { count: 0, text: "@Mitchell Admin" });
     // simulate receiving a new needaction message
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
         author_id: partnerId,
@@ -976,5 +977,5 @@ QUnit.test("messaging menu should show new needaction messages from chatter", as
         res_id: partnerId,
         record_name: "Frodo Baggins",
     });
-    await contains(".o-mail-NotificationItem-text", 1, { text: "@Mitchell Admin" });
+    await contains(".o-mail-NotificationItem-text", { text: "@Mitchell Admin" });
 });

--- a/addons/mail/static/tests/messaging_menu/messaging_menu_tests.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu_tests.js
@@ -23,18 +23,18 @@ QUnit.test("should have messaging menu button in systray", async () => {
     await contains(".o_menu_systray i[aria-label='Messages'].fa-comments");
 });
 
-QUnit.test("messaging menu should have topbar buttons", async (assert) => {
+QUnit.test("messaging menu should have topbar buttons", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
     await contains(".o-mail-MessagingMenu-header button", 4);
-    await contains("button:contains(All)");
-    await contains("button:contains(Chat)");
-    await contains("button:contains(Channel)");
-    await contains("button:contains(New Message)");
+    await contains("button", 1, { text: "All" });
+    await contains("button", 1, { text: "Chats" });
+    await contains("button", 1, { text: "Channels" });
+    await contains("button", 1, { text: "New Message" });
     await contains("button:contains(All).fw-bolder");
-    assert.doesNotHaveClass($("button:contains(Chat)"), "fw-bolder");
-    assert.doesNotHaveClass($("button:contains(Channel)"), "fw-bolder");
+    await contains("button:contains(Chats).fw-bolder", 0);
+    await contains("button:contains(Channels).fw-bolder", 0);
 });
 
 QUnit.test("counter is taking into account failure notification", async (assert) => {
@@ -74,7 +74,7 @@ QUnit.test("rendering with OdooBot has a request (default)", async (assert) => {
             .data("src")
             .includes("/web/image?field=avatar_128&id=2&model=res.partner")
     );
-    assert.strictEqual($(".o-mail-NotificationItem-name").text().trim(), "OdooBot has a request");
+    await contains(".o-mail-NotificationItem-name", 1, { text: "OdooBot has a request" });
 });
 
 QUnit.test("rendering without OdooBot has a request (denied)", async () => {
@@ -131,26 +131,26 @@ QUnit.test("no 'OdooBot has a request' in mobile app", async () => {
 QUnit.test("Is closed after clicking on new message", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
+    await click("button", { text: "New Message" });
     await contains(".o-mail-MessagingMenu", 0);
 });
 
 QUnit.test("no 'New Message' button when discuss is open", async () => {
     const { openDiscuss, openView } = await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains("button:contains(New Message)");
+    await contains("button", 1, { text: "New Message" });
 
     await openDiscuss();
-    await contains("button:contains(New Message)", 0);
+    await contains("button", 0, { text: "New Message" });
 
     await openView({
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(New Message)");
+    await contains("button", 1, { text: "New Message" });
 
     await openDiscuss();
-    await contains("button:contains(New Message)", 0);
+    await contains("button", 0, { text: "New Message" });
 });
 
 QUnit.test("grouped notifications by document", async () => {
@@ -184,7 +184,7 @@ QUnit.test("grouped notifications by document", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem:contains(Partner) .badge:contains(2)");
+    await contains(".o-mail-NotificationItem:contains(Partner) .badge", 1, { text: "2" });
     await contains(".o-mail-ChatWindow", 0);
 
     await click(".o-mail-NotificationItem");
@@ -243,7 +243,7 @@ QUnit.test("grouped notifications by document model", async (assert) => {
         },
     });
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(Partner) .badge:contains(2)");
+    await contains(".o-mail-NotificationItem:contains(Partner) .badge", 1, { text: "2" });
 
     $(".o-mail-NotificationItem")[0].click();
     assert.verifySteps(["do_action"]);
@@ -371,14 +371,19 @@ QUnit.test("mark failure as read", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(Channel)");
-    await contains(".o-mail-NotificationItem:contains(An error occurred when sending an email)");
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Channel" });
+    await contains(".o-mail-NotificationItem-text", 1, {
+        text: "An error occurred when sending an email",
+    });
     await triggerEvent($(".o-mail-NotificationItem:contains(Channel)")[0], null, "mouseenter");
     await contains(".o-mail-NotificationItem:contains(Channel) [title='Mark As Read']");
 
     await click(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem:contains(Channel)", 0);
-    await contains(".o-mail-NotificationItem:contains(An error occurred when sending an email)", 0);
+    await contains(".o-mail-NotificationItem-name", 0, { text: "Channel" });
+
+    await contains("o-mail-NotificationItem-text", 0, {
+        text: "An error occurred when sending an email",
+    });
 });
 
 QUnit.test("different discuss.channel are not grouped", async () => {
@@ -434,7 +439,7 @@ QUnit.test("mobile: active icon is highlighted", async () => {
     patchUiSize({ size: SIZES.SM });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-MessagingMenu-tab:contains(Chat)");
+    await click(".o-mail-MessagingMenu-tab", { text: "Chat" });
     await contains(".o-mail-MessagingMenu-tab:contains(Chat).fw-bolder");
 });
 
@@ -451,32 +456,34 @@ QUnit.test('"Start a conversation" in mobile shows channel selector (+ click awa
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     await openDiscuss();
-    await click("button:contains(Chat)");
-    await contains("button:contains(Start a conversation)");
+    await click("button", { text: "Chat" });
+    await contains("button", 1, { text: "Start a conversation" });
     await contains("input[placeholder='Start a conversation']", 0);
 
-    await click("button:contains(Start a conversation)");
-    await contains("button:contains(Start a conversation)", 0);
+    await click("button", { text: "Start a conversation" });
+    await contains("button", 0, { text: "Start a conversation" });
+
     await contains("input[placeholder='Start a conversation']");
 
     await click(".o-mail-MessagingMenu");
-    await contains("button:contains(Start a conversation)");
+    await contains("button", 1, { text: "Start a conversation" });
     await contains("input[placeholder='Start a conversation']", 0);
 });
 QUnit.test('"New Channel" in mobile shows channel selector (+ click away)', async () => {
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     await openDiscuss();
-    await click("button:contains(Channel)");
-    await contains("button:contains(New Channel)");
+    await click("button", { text: "Channel" });
+    await contains("button", 1, { text: "New Channel" });
     await contains("input[placeholder='Add or join a channel']", 0);
 
-    await click("button:contains(New Channel)");
-    await contains("button:contains(New Channel)", 0);
+    await click("button", { text: "New Channel" });
+    await contains("button", 0, { text: "New Channel" });
+
     await contains("input[placeholder='Add or join a channel']");
 
     await click(".o-mail-MessagingMenu");
-    await contains("button:contains(New Channel)");
+    await contains("button", 1, { text: "New Channel" });
     await contains("input[placeholder='Add or join a channel']", 0);
 });
 
@@ -484,7 +491,7 @@ QUnit.test("'New Message' button should open a chat window in mobile", async () 
     patchUiSize({ height: 360, width: 640 });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click("button:contains(New Message)");
+    await click("button", { text: "New Message" });
     await contains(".o-mail-ChatWindow");
 });
 
@@ -516,7 +523,7 @@ QUnit.test("Counter is updated when receiving new message", async () => {
             })
         )
     );
-    await contains(".o-mail-MessagingMenu-counter:contains(1)");
+    await contains(".o-mail-MessagingMenu-counter", 1, { text: "1" });
 });
 
 QUnit.test("basic rendering", async (assert) => {
@@ -546,7 +553,7 @@ QUnit.test("basic rendering", async (assert) => {
     await contains('.o-mail-MessagingMenu button:contains("All").fw-bolder');
     await contains('.o-mail-MessagingMenu button:contains("Chats"):not(.fw-bolder)');
     await contains('.o-mail-MessagingMenu button:contains("Channels"):not(.fw-bolder)');
-    await contains("button:contains(New Message)");
+    await contains("button", 1, { text: "New Message" });
     await contains('.o-mail-MessagingMenu:contains("No conversation yet...")');
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     assert.doesNotHaveClass(
@@ -662,7 +669,7 @@ QUnit.test("no code injection in message body preview from sanitized message", a
     await contains(".o-mail-NotificationItem-text script", 0);
 });
 
-QUnit.test("<br/> tags in message body preview are transformed in spaces", async (assert) => {
+QUnit.test("<br/> tags in message body preview are transformed in spaces", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({});
     pyEnv["mail.message"].create({
@@ -672,9 +679,7 @@ QUnit.test("<br/> tags in message body preview are transformed in spaces", async
     });
     await start();
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
-    await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem-text");
-    assert.strictEqual($(".o-mail-NotificationItem-text").text(), "You: a b c d");
+    await contains(".o-mail-NotificationItem-text", 1, { text: "You: a b c d" });
 });
 
 QUnit.test(
@@ -698,7 +703,8 @@ QUnit.test(
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         assert.strictEqual(
-            (await contains(".o-mail-NotificationItem")).text().split("Demo User").length - 1,
+            (await contains(".o-mail-NotificationItem"))[0].textContent.split("Demo User").length -
+                1,
             1
         );
     }
@@ -735,12 +741,12 @@ QUnit.test("click on preview should mark as read and open the thread", async () 
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(Frodo Baggins)");
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Frodo Baggins" });
     await contains(".o-mail-ChatWindow", 0);
-    await click(".o-mail-NotificationItem:contains(Frodo Baggins)");
+    await click(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
     await contains(".o-mail-ChatWindow");
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(Frodo Baggins)", 0);
+    await contains(".o-mail-NotificationItem-name", 0, { text: "Frodo Baggins" });
 });
 
 QUnit.test(
@@ -771,7 +777,7 @@ QUnit.test(
             },
         });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem:contains(Frodo Baggins)");
+        await click(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
         await click(".o-mail-ChatWindow-command i.fa-expand");
         await contains(".o-mail-ChatWindow", 0);
         assert.verifySteps(["do_action"], "should have done an action to open the form view");
@@ -805,7 +811,9 @@ QUnit.test(
         });
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-NotificationItem:contains(I am the oldest but needaction)");
+        await contains(".o-mail-NotificationItem-text", 1, {
+            text: "Stranger: I am the oldest but needaction",
+        });
     }
 );
 
@@ -866,8 +874,9 @@ QUnit.test("chat should show unread counter on receiving new messages", async ()
     await start();
     click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem:contains(Partner1)");
-    await contains(".o-mail-NotificationItem .badge:contains('1')", 0);
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Partner1" });
+    await contains(".o-mail-NotificationItem .badge", 0, { text: "1" });
+
     // simulate receiving a new message
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     pyEnv["bus.bus"]._sendone(channel, "discuss.channel/new_message", {
@@ -880,7 +889,7 @@ QUnit.test("chat should show unread counter on receiving new messages", async ()
             res_id: channelId,
         },
     });
-    await contains(".o-mail-NotificationItem .badge:contains('1')");
+    await contains(".o-mail-NotificationItem .badge", 1, { text: "1" });
 });
 
 QUnit.test("preview for channel should show latest non-deleted message", async () => {
@@ -903,7 +912,7 @@ QUnit.test("preview for channel should show latest non-deleted message", async (
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(message-2)");
+    await contains(".o-mail-NotificationItem-text", 1, { text: "Partner1: message-2" });
     // Simulate deletion of message-2
     await afterNextRender(() =>
         env.services.rpc("/mail/message/update_content", {
@@ -912,7 +921,7 @@ QUnit.test("preview for channel should show latest non-deleted message", async (
             attachment_ids: [],
         })
     );
-    await contains(".o-mail-NotificationItem:contains(message-1)");
+    await contains(".o-mail-NotificationItem-text", 1, { text: "Partner1: message-1" });
 });
 
 QUnit.test("failure notifications are shown before channel preview", async () => {
@@ -942,8 +951,10 @@ QUnit.test("failure notifications are shown before channel preview", async () =>
     pyEnv["discuss.channel.member"].write([memberId], { seen_message_id: messageId });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(An error occurred when sending an email)");
-    await contains(".o-mail-NotificationItem:contains(message)");
+    await contains(".o-mail-NotificationItem-text", 1, {
+        text: "An error occurred when sending an email",
+    });
+    await contains(".o-mail-NotificationItem-text", 1, { text: "Partner1: message" });
     await contains(
         ".o-mail-NotificationItem:contains(An error occurred when sending an email) ~ .o-mail-NotificationItem:contains(message)"
     );
@@ -954,18 +965,16 @@ QUnit.test("messaging menu should show new needaction messages from chatter", as
     const partnerId = pyEnv["res.partner"].create({ name: "Frodo Baggins" });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(@Mitchell Admin)", 0);
-
+    await contains(".o-mail-NotificationItem-text", 0, { text: "@Mitchell Admin" });
     // simulate receiving a new needaction message
-    await afterNextRender(() => {
-        pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
-            body: "@Mitchell Admin",
-            id: 100,
-            needaction_partner_ids: [pyEnv.currentPartnerId],
-            model: "res.partner",
-            res_id: partnerId,
-            record_name: "Frodo Baggins",
-        });
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", {
+        author_id: partnerId,
+        body: "@Mitchell Admin",
+        id: 100,
+        needaction_partner_ids: [pyEnv.currentPartnerId],
+        model: "res.partner",
+        res_id: partnerId,
+        record_name: "Frodo Baggins",
     });
-    await contains(".o-mail-NotificationItem:contains(@Mitchell Admin)");
+    await contains(".o-mail-NotificationItem-text", 1, { text: "@Mitchell Admin" });
 });

--- a/addons/mail/static/tests/messaging_menu/notification_tests.js
+++ b/addons/mail/static/tests/messaging_menu/notification_tests.js
@@ -30,8 +30,8 @@ QUnit.test("basic layout", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name:contains(Channel)");
-    await contains(".o-mail-NotificationItem-counter:contains(2)");
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Channel" });
+    await contains(".o-mail-NotificationItem-counter", 1, { text: "2" });
     await contains(
         ".o-mail-NotificationItem:contains(Channel) .o-mail-NotificationItem-date:contains(now)"
     );
@@ -64,7 +64,7 @@ QUnit.test("mark as read", async () => {
         "mouseenter"
     );
     await click(".o-mail-NotificationItem:contains(Channel) .o-mail-NotificationItem-markAsRead");
-    await contains(".o-mail-NotificationItem:contains(Channel)", 0);
+    await contains(".o-mail-NotificationItem-name", 0, { text: "Channel" });
 });
 
 QUnit.test("open non-channel failure", async (assert) => {
@@ -168,7 +168,9 @@ QUnit.test("different discuss.channel are not grouped", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem:contains(An error occurred when sending an email)", 2);
+    await contains(".o-mail-NotificationItem-text", 2, {
+        text: "An error occurred when sending an email",
+    });
 });
 
 QUnit.test("multiple grouped notifications by model", async () => {
@@ -212,7 +214,7 @@ QUnit.test("multiple grouped notifications by model", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", 2);
-    await contains(".o-mail-NotificationItem-counter:contains(2)", 2);
+    await contains(".o-mail-NotificationItem-counter", 2, { text: "2" });
 });
 
 QUnit.test("non-failure notifications are ignored", async () => {

--- a/addons/mail/static/tests/messaging_menu/notification_tests.js
+++ b/addons/mail/static/tests/messaging_menu/notification_tests.js
@@ -30,8 +30,8 @@ QUnit.test("basic layout", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Channel" });
-    await contains(".o-mail-NotificationItem-counter", 1, { text: "2" });
+    await contains(".o-mail-NotificationItem-name", { text: "Channel" });
+    await contains(".o-mail-NotificationItem-counter", { text: "2" });
     await contains(
         ".o-mail-NotificationItem:contains(Channel) .o-mail-NotificationItem-date:contains(now)"
     );
@@ -64,7 +64,7 @@ QUnit.test("mark as read", async () => {
         "mouseenter"
     );
     await click(".o-mail-NotificationItem:contains(Channel) .o-mail-NotificationItem-markAsRead");
-    await contains(".o-mail-NotificationItem-name", 0, { text: "Channel" });
+    await contains(".o-mail-NotificationItem-name", { count: 0, text: "Channel" });
 });
 
 QUnit.test("open non-channel failure", async (assert) => {
@@ -168,7 +168,8 @@ QUnit.test("different discuss.channel are not grouped", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-text", 2, {
+    await contains(".o-mail-NotificationItem-text", {
+        count: 2,
         text: "An error occurred when sending an email",
     });
 });
@@ -213,8 +214,8 @@ QUnit.test("multiple grouped notifications by model", async () => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 2);
-    await contains(".o-mail-NotificationItem-counter", 2, { text: "2" });
+    await contains(".o-mail-NotificationItem", { count: 2 });
+    await contains(".o-mail-NotificationItem-counter", { count: 2, text: "2" });
 });
 
 QUnit.test("non-failure notifications are ignored", async () => {
@@ -232,7 +233,7 @@ QUnit.test("non-failure notifications are ignored", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test(
@@ -257,7 +258,7 @@ QUnit.test(
         ]);
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-NotificationItem-name", 2);
+        await contains(".o-mail-NotificationItem-name", { count: 2 });
         assert.strictEqual($(".o-mail-NotificationItem-name:eq(0)").text(), "Channel 2020");
         assert.strictEqual($(".o-mail-NotificationItem-name:eq(1)").text(), "Channel 2019");
     }
@@ -283,7 +284,7 @@ QUnit.test("thread notifications are re-ordered on receiving a new message", asy
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 2);
+    await contains(".o-mail-NotificationItem", { count: 2 });
 
     const channel_1 = pyEnv["discuss.channel"].searchRead([["id", "=", channelId_1]])[0];
     pyEnv["bus.bus"]._sendone(channel_1, "discuss.channel/new_message", {
@@ -299,7 +300,7 @@ QUnit.test("thread notifications are re-ordered on receiving a new message", asy
             res_id: channelId_1,
         },
     });
-    await contains(".o-mail-NotificationItem", 2);
+    await contains(".o-mail-NotificationItem", { count: 2 });
     await contains(
         ".o-mail-NotificationItem:eq(0) .o-mail-NotificationItem-name:contains(Channel 2019)"
     );
@@ -333,6 +334,6 @@ QUnit.test(
         ]);
         await start();
         await contains(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-MessagingMenu-counter", 0);
+        await contains(".o-mail-MessagingMenu-counter", { count: 0 });
     }
 );

--- a/addons/mail/static/tests/messaging_menu/notification_tests.js
+++ b/addons/mail/static/tests/messaging_menu/notification_tests.js
@@ -236,33 +236,30 @@ QUnit.test("non-failure notifications are ignored", async () => {
     await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
-QUnit.test(
-    "marked as read thread notifications are ordered by last message date",
-    async (assert) => {
-        const pyEnv = await startServer();
-        const [channelId_1, channelId_2] = pyEnv["discuss.channel"].create([
-            { name: "Channel 2019" },
-            { name: "Channel 2020" },
-        ]);
-        pyEnv["mail.message"].create([
-            {
-                date: "2019-01-01 00:00:00",
-                model: "discuss.channel",
-                res_id: channelId_1,
-            },
-            {
-                date: "2020-01-01 00:00:00",
-                model: "discuss.channel",
-                res_id: channelId_2,
-            },
-        ]);
-        await start();
-        await click(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-NotificationItem-name", { count: 2 });
-        assert.strictEqual($(".o-mail-NotificationItem-name:eq(0)").text(), "Channel 2020");
-        assert.strictEqual($(".o-mail-NotificationItem-name:eq(1)").text(), "Channel 2019");
-    }
-);
+QUnit.test("marked as read thread notifications are ordered by last message date", async () => {
+    const pyEnv = await startServer();
+    const [channelId_1, channelId_2] = pyEnv["discuss.channel"].create([
+        { name: "Channel 2019" },
+        { name: "Channel 2020" },
+    ]);
+    pyEnv["mail.message"].create([
+        {
+            date: "2019-01-01 00:00:00",
+            model: "discuss.channel",
+            res_id: channelId_1,
+        },
+        {
+            date: "2020-01-01 00:00:00",
+            model: "discuss.channel",
+            res_id: channelId_2,
+        },
+    ]);
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem-name", { count: 2 });
+    await contains(".o-mail-NotificationItem-name:eq(0)", { text: "Channel 2020" });
+    await contains(".o-mail-NotificationItem-name:eq(1)", { text: "Channel 2019" });
+});
 
 QUnit.test("thread notifications are re-ordered on receiving a new message", async () => {
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/mobile/mobile_tests.js
+++ b/addons/mail/static/tests/mobile/mobile_tests.js
@@ -12,9 +12,9 @@ QUnit.test("auto-select 'Inbox' when discuss had channel as active thread", asyn
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", 1, { text: "Channel" });
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Channel" });
 
     await click("button", { text: "Mailboxes" });
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", 1, { text: "Mailboxes" });
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Mailboxes" });
     await contains("button:contains(Inbox).active");
 });

--- a/addons/mail/static/tests/mobile/mobile_tests.js
+++ b/addons/mail/static/tests/mobile/mobile_tests.js
@@ -12,9 +12,9 @@ QUnit.test("auto-select 'Inbox' when discuss had channel as active thread", asyn
     patchUiSize({ height: 360, width: 640 });
     const { openDiscuss } = await start();
     openDiscuss(channelId, { waitUntilMessagesLoaded: false });
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder:contains(Channel)");
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", 1, { text: "Channel" });
 
-    await click("button:contains(Mailboxes)");
-    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder:contains(Mailboxes)");
+    await click("button", { text: "Mailboxes" });
+    await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", 1, { text: "Mailboxes" });
     await contains("button:contains(Inbox).active");
 });

--- a/addons/mail/static/tests/suggestion/suggestion_tests.js
+++ b/addons/mail/static/tests/suggestion/suggestion_tests.js
@@ -39,7 +39,7 @@ QUnit.test('display partner mention suggestions on typing "@"', async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion strong", 3);
+    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
 });
 
 QUnit.test(
@@ -70,7 +70,7 @@ QUnit.test(
         await click("button:contains(Send):not(:disabled)");
         await contains(".o-mail-Message");
         await insertText(".o-mail-Composer-input", "@");
-        await contains(".o-mail-Composer-suggestion strong", 3);
+        await contains(".o-mail-Composer-suggestion strong", { count: 3 });
     }
 );
 
@@ -80,7 +80,7 @@ QUnit.test('display partner mention suggestions on typing "@" in chatter', async
     openFormView("res.partner", pyEnv.currentPartnerId);
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "Mitchell Admin" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
 });
 
 QUnit.test("show other channel member in @ mention", async () => {
@@ -99,7 +99,7 @@ QUnit.test("show other channel member in @ mention", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "TestPartner" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
 });
 
 QUnit.test("select @ mention insert mention text in composer", async () => {
@@ -119,7 +119,7 @@ QUnit.test("select @ mention insert mention text in composer", async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
-    await contains(".o-mail-Composer-input", 1, { value: "@TestPartner " });
+    await contains(".o-mail-Composer-input", { value: "@TestPartner " });
 });
 
 QUnit.test("select @ mention closes suggestions", async () => {
@@ -139,7 +139,7 @@ QUnit.test("select @ mention closes suggestions", async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
-    await contains(".o-mail-Composer-suggestion strong", 0);
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
 });
 
 QUnit.test('display channel mention suggestions on typing "#"', async () => {
@@ -151,7 +151,7 @@ QUnit.test('display channel mention suggestions on typing "#"', async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
     await insertText(".o-mail-Composer-input", "#");
     await contains(".o-mail-Composer-suggestionList .o-open");
 });
@@ -165,11 +165,11 @@ QUnit.test("mention a channel", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-suggestionList");
-    await contains(".o-mail-Composer-suggestionList .o-open", 0);
-    await contains(".o-mail-Composer-input", 1, { value: "" });
+    await contains(".o-mail-Composer-suggestionList .o-open", { count: 0 });
+    await contains(".o-mail-Composer-input", { value: "" });
     await insertText(".o-mail-Composer-input", "#");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "#General " });
+    await contains(".o-mail-Composer-input", { value: "#General " });
 });
 
 QUnit.test("Channel suggestions do not crash after rpc returns", async (assert) => {
@@ -204,9 +204,9 @@ QUnit.test("Suggestions are shown after delimiter was used in text (@)", async (
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-Composer-suggestion");
     await insertText(".o-mail-Composer-input", "NonExistingUser");
-    await contains(".o-mail-Composer-suggestion strong", 0);
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
     await insertText(".o-mail-Composer-input", " @");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "Mitchell Admin" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "Mitchell Admin" });
 });
 
 QUnit.test("Suggestions are shown after delimiter was used in text (#)", async () => {
@@ -217,9 +217,9 @@ QUnit.test("Suggestions are shown after delimiter was used in text (#)", async (
     await insertText(".o-mail-Composer-input", "#");
     await contains(".o-mail-Composer-suggestion");
     await insertText(".o-mail-Composer-input", "NonExistingChannel");
-    await contains(".o-mail-Composer-suggestion strong", 0);
+    await contains(".o-mail-Composer-suggestion strong", { count: 0 });
     await insertText(".o-mail-Composer-input", " #");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "#General" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "#General" });
 });
 
 QUnit.test("display partner mention when typing more than 2 words if they match", async () => {
@@ -242,10 +242,10 @@ QUnit.test("display partner mention when typing more than 2 words if they match"
     openFormView("res.partner", pyEnv.currentPartnerId);
     await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@My ");
-    await contains(".o-mail-Composer-suggestion strong", 3);
+    await contains(".o-mail-Composer-suggestion strong", { count: 3 });
     await insertText(".o-mail-Composer-input", "Test ");
-    await contains(".o-mail-Composer-suggestion strong", 2);
+    await contains(".o-mail-Composer-suggestion strong", { count: 2 });
     await insertText(".o-mail-Composer-input", "Partner");
     await contains(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-suggestion strong", 1, { text: "My Test Partner" });
+    await contains(".o-mail-Composer-suggestion strong", { text: "My Test Partner" });
 });

--- a/addons/mail/static/tests/suggestion/suggestion_tests.js
+++ b/addons/mail/static/tests/suggestion/suggestion_tests.js
@@ -39,7 +39,7 @@ QUnit.test('display partner mention suggestions on typing "@"', async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion", 3);
+    await contains(".o-mail-Composer-suggestion strong", 3);
 });
 
 QUnit.test(
@@ -70,7 +70,7 @@ QUnit.test(
         await click("button:contains(Send):not(:disabled)");
         await contains(".o-mail-Message");
         await insertText(".o-mail-Composer-input", "@");
-        await contains(".o-mail-Composer-suggestion", 3);
+        await contains(".o-mail-Composer-suggestion strong", 3);
     }
 );
 
@@ -78,9 +78,9 @@ QUnit.test('display partner mention suggestions on typing "@" in chatter', async
     const pyEnv = await startServer();
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion:contains(Mitchell Admin)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "Mitchell Admin" });
 });
 
 QUnit.test("show other channel member in @ mention", async () => {
@@ -99,7 +99,7 @@ QUnit.test("show other channel member in @ mention", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion:contains(TestPartner)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "TestPartner" });
 });
 
 QUnit.test("select @ mention insert mention text in composer", async () => {
@@ -118,7 +118,7 @@ QUnit.test("select @ mention insert mention text in composer", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
-    await click(".o-mail-Composer-suggestion:contains(TestPartner)");
+    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", 1, { value: "@TestPartner " });
 });
 
@@ -138,8 +138,8 @@ QUnit.test("select @ mention closes suggestions", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
-    await click(".o-mail-Composer-suggestion:contains(TestPartner)");
-    await contains(".o-mail-Composer-suggestion", 0);
+    await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
+    await contains(".o-mail-Composer-suggestion strong", 0);
 });
 
 QUnit.test('display channel mention suggestions on typing "#"', async () => {
@@ -204,9 +204,9 @@ QUnit.test("Suggestions are shown after delimiter was used in text (@)", async (
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-Composer-suggestion");
     await insertText(".o-mail-Composer-input", "NonExistingUser");
-    await contains(".o-mail-Composer-suggestion", 0);
+    await contains(".o-mail-Composer-suggestion strong", 0);
     await insertText(".o-mail-Composer-input", " @");
-    await contains(".o-mail-Composer-suggestion:contains(Mitchell Admin)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "Mitchell Admin" });
 });
 
 QUnit.test("Suggestions are shown after delimiter was used in text (#)", async () => {
@@ -217,9 +217,9 @@ QUnit.test("Suggestions are shown after delimiter was used in text (#)", async (
     await insertText(".o-mail-Composer-input", "#");
     await contains(".o-mail-Composer-suggestion");
     await insertText(".o-mail-Composer-input", "NonExistingChannel");
-    await contains(".o-mail-Composer-suggestion", 0);
+    await contains(".o-mail-Composer-suggestion strong", 0);
     await insertText(".o-mail-Composer-input", " #");
-    await contains(".o-mail-Composer-suggestion:contains(General)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "#General" });
 });
 
 QUnit.test("display partner mention when typing more than 2 words if they match", async () => {
@@ -240,12 +240,12 @@ QUnit.test("display partner mention when typing more than 2 words if they match"
     ]);
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "@My ");
-    await contains(".o-mail-Composer-suggestion", 3);
+    await contains(".o-mail-Composer-suggestion strong", 3);
     await insertText(".o-mail-Composer-input", "Test ");
-    await contains(".o-mail-Composer-suggestion", 2);
+    await contains(".o-mail-Composer-suggestion strong", 2);
     await insertText(".o-mail-Composer-input", "Partner");
     await contains(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-suggestion:contains(My Test Partner)");
+    await contains(".o-mail-Composer-suggestion strong", 1, { text: "My Test Partner" });
 });

--- a/addons/mail/static/tests/thread/attachment_list_tests.js
+++ b/addons/mail/static/tests/thread/attachment_list_tests.js
@@ -55,8 +55,8 @@ QUnit.test("layout with card details and filename and extension", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard:contains('test.txt')");
-    await contains(".o-mail-AttachmentCard small:contains('txt')");
+    await contains(".o-mail-AttachmentCard div", 1, { text: "test.txt" });
+    await contains(".o-mail-AttachmentCard small", 1, { text: "txt" });
 });
 
 QUnit.test(
@@ -309,7 +309,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await contains(".o-mail-AttachmentImage[title='test.png']");
-        await contains(".o-mail-AttachmentCard:contains(test.odt)");
+        await contains(".o-mail-AttachmentCard div", 1, { text: "test.odt" });
         assert.hasClass($(".o-mail-AttachmentImage[title='test.png'] img"), "o-viewable");
         assert.doesNotHaveClass($(".o-mail-AttachmentCard:contains(test.odt)"), "o-viewable");
 

--- a/addons/mail/static/tests/thread/attachment_list_tests.js
+++ b/addons/mail/static/tests/thread/attachment_list_tests.js
@@ -31,7 +31,7 @@ QUnit.test("simplest layout", async (assert) => {
     await contains(".o-mail-AttachmentCard-image");
     assert.hasClass($(".o-mail-AttachmentCard-image"), "o_image"); // required for mimetype.scss style
     assert.hasAttrValue($(".o-mail-AttachmentCard-image"), "data-mimetype", "text/plain"); // required for mimetype.scss style
-    await contains(".o-mail-AttachmentCard-aside button", 2);
+    await contains(".o-mail-AttachmentCard-aside button", { count: 2 });
     await contains(".o-mail-AttachmentCard-unlink");
     await contains(".o-mail-AttachmentCard-aside button[title='Download']");
 });
@@ -55,8 +55,8 @@ QUnit.test("layout with card details and filename and extension", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard div", 1, { text: "test.txt" });
-    await contains(".o-mail-AttachmentCard small", 1, { text: "txt" });
+    await contains(".o-mail-AttachmentCard div", { text: "test.txt" });
+    await contains(".o-mail-AttachmentCard small", { text: "txt" });
 });
 
 QUnit.test(
@@ -90,7 +90,7 @@ QUnit.test(
         click(".modal-footer .btn-primary");
         click(".modal-footer .btn-primary");
         click(".modal-footer .btn-primary");
-        await contains(".o-mail-AttachmentCard-unlink", 0);
+        await contains(".o-mail-AttachmentCard-unlink", { count: 0 });
         assert.verifySteps(["attachment_unlink"], "The unlink method must be called once");
     }
 );
@@ -144,7 +144,7 @@ QUnit.test("close attachment viewer", async () => {
     await contains(".o-FileViewer");
 
     await click(".o-FileViewer div[aria-label='Close']");
-    await contains(".o-FileViewer", 0);
+    await contains(".o-FileViewer", { count: 0 });
 });
 
 QUnit.test(
@@ -309,13 +309,13 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await contains(".o-mail-AttachmentImage[title='test.png']");
-        await contains(".o-mail-AttachmentCard div", 1, { text: "test.odt" });
+        await contains(".o-mail-AttachmentCard div", { text: "test.odt" });
         assert.hasClass($(".o-mail-AttachmentImage[title='test.png'] img"), "o-viewable");
         assert.doesNotHaveClass($(".o-mail-AttachmentCard:contains(test.odt)"), "o-viewable");
 
         click(".o-mail-AttachmentCard:contains(test.odt)").catch(() => {});
         await nextTick();
-        await contains(".o-FileViewer", 0);
+        await contains(".o-FileViewer", { count: 0 });
 
         await click(".o-mail-AttachmentImage[title='test.png']");
         await contains(".o-FileViewer");

--- a/addons/mail/static/tests/thread/file_upload_tests.js
+++ b/addons/mail/static/tests/thread/file_upload_tests.js
@@ -25,7 +25,7 @@ QUnit.test("no conflicts between file uploads", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     const file1 = await createFile({
         name: "text1.txt",
         content: "hello, world",

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -1023,7 +1023,7 @@ QUnit.test("New message separator not appearing after showing composer on thread
     await contains(".o-mail-Thread-newMessage", { count: 0 });
 });
 
-QUnit.test("Transient messages are added at the end of the thread", async (assert) => {
+QUnit.test("Transient messages are added at the end of the thread", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
@@ -1034,6 +1034,6 @@ QUnit.test("Transient messages are added at the end of the thread", async (asser
     await insertText(".o-mail-Composer-input", "/help");
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(".o-mail-Message", { count: 2 });
-    const lastMessage = document.querySelectorAll(".o-mail-Message")[1];
-    assert.ok(lastMessage.innerText.includes("You are in channel #General"));
+    await contains(".o-mail-Message-author:eq(0)", { text: "Mitchell Admin" });
+    await contains(".o-mail-Message-author:eq(1)", { text: "OdooBot" });
 });

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -51,11 +51,11 @@ QUnit.test("load more messages from channel (auto-load on scroll)", async () => 
     }
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains("button:contains(Load More) ~ .o-mail-Message", 30);
-    await contains(".o-mail-Message", 30);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains("button:contains(Load More) ~ .o-mail-Message", { count: 30 });
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Message", 60);
+    await contains(".o-mail-Message", { count: 60 });
 });
 
 QUnit.test("show message subject when subject is not the same as the thread name", async () => {
@@ -73,7 +73,7 @@ QUnit.test("show message subject when subject is not the same as the thread name
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message .o-mail-Message-content", {
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -93,10 +93,11 @@ QUnit.test("do not show message subject when subject is the same as the thread n
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message .o-mail-Message-content", {
         text: "not empty",
     });
-    await contains(".o-mail-Message .o-mail-Message-content", 0, {
+    await contains(".o-mail-Message .o-mail-Message-content", {
+        count: 0,
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -113,8 +114,8 @@ QUnit.test("auto-scroll to bottom of thread on load", async () => {
     }
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 25);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 25 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
 QUnit.test("display day separator before first message of the day", async () => {
@@ -148,7 +149,7 @@ QUnit.test("do not display day separator if all messages of the day are empty", 
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Thread-empty");
-    await contains(".o-mail-DateSection", 0);
+    await contains(".o-mail-DateSection", { count: 0 });
 });
 
 QUnit.test("scroll position is kept when navigating from one channel to another", async () => {
@@ -169,21 +170,21 @@ QUnit.test("scroll position is kept when navigating from one channel to another"
     );
     const { openDiscuss } = await start();
     openDiscuss(channelId_1);
-    await contains(".o-mail-Message", 20);
+    await contains(".o-mail-Message", { count: 20 });
     const scrollValue1 = $(".o-mail-Thread")[0].scrollHeight / 2;
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", scrollValue1);
     await click(".o-mail-DiscussSidebarChannel span", { text: "channel-2" });
-    await contains(".o-mail-Message", 30);
+    await contains(".o-mail-Message", { count: 30 });
     const scrollValue2 = $(".o-mail-Thread")[0].scrollHeight / 3;
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", scrollValue2);
     await click(".o-mail-DiscussSidebarChannel span", { text: "channel-1" });
-    await contains(".o-mail-Message", 20);
-    await contains(".o-mail-Thread", 1, { scroll: scrollValue1 });
+    await contains(".o-mail-Message", { count: 20 });
+    await contains(".o-mail-Thread", { scroll: scrollValue1 });
     await click(".o-mail-DiscussSidebarChannel span", { text: "channel-2" });
-    await contains(".o-mail-Message", 30);
-    await contains(".o-mail-Thread", 1, { scroll: scrollValue2 });
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Thread", { scroll: scrollValue2 });
 });
 
 QUnit.test("thread is still scrolling after scrolling up then to bottom", async () => {
@@ -201,14 +202,14 @@ QUnit.test("thread is still scrolling after scrolling up then to bottom", async 
     );
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message", 20);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 20 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", $(".o-mail-Thread")[0].scrollHeight / 2);
     await scroll(".o-mail-Thread", "bottom");
     await insertText(".o-mail-Composer-input", "123");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message", 21);
-    await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+    await contains(".o-mail-Message", { count: 21 });
+    await contains(".o-mail-Thread", { scroll: "bottom" });
 });
 
 QUnit.test("mention a channel with space in the name", async () => {
@@ -218,9 +219,9 @@ QUnit.test("mention a channel with space in the name", async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "#General good boy " });
+    await contains(".o-mail-Composer-input", { value: "#General good boy " });
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body .o_channel_redirect", 1, { text: "#General good boy" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General good boy" });
 });
 
 QUnit.test('mention a channel with "&" in the name', async () => {
@@ -230,9 +231,9 @@ QUnit.test('mention a channel with "&" in the name', async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "#General & good " });
+    await contains(".o-mail-Composer-input", { value: "#General & good " });
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body .o_channel_redirect", 1, { text: "#General & good" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General & good" });
 });
 
 QUnit.test(
@@ -274,9 +275,9 @@ QUnit.test(
         );
         await contains(".o-mail-Message");
         assert.verifySteps(["rpc:channel_fetch"]);
-        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+        await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
         $(".o-mail-Composer-input")[0].focus();
-        await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+        await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 
         assert.verifySteps(["rpc:set_last_seen_message"]);
     }
@@ -346,8 +347,8 @@ QUnit.test(
         const { env } = await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Message", 11);
-        await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+        await contains(".o-mail-Message", { count: 11 });
+        await contains(".o-mail-Thread", { scroll: "bottom" });
         // simulate receiving a message
         pyEnv.withUser(userId, () =>
             env.services.rpc("/mail/message/post", {
@@ -356,8 +357,8 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-Message", 12);
-        await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+        await contains(".o-mail-Message", { count: 12 });
+        await contains(".o-mail-Thread", { scroll: "bottom" });
     }
 );
 
@@ -383,8 +384,8 @@ QUnit.test(
         const { env } = await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         await click(".o-mail-NotificationItem");
-        await contains(".o-mail-Message", 11);
-        await contains(".o-mail-Thread", 1, { scroll: "bottom" });
+        await contains(".o-mail-Message", { count: 11 });
+        await contains(".o-mail-Thread", { scroll: "bottom" });
         await scroll(".o-mail-Thread", 0);
         // simulate receiving a message
         pyEnv.withUser(userId, () =>
@@ -394,8 +395,8 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-Message", 12);
-        await contains(".o-mail-ChatWindow .o-mail-Thread", 1, { scroll: 0 });
+        await contains(".o-mail-Message", { count: 12 });
+        await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 0 });
     }
 );
 
@@ -404,10 +405,10 @@ QUnit.test("show empty placeholder when thread contains no message", async () =>
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Thread .o-mail-Thread-empty", 1, {
+    await contains(".o-mail-Thread .o-mail-Thread-empty", {
         text: "There are no messages in this conversation.",
     });
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test("show empty placeholder when thread contains only empty messages", async () => {
@@ -416,10 +417,10 @@ QUnit.test("show empty placeholder when thread contains only empty messages", as
     pyEnv["mail.message"].create({ model: "discuss.channel", res_id: channelId });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Thread .o-mail-Thread-empty", 1, {
+    await contains(".o-mail-Thread .o-mail-Thread-empty", {
         text: "There are no messages in this conversation.",
     });
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test(
@@ -444,8 +445,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         // initial load: +30 empty ; (auto) load more: +20 empty +10 non-empty
-        await contains(".o-mail-Message", 10);
-        await contains("button", 1, { text: "Load More" }); // still 40 non-empty
+        await contains(".o-mail-Message", { count: 10 });
+        await contains("button", { text: "Load More" }); // still 40 non-empty
     }
 );
 
@@ -471,14 +472,14 @@ QUnit.test("no new messages separator on posting message (some message history)"
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 
     await insertText(".o-mail-Composer-input", "hey!");
     // need to remove focus from text area to avoid set_last_seen_message
     (await contains(".o-mail-Composer-send:not(:disabled)"))[0].focus();
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 });
 
 QUnit.test("new messages separator on receiving new message [REQUIRE FOCUS]", async () => {
@@ -510,7 +511,7 @@ QUnit.test("new messages separator on receiving new message [REQUIRE FOCUS]", as
     const { env, openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 
     $(".o-mail-Composer-input")[0].blur();
     // simulate receiving a message
@@ -523,15 +524,15 @@ QUnit.test("new messages separator on receiving new message [REQUIRE FOCUS]", as
             })
         )
     );
-    await contains(".o-mail-Message", 2);
-    await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", {
         text: "hu",
     });
 
     $(".o-mail-Composer-input")[0].focus();
     await nextTick();
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 });
 
 QUnit.test("no new messages separator on posting message (no message history)", async () => {
@@ -546,13 +547,13 @@ QUnit.test("no new messages separator on posting message (no message history)", 
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-input");
-    await contains(".o-mail-Message", 0);
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Message", { count: 0 });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 
     await insertText(".o-mail-Composer-input", "hey!");
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Thread-newMessage hr + span", 0, { text: "New messages" });
+    await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
 });
 
 QUnit.test("Mention a partner with special character (e.g. apostrophe ')", async () => {
@@ -573,7 +574,7 @@ QUnit.test("Mention a partner with special character (e.g. apostrophe ')", async
     await insertText(".o-mail-Composer-input", "@");
     await insertText(".o-mail-Composer-input", "Pyn");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "@Pynya's spokesman " });
+    await contains(".o-mail-Composer-input", { value: "@Pynya's spokesman " });
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(
         `.o-mail-Message-body .o_mail_redirect[data-oe-id="${partnerId}"][data-oe-model="res.partner"]:contains("@Pynya's spokesman")`
@@ -604,10 +605,10 @@ QUnit.test("mention 2 different partners that have the same name", async () => {
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@Te");
     await click(".o-mail-Composer-suggestion:eq(0)");
-    await contains(".o-mail-Composer-input", 1, { value: "@TestPartner " });
+    await contains(".o-mail-Composer-input", { value: "@TestPartner " });
     await insertText(".o-mail-Composer-input", "@Te");
     await click(".o-mail-Composer-suggestion:eq(1)");
-    await contains(".o-mail-Composer-input", 1, { value: "@TestPartner @TestPartner " });
+    await contains(".o-mail-Composer-input", { value: "@TestPartner @TestPartner " });
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(
         `.o-mail-Message-body .o_mail_redirect[data-oe-id="${partnerId_1}"][data-oe-model="res.partner"]:contains("@TestPartner")`
@@ -624,9 +625,9 @@ QUnit.test("mention a channel on a second line when the first line contains #", 
     openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "#blabla\n#");
     await click(".o-mail-Composer-suggestion");
-    await contains(".o-mail-Composer-input", 1, { value: "#blabla\n#General good " });
+    await contains(".o-mail-Composer-input", { value: "#blabla\n#General good " });
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message-body .o_channel_redirect", 1, { text: "#General good" });
+    await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General good" });
 });
 
 QUnit.test(
@@ -638,12 +639,12 @@ QUnit.test(
         openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "#");
         await click(".o-mail-Composer-suggestion");
-        await contains(".o-mail-Composer-input", 1, { value: "#General good " });
+        await contains(".o-mail-Composer-input", { value: "#General good " });
         const text = $(".o-mail-Composer-input").val();
         $(".o-mail-Composer-input").val(text.slice(0, -1));
         await insertText(".o-mail-Composer-input", ", test");
         await click(".o-mail-Composer-send:not(:disabled)");
-        await contains(".o-mail-Message-body .o_channel_redirect", 1, { text: "#General good" });
+        await contains(".o-mail-Message-body .o_channel_redirect", { text: "#General good" });
     }
 );
 
@@ -664,10 +665,10 @@ QUnit.test("mention 2 different channels that have the same name", async () => {
     openDiscuss(channelId_1);
     await insertText(".o-mail-Composer-input", "#m");
     await click(".o-mail-Composer-suggestion:eq(0)");
-    await contains(".o-mail-Composer-input", 1, { value: "#my channel " });
+    await contains(".o-mail-Composer-input", { value: "#my channel " });
     await insertText(".o-mail-Composer-input", "#m");
     await click(".o-mail-Composer-suggestion:eq(1)");
-    await contains(".o-mail-Composer-input", 1, { value: "#my channel #my channel " });
+    await contains(".o-mail-Composer-input", { value: "#my channel #my channel " });
     await click(".o-mail-Composer-send:not(:disabled)");
     await contains(
         `.o-mail-Message-body .o_channel_redirect[data-oe-id="${channelId_1}"][data-oe-model="discuss.channel"]:contains("#my channel")`
@@ -696,7 +697,7 @@ QUnit.test(
         openDiscuss(channelId);
         await insertText(".o-mail-Composer-input", "email@odoo.com\n@Te");
         await click(".o-mail-Composer-suggestion");
-        await contains(".o-mail-Composer-input", 1, { value: "email@odoo.com\n@TestPartner " });
+        await contains(".o-mail-Composer-input", { value: "email@odoo.com\n@TestPartner " });
         await click(".o-mail-Composer-send:not(:disabled)");
         await contains(
             `.o-mail-Message-body .o_mail_redirect[data-oe-id="${partnerId}"][data-oe-model="res.partner"]:contains("@TestPartner")`
@@ -728,7 +729,7 @@ QUnit.test("basic rendering of canceled notification", async () => {
     await click(".o-mail-Message-notification");
     await contains(".o-mail-MessageNotificationPopover");
     await contains(".o-mail-MessageNotificationPopover .fa-trash-o");
-    await contains(".o-mail-MessageNotificationPopover", 1, { text: "Someone" });
+    await contains(".o-mail-MessageNotificationPopover", { text: "Someone" });
 });
 
 QUnit.test(
@@ -765,7 +766,7 @@ QUnit.test(
         // send a command that leads to receiving a transient message
         await insertText(".o-mail-Composer-input", "/who");
         await click(".o-mail-Composer-send:not(:disabled)");
-        await contains(".o-mail-Message", 2);
+        await contains(".o-mail-Message", { count: 2 });
         // composer is focused by default, we remove that focus
         $(".o-mail-Composer-input")[0].blur();
         // simulate receiving a message
@@ -776,8 +777,8 @@ QUnit.test(
                 thread_model: "discuss.channel",
             })
         );
-        await contains(".o-mail-Message", 3);
-        await contains(".o-mail-Thread-newMessage hr + span", 1, { text: "New messages" });
+        await contains(".o-mail-Message", { count: 3 });
+        await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
         await contains(".o-mail-Message[aria-label='Note'] + .o-mail-Thread-newMessage");
     }
 );
@@ -815,7 +816,7 @@ QUnit.test("chat window header should not have unread counter for non-channel th
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name");
-    await contains(".o-mail-ChatWindow-counter", 0, { text: "1" });
+    await contains(".o-mail-ChatWindow-counter", { count: 0, text: "1" });
 });
 
 QUnit.test(
@@ -852,7 +853,7 @@ QUnit.test(
         });
         await click(".o_menu_systray i[aria-label='Messages']");
         await contains(".o-mail-NotificationItem");
-        await contains(".o-mail-ChatWindow", 0);
+        await contains(".o-mail-ChatWindow", { count: 0 });
 
         await click(".o-mail-NotificationItem");
         await contains(".o-mail-ChatWindow");
@@ -884,11 +885,11 @@ QUnit.test("Thread messages are only loaded once", async (assert) => {
     ]);
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel:eq(0)");
-    await contains(".o-mail-Message-content", 1, { text: "Message on channel1" });
+    await contains(".o-mail-Message-content", { text: "Message on channel1" });
     await click(".o-mail-DiscussSidebarChannel:eq(1)");
-    await contains(".o-mail-Message-content", 1, { text: "Message on channel2" });
+    await contains(".o-mail-Message-content", { text: "Message on channel2" });
     await click(".o-mail-DiscussSidebarChannel:eq(0)");
-    await contains(".o-mail-Message-content", 1, { text: "Message on channel1" });
+    await contains(".o-mail-Message-content", { text: "Message on channel1" });
     assert.verifySteps([`load messages - ${channelIds[0]}`, `load messages - ${channelIds[1]}`]);
 });
 
@@ -913,7 +914,7 @@ QUnit.test(
         // ensure focusout is triggered on composers' textarea
         triggerEvents((await contains(".o-mail-Composer-input"))[0], null, ["blur", "focusout"]);
         await click("button div", { text: "Inbox" });
-        await contains("h4", 1, { text: "Congratulations, your inbox is empty" });
+        await contains("h4", { text: "Congratulations, your inbox is empty" });
         const messageId = pyEnv["mail.message"].create({
             author_id: partnerId,
             body: "@Mitchel Admin",
@@ -933,10 +934,10 @@ QUnit.test(
             [messageId],
         ]);
         pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", formattedMessage);
-        await contains("button:contains(Inbox) .badge", 1, { text: "1" });
+        await contains("button:contains(Inbox) .badge", { text: "1" });
         await click("button span", { text: "General" });
-        await contains(".o-discuss-badge", 0);
-        await contains("button:contains(Inbox) .badge", 0);
+        await contains(".o-discuss-badge", { count: 0 });
+        await contains("button:contains(Inbox) .badge", { count: 0 });
         assert.verifySteps(["mark-all-messages-as-read"]);
     }
 );
@@ -994,10 +995,10 @@ QUnit.test("can be marked as read while loading", async function () {
         },
     });
     openDiscuss(undefined, { waitUntilMessagesLoaded: false });
-    await contains(".o-discuss-badge", 1, { text: "1" });
+    await contains(".o-discuss-badge", { text: "1" });
     await click(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
     await afterNextRender(loadDeferred.resolve);
-    await contains(".o-discuss-badge", 0);
+    await contains(".o-discuss-badge", { count: 0 });
 });
 
 QUnit.test("New message separator not appearing after showing composer on thread", async () => {
@@ -1016,10 +1017,10 @@ QUnit.test("New message separator not appearing after showing composer on thread
     ]);
     const { openFormView } = await start();
     openFormView("res.partner", pyEnv.currentPartnerId);
-    await contains("button", 1, { text: "Log note" });
-    await contains(".o-mail-Thread-newMessage", 0);
+    await contains("button", { text: "Log note" });
+    await contains(".o-mail-Thread-newMessage", { count: 0 });
     await click("button", { text: "Log note" });
-    await contains(".o-mail-Thread-newMessage", 0);
+    await contains(".o-mail-Thread-newMessage", { count: 0 });
 });
 
 QUnit.test("Transient messages are added at the end of the thread", async (assert) => {
@@ -1032,7 +1033,7 @@ QUnit.test("Transient messages are added at the end of the thread", async (asser
     await contains(".o-mail-Message");
     await insertText(".o-mail-Composer-input", "/help");
     await click(".o-mail-Composer-send:not(:disabled)");
-    await contains(".o-mail-Message", 2);
+    await contains(".o-mail-Message", { count: 2 });
     const lastMessage = document.querySelectorAll(".o-mail-Message")[1];
     assert.ok(lastMessage.innerText.includes("You are in channel #General"));
 });

--- a/addons/mail/static/tests/web/activity/activity_widget_tests.js
+++ b/addons/mail/static/tests/web/activity/activity_widget_tests.js
@@ -41,7 +41,7 @@ QUnit.test("list activity widget with no activity", async (assert) => {
         views: [[false, "list"]],
     });
     await contains(".o-mail-ActivityButton i.text-muted");
-    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "" });
+    await contains(".o-mail-ListActivity-summary:eq(0)", { text: "" });
     assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
@@ -141,7 +141,7 @@ QUnit.test("list activity widget with exception", async (assert) => {
         views: [[false, "list"]],
     });
     await contains(".o-mail-ActivityButton i.text-warning.fa-warning");
-    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "Warning" });
+    await contains(".o-mail-ListActivity-summary:eq(0)", { text: "Warning" });
     assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
@@ -220,12 +220,12 @@ QUnit.test("list activity widget: open dropdown", async (assert) => {
         res_model: "res.users",
         views: [[false, "list"]],
     });
-    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "Call with Al" });
+    await contains(".o-mail-ListActivity-summary:eq(0)", { text: "Call with Al" });
 
     await click(".o-mail-ActivityButton"); // open the popover
     await click(".o-mail-ActivityListPopoverItem-markAsDone:eq(0)"); // mark the first activity as done
     await click(".o-mail-ActivityMarkAsDone button[aria-label='Done']"); // confirm
-    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "Meet FP" });
+    await contains(".o-mail-ListActivity-summary:eq(0)", { text: "Meet FP" });
     assert.verifySteps(["web_search_read", "activity_format", "action_feedback", "web_read"]);
 });
 
@@ -275,7 +275,9 @@ QUnit.test("list activity exception widget with activity", async () => {
         res_model: "res.users",
         views: [[false, "list"]],
     });
-    await contains(".o_data_row", 2);
-    await contains(".o_data_row .o_activity_exception_cell:eq(0) .o-mail-ActivityException", 0);
+    await contains(".o_data_row", { count: 2 });
+    await contains(".o_data_row .o_activity_exception_cell:eq(0) .o-mail-ActivityException", {
+        count: 0,
+    });
     await contains(".o_data_row .o_activity_exception_cell:eq(1) .o-mail-ActivityException");
 });

--- a/addons/mail/static/tests/web/activity/activity_widget_tests.js
+++ b/addons/mail/static/tests/web/activity/activity_widget_tests.js
@@ -41,7 +41,7 @@ QUnit.test("list activity widget with no activity", async (assert) => {
         views: [[false, "list"]],
     });
     await contains(".o-mail-ActivityButton i.text-muted");
-    await contains(".o-mail-ListActivity-summary:eq(0):contains()");
+    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "" });
     assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
@@ -141,7 +141,7 @@ QUnit.test("list activity widget with exception", async (assert) => {
         views: [[false, "list"]],
     });
     await contains(".o-mail-ActivityButton i.text-warning.fa-warning");
-    await contains(".o-mail-ListActivity-summary:eq(0):contains(Warning)");
+    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "Warning" });
     assert.verifySteps(["/web/dataset/call_kw/res.users/web_search_read"]);
 });
 
@@ -220,12 +220,12 @@ QUnit.test("list activity widget: open dropdown", async (assert) => {
         res_model: "res.users",
         views: [[false, "list"]],
     });
-    await contains(".o-mail-ListActivity-summary:eq(0):contains(Call with Al)");
+    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "Call with Al" });
 
     await click(".o-mail-ActivityButton"); // open the popover
     await click(".o-mail-ActivityListPopoverItem-markAsDone:eq(0)"); // mark the first activity as done
     await click(".o-mail-ActivityMarkAsDone button[aria-label='Done']"); // confirm
-    await contains(".o-mail-ListActivity-summary:eq(0):contains(Meet FP)");
+    await contains(".o-mail-ListActivity-summary:eq(0)", 1, { text: "Meet FP" });
     assert.verifySteps(["web_search_read", "activity_format", "action_feedback", "web_read"]);
 });
 

--- a/addons/mail/static/tests/web/attachment_box_tests.js
+++ b/addons/mail/static/tests/web/attachment_box_tests.js
@@ -25,7 +25,7 @@ QUnit.test("base empty rendering", async () => {
         views: [[false, "form"]],
     });
     await contains(".o-mail-AttachmentBox");
-    await contains("button:contains('Attach files')");
+    await contains("button", 1, { text: "Attach files" });
     await contains(".o-mail-Chatter .o-mail-AttachmentImage", 0);
 });
 
@@ -63,7 +63,7 @@ QUnit.test("base non-empty rendering", async () => {
         views: [[false, "form"]],
     });
     await contains(".o-mail-AttachmentBox");
-    await contains("button:contains('Attach files')");
+    await contains("button", 1, { text: "Attach files" });
     await contains(".o-mail-Chatter input[type='file']");
     await contains(".o-mail-AttachmentList");
 });
@@ -97,7 +97,7 @@ QUnit.test("remove attachment should ask for confirmation", async () => {
     await contains("button[title='Remove']");
 
     await click("button[title='Remove']");
-    await contains(".modal-body:contains('Do you really want to delete \"Blah.txt\"?')");
+    await contains(".modal-body", 1, { text: 'Do you really want to delete "Blah.txt"?' });
 
     // Confirm the deletion
     await click(".modal-footer .btn-primary");
@@ -137,15 +137,15 @@ QUnit.test("view attachments", async () => {
     });
     await click('.o-mail-AttachmentCard[aria-label="Blah.txt"] .o-mail-AttachmentCard-image');
     await contains(".o-FileViewer");
-    await contains(".o-FileViewer-header:contains(Blah.txt)");
+    await contains(".o-FileViewer-header span", 1, { text: "Blah.txt" });
     await contains(".o-FileViewer div[aria-label='Next']");
 
     await click(".o-FileViewer div[aria-label='Next']");
-    await contains(".o-FileViewer-header:contains(Blu.txt)");
+    await contains(".o-FileViewer-header span", 1, { text: "Blu.txt" });
     await contains(".o-FileViewer div[aria-label='Next']");
 
     await click(".o-FileViewer div[aria-label='Next']");
-    await contains(".o-FileViewer-header:contains(Blah.txt)");
+    await contains(".o-FileViewer-header span", 1, { text: "Blah.txt" });
 });
 
 QUnit.test("scroll to attachment box when toggling on", async (assert) => {
@@ -194,9 +194,9 @@ QUnit.test("attachment box should order attachments from newest to oldest", asyn
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Chatter [aria-label='Attach files']:contains(3)");
+    await contains(".o-mail-Chatter [aria-label='Attach files']", 1, { text: "3" });
     await click(".o-mail-Chatter [aria-label='Attach files']"); // open attachment box
-    await contains(".o-mail-AttachmentCard:eq(0):contains(C.txt)");
-    await contains(".o-mail-AttachmentCard:eq(1):contains(B.txt)");
-    await contains(".o-mail-AttachmentCard:eq(2):contains(A.txt)");
+    await contains(".o-mail-AttachmentCard:eq(0) div", 1, { text: "C.txt" });
+    await contains(".o-mail-AttachmentCard:eq(1) div", 1, { text: "B.txt" });
+    await contains(".o-mail-AttachmentCard:eq(2) div", 1, { text: "A.txt" });
 });

--- a/addons/mail/static/tests/web/attachment_box_tests.js
+++ b/addons/mail/static/tests/web/attachment_box_tests.js
@@ -25,8 +25,8 @@ QUnit.test("base empty rendering", async () => {
         views: [[false, "form"]],
     });
     await contains(".o-mail-AttachmentBox");
-    await contains("button", 1, { text: "Attach files" });
-    await contains(".o-mail-Chatter .o-mail-AttachmentImage", 0);
+    await contains("button", { text: "Attach files" });
+    await contains(".o-mail-Chatter .o-mail-AttachmentImage", { count: 0 });
 });
 
 QUnit.test("base non-empty rendering", async () => {
@@ -63,7 +63,7 @@ QUnit.test("base non-empty rendering", async () => {
         views: [[false, "form"]],
     });
     await contains(".o-mail-AttachmentBox");
-    await contains("button", 1, { text: "Attach files" });
+    await contains("button", { text: "Attach files" });
     await contains(".o-mail-Chatter input[type='file']");
     await contains(".o-mail-AttachmentList");
 });
@@ -97,11 +97,11 @@ QUnit.test("remove attachment should ask for confirmation", async () => {
     await contains("button[title='Remove']");
 
     await click("button[title='Remove']");
-    await contains(".modal-body", 1, { text: 'Do you really want to delete "Blah.txt"?' });
+    await contains(".modal-body", { text: 'Do you really want to delete "Blah.txt"?' });
 
     // Confirm the deletion
     await click(".modal-footer .btn-primary");
-    await contains(".o-mail-AttachmentImage", 0);
+    await contains(".o-mail-AttachmentImage", { count: 0 });
 });
 
 QUnit.test("view attachments", async () => {
@@ -137,15 +137,15 @@ QUnit.test("view attachments", async () => {
     });
     await click('.o-mail-AttachmentCard[aria-label="Blah.txt"] .o-mail-AttachmentCard-image');
     await contains(".o-FileViewer");
-    await contains(".o-FileViewer-header span", 1, { text: "Blah.txt" });
+    await contains(".o-FileViewer-header span", { text: "Blah.txt" });
     await contains(".o-FileViewer div[aria-label='Next']");
 
     await click(".o-FileViewer div[aria-label='Next']");
-    await contains(".o-FileViewer-header span", 1, { text: "Blu.txt" });
+    await contains(".o-FileViewer-header span", { text: "Blu.txt" });
     await contains(".o-FileViewer div[aria-label='Next']");
 
     await click(".o-FileViewer div[aria-label='Next']");
-    await contains(".o-FileViewer-header span", 1, { text: "Blah.txt" });
+    await contains(".o-FileViewer-header span", { text: "Blah.txt" });
 });
 
 QUnit.test("scroll to attachment box when toggling on", async (assert) => {
@@ -171,11 +171,11 @@ QUnit.test("scroll to attachment box when toggling on", async (assert) => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message", 30);
+    await contains(".o-mail-Message", { count: 30 });
     await scroll(".o-mail-Chatter", "bottom");
     await click("button[aria-label='Attach files']");
     await contains(".o-mail-AttachmentBox");
-    await contains(".o-mail-Chatter", 1, { scroll: 0 });
+    await contains(".o-mail-Chatter", { scroll: 0 });
     assert.isVisible($(".o-mail-AttachmentBox"));
 });
 
@@ -194,9 +194,9 @@ QUnit.test("attachment box should order attachments from newest to oldest", asyn
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Chatter [aria-label='Attach files']", 1, { text: "3" });
+    await contains(".o-mail-Chatter [aria-label='Attach files']", { text: "3" });
     await click(".o-mail-Chatter [aria-label='Attach files']"); // open attachment box
-    await contains(".o-mail-AttachmentCard:eq(0) div", 1, { text: "C.txt" });
-    await contains(".o-mail-AttachmentCard:eq(1) div", 1, { text: "B.txt" });
-    await contains(".o-mail-AttachmentCard:eq(2) div", 1, { text: "A.txt" });
+    await contains(".o-mail-AttachmentCard:eq(0) div", { text: "C.txt" });
+    await contains(".o-mail-AttachmentCard:eq(1) div", { text: "B.txt" });
+    await contains(".o-mail-AttachmentCard:eq(2) div", { text: "A.txt" });
 });

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -68,10 +68,10 @@ QUnit.test("can post a message on a record thread", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains("button:contains(Send message)");
+    await contains("button", 1, { text: "Send message" });
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Composer");
 
     await insertText(".o-mail-Composer-input", "hey");
@@ -109,10 +109,10 @@ QUnit.test("can post a note on a record thread", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains("button:contains(Log note)");
+    await contains("button", 1, { text: "Log note" });
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains(".o-mail-Composer");
 
     await insertText(".o-mail-Composer-input", "hey");
@@ -156,7 +156,7 @@ QUnit.test("Composer toggle state is kept when switching from aside to bottom", 
     const { openFormView, pyEnv } = await start();
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     openFormView("res.partner", partnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Form-chatter.o-aside .o-mail-Composer-input");
     patchUiSize({ size: SIZES.LG });
     window.dispatchEvent(new Event("resize"));
@@ -168,7 +168,7 @@ QUnit.test("Textarea content is kept when switching from aside to bottom", async
     const { openFormView, pyEnv } = await start();
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     openFormView("res.partner", partnerId);
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Form-chatter.o-aside .o-mail-Composer-input");
     await insertText(".o-mail-Composer-input", "Hello world !");
     patchUiSize({ size: SIZES.LG });
@@ -182,7 +182,7 @@ QUnit.test("Composer type is kept when switching from aside to bottom", async (a
     const { openFormView, pyEnv } = await start();
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
     openFormView("res.partner", partnerId);
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     patchUiSize({ size: SIZES.LG });
     window.dispatchEvent(new Event("resize"));
     await contains(".o-mail-Form-chatter:not(.o-aside) .o-mail-Composer-input");
@@ -249,7 +249,9 @@ QUnit.test("should display subject when subject isn't infered from the record", 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message:contains(Subject: Salutations, voyageur)");
+    await contains(".o-mail-Message-content", 1, {
+        text: "Subject: Salutations, voyageurnot empty",
+    });
 });
 
 QUnit.test("should not display user notification messages in chatter", async () => {
@@ -279,7 +281,7 @@ QUnit.test('post message with "CTRL-Enter" keyboard shortcut in chatter', async 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Message", 0);
     await insertText(".o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
@@ -321,7 +323,8 @@ QUnit.test("base rendering when chatter has no record", async (assert) => {
     await contains(".o-mail-Chatter .o-mail-Thread");
     await contains(".o-mail-Message");
     assert.strictEqual($(".o-mail-Message-body").text(), "Creating a new record...");
-    await contains("button:contains(Load More)", 0);
+    await contains("button", 0, { text: "Load More" });
+
     await contains(".o-mail-Message-actions");
     await contains(".o-mail-Message-actions i", 0);
 });
@@ -380,7 +383,7 @@ QUnit.test("show attachment box", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']:contains(2)");
+    await contains("button[aria-label='Attach files']", 1, { text: "2" });
     await contains(".o-mail-AttachmentBox", 0);
 
     await click("button[aria-label='Attach files']");
@@ -396,25 +399,25 @@ QUnit.test("composer show/hide on log note/send message [REQUIRE FOCUS]", async 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(Send message)");
-    await contains("button:contains(Log note)");
+    await contains("button", 1, { text: "Send message" });
+    await contains("button", 1, { text: "Log note" });
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Composer");
     assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains(".o-mail-Composer");
     assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Composer");
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Composer", 0);
 });
 
@@ -427,7 +430,7 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains(".o-mail-Message", 0);
     await insertText(".o-mail-Composer-input", "Test");
     triggerHotkey("Enter");
@@ -452,7 +455,12 @@ QUnit.test("should not display subject when subject is the same as the thread na
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message:not(:contains(Salutations, voyageur))");
+    await contains(".o-mail-Message .o-mail-Message-content", 1, {
+        text: "not empty",
+    });
+    await contains(".o-mail-Message .o-mail-Message-content", 0, {
+        text: "Subject: Salutations, voyageurnot empty",
+    });
 });
 
 QUnit.test("scroll position is kept when navigating from one record to another", async () => {
@@ -534,7 +542,8 @@ QUnit.test("basic chatter rendering without activities", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button:contains(Activities)", 0);
+    await contains("button", 0, { text: "Activities" });
+
     await contains(".o-mail-Followers");
     await contains(".o-mail-Thread");
 });
@@ -563,7 +572,26 @@ QUnit.test(
         });
         await click(".o_form_button_create:eq(0)");
         await contains(".o-mail-Message");
-        await contains(".o-mail-Message-body:contains(Creating a new record...)");
+        await contains(".o-mail-Message-body", 1, { text: "Creating a new record..." });
+    }
+);
+
+QUnit.test(
+    "should display subject when subject is not the same as the default subject",
+    async () => {
+        const pyEnv = await startServer();
+        const fakeId = pyEnv["res.fake"].create({ name: "Salutations, voyageur" });
+        pyEnv["mail.message"].create({
+            body: "not empty",
+            model: "res.fake",
+            res_id: fakeId,
+            subject: "Another Subject",
+        });
+        const { openFormView } = await start();
+        openFormView("res.fake", fakeId);
+        await contains(".o-mail-Message .o-mail-Message-content", 1, {
+            text: "Subject: Another Subjectnot empty",
+        });
     }
 );
 
@@ -576,11 +604,16 @@ QUnit.test(
             body: "not empty",
             model: "res.fake",
             res_id: fakeId,
-            subject: "Custom Default Subject", // default subject for res.fake, set on the model
+            subject: "Custom Default Subject",
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message:not(:contains(Custom Default Subject))");
+        await contains(".o-mail-Message .o-mail-Message-content", 1, {
+            text: "not empty",
+        });
+        await contains(".o-mail-Message .o-mail-Message-content", 0, {
+            text: "Subject: Custom Default Subjectnot empty",
+        });
     }
 );
 
@@ -597,7 +630,12 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message:not(:contains(Custom Default Subject))");
+        await contains(".o-mail-Message .o-mail-Message-content", 1, {
+            text: "not empty",
+        });
+        await contains(".o-mail-Message .o-mail-Message-content", 0, {
+            text: "Subject: Custom Default Subjectnot empty",
+        });
     }
 );
 
@@ -626,7 +664,7 @@ QUnit.test("basic chatter rendering without followers", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button:contains(Activities)");
+    await contains("button", 1, { text: "Activities" });
     await contains(".o-mail-Chatter .o-mail-Thread");
     await contains(".o-mail-Followers", 0);
 });
@@ -656,7 +694,7 @@ QUnit.test("basic chatter rendering without messages", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button:contains(Activities)");
+    await contains("button", 1, { text: "Activities" });
     await contains(".o-mail-Followers");
     await contains(".o-mail-Chatter .o-mail-Thread", 0);
 });
@@ -708,11 +746,11 @@ QUnit.test("post message on draft record", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await insertText(".o-mail-Composer-input", "Test");
     await click(".o-mail-Composer button:contains(Send):not(:disabled)");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message:contains(Test)");
+    await contains(".o-mail-Message-content", 1, { text: "Test" });
 });
 
 QUnit.test(
@@ -731,8 +769,8 @@ QUnit.test(
         };
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.partner");
-        await click("button:contains(Activities)");
-        await contains(".o_dialog:contains(Schedule Activity)");
+        await click("button", { text: "Activities" });
+        await contains(".o_dialog h4", 1, { text: "Schedule Activity" });
     }
 );
 
@@ -761,14 +799,15 @@ QUnit.test("upload attachment on draft record", async () => {
             name: "text.txt",
         }),
     ]);
-    await contains(".button[aria-label='Attach files']:contains(1)", 0);
+    await contains(".button[aria-label='Attach files']", 0, { text: "1" });
+
     dragenterFiles(chatter[0]);
     dropFiles((await contains(".o-mail-Dropzone"))[0], [file]);
-    await contains("button[aria-label='Attach files']:contains(1)");
+    await contains("button[aria-label='Attach files']", 1, { text: "1" });
 });
 
 QUnit.test("Follower count of draft record is set to 0", async (assert) => {
     const { openView } = await start();
     await openView({ res_model: "res.partner", views: [[false, "form"]] });
-    await contains(".o-mail-Followers:contains(0)");
+    await contains(".o-mail-Followers", 1, { text: "0" });
 });

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -68,14 +68,14 @@ QUnit.test("can post a message on a record thread", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains("button", 1, { text: "Send message" });
-    await contains(".o-mail-Composer", 0);
+    await contains("button", { text: "Send message" });
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Send message" });
     await contains(".o-mail-Composer");
 
     await insertText(".o-mail-Composer-input", "hey");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 
     await click(".o-mail-Composer button:contains(Send):not(:disabled)");
     await contains(".o-mail-Message");
@@ -109,14 +109,14 @@ QUnit.test("can post a note on a record thread", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains("button", 1, { text: "Log note" });
-    await contains(".o-mail-Composer", 0);
+    await contains("button", { text: "Log note" });
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Log note" });
     await contains(".o-mail-Composer");
 
     await insertText(".o-mail-Composer-input", "hey");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 
     await click(".o-mail-Composer button:contains(Log):not(:disabled)");
     await contains(".o-mail-Message");
@@ -127,7 +127,7 @@ QUnit.test("No attachment loading spinner when creating records", async () => {
     const { openFormView } = await start();
     openFormView("res.partner");
     await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files'] .fa-spin", 0);
+    await contains("button[aria-label='Attach files'] .fa-spin", { count: 0 });
 });
 
 QUnit.test(
@@ -147,7 +147,7 @@ QUnit.test(
         await advanceTime(DELAY_FOR_SPINNER);
         await contains("button[aria-label='Attach files'] .fa-spin");
         await click(".o_form_button_create:eq(0)");
-        await contains("button[aria-label='Attach files'] .fa-spin", 0);
+        await contains("button[aria-label='Attach files'] .fa-spin", { count: 0 });
     }
 );
 
@@ -174,7 +174,7 @@ QUnit.test("Textarea content is kept when switching from aside to bottom", async
     patchUiSize({ size: SIZES.LG });
     window.dispatchEvent(new Event("resize"));
     await contains(".o-mail-Form-chatter:not(.o-aside) .o-mail-Composer-input");
-    await contains(".o-mail-Composer-input", 1, { value: "Hello world !" });
+    await contains(".o-mail-Composer-input", { value: "Hello world !" });
 });
 
 QUnit.test("Composer type is kept when switching from aside to bottom", async (assert) => {
@@ -217,10 +217,10 @@ QUnit.test("chatter: drop attachments", async (assert) => {
     ];
     await afterNextRender(() => dragenterFiles($(".o-mail-Chatter")[0]));
     await contains(".o-mail-Dropzone");
-    await contains(".o-mail-AttachmentCard", 0);
+    await contains(".o-mail-AttachmentCard", { count: 0 });
 
     await afterNextRender(() => dropFiles($(".o-mail-Dropzone")[0], files));
-    await contains(".o-mail-AttachmentCard", 2);
+    await contains(".o-mail-AttachmentCard", { count: 2 });
 
     await afterNextRender(() => dragenterFiles($(".o-mail-Chatter")[0]));
     files = [
@@ -231,7 +231,7 @@ QUnit.test("chatter: drop attachments", async (assert) => {
         }),
     ];
     await afterNextRender(() => dropFiles($(".o-mail-Dropzone")[0], files));
-    await contains(".o-mail-AttachmentCard", 3);
+    await contains(".o-mail-AttachmentCard", { count: 3 });
 });
 
 QUnit.test("should display subject when subject isn't infered from the record", async () => {
@@ -249,7 +249,7 @@ QUnit.test("should display subject when subject isn't infered from the record", 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message-content", 1, {
+    await contains(".o-mail-Message-content", {
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -269,7 +269,7 @@ QUnit.test("should not display user notification messages in chatter", async () 
         views: [[false, "form"]],
     });
     await contains(".o-mail-Thread-empty");
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test('post message with "CTRL-Enter" keyboard shortcut in chatter', async () => {
@@ -282,7 +282,7 @@ QUnit.test('post message with "CTRL-Enter" keyboard shortcut in chatter', async 
         views: [[false, "form"]],
     });
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
     await insertText(".o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
     await contains(".o-mail-Message");
@@ -306,9 +306,9 @@ QUnit.test("base rendering when chatter has no attachment", async (assert) => {
     });
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
-    await contains(".o-mail-AttachmentBox", 0);
+    await contains(".o-mail-AttachmentBox", { count: 0 });
     await contains(".o-mail-Thread");
-    await contains(".o-mail-Message", 30);
+    await contains(".o-mail-Message", { count: 30 });
 });
 
 QUnit.test("base rendering when chatter has no record", async (assert) => {
@@ -319,14 +319,14 @@ QUnit.test("base rendering when chatter has no record", async (assert) => {
     });
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
-    await contains(".o-mail-AttachmentBox", 0);
+    await contains(".o-mail-AttachmentBox", { count: 0 });
     await contains(".o-mail-Chatter .o-mail-Thread");
     await contains(".o-mail-Message");
     assert.strictEqual($(".o-mail-Message-body").text(), "Creating a new record...");
-    await contains("button", 0, { text: "Load More" });
+    await contains("button", { count: 0, text: "Load More" });
 
     await contains(".o-mail-Message-actions");
-    await contains(".o-mail-Message-actions i", 0);
+    await contains(".o-mail-Message-actions i", { count: 0 });
 });
 
 QUnit.test("base rendering when chatter has attachments", async () => {
@@ -354,7 +354,7 @@ QUnit.test("base rendering when chatter has attachments", async () => {
     });
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
-    await contains(".o-mail-AttachmentBox", 0);
+    await contains(".o-mail-AttachmentBox", { count: 0 });
 });
 
 QUnit.test("show attachment box", async () => {
@@ -383,8 +383,8 @@ QUnit.test("show attachment box", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']", 1, { text: "2" });
-    await contains(".o-mail-AttachmentBox", 0);
+    await contains("button[aria-label='Attach files']", { text: "2" });
+    await contains(".o-mail-AttachmentBox", { count: 0 });
 
     await click("button[aria-label='Attach files']");
     await contains(".o-mail-AttachmentBox");
@@ -399,9 +399,9 @@ QUnit.test("composer show/hide on log note/send message [REQUIRE FOCUS]", async 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button", 1, { text: "Send message" });
-    await contains("button", 1, { text: "Log note" });
-    await contains(".o-mail-Composer", 0);
+    await contains("button", { text: "Send message" });
+    await contains("button", { text: "Log note" });
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Send message" });
     await contains(".o-mail-Composer");
@@ -412,13 +412,13 @@ QUnit.test("composer show/hide on log note/send message [REQUIRE FOCUS]", async 
     assert.strictEqual(document.activeElement, $(".o-mail-Composer-input")[0]);
 
     await click("button", { text: "Log note" });
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Send message" });
     await contains(".o-mail-Composer");
 
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 });
 
 QUnit.test('do not post message with "Enter" keyboard shortcut', async () => {
@@ -431,11 +431,11 @@ QUnit.test('do not post message with "Enter" keyboard shortcut', async () => {
         views: [[false, "form"]],
     });
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
     await insertText(".o-mail-Composer-input", "Test");
     triggerHotkey("Enter");
     // weak test, no guarantee that we waited long enough for the potential message to be posted
-    await contains(".o-mail-Message", 0);
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 QUnit.test("should not display subject when subject is the same as the thread name", async () => {
@@ -455,10 +455,11 @@ QUnit.test("should not display subject when subject is the same as the thread na
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message .o-mail-Message-content", 1, {
+    await contains(".o-mail-Message .o-mail-Message-content", {
         text: "not empty",
     });
-    await contains(".o-mail-Message .o-mail-Message-content", 0, {
+    await contains(".o-mail-Message .o-mail-Message-content", {
+        count: 0,
         text: "Subject: Salutations, voyageurnot empty",
     });
 });
@@ -481,20 +482,20 @@ QUnit.test("scroll position is kept when navigating from one record to another",
     );
     const { openFormView } = await start();
     openFormView("res.partner", partnerId_1);
-    await contains(".o-mail-Message", 20);
+    await contains(".o-mail-Message", { count: 20 });
     const scrollValue1 = $(".o-mail-Chatter")[0].scrollHeight / 2;
-    await contains(".o-mail-Chatter", 1, { scroll: 0 });
+    await contains(".o-mail-Chatter", { scroll: 0 });
     await scroll(".o-mail-Chatter", scrollValue1);
     openFormView("res.partner", partnerId_2);
-    await contains(".o-mail-Message", 30);
+    await contains(".o-mail-Message", { count: 30 });
     const scrollValue2 = $(".o-mail-Chatter")[0].scrollHeight / 3;
     await scroll(".o-mail-Chatter", scrollValue2);
     openFormView("res.partner", partnerId_1);
-    await contains(".o-mail-Message", 20);
-    await contains(".o-mail-Chatter", 1, { scroll: scrollValue1 });
+    await contains(".o-mail-Message", { count: 20 });
+    await contains(".o-mail-Chatter", { scroll: scrollValue1 });
     openFormView("res.partner", partnerId_2);
-    await contains(".o-mail-Message", 30);
-    await contains(".o-mail-Chatter", 1, { scroll: scrollValue2 });
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Chatter", { scroll: scrollValue2 });
 });
 
 QUnit.test("basic chatter rendering", async () => {
@@ -542,7 +543,7 @@ QUnit.test("basic chatter rendering without activities", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button", 0, { text: "Activities" });
+    await contains("button", { count: 0, text: "Activities" });
 
     await contains(".o-mail-Followers");
     await contains(".o-mail-Thread");
@@ -572,7 +573,7 @@ QUnit.test(
         });
         await click(".o_form_button_create:eq(0)");
         await contains(".o-mail-Message");
-        await contains(".o-mail-Message-body", 1, { text: "Creating a new record..." });
+        await contains(".o-mail-Message-body", { text: "Creating a new record..." });
     }
 );
 
@@ -589,7 +590,7 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message .o-mail-Message-content", 1, {
+        await contains(".o-mail-Message .o-mail-Message-content", {
             text: "Subject: Another Subjectnot empty",
         });
     }
@@ -608,10 +609,11 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message .o-mail-Message-content", 1, {
+        await contains(".o-mail-Message .o-mail-Message-content", {
             text: "not empty",
         });
-        await contains(".o-mail-Message .o-mail-Message-content", 0, {
+        await contains(".o-mail-Message .o-mail-Message-content", {
+            count: 0,
             text: "Subject: Custom Default Subjectnot empty",
         });
     }
@@ -630,10 +632,11 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message .o-mail-Message-content", 1, {
+        await contains(".o-mail-Message .o-mail-Message-content", {
             text: "not empty",
         });
-        await contains(".o-mail-Message .o-mail-Message-content", 0, {
+        await contains(".o-mail-Message .o-mail-Message-content", {
+            count: 0,
             text: "Subject: Custom Default Subjectnot empty",
         });
     }
@@ -664,9 +667,9 @@ QUnit.test("basic chatter rendering without followers", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button", 1, { text: "Activities" });
+    await contains("button", { text: "Activities" });
     await contains(".o-mail-Chatter .o-mail-Thread");
-    await contains(".o-mail-Followers", 0);
+    await contains(".o-mail-Followers", { count: 0 });
 });
 
 QUnit.test("basic chatter rendering without messages", async () => {
@@ -694,9 +697,9 @@ QUnit.test("basic chatter rendering without messages", async () => {
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Chatter-topbar");
     await contains("button[aria-label='Attach files']");
-    await contains("button", 1, { text: "Activities" });
+    await contains("button", { text: "Activities" });
     await contains(".o-mail-Followers");
-    await contains(".o-mail-Chatter .o-mail-Thread", 0);
+    await contains(".o-mail-Chatter .o-mail-Thread", { count: 0 });
 });
 
 QUnit.test("chatter updating", async () => {
@@ -750,7 +753,7 @@ QUnit.test("post message on draft record", async () => {
     await insertText(".o-mail-Composer-input", "Test");
     await click(".o-mail-Composer button:contains(Send):not(:disabled)");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", 1, { text: "Test" });
+    await contains(".o-mail-Message-content", { text: "Test" });
 });
 
 QUnit.test(
@@ -770,7 +773,7 @@ QUnit.test(
         const { openFormView } = await start({ serverData: { views } });
         openFormView("res.partner");
         await click("button", { text: "Activities" });
-        await contains(".o_dialog h4", 1, { text: "Schedule Activity" });
+        await contains(".o_dialog h4", { text: "Schedule Activity" });
     }
 );
 
@@ -799,15 +802,15 @@ QUnit.test("upload attachment on draft record", async () => {
             name: "text.txt",
         }),
     ]);
-    await contains(".button[aria-label='Attach files']", 0, { text: "1" });
+    await contains(".button[aria-label='Attach files']", { count: 0, text: "1" });
 
     dragenterFiles(chatter[0]);
     dropFiles((await contains(".o-mail-Dropzone"))[0], [file]);
-    await contains("button[aria-label='Attach files']", 1, { text: "1" });
+    await contains("button[aria-label='Attach files']", { text: "1" });
 });
 
 QUnit.test("Follower count of draft record is set to 0", async (assert) => {
     const { openView } = await start();
     await openView({ res_model: "res.partner", views: [[false, "form"]] });
-    await contains(".o-mail-Followers", 1, { text: "0" });
+    await contains(".o-mail-Followers", { text: "0" });
 });

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -311,7 +311,7 @@ QUnit.test("base rendering when chatter has no attachment", async (assert) => {
     await contains(".o-mail-Message", { count: 30 });
 });
 
-QUnit.test("base rendering when chatter has no record", async (assert) => {
+QUnit.test("base rendering when chatter has no record", async () => {
     const { openView } = await start();
     openView({
         res_model: "res.partner",
@@ -322,9 +322,8 @@ QUnit.test("base rendering when chatter has no record", async (assert) => {
     await contains(".o-mail-AttachmentBox", { count: 0 });
     await contains(".o-mail-Chatter .o-mail-Thread");
     await contains(".o-mail-Message");
-    assert.strictEqual($(".o-mail-Message-body").text(), "Creating a new record...");
+    await contains(".o-mail-Message-body", { text: "Creating a new record..." });
     await contains("button", { count: 0, text: "Load More" });
-
     await contains(".o-mail-Message-actions");
     await contains(".o-mail-Message-actions i", { count: 0 });
 });

--- a/addons/mail/static/tests/web/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/web/chatter_topbar_tests.js
@@ -30,7 +30,7 @@ QUnit.test("base rendering", async () => {
     await contains(".o-mail-Followers");
 });
 
-QUnit.test("rendering with multiple partner followers", async (assert) => {
+QUnit.test("rendering with multiple partner followers", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2, partnerId_3] = pyEnv["res.partner"].create([
         { name: "Eden Hazard" },
@@ -55,15 +55,13 @@ QUnit.test("rendering with multiple partner followers", async (assert) => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-
     await contains(".o-mail-Followers");
     await contains(".o-mail-Followers-button");
-
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Followers-dropdown");
     await contains(".o-mail-Follower", { count: 2 });
-    assert.strictEqual($(".o-mail-Follower:eq(0)").text().trim(), "Jean Michang");
-    assert.strictEqual($(".o-mail-Follower:eq(1)").text().trim(), "Eden Hazard");
+    await contains(".o-mail-Follower:eq(0)", { text: "Jean Michang" });
+    await contains(".o-mail-Follower:eq(1)", { text: "Eden Hazard" });
 });
 
 QUnit.test("log note toggling", async () => {

--- a/addons/mail/static/tests/web/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/web/chatter_topbar_tests.js
@@ -23,9 +23,9 @@ QUnit.test("base rendering", async () => {
         views: [[false, "form"]],
     });
     await contains(".o-mail-Chatter-topbar");
-    await contains("button", 1, { text: "Send message" });
-    await contains("button", 1, { text: "Log note" });
-    await contains("button", 1, { text: "Activities" });
+    await contains("button", { text: "Send message" });
+    await contains("button", { text: "Log note" });
+    await contains("button", { text: "Activities" });
     await contains("button[aria-label='Attach files']");
     await contains(".o-mail-Followers");
 });
@@ -61,7 +61,7 @@ QUnit.test("rendering with multiple partner followers", async (assert) => {
 
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Followers-dropdown");
-    await contains(".o-mail-Follower", 2);
+    await contains(".o-mail-Follower", { count: 2 });
     assert.strictEqual($(".o-mail-Follower:eq(0)").text().trim(), "Jean Michang");
     assert.strictEqual($(".o-mail-Follower:eq(1)").text().trim(), "Eden Hazard");
 });
@@ -75,9 +75,9 @@ QUnit.test("log note toggling", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button", 1, { text: "Log note" });
+    await contains("button", { text: "Log note" });
     await contains("button:contains(Log note):not(.active)");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Log note" });
     await contains("button:contains(Log note).active");
@@ -85,7 +85,7 @@ QUnit.test("log note toggling", async () => {
 
     await click("button", { text: "Log note" });
     await contains("button:contains(Log note):not(.active)");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("send message toggling", async () => {
@@ -97,9 +97,9 @@ QUnit.test("send message toggling", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button", 1, { text: "Send message" });
+    await contains("button", { text: "Send message" });
     await contains("button:contains(Send message):not(.active)");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Send message" });
     await contains("button:contains(Send message).active");
@@ -107,7 +107,7 @@ QUnit.test("send message toggling", async () => {
 
     await click("button", { text: "Send message" });
     await contains("button:contains(Send message):not(.active)");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 });
 
 QUnit.test("log note/send message switching", async () => {
@@ -119,11 +119,11 @@ QUnit.test("log note/send message switching", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button", 1, { text: "Send message" });
+    await contains("button", { text: "Send message" });
     await contains("button:contains(Send message):not(.active)");
-    await contains("button", 1, { text: "Log note" });
+    await contains("button", { text: "Log note" });
     await contains("button:contains(Log note):not(.active)");
-    await contains(".o-mail-Composer", 0);
+    await contains(".o-mail-Composer", { count: 0 });
 
     await click("button", { text: "Send message" });
     await contains("button:contains(Send message).active");
@@ -146,7 +146,7 @@ QUnit.test("attachment counter without attachments", async () => {
         views: [[false, "form"]],
     });
     await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']", 0, { text: "0" });
+    await contains("button[aria-label='Attach files']", { count: 0, text: "0" });
 });
 
 QUnit.test("attachment counter with attachments", async () => {
@@ -172,7 +172,7 @@ QUnit.test("attachment counter with attachments", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button[aria-label='Attach files']", 1, { text: "2" });
+    await contains("button[aria-label='Attach files']", { text: "2" });
 });
 
 QUnit.test("attachment counter while loading attachments", async () => {
@@ -194,7 +194,7 @@ QUnit.test("attachment counter while loading attachments", async () => {
     await contains("button[aria-label='Attach files']");
     await advanceTime(DELAY_FOR_SPINNER);
     await contains("button[aria-label='Attach files'] .fa-spin");
-    await contains("button[aria-label='Attach files']", 0, { text: "0" });
+    await contains("button[aria-label='Attach files']", { count: 0, text: "0" });
 });
 
 QUnit.test("attachment counter transition when attachments become loaded", async () => {
@@ -218,7 +218,7 @@ QUnit.test("attachment counter transition when attachments become loaded", async
     await advanceTime(DELAY_FOR_SPINNER);
     await contains("button[aria-label='Attach files'] .fa-spin");
     deferred.resolve();
-    await contains("button[aria-label='Attach files'] .fa-spin", 0);
+    await contains("button[aria-label='Attach files'] .fa-spin", { count: 0 });
 });
 
 QUnit.test(
@@ -233,7 +233,7 @@ QUnit.test(
             views: [[false, "form"]],
         });
         await contains(".o-mail-Chatter-fileUploader");
-        await contains(".o-mail-AttachmentBox", 0);
+        await contains(".o-mail-AttachmentBox", { count: 0 });
     }
 );
 
@@ -257,8 +257,8 @@ QUnit.test(
             views: [[false, "form"]],
         });
         await contains("button[aria-label='Attach files']");
-        await contains(".o-mail-AttachmentBox", 0);
-        await contains(".o-mail-Chatter-fileUploader", 0);
+        await contains(".o-mail-AttachmentBox", { count: 0 });
+        await contains(".o-mail-Chatter-fileUploader", { count: 0 });
         await click("button[aria-label='Attach files']");
         await contains(".o-mail-AttachmentBox");
         await contains(".o-mail-Chatter-fileUploader");
@@ -271,16 +271,16 @@ QUnit.test("composer state conserved when clicking on another topbar button", as
     const { openFormView } = await start();
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Chatter-topbar");
-    await contains("button", 1, { text: "Send message" });
-    await contains("button", 1, { text: "Log note" });
+    await contains("button", { text: "Send message" });
+    await contains("button", { text: "Log note" });
     await contains("button[aria-label='Attach files']");
 
     await click("button", { text: "Log note" });
     await contains("button:contains(Log note).active");
-    await contains("button:contains(Send message).active", 0);
+    await contains("button:contains(Send message).active", { count: 0 });
 
     $(`button[aria-label='Attach files']`)[0].click();
     await nextAnimationFrame();
     await contains("button:contains(Log note).active");
-    await contains("button:contains(Send message).active", 0);
+    await contains("button:contains(Send message).active", { count: 0 });
 });

--- a/addons/mail/static/tests/web/chatter_topbar_tests.js
+++ b/addons/mail/static/tests/web/chatter_topbar_tests.js
@@ -23,9 +23,9 @@ QUnit.test("base rendering", async () => {
         views: [[false, "form"]],
     });
     await contains(".o-mail-Chatter-topbar");
-    await contains("button:contains(Send message)");
-    await contains("button:contains(Log note)");
-    await contains("button:contains(Activities)");
+    await contains("button", 1, { text: "Send message" });
+    await contains("button", 1, { text: "Log note" });
+    await contains("button", 1, { text: "Activities" });
     await contains("button[aria-label='Attach files']");
     await contains(".o-mail-Followers");
 });
@@ -75,15 +75,15 @@ QUnit.test("log note toggling", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(Log note)");
+    await contains("button", 1, { text: "Log note" });
     await contains("button:contains(Log note):not(.active)");
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains("button:contains(Log note).active");
     await contains(".o-mail-Composer .o-mail-Composer-input[placeholder='Log an internal note…']");
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains("button:contains(Log note):not(.active)");
     await contains(".o-mail-Composer", 0);
 });
@@ -97,15 +97,15 @@ QUnit.test("send message toggling", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(Send message)");
+    await contains("button", 1, { text: "Send message" });
     await contains("button:contains(Send message):not(.active)");
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains("button:contains(Send message).active");
     await contains(".o-mail-Composer-input[placeholder='Send a message to followers…']");
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains("button:contains(Send message):not(.active)");
     await contains(".o-mail-Composer", 0);
 });
@@ -119,18 +119,18 @@ QUnit.test("log note/send message switching", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(Send message)");
+    await contains("button", 1, { text: "Send message" });
     await contains("button:contains(Send message):not(.active)");
-    await contains("button:contains(Log note)");
+    await contains("button", 1, { text: "Log note" });
     await contains("button:contains(Log note):not(.active)");
     await contains(".o-mail-Composer", 0);
 
-    await click("button:contains(Send message)");
+    await click("button", { text: "Send message" });
     await contains("button:contains(Send message).active");
     await contains("button:contains(Log note):not(.active)");
     await contains(".o-mail-Composer-input[placeholder='Send a message to followers…']");
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains("button:contains(Send message):not(.active)");
     await contains("button:contains(Log note).active");
     await contains(".o-mail-Composer-input[placeholder='Log an internal note…']");
@@ -146,7 +146,7 @@ QUnit.test("attachment counter without attachments", async () => {
         views: [[false, "form"]],
     });
     await contains("button[aria-label='Attach files']");
-    await contains("button[aria-label='Attach files']:contains(0)", 0);
+    await contains("button[aria-label='Attach files']", 0, { text: "0" });
 });
 
 QUnit.test("attachment counter with attachments", async () => {
@@ -172,7 +172,7 @@ QUnit.test("attachment counter with attachments", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button[aria-label='Attach files']:contains(2)");
+    await contains("button[aria-label='Attach files']", 1, { text: "2" });
 });
 
 QUnit.test("attachment counter while loading attachments", async () => {
@@ -194,7 +194,7 @@ QUnit.test("attachment counter while loading attachments", async () => {
     await contains("button[aria-label='Attach files']");
     await advanceTime(DELAY_FOR_SPINNER);
     await contains("button[aria-label='Attach files'] .fa-spin");
-    await contains("button[aria-label='Attach files']:contains(0)", 0);
+    await contains("button[aria-label='Attach files']", 0, { text: "0" });
 });
 
 QUnit.test("attachment counter transition when attachments become loaded", async () => {
@@ -271,11 +271,11 @@ QUnit.test("composer state conserved when clicking on another topbar button", as
     const { openFormView } = await start();
     await openFormView("res.partner", partnerId);
     await contains(".o-mail-Chatter-topbar");
-    await contains("button:contains(Send message)");
-    await contains("button:contains(Log note)");
+    await contains("button", 1, { text: "Send message" });
+    await contains("button", 1, { text: "Log note" });
     await contains("button[aria-label='Attach files']");
 
-    await click("button:contains(Log note)");
+    await click("button", { text: "Log note" });
     await contains("button:contains(Log note).active");
     await contains("button:contains(Send message).active", 0);
 

--- a/addons/mail/static/tests/web/fields/avatar_tests.js
+++ b/addons/mail/static/tests/web/fields/avatar_tests.js
@@ -21,7 +21,7 @@ QUnit.test("basic rendering", async () => {
     await contains(".o-mail-Avatar img");
     await contains(".o-mail-Avatar img[data-src='/web/image/res.users/2/avatar_128']");
     await contains(".o-mail-Avatar span");
-    await contains(".o-mail-Avatar span:contains(User display name)");
+    await contains(".o-mail-Avatar span", 1, { text: "User display name" });
     await contains(".o-mail-ChatWindow", 0);
     await click(".o-mail-Avatar img");
     await contains(".o-mail-ChatWindow");

--- a/addons/mail/static/tests/web/fields/avatar_tests.js
+++ b/addons/mail/static/tests/web/fields/avatar_tests.js
@@ -21,8 +21,8 @@ QUnit.test("basic rendering", async () => {
     await contains(".o-mail-Avatar img");
     await contains(".o-mail-Avatar img[data-src='/web/image/res.users/2/avatar_128']");
     await contains(".o-mail-Avatar span");
-    await contains(".o-mail-Avatar span", 1, { text: "User display name" });
-    await contains(".o-mail-ChatWindow", 0);
+    await contains(".o-mail-Avatar span", { text: "User display name" });
+    await contains(".o-mail-ChatWindow", { count: 0 });
     await click(".o-mail-Avatar img");
     await contains(".o-mail-ChatWindow");
 });

--- a/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
@@ -125,7 +125,7 @@ QUnit.test(
             view_mode: "form",
             views: [[false, "form"]],
         });
-        await contains(".o_field_many2one_avatar_user input", 1, { value: "Mario" });
+        await contains(".o_field_many2one_avatar_user input", { value: "Mario" });
 
         triggerHotkey("control+k");
         await nextTick();
@@ -142,7 +142,7 @@ QUnit.test(
         );
         await click(document.body, "#o_command_3");
         await nextTick();
-        await contains(".o_field_many2one_avatar_user input", 1, { value: "Luigi" });
+        await contains(".o_field_many2one_avatar_user input", { value: "Luigi" });
     }
 );
 
@@ -169,7 +169,7 @@ QUnit.test(
             view_mode: "form",
             views: [[false, "form"]],
         });
-        await contains(".o_field_many2one_avatar_user input", 1, { value: "Mario" });
+        await contains(".o_field_many2one_avatar_user input", { value: "Mario" });
         triggerHotkey("control+k");
         await nextTick();
         const idx = [...document.querySelectorAll(".o_command")]
@@ -180,14 +180,14 @@ QUnit.test(
         // Assign me (Luigi)
         triggerHotkey("alt+shift+i");
         await nextTick();
-        await contains(".o_field_many2one_avatar_user input", 1, { value: "Luigi" });
+        await contains(".o_field_many2one_avatar_user input", { value: "Luigi" });
 
         // Unassign me
         triggerHotkey("control+k");
         await nextTick();
         await click([...document.querySelectorAll(".o_command")][idx]);
         await nextTick();
-        await contains(".o_field_many2one_avatar_user input", 1, { value: "" });
+        await contains(".o_field_many2one_avatar_user input", { value: "" });
     }
 );
 
@@ -402,7 +402,7 @@ QUnit.test("avatar card preview", async (assert) => {
     // Close card
     await triggerEvent(document, ".o_control_panel", "mouseover");
     assert.verifySteps(["setTimeout of 400ms"]);
-    await contains(".o_avatar_card", 0);
+    await contains(".o_avatar_card", { count: 0 });
 });
 
 QUnit.test(

--- a/addons/mail/static/tests/web/fields/many2many_tags_email_tests.js
+++ b/addons/mail/static/tests/web/fields/many2many_tags_email_tests.js
@@ -53,13 +53,15 @@ QUnit.test("fieldmany2many tags email (edition)", async (assert) => {
     // add an other existing tag
     await selectDropdownItem(document.body, "partner_ids", "silver");
     await contains(".modal-content .o_form_view");
-    await contains(".modal-content .o_form_view .o_input#name_0", 1, { value: "silver" });
+    await contains(".modal-content .o_form_view .o_input#name_0", { value: "silver" });
     await contains(".modal-content .o_form_view .o_input#email_0");
 
     // set the email and save the modal (will rerender the form view)
     await insertText(".modal-content .o_form_view .o_input#email_0", "coucou@petite.perruche");
     await click(".modal-content .o_form_button_save");
-    await contains('.o_field_many2many_tags_email[name="partner_ids"] .badge.o_tag_color_0', 2);
+    await contains('.o_field_many2many_tags_email[name="partner_ids"] .badge.o_tag_color_0', {
+        count: 2,
+    });
     const firstTag = $('.o_field_many2many_tags_email[name="partner_ids"] .badge.o_tag_color_0')[0];
     assert.strictEqual(
         firstTag.querySelector(".o_badge_text").innerText,
@@ -90,10 +92,10 @@ QUnit.test("many2many_tags_email widget can load more than 40 records", async ()
         views: [[false, "form"]],
     });
 
-    await contains('.o_field_widget[name="partner_ids"] .badge', 100);
+    await contains('.o_field_widget[name="partner_ids"] .badge', { count: 100 });
     await contains(".o_form_editable");
 
     // add a record to the relation
     await selectDropdownItem(document.body, "partner_ids", "Public user");
-    await contains('.o_field_widget[name="partner_ids"] .badge', 101);
+    await contains('.o_field_widget[name="partner_ids"] .badge', { count: 101 });
 });

--- a/addons/mail/static/tests/web/follow_button_tests.js
+++ b/addons/mail/static/tests/web/follow_button_tests.js
@@ -29,11 +29,11 @@ QUnit.test("hover following button", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".fa-check + span", 1, { text: "Following" });
-    await contains(".fa-times + span", 0, { text: "Following" });
+    await contains(".fa-check + span", { text: "Following" });
+    await contains(".fa-times + span", { count: 0, text: "Following" });
     $("button:contains(Following)")[0].dispatchEvent(new window.MouseEvent("mouseenter"));
-    await contains(".fa-times + span", 1, { text: "Unfollow" });
-    await contains(".fa-check + span", 0, { text: "Unfollow" });
+    await contains(".fa-times + span", { text: "Unfollow" });
+    await contains(".fa-check + span", { count: 0, text: "Unfollow" });
 });
 
 QUnit.test('click on "follow" button', async () => {
@@ -43,10 +43,10 @@ QUnit.test('click on "follow" button', async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button span", 1, { text: "Follow" });
+    await contains("button span", { text: "Follow" });
 
     await click("button span", { text: "Follow" });
-    await contains("button span", 1, { text: "Following" });
+    await contains("button span", { text: "Following" });
 });
 
 QUnit.test('Click on "follow" button should save draft record', async () => {
@@ -63,7 +63,7 @@ QUnit.test('Click on "follow" button should save draft record', async () => {
     };
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.partner");
-    await contains("button span", 1, { text: "Follow" });
+    await contains("button span", { text: "Follow" });
     await contains("div.o_field_char");
     await click("button span", { text: "Follow" });
     await contains("div.o_field_invalid");
@@ -85,5 +85,5 @@ QUnit.test('click on "unfollow" button', async () => {
         views: [[false, "form"]],
     });
     await click(".fa-check + span", { text: "Following" });
-    await contains("button span", 1, { text: "Follow" });
+    await contains("button span", { text: "Follow" });
 });

--- a/addons/mail/static/tests/web/follow_button_tests.js
+++ b/addons/mail/static/tests/web/follow_button_tests.js
@@ -29,14 +29,11 @@ QUnit.test("hover following button", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(Following)");
-    await contains(".fa-times + span:contains(Following)", 0);
-    await contains(".fa-check + span:contains(Following)");
-
+    await contains(".fa-check + span", 1, { text: "Following" });
+    await contains(".fa-times + span", 0, { text: "Following" });
     $("button:contains(Following)")[0].dispatchEvent(new window.MouseEvent("mouseenter"));
-    await contains("button:contains(Unfollow)");
-    await contains(".fa-times + span:contains(Unfollow)");
-    await contains(".fa-check + span:contains(Unfollow)", 0);
+    await contains(".fa-times + span", 1, { text: "Unfollow" });
+    await contains(".fa-check + span", 0, { text: "Unfollow" });
 });
 
 QUnit.test('click on "follow" button', async () => {
@@ -46,10 +43,10 @@ QUnit.test('click on "follow" button', async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button:contains(Follow)");
+    await contains("button span", 1, { text: "Follow" });
 
-    await click("button:contains(Follow)");
-    await contains("button:contains(Following)");
+    await click("button span", { text: "Follow" });
+    await contains("button span", 1, { text: "Following" });
 });
 
 QUnit.test('Click on "follow" button should save draft record', async () => {
@@ -66,9 +63,9 @@ QUnit.test('Click on "follow" button should save draft record', async () => {
     };
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.partner");
-    await contains("button:contains(Follow)");
+    await contains("button span", 1, { text: "Follow" });
     await contains("div.o_field_char");
-    await click("button:contains(Follow)");
+    await click("button span", { text: "Follow" });
     await contains("div.o_field_invalid");
 });
 
@@ -87,6 +84,6 @@ QUnit.test('click on "unfollow" button', async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await click("button:contains(Following)");
-    await contains("button:contains(Follow)");
+    await click(".fa-check + span", { text: "Following" });
+    await contains("button span", 1, { text: "Follow" });
 });

--- a/addons/mail/static/tests/web/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/web/follower_list_menu_tests.js
@@ -110,9 +110,9 @@ QUnit.test('click on "add followers" button', async (assert) => {
 
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Followers-dropdown");
-    await contains("a:contains(Add Followers)");
+    await contains("a", 1, { text: "Add Followers" });
 
-    await click("a:contains(Add Followers)");
+    await click("a", { text: "Add Followers" });
     await contains(".o-mail-Followers-dropdown", 0);
     assert.verifySteps(["action:open_view"]);
     assert.strictEqual($(".o-mail-Followers-counter").text(), "2");
@@ -204,7 +204,8 @@ QUnit.test(
         });
 
         await click(".o-mail-Followers-button");
-        await contains("a:contains(Add Followers)", 0);
+        await contains("a", 0, { text: "Add Followers" });
+
         await contains(".o-mail-Follower:eq(0) button[title='Edit subscription']");
         await contains(".o-mail-Follower:eq(0) button[title='Remove this follower']");
         await contains(".o-mail-Follower:eq(1):not(:has(button[title='Edit subscription']))");
@@ -229,17 +230,17 @@ QUnit.test("Load 100 followers at once", async () => {
     );
     const { openFormView } = await start();
     await openFormView("res.partner", partnerIds[0]);
-    await contains("button[title='Show Followers']:contains(210)");
+    await contains("button[title='Show Followers']", 1, { text: "210" });
 
     await click("button[title='Show Followers']");
-    await contains(".o-mail-Follower:contains(Mitchell Admin)");
+    await contains(".o-mail-Follower", 1, { text: "Mitchell Admin" });
     await contains(".o-mail-Follower", 100);
     $(".o-mail-Followers-dropdown span:contains(Load more)")[0].scrollIntoView();
     await contains(".o-mail-Follower", 200);
     await nextAnimationFrame(); // give enough time for the Load more button to scroll out of view
     $(".o-mail-Followers-dropdown span:contains(Load more)")[0].scrollIntoView();
     await contains(".o-mail-Follower", 210);
-    await contains(".o-mail-Followers-dropdown span:contains(Load more)", 0);
+    await contains(".o-mail-Followers-dropdown span", 0, { text: "Load more" });
 });
 
 QUnit.test("Load 100 recipients at once", async () => {
@@ -263,9 +264,11 @@ QUnit.test("Load 100 recipients at once", async () => {
     );
     const { openFormView } = await start();
     await openFormView("res.partner", partnerIds[0]);
-    await contains("button[title='Show Followers']:contains(210)");
-    await click("button:contains(Send message)");
-    await contains(".o-mail-Chatter:contains('me, partner1, partner2, partner3, partner4, …')");
+    await contains("button[title='Show Followers']", 1, { text: "210" });
+    await click("button", { text: "Send message" });
+    await contains(".o-mail-Chatter div", 1, {
+        text: "To: me, partner1, partner2, partner3, partner4, …",
+    });
     await contains("button[title='Show all recipients']");
     await click("button[title='Show all recipients']");
     await contains(".o-mail-RecipientList li", 100);
@@ -274,7 +277,7 @@ QUnit.test("Load 100 recipients at once", async () => {
     await nextAnimationFrame(); // give enough time for the Load more button to scroll out of view
     $(".o-mail-RecipientList span:contains(Load more)")[0].scrollIntoView();
     await contains(".o-mail-RecipientList li", 210);
-    await contains(".o-mail-RecipientList span:contains(Load more)", 0);
+    await contains(".o-mail-RecipientList span", 0, { text: "Load more" });
 });
 
 QUnit.test(
@@ -316,7 +319,7 @@ QUnit.test(
         });
 
         await click(".o-mail-Followers-button");
-        await contains("a:contains(Add Followers)");
+        await contains("a", 1, { text: "Add Followers" });
         await contains(".o-mail-Follower:eq(0) button[title='Edit subscription']");
         await contains(".o-mail-Follower:eq(0) button[title='Remove this follower']");
         await contains(".o-mail-Follower:eq(1) button[title='Edit subscription']");

--- a/addons/mail/static/tests/web/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/web/follower_list_menu_tests.js
@@ -23,9 +23,9 @@ QUnit.test("base rendering not editable", async () => {
     );
     await contains(".o-mail-Followers");
     await contains(".o-mail-Followers-button:disabled");
-    await contains(".o-mail-Followers-dropdown", 0);
+    await contains(".o-mail-Followers-dropdown", { count: 0 });
     await click(".o-mail-Followers-button");
-    await contains(".o-mail-Followers-dropdown", 0);
+    await contains(".o-mail-Followers-dropdown", { count: 0 });
 });
 
 QUnit.test("base rendering editable", async (assert) => {
@@ -49,7 +49,7 @@ QUnit.test("base rendering editable", async (assert) => {
     await contains(".o-mail-Followers");
     await contains(".o-mail-Followers-button");
     assert.notOk($(".o-mail-Followers-button")[0].disabled);
-    await contains(".o-mail-Followers-dropdown", 0);
+    await contains(".o-mail-Followers-dropdown", { count: 0 });
 
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Followers-dropdown");
@@ -110,15 +110,15 @@ QUnit.test('click on "add followers" button', async (assert) => {
 
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Followers-dropdown");
-    await contains("a", 1, { text: "Add Followers" });
+    await contains("a", { text: "Add Followers" });
 
     await click("a", { text: "Add Followers" });
-    await contains(".o-mail-Followers-dropdown", 0);
+    await contains(".o-mail-Followers-dropdown", { count: 0 });
     assert.verifySteps(["action:open_view"]);
     assert.strictEqual($(".o-mail-Followers-counter").text(), "2");
 
     await click(".o-mail-Followers-button");
-    await contains(".o-mail-Follower", 2);
+    await contains(".o-mail-Follower", { count: 2 });
     assert.strictEqual($(".o-mail-Follower").text(), "François PerussePartner3");
 });
 
@@ -162,7 +162,7 @@ QUnit.test("click on remove follower", async (assert) => {
 
     await click("button[title='Remove this follower']");
     assert.verifySteps(["message_unsubscribe"]);
-    await contains(".o-mail-Follower", 0);
+    await contains(".o-mail-Follower", { count: 0 });
 });
 
 QUnit.test(
@@ -204,7 +204,7 @@ QUnit.test(
         });
 
         await click(".o-mail-Followers-button");
-        await contains("a", 0, { text: "Add Followers" });
+        await contains("a", { count: 0, text: "Add Followers" });
 
         await contains(".o-mail-Follower:eq(0) button[title='Edit subscription']");
         await contains(".o-mail-Follower:eq(0) button[title='Remove this follower']");
@@ -230,17 +230,17 @@ QUnit.test("Load 100 followers at once", async () => {
     );
     const { openFormView } = await start();
     await openFormView("res.partner", partnerIds[0]);
-    await contains("button[title='Show Followers']", 1, { text: "210" });
+    await contains("button[title='Show Followers']", { text: "210" });
 
     await click("button[title='Show Followers']");
-    await contains(".o-mail-Follower", 1, { text: "Mitchell Admin" });
-    await contains(".o-mail-Follower", 100);
+    await contains(".o-mail-Follower", { text: "Mitchell Admin" });
+    await contains(".o-mail-Follower", { count: 100 });
     $(".o-mail-Followers-dropdown span:contains(Load more)")[0].scrollIntoView();
-    await contains(".o-mail-Follower", 200);
+    await contains(".o-mail-Follower", { count: 200 });
     await nextAnimationFrame(); // give enough time for the Load more button to scroll out of view
     $(".o-mail-Followers-dropdown span:contains(Load more)")[0].scrollIntoView();
-    await contains(".o-mail-Follower", 210);
-    await contains(".o-mail-Followers-dropdown span", 0, { text: "Load more" });
+    await contains(".o-mail-Follower", { count: 210 });
+    await contains(".o-mail-Followers-dropdown span", { count: 0, text: "Load more" });
 });
 
 QUnit.test("Load 100 recipients at once", async () => {
@@ -264,20 +264,20 @@ QUnit.test("Load 100 recipients at once", async () => {
     );
     const { openFormView } = await start();
     await openFormView("res.partner", partnerIds[0]);
-    await contains("button[title='Show Followers']", 1, { text: "210" });
+    await contains("button[title='Show Followers']", { text: "210" });
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Chatter div", 1, {
+    await contains(".o-mail-Chatter div", {
         text: "To: me, partner1, partner2, partner3, partner4, …",
     });
     await contains("button[title='Show all recipients']");
     await click("button[title='Show all recipients']");
-    await contains(".o-mail-RecipientList li", 100);
+    await contains(".o-mail-RecipientList li", { count: 100 });
     $(".o-mail-RecipientList span:contains(Load more)")[0].scrollIntoView();
-    await contains(".o-mail-RecipientList li", 200);
+    await contains(".o-mail-RecipientList li", { count: 200 });
     await nextAnimationFrame(); // give enough time for the Load more button to scroll out of view
     $(".o-mail-RecipientList span:contains(Load more)")[0].scrollIntoView();
-    await contains(".o-mail-RecipientList li", 210);
-    await contains(".o-mail-RecipientList span", 0, { text: "Load more" });
+    await contains(".o-mail-RecipientList li", { count: 210 });
+    await contains(".o-mail-RecipientList span", { count: 0, text: "Load more" });
 });
 
 QUnit.test(
@@ -319,7 +319,7 @@ QUnit.test(
         });
 
         await click(".o-mail-Followers-button");
-        await contains("a", 1, { text: "Add Followers" });
+        await contains("a", { text: "Add Followers" });
         await contains(".o-mail-Follower:eq(0) button[title='Edit subscription']");
         await contains(".o-mail-Follower:eq(0) button[title='Remove this follower']");
         await contains(".o-mail-Follower:eq(1) button[title='Edit subscription']");

--- a/addons/mail/static/tests/web/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/web/follower_list_menu_tests.js
@@ -103,23 +103,18 @@ QUnit.test('click on "add followers" button', async (assert) => {
             options.onClose();
         },
     });
-
     await contains(".o-mail-Followers");
-    await contains(".o-mail-Followers-button");
-    assert.strictEqual($(".o-mail-Followers-counter").text(), "1");
-
+    await contains(".o-mail-Followers-counter", { text: "1" });
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Followers-dropdown");
-    await contains("a", { text: "Add Followers" });
-
     await click("a", { text: "Add Followers" });
     await contains(".o-mail-Followers-dropdown", { count: 0 });
     assert.verifySteps(["action:open_view"]);
-    assert.strictEqual($(".o-mail-Followers-counter").text(), "2");
-
+    await contains(".o-mail-Followers-counter", { text: "2" });
     await click(".o-mail-Followers-button");
     await contains(".o-mail-Follower", { count: 2 });
-    assert.strictEqual($(".o-mail-Follower").text(), "François PerussePartner3");
+    await contains(".o-mail-Follower:eq(0)", { text: "François Perusse" });
+    await contains(".o-mail-Follower:eq(1)", { text: "Partner3" });
 });
 
 QUnit.test("click on remove follower", async (assert) => {

--- a/addons/mail/static/tests/web/follower_subtype_tests.js
+++ b/addons/mail/static/tests/web/follower_subtype_tests.js
@@ -173,7 +173,7 @@ QUnit.test("follower subtype apply", async () => {
     await contains(
         `.o-mail-FollowerSubtypeDialog-subtype[data-follower-subtype-id=${subtypeId2}] input[type='checkbox']:checked`
     );
-    await click(".modal-footer button:contains(Apply)");
+    await click(".modal-footer button", { text: "Apply" });
     await contains(
         ".o_notification:contains(The subscription preferences were successfully applied.)"
     );

--- a/addons/mail/static/tests/web/follower_tests.js
+++ b/addons/mail/static/tests/web/follower_tests.js
@@ -155,7 +155,7 @@ QUnit.test("edit follower and close subtype dialog", async (assert) => {
     await contains(".o-mail-FollowerSubtypeDialog");
     assert.verifySteps(["fetch_subtypes"]);
 
-    await click(".o-mail-FollowerSubtypeDialog button:contains(Cancel)");
+    await click(".o-mail-FollowerSubtypeDialog button", { text: "Cancel" });
     await contains(".o-mail-FollowerSubtypeDialog", 0);
 });
 
@@ -183,15 +183,15 @@ QUnit.test("remove a follower in a dirty form view", async (assert) => {
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.partner", threadId);
     await click(".o_field_many2many_tags[name='channel_ids'] input");
-    await click(".dropdown-item:contains(General)");
-    await contains(".o_tag:contains(General)");
-    await contains(".o-mail-Followers-counter:contains(1)");
+    await click(".dropdown-item", { text: "General" });
+    await contains(".o_tag", 1, { text: "General" });
+    await contains(".o-mail-Followers-counter", 1, { text: "1" });
     await editInput(document.body, ".o_field_char[name=name] input", "some value");
     await click(".o-mail-Followers-button");
     await click("button[title='Remove this follower']");
-    await contains(".o-mail-Followers-counter:contains(0)");
+    await contains(".o-mail-Followers-counter", 1, { text: "0" });
     await contains(".o_field_char[name=name] input", 1, { value: "some value" });
-    await contains(".o_tag:contains(General)");
+    await contains(".o_tag", 1, { text: "General" });
 });
 
 QUnit.test("removing a follower should reload form view", async function (assert) {
@@ -215,6 +215,6 @@ QUnit.test("removing a follower should reload form view", async function (assert
     assert.verifySteps([`read ${threadId}`]);
     await click(".o-mail-Followers-button");
     await click("button[title='Remove this follower']");
-    await contains(".o-mail-Followers-counter:contains(0)");
+    await contains(".o-mail-Followers-counter", 1, { text: "0" });
     assert.verifySteps([`read ${threadId}`]);
 });

--- a/addons/mail/static/tests/web/follower_tests.js
+++ b/addons/mail/static/tests/web/follower_tests.js
@@ -34,7 +34,7 @@ QUnit.test("base rendering not editable", async () => {
     await contains(".o-mail-Follower");
     await contains(".o-mail-Follower-details");
     await contains(".o-mail-Follower-avatar");
-    await contains(".o-mail-Follower-action", 0);
+    await contains(".o-mail-Follower-action", { count: 0 });
 });
 
 QUnit.test("base rendering editable", async () => {
@@ -121,7 +121,7 @@ QUnit.test("click on edit follower", async (assert) => {
     await contains("button[title='Edit subscription']");
 
     await click("button[title='Edit subscription']");
-    await contains(".o-mail-Follower", 0);
+    await contains(".o-mail-Follower", { count: 0 });
     assert.verifySteps(["fetch_subtypes"]);
     await contains(".o-mail-FollowerSubtypeDialog");
 });
@@ -156,7 +156,7 @@ QUnit.test("edit follower and close subtype dialog", async (assert) => {
     assert.verifySteps(["fetch_subtypes"]);
 
     await click(".o-mail-FollowerSubtypeDialog button", { text: "Cancel" });
-    await contains(".o-mail-FollowerSubtypeDialog", 0);
+    await contains(".o-mail-FollowerSubtypeDialog", { count: 0 });
 });
 
 QUnit.test("remove a follower in a dirty form view", async (assert) => {
@@ -184,14 +184,14 @@ QUnit.test("remove a follower in a dirty form view", async (assert) => {
     openFormView("res.partner", threadId);
     await click(".o_field_many2many_tags[name='channel_ids'] input");
     await click(".dropdown-item", { text: "General" });
-    await contains(".o_tag", 1, { text: "General" });
-    await contains(".o-mail-Followers-counter", 1, { text: "1" });
+    await contains(".o_tag", { text: "General" });
+    await contains(".o-mail-Followers-counter", { text: "1" });
     await editInput(document.body, ".o_field_char[name=name] input", "some value");
     await click(".o-mail-Followers-button");
     await click("button[title='Remove this follower']");
-    await contains(".o-mail-Followers-counter", 1, { text: "0" });
-    await contains(".o_field_char[name=name] input", 1, { value: "some value" });
-    await contains(".o_tag", 1, { text: "General" });
+    await contains(".o-mail-Followers-counter", { text: "0" });
+    await contains(".o_field_char[name=name] input", { value: "some value" });
+    await contains(".o_tag", { text: "General" });
 });
 
 QUnit.test("removing a follower should reload form view", async function (assert) {
@@ -215,6 +215,6 @@ QUnit.test("removing a follower should reload form view", async function (assert
     assert.verifySteps([`read ${threadId}`]);
     await click(".o-mail-Followers-button");
     await click("button[title='Remove this follower']");
-    await contains(".o-mail-Followers-counter", 1, { text: "0" });
+    await contains(".o-mail-Followers-counter", { text: "0" });
     assert.verifySteps([`read ${threadId}`]);
 });

--- a/addons/mail/static/tests/web/form_renderer_tests.js
+++ b/addons/mail/static/tests/web/form_renderer_tests.js
@@ -44,16 +44,16 @@ QUnit.test("Form view not scrolled when switching record", async () => {
         },
         { resIds: [partnerId_1, partnerId_2] }
     );
-    await contains(".o-mail-Message", 29);
-    await contains(".o_content", 1, { scroll: 0 });
+    await contains(".o-mail-Message", { count: 29 });
+    await contains(".o_content", { scroll: 0 });
     await scroll(".o_content", 150);
     await click(".o_pager_next");
-    await contains(".o-mail-Message", 30);
-    await contains(".o_content", 1, { scroll: 150 });
+    await contains(".o-mail-Message", { count: 30 });
+    await contains(".o_content", { scroll: 150 });
     await scroll(".o_content", 0);
     await click(".o_pager_previous");
-    await contains(".o-mail-Message", 29);
-    await contains(".o_content", 1, { scroll: 0 });
+    await contains(".o-mail-Message", { count: 29 });
+    await contains(".o_content", { scroll: 0 });
 });
 
 QUnit.test(
@@ -102,7 +102,7 @@ QUnit.test(
                 resIds: [partnerId_1, partnerId_2],
             }
         );
-        await contains("button[aria-label='Attach files']", 1, { text: "2" });
+        await contains("button[aria-label='Attach files']", { text: "2" });
         // The attachment links are updated on (re)load,
         // so using pager is a way to reload the record "Partner1".
         await click(".o_pager_next");
@@ -110,7 +110,7 @@ QUnit.test(
         // Simulate unlinking attachment 1 from Partner 1.
         pyEnv["ir.attachment"].write([attachmentId_1], { res_id: 0 });
         await click(".o_pager_previous");
-        await contains("button[aria-label='Attach files']", 1, { text: "1" });
+        await contains("button[aria-label='Attach files']", { text: "1" });
     }
 );
 
@@ -202,10 +202,10 @@ QUnit.test("read more links becomes read less after being clicked", async (asser
     openView(openViewAction);
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Message");
-    await contains(".o-mail-read-more-less", 1, { text: "Read More" });
+    await contains(".o-mail-read-more-less", { text: "Read More" });
 
     await click(".o-mail-read-more-less");
-    await contains(".o-mail-read-more-less", 1, { text: "Read Less" });
+    await contains(".o-mail-read-more-less", { text: "Read Less" });
 });
 
 QUnit.test(
@@ -256,13 +256,13 @@ QUnit.test(
             res_id: partnerId,
             views: [[false, "form"]],
         });
-        await contains(".o-mail-read-more-less", 1, { text: "Read More" });
+        await contains(".o-mail-read-more-less", { text: "Read More" });
 
         await click(".o-mail-read-more-less");
-        await contains(".o-mail-read-more-less", 1, { text: "Read Less" });
+        await contains(".o-mail-read-more-less", { text: "Read Less" });
 
         await click(".o-mail-Message");
-        await contains(".o-mail-read-more-less", 1, { text: "Read Less" });
+        await contains(".o-mail-read-more-less", { text: "Read Less" });
     }
 );
 
@@ -305,5 +305,5 @@ QUnit.test("read more/less links on message of type notification", async () => {
         views: [[false, "form"]],
     };
     openView(openViewAction);
-    await contains(".o-mail-Message a", 1, { text: "Read More" });
+    await contains(".o-mail-Message a", { text: "Read More" });
 });

--- a/addons/mail/static/tests/web/form_renderer_tests.js
+++ b/addons/mail/static/tests/web/form_renderer_tests.js
@@ -102,7 +102,7 @@ QUnit.test(
                 resIds: [partnerId_1, partnerId_2],
             }
         );
-        await contains("button[aria-label='Attach files']:contains(2)");
+        await contains("button[aria-label='Attach files']", 1, { text: "2" });
         // The attachment links are updated on (re)load,
         // so using pager is a way to reload the record "Partner1".
         await click(".o_pager_next");
@@ -110,7 +110,7 @@ QUnit.test(
         // Simulate unlinking attachment 1 from Partner 1.
         pyEnv["ir.attachment"].write([attachmentId_1], { res_id: 0 });
         await click(".o_pager_previous");
-        await contains("button[aria-label='Attach files']:contains(1)");
+        await contains("button[aria-label='Attach files']", 1, { text: "1" });
     }
 );
 
@@ -202,10 +202,10 @@ QUnit.test("read more links becomes read less after being clicked", async (asser
     openView(openViewAction);
     await contains(".o-mail-Chatter");
     await contains(".o-mail-Message");
-    await contains(".o-mail-read-more-less:contains(Read More)");
+    await contains(".o-mail-read-more-less", 1, { text: "Read More" });
 
     await click(".o-mail-read-more-less");
-    await contains(".o-mail-read-more-less:contains(Read Less)");
+    await contains(".o-mail-read-more-less", 1, { text: "Read Less" });
 });
 
 QUnit.test(
@@ -256,13 +256,13 @@ QUnit.test(
             res_id: partnerId,
             views: [[false, "form"]],
         });
-        await contains(".o-mail-read-more-less:contains(Read More)");
+        await contains(".o-mail-read-more-less", 1, { text: "Read More" });
 
         await click(".o-mail-read-more-less");
-        await contains(".o-mail-read-more-less:contains(Read Less)");
+        await contains(".o-mail-read-more-less", 1, { text: "Read Less" });
 
         await click(".o-mail-Message");
-        await contains(".o-mail-read-more-less:contains(Read Less)");
+        await contains(".o-mail-read-more-less", 1, { text: "Read Less" });
     }
 );
 
@@ -305,5 +305,5 @@ QUnit.test("read more/less links on message of type notification", async () => {
         views: [[false, "form"]],
     };
     openView(openViewAction);
-    await contains(".o-mail-Message a:contains(Read More)");
+    await contains(".o-mail-Message a", 1, { text: "Read More" });
 });

--- a/addons/mrp/static/tests/mrp_document_kanban_tests.js
+++ b/addons/mrp/static/tests/mrp_document_kanban_tests.js
@@ -222,7 +222,7 @@ QUnit.module('MrpDocumentsKanbanView', {
         await click(".o_kanban_previewer");
         await contains(".o-FileViewer");
         await click(".o-FileViewer-headerButton .fa-times");
-        await contains(".o-FileViewer", 0);
+        await contains(".o-FileViewer", { count: 0 });
     });
 });
 

--- a/addons/project_todo/static/tests/activity_menu_tests.js
+++ b/addons/project_todo/static/tests/activity_menu_tests.js
@@ -12,35 +12,36 @@ QUnit.test("create todo from activity menu without date", async function () {
     await contains(
         ".o-mail-ActivityMenu:contains(Congratulations, you're done with your activities.)"
     );
-    await click(".btn:contains(Add a To-do)");
-    await contains(".btn:contains(Add a To-do)", 0);
+    await click(".btn", { text: "Add a To-do" });
+    await contains(".btn", 0, { text: "Add a To-do" });
+
     await contains(".o-mail-ActivityMenu-show");
     await insertText("input.o-mail-ActivityMenu-input", "New To-do");
-    await click(".btn:contains(SAVE)");
+    await click(".btn", { text: "SAVE" });
     await contains(
         ".o_notification:contains(Your to-do has been successfully added to your tasks and scheduled for completion.)"
     );
     // Need to reopen systray as it automatically closes when a todo is created
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter:contains(1)");
-    await contains(".o-mail-ActivityGroup");
-    await contains(".o-mail-ActivityGroup:contains(project.task)");
-    await contains(".btn:contains(1 Today)");
-    await contains(".btn:contains(Add a To-do)");
+    await contains(".o-mail-ActivityMenu-counter", 1, { text: "1" });
+    await contains(".o-mail-ActivityGroup span", 1, { text: "project.task" });
+    await contains(".btn", 1, { text: "1 Today" });
+    await contains(".btn", 1, { text: "Add a To-do" });
     await contains(".o-mail-ActivityMenu-show", 0);
     await contains(".o-mail-ActivityMenu-input", 0);
-    await click(".btn:contains(Add a To-do)");
-    await contains(".btn:contains(Add a To-do)", 0);
+    await click(".btn", { text: "Add a To-do" });
+    await contains(".btn", 0, { text: "Add a To-do" });
+
     await insertText("input.o-mail-ActivityMenu-input", "New To-do");
-    await click(".btn:contains(SAVE)");
+    await click(".btn", { text: "SAVE" });
     // Need to reopen systray as it automatically closes when a todo is created
     await contains(
         ".o_notification:contains(Your to-do has been successfully added to your tasks and scheduled for completion.)",
         2
     );
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter:contains(2)");
-    await contains(".btn:contains(2 Today)");
+    await contains(".o-mail-ActivityMenu-counter", 1, { text: "2" });
+    await contains(".btn", 1, { text: "2 Today" });
 });
 
 QUnit.test("create to-do from activity menu with date", async function () {
@@ -53,7 +54,7 @@ QUnit.test("create to-do from activity menu with date", async function () {
     await contains(".o-mail-ActivityMenu-counter", 0);
 
     await click(".o_menu_systray i[aria-label='Activities']");
-    await click(".btn:contains(Add a To-do)");
+    await click(".btn", { text: "Add a To-do" });
     await insertText("input.o-mail-ActivityMenu-input", "New To-do");
     await editInput(
         document.body,
@@ -63,14 +64,13 @@ QUnit.test("create to-do from activity menu with date", async function () {
             replace: true,
         }
     );
-    await click(".btn:contains(SAVE)");
+    await click(".btn", { text: "SAVE" });
     await contains(
         ".o_notification:contains(Your to-do has been successfully added to your tasks and scheduled for completion.)"
     );
     // Need to reopen systray as it automatically closes when a todo is created
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter:contains(1)");
-    await contains(".o-mail-ActivityGroup");
-    await contains(".o-mail-ActivityGroup:contains(project.task)");
-    await contains(".btn:contains(1 Future)");
+    await contains(".o-mail-ActivityMenu-counter", 1, { text: "1" });
+    await contains(".o-mail-ActivityGroup span", 1, { text: "project.task" });
+    await contains(".btn", 1, { text: "1 Future" });
 });

--- a/addons/project_todo/static/tests/activity_menu_tests.js
+++ b/addons/project_todo/static/tests/activity_menu_tests.js
@@ -7,13 +7,13 @@ import { editInput, patchDate } from "@web/../tests/helpers/utils";
 QUnit.test("create todo from activity menu without date", async function () {
     await start();
     await contains(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter", 0);
+    await contains(".o-mail-ActivityMenu-counter", { count: 0 });
     await click(".o_menu_systray i[aria-label='Activities']");
     await contains(
         ".o-mail-ActivityMenu:contains(Congratulations, you're done with your activities.)"
     );
     await click(".btn", { text: "Add a To-do" });
-    await contains(".btn", 0, { text: "Add a To-do" });
+    await contains(".btn", { count: 0, text: "Add a To-do" });
 
     await contains(".o-mail-ActivityMenu-show");
     await insertText("input.o-mail-ActivityMenu-input", "New To-do");
@@ -23,25 +23,25 @@ QUnit.test("create todo from activity menu without date", async function () {
     );
     // Need to reopen systray as it automatically closes when a todo is created
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter", 1, { text: "1" });
-    await contains(".o-mail-ActivityGroup span", 1, { text: "project.task" });
-    await contains(".btn", 1, { text: "1 Today" });
-    await contains(".btn", 1, { text: "Add a To-do" });
-    await contains(".o-mail-ActivityMenu-show", 0);
-    await contains(".o-mail-ActivityMenu-input", 0);
+    await contains(".o-mail-ActivityMenu-counter", { text: "1" });
+    await contains(".o-mail-ActivityGroup span", { text: "project.task" });
+    await contains(".btn", { text: "1 Today" });
+    await contains(".btn", { text: "Add a To-do" });
+    await contains(".o-mail-ActivityMenu-show", { count: 0 });
+    await contains(".o-mail-ActivityMenu-input", { count: 0 });
     await click(".btn", { text: "Add a To-do" });
-    await contains(".btn", 0, { text: "Add a To-do" });
+    await contains(".btn", { count: 0, text: "Add a To-do" });
 
     await insertText("input.o-mail-ActivityMenu-input", "New To-do");
     await click(".btn", { text: "SAVE" });
     // Need to reopen systray as it automatically closes when a todo is created
     await contains(
         ".o_notification:contains(Your to-do has been successfully added to your tasks and scheduled for completion.)",
-        2
+        { count: 2 }
     );
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter", 1, { text: "2" });
-    await contains(".btn", 1, { text: "2 Today" });
+    await contains(".o-mail-ActivityMenu-counter", { text: "2" });
+    await contains(".btn", { text: "2 Today" });
 });
 
 QUnit.test("create to-do from activity menu with date", async function () {
@@ -51,7 +51,7 @@ QUnit.test("create to-do from activity menu with date", async function () {
     const futureDay = today.plus({ days: 2 });
     await start();
     await contains(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter", 0);
+    await contains(".o-mail-ActivityMenu-counter", { count: 0 });
 
     await click(".o_menu_systray i[aria-label='Activities']");
     await click(".btn", { text: "Add a To-do" });
@@ -70,7 +70,7 @@ QUnit.test("create to-do from activity menu with date", async function () {
     );
     // Need to reopen systray as it automatically closes when a todo is created
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains(".o-mail-ActivityMenu-counter", 1, { text: "1" });
-    await contains(".o-mail-ActivityGroup span", 1, { text: "project.task" });
-    await contains(".btn", 1, { text: "1 Future" });
+    await contains(".o-mail-ActivityMenu-counter", { text: "1" });
+    await contains(".o-mail-ActivityGroup span", { text: "project.task" });
+    await contains(".btn", { text: "1 Future" });
 });

--- a/addons/sms/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/sms/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -24,11 +24,11 @@ QUnit.test("mark as read", async () => {
     await contains(".o-mail-NotificationItem");
     await triggerEvent($(".o-mail-NotificationItem")[0], null, "mouseenter");
     await contains(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem-text", 1, {
+    await contains(".o-mail-NotificationItem-text", {
         text: "An error occurred when sending an SMS",
     });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("notifications grouped by notification_type", async (assert) => {
@@ -72,7 +72,7 @@ QUnit.test("notifications grouped by notification_type", async (assert) => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 2);
+    await contains(".o-mail-NotificationItem", { count: 2 });
     const items = $(".o-mail-NotificationItem");
     assert.ok(items[0].textContent.includes("Partner"));
     assert.ok(items[0].textContent.includes("2")); // counter
@@ -136,7 +136,7 @@ QUnit.test("grouped notifications by document model", async (assert) => {
 
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem:contains(Partner) .badge", 1, { text: "2" });
+    await contains(".o-mail-NotificationItem:contains(Partner) .badge", { text: "2" });
     await click(".o-mail-NotificationItem");
     assert.verifySteps(["do_action"]);
 });

--- a/addons/sms/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/sms/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -24,7 +24,9 @@ QUnit.test("mark as read", async () => {
     await contains(".o-mail-NotificationItem");
     await triggerEvent($(".o-mail-NotificationItem")[0], null, "mouseenter");
     await contains(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem:contains(An error occurred when sending an SMS)");
+    await contains(".o-mail-NotificationItem-text", 1, {
+        text: "An error occurred when sending an SMS",
+    });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem", 0);
 });
@@ -134,7 +136,7 @@ QUnit.test("grouped notifications by document model", async (assert) => {
 
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem:contains(Partner) .badge:contains(2)");
+    await contains(".o-mail-NotificationItem:contains(Partner) .badge", 1, { text: "2" });
     await click(".o-mail-NotificationItem");
     assert.verifySteps(["do_action"]);
 });

--- a/addons/sms/static/tests/thread/message_patch_test.js
+++ b/addons/sms/static/tests/thread/message_patch_test.js
@@ -32,7 +32,7 @@ QUnit.test("Notification Sent", async (assert) => {
     await contains(".o-mail-MessageNotificationPopover");
     await contains(".o-mail-MessageNotificationPopover i");
     assert.hasClass($(".o-mail-MessageNotificationPopover i"), "fa-check");
-    await contains(".o-mail-MessageNotificationPopover", 1, { text: "Someone" });
+    await contains(".o-mail-MessageNotificationPopover", { text: "Someone" });
 });
 
 QUnit.test("Notification Error", async (assert) => {

--- a/addons/sms/static/tests/thread/message_patch_test.js
+++ b/addons/sms/static/tests/thread/message_patch_test.js
@@ -32,7 +32,7 @@ QUnit.test("Notification Sent", async (assert) => {
     await contains(".o-mail-MessageNotificationPopover");
     await contains(".o-mail-MessageNotificationPopover i");
     assert.hasClass($(".o-mail-MessageNotificationPopover i"), "fa-check");
-    await contains(".o-mail-MessageNotificationPopover:contains(Someone)");
+    await contains(".o-mail-MessageNotificationPopover", 1, { text: "Someone" });
 });
 
 QUnit.test("Notification Error", async (assert) => {

--- a/addons/snailmail/static/tests/message/message_patch_tests.js
+++ b/addons/snailmail/static/tests/message/message_patch_tests.js
@@ -6,7 +6,7 @@ import { makeDeferred, patchWithCleanup } from "@web/../tests/helpers/utils";
 
 QUnit.module("message (patch)");
 
-QUnit.test("Sent", async (assert) => {
+QUnit.test("Sent", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         name: "Someone",
@@ -26,19 +26,12 @@ QUnit.test("Sent", async (assert) => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    await click(".o-mail-Message-notification");
-    await contains(".o-snailmail-SnailmailNotificationPopover");
-    await contains(".o-snailmail-SnailmailNotificationPopover i");
-    assert.hasClass($(".o-snailmail-SnailmailNotificationPopover i"), "fa-check");
-    assert.strictEqual($(".o-snailmail-SnailmailNotificationPopover").text(), "Sent");
+    await click(".o-mail-Message-notification i.fa-paper-plane");
+    await contains(".o-snailmail-SnailmailNotificationPopover i.fa-check");
+    await contains(".o-snailmail-SnailmailNotificationPopover", { text: "Sent" });
 });
 
-QUnit.test("Canceled", async (assert) => {
+QUnit.test("Canceled", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         name: "Someone",
@@ -58,19 +51,12 @@ QUnit.test("Canceled", async (assert) => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    await click(".o-mail-Message-notification");
-    await contains(".o-snailmail-SnailmailNotificationPopover");
-    await contains(".o-snailmail-SnailmailNotificationPopover i");
-    assert.hasClass($(".o-snailmail-SnailmailNotificationPopover i"), "fa-trash-o");
-    assert.strictEqual($(".o-snailmail-SnailmailNotificationPopover").text(), "Canceled");
+    await click(".o-mail-Message-notification i.fa-paper-plane");
+    await contains(".o-snailmail-SnailmailNotificationPopover i.fa-trash-o");
+    await contains(".o-snailmail-SnailmailNotificationPopover", { text: "Canceled" });
 });
 
-QUnit.test("Pending", async (assert) => {
+QUnit.test("Pending", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         name: "Someone",
@@ -90,16 +76,9 @@ QUnit.test("Pending", async (assert) => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    await click(".o-mail-Message-notification");
-    await contains(".o-snailmail-SnailmailNotificationPopover");
-    await contains(".o-snailmail-SnailmailNotificationPopover i");
-    assert.hasClass($(".o-snailmail-SnailmailNotificationPopover i"), "fa-clock-o");
-    assert.strictEqual($(".o-snailmail-SnailmailNotificationPopover").text(), "Awaiting Dispatch");
+    await click(".o-mail-Message-notification i.fa-paper-plane");
+    await contains(".o-snailmail-SnailmailNotificationPopover i.fa-clock-o");
+    await contains(".o-snailmail-SnailmailNotificationPopover", { text: "Awaiting Dispatch" });
 });
 
 QUnit.test("No Price Available", async (assert) => {
@@ -133,18 +112,10 @@ QUnit.test("No Price Available", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    await click(".o-mail-Message-notification");
-    await contains(".o-snailmail-SnailmailError");
-    assert.strictEqual(
-        $(".o-snailmail-SnailmailError .modal-body").text().trim(),
-        "The country to which you want to send the letter is not supported by our service."
-    );
-    await contains("button", { text: "Cancel letter" });
+    await click(".o-mail-Message-notification i.fa-paper-plane");
+    await contains(".o-snailmail-SnailmailError .modal-body", {
+        text: "The country to which you want to send the letter is not supported by our service.",
+    });
     await click("button", { text: "Cancel letter" });
     await contains(".o-snailmail-SnailmailError", { count: 0 });
     assert.verifySteps(["cancel_letter"]);
@@ -181,18 +152,10 @@ QUnit.test("Credit Error", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    await click(".o-mail-Message-notification");
-    await contains(".o-snailmail-SnailmailError");
-    assert.strictEqual(
-        $(".o-snailmail-SnailmailError p").text().trim(),
-        "The letter could not be sent due to insufficient credits on your IAP account."
-    );
-    await contains("button", { text: "Re-send letter" });
+    await click(".o-mail-Message-notification i.fa-paper-plane");
+    await contains(".o-snailmail-SnailmailError p", {
+        text: "The letter could not be sent due to insufficient credits on your IAP account.",
+    });
     await contains("button", { text: "Cancel letter" });
     await click("button", { text: "Re-send letter" });
     await contains(".o-snailmail-SnailmailError", { count: 0 });
@@ -230,18 +193,10 @@ QUnit.test("Trial Error", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    await click(".o-mail-Message-notification");
-    await contains(".o-snailmail-SnailmailError");
-    assert.strictEqual(
-        $(".o-snailmail-SnailmailError p").text().trim(),
-        "You need credits on your IAP account to send a letter."
-    );
-    await contains("button", { text: "Re-send letter" });
+    await click(".o-mail-Message-notification i.fa-paper-plane");
+    await contains(".o-snailmail-SnailmailError p", {
+        text: "You need credits on your IAP account to send a letter.",
+    });
     await contains("button", { text: "Cancel letter" });
     await click("button", { text: "Re-send letter" });
     await contains(".o-snailmail-SnailmailError", { count: 0 });
@@ -278,12 +233,7 @@ QUnit.test("Format Error", async (assert) => {
             openFormatErrorActionDef.resolve();
         },
     });
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    click(".o-mail-Message-notification").then(() => {});
+    await click(".o-mail-Message-notification i.fa-paper-plane");
     await openFormatErrorActionDef;
     assert.verifySteps(["do_action"]);
 });
@@ -317,12 +267,7 @@ QUnit.test("Missing Required Fields", async (assert) => {
             openRequiredFieldsActionDef.resolve();
         },
     });
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-notification");
-    await contains(".o-mail-Message-notification i");
-    assert.hasClass($(".o-mail-Message-notification i"), "fa-paper-plane");
-
-    click(".o-mail-Message-notification").then(() => {});
+    await click(".o-mail-Message-notification i.fa-paper-plane");
     await openRequiredFieldsActionDef;
     assert.verifySteps(["do_action"]);
 });

--- a/addons/snailmail/static/tests/message/message_patch_tests.js
+++ b/addons/snailmail/static/tests/message/message_patch_tests.js
@@ -144,9 +144,9 @@ QUnit.test("No Price Available", async (assert) => {
         $(".o-snailmail-SnailmailError .modal-body").text().trim(),
         "The country to which you want to send the letter is not supported by our service."
     );
-    await contains("button", 1, { text: "Cancel letter" });
+    await contains("button", { text: "Cancel letter" });
     await click("button", { text: "Cancel letter" });
-    await contains(".o-snailmail-SnailmailError", 0);
+    await contains(".o-snailmail-SnailmailError", { count: 0 });
     assert.verifySteps(["cancel_letter"]);
 });
 
@@ -192,10 +192,10 @@ QUnit.test("Credit Error", async (assert) => {
         $(".o-snailmail-SnailmailError p").text().trim(),
         "The letter could not be sent due to insufficient credits on your IAP account."
     );
-    await contains("button", 1, { text: "Re-send letter" });
-    await contains("button", 1, { text: "Cancel letter" });
+    await contains("button", { text: "Re-send letter" });
+    await contains("button", { text: "Cancel letter" });
     await click("button", { text: "Re-send letter" });
-    await contains(".o-snailmail-SnailmailError", 0);
+    await contains(".o-snailmail-SnailmailError", { count: 0 });
     assert.verifySteps(["send_letter"]);
 });
 
@@ -241,10 +241,10 @@ QUnit.test("Trial Error", async (assert) => {
         $(".o-snailmail-SnailmailError p").text().trim(),
         "You need credits on your IAP account to send a letter."
     );
-    await contains("button", 1, { text: "Re-send letter" });
-    await contains("button", 1, { text: "Cancel letter" });
+    await contains("button", { text: "Re-send letter" });
+    await contains("button", { text: "Cancel letter" });
     await click("button", { text: "Re-send letter" });
-    await contains(".o-snailmail-SnailmailError", 0);
+    await contains(".o-snailmail-SnailmailError", { count: 0 });
     assert.verifySteps(["send_letter"]);
 });
 

--- a/addons/snailmail/static/tests/message/message_patch_tests.js
+++ b/addons/snailmail/static/tests/message/message_patch_tests.js
@@ -144,8 +144,8 @@ QUnit.test("No Price Available", async (assert) => {
         $(".o-snailmail-SnailmailError .modal-body").text().trim(),
         "The country to which you want to send the letter is not supported by our service."
     );
-    await contains("button:contains(Cancel letter)");
-    await click("button:contains(Cancel letter)");
+    await contains("button", 1, { text: "Cancel letter" });
+    await click("button", { text: "Cancel letter" });
     await contains(".o-snailmail-SnailmailError", 0);
     assert.verifySteps(["cancel_letter"]);
 });
@@ -192,9 +192,9 @@ QUnit.test("Credit Error", async (assert) => {
         $(".o-snailmail-SnailmailError p").text().trim(),
         "The letter could not be sent due to insufficient credits on your IAP account."
     );
-    await contains("button:contains(Re-send letter)");
-    await contains("button:contains(Cancel letter)");
-    await click("button:contains(Re-send letter)");
+    await contains("button", 1, { text: "Re-send letter" });
+    await contains("button", 1, { text: "Cancel letter" });
+    await click("button", { text: "Re-send letter" });
     await contains(".o-snailmail-SnailmailError", 0);
     assert.verifySteps(["send_letter"]);
 });
@@ -241,9 +241,9 @@ QUnit.test("Trial Error", async (assert) => {
         $(".o-snailmail-SnailmailError p").text().trim(),
         "You need credits on your IAP account to send a letter."
     );
-    await contains("button:contains(Re-send letter)");
-    await contains("button:contains(Cancel letter)");
-    await click("button:contains(Re-send letter)");
+    await contains("button", 1, { text: "Re-send letter" });
+    await contains("button", 1, { text: "Cancel letter" });
+    await click("button", { text: "Re-send letter" });
     await contains(".o-snailmail-SnailmailError", 0);
     assert.verifySteps(["send_letter"]);
 });

--- a/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -30,7 +30,7 @@ QUnit.test("mark as read", async () => {
         ".o-mail-NotificationItem:contains(An error occurred when sending a letter with Snailmail.)"
     );
     await click(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem", 0);
+    await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
 QUnit.test("notifications grouped by notification_type", async (assert) => {
@@ -74,7 +74,7 @@ QUnit.test("notifications grouped by notification_type", async (assert) => {
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem", 2);
+    await contains(".o-mail-NotificationItem", { count: 2 });
     assert.ok($(".o-mail-NotificationItem:eq(0)").text().includes("Partner"));
     assert.ok($(".o-mail-NotificationItem:eq(0)").text().includes("2")); // counter
     assert.ok(
@@ -145,8 +145,8 @@ QUnit.test("grouped notifications by document model", async (assert) => {
     });
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem-name", 1, { text: "Partner" });
-    await contains(".o-mail-NotificationItem-counter", 1, { text: "2" });
+    await contains(".o-mail-NotificationItem-name", { text: "Partner" });
+    await contains(".o-mail-NotificationItem-counter", { text: "2" });
     await click(".o-mail-NotificationItem");
     assert.verifySteps(["do_action"]);
 });

--- a/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -25,15 +25,14 @@ QUnit.test("mark as read", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
     await triggerEvent($(".o-mail-NotificationItem")[0], null, "mouseenter");
-    await contains(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(
-        ".o-mail-NotificationItem:contains(An error occurred when sending a letter with Snailmail.)"
-    );
+    await contains(".o-mail-NotificationItem-text", {
+        text: "An error occurred when sending a letter with Snailmail.",
+    });
     await click(".o-mail-NotificationItem [title='Mark As Read']");
     await contains(".o-mail-NotificationItem", { count: 0 });
 });
 
-QUnit.test("notifications grouped by notification_type", async (assert) => {
+QUnit.test("notifications grouped by notification_type", async () => {
     const pyEnv = await startServer();
     const partnerId = await pyEnv["res.partner"].create({});
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
@@ -75,20 +74,16 @@ QUnit.test("notifications grouped by notification_type", async (assert) => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { count: 2 });
-    assert.ok($(".o-mail-NotificationItem:eq(0)").text().includes("Partner"));
-    assert.ok($(".o-mail-NotificationItem:eq(0)").text().includes("2")); // counter
-    assert.ok(
-        $(".o-mail-NotificationItem:eq(0)")
-            .text()
-            .includes("An error occurred when sending an email")
-    );
-    assert.ok($(".o-mail-NotificationItem:eq(1)").text().includes("Partner"));
-    assert.ok($(".o-mail-NotificationItem:eq(1)").text().includes("2")); // counter
-    assert.ok(
-        $(".o-mail-NotificationItem:eq(1)")
-            .text()
-            .includes("An error occurred when sending a letter with Snailmail.")
-    );
+    await contains(".o-mail-NotificationItem-name:eq(0)", { text: "Partner" });
+    await contains(".o-mail-NotificationItem-counter:eq(0)", { text: "2" });
+    await contains(".o-mail-NotificationItem-text:eq(0)", {
+        text: "An error occurred when sending an email",
+    });
+    await contains(".o-mail-NotificationItem-name:eq(1)", { text: "Partner" });
+    await contains(".o-mail-NotificationItem-counter:eq(1)", { text: "2" });
+    await contains(".o-mail-NotificationItem-text:eq(1)", {
+        text: "An error occurred when sending a letter with Snailmail.",
+    });
 });
 
 QUnit.test("grouped notifications by document model", async (assert) => {
@@ -144,7 +139,6 @@ QUnit.test("grouped notifications by document model", async (assert) => {
         },
     });
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem");
     await contains(".o-mail-NotificationItem-name", { text: "Partner" });
     await contains(".o-mail-NotificationItem-counter", { text: "2" });
     await click(".o-mail-NotificationItem");

--- a/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -145,8 +145,8 @@ QUnit.test("grouped notifications by document model", async (assert) => {
     });
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem:contains(Partner)");
-    await contains(".o-mail-NotificationItem:contains(2)"); // counter
+    await contains(".o-mail-NotificationItem-name", 1, { text: "Partner" });
+    await contains(".o-mail-NotificationItem-counter", 1, { text: "2" });
     await click(".o-mail-NotificationItem");
     assert.verifySteps(["do_action"]);
 });

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -680,7 +680,7 @@ QUnit.module("test_mail", {}, function () {
         assert.containsOnce($, ".modal.o_technical_modal", "Activity Modal should be opened");
 
         await testUtils.dom.click($('.modal.o_technical_modal button[special="cancel"]'));
-        assert.containsNone($, ".modal.o_technical_modal", "Activity Modal should be closed");
+        await contains(".modal.o_technical_modal", { count: 0 });
     });
 
     QUnit.test(
@@ -721,17 +721,14 @@ QUnit.module("test_mail", {}, function () {
             const { webClient } = await start({ serverData });
             await doAction(webClient, 1);
 
-            assert.containsN(document.body, ".o_m2o_avatar", 2);
+            await contains(".o_m2o_avatar", { count: 2 });
             assert.containsOnce(
                 document.body,
                 `tr:nth-child(2) .o_m2o_avatar > img[data-src="/web/image/res.users/${resUsersId1}/avatar_128"]`,
                 "should have m2o avatar image"
             );
-            assert.containsNone(
-                document.body,
-                ".o_m2o_avatar > span",
-                "should not have text on many2one_avatar_user if onlyImage node option is passed"
-            );
+            // "should not have text on many2one_avatar_user if onlyImage node option is passed"
+            await contains(".o_m2o_avatar > span", { count: 0 });
         }
     );
 
@@ -1001,7 +998,7 @@ QUnit.module("test_mail", {}, function () {
             res_model: "mail.test.activity",
             views: [[false, "activity"]],
         });
-        assert.containsN(document.body, ".luxon", 2);
+        await contains(".luxon", { count: 2 });
     });
 
     QUnit.test("test displaying image (write_date field)", async (assert) => {

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -2,7 +2,7 @@
 
 import { ActivityModel } from "@mail/views/web/activity/activity_model";
 import { ActivityRenderer } from "@mail/views/web/activity/activity_renderer";
-import { start, startServer } from "@mail/../tests/helpers/test_utils";
+import { contains, start, startServer } from "@mail/../tests/helpers/test_utils";
 import { serializeDate } from "@web/core/l10n/dates";
 
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
@@ -94,10 +94,6 @@ QUnit.module("test_mail", {}, function () {
         },
     });
 
-    var activityDateFormat = function (date) {
-        return DateTime.now().toLocaleString({ day: "numeric", month: "short" });
-    };
-
     QUnit.test("activity view: simple activity rendering", async function (assert) {
         assert.expect(14);
         const mailTestActivityIds = pyEnv["mail.test.activity"].search([]);
@@ -137,7 +133,7 @@ QUnit.module("test_mail", {}, function () {
 
         const $activity = $(document.querySelector(".o_activity_view"));
         assert.containsOnce($activity, "table", "should have a table");
-        var $th1 = $activity.find("table thead tr:first th:nth-child(2)");
+        const $th1 = $activity.find("table thead tr:first th:nth-child(2)");
         assert.containsOnce(
             $th1,
             "span:first:contains(Email)",
@@ -160,7 +156,7 @@ QUnit.module("test_mail", {}, function () {
             "1 Today",
             "the counter progressbars should be correctly displayed"
         );
-        var $th2 = $activity.find("table thead tr:first th:nth-child(3)");
+        const $th2 = $activity.find("table thead tr:first th:nth-child(3)");
         assert.containsOnce(
             $th2,
             "span:first:contains(Call)",
@@ -187,7 +183,7 @@ QUnit.module("test_mail", {}, function () {
             'should contain "Meeting Room Furnitures" in first colum of second row'
         );
 
-        var today = activityDateFormat(new Date());
+        const today = DateTime.now().toLocaleString({ day: "numeric", month: "short" });
 
         assert.ok(
             $activity.find(
@@ -197,7 +193,7 @@ QUnit.module("test_mail", {}, function () {
             ).length,
             "should contain an activity for today in second cell of first line " + today
         );
-        var td = "table tbody tr:nth-child(1) td.o_activity_empty_cell";
+        const td = "table tbody tr:nth-child(1) td.o_activity_empty_cell";
         assert.containsN(
             $activity,
             td,
@@ -261,26 +257,18 @@ QUnit.module("test_mail", {}, function () {
         }
     );
 
-    QUnit.test("activity view: no content rendering", async function (assert) {
-        assert.expect(2);
-
-        const { openView, pyEnv } = await start({
-            serverData,
-        });
+    QUnit.test("activity view: no content rendering", async function () {
+        const { openView, pyEnv } = await start({ serverData });
         // reset incompatible setup
         pyEnv["mail.activity.type"].unlink(pyEnv["mail.activity.type"].search([]));
         await openView({
             res_model: "mail.test.activity",
             views: [[false, "activity"]],
         });
-        const $activity = $(document);
-
-        assert.containsOnce($activity, ".o_view_nocontent", "should display the no content helper");
-        assert.strictEqual(
-            $activity.find(".o_view_nocontent .o_view_nocontent_empty_folder").text().trim(),
-            "No data to display",
-            "should display the no content helper text"
-        );
+        await contains(".o_view_nocontent");
+        await contains(".o_view_nocontent .o_view_nocontent_empty_folder", {
+            text: "No data to display",
+        });
     });
 
     QUnit.test("activity view: batch send mail on activity", async function (assert) {
@@ -600,7 +588,7 @@ QUnit.module("test_mail", {}, function () {
             patchWithCleanup(env.services.action, {
                 doAction(action, options) {
                     assert.step("doAction");
-                    var expectedAction = {
+                    const expectedAction = {
                         context: {
                             default_res_id: mailTestActivityId1,
                             default_res_model: "mail.test.activity",
@@ -631,7 +619,7 @@ QUnit.module("test_mail", {}, function () {
             );
             await testUtils.dom.click(activity.find("table tfoot tr .o_record_selector"));
             // search create dialog
-            var $modal = $(".modal-lg");
+            const $modal = $(".modal-lg");
             assert.strictEqual(
                 $modal.find(".o_data_row").length,
                 3,
@@ -677,7 +665,7 @@ QUnit.module("test_mail", {}, function () {
         await testUtils.dom.click(
             document.querySelector(".o_activity_view .o_data_row .o_activity_empty_cell")
         );
-        assert.containsOnce($, ".modal.o_technical_modal", "Activity Modal should be opened");
+        await contains(".modal.o_technical_modal", "Activity Modal should be opened");
 
         await testUtils.dom.click($('.modal.o_technical_modal button[special="cancel"]'));
         await contains(".modal.o_technical_modal", { count: 0 });

--- a/addons/test_mail/static/tests/systray_activity_menu_tests.js
+++ b/addons/test_mail/static/tests/systray_activity_menu_tests.js
@@ -72,7 +72,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
     const { env } = await start();
     await contains(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu-counter");
-    await contains(".o-mail-ActivityMenu-counter:contains(5)");
+    await contains(".o-mail-ActivityMenu-counter", 1, { text: "5" });
     let context = {};
     patchWithCleanup(env.services.action, {
         doAction(action) {
@@ -86,7 +86,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
     await click(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu");
     await contains(".o-mail-ActivityMenu .o-mail-ActivityGroup", 2);
-    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button:contains('Late')");
+    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button", { text: "1 Late" });
     await contains(".o-mail-ActivityMenu", 0);
     context = {
         force_search_count: 1,
@@ -100,7 +100,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
         search_default_activities_upcoming_all: 1,
     };
     await click(".o_menu_systray i[aria-label='Activities']");
-    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button:contains('Future')");
+    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button", { text: "2 Future" });
     await contains(".o-mail-ActivityMenu", 0);
     context = {
         force_search_count: 1,
@@ -108,7 +108,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
         search_default_activities_today: 1,
     };
     await click(".o_menu_systray i[aria-label='Activities']");
-    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup:contains('mail.test.activity')");
+    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup span", { text: "mail.test.activity" });
     await contains(".o-mail-ActivityMenu", 0);
 });
 

--- a/addons/test_mail/static/tests/systray_activity_menu_tests.js
+++ b/addons/test_mail/static/tests/systray_activity_menu_tests.js
@@ -38,7 +38,7 @@ QUnit.test("do not show empty text when at least some future activities", async 
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Activities'])");
     await contains(
         ".o-mail-ActivityMenu:contains(Congratulations, you're done with your activities.)",
-        0
+        { count: 0 }
     );
 });
 
@@ -72,7 +72,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
     const { env } = await start();
     await contains(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu-counter");
-    await contains(".o-mail-ActivityMenu-counter", 1, { text: "5" });
+    await contains(".o-mail-ActivityMenu-counter", { text: "5" });
     let context = {};
     patchWithCleanup(env.services.action, {
         doAction(action) {
@@ -85,23 +85,23 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
     };
     await click(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu");
-    await contains(".o-mail-ActivityMenu .o-mail-ActivityGroup", 2);
+    await contains(".o-mail-ActivityMenu .o-mail-ActivityGroup", { count: 2 });
     await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button", { text: "1 Late" });
-    await contains(".o-mail-ActivityMenu", 0);
+    await contains(".o-mail-ActivityMenu", { count: 0 });
     context = {
         force_search_count: 1,
         search_default_activities_today: 1,
     };
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Activities'])");
     await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button:contains('Today'):eq(0)");
-    await contains(".o-mail-ActivityMenu", 0);
+    await contains(".o-mail-ActivityMenu", { count: 0 });
     context = {
         force_search_count: 1,
         search_default_activities_upcoming_all: 1,
     };
     await click(".o_menu_systray i[aria-label='Activities']");
     await click(".o-mail-ActivityMenu .o-mail-ActivityGroup button", { text: "2 Future" });
-    await contains(".o-mail-ActivityMenu", 0);
+    await contains(".o-mail-ActivityMenu", { count: 0 });
     context = {
         force_search_count: 1,
         search_default_activities_overdue: 1,
@@ -109,7 +109,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
     };
     await click(".o_menu_systray i[aria-label='Activities']");
     await click(".o-mail-ActivityMenu .o-mail-ActivityGroup span", { text: "mail.test.activity" });
-    await contains(".o-mail-ActivityMenu", 0);
+    await contains(".o-mail-ActivityMenu", { count: 0 });
 });
 
 QUnit.test("activity menu widget: activity view icon", async (assert) => {
@@ -141,7 +141,7 @@ QUnit.test("activity menu widget: activity view icon", async (assert) => {
     ]);
     const { env } = await start();
     await click(".o_menu_systray i[aria-label='Activities']");
-    await contains("button[title='Summary']", 2);
+    await contains("button[title='Summary']", { count: 2 });
     const first = $(".o-mail-ActivityGroup:contains('res.partner') button[title='Summary']");
     const second = $(
         ".o-mail-ActivityGroup:contains('mail.test.activity') button[title='Summary']"
@@ -163,7 +163,7 @@ QUnit.test("activity menu widget: activity view icon", async (assert) => {
         },
     });
     await click(".o-mail-ActivityGroup:contains('mail.test.activity') button[title='Summary']");
-    await contains(".dropdown-menu", 0);
+    await contains(".dropdown-menu", { count: 0 });
     await click(".o_menu_systray i[aria-label='Activities']");
     await click(".o-mail-ActivityGroup:contains('res.partner') button[title='Summary']");
     assert.verifySteps(["do_action:mail.test.activity", "do_action:res.partner"]);
@@ -174,5 +174,5 @@ QUnit.test("activity menu widget: close on messaging menu click", async (assert)
     await click(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu");
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-ActivityMenu", 0);
+    await contains(".o-mail-ActivityMenu", { count: 0 });
 });

--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -58,10 +58,10 @@ QUnit.test("basic rendering of tracking value (float type)", async function () {
     await contains(".o-mail-Message-trackingField");
     await contains(".o-mail-Message-trackingField:contains('(Float)')");
     await contains(".o-mail-Message-trackingOld");
-    await contains(".o-mail-Message-trackingOld", 1, { text: "12.30" });
+    await contains(".o-mail-Message-trackingOld", { text: "12.30" });
     await contains(".o-mail-Message-trackingSeparator");
     await contains(".o-mail-Message-trackingNew");
-    await contains(".o-mail-Message-trackingNew", 1, { text: "45.67" });
+    await contains(".o-mail-Message-trackingNew", { text: "45.67" });
 });
 
 QUnit.test("rendering of tracked field of type float: from non-0 to 0", async function () {

--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -58,10 +58,10 @@ QUnit.test("basic rendering of tracking value (float type)", async function () {
     await contains(".o-mail-Message-trackingField");
     await contains(".o-mail-Message-trackingField:contains('(Float)')");
     await contains(".o-mail-Message-trackingOld");
-    await contains(".o-mail-Message-trackingOld:contains('12.30')");
+    await contains(".o-mail-Message-trackingOld", 1, { text: "12.30" });
     await contains(".o-mail-Message-trackingSeparator");
     await contains(".o-mail-Message-trackingNew");
-    await contains(".o-mail-Message-trackingNew:contains('45.67')");
+    await contains(".o-mail-Message-trackingNew", 1, { text: "45.67" });
 });
 
 QUnit.test("rendering of tracked field of type float: from non-0 to 0", async function () {

--- a/addons/website_livechat/static/tests/messaging_service_patch_tests.js
+++ b/addons/website_livechat/static/tests/messaging_service_patch_tests.js
@@ -1,10 +1,10 @@
-/** @odoo-module */
+/* @odoo-module */
 
-import { startServer, start, afterNextRender } from "@mail/../tests/helpers/test_utils";
+import { contains, startServer, start } from "@mail/../tests/helpers/test_utils";
 
 QUnit.module("messaging service (patch)");
 
-QUnit.test("Should open chat window on send chat request to website visitor", async (assert) => {
+QUnit.test("Should open chat window on send chat request to website visitor", async () => {
     const pyEnv = await startServer();
     const visitorId = pyEnv["website.visitor"].create({
         display_name: "Visitor #11",
@@ -26,15 +26,12 @@ QUnit.test("Should open chat window on send chat request to website visitor", as
         waitUntilDataLoaded: false,
         waitUntilMessagesLoaded: false,
     });
-    await afterNextRender(async () => {
-        await env.services.rpc("/web/dataset/call_button", {
-            args: [visitorId],
-            kwargs: { context: env.context },
-            method: "action_send_chat_request",
-            model: "website.visitor",
-        });
+    await env.services.rpc("/web/dataset/call_button", {
+        args: [visitorId],
+        kwargs: { context: env.context },
+        method: "action_send_chat_request",
+        model: "website.visitor",
     });
-    assert.containsOnce($, ".o-mail-ChatWindow");
-    assert.ok(document.activeElement, $(".o-mail-ChatWindow .o-mail-Composer-input")[0]);
-    assert.strictEqual($(".o-mail-ChatWindow-name").text(), "Visitor #11");
+    await contains(".o-mail-ChatWindow-name", { text: "Visitor #11" });
+    await contains(".o-mail-ChatWindow .o-mail-Composer-input:focus");
 });

--- a/addons/website_slides/static/tests/activity_patch_tests.js
+++ b/addons/website_slides/static/tests/activity_patch_tests.js
@@ -35,7 +35,7 @@ QUnit.test("grant course access", async (assert) => {
     assert.containsOnce($, ".o-mail-Activity");
     assert.containsOnce($, "button:contains(Grant Access)");
 
-    await click("button:contains(Grant Access)");
+    await click("button", { text: "Grant Access" });
     assert.verifySteps(["access_grant"]);
 });
 
@@ -70,6 +70,6 @@ QUnit.test("refuse course access", async (assert) => {
     assert.containsOnce($, ".o-mail-Activity");
     assert.containsOnce($, "button:contains(Refuse Access)");
 
-    await click("button:contains(Refuse Access)");
+    await click("button", { text: "Refuse Access" });
     assert.verifySteps(["access_refuse"]);
 });


### PR DESCRIPTION
* = calendar, im_livechat, project_todo, sms, snailmail, test_mail, website_slides

The choice was made to have "trimmed text" check rather than "contains" to have more robust tests, at the cost of slightly more effort to write complete and unique asserts.

There is no direct speed improvement from this one, but it is one step closer to removing jQuery.

Moreover, it will fix infinite loops in some situations, because jQuery selectors would write attributes on the body, which would trigger the mutation observer, which itself will call the selector again.

https://github.com/odoo/enterprise/pull/46603