### PR TITLE
[FIX] account: invoice currency on journal change

### DIFF
--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3526,6 +3526,31 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         move.journal_id = second_journal
         self.assertEqual(move.currency_id, self.currency_data['currency'])
 
+    def test_currency_change_journal(self):
+        """
+        Test that the currency does not change when changing the journal if no currency is set on the new journal
+        """
+        second_journal = self.company_data['default_journal_sale'].copy()
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'currency_id': self.currency_data['currency'].id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'My super product.',
+                    'quantity': 1.0,
+                    'price_unit': 750.0,
+                    'account_id': self.product_a.property_account_income_id.id,
+                    'tax_ids': False,
+                })
+            ],
+        })
+
+        self.assertEqual(move.currency_id, self.currency_data['currency'])
+        move.journal_id = second_journal
+        self.assertEqual(move.currency_id, self.currency_data['currency'])
+
     @freeze_time('2023-01-01')
     def test_change_first_journal_move_sequence(self):
         """Invoice name should not be reset when posting the invoice"""


### PR DESCRIPTION
We avoid changing currency of an invcoie when
changing the journal, if the chosen journal
has no currency set.

Steps:

- Activate a foreign currency XXX
- Create a new sale journal without currency_id
- Create an invoice, and set the currency to XXX
- Change the journal to the new journal
-> The currency is reset to company currency, it
   should not change, unless the new journal
   have an other currency set on it.

opw-3479539
