### PR TITLE
[FIX] mass_mailing: preserve comments when testing a mailing

### DIFF
--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -38,7 +38,7 @@ class TestMassMailing(models.TransientModel):
         if record:
             # Returns a proper error if there is a syntax error with Qweb
             # do not force lang, will simply use user context
-            body = mailing._render_field('body_html', record.ids, compute_lang=False)[record.id]
+            body = mailing._render_field('body_html', record.ids, compute_lang=False, options={'preserve_comments': True})[record.id]
             preview = mailing._render_field('preview', record.ids, compute_lang=False)[record.id]
             full_body = mailing._prepend_preview(Markup(body), preview)
             subject = mailing._render_field('subject', record.ids, compute_lang=False)[record.id]


### PR DESCRIPTION
When sending a mailing we make sure to preserve comments (in particular so that MSO comments can be read by Outlook). However this was not the case when testing a mailing using the Test button in the form view.

opw-3290548

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
