### PR TITLE
[FIX] sale_timesheet: Check for so_line before unlinking invoice lines

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -124,7 +124,7 @@ class AccountMoveLine(models.Model):
         timesheet_ids = []
         for timesheet in timesheet_read_group:
             move_id = timesheet['timesheet_invoice_id'][0]
-            if timesheet['so_line'][0] in sale_line_ids_per_move[move_id].ids:
+            if timesheet['so_line'] and timesheet['so_line'][0] in sale_line_ids_per_move[move_id].ids:
                 timesheet_ids += timesheet['ids']
 
         self.sudo().env['account.analytic.line'].browse(timesheet_ids).write({'timesheet_invoice_id': False})


### PR DESCRIPTION
Steps to reproduce:
 1. Create an SO with billable timesheet entries
 2. Create an invoice
 3. If using enterprise, first cancel the invoice and reset the timesheet entries back to draft, then set the invoice back to draft
 4. Remove the sale order items from the timesheet entries
 5. Remove the invoice line associated with the timesheet entries

Current behavior:
 - Throws an error since the so_line value from read_group is now False and is not subscriptable

Expected behavior:
 - Removes the invoice lines

Fix:
 - Check that the so_line is not False before continuing with the logic

---
This also impacts when clients want to be able to invoice nonbillable timesheet entries as an addendum to the invoice since now it will properly ignore timesheet entries without an so_line

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
