### PR TITLE
[IMP] account, base_vat: Foreign Tax ID checking for country_group

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12997,6 +12997,13 @@ msgid "The company this distribution line belongs to."
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/partner.py:0
+#, python-format
+msgid ""
+"The country of the foreign VAT number could not be detected. Please assign a country to the fiscal position or set a country group"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_tax_group__country_id
 msgid "The country for which this tax group is applicable."
 msgstr ""
@@ -15191,6 +15198,14 @@ msgstr ""
 msgid ""
 "You cannot change the owner company of an account that already contains "
 "journal items."
+msgstr ""
+
+#. module: account
+#: code:addons/account/models/partner.py:0
+#, python-format
+msgid ""
+"You cannot create a fiscal position with a country outside of the selected "
+"country group."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -73,7 +73,7 @@ class AccountFiscalPosition(models.Model):
             if bool(position.zip_from) != bool(position.zip_to) or position.zip_from > position.zip_to:
                 raise ValidationError(_('Invalid "Zip Range", You have to configure both "From" and "To" values for the zip range and "To" should be greater than "From".'))
 
-    @api.constrains('country_id', 'state_ids', 'foreign_vat')
+    @api.constrains('country_id', 'country_group_id', 'state_ids', 'foreign_vat')
     def _validate_foreign_vat_country(self):
         for record in self:
             if record.foreign_vat:
@@ -86,15 +86,28 @@ class AccountFiscalPosition(models.Model):
                             raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country without assigning it a state."))
                         else:
                             raise ValidationError(_("You cannot create a fiscal position with a foreign VAT within your fiscal country."))
+                if record.country_group_id and record.country_id:
+                    if record.country_id not in record.country_group_id.country_ids:
+                        raise ValidationError(_("You cannot create a fiscal position with a country outside of the selected country group."))
 
                 similar_fpos_domain = [
                     ('foreign_vat', '!=', False),
-                    ('country_id', '=', record.country_id.id),
                     ('company_id', '=', record.company_id.id),
                     ('id', '!=', record.id),
                 ]
+
+                if record.country_group_id:
+                    foreign_vat_country = self.country_group_id.country_ids.filtered(lambda c: c.code == record.foreign_vat[:2].upper())
+                    if not foreign_vat_country:
+                        raise ValidationError(_("The country code of the foreign VAT number does not match any country in the group."))
+                    similar_fpos_domain += [('country_group_id', '=', record.country_group_id.id), ('country_id', '=', foreign_vat_country.id)]
+                elif record.country_id:
+                    similar_fpos_domain += [('country_id', '=', record.country_id.id), ('country_group_id', '=', False)]
+
                 if record.state_ids:
                     similar_fpos_domain.append(('state_ids', 'in', record.state_ids.ids))
+                else:
+                    similar_fpos_domain.append(('state_ids', '=', False))
 
                 similar_fpos_count = self.env['account.fiscal.position'].search_count(similar_fpos_domain)
                 if similar_fpos_count:
@@ -129,14 +142,14 @@ class AccountFiscalPosition(models.Model):
     @api.onchange('country_id')
     def _onchange_country_id(self):
         if self.country_id:
-            self.zip_from = self.zip_to = self.country_group_id = False
+            self.zip_from = self.zip_to = False
             self.state_ids = [(5,)]
             self.states_count = len(self.country_id.state_ids)
 
     @api.onchange('country_group_id')
     def _onchange_country_group_id(self):
         if self.country_group_id:
-            self.zip_from = self.zip_to = self.country_id = False
+            self.zip_from = self.zip_to = False
             self.state_ids = [(5,)]
 
     @api.model

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -50,9 +50,9 @@
                             <field name="auto_apply"/>
                             <field name="vat_required" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
                             <field name="foreign_vat"/>
-                            <field name="country_group_id" attrs="{'invisible': [('auto_apply', '!=', True)]}"/>
+                            <field name="country_group_id" attrs="{'invisible': [('auto_apply', '=', False), ('foreign_vat', '=', False)], 'required': [('foreign_vat', '!=', False), ('country_id', '=', False)]}"/>
                             <field name="country_id"
-                                attrs="{'required': [('foreign_vat', '!=', False)]}"
+                                attrs="{'required': [('foreign_vat', '!=', False), ('country_group_id', '=', False)]}"
                                 options="{'no_open': True, 'no_create': True}"/>
                             <field name="state_ids" widget="many2many_tags" domain="[('country_id', '=', country_id)]"
                                 attrs="{'invisible': ['|', '|', '&amp;', ('auto_apply', '!=', True), ('foreign_vat', '=', False), ('country_id', '=', False), ('states_count', '=', 0)]}"/>

--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -151,8 +151,16 @@ msgstr ""
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid ""
-"The country detected for this foreign VAT number does not match the one set "
-"on this fiscal position."
+"The country detected for this foreign VAT number does not match any of the "
+"countries composing the country group set on this fiscal position."
+msgstr ""
+
+#. module: base_vat
+#: code:addons/base_vat/models/account_fiscal_position.py:0
+#, python-format
+msgid ""
+"The country of the foreign VAT number could not be detected. Please assign a"
+" country to the fiscal position or set a country group"
 msgstr ""
 
 #. module: base_vat

--- a/addons/base_vat/models/account_fiscal_position.py
+++ b/addons/base_vat/models/account_fiscal_position.py
@@ -7,18 +7,52 @@ from odoo.exceptions import ValidationError
 class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 
+    @api.model
+    def create(self, vals):
+        vals = self.adjust_vals_country_id(vals)
+        return super().create(vals)
+
+    def write(self, vals):
+        vals = self.adjust_vals_country_id(vals)
+        return super().write(vals)
+
+    def adjust_vals_country_id(self, vals):
+        foreign_vat = vals.get('foreign_vat')
+        country_group_id = vals.get('country_group_id')
+        if foreign_vat and country_group_id and not (self.country_id or vals.get('country_id')):
+            vals['country_id'] = self.env['res.country.group'].browse(country_group_id).country_ids.filtered(lambda c: c.code == foreign_vat[:2].upper()).id or False
+        return vals
+
     @api.constrains('country_id', 'foreign_vat')
     def _validate_foreign_vat(self):
         for record in self:
             if not record.foreign_vat:
                 continue
 
-            checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, record.country_id)
+            if record.country_group_id:
+                # Checks the foreign vat is a VAT Number linked to a country of the country group
+                foreign_vat_country = self.country_group_id.country_ids.filtered(lambda c: c.code == record.foreign_vat[:2].upper())
+                if not foreign_vat_country:
+                    raise ValidationError(_("The country detected for this foreign VAT number does not match any of the countries composing the country group set on this fiscal position."))
+                if record.country_id:
+                    checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, record.country_id) or self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country)
+                    if not checked_country_code:
+                        record.raise_vat_error_message(foreign_vat_country)
+                else:
+                    checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country)
+                    if not checked_country_code:
+                        record.raise_vat_error_message(record.country_id)
+            elif record.country_id:
+                foreign_vat_country = self.env['res.country'].search([('code', '=', record.foreign_vat[:2].upper())], limit=1)
+                checked_country_code = self.env['res.partner']._run_vat_test(record.foreign_vat, foreign_vat_country or record.country_id)
+                if not checked_country_code:
+                    record.raise_vat_error_message()
 
-            if checked_country_code and checked_country_code != record.country_id.code.lower():
-                raise ValidationError(_("The country detected for this foreign VAT number does not match the one set on this fiscal position."))
+            if record.foreign_vat and not record.country_id and not record.country_group_id:
+                raise ValidationError(_("The country of the foreign VAT number could not be detected. Please assign a country to the fiscal position or set a country group"))
 
-            if not checked_country_code:
-                fp_label = _("fiscal position [%s]", record.name)
-                error_message = self.env['res.partner']._build_vat_error_message(record.country_id.code.lower(), record.foreign_vat, fp_label)
-                raise ValidationError(error_message)
+    def raise_vat_error_message(self, country=False):
+        fp_label = _("fiscal position [%s]", self.name)
+        country_code = country.code.lower() if country else self.country_id.code.lower()
+        error_message = self.env['res.partner']._build_vat_error_message(country_code, self.foreign_vat, fp_label)
+        raise ValidationError(error_message)


### PR DESCRIPTION
Description of the issue/behavior this commit addresses:

The restrictions on fiscal positions using a foreign VAT are too restricitve,
this commits addresses the issue by allowing new scenarios.

---

Desired behavior after the commit is merged :

This commit allows to use a foreign VAT with only a country group which
will automatically set the corresponding country on the FP. For example, you
can now use a Belgian VAT number on the country group Europe and therefore use
that fiscal positions for all countries in Europe which do not have their own.

On a fiscal position with a foreign VAT, this commit allows the user to set a
country which is not the country linked to the foreign VAT. For example, if you
are belgian, you have a warehouse in France and export goods to Germany, you
can create a fiscal position with a french foreign vat and germany as country.

This commit also allows a lot more "duplicates". You can set multiple FP inside
the same country depending on the states/foreign vat you set it up with.

---

enterprise: https://github.com/odoo/enterprise/pull/61969
task-3088020



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
