### PR TITLE
[IMP] web, *: Add more formatters in assets_frontend

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { formatFloat, formatMonetary } from "@web/views/fields/formatters";
+import { formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { parseFloat } from "@web/views/fields/parsers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { registry } from "@web/core/registry";

--- a/addons/hr_timesheet/static/src/services/timesheet_uom_service.js
+++ b/addons/hr_timesheet/static/src/services/timesheet_uom_service.js
@@ -2,7 +2,8 @@
 
 import { session } from "@web/session";
 import { registry } from "@web/core/registry";
-import { formatFloatTime, formatFloatFactor, formatFloat } from "@web/views/fields/formatters";
+import { formatFloatTime, formatFloatFactor } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { FloatFactorField } from "@web/views/fields/float_factor/float_factor_field";
 
 export const timesheetUOMService = {

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -7,11 +7,11 @@ import { deserializeDateTime, formatDate, formatDateTime } from "@web/core/l10n/
 import { _t } from "@web/core/l10n/translation";
 import {
     formatChar,
-    formatFloat,
     formatInteger,
     formatMonetary,
     formatText,
 } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { useState } from "@odoo/owl";

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
@@ -2,7 +2,8 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat, formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 
 const { Component } = owl;
 

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { formatFloat, formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 
 const { Component } = owl;
 

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.js
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.js
@@ -1,6 +1,7 @@
 /** @odoo-module **/
 
-import { formatMonetary, formatFloat } from "@web/views/fields/formatters";
+import { formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { useService } from "@web/core/utils/hooks";
 import { BomOverviewLine } from "../bom_overview_line/mrp_bom_overview_line";
 import { BomOverviewComponentsBlock } from "../bom_overview_components_block/mrp_bom_overview_components_block";

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
@@ -3,7 +3,8 @@
 import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat, formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { getStateDecorator } from "./mo_overview_colors";
 
 export class MoOverviewLine extends Component {
@@ -87,7 +88,7 @@ export class MoOverviewLine extends Component {
     }
 
     //---- Getters ----
-    
+
     get data() {
         return this.props.data;
     }

--- a/addons/mrp/static/src/widgets/mrp_should_consume.js
+++ b/addons/mrp/static/src/widgets/mrp_should_consume.js
@@ -2,7 +2,7 @@
 
 import { FloatField, floatField } from "@web/views/fields/float/float_field";
 import { registry } from "@web/core/registry";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";;
 
 /**
  * This widget is used to display alongside the total quantity to consume of a production order,
@@ -41,7 +41,7 @@ export class MrpShouldConsumeOwl extends FloatField {
             ...this.nodeOptions,
         });
     }
-} 
+}
 
 MrpShouldConsumeOwl.template = "mrp.ShouldConsume";
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/order_details/orderline_details.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/order_details/orderline_details.js
@@ -2,8 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
-import { formatFloat } from "@web/views/fields/formatters";
-import { roundPrecision as round_pr } from "@web/core/utils/numbers";
+import { formatFloat, roundPrecision as round_pr } from "@web/core/utils/numbers";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 
 /**

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1,6 +1,5 @@
 /** @odoo-module */
 
-import { formatFloat } from "@web/views/fields/formatters";
 import { uuidv4 } from "@point_of_sale/utils";
 // FIXME POSREF - unify use of native parseFloat and web's parseFloat. We probably don't need the native version.
 import { parseFloat as oParseFloat } from "@web/views/fields/parsers";
@@ -12,6 +11,7 @@ import {
     deserializeDateTime,
 } from "@web/core/l10n/dates";
 import {
+    formatFloat,
     roundDecimals as round_di,
     roundPrecision as round_pr,
     floatIsZero,

--- a/addons/point_of_sale/static/src/app/utils/contextual_utils_service.js
+++ b/addons/point_of_sale/static/src/app/utils/contextual_utils_service.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
-import { formatMonetary, formatFloat } from "@web/views/fields/formatters";
-import { roundDecimals } from "@web/core/utils/numbers";
+import { formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat, roundDecimals } from "@web/core/utils/numbers";
 import { escapeRegExp } from '@web/core/utils/strings';
 import { registry } from "@web/core/registry";
 

--- a/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
+++ b/addons/pos_loyalty/static/src/overrides/components/partner_line/partner_line.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { PartnerLine } from "@point_of_sale/app/screens/partner_list/partner_line/partner_line";
 import { patch } from "@web/core/utils/patch";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 
 patch(PartnerLine.prototype, {
     setup() {

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from '@web/core/utils/hooks';
-import { formatFloat } from '@web/views/fields/formatters';
+import { formatFloat } from "@web/core/utils/numbers";
 import { ViewButton } from '@web/views/view_button/view_button';
 import { FormViewDialog } from '@web/views/view_dialogs/form_view_dialog';
 

--- a/addons/sale_product_configurator/static/src/js/badge_extra_price/badge_extra_price.js
+++ b/addons/sale_product_configurator/static/src/js/badge_extra_price/badge_extra_price.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { Component } from "@odoo/owl";
-import { formatMonetary } from "@web/views/fields/formatters";
+import { formatCurrency } from "@web/core/currency";
 
 export class BadgeExtraPrice extends Component {
     static template = "product.badge_extra_price";
@@ -16,6 +16,6 @@ export class BadgeExtraPrice extends Component {
      * @return {String} - The price, in the format of the given currency.
      */
     getFormattedPrice() {
-        return formatMonetary( Math.abs(this.props.price), {currencyId: this.props.currencyId});
+        return formatCurrency( Math.abs(this.props.price), this.props.currencyId);
     }
 }

--- a/addons/sale_product_configurator/static/src/js/product/product.js
+++ b/addons/sale_product_configurator/static/src/js/product/product.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { Component } from "@odoo/owl";
-import { formatMonetary } from "@web/views/fields/formatters";
+import { formatCurrency } from "@web/core/currency";
 import {
     ProductTemplateAttributeLine as PTAL
 } from "../product_template_attribute_line/product_template_attribute_line";
@@ -62,6 +62,6 @@ export class Product extends Component {
      * @return {String} - The price, in the format of the given currency.
      */
     getFormattedPrice() {
-        return formatMonetary(this.props.price, {currencyId: this.env.currencyId});
+        return formatCurrency(this.props.price, this.env.currencyId);
     }
 }

--- a/addons/sale_product_configurator/static/src/js/product_list/product_list.js
+++ b/addons/sale_product_configurator/static/src/js/product_list/product_list.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { Component } from "@odoo/owl";
-import { formatMonetary } from "@web/views/fields/formatters";
+import { formatCurrency } from "@web/core/currency";
 import { Product } from "../product/product";
 
 export class ProductList extends Component {
@@ -21,11 +21,11 @@ export class ProductList extends Component {
      * @return {String} - The sum of all items in the list, in the currency of the `sale.order`.
      */
     getFormattedTotal() {
-        return formatMonetary(
+        return formatCurrency(
             this.props.products.reduce(
                 (totalPrice, product) => totalPrice + product.price * product.quantity, 0
             ),
-            {currencyId: this.env.currencyId},
+            this.env.currencyId,
         )
     }
 }

--- a/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { Component } from "@odoo/owl";
-import { formatMonetary } from "@web/views/fields/formatters";
+import { formatCurrency } from "@web/core/currency";
 import { BadgeExtraPrice } from "../badge_extra_price/badge_extra_price";
 
 export class ProductTemplateAttributeLine extends Component {
@@ -110,8 +110,8 @@ export class ProductTemplateAttributeLine extends Component {
     getPTAVSelectName(ptav) {
         if (ptav.price_extra) {
             const sign = ptav.price_extra > 0 ? '+' : '-';
-            const price = formatMonetary(
-                Math.abs(ptav.price_extra),{currencyId: this.env.currencyId}
+            const price = formatCurrency(
+                Math.abs(ptav.price_extra), this.env.currencyId
             );
             return ptav.name +" ("+ sign + " " + price + ")";
         } else {

--- a/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/sale_project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -1,7 +1,8 @@
 /** @odoo-module */
 
 import { patch } from "@web/core/utils/patch";
-import { formatFloatTime, formatFloat } from "@web/views/fields/formatters";
+import { formatFloatTime } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { ProjectRightSidePanel } from '@project/components/project_right_side_panel/project_right_side_panel';
 
 patch(ProjectRightSidePanel.prototype, {

--- a/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.js
+++ b/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 
 const { Component } = owl;
 

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -1,5 +1,5 @@
 /** @odoo-module **/
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { useService } from "@web/core/utils/hooks";
 
 const { Component } = owl;

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 
 const { Component } = owl;
 

--- a/addons/stock/static/src/widgets/forecast_widget.js
+++ b/addons/stock/static/src/widgets/forecast_widget.js
@@ -2,7 +2,7 @@
 
 import { FloatField, floatField } from "@web/views/fields/float/float_field";
 import { formatDate } from "@web/core/l10n/dates";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -2,16 +2,13 @@
 
 import hashlib
 import json
-import logging
 
 import odoo
-from odoo import api, http, models
+from odoo import api, models
 from odoo.http import request, DEFAULT_MAX_CONTENT_LENGTH
-from odoo.tools import file_open, image_process, ustr
+from odoo.tools import ormcache, ustr
 from odoo.tools.misc import str2bool
 
-
-_logger = logging.getLogger(__name__)
 
 """
 Debug mode is stored in session and should always be a string.
@@ -167,6 +164,7 @@ class Http(models.AbstractModel):
             'profile_collectors': request.session.profile_collectors,
             'profile_params': request.session.profile_params,
             'show_effect': bool(request.env['ir.config_parameter'].sudo().get_param('base_setup.show_effect')),
+            'currencies': self.get_currencies(),
             'bundle_params': {
                 'lang': request.session.context['lang'],
             },
@@ -181,6 +179,7 @@ class Http(models.AbstractModel):
             })
         return session_info
 
+    @ormcache()
     def get_currencies(self):
         Currency = self.env['res.currency']
         currencies = Currency.search_fetch([], ['symbol', 'position', 'decimal_places'])

--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -1,6 +1,8 @@
 /** @odoo-module **/
 
+import { formatFloat, humanNumber } from "@web/core/utils/numbers";
 import { session } from "@web/session";
+import { nbsp } from "@web/core/utils/strings";
 
 export const currencies = session.currencies || {};
 // to make sure code is reading currencies from here
@@ -8,4 +10,44 @@ delete session.currencies;
 
 export function getCurrency(id) {
     return currencies[id];
+}
+
+/**
+ * Returns a string representing a monetary value. The result takes into account
+ * the user settings (to display the correct decimal separator, currency, ...).
+ *
+ * @param {number} value the value that should be formatted
+ * @param {number} [currencyId] the id of the 'res.currency' to use
+ * @param {Object} [options]
+ *   additional options to override the values in the python description of the
+ *   field.
+ * @param {Object} [options.data] a mapping of field names to field values,
+ *   required with options.currencyField
+ * @param {boolean} [options.noSymbol] this currency has not a sympbol
+ * @param {boolean} [options.humanReadable] if true, large numbers are formatted
+ *   to a human readable format.
+ * @param {[number, number]} [options.digits] the number of digits that should
+ *   be used, instead of the default digits precision in the field.  The first
+ *   number is always ignored (legacy constraint)
+ * @returns {string}
+ */
+export function formatCurrency(amount, currencyId, options = {}) {
+    const currency = getCurrency(currencyId);
+    const digits = options.digits || (currency && currency.digits);
+
+    let formattedAmount;
+    if (options.humanReadable) {
+        formattedAmount = humanNumber(amount, { decimals: digits ? digits[1] : 2 });
+    } else {
+        formattedAmount = formatFloat(amount, { digits });
+    }
+
+    if (!currency || options.noSymbol) {
+        return formattedAmount;
+    }
+    const formatted = [currency.symbol, formattedAmount];
+    if (currency.position === "after") {
+        formatted.reverse();
+    }
+    return formatted.join(nbsp);
 }

--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -156,3 +156,43 @@ export function humanNumber(number, options = { decimals: 0, minDigits: 1 }) {
     }
     return int + decimalPoint + decimalPart + symbol;
 }
+
+/**
+ * Returns a string representing a float.  The result takes into account the
+ * user settings (to display the correct decimal separator).
+ *
+ * @param {number} value the value that should be formatted
+ * @param {Object} [options]
+ * @param {number[]} [options.digits] the number of digits that should be used,
+ *   instead of the default digits precision in the field.
+ * @param {boolean} [options.humanReadable] if true, large numbers are formatted
+ *   to a human readable format.
+ * @param {string} [options.decimalPoint] decimal separating character
+ * @param {string} [options.thousandsSep] thousands separator to insert
+ * @param {number[]} [options.grouping] array of relative offsets at which to
+ *   insert `thousandsSep`. See `insertThousandsSep` method.
+ * @param {number} [options.decimals] used for humanNumber formmatter
+ * @param {boolean} [options.trailingZeros=true] if false, the decimal part
+ *   won't contain unnecessary trailing zeros.
+ * @returns {string}
+ */
+export function formatFloat(value, options = {}) {
+    if (options.humanReadable) {
+        return humanNumber(value, options);
+    }
+    const grouping = options.grouping || l10n.grouping;
+    const thousandsSep = "thousandsSep" in options ? options.thousandsSep : l10n.thousandsSep;
+    const decimalPoint = "decimalPoint" in options ? options.decimalPoint : l10n.decimalPoint;
+    let precision;
+    if (options.digits && options.digits[1] !== undefined) {
+        precision = options.digits[1];
+    } else {
+        precision = 2;
+    }
+    const formatted = value.toFixed(precision).split(".");
+    formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
+    if (options.trailingZeros === false && formatted[1]) {
+        formatted[1] = formatted[1].replace(/0+$/, "");
+    }
+    return formatted[1] ? formatted.join(decimalPoint) : formatted[0];
+}

--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useInputField } from "../input_field_hook";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
-import { formatFloat } from "../formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { parseFloat } from "../parsers";
 import { standardFieldProps } from "../standard_field_props";
 
@@ -31,7 +31,7 @@ export class FloatField extends Component {
 
     setup() {
         this.state = useState({
-            hasFocus: false, 
+            hasFocus: false,
         })
         this.inputRef = useInputField({
             getValue: () => this.formattedValue,

--- a/addons/web/static/src/views/fields/gauge/gauge_field.js
+++ b/addons/web/static/src/views/fields/gauge/gauge_field.js
@@ -3,7 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { loadJS } from "@web/core/assets";
 import { registry } from "@web/core/registry";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 import { Component, onWillStart, useEffect, useRef } from "@odoo/owl";

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -18,7 +18,8 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { TagsList } from "@web/core/tags_list/tags_list";
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat, formatInteger, formatMany2one } from "@web/views/fields/formatters";
+import { formatInteger, formatMany2one } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { m2oTupleFromData } from "@web/views/fields/many2one/many2one_field";
 import { parseFloat, parseInteger } from "@web/views/fields/parsers";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "@web/views/fields/relational_utils";

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { getBorderWhite, DEFAULT_BG, getColor, hexToRGBA } from "@web/core/colors/colors";
-import { formatFloat } from "@web/views/fields/formatters";
+import { formatFloat } from "@web/core/utils/numbers";
 import { SEP } from "./graph_model";
 import { sortBy } from "@web/core/utils/arrays";
 import { loadJS } from "@web/core/assets";

--- a/addons/web/static/tests/core/currency_tests.js
+++ b/addons/web/static/tests/core/currency_tests.js
@@ -1,0 +1,78 @@
+/** @odoo-module **/
+
+import { defaultLocalization } from "@web/../tests/helpers/mock_services";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { localization } from "@web/core/l10n/localization";
+
+import { currencies, formatCurrency } from "@web/core/currency";
+import { session } from "@web/session";
+
+QUnit.module("utils", (hooks) => {
+    hooks.beforeEach(() => {
+        patchWithCleanup(localization, { ...defaultLocalization, grouping: [3, 0] });
+    });
+
+    QUnit.module("Currency");
+
+    QUnit.test("formatCurrency", function (assert) {
+        patchWithCleanup(currencies, {
+            10: {
+                digits: [69, 2],
+                position: "after",
+                symbol: "€",
+            },
+            11: {
+                digits: [69, 2],
+                position: "before",
+                symbol: "$",
+            },
+            12: {
+                digits: [69, 2],
+                position: "after",
+                symbol: "&",
+            },
+        });
+
+        assert.strictEqual(formatCurrency(200), "200.00");
+
+        assert.deepEqual(formatCurrency(1234567.654, 10), "1,234,567.65\u00a0€");
+        assert.deepEqual(formatCurrency(1234567.654, 11), "$\u00a01,234,567.65");
+        assert.deepEqual(formatCurrency(1234567.654, 44), "1,234,567.65");
+        assert.deepEqual(
+            formatCurrency(1234567.654, 10, { noSymbol: true }),
+            "1,234,567.65"
+        );
+        assert.deepEqual(
+            formatCurrency(8.0, 10, { humanReadable: true }),
+            "8.00\u00a0€"
+        );
+        assert.deepEqual(
+            formatCurrency(1234567.654, 10, { humanReadable: true }),
+            "1.23M\u00a0€"
+        );
+        assert.deepEqual(
+            formatCurrency(1990000.001, 10, { humanReadable: true }),
+            "1.99M\u00a0€"
+        );
+        assert.deepEqual(
+            formatCurrency(1234567.654, 44, { digits: [69, 1] }),
+            "1,234,567.7"
+        );
+        assert.deepEqual(
+            formatCurrency(1234567.654, 11, { digits: [69, 1] }),
+            "$\u00a01,234,567.7",
+            "options digits should take over currency digits when both are defined"
+        );
+    });
+
+    QUnit.test("formatCurrency without currency", function (assert) {
+        patchWithCleanup(session, {
+            currencies: {},
+        });
+        assert.deepEqual(
+            formatCurrency(1234567.654, 10, { humanReadable: true }),
+            "1.23M"
+        );
+        assert.deepEqual(formatCurrency(1234567.654, 10), "1,234,567.65");
+    });
+});

--- a/addons/web/static/tests/core/utils/numbers_tests.js
+++ b/addons/web/static/tests/core/utils/numbers_tests.js
@@ -1,6 +1,10 @@
 /** @odoo-module **/
 
-import { roundPrecision, roundDecimals, floatIsZero } from "@web/core/utils/numbers";
+import { defaultLocalization } from "@web/../tests/helpers/mock_services";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { localization } from "@web/core/l10n/localization";
+
+import { roundPrecision, roundDecimals, floatIsZero, formatFloat } from "@web/core/utils/numbers";
 
 QUnit.module("utils", () => {
     QUnit.module("numbers");
@@ -135,5 +139,145 @@ QUnit.module("utils", () => {
         assert.strictEqual(floatIsZero(-0.00000005, 7), false);
         assert.strictEqual(floatIsZero(-0.000000099999, 7), false);
         assert.strictEqual(floatIsZero(-0.0000001, 7), false);
+    });
+});
+
+QUnit.module("utils", (hooks) => {
+    hooks.beforeEach(() => {
+        patchWithCleanup(localization, { ...defaultLocalization, grouping: [3, 0] });
+    });
+
+    QUnit.module("numbers");
+
+    QUnit.test("formatFloat", function (assert) {
+        assert.strictEqual(formatFloat(1000000), "1,000,000.00");
+
+        const options = { grouping: [3, 2, -1], decimalPoint: "?", thousandsSep: "€" };
+        assert.strictEqual(formatFloat(106500, options), "1€06€500?00");
+
+        assert.strictEqual(formatFloat(1500, { thousandsSep: "" }), "1500.00");
+        assert.strictEqual(formatFloat(-1.01), "-1.01");
+        assert.strictEqual(formatFloat(-0.01), "-0.01");
+
+        assert.strictEqual(formatFloat(38.0001, { trailingZeros: false }), "38");
+        assert.strictEqual(formatFloat(38.1, { trailingZeros: false }), "38.1");
+        assert.strictEqual(formatFloat(38.0001, { digits: [16, 0], trailingZeros: false }), "38");
+
+        patchWithCleanup(localization, { grouping: [3, 3, 3, 3] });
+        assert.strictEqual(formatFloat(1000000), "1,000,000.00");
+
+        patchWithCleanup(localization, { grouping: [3, 2, -1] });
+        assert.strictEqual(formatFloat(106500), "1,06,500.00");
+
+        patchWithCleanup(localization, { grouping: [1, 2, -1] });
+        assert.strictEqual(formatFloat(106500), "106,50,0.00");
+
+        patchWithCleanup(localization, {
+            grouping: [2, 0],
+            decimalPoint: "!",
+            thousandsSep: "@",
+        });
+        assert.strictEqual(formatFloat(6000), "60@00!00");
+    });
+
+    QUnit.test("formatFloat (humanReadable=true)", async (assert) => {
+        assert.strictEqual(
+            formatFloat(1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "1.02k"
+        );
+        assert.strictEqual(
+            formatFloat(1020000, { humanReadable: true, decimals: 2, minDigits: 2 }),
+            "1,020k"
+        );
+        assert.strictEqual(
+            formatFloat(10200000, { humanReadable: true, decimals: 2, minDigits: 2 }),
+            "10.20M"
+        );
+        assert.strictEqual(
+            formatFloat(1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "1.02k"
+        );
+        assert.strictEqual(
+            formatFloat(1002, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "1.00k"
+        );
+        assert.strictEqual(
+            formatFloat(101, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "101.00"
+        );
+        assert.strictEqual(
+            formatFloat(64.2, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "64.20"
+        );
+        assert.strictEqual(formatFloat(1e18, { humanReadable: true }), "1E");
+        assert.strictEqual(
+            formatFloat(1e21, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "1e+21"
+        );
+        assert.strictEqual(
+            formatFloat(1.0045e22, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "1e+22"
+        );
+        assert.strictEqual(
+            formatFloat(1.0045e22, { humanReadable: true, decimals: 3, minDigits: 1 }),
+            "1.005e+22"
+        );
+        assert.strictEqual(
+            formatFloat(1.012e43, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "1.01e+43"
+        );
+        assert.strictEqual(
+            formatFloat(1.012e43, { humanReadable: true, decimals: 2, minDigits: 2 }),
+            "1.01e+43"
+        );
+        assert.strictEqual(
+            formatFloat(-1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-1.02k"
+        );
+        assert.strictEqual(
+            formatFloat(-1020000, { humanReadable: true, decimals: 2, minDigits: 2 }),
+            "-1,020k"
+        );
+        assert.strictEqual(
+            formatFloat(-10200000, { humanReadable: true, decimals: 2, minDigits: 2 }),
+            "-10.20M"
+        );
+        assert.strictEqual(
+            formatFloat(-1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-1.02k"
+        );
+        assert.strictEqual(
+            formatFloat(-1002, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-1.00k"
+        );
+        assert.strictEqual(
+            formatFloat(-101, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-101.00"
+        );
+        assert.strictEqual(
+            formatFloat(-64.2, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-64.20"
+        );
+        assert.strictEqual(formatFloat(-1e18, { humanReadable: true }), "-1E");
+        assert.strictEqual(
+            formatFloat(-1e21, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-1e+21"
+        );
+        assert.strictEqual(
+            formatFloat(-1.0045e22, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-1e+22"
+        );
+        assert.strictEqual(
+            formatFloat(-1.0045e22, { humanReadable: true, decimals: 3, minDigits: 1 }),
+            "-1.004e+22"
+        );
+        assert.strictEqual(
+            formatFloat(-1.012e43, { humanReadable: true, decimals: 2, minDigits: 1 }),
+            "-1.01e+43"
+        );
+        assert.strictEqual(
+            formatFloat(-1.012e43, { humanReadable: true, decimals: 2, minDigits: 2 }),
+            "-1.01e+43"
+        );
     });
 });

--- a/addons/web/static/tests/views/fields/formatters_tests.js
+++ b/addons/web/static/tests/views/fields/formatters_tests.js
@@ -5,7 +5,6 @@ import { defaultLocalization } from "@web/../tests/helpers/mock_services";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { currencies } from "@web/core/currency";
 import { localization } from "@web/core/l10n/localization";
-import { session } from "@web/session";
 import {
     formatFloat,
     formatFloatFactor,
@@ -29,135 +28,6 @@ QUnit.module("Fields", (hooks) => {
 
     QUnit.test("formatFloat", function (assert) {
         assert.strictEqual(formatFloat(false), "");
-        assert.strictEqual(formatFloat(null), "0.00");
-        assert.strictEqual(formatFloat(1000000), "1,000,000.00");
-
-        const options = { grouping: [3, 2, -1], decimalPoint: "?", thousandsSep: "€" };
-        assert.strictEqual(formatFloat(106500, options), "1€06€500?00");
-
-        assert.strictEqual(formatFloat(1500, { thousandsSep: "" }), "1500.00");
-        assert.strictEqual(formatFloat(-1.01), "-1.01");
-        assert.strictEqual(formatFloat(-0.01), "-0.01");
-
-        assert.strictEqual(formatFloat(38.0001, { noTrailingZeros: true }), "38");
-        assert.strictEqual(formatFloat(38.1, { noTrailingZeros: true }), "38.1");
-
-        patchWithCleanup(localization, { grouping: [3, 3, 3, 3] });
-        assert.strictEqual(formatFloat(1000000), "1,000,000.00");
-
-        patchWithCleanup(localization, { grouping: [3, 2, -1] });
-        assert.strictEqual(formatFloat(106500), "1,06,500.00");
-
-        patchWithCleanup(localization, { grouping: [1, 2, -1] });
-        assert.strictEqual(formatFloat(106500), "106,50,0.00");
-
-        patchWithCleanup(localization, {
-            grouping: [2, 0],
-            decimalPoint: "!",
-            thousandsSep: "@",
-        });
-        assert.strictEqual(formatFloat(6000), "60@00!00");
-    });
-
-    QUnit.test("formatFloat (humanReadable=true)", async (assert) => {
-        assert.strictEqual(
-            formatFloat(1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "1.02k"
-        );
-        assert.strictEqual(
-            formatFloat(1020000, { humanReadable: true, decimals: 2, minDigits: 2 }),
-            "1,020k"
-        );
-        assert.strictEqual(
-            formatFloat(10200000, { humanReadable: true, decimals: 2, minDigits: 2 }),
-            "10.20M"
-        );
-        assert.strictEqual(
-            formatFloat(1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "1.02k"
-        );
-        assert.strictEqual(
-            formatFloat(1002, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "1.00k"
-        );
-        assert.strictEqual(
-            formatFloat(101, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "101.00"
-        );
-        assert.strictEqual(
-            formatFloat(64.2, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "64.20"
-        );
-        assert.strictEqual(formatFloat(1e18, { humanReadable: true }), "1E");
-        assert.strictEqual(
-            formatFloat(1e21, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "1e+21"
-        );
-        assert.strictEqual(
-            formatFloat(1.0045e22, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "1e+22"
-        );
-        assert.strictEqual(
-            formatFloat(1.0045e22, { humanReadable: true, decimals: 3, minDigits: 1 }),
-            "1.005e+22"
-        );
-        assert.strictEqual(
-            formatFloat(1.012e43, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "1.01e+43"
-        );
-        assert.strictEqual(
-            formatFloat(1.012e43, { humanReadable: true, decimals: 2, minDigits: 2 }),
-            "1.01e+43"
-        );
-        assert.strictEqual(
-            formatFloat(-1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-1.02k"
-        );
-        assert.strictEqual(
-            formatFloat(-1020000, { humanReadable: true, decimals: 2, minDigits: 2 }),
-            "-1,020k"
-        );
-        assert.strictEqual(
-            formatFloat(-10200000, { humanReadable: true, decimals: 2, minDigits: 2 }),
-            "-10.20M"
-        );
-        assert.strictEqual(
-            formatFloat(-1020, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-1.02k"
-        );
-        assert.strictEqual(
-            formatFloat(-1002, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-1.00k"
-        );
-        assert.strictEqual(
-            formatFloat(-101, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-101.00"
-        );
-        assert.strictEqual(
-            formatFloat(-64.2, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-64.20"
-        );
-        assert.strictEqual(formatFloat(-1e18, { humanReadable: true }), "-1E");
-        assert.strictEqual(
-            formatFloat(-1e21, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-1e+21"
-        );
-        assert.strictEqual(
-            formatFloat(-1.0045e22, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-1e+22"
-        );
-        assert.strictEqual(
-            formatFloat(-1.0045e22, { humanReadable: true, decimals: 3, minDigits: 1 }),
-            "-1.004e+22"
-        );
-        assert.strictEqual(
-            formatFloat(-1.012e43, { humanReadable: true, decimals: 2, minDigits: 1 }),
-            "-1.01e+43"
-        );
-        assert.strictEqual(
-            formatFloat(-1.012e43, { humanReadable: true, decimals: 2, minDigits: 2 }),
-            "-1.01e+43"
-        );
     });
 
     QUnit.test("formatFloatFactor", function (assert) {
@@ -278,67 +148,24 @@ QUnit.module("Fields", (hooks) => {
         });
 
         assert.strictEqual(formatMonetary(false), "");
-        assert.strictEqual(formatMonetary(200), "200.00");
 
-        assert.deepEqual(formatMonetary(1234567.654, { currencyId: 10 }), "1,234,567.65\u00a0€");
-        assert.deepEqual(formatMonetary(1234567.654, { currencyId: 11 }), "$\u00a01,234,567.65");
-        assert.deepEqual(formatMonetary(1234567.654, { currencyId: 44 }), "1,234,567.65");
-        assert.deepEqual(
-            formatMonetary(1234567.654, { currencyId: 10, noSymbol: true }),
-            "1,234,567.65"
-        );
-        assert.deepEqual(
-            formatMonetary(8.0, { currencyId: 10, humanReadable: true }),
-            "8.00\u00a0€"
-        );
-        assert.deepEqual(
-            formatMonetary(1234567.654, { currencyId: 10, humanReadable: true }),
-            "1.23M\u00a0€"
-        );
-        assert.deepEqual(
-            formatMonetary(1990000.001, { currencyId: 10, humanReadable: true }),
-            "1.99M\u00a0€"
-        );
-        assert.deepEqual(
-            formatMonetary(1234567.654, { currencyId: 44, digits: [69, 1] }),
-            "1,234,567.7"
-        );
-        assert.deepEqual(
-            formatMonetary(1234567.654, { currencyId: 11, digits: [69, 1] }),
-            "$\u00a01,234,567.7",
-            "options digits should take over currency digits when both are defined"
-        );
+        const field = {
+            type: "monetary",
+            currency_field: "c_x",
+        };
+        let data = {
+            c_x: [11],
+            c_y: 12,
+        };
+        assert.deepEqual(formatMonetary(200, { field, currencyId: 10, data }), "200.00\u00a0€");
+        assert.deepEqual(formatMonetary(200, { field, data }), "$\u00a0200.00");
+        assert.deepEqual(formatMonetary(200, { field, currencyField: "c_y", data }), "200.00\u00a0&");
 
-        // GES TODO do we keep below behavior ?
-        // with field and data
-        // const field = {
-        //     type: "monetary",
-        //     currency_field: "c_x",
-        // };
-        // let data = {
-        //     c_x: { res_id: 11 },
-        //     c_y: { res_id: 12 },
-        // };
-        // assert.strictEqual(formatMonetary(200, { field, currencyId: 10, data }), "200.00 €");
-        // assert.strictEqual(formatMonetary(200, { field, data }), "$ 200.00");
-        // assert.strictEqual(formatMonetary(200, { field, currencyField: "c_y", data }), "200.00 &");
-        //
-        // const floatField = { type: "float" };
-        // data = {
-        //     currency_id: { res_id: 11 },
-        // };
-        // assert.strictEqual(formatMonetary(200, { field: floatField, data }), "$ 200.00");
-    });
-
-    QUnit.test("formatMonetary without currency", function (assert) {
-        patchWithCleanup(session, {
-            currencies: {},
-        });
-        assert.deepEqual(
-            formatMonetary(1234567.654, { currencyId: 10, humanReadable: true }),
-            "1.23M"
-        );
-        assert.deepEqual(formatMonetary(1234567.654, { currencyId: 10 }), "1,234,567.65");
+        const floatField = { type: "float" };
+        data = {
+            currency_id: [11],
+        };
+        assert.deepEqual(formatMonetary(200, { field: floatField, data }), "$\u00a0200.00");
     });
 
     QUnit.test("formatPercentage", function (assert) {

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1888,13 +1888,8 @@ class CustomerPortal(sale_portal.CustomerPortal):
             return request.redirect('/my')
 
         pricelist = request.env['website'].get_current_website().get_current_pricelist()
-        currency = pricelist.currency_id
         result = {
-            'currency': {
-                'symbol': currency.symbol,
-                'decimal_places': currency.decimal_places,
-                'position': currency.position,
-            },
+            'currency': pricelist.currency_id.id,
             'products': [],
         }
         for line in sale_order.order_line:

--- a/addons/website_sale/static/src/js/website_sale_reorder.js
+++ b/addons/website_sale/static/src/js/website_sale_reorder.js
@@ -3,61 +3,9 @@
 import { _t } from "@web/core/l10n/translation";
 import { debounce as debounceFn } from "@web/core/utils/timing";
 import publicWidget from "@web/legacy/js/public/public_widget";
-import { localization as l10n } from "@web/core/l10n/localization";
 import { ComponentWrapper } from "@web/legacy/js/owl_compatibility";
-import { intersperse, nbsp } from "@web/core/utils/strings";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-
-/**
- * Inserts "thousands" separators in the provided number.
- *
- * @private
- * @param {string} string representing integer number
- * @param {string} [thousandsSep=","] the separator to insert
- * @param {number[]} [grouping=[]]
- *   array of relative offsets at which to insert `thousandsSep`.
- *   See `strings.intersperse` method.
- * @returns {string}
- */
-function insertThousandsSep(number, thousandsSep = ",", grouping = []) {
-    const negative = number[0] === "-";
-    number = negative ? number.slice(1) : number;
-    return (negative ? "-" : "") + intersperse(number, grouping, thousandsSep);
-}
-
-export function formatFloat(value, digits = 2) {
-    if (value === false) {
-        return "";
-    }
-    const grouping = l10n.grouping;
-    const thousandsSep = l10n.thousandsSep;
-    const decimalPoint = l10n.decimalPoint;
-    let precision = digits;
-    const formatted = (value || 0).toFixed(precision).split(".");
-    formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
-    return formatted[1] ? formatted.join(decimalPoint) : formatted[0];
-}
-
-export function formatMonetary(value, currency) {
-    // Monetary fields want to display nothing when the value is unset.
-    // You wouldn't want a value of 0 euro if nothing has been provided.
-    if (value === false) {
-        return "";
-    }
-
-    const digits = (currency && currency.decimal_places) || 2;
-
-    let formattedValue = formatFloat(value, digits);
-
-    if (!currency) {
-        return formattedValue;
-    }
-    const formatted = [currency.symbol, formattedValue];
-    if (currency.position === "after") {
-        formatted.reverse();
-    }
-    return formatted.join(nbsp);
-}
+import { formatCurrency } from "@web/core/currency";
 
 // Widget responsible for openingn the modal (giving out the sale order id)
 
@@ -108,7 +56,7 @@ export class ReorderDialog extends Component {
         this.rpc = useService("rpc");
         this.orm = useService("orm");
         this.dialogService = useService("dialog");
-        this.formatMonetary = formatMonetary;
+        this.formatCurrency = formatCurrency;
 
         onWillStart(this.onWillStartHandler.bind(this));
     }

--- a/addons/website_sale/static/src/xml/website_sale_reorder_modal.xml
+++ b/addons/website_sale/static/src/xml/website_sale_reorder_modal.xml
@@ -44,7 +44,7 @@
                                     </div>
                                 </td>
                                 <td class="text-end td-price">
-                                    <span t-esc="formatMonetary(product.combinationInfo.price, content.currency)"/>
+                                    <span t-esc="formatCurrency(product.combinationInfo.price, content.currency)"/>
                                 </td>
                             </t>
                             <t t-else="">
@@ -67,7 +67,7 @@
                                 <strong>Total</strong>
                             </td>
                             <td class="text-end">
-                                <span t-out="formatMonetary(total, content.currency)"/>
+                                <span t-out="formatCurrency(total, content.currency)"/>
                             </td>
                         </tr>
                     </table>

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -56,17 +56,27 @@ class Currency(models.Model):
     def create(self, vals_list):
         res = super().create(vals_list)
         self._toggle_group_multi_currency()
+        # Currency info is cached to reduce the number of SQL queries when building the session
+        # info. See `ir_http.get_currencies`.
+        self.env.registry.clear_cache()
         return res
 
     def unlink(self):
         res = super().unlink()
         self._toggle_group_multi_currency()
+        # Currency info is cached to reduce the number of SQL queries when building the session
+        # info. See `ir_http.get_currencies`.
+        self.env.registry.clear_cache()
         return res
 
     def write(self, vals):
         res = super().write(vals)
         if 'active' not in vals:
             return res
+        if set(vals.keys()) & {'active', 'digits', 'position', 'symbol'}:
+            # Currency info is cached to reduce the number of SQL queries when building the session
+            # info. See `ir_http.get_currencies`.
+            self.env.registry.clear_cache()
         self._toggle_group_multi_currency()
         return res
 


### PR DESCRIPTION
Before this commit, formatters like `formatMonetary` and `formatFloat`
weren't loaded in the assets front-end.

This commit introduces `formatAmount` ( `formatMonetary` calls
`formatAmount` but makes some prior processing to deduce the currency
from the field) and makes `formatAmount` and `formatFloat` accessible
from any front-end application.

Note: The currencies were added in the front-end session info because
they are needed in `formatAmount`.

See also:
- https://github.com/odoo/enterprise/pull/46658
