### PR TITLE
[IMP] pos_self_order: order number and tracking_number

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -223,16 +223,6 @@ class PosSession(models.Model):
             sessions = super().create(vals_list)
         sessions.action_pos_session_open()
 
-        for session in sessions:
-            session.env['ir.sequence'].sudo().create({
-                'name': _("PoS Order by Session"),
-                'padding': 4,
-                'code': f'pos.order_{session.id}',
-                'number_next': 1,
-                'number_increment': 1,
-                'company_id': False,
-            })
-
         return sessions
 
     def unlink(self):

--- a/addons/pos_self_order/models/__init__.py
+++ b/addons/pos_self_order/models/__init__.py
@@ -8,3 +8,4 @@ from . import pos_payment_method
 from . import pos_self_order_custom_link
 from . import product_product
 from . import res_config_settings
+from . import pos_session

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -47,7 +47,7 @@ class PosOrderLine(models.Model):
 class PosOrder(models.Model):
     _inherit = "pos.order"
 
-    tracking_number = fields.Integer(string="Tracking Number")
+    tracking_number = fields.Char(string="Tracking Number")
     take_away = fields.Boolean(string="Take Away", default=False)
 
     @api.model

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, api, _, fields
+
+
+class PosSession(models.Model):
+    _inherit = 'pos.session'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        sessions = super(PosSession, self).create(vals_list)
+        date_string = fields.Date.today().isoformat()
+        ir_sequence = self.env['ir.sequence'].sudo().search([('code', '=', f'pos.order_{date_string}')])
+        company_id = self.env.company.id
+
+        for session in sessions:
+            session.env['ir.sequence'].sudo().create({
+                'name': _("PoS Order by Session"),
+                'padding': 4,
+                'code': f'pos.order_{session.id}',
+                'number_next': 1,
+                'number_increment': 1,
+                'company_id': company_id,
+            })
+
+        if not ir_sequence:
+            self.env['ir.sequence'].sudo().create({
+                'name': _("PoS Order"),
+                'padding': 0,
+                'code': f'pos.order_{date_string}',
+                'number_next': 1,
+                'number_increment': 1,
+                'company_id': company_id,
+            })
+
+        return sessions


### PR DESCRIPTION
To begin with, there are two different fields.
- tracking_number: used with the kiosk or self so that the customer can track his order.
- name (order_reference): classic order number, used to find them in the odoo backend.

Example of tracking number:
- A1
- B1

Example of order_reference:
- Classic PoS: Order 00001-001-0001
- SelfOrder Mobile: Self-Order 00001-001-0001
- Kiosk: Kiosk 00001-001-0001

Two ir.sequences are used to generate these numbers. The first to generate order_reference numbers per session, and the second to generate tracking_numbers, which are common to all pos_configs and reset once a day.
