### PR TITLE
[FIX] sale: groupBy and edit record in kanban catalog

### DIFF
--- a/addons/sale/static/src/js/product_catalog/kanban_model.js
+++ b/addons/sale/static/src/js/product_catalog/kanban_model.js
@@ -17,12 +17,14 @@ export class ProductCatalogKanbanModel extends RelationalModel {
 
     async _loadData(params) {
         const result = await super._loadData(...arguments);
-        const saleOrderLinesInfo = await this.rpc("/sales/catalog/sale_order_lines_info", {
-            order_id: params.context.order_id,
-            product_ids: result.records.map((rec) => rec.id),
-        });
-        for (const record of result.records) {
-            record.productCatalogData = saleOrderLinesInfo[record.id];
+        if (!params.isMonoRecord && !params.groupBy.length) {
+            const saleOrderLinesInfo = await this.rpc("/sales/catalog/sale_order_lines_info", {
+                order_id: params.context.order_id,
+                product_ids: result.records.map((rec) => rec.id),
+            });
+            for (const record of result.records) {
+                record.productCatalogData = saleOrderLinesInfo[record.id];
+            }
         }
         return result;
     }


### PR DESCRIPTION
Before this commit, in the kanban catalog view, when you make a groupBy or update a record (click on the star), a crash is displayed.

Why does this happen?
The RPC for "sale_order_lines_info" is called during loadData of all dataPoint types.

Solution:
The RPC for "sale_order_lines_info" should only be called for DynamicRecordList.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
