### PR TITLE
[FIX] mrp: remove workcenter auto enable

### DIFF
--- a/addons/mrp/data/mrp_data.xml
+++ b/addons/mrp/data/mrp_data.xml
@@ -71,10 +71,6 @@
             <field name="sequence">0</field>
         </record>
 
-        <!-- Groups -->
-        <record model="res.groups" id="base.group_user">
-            <field name="implied_ids" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
-        </record>
     </data>
 
 </odoo>

--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -6,6 +6,11 @@
             <field eval="[(3, ref('group_mrp_manager')), (4, ref('group_mrp_user'))]" name="groups_id"/>
         </record>
 
+        <!-- Groups -->
+        <record model="res.groups" id="base.group_user">
+            <field name="implied_ids" eval="[(4, ref('mrp.group_mrp_routings'))]"/>
+        </record>
+
         <!-- Resource: res.company -->
         <record id="stock.res_company_1" model="res.company">
             <field eval="1.0" name="manufacturing_lead"/>
@@ -41,7 +46,6 @@
         </record>
         <record id="mrp_routing_workcenter_0" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_manufacture"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Manual Assembly</field>
             <field name="time_cycle">60</field>
@@ -256,7 +260,6 @@
         </record>
         <record id="mrp_routing_workcenter_5" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_desk"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="time_cycle">120</field>
             <field name="sequence">10</field>
@@ -315,7 +318,6 @@
         </record>
         <record id="mrp_routing_workcenter_0" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_table_top"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Manual Assembly</field>
             <field name="time_cycle">60</field>
@@ -347,7 +349,6 @@
         </record>
         <record id="mrp_routing_workcenter_1" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_plastic_laminate"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Long time assembly</field>
             <field name="time_cycle">180</field>
@@ -358,7 +359,6 @@
 
         <record id="mrp_routing_workcenter_3" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_plastic_laminate"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Testing</field>
             <field name="time_cycle">60</field>
@@ -369,7 +369,6 @@
 
         <record id="mrp_routing_workcenter_4" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_plastic_laminate"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
             <field name="name">Packing</field>
             <field name="time_cycle">30</field>
@@ -601,7 +600,6 @@
         </record>
         <record id="mrp_routing_workcenter_1" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_drawer_rout"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Long time assembly</field>
             <field name="time_cycle">180</field>
@@ -612,7 +610,6 @@
 
         <record id="mrp_routing_workcenter_3" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_drawer_rout"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_3"/>
             <field name="name">Testing</field>
             <field name="time_cycle">60</field>
@@ -623,7 +620,6 @@
 
         <record id="mrp_routing_workcenter_4" model="mrp.routing.workcenter">
             <field name="bom_id" ref="mrp_bom_drawer_rout"/>
-            <field name="active">False</field>
             <field name="workcenter_id" ref="mrp_workcenter_1"/>
             <field name="name">Packing</field>
             <field name="time_cycle">30</field>


### PR DESCRIPTION
Following commit 5620e47f8040e4c231f73029551109fa91650abb

1. workcenter automatic setting should be in demo data
2. Routings in demo data where set to active=False and enable in mrp_workorder (OE) module. Since we enable by default workcenters in mrp, we could remove this restriction

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
