### PR TITLE
[FIX] pos_self_order, pos_self_order_sale: kiosk mode settings

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -146,13 +146,6 @@ class PosConfig(models.Model):
         self.access_token = self._get_access_token()
         self.floor_ids.table_ids._update_identifier()
 
-    @api.onchange("self_order_kiosk")
-    def _self_order_kiosk_change(self):
-        for record in self:
-            if record.self_order_kiosk:
-                record.self_order_view_mode = False
-                record.self_order_table_mode = False
-
     @api.model
     def _init_access_token(self):
         pos_config_ids = self.env["pos.config"].search([])

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -57,7 +57,7 @@ class ResConfigSettings(models.TransientModel):
         for record in self:
             record.is_kiosk_mode = record.pos_self_order_kiosk
 
-            if record.pos_config_id.self_order_kiosk:
+            if record.pos_self_order_kiosk:
                 record.pos_config_id.self_order_view_mode = False
                 record.pos_config_id.self_order_table_mode = False
 

--- a/addons/pos_self_order_sale/models/res_config_settings.py
+++ b/addons/pos_self_order_sale/models/res_config_settings.py
@@ -8,6 +8,8 @@ class ResConfigSettings(models.TransientModel):
 
     @api.onchange("pos_self_order_kiosk")
     def _self_order_kiosk_change(self):
+        super()._self_order_kiosk_change()
+
         for record in self:
             if record.pos_config_id.self_order_kiosk:
                 if not record.pos_crm_team_id:


### PR DESCRIPTION
Kiosk parameters were not displayed when the pos_self_order_sale module was installed.

This was due to an overridden function in this module that didn't call super().

This is now fixed and functional.