### PR TITLE
[FIX] pos_self_order: pay button visibility

### DIFF
--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_each_cart_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_each_cart_tour.js
@@ -3,7 +3,7 @@
 import { registry } from "@web/core/registry";
 import { PosSelf } from "@pos_self_order/../tests/tours/tour_utils";
 
-registry.category("web_tour.tours").add("self_order_after_each_cart_tour", {
+registry.category("web_tour.tours").add("pos_online_payment_self_order_after_each_cart_tour", {
     test: true,
     steps: () => [
         // Check that the self is open

--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_meal_cart_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_online_payment_self_order_after_meal_cart_tour.js
@@ -1,0 +1,42 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { PosSelf } from "@pos_self_order/../tests/tours/tour_utils";
+
+registry.category("web_tour.tours").add("pos_online_payment_self_order_after_meal_cart_tour", {
+    test: true,
+    steps: () => [
+        // Check that the self is open
+        PosSelf.check.isNotNotification(),
+
+        PosSelf.action.clickPrimaryBtn("View Menu"),
+        ...PosSelf.action.addProduct("Office Chair Black", 1),
+        PosSelf.action.clickPrimaryBtn("Review"),
+        PosSelf.check.isOrderline("Office Chair Black", "138.58", ""),
+
+        PosSelf.action.clickPrimaryBtn("Order"),
+        PosSelf.check.tablePopupIsShown(),
+        PosSelf.action.selectTable({ id: "1", name: "1" }),
+        PosSelf.action.clickPrimaryBtn("Confirm"),
+        PosSelf.check.isNotification("Your order has been placed!"),
+        PosSelf.check.isPrimaryBtn("Pay"), // Not clicked on because it would open another page, losing the tour setup.
+
+        // Modification of the order
+        PosSelf.action.clickBack(),
+        ...PosSelf.action.addProduct("Funghi", 1),
+        PosSelf.action.clickPrimaryBtn("Review"),
+        PosSelf.check.isOrderline("Funghi", "8.05", ""),
+
+        PosSelf.action.clickPrimaryBtn("Order"),
+        PosSelf.check.isNotification("Your order has been placed!"),
+        PosSelf.check.isPrimaryBtn("Pay"), // Not clicked on because it would open another page, losing the tour setup.
+
+        // No modification of the order
+        PosSelf.action.clickBack(),
+        PosSelf.action.clickPrimaryBtn("Review"),
+        PosSelf.check.isOrderline("Office Chair Black", "138.58", ""),
+        PosSelf.check.isOrderline("Funghi", "8.05", ""),
+
+        PosSelf.check.isPrimaryBtn("Pay"), // Not clicked on because it would open another page, losing the tour setup.
+    ],
+});

--- a/addons/pos_online_payment_self_order/tests/test_self_order_frontend.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_frontend.py
@@ -10,12 +10,13 @@ from odoo.addons.pos_online_payment.models.pos_payment_method import PosPaymentM
 @odoo.tests.tagged("post_install", "-at_install")
 class TestSelfOrderFrontendMobile(SelfOrderCommonTest):
 
-    def test_self_order_pay_after_each_tour(self):
+    def _test_self_order_tour(self, self_order_pay_after, tour_name):
         self.pos_config.self_order_table_mode = True
         self.self_order_online_payment_method_id = self.env['pos.payment.method'].sudo()._get_or_create_online_payment_method(self.pos_config.company_id.id, self.pos_config.id)
         self.fake_provider = self.env['payment.provider'].create({
             'name': 'SelfOrderTest',
         })
+
         real_get_online_payment_providers = PosPaymentMethod._get_online_payment_providers
         def _fake_get_online_payment_providers(method_self, pos_config_id=False, error_if_invalid=True):
             if method_self.id == self.self_order_online_payment_method_id.id:
@@ -25,15 +26,21 @@ class TestSelfOrderFrontendMobile(SelfOrderCommonTest):
 
         with patch.object(PosPaymentMethod, '_get_online_payment_providers', _fake_get_online_payment_providers):
             self.pos_config.update({
-                'self_order_pay_after': 'each',
+                'self_order_pay_after': self_order_pay_after,
                 'self_order_online_payment_method_id': self.self_order_online_payment_method_id,
             })
             self.pos_config.with_user(self.pos_user).open_ui()
 
             self.start_tour(
                 self.pos_config._get_self_order_route(),
-                "self_order_after_each_cart_tour",
+                tour_name,
                 login=None,
             )
 
         self.fake_provider.unlink()
+
+    def test_self_order_pay_after_each_tour(self):
+        self._test_self_order_tour('each', 'pos_online_payment_self_order_after_each_cart_tour')
+
+    def test_self_order_pay_after_meal_tour(self):
+        self._test_self_order_tour('meal', 'pos_online_payment_self_order_after_meal_cart_tour')

--- a/addons/pos_self_order/static/src/common/models/line.js
+++ b/addons/pos_self_order/static/src/common/models/line.js
@@ -62,7 +62,12 @@ export class Line extends Reactive {
 
     updateDataFromServer(data) {
         for (const key in data) {
-            this[key] = data[key];
+            let updatedValue = data[key];
+            if (key === "selected_attributes") {
+                updatedValue ||= {};
+            }
+
+            this[key] = updatedValue;
         }
     }
 }


### PR DESCRIPTION
*: pos_online_payment_self_order

Since https://github.com/odoo/odoo/commit/605943b5eaafe7e9224f0e7fb4fbdd020102c7a5, the pay button is not always displayed in the self-order UI after clicking on the "Order" button.

The issue is due to the selected_attributes value received from the server, that can be "false", while the JS code of self-order UI is designed with "{}" as the empty/null value.
When the local order of the self-order UI is updated with the data from the server, the false value was saved instead of the {}, resulting in the line being considered as "modified" according to the isChange method which uses JSON.stringify for comparing changes.

The fix consists in correctly updating the local order selected_attributes value when receiving data from the server.
This commits adds some tests for the pay after meal self-order mode, to check that the pay button is visible.

task-id: 3489173