### PR TITLE
[REF] web: remove dependency on Bootstrap Collapse in OnboardingBanner

### DIFF
--- a/addons/onboarding/static/src/scss/onboarding.scss
+++ b/addons/onboarding/static/src/scss/onboarding.scss
@@ -2,6 +2,16 @@
 // ============================================================================
 $o-onboarding-step-width: map-get($container-max-widths, 'lg') / 4 !default;
 
+.o_onboarding_container {
+    transition: height 0.4s;
+
+    &.o-vertical-slide-enter, &.o-vertical-slide-leave {
+        height: 0 !important;
+        * {
+            display: none;
+        }
+    }
+}
 
 .o_onboarding_main {
     background: linear-gradient(0deg, #{$o-gray-200} 0%, #{$o-gray-100} 100%);

--- a/addons/onboarding/views/onboarding_templates.xml
+++ b/addons/onboarding/views/onboarding_templates.xml
@@ -44,24 +44,21 @@
                 </div>
             </div>
         </div>
+        <div class="o_onboarding_main position-relative border-bottom overflow-hidden">
+            <div class="o_onboarding_wrap py-3 py-lg-4">
+                <a href="#" data-bs-toggle="modal" data-bs-target=".o_onboarding_modal" class="o_onboarding_btn_close position-absolute top-0 end-0 py-2 px-3 h2 z-index-1" title="Close the onboarding panel"><i class="oi oi-close"/></a>
+                <div class="o_onboarding_steps d-flex" t-out="0"/>
 
-        <div class="o_onboarding_container collapse show">
-            <div class="o_onboarding_main position-relative border-bottom overflow-hidden">
-                <div class="o_onboarding_wrap py-3 py-lg-4">
-                    <a href="#" data-bs-toggle="modal" data-bs-target=".o_onboarding_modal" class="o_onboarding_btn_close position-absolute top-0 end-0 py-2 px-3 h2 z-index-1" title="Close the onboarding panel"><i class="oi oi-close"/></a>
-                    <div class="o_onboarding_steps d-flex" t-out="0"/>
-
-                    <div t-if="state.get('onboarding_state') == 'just_done'"
-                         t-att-state="state.get('onboarding_state')"
-                         class="o_onboarding_completed_message position-absolute end-0 start-0 border-bottom py-4 bg-white d-flex align-items-center justify-content-center">
-                        <span class="h3 m-0">
-                            <i class="fa fa-check text-success me-3" />
-                            <t t-if="text_completed" t-out="text_completed" />
-                        </span>
-                        <a type="action" class="btn btn-primary ms-4" data-bs-toggle="collapse" href=".o_onboarding_container" t-att-data-model="close_model" t-att-data-method="close_method">
-                            Close Panel
-                        </a>
-                    </div>
+                <div t-if="state.get('onboarding_state') == 'just_done'"
+                        t-att-state="state.get('onboarding_state')"
+                        class="o_onboarding_completed_message position-absolute end-0 start-0 border-bottom py-4 bg-white d-flex align-items-center justify-content-center">
+                    <span class="h3 m-0">
+                        <i class="fa fa-check text-success me-3" />
+                        <t t-if="text_completed" t-out="text_completed" />
+                    </span>
+                    <a type="action" class="btn btn-primary ms-4" t-att-data-model="close_model" t-att-data-method="close_method">
+                        Close Panel
+                    </a>
                 </div>
             </div>
         </div>

--- a/addons/web/static/src/views/onboarding_banner.js
+++ b/addons/web/static/src/views/onboarding_banner.js
@@ -5,6 +5,7 @@ import { useService } from "@web/core/utils/hooks";
 import { useActionLinks } from "@web/views/view_hook";
 
 import { Component, markup, onWillStart, useRef, xml } from "@odoo/owl";
+import { useTransition } from "@web/core/transition";
 
 export class OnboardingBanner extends Component {
     setup() {
@@ -19,14 +20,16 @@ export class OnboardingBanner extends Component {
                 this.render();
             },
         });
+        this.transition = useTransition({
+            name: "o-vertical-slide",
+            initialVisibility: true,
+            leaveDuration: 400,
+        });
         this.handleActionLinks = (event) => {
             if (event.target.dataset.oHideBanner) {
-                const collapseElement = this.onboardingContainerRef.el.querySelector(
-                    ".o_onboarding_container.collapse.show"
-                );
-                if (collapseElement) {
-                    Collapse.getOrCreateInstance(collapseElement).toggle();
-                }
+                const container = this.onboardingContainerRef.el;
+                container.style.height = `${container.getBoundingClientRect().height}px`;
+                this.transition.shouldMount = false;
             }
             this._handleActionLinks(event);
         };
@@ -63,5 +66,5 @@ export class OnboardingBanner extends Component {
     }
 }
 
-OnboardingBanner.template = xml`<div class="w-100" t-ref="onboardingContainer" t-on-click="handleActionLinks" t-out="bannerHTML"/>`;
+OnboardingBanner.template = xml`<div t-if="transition.shouldMount" t-attf-class="o_onboarding_container w-100 {{transition.className}}" t-ref="onboardingContainer" t-on-click="handleActionLinks" t-out="bannerHTML"/>`;
 OnboardingBanner.props = {};


### PR DESCRIPTION
This commit removes the usage of Bootstrap's Collapse widget and replace
it by the `useTransition` hook when discarding an OnboardingBanner.

task-3439226

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
