### PR TITLE
[FIX] core: improve fallback of display_name

### DIFF
--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -369,18 +369,29 @@ class TestIrModel(TransactionCase):
         self.assertEqual(self.registry.field_depends[type(record).display_name], ('x_name',))
         self.assertEqual(record.display_name, "Ifan Ben-Mezd")
 
-        fallback_display_name = f"x_bananas,{record.id}"
+        new_record = self.env['x_bananas'].new({'x_name': "Ifan Ben-Mezd"})
+        self.assertEqual(new_record.display_name, "Ifan Ben-Mezd")
 
         # When _rec_name value is Falsy, we should fallback correctly.
         record.x_name = False
-        self.assertEqual(record.display_name, fallback_display_name)
+        self.assertEqual(record.display_name, f"Bananas ({record.id})")
+        self.env['res.lang']._activate_lang('es_ES')
+        self.env['ir.model'].with_context(lang='es_ES')._get('x_bananas').name = "Plátano"
+        # We need to invalidate `display_name` because it deosn't depends from
+        # the lang context (too costly?)
+        record.invalidate_recordset(['display_name'])
+        self.assertEqual(record.with_context(lang='es_ES').display_name, f"Plátano ({record.id})")
 
-        # unlinking x_name should fixup _rec_name and display_name
+        # unlinking x_name should fixup _rec_name, display_name and invalidate all the cache
         self.env['ir.model.fields']._get('x_bananas', 'x_name').unlink()
         record = self.env['x_bananas'].browse(record.id)
         self.assertEqual(record._rec_name, None)
         self.assertEqual(self.registry.field_depends[type(record).display_name], ())
-        self.assertEqual(record.display_name, fallback_display_name)
+        self.assertEqual(record.display_name, f"Bananas ({record.id})")
+        new_record = self.env['x_bananas'].new({})
+        self.assertEqual(new_record.display_name, "Bananas (New)")
+
+
 
     def test_monetary_currency_field(self):
         fields_value = [


### PR DESCRIPTION
Because, now `display_name` is always implicitly add in the view
(use in the broadcumb), then it is asked by the onchange. Then in case
of new records where the `_rec_name` isn't set yet, it will use the
fallback and returns a not user-friendly display_name to the user
("<model_name>,NewId(...)").

Change the fallback to be user-friendly (use name of the model).