### PR TITLE
[IMP] mail: reacted people list on hover

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -1,0 +1,50 @@
+/* @odoo-module */
+
+import { Component, markup } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+
+export class MessageReactionList extends Component {
+    static template = "mail.MessageReaction.List";
+    static props = {
+        id: { type: Number, required: true },
+        close: { type: Function, required: true },
+        reaction: { type: Object, required: true },
+        openReactionMenu: { type: Function, required: true },
+    };
+
+    setup() {
+        super.setup();
+    }
+
+    getReactionSummary() {
+        const reaction = this.props.reaction;
+        const [firstUserName, secondUserName, thirdUserName] = reaction.personas.map(
+            ({ name, displayName }) => name || displayName
+        );
+        switch (reaction.count) {
+            case 1:
+                return markup(
+                    _t(`<span>${firstUserName} has reacted with ${reaction.content}</span>`)
+                );
+            case 2:
+                return markup(
+                    _t(
+                        `<span>${firstUserName} and ${secondUserName} has reacted with ${reaction.content}</span>`
+                    )
+                );
+            case 3:
+                return markup(
+                    _t(
+                        `<span>${firstUserName}, ${secondUserName} and ${thirdUserName} has reacted with ${reaction.content}</span>`
+                    )
+                );
+            default:
+                return markup(_t(`${firstUserName}, ${secondUserName}, ${thirdUserName} and `));
+        }
+    }
+
+    manageReactionMenu() {
+        this.props.openReactionMenu();
+        this.props.close();
+    }
+}

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -1,6 +1,6 @@
 /* @odoo-module */
 
-import { Component, markup } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 
 export class MessageReactionList extends Component {
@@ -12,10 +12,6 @@ export class MessageReactionList extends Component {
         openReactionMenu: { type: Function, required: true },
     };
 
-    setup() {
-        super.setup();
-    }
-
     getReactionSummary() {
         const reaction = this.props.reaction;
         const [firstUserName, secondUserName, thirdUserName] = reaction.personas.map(
@@ -23,28 +19,40 @@ export class MessageReactionList extends Component {
         );
         switch (reaction.count) {
             case 1:
-                return markup(
-                    _t(`<span>${firstUserName} has reacted with ${reaction.content}</span>`)
-                );
+                return _t("%s has reacted with %s", firstUserName, reaction.content);
             case 2:
-                return markup(
-                    _t(
-                        `<span>${firstUserName} and ${secondUserName} has reacted with ${reaction.content}</span>`
-                    )
+                return _t(
+                    "%s and %s have reacted with %s",
+                    firstUserName,
+                    secondUserName,
+                    reaction.content
                 );
             case 3:
-                return markup(
-                    _t(
-                        `<span>${firstUserName}, ${secondUserName} and ${thirdUserName} has reacted with ${reaction.content}</span>`
-                    )
+                return _t(
+                    "%s, %s, %s have reacted with %s",
+                    firstUserName,
+                    secondUserName,
+                    thirdUserName,
+                    reaction.content
                 );
             default:
-                return markup(_t(`${firstUserName}, ${secondUserName}, ${thirdUserName} and `));
+                return {
+                    names: _t("%s, %s, %s and ", firstUserName, secondUserName, thirdUserName),
+                    highlightText: _t("%s other", reaction.personas.length - 3),
+                    content: _t(" persons have reacted with %s", reaction.content),
+                };
         }
     }
 
     manageReactionMenu() {
         this.props.openReactionMenu();
         this.props.close();
+    }
+
+    highlightSummary(ev) {
+        const { reaction } = this.props;
+        if (reaction.count > 3) {
+            ev.target.classList.toggle("active");
+        }
     }
 }

--- a/addons/mail/static/src/core/common/message_reaction_list.scss
+++ b/addons/mail/static/src/core/common/message_reaction_list.scss
@@ -1,0 +1,19 @@
+.o-mail-MessageReactionList {
+    max-width: 250px;
+    overflow: hidden;
+    word-break: break-word;
+}
+
+.o-mail-MessageReaction-Summary {
+    cursor: pointer;
+
+    &.active {
+        > .o-mail-MessageReaction-Summary-Highlight {
+            text-decoration: underline #017e84;
+        }
+    }
+
+    &-Highlight {
+        color: #017e84;
+    }
+}

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+<t t-name="mail.MessageReaction.List">
+    <div class="o-mail-MessageReactionList p-2">
+        <t t-if="this.props.reaction.count > 3">
+            <span>
+                <t t-out="getReactionSummary()"/>
+                <a href="#" t-on-click="() => this.manageReactionMenu()">
+                    <t t-esc="this.props.reaction.count - 3"/> other people</a>
+                     has reacted with 
+                    <t t-esc="this.props.reaction.content"/>
+            </span>
+        </t>
+        <t t-else="">
+            <t t-out="getReactionSummary()"/>
+        </t>
+    </div>
+</t>
+</templates>

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="mail.MessageReaction.List">
-    <div class="o-mail-MessageReactionList p-2">
-        <t t-if="this.props.reaction.count > 3">
-            <span>
-                <t t-out="getReactionSummary()"/>
-                <a href="#" t-on-click="() => this.manageReactionMenu()">
-                    <t t-esc="this.props.reaction.count - 3"/> other people</a>
-                     has reacted with 
-                    <t t-esc="this.props.reaction.content"/>
-            </span>
-        </t>
-        <t t-else="">
-            <t t-out="getReactionSummary()"/>
-        </t>
+    <div class="o-mail-MessageReactionList p-2" maxlength="20">
+        <span
+            class="o-mail-MessageReaction-Summary"
+            t-on-click="() => this.manageReactionMenu()"
+            t-on-mouseenter="(ev) => this.highlightSummary(ev)"
+            t-on-mouseleave="(ev) => this.highlightSummary(ev)">
+            <t t-if="this.props.reaction.count > 3">
+               <t t-set="reactionMessage" t-value="getReactionSummary()"/>
+                <t t-out="reactionMessage['names']"/>
+                <span class="o-mail-MessageReaction-Summary-Highlight">
+                    <t t-out="reactionMessage['highlightText']"/>
+                </span>
+                <t t-out="reactionMessage['content']"/>
+            </t>
+            <t t-else="">
+                <t t-out="getReactionSummary()" />
+            </t>
+        </span>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -1,62 +1,28 @@
 /* @odoo-module */
 
+import { usePopover } from "@web/core/popover/popover_hook";
+import { MessageReactionList } from "@mail/core/common/message_reaction_list";
+import { browser } from "@web/core/browser/browser";
 import { Component, useState } from "@odoo/owl";
-
-import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 export class MessageReactions extends Component {
     static props = ["message", "openReactionMenu"];
     static template = "mail.MessageReactions";
+    static components = { MessageReactionList };
 
     setup() {
         this.user = useService("user");
         this.store = useState(useService("mail.store"));
         this.ui = useService("ui");
         this.messageService = useState(useService("mail.message"));
-    }
-
-    /** @param {import("models").MessageReactions} reaction */
-    getReactionSummary(reaction) {
-        const [firstUserName, secondUserName, thirdUserName] = reaction.personas.map(
-            ({ name, displayName }) => name || displayName
-        );
-        switch (reaction.count) {
-            case 1:
-                return _t("%s has reacted with %s", firstUserName, reaction.content);
-            case 2:
-                return _t(
-                    "%s and %s have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    reaction.content
-                );
-            case 3:
-                return _t(
-                    "%s, %s, %s have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    thirdUserName,
-                    reaction.content
-                );
-            case 4:
-                return _t(
-                    "%s, %s, %s and 1 other person have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    thirdUserName,
-                    reaction.content
-                );
-            default:
-                return _t(
-                    "%s, %s, %s and %s other persons have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    thirdUserName,
-                    reaction.personas.length - 3,
-                    reaction.content
-                );
-        }
+        this.reactionOpened = false;
+        this.reactionPopover = usePopover(MessageReactionList, {
+            closeOnHoverAway: true,
+            popoverClass: "o-mail-MessageReactionList-Popover",
+            position: "bottom-start",
+        });
+        this.lastedOpenedId = 0;
     }
 
     hasSelfReacted(reaction) {
@@ -76,5 +42,28 @@ export class MessageReactions extends Component {
             ev.preventDefault();
             this.props.openReactionMenu();
         }
+    }
+
+    openCard(params) {
+        const target = params.ev.currentTarget;
+        const reaction = params.reaction;
+        this.reactionOpened = browser.setTimeout(() => {
+            if (
+                !this.reactionPopover.isOpen ||
+                (this.lastOpenedId && reaction.messageId !== this.lastOpenedId)
+            ) {
+                this.reactionPopover.open(target, {
+                    id: reaction.messageId,
+                    reaction: params.reaction,
+                    openReactionMenu: this.props.openReactionMenu,
+                });
+                this.lastOpenId = reaction.messageId;
+            }
+        }, 350);
+    }
+
+    clearTimeout() {
+        browser.clearTimeout(this.reactionOpened);
+        delete this.reactionOpened;
     }
 }

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -44,7 +44,7 @@ export class MessageReactions extends Component {
         }
     }
 
-    openCard(params) {
+    openReactions(params) {
         const target = params.ev.currentTarget;
         const reaction = params.reaction;
         this.reactionOpened = browser.setTimeout(() => {
@@ -53,7 +53,7 @@ export class MessageReactions extends Component {
                 (this.lastOpenedId && reaction.messageId !== this.lastOpenedId)
             ) {
                 this.reactionPopover.open(target, {
-                    id: reaction.messageId,
+                    id: reaction.message.id,
                     reaction: params.reaction,
                     openReactionMenu: this.props.openReactionMenu,
                 });

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,3 +1,3 @@
-.o-mail-MessageReaction.o-selfReacted {
+.o-mail-MessageReaction-btn.o-selfReacted {
     background: mix($o-brand-primary, $o-view-background-color, 10%);
 }

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,3 +1,7 @@
-.o-mail-MessageReaction-btn.o-selfReacted {
+.o-mail-MessageReaction.o-selfReacted {
     background: mix($o-brand-primary, $o-view-background-color, 10%);
+}
+
+.o-mail-MessageReactionList-Popover > .popover-arrow {
+    width: 100%;
 }

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -6,19 +6,25 @@
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.isDiscussion),
         }"
-        t-attf-class="{{ props.message.isDiscussion ? 'mt-n2' : 'mt-1' }}">
-        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
-            t-on-click="() => this.onClickReaction(reaction)"
-            t-on-contextmenu="onContextMenu"
-            t-att-class="{
-                'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
-                'bg-view': !hasSelfReacted(reaction),
-                'ms-1': env.inChatWindow and env.alignedRight,
-                'me-1': !(env.inChatWindow and env.alignedRight),
-         }" t-att-title="getReactionSummary(reaction)">
-            <span class="mx-1" t-esc="reaction.content"/>
-            <span class="mx-1" t-esc="reaction.count"/>
-        </button>
+        t-attf-class="{{ props.message.isDiscussion ? 'mt-n2' : 'mt-1' }}"
+        >
+        <div t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction"
+            t-on-mouseover="(ev) => this.openCard({ev: ev, reaction: reaction,})"
+            t-on-mouseleave="() => this.clearTimeout()"
+            >
+            <button class="o-mail-MessageReaction-btn btn p-0 border rounded-1 mb-1"
+                t-on-click="() => this.onClickReaction(reaction)"
+                t-on-contextmenu="onContextMenu"
+                t-att-class="{
+                    'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
+                    'bg-view': !hasSelfReacted(reaction),
+                    'ms-1': env.inChatWindow and env.alignedRight,
+                    'me-1': !(env.inChatWindow and env.alignedRight),
+            }">
+                <span class="mx-1" t-esc="reaction.content"/>
+                <span class="mx-1" t-esc="reaction.count"/>
+            </button>
+        </div>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -6,25 +6,21 @@
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.isDiscussion),
         }"
-        t-attf-class="{{ props.message.isDiscussion ? 'mt-n2' : 'mt-1' }}"
-        >
-        <div t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction"
-            t-on-mouseover="(ev) => this.openCard({ev: ev, reaction: reaction,})"
+        t-attf-class="{{ props.message.isDiscussion ? 'mt-n2' : 'mt-1' }}">
+        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
+            t-on-click="() => this.onClickReaction(reaction)"
+            t-on-contextmenu="onContextMenu"
+            t-on-mouseover="(ev) => this.openReactions({ev: ev, reaction: reaction})"
             t-on-mouseleave="() => this.clearTimeout()"
-            >
-            <button class="o-mail-MessageReaction-btn btn p-0 border rounded-1 mb-1"
-                t-on-click="() => this.onClickReaction(reaction)"
-                t-on-contextmenu="onContextMenu"
-                t-att-class="{
-                    'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
-                    'bg-view': !hasSelfReacted(reaction),
-                    'ms-1': env.inChatWindow and env.alignedRight,
-                    'me-1': !(env.inChatWindow and env.alignedRight),
-            }">
-                <span class="mx-1" t-esc="reaction.content"/>
-                <span class="mx-1" t-esc="reaction.count"/>
-            </button>
-        </div>
+            t-att-class="{
+                'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
+                'bg-view': !hasSelfReacted(reaction),
+                'ms-1': env.inChatWindow and env.alignedRight,
+                'me-1': !(env.inChatWindow and env.alignedRight),
+        }">
+            <span class="mx-1" t-esc="reaction.content"/>
+            <span class="mx-1" t-esc="reaction.count"/>
+        </button>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -13,9 +13,7 @@ import {
     makeDeferred,
     patchWithCleanup,
     triggerHotkey,
-    getFixture,
     triggerEvent,
-    nextTick,
 } from "@web/../tests/helpers/utils";
 
 const { DateTime } = luxon;
@@ -505,7 +503,7 @@ QUnit.test("Can remove a reaction", async () => {
     openDiscuss(channelId);
     await click("[title='Add a Reaction']");
     await click(".o-Emoji", { text: "😅" });
-    await click(".o-mail-MessageReaction-btn");
+    await click(".o-mail-MessageReaction");
     await contains(".o-mail-MessageReaction", { count: 0 });
 });
 
@@ -537,7 +535,7 @@ QUnit.test("Two users reacting with the same emoji", async () => {
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-MessageReaction", { text: "😅2" });
-    await click(".o-mail-MessageReaction-btn");
+    await click(".o-mail-MessageReaction");
     await contains(".o-mail-MessageReaction", { text: "😅1" });
     await click(".o-mail-MessageReaction");
     await contains(".o-mail-MessageReaction", { text: "😅2" });
@@ -560,20 +558,21 @@ QUnit.test("Reaction summary", async () => {
     const partnerNames = ["Foo", "Bar", "FooBar", "Bob"];
     const expectedSummaries = [
         "Foo has reacted with 😅",
-        "Foo and Bar has reacted with 😅",
-        "Foo, Bar and FooBar has reacted with 😅",
-        "Foo, Bar, FooBar and 1 other people has reacted with 😅",
+        "Foo and Bar have reacted with 😅",
+        "Foo, Bar, FooBar have reacted with 😅",
+        "Foo, Bar, FooBar and 1 other persons have reacted with 😅",
     ];
     for (const [idx, name] of partnerNames.entries()) {
         const userId = pyEnv["res.users"].create({ name });
         pyEnv["res.partner"].create({ name, user_ids: [Command.link(userId)] });
         await pyEnv.withUser(userId, async () => {
             await click("[title='Add a Reaction']");
-            await click(".o-Emoji:contains(😅):eq(0)");
-            const target = getFixture();
-            await nextTick();
-            await triggerEvent(target, ".o-mail-MessageReaction-btn", "mouseover");
-            await new Promise((resolve) => setTimeout(resolve, 400));
+            await click(".o-Emoji", {
+                after: ["span", { textContent: "Smileys & Emotion" }],
+                text: "😅",
+            });
+            await contains(".o-mail-MessageReaction", { text: `😅${idx + 1}` });
+            await triggerEvent(document, ".o-mail-MessageReaction", "mouseover");
             await contains(".o-mail-MessageReactionList", { text: expectedSummaries[idx] });
         });
     }

--- a/addons/web/static/src/core/popover/popover_controller.js
+++ b/addons/web/static/src/core/popover/popover_controller.js
@@ -4,6 +4,7 @@ import { Component, onWillDestroy, useExternalListener, xml } from "@odoo/owl";
 import { useHotkey } from "../hotkeys/hotkey_hook";
 import { useChildRef } from "../utils/hooks";
 import { Popover } from "./popover";
+import { browser } from "../browser/browser";
 
 export class PopoverController extends Component {
     static template = xml`
@@ -16,6 +17,7 @@ export class PopoverController extends Component {
         "target",
         "close",
         "closeOnClickAway",
+        "closeOnHoverAway",
         "component",
         "componentProps",
         "popoverProps",
@@ -25,6 +27,10 @@ export class PopoverController extends Component {
         if (this.props.target.isConnected) {
             this.popoverRef = useChildRef();
             useExternalListener(window, "pointerdown", this.onClickAway, { capture: true });
+            if (this.props.closeOnHoverAway) {
+                this.closePopoverTimeout = false;
+                useExternalListener(window, "mouseover", this.onHoverAway, { capture: true });
+            }
             useHotkey("escape", () => this.props.close());
             const targetObserver = new MutationObserver(this.onTargetMutate.bind(this));
             targetObserver.observe(this.props.target.parentElement, { childList: true });
@@ -42,6 +48,17 @@ export class PopoverController extends Component {
             !this.popoverRef.el.contains(target)
         ) {
             this.props.close();
+        }
+    }
+
+    onHoverAway(ev) {
+        const target = ev.composedPath()[0];
+        if (!this.props.target.contains(target) && !this.popoverRef.el.contains(target)) {
+            this.closePopoverTimeout = browser.setTimeout(() => {
+                this.props.close();
+            }, 400);
+        } else {
+            browser.clearTimeout(this.closePopoverTimeout);
         }
     }
 

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -7,6 +7,7 @@ import { PopoverController } from "./popover_controller";
 /**
  * @typedef {{
  *   closeOnClickAway?: boolean | (target: HTMLElement) => boolean;
+ *   closeOnHoverAway?: boolean;
  *   onClose?: () => void;
  *   popoverClass?: string;
  *   position?: import("@web/core/position_hook").Options["position"];
@@ -31,12 +32,14 @@ export const popoverService = {
                 typeof options.closeOnClickAway === "function"
                     ? options.closeOnClickAway
                     : () => options.closeOnClickAway ?? true;
+            const closeOnHoverAway = options.closeOnHoverAway || false;
             const remove = overlay.add(
                 PopoverController,
                 {
                     target,
                     close: () => remove(),
                     closeOnClickAway,
+                    closeOnHoverAway,
                     component,
                     componentProps: markRaw(props),
                     popoverProps: {


### PR DESCRIPTION
**Before this commit:**
To view the users who reacted to a message, users had to access the
"view reaction" menu through the message actions.

**After this commit:**
With this update, users can easily see who reacted to a message by
simply hovering over the reaction icon and clicking on the "x others"
link that appears.

**task-3390326**