### PR TITLE
[IMP] repair: inventory kanban view repair_improvements

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -13,8 +13,8 @@
                 <field name="name"/>
                 <field name="schedule_date" optional="show" widget="remaining_days"/>
                 <field name="product_id" readonly="1" optional="show"/>
-                <field name="parts_availability_state" column_invisible="True" options='{"lazy": true}'/>
-                <field name="parts_availability" options='{"lazy": true}'
+                <field name="parts_availability_state" column_invisible="True"/>
+                <field name="parts_availability"
                     invisible="state not in ['confirmed', 'under_repair']"
                     optional="show"
                     decoration-success="parts_availability_state == 'available'"
@@ -79,6 +79,8 @@
                     </div>
                     <group>
                         <group>
+                            <field name="picking_product_ids" invisible="1"/>
+                            <field name="picking_product_id" invisible="1"/>
                             <field name="tracking" invisible="1" readonly="True"/>
                             <field name="company_id" invisible="1"/>
                             <field name="sale_order_id" invisible="1"/>
@@ -93,15 +95,20 @@
                                 <field name="product_qty" readonly="tracking == 'serial' or state in ('done', 'cancel')"/>
                                 <field name="product_uom" groups="uom.group_uom" readonly="state != 'draft'"/>
                             </div>
-                            <field name="allowed_picking_type_ids" invisible="1"/>
-                            <field name="picking_id" domain="[('picking_type_id','in', allowed_picking_type_ids)]" options="{'no_create': True}"/>
+                            <field name="picking_id" options="{'no_create': True}"/>
+                            <field name="under_warranty" readonly="state in ['cancel', 'done']"/>
                         </group>
                         <group>
                             <field name="schedule_date" readonly="state in ['done', 'cancel']"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
-                            <field name="under_warranty" readonly="state in ['cancel', 'done']"/>
+                            <field name="parts_availability_state" invisible="True"/>
+                            <field name="parts_availability"
+                                invisible="state not in ['confirmed', 'under_repair']"
+                                decoration-success="parts_availability_state == 'available'"
+                                decoration-warning="parts_availability_state == 'expected'"
+                                decoration-danger="parts_availability_state == 'late'"/>
                         </group>
                     </group>
                 <notebook>
@@ -231,12 +238,15 @@
                 <field name="product_id"/>
                 <field name="partner_id" filter_domain="[('partner_id', 'child_of', self)]"/>
                 <field name="sale_order_id"/>
-                <filter string="Confirmed" domain="[('state', '=', 'confirmed')]" name="current" />
-                <filter string="Ready To Repair" name="ready" domain="[('state', 'in', ('confirmed', 'under_repair')),('is_parts_available', '=', True)]"/>
-                <filter string="Waiting" name="filter_waiting" domain="[('state', 'in', ('confirmed', 'under_repair'))]"/>
-                <filter string="Late" name="filter_late" domain="[('state', 'in', ('confirmed', 'under_repair')), '|', ('schedule_date', '&lt;', context_today().strftime('%Y-%m-%d')), ('is_parts_late', '=', True)]"/>
-                <filter string="Returned" name="is_returned" domain="[('picking_id', '!=', False), ('picking_id.state', '=', 'done'), ('state', 'not in', ['cancel', 'done'])]"/>
+                <filter string="New" domain="[('state', '=', 'draft')]" name="filter_draft" />
+                <filter string="Confirmed" domain="[('state', '=', 'confirmed')]" name="filter_confirmed" />
+                <filter string="Under Repair" name="filter_under_repair" domain="[('state', '=', 'under_repair')]"/>
+                <filter string="Repaired" name="filter_done" domain="[('state', '=', 'done')]"/>
+                <filter string="Cancelled" name="filter_cancel" domain="[('state', '=', 'cancel')]"/>
+                <filter string="Returned" name="returned" domain="[('picking_id', '!=', False), ('picking_id.state', '=', 'done')]"/>
                 <separator/>
+                <filter string="Ready" name="ready" domain="[('state', 'in', ('confirmed', 'under_repair')),('is_parts_available', '=', True)]" invisible="True"/>
+                <filter string="Late" name="filter_late" domain="[('state', 'in', ('confirmed', 'under_repair')), '|', ('schedule_date', '&lt;', context_today().strftime('%Y-%m-%d')), ('is_parts_late', '=', True)]"/>
                 <filter name="filter_create_date" date="create_date"/>
                 <separator/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -5,16 +5,13 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
-            <field name="default_location_dest_id" position="attributes">
-                <attribute name="readonly">code == 'repair_operation'</attribute>
-            </field>
             <xpath expr="//field[@name='default_location_dest_id']" position="after">
                 <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
                 <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
             </xpath>
             <xpath expr="//group[@name='locations']" position="after">
                 <field name="return_type_of_ids" invisible="1"/>
-                <group string="Repairs" invisible="code != 'incoming' or not return_type_of_ids">
+                <group string="Repairs" invisible="not return_type_of_ids">
                     <field name="is_repairable"/>
                 </group>
             </xpath>
@@ -51,8 +48,6 @@
         <field name="arch" type="xml">
             <field name="code" position="after">
                 <field name="count_repair_ready"/>
-                <field name="count_repair_waiting"/>
-                <field name="count_repair_late"/>
             </field>
             <xpath expr="//t[@t-name='kanban-menu']" position="inside">
                 <div class="container" t-if="record.code.raw_value == 'repair_operation'">
@@ -65,21 +60,12 @@
                                     <a name="get_repair_stock_picking_action_picking_type" type="object">All</a>
                                 </div>
                                 <div role="menuitem">
-                                    <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">Parts Available</a>
-                                </div>
-                                <div role="menuitem">
-                                    <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_waiting': 1}" type="object">Waiting</a>
-                                </div>
-                                <div role="menuitem">
-                                    <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_late': 1}" type="object">Late</a>
+                                    <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">Ready</a>
                                 </div>
                             </div>
                             <div class="col-6 o_kanban_card_manage_section o_kanban_manage_new">
                                 <div role="menuitem" class="o_kanban_card_manage_title">
-                                    <span>New</span>
-                                </div>
-                                <div role="menuitem">
-                                    <a name="%(action_repair_order_form)d" type="action" context="{'default_picking_type_id': id}">Repair Order</a>
+                                    <a name="%(action_repair_order_form)d" type="action" context="{'default_picking_type_id': id}">New</a>
                                 </div>
                             </div>
                         </div>
@@ -116,30 +102,26 @@
                             <div class="row">
                                 <div class="col-6 o_kanban_primary_left">
                                     <button class="btn btn-primary" name="get_repair_stock_picking_action_picking_type" context="{'search_default_ready': 1}" type="object">
-                                        <span t-if="record.code.raw_value == 'repair_operation'">
+                                        <span>
                                             <t t-esc="record.count_repair_ready.value"/> To Process
                                         </span>
                                     </button>
                                 </div>
                                 <div class="col-6 o_kanban_primary_right">
-                                    <div t-if="record.count_repair_waiting.raw_value > 0" class="row">
-                                        <div class="col-9">
-                                            <a class="oe_kanban_stock_picking_type_list" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_waiting': 1}" type="object">
-                                                Waiting
+                                    <div t-if="record.count_repair_confirmed.raw_value > 0" class="row">
+                                        <div class="col-12">
+                                            <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_confirmed': 1}" type="object">
+                                                <field name="count_repair_confirmed"/>
+                                                Confirmed
                                             </a>
-                                        </div>
-                                        <div class="col-3">
-                                            <field name="count_repair_waiting"/>
                                         </div>
                                     </div>
-                                    <div t-if="record.count_repair_late.raw_value > 0" class="row">
-                                        <div class="col-9">
-                                            <a class="oe_kanban_stock_picking_type_list" name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_late': 1}" type="object">
-                                                Late
+                                    <div t-if="record.count_repair_under_repair.raw_value > 0" class="row">
+                                        <div class="col-12">
+                                            <a name="get_repair_stock_picking_action_picking_type" context="{'search_default_filter_under_repair': 1}" type="object">
+                                                <field name="count_repair_under_repair"/>
+                                                Under Repair
                                             </a>
-                                        </div>
-                                        <div class="col-3">
-                                            <field name="count_repair_late"/>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
1. Add Confirmed and Under Repair section to repair kanban cards.
2. Modify default filters for repair orders.
3. Modify the repair's location_id field's name
4. Following recent changes on stock.picking.type, adapt return option
   creation on repair operation type defined as return.
5. Only return transfers are proposed on the repair orders.
6. Filter product_id selection based on set picking_id and vice-versa

Task : 3369400
Upgrade : https://github.com/odoo/upgrade/pull/5108



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
