### PR TITLE
[FIX] web editor: infinite loop in email marketing

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -2609,32 +2609,6 @@ var SnippetsMenu = Widget.extend({
                 }
 
                 return editorToEnable;
-            }).then(async editor => {
-                // If a link was clicked, the linktools should be focused after
-                // the right panel is shown to the user.
-                // TODO: this should be reviewed to be done another way: we
-                // should avoid focusing something here while it is being
-                // rendered elsewhere.
-                if (this.options.wysiwyg.state.linkToolProps) {
-                    let inputElement = document.querySelector('#o_link_dialog_url_input');
-                    if (!inputElement) {
-                        // Wait for `linkTools` potential in-progress rendering
-                        // before focusing the URL input on `snippetsMenu` (this
-                        // prevents race condition for automated testing).
-                        inputElement = await new Promise((resolve) => {
-                            const observer = new MutationObserver(() => {
-                                const inputElement = document.querySelector('#o_link_dialog_url_input');
-                                if (inputElement) {
-                                    observer.disconnect();
-                                    resolve(inputElement);
-                                }
-                            });
-                            observer.observe(document.body, { childList: true, subtree: true });
-                        });
-                    }
-                    inputElement.focus();
-                }
-                return editor;
             });
         });
     },

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -80,6 +80,7 @@ export class Link extends Component {
             this.$el.find('input, select').on('change', this._onAnyChange.bind(this));
             this.$el.find('[name="url"]').on('input', this.__onURLInput.bind(this));
             this.$el.find('[name="url"]').on('change', this._onURLInputChange.bind(this));
+            this.$el.find('[name="url"]').focus()
 
             await this.start();
         });
@@ -173,8 +174,10 @@ export class Link extends Component {
      */
     focusUrl() {
         const urlInput = this.linkComponentWrapperRef.el.querySelector('input[name="url"]');
-        urlInput.focus();
-        urlInput.select();
+        if (urlInput) {
+            urlInput.focus();
+            urlInput.select();
+        };
     }
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1465,7 +1465,7 @@ export class Wysiwyg extends Component {
                     ) {
                         // Destroy the link tools on click anywhere outside the
                         // toolbar if the target is the orgiginal target not in the original target.
-                        this.destroyLinkTools();
+                        this.destroyLinkTools(!ev.target.matches('input[type="text"]'));
                         this.odooEditor.document.removeEventListener('click', _onClick, true);
                         document.removeEventListener('click', _onClick, true);
                     }
@@ -1531,8 +1531,8 @@ export class Wysiwyg extends Component {
      * Destroy the Link tools/dialog and restore the selection.
      */
     // todo: review me
-    async destroyLinkTools() {
-        if (this.state.linkToolProps) {
+    async destroyLinkTools(shouldFocusLink = true) {
+        if (this.state.linkToolProps && shouldFocusLink) {
             const selection = this.odooEditor.document.getSelection();
             const link = this.linkToolsInfos.link;
             let anchorNode
@@ -1565,6 +1565,9 @@ export class Wysiwyg extends Component {
                     setSelection(anchorNode, anchorOffset, focusNode, focusOffset, false);
                 }
             }
+        }
+        if (this.state.linkToolProps) {
+            this.linkToolsInfos.removeHintClasses();
             this.state.linkToolProps = undefined;
         }
     }


### PR DESCRIPTION
This commit fixes (partially) both the issue of infinite loop that occured in email marketing and a problem with the focus when bluring the link tool.

The issue described in the task (3475046) is due to the fact that we wait for focus on url input of linktools. But the element never appears because in the big chunk removed (which controls this behavior), the document doesn't correspond to the frame the linktools is.

We go even further that correcting this as we believe that this shouldn't happen here, but onMount of the linktools.

Moreover, we notice that the double click behavior previously specified, which consists of focusing the input doesn't work anymore. This resolved within the task 3444671.

We also make sure that we focus the contenteditable, on the destruction of linktools, only when we are not aiming for a text input.

Task-3475046