### PR TITLE
[FIX] resource: singleton error while opening staff schedule in appointments

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -447,13 +447,16 @@ class ResourceCalendar(models.Model):
 
     def _unavailable_intervals_batch(self, start_dt, end_dt, resources=None, domain=None, tz=None):
         """ Return the unavailable intervals between the given datetimes. """
+        if not self:
+            return {}
         if not resources:
             resources = self.env['resource.resource']
             resources_list = [resources]
         else:
             resources_list = list(resources)
-
-        resources_work_intervals = self._work_intervals_batch(start_dt, end_dt, resources, domain, tz)
+        resources_work_intervals = {}
+        for record in self:
+            resources_work_intervals.update(record._work_intervals_batch(start_dt, end_dt, resources, domain, tz))
         result = {}
         for resource in resources_list:
             work_intervals = [(start, stop) for start, stop, meta in resources_work_intervals[resource.id]]


### PR DESCRIPTION
When user doesn't set working hours for employee, then creates a appointment with that employee as users and tries to open staff schedule, a traceback will appear.

Steps to reproduce the error:
- Create Database without demo data
- Install 'appointment_hr'
- Go to Employees > Open 'Administrator' Employee > SCHEDULE > Remove Working Hours
- Go to Appointments > Create new Appointment > in Users, select 'Administrator'
- Open Schedule > Staff Schedule

Traceback:
```
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5418, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: resource.calendar()
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 233, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/enterprise/saas-16.4/appointment_hr/models/calendar_event.py", line 23, in gantt_unavailability
    employee_unavailabilities = user_ids.employee_id.resource_calendar_id._unavailable_intervals_batch(
  File "addons/resource/models/resource_calendar.py", line 456, in _unavailable_intervals_batch
    resources_work_intervals = self._work_intervals_batch(start_dt, end_dt, resources, domain, tz)
  File "addons/resource/models/resource_calendar.py", line 430, in _work_intervals_batch
    attendance_intervals = self._attendance_intervals_batch(start_dt, end_dt, resources, tz=tz)
  File "addons/resource/models/resource_calendar.py", line 274, in _attendance_intervals_batch
    self.ensure_one()
  File "odoo/models.py", line 5421, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

https://github.com/odoo/odoo/blob/30c7fe60bc5d6d7c1deaf2e399592aba347ae5f9/addons/resource/models/resource_calendar.py#L274 When user tries to open staff schedule, it will get zero or multiple records in self
based on 'working hours' set in employees.
So, here it will lead to above traceback.

sentry-4416833826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
