### PR TITLE
[IMP] web: Add duplicate action on view list

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -71,6 +71,10 @@ export class DynamicList extends DataPoint {
         return this.model.mutex.exec(() => this._deleteRecords(records));
     }
 
+    duplicateRecords(records = []) {
+        return this.model.mutex.exec(() => this._duplicateRecords(records));
+    }
+
     async enterEditMode(record) {
         if (this.editedRecord === record) {
             return true;
@@ -179,6 +183,23 @@ export class DynamicList extends DataPoint {
     // -------------------------------------------------------------------------
     // Protected
     // -------------------------------------------------------------------------
+
+    async _duplicateRecords(records) {
+        let resIds;
+        if (records.length) {
+            resIds = records.map((r) => r.resId);
+        } else {
+            resIds = await this.getResIds(true);
+        }
+
+        const duplicated = await this.model.orm.call(this.resModel, "copy_multi", [resIds]);
+        if (resIds.length > duplicated.length) {
+            this.model.notification.add(_t("Some records could not be duplicated"), {
+                title: _t("Warning"),
+            });
+        }
+        return this.model.load();
+    }
 
     async _deleteRecords(records) {
         let resIds;

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -329,6 +329,13 @@ export class ListController extends Component {
                 description: _t("Unarchive"),
                 callback: () => this.toggleArchiveState(false),
             },
+            duplicate: {
+                isAvailable: () => this.activeActions.duplicate && !isM2MGrouped,
+                sequence: 35,
+                icon: "fa fa-clone",
+                description: _t("Duplicate"),
+                callback: () => this.duplicateRecords(),
+            },
             delete: {
                 isAvailable: () => this.activeActions.delete && !isM2MGrouped,
                 sequence: 40,
@@ -514,6 +521,10 @@ export class ListController extends Component {
             return this.model.root.archive(true);
         }
         return this.model.root.unarchive(true);
+    }
+
+    async duplicateRecords(){
+        return this.model.root.duplicateRecords()
     }
 
     get deleteConfirmationDialogProps() {

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -599,6 +599,8 @@ export class MockServer {
                 return this.mockWrite(args.model, [args.args[0], { active: true }]);
             case "copy":
                 return this.mockCopy(args.model, args.args);
+            case "copy_multi":
+                return this.mockCopyMulti(args.model, args.args);
             case "create":
                 return this.mockCreate(args.model, args.args[0], args.kwargs);
             case "fields_get":
@@ -665,6 +667,21 @@ export class MockServer {
         duplicatedRecord.display_name = `${originalRecord.display_name} (copy)`;
         model.records.push(duplicatedRecord);
         return newID;
+    }
+
+    /**
+     * Simulate a 'copy_multi' operation, so we simply try to duplicate records in
+     * memory
+     *
+     * @private
+     * @param {string} modelName
+     * @param {[number[], Record<string, any>]} params the ID of a valid record
+     * @returns {number} the ID of the duplicated record
+     */
+    mockCopyMulti(modelName, [ids, defaultData]) {
+        const newIDs = [];
+        ids.forEach((id) => newIDs.push(this.mockCopy(modelName, [id, defaultData])));
+        return newIDs;
     }
 
     mockCreate(modelName, valsList, kwargs = {}) {

--- a/addons/web/static/tests/mobile/views/list_view_tests.js
+++ b/addons/web/static/tests/mobile/views/list_view_tests.js
@@ -87,8 +87,8 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
         await toggleActionMenu(fixture);
         assert.deepEqual(
             getMenuItemTexts(fixture.querySelector(".o_cp_action_menus")),
-            ["Delete"],
-            "action menu should contain the Delete action"
+            ["Duplicate", "Delete"],
+            "action menu should contain the Duplicate and Delete actions"
         );
 
         // unselect all
@@ -134,8 +134,8 @@ QUnit.module("Mobile Views", ({ beforeEach }) => {
         await toggleActionMenu(fixture);
         assert.deepEqual(
             getMenuItemTexts(fixture.querySelector(".o_cp_action_menus")),
-            ["Delete"],
-            "action menu should contain the Delete action"
+            ["Duplicate", "Delete"],
+            "action menu should contain the Duplicate and Delete actions"
         );
 
         // select all records of first page

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5410,6 +5410,19 @@ class BaseModel(metaclass=MetaModel):
         return record_copy
 
     @api.returns('self')
+    def copy_multi(self, default=None):
+        """ copy_multi(default=None)
+
+        Duplicate records in ``self`` updating it with default values
+
+        :param dict default: dictionary of field values to override in the
+               original values of the copied records, e.g: ``{'field_name': overridden_value, ...}``
+        :returns: new records
+
+        """
+        return self.browse([record.copy(default).id for record in self])
+
+    @api.returns('self')
     def exists(self):
         """  exists() -> records
 


### PR DESCRIPTION
Include the 'duplicate' action in the action menu in list view. The copy_batch
method will call the copy method with a loop to keep any existing override.

TASK-ID: 3456679

Description of the issue/feature this PR addresses:
Allow to mass duplicate in the list view

Current behavior before PR:
No duplicate in list views

Desired behavior after PR is merged:
Duplicate recards from the list views



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
