### PR TITLE
[FIX] pos_self_order: Kiosk, post-merge fixes

### DIFF
--- a/addons/pos_self_order/static/src/kiosk/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/kiosk/components/product_card/product_card.js
@@ -45,7 +45,7 @@ export class ProductCard extends Component {
 
         requestAnimationFrame(() => {
             clonedCard.style.top = `${cartRect.top}px`;
-            clonedCard.style.left = `${cartRect.left * 1.25}px`;
+            clonedCard.style.left = `${cartRect.left * 0.35}px`;
             clonedCard.style.width = `${cardRect.width * 0.80}px`;
             clonedCard.style.height = `${cardRect.height * 0.80}px`;
             clonedCard.style.opacity = "0"; // Fading out the card
@@ -54,19 +54,6 @@ export class ProductCard extends Component {
         clonedCard.addEventListener('transitionend', () => {
             clonedCard.remove();
         });
-    }
-
-    scaleUpPrice() {
-        const priceElement = document.querySelector(".total-price");
-        console.log(priceElement);
-
-        if (!priceElement) return;    
-        
-        priceElement.classList.add('scale-up');
-    
-        setTimeout(() => {
-            priceElement.classList.remove('scale-up');
-        }, 600);
     }
     
     async selectProduct() {
@@ -78,7 +65,6 @@ export class ProductCard extends Component {
             this.router.navigate("product", { id: product.id });
         } else {
             this.flyToCart();
-            this.scaleUpPrice();
             const isProductInCart = this.selfOrder.currentOrder.lines.find(
                 (line) => line.product_id === product.id
             );

--- a/addons/pos_self_order/static/src/kiosk/components/product_card/product_card.scss
+++ b/addons/pos_self_order/static/src/kiosk/components/product_card/product_card.scss
@@ -5,8 +5,3 @@
         aspect-ratio:1/1;
     }
 }
-
-.scale-up {
-    transform: scale(1.2);
-    transition: transform .75s ease-in-out;
-}

--- a/addons/pos_self_order/static/src/kiosk/pages/combo/combo.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/combo/combo.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.Combo" owl="1">
-        <KioskTemplate headerHeight="10" contentHeight="80" footerHeight="10">
+        <KioskTemplate headerHeight="10" contentHeight="78" footerHeight="12">
             <t t-set-slot="header">
                 <div class="d-flex flex-column h-100 w-100 fs-2 text-center border-bottom">
-                    <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-primary text-white"><t t-esc="props.product.name" /></div>
+                    <div class="w-100 h-100 d-flex align-items-center justify-content-center text-bg-300"><t t-esc="props.product.name" /></div>
                     <div t-if="!state.showResume" class="breadcrumb h-100 w-100 d-flex flex-nowrap p-0 bg-200 overflow-x-auto overflow-y-hidden">
                         <t t-foreach="props.product.pos_combo_ids" t-as="combo_id" t-key="combo_id">
                             <div t-attf-class="d-flex align-items-center justify-content-center {{ currentComboId === combo_id ? 'active-step bg-100' : 'bg-200' }}">
@@ -52,8 +52,9 @@
                                 <div t-foreach="state.selectedCombos" t-as="combo" t-key="combo.id" class="d-flex align-items-center justify-content-between w-100 gap-3 py-3 p-2 pe-4 mb-3 rounded shadow-sm bg-view">
                                     <t t-set="product" t-value="this.selfOrder.productByIds[combo.product.id]"/>
                                     <img
-                                        class="o_self_order_item_card_image w-auto h-100 rounded bg-view"
+                                        class="o_self_order_item_card_image w-auto rounded bg-view"
                                         t-attf-src="/menu/get-image/{{ combo.product.id }}/512?unique={{product.write_date}}"
+                                        t-attf-style="height: 150px"
                                         alt="Product image"
                                         loading="lazy"
                                         onerror="this.remove()" />

--- a/addons/pos_self_order/static/src/kiosk/pages/eating_location/eating_location.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/eating_location/eating_location.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.EatingLocation" owl="1">
-        <KioskTemplate headerHeight="0" contentHeight="90" footerHeight="10">
+        <KioskTemplate headerHeight="0" contentHeight="88" footerHeight="12">
             <t t-set-slot="content">
                 <div class="o_kiosk_eating_location d-flex flex-column h-100 align-items-center bg-100 overflow-hidden">
                     <div class="d-flex align-items-center justify-content-center flex-column w-100 h-100 my-auto px-5 text-center">
                         <h1>Choose your eating location</h1>
-                        <div class="d-flex gap-3 h-50 h-lg-25 w-100 mt-5">
+                        <div class="d-flex gap-3 h-25 h-xl-50 w-100 mt-5">
                             <button t-on-click="() => this.selectLocation('in')" class="btn btn-light d-flex flex-column align-items-center h-100 w-50 p-0 border">
-                                <div class="d-flex flex-column flex-grow-1 align-items-center justify-content-center w-100">
+                                <div class="d-flex flex-column flex-grow-1 align-items-center justify-content-center w-50 w-xl-1OO">
                                     <img src="/pos_self_order/static/img/eatin.svg" />
                                 </div>
                                 <span class="w-100 rounded-bottom border-top fs-1">Eat In</span>
                             </button>
                             <button t-on-click="() => this.selectLocation('out')" class="btn btn-light d-flex flex-column align-items-center h-100 w-50 p-0 border">
-                                <div class="d-flex flex-column flex-grow-1 align-items-center justify-content-center w-100">
+                                <div class="d-flex flex-column flex-grow-1 align-items-center justify-content-center w-50 w-xl-1OO">
                                     <img src="/pos_self_order/static/img/takeAway.svg" />
                                 </div>
                                 <span class="w-100 rounded-bottom border-top fs-1">Take Out</span>

--- a/addons/pos_self_order/static/src/kiosk/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/landing_page/landing_page.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.LandingPage" owl="1">
-        <KioskTemplate headerHeight="0" contentHeight="90" footerHeight="10">
+        <KioskTemplate headerHeight="0" contentHeight="88" footerHeight="12">
             <t t-set-slot="content">
                 <div t-if="languages.length > 1" t-on-click="openLanguages" class="o_kiosk_language_selector position-absolute top-0 end-0 m-4 rounded p-4 bg-white shadow-lg">
                     <img class="rounded" t-attf-src="{{currentLanguage.flag_image_url}}" />
@@ -18,7 +18,7 @@
                 </div>
             </t>
             <t t-set-slot="footer">
-                <button class="btn btn-primary h-100 w-100 p-0 m-0 fs-1 text-uppercase" t-on-click="start">TOUCH TO START</button>
+                <button class="btn btn-primary h-100 w-100 p-0 m-0 fs-2 text-uppercase" t-on-click="start">TOUCH TO START</button>
             </t>
         </KioskTemplate>
     </t>

--- a/addons/pos_self_order/static/src/kiosk/pages/order_cart/order_cart.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/order_cart/order_cart.xml
@@ -9,7 +9,7 @@
             </t>
             <t t-set-slot="content">
                 <div class="o_kiosk-order-cart position-relative h-100 d-flex flex-column justify-content-between bg-100">
-                    <div class="order-content bg-100 px-3 py-4 overflow-auto">
+                    <div class="order-content h-90 px-3 py-4 bg-100 overflow-auto">
                         <t t-foreach="lines" t-as="line" t-key="line.uuid">
                             <div t-if="!line.combo_parent_uuid" class="d-flex align-items-start justify-content-between w-100 gap-3 py-3 p-2 pe-4 mb-3 rounded shadow-sm bg-view">
                                 <t t-set="childLines" t-value="getChildLines(line)"/>
@@ -58,8 +58,8 @@
                             </div>
                         </t>
                     </div>
-                    <div class="order-price absolute-content position-absolute fixed-bottom w-100">
-                        <div class="absolute-content-price d-flex flex-column justify-content-center py-4 px-5 border-top bg-view text-end lh-sm">
+                    <div class="order-price absolute-content position-absolute h-10 fixed-bottom w-100">
+                        <div class="absolute-content-price d-flex flex-column justify-content-center h-100 py-4 px-5 border-top bg-view text-end lh-sm">
                             <p class="mb-0 fs-1 fw-bolder">Total: <t t-esc="selfOrder.formatMonetary(selfOrder.currentOrder.amount_total)" /></p>
                             <p class="mb-0 fs-2 text-muted">Taxes: <t t-esc="selfOrder.formatMonetary(selfOrder.currentOrder.amount_tax)" /></p>
                         </div>

--- a/addons/pos_self_order/static/src/kiosk/pages/payment_success/payment_success.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/payment_success/payment_success.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.PaymentSuccess" owl="1">
-        <KioskTemplate headerHeight="0" contentHeight="90" footerHeight="10">
+        <KioskTemplate headerHeight="0" contentHeight="88" footerHeight="12">
             <t t-set-slot="header">
                 <div t-if="this.state.onReload" class="o_kiosk-success_loader position-absolute vh-100 w-100 d-flex justify-content-center align-items-center opacity-50 bg-dark">
                     <div class="page-loader d-flex justify-content-center align-items-center">

--- a/addons/pos_self_order/static/src/kiosk/pages/product_list/product_list.scss
+++ b/addons/pos_self_order/static/src/kiosk/pages/product_list/product_list.scss
@@ -26,3 +26,7 @@
         }
     }
 }
+
+.cart {
+    min-width: 330px;
+}

--- a/addons/pos_self_order/static/src/kiosk/pages/product_list/product_list.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/product_list/product_list.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ProductList" owl="1">
         <t t-set="categories" t-value="Array.from(selfOrder.categoryList)" />
-        <KioskTemplate headerHeight="selfOrder.kiosk_image_brand ? 8 : 0" contentHeight="selfOrder.kiosk_image_brand ? 82 : 90" footerHeight="10">
+        <KioskTemplate headerHeight="selfOrder.kiosk_image_brand ? 8 : 0" contentHeight="selfOrder.kiosk_image_brand ? 80 : 88" footerHeight="12">
             <t t-set-slot="header">
                 <div class="header-image h-100" t-attf-style="background-image: url('data:image/png;base64,{{selfOrder.kiosk_image_brand}}')" />
             </t>
@@ -22,7 +22,7 @@
                                 alt="Product image"
                                 loading="lazy"
                                 onerror="this.remove()" />
-                            <span class="w-100 fs-3 text-truncate" t-esc="category.name" />
+                            <span class="w-100 fs-3 text-truncate mt-2" t-esc="category.name" />
                         </button>
                     </div>
                     <div class="product-list pb-4" t-ref="productsList">
@@ -40,12 +40,23 @@
 
             <t t-set-slot="footer">
                 <div class="d-flex flex-row w-100 h-100 gap-3">
-                    <button class="btn btn-secondary h-100 w-100 p-0 m-0 fs-2 text-uppercase" t-on-click="cancelOrder">CANCEL ORDER</button>
-                    <button t-attf-class="{{ selfOrder.currentOrder.lines.length === 0 ? 'd-none' : '' }} cart btn btn-primary h-100 w-100 d-flex flex-column justify-content-center align-items-center p-0 m-0 fs-2 text-uppercase" t-on-click="review">
-                        Review Order
-                        <span t-attf-class="total-price {{ selfOrder.currentOrder.lines.length === 0 ? 'd-none' : '' }} fs-4">
-                            Total: <t t-esc="selfOrder.formatMonetary(selfOrder.currentOrder.amount_total)" />
-                        </span>
+                    <button class="btn btn-secondary h-100 px-5 d-flex flex-column justify-content-center align-items-center m-0 fs-2 text-uppercase" t-on-click="cancelOrder">CANCEL</button>
+                    <div class="footer-information d-flex flex-column flex-xl-row flex-grow-1 align-items-start align-items-xl-center justify-content-between px-4 py-5 py-xl-0 m-0 rounded border">
+                        <h2 class="fw-bolder m-0">Your Order</h2>
+                        <div class="footer-information-content d-flex align-items-center">
+                            <span class="info-number position-relative d-flex me-4">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="36" height="47" fill="none">
+                                    <path fill="var(--companyColor)" d="m35.289 26.702.703 18.887c.04.371-.067.702-.322.994a1.25 1.25 0 0 1-.963.417H1.293c-.388 0-.71-.14-.964-.417a1.25 1.25 0 0 1-.32-.994L.71 26.702h34.578Zm-1.867-15.398 1.726 15.398H.852l1.726-15.398c.04-.317.181-.586.422-.804.241-.219.529-.328.864-.328h5.14v2.543c0 .702.251 1.301.753 1.798a2.49 2.49 0 0 0 1.817.745 2.49 2.49 0 0 0 1.818-.745 2.437 2.437 0 0 0 .753-1.798v-2.543h7.71v2.543c0 .702.251 1.301.753 1.798a2.49 2.49 0 0 0 1.818.745 2.49 2.49 0 0 0 1.817-.745 2.437 2.437 0 0 0 .753-1.798v-2.543h5.14c.335 0 .623.11.864.328.24.218.381.487.422.805ZM25.71 7.63v5.086c0 .344-.127.642-.382.894a1.242 1.242 0 0 1-.903.377c-.348 0-.65-.125-.904-.377a1.216 1.216 0 0 1-.381-.894V7.629c0-1.404-.502-2.603-1.506-3.596-1.005-.993-2.216-1.49-3.635-1.49-1.419 0-2.63.497-3.634 1.49-1.005.993-1.506 2.192-1.506 3.596v5.086c0 .344-.128.642-.382.894a1.242 1.242 0 0 1-.904.377c-.348 0-.649-.125-.903-.377a1.216 1.216 0 0 1-.382-.894V7.629c0-2.106.753-3.904 2.26-5.394C14.053.745 15.87 0 18 0c2.128 0 3.946.745 5.452 2.235 1.506 1.49 2.259 3.288 2.259 5.394Z"/>
+                                </svg>
+                                <span class="position-absolute position-absolute top-50 start-50 translate-middle fs-3 fw-bolder pt-3 text-white">
+                                    <t t-esc="selfOrder.currentOrder.lines.length"/>
+                                </span>
+                            </span>
+                            <span class="total-price fs-1 fw-bolder mt-1"><t t-esc="selfOrder.formatMonetary(selfOrder.currentOrder.amount_total)" /></span>
+                        </div>
+                    </div>
+                    <button t-attf-class="cart btn btn-primary h-100 d-flex flex-column justify-content-center align-items-center m-0 fs-2 text-uppercase" t-on-click="review">
+                        PAY
                     </button>
                 </div>
             </t>

--- a/addons/pos_self_order/static/src/kiosk/pages/stand_number/stand_number.xml
+++ b/addons/pos_self_order/static/src/kiosk/pages/stand_number/stand_number.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.StandNumber" owl="1">
-        <KioskTemplate headerHeight="0" contentHeight="90" footerHeight="10">
+        <KioskTemplate headerHeight="0" contentHeight="88" footerHeight="12">
             <t t-set-slot="content">
                 <div class="h-100 o_kiosk-stand_number">
                     <div class="d-flex flex-column justify-content-between h-100">

--- a/addons/pos_self_order/static/src/kiosk/self_order_kiosk_index.scss
+++ b/addons/pos_self_order/static/src/kiosk/self_order_kiosk_index.scss
@@ -6,7 +6,7 @@ body {
   padding: 0;
   box-sizing: border-box;
   overflow: hidden;
-  font-size: 24px;
+  font-size: clamp(.75rem, 1.25rem, 1.50em);
   -webkit-user-select: none !important;
   -ms-user-select: none !important;
   user-select: none !important;
@@ -23,4 +23,37 @@ body {
 .o_kiosk-card img {
   object-fit: contain;
   aspect-ratio: 1/1;
+}
+
+/* Custom styling for .btn-primary to reflect company settings colors */
+
+.btn-primary {
+  background-color: var(--companyColor);
+  border-color: transparent;
+
+  &:hover {
+      background-color: var(--companyColor);
+      border-color: var(--companyColor);
+  }
+
+  &:active, &:focus {
+      background-color: $white;
+      color: var(--companyColor);
+      border-color: var(--companyColor);
+  }
+
+  &.disabled {
+      background-color: var(--companyColor);
+      border-color: var(--companyColor);
+      opacity: .5;
+  }
+}
+
+.text-bg-primary, .bg-primary {
+  background-color: var(--companyColor) !important;
+  border-color: var(--companyColor) !important;
+}
+
+.border-primary {
+  border-color: var(--companyColor) !important;
 }

--- a/addons/pos_self_order/static/src/kiosk/template/kiosk_template.js
+++ b/addons/pos_self_order/static/src/kiosk/template/kiosk_template.js
@@ -18,11 +18,9 @@ export class KioskTemplate extends Component {
         onMounted(() => {
             const style = document.createElement("style");
             const color = escape(this.selfOrder.color);
-            style.innerHTML = markup(`.btn-primary,.text-bg-primary,.bg-primary {
-                background-color: ${color} !important;
-                border-color: ${color} !important;
-            } .border-primary {
-                border-color: ${color} !important;
+            style.innerHTML = markup(`
+            body {
+                --companyColor: ${color};
             }`);
 
             document.getElementsByTagName("head")[0].appendChild(style);


### PR DESCRIPTION
Before this commit, some UI improvements and fixes were needed.

- Revamped the Product List Footer
  * Removed the total amount from the "pay/review order" button.
  * Introduced a separate panel to display the total amount.
  * Added a count of items in the cart to the new panel.
  * Adapt the "click on product to cart" animation

- Adjusted the Combo screen layout:
  * Set a fixed height for product images in the summary view, post
  combo selection.

- Adjusted font-size, and height for desktop (landscape) view

- btn-primary for company colors scss

task-3488361

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
