### PR TITLE
[IMP] l10n_us,account: TaxCloud setting should only be on l10n_us

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -23,6 +23,7 @@
                     <app data-string="Invoicing" string="Invoicing" name="account" groups="account.group_account_manager">
                         <field name="has_chart_of_accounts" invisible="1"/>
                         <field name="has_accounting_entries" invisible="1"/>
+                        <field name="module_account_taxcloud" invisible="1"/>   
                         <block title="Fiscal Localization" name="fiscal_localization_setting_container" invisible="not is_root_company">
                             <setting string="Fiscal Localization" company_dependent="1" help="Taxes, fiscal positions, chart of accounts &amp; legal statements for your country"
                                 documentation="/applications/finance/fiscal_localizations.html">
@@ -59,7 +60,9 @@
                                 <field name="tax_calculation_rounding_method" class="o_light_label mt16" widget="radio"/>
                             </setting>
                             <setting id="taxcloud_settings" string="TaxCloud" help="Compute tax rates based on U.S. ZIP codes"
-                                documentation="/applications/finance/accounting/taxation/taxes/taxcloud.html">
+                                documentation="/applications/finance/accounting/taxation/taxes/taxcloud.html"
+                                invisible="not module_account_taxcloud"
+                            >
                                 <field name="module_account_taxcloud" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="eu_service" title="If you sell goods and services to customers in a foreign EU country, you must charge VAT based on the delivery address. This rule applies regardless of where you are located." documentation="/applications/finance/accounting/taxation/taxes/eu_distance_selling.html" help="Apply VAT of the EU country to which goods and services are delivered.">


### PR DESCRIPTION
Taxcloud setting should only be visible if l10n_us is installed. Removing it from account module and putting the setting on l10n_us module.

Task-id: 3475032

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
