### PR TITLE
[FIX] mail: raise error when user have no right to update channel

### DIFF
--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -18,6 +18,27 @@
                             ('group_public_id', 'in', [g.id for g in user.groups_id])]
             </field>
             <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
+        <record id="discuss_channel_rule_write_groups_chat" model="ir.rule">
+            <field name="name">discuss.channel: Update joined groups and chats</field>
+            <field name="model_id" ref="mail.model_discuss_channel"/>
+            <field name="groups" eval="[Command.link(ref('base.group_user')), Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
+            <field name="domain_force">[
+                '|',
+                    '&amp;',
+                        ('channel_type', '!=', 'channel'),
+                        ('is_member', '=', True),
+                    '&amp;',
+                        ('channel_type', '=', 'channel'),
+                        ('create_uid', '=', user.id)]
+            </field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
         </record>
 
         <record id="discuss_channel_admin" model="ir.rule">

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -119,11 +119,18 @@ class TestChannelAccessRights(MailCommon):
         # Read a chat when being a member: ok
         self.env['discuss.channel'].browse(self.chat_user_employee.id).read()
 
-        # Update channel/group/chat when being a member: ok
-        self.env['discuss.channel'].browse(self.public_channel.id).write({'name': 'modified again'})
-        self.env['discuss.channel'].browse(self.group_restricted_channel.id).write({'name': 'modified again'})
-        self.env['discuss.channel'].browse(self.private_group.id).write({'name': 'modified again'})
+        # Update (not owned)channel when being a member: ko, no access rights
+        with self.assertRaises(AccessError):
+            self.env['discuss.channel'].browse(self.public_channel.id).write({'name': 'modified again'})
+        with self.assertRaises(AccessError):
+            self.env['discuss.channel'].browse(self.group_restricted_channel.id).write({'name': 'modified again'})
+
+        # update owned channel
+        self.env['discuss.channel'].create({'name': 'Test', 'channel_type': 'channel'}).write({'name': 'modified again'})
+
+        # Update chat/group when being a member: ok
         self.env['discuss.channel'].browse(self.chat_user_employee.id).write({'name': 'modified again'})
+        self.env['discuss.channel'].browse(self.private_group.id).write({'name': 'modified again'})
 
         # Create channel/group/chat: ok
         new_channel = self.env['discuss.channel'].create(


### PR DESCRIPTION
Issue:
======
Users can edit channels when they aren't admin or owners of the
channels.

Steps to reproduce the error:
==============================
- Install Discuss
- Connect with another user (marc demo)
- Go to discuss , you can see that you can't update the name and
  description because `is_editable=False`
- Click on the config icon of the channel
- Update the Channel  => you can update it.

Solution:
=========
- For portal and public users I removed the write access right for the
non owned channels.
- For internal users I removed the write access right for the non owned
  channels but add condition to exectue add_members so they can invite other
  users.

opw-3469936
