### PR TITLE
[FIX] [14.0] error in compute_notify_recipients query

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2531,9 +2531,9 @@ class MailThread(models.AbstractModel):
                             left join mail_channel c on c.id = mcp.channel_id
                             left join res_users u on p.id = u.partner_id
                                 where (u.notification_type != 'inbox' or u.id is null)
-                                and (p.email != ANY(%s) or p.email is null)
+                                and (p.email != ALL(%s) or p.email is null)
                                 and c.id = ANY(%s)
-                                and p.id != ANY(%s)"""
+                                and p.id != ALL(%s)"""
 
             self.env.cr.execute(sql_query, (([email_from], ), (email_cids, ), (exept_partner, )))
             for partner_id in self._cr.fetchall():


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We found ourselves in very specific conditions raising a sql constraint forbidding duplicate mail.notifications on same partner when simply posting a message in a channel, and were also followers of the channel record itself.

There seems to be an error in the query  in:
https://github.com/odoo/odoo/blob/14.0/addons/mail/models/mail_thread.py#L2523-L2539

in our specific case  exept_partner was already computed as:  
>>> exept_partner
[817, 245] 

but the query would still return 817 in our results, therefore adding a duplicate partner to the response.


By analyzing the query, and the logic of the code in https://github.com/odoo/odoo/blob/14.0/addons/mail/models/mail_thread.py#L2465   i see that the use of "ANY" is incorrect.


By writing :  
`          and p.id != ANY('{817,245}') ;`
if p.id is 817 we are actually  expressing :    and ( 817 != 817  OR 817 != 245)     therefore including 817 in our results.
Actually we are including everything, as-is this condition restricts no values, it has no effect.

By changing this to 
`          and p.id != ALL('{817,245}') ;`
if p.id is 817 we are actually  expressing :    and ( 817 != 817  AND 817 != 245)  wich is what we want , and wich was the intention of the query itself,   Not to return partners we had already added in the code before.


This Query needs to be changed, We have deployed this  on production and are happy with it.   








