### PR TITLE
[IMP] web: remove PublicWidget fix for deprecated old apple devices

### DIFF
--- a/addons/web/static/src/legacy/js/public/public_widget.js
+++ b/addons/web/static/src/legacy/js/public/public_widget.js
@@ -590,19 +590,6 @@ var RootWidget = PublicWidget.extend({
  */
 var registry = {};
 
-/**
- * This is a fix for apple device (<= IPhone 4, IPad 2)
- * Standard bootstrap requires data-bs-toggle='collapse' element to be <a/> tags.
- * Unfortunately some layouts use a <div/> tag instead. The fix forces an empty
- * click handler on these div, which allows standard bootstrap to work.
- */
-registry._fixAppleCollapse = PublicWidget.extend({
-    selector: 'div[data-bs-toggle="collapse"]',
-    events: {
-        'click': function () {},
-    },
-});
-
 export default {
     RootWidget: RootWidget,
     Widget: PublicWidget,


### PR DESCRIPTION
Introduced in https://github.com/odoo/odoo/commit/f242721eb0cb73dc791380beff3ca150c100b2af,
this Bootstrap's Collapse fix was targetting very old Apple devices.

task-3439226

Design-themes PR: https://github.com/odoo/design-themes/pull/694




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
