### PR TITLE
Search child_of/parent_of without active_test

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -548,7 +548,7 @@ class expression(object):
                     records = records.search([(parent_name, 'in', records.ids)], order='id') - records.browse(child_ids)
                 domain = [('id', 'in', list(child_ids))]
             if prefix:
-                return [(left, 'in', left_model._search(domain, order='id'))]
+                return [(left, 'in', left_model.with_context(active_test=False)._search(domain, order='id'))]
             return domain
 
         def parent_of_domain(left, ids, left_model, parent=None, prefix=''):
@@ -576,7 +576,7 @@ class expression(object):
                     records = records[parent_name] - records.browse(parent_ids)
                 domain = [('id', 'in', list(parent_ids))]
             if prefix:
-                return [(left, 'in', left_model._search(domain, order='id'))]
+                return [(left, 'in', left_model.with_context(active_test=False)._search(domain, order='id'))]
             return domain
 
         HIERARCHY_FUNCS = {'child_of': child_of_domain,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Using child_of/parent_of searches may loose inactive records

Current behavior before PR:
When the child_of_domain and parent_of_domain methods in expression.py is called with parameter "prefix" set, the method performs a new search and returns the result, - but the search is performed without setting active_test.

This is a problem if an access rule uses child_of/parent_of operators, since rule checking even for inactive records is done without setting active_test.

Desired behavior after PR is merged:
Search with active_test=False. This is the same behavior as performed when "prefix" is not set and must be the desired behavior.

(Also see PR131427)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
