### PR TITLE
[FIX] mass_mailing_themes: fix image path

### DIFF
--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -978,7 +978,7 @@
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>
         </div>
         <div class="s_cover o_mail_snippet_general" data-snippet="s_cover" data-name="Cover">
-            <img src="/mass_mailing/static/src/img/theme_coffeebreak/s_default_image_block_banner.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
+            <img src="/mass_mailing_themes/static/src/img/theme_coffeebreak/s_default_image_block_banner.jpg" alt="Cover image" class="img-fluid w-100 mx-auto"/>
         </div>
         <div class="s_hr o_mail_snippet_general pt16 pb0" style="background-color: rgb(238, 233, 226) !important;" data-snippet="s_hr" data-name="Separator">
             <hr class="s_hr_1px s_hr_solid" style="border-color: rgba(0,0,0,0)"/>


### PR DESCRIPTION
The image from mass_mailing was moved to mass_mailing_themes Therefore we should also update its path.

task-3328661
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
