### PR TITLE
[IMP] web: add alwaysApply in useDebounce

### DIFF
--- a/addons/hr_attendance/static/src/components/check_in_out/check_in_out.js
+++ b/addons/hr_attendance/static/src/components/check_in_out/check_in_out.js
@@ -10,7 +10,7 @@ export class CheckInOut extends Component {
         this.orm = useService("orm");
         this.notification = useService("notification");
 
-        this.onClickSignInOut = useDebounced(this.signInOut, 200, true);
+        this.onClickSignInOut = useDebounced(this.signInOut, 200, { immediate: true });
     }
 
     async signInOut() {

--- a/addons/sale/static/src/js/product_catalog/kanban_record.js
+++ b/addons/sale/static/src/js/product_catalog/kanban_record.js
@@ -12,7 +12,9 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
     setup() {
         super.setup();
         this.rpc = useService("rpc");
-        this.debouncedUpdateQuantity = useDebounced(this._updateQuantity, 500);
+        this.debouncedUpdateQuantity = useDebounced(this._updateQuantity, 500, {
+            execBeforeUnmount: true,
+        });
 
         useSubEnv({
             currencyId: this.props.record.context.product_catalog_currency_id,


### PR DESCRIPTION
The purpose of this commit is to add the alwaysApply option to useDebounced. This option is used to force execution of the callBack if the debounced function has been called and is still not resolved when the component is destroyed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
