### PR TITLE
[IMP] base: add helper to easily retrieve a company in the hierarchy …

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -104,6 +104,15 @@ class Company(models.Model):
         return dict((fname, partner[fname])
                     for fname in self._get_company_address_field_names())
 
+    def _get_first_company_having(self, predicate):
+        """ Find the first company of the hierarchy matching the given predicate.
+
+        :param predicate: A function returning True if the company can be returned, False if we need to fallback on the parent.
+        :return: A res.company
+        """
+        self.ensure_one()
+        return self.parent_ids[::-1].filtered(predicate)[:1]
+
     @api.depends('parent_path')
     def _compute_parent_ids(self):
         for company in self:


### PR DESCRIPTION
…based on criteria

To handle EDI with branches management, we need a way to retrieve which company in the hierarchy will be used to generate the document.
For example, in Mexico, we need to use the first company having configured certificates.

task: 3483509

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
