### PR TITLE
[IMP] fleet: changed tree view to editable

### DIFF
--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -101,7 +101,7 @@
         <field name="name">fleet.vehicle.model.tree</field>
         <field name="model">fleet.vehicle.model</field>
         <field name="arch" type="xml">
-            <tree string="Models">
+            <tree string="Models" multi_edit="1">
                 <field name="brand_id" />
                 <field name="name" />
                 <field name="vehicle_count" string="Vehicles"/>


### PR DESCRIPTION
Before these commit :
field are not editable in the tree view when we click on
the field its open the form view.
After these commit :
Now the fields are editable through the checkbox in tree view.

task-3487625