### PR TITLE
[FIX] product: enable uniqueness of barcode even on archived products

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -175,7 +175,7 @@ class ProductProduct(models.Model):
         to ensure the uniqueness between products' barcodes and packagings' ones"""
         all_barcode = [b for b in self.mapped('barcode') if b]
         domain = [('barcode', 'in', all_barcode)]
-        matched_products = self.sudo().search(domain, order='id')
+        matched_products = self.sudo().with_context(active_test=False).search(domain, order='id')
         if len(matched_products) > len(all_barcode):  # It means that you find more than `self` -> there are duplicates
             products_by_barcode = defaultdict(list)
             for product in matched_products:

--- a/addons/product/tests/test_barcode.py
+++ b/addons/product/tests/test_barcode.py
@@ -31,6 +31,13 @@ class TestProductBarcode(TransactionCase):
         with self.assertRaises(ValidationError):
             self.env['product.product'].create({'name': 'BC3', 'barcode': '1'})
 
+    def test_duplicated_barcode_archived(self):
+        """Test uniqueness of barcode for archived products."""
+        with self.assertRaises(ValidationError):
+            product = self.env['product.product'].create({'name': 'BC3', 'barcode': '3'})
+            product.active = False
+            self.env['product.product'].create({'name': 'BC4', 'barcode': '3'})
+
     def test_duplicated_barcode_in_batch_edit(self):
         """Tests for duplication in batch edits."""
         batch = [


### PR DESCRIPTION
### Steps
- Create a product with a barcode.
- Archive it.
- Try to create another product with the same barcode.

### Issue
You are able to do that but barcodes are meant to be unique per product.

### Reason
The domain used to check for other products with the same barcode doesn't consider the archived ones

opw-3477371