### PR TITLE
[FIX] mail: avoid crash with link preview from bus notification

### DIFF
--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -9,13 +9,14 @@ export class LinkPreview extends Record {
      * @returns {LinkPreview}
      */
     static insert(data) {
-        let linkPreview = data.message.linkPreviews.find((lp) => lp.id === data.id);
+        const message = this.store.Message.get(data.message.id);
+        let linkPreview = message?.linkPreviews.find((lp) => lp.id === data.id);
         if (linkPreview) {
             return Object.assign(linkPreview, data);
         }
         linkPreview = this.new(data);
         Object.assign(linkPreview, data);
-        this.store.Message.get(data.message.id)?.linkPreviews.push(linkPreview);
+        message?.linkPreviews.push(linkPreview);
         return linkPreview;
     }
 

--- a/addons/mail/static/src/core/common/mail_core_common_service.js
+++ b/addons/mail/static/src/core/common/mail_core_common_service.js
@@ -100,9 +100,7 @@ export class MailCoreCommon {
                 const { LinkPreview: linkPreviews } = payload;
                 if (linkPreviews) {
                     for (const linkPreview of linkPreviews) {
-                        this.store.Message.get(linkPreview.message.id)?.linkPreviews.push(
-                            this.store.LinkPreview.insert(linkPreview)
-                        );
+                        this.store.LinkPreview.insert(linkPreview);
                     }
                 }
                 const { Message: messageData } = payload;

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -281,7 +281,7 @@ patch(MockServer.prototype, {
     _mockRouteMailLinkPreview(message_id, clear = false) {
         const linkPreviews = [];
         const [message] = this.pyEnv["mail.message"].searchRead([["id", "=", message_id]]);
-        if (message.body === "https://make-link-preview.com") {
+        if (message.body.includes("https://make-link-preview.com")) {
             if (clear) {
                 const [linkPreview] = this.pyEnv["mail.link.preview"].searchRead([
                     ["message_id", "=", message_id],
@@ -297,6 +297,7 @@ patch(MockServer.prototype, {
             }
 
             const linkPreviewId = this.pyEnv["mail.link.preview"].create({
+                message_id: message.id,
                 og_description: "test description",
                 og_title: "Article title",
                 og_type: "article",

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
@@ -13,7 +13,7 @@ patch(MockServer.prototype, {
     _mockMailLinkPreviewFormat(linkPreview) {
         return {
             id: linkPreview.id,
-            message: { id: linkPreview.message_id },
+            message: { id: linkPreview.message_id[0] },
             image_mimetype: linkPreview.image_mimetype,
             og_description: linkPreview.og_description,
             og_image: linkPreview.og_image,

--- a/addons/mail/static/tests/message/link_preview_test.js
+++ b/addons/mail/static/tests/message/link_preview_test.js
@@ -3,6 +3,7 @@
 import {
     click,
     contains,
+    insertText,
     nextAnimationFrame,
     start,
     startServer,
@@ -342,3 +343,13 @@ QUnit.test(
         await contains(".o-mail-Message-bubble");
     }
 );
+
+QUnit.test("Sending message with link preview URL should show a link preview card", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "wololo" });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", "https://make-link-preview.com");
+    await click("button:not([disabled])", { text: "Send" });
+    await contains(".o-mail-LinkPreviewCard");
+});


### PR DESCRIPTION
Before this PR, a crash occured when a link preview was recieved from the bus. This is because the link preview was pushed twice on the `message.linkPreviews` array.

task-3491629
