### PR TITLE
[REF] point_of_sale: pass lot id in lot value dict

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -39,6 +39,7 @@ class AccountMove(models.Model):
                             'quantity': line.qty if lot.product_id.tracking == 'lot' else 1.0,
                             'uom_name': line.product_uom_id.name,
                             'lot_name': lot.lot_name,
+                            'lot_id': lot.id,
                         })
 
         return lot_values


### PR DESCRIPTION
before this commit, for the localization need if there is a need to extended any further details in the lot details in the invoice report, it is difficult as there is no reference to the lot in the dictionary

scenario:

* to add expiry date along with the lot values
* enable "Display Lots & Serial Numbers on Invoices" from accounting settings

from sale_stock module, the value is already passed in the dict.

after this commit, it can be easily customized by
adding new values from the lot

Related EE: https://github.com/odoo/enterprise/pull/46806

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
