### PR TITLE
[FIX] web: correctly eval context for nested x2many

### DIFF
--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -180,7 +180,7 @@ function applyBinaryOp(ast, context) {
                 }
             }
             if (left instanceof Array && right instanceof Array) {
-                return [...left, ...right]
+                return [...left, ...right];
             }
 
             return left + right;
@@ -376,10 +376,10 @@ export function evaluate(ast, context = {}) {
                     // this is a dictionary => need to apply dict methods
                     return DICT[ast.key](left);
                 }
-                if (typeof left === 'string') {
+                if (typeof left === "string") {
                     return STRING[ast.key](left);
                 }
-                if (ast.key == 'get' && typeof left === 'object') {
+                if (ast.key == "get" && typeof left === "object") {
                     return DICT[ast.key](toPyDict(left));
                 }
                 const result = left[ast.key];

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -940,5 +940,8 @@ export class StaticList extends DataPoint {
 
     _updateContext(context) {
         Object.assign(this.context, context);
+        for (const record of Object.values(this._cache)) {
+            record._updateChildrenContext();
+        }
     }
 }


### PR DESCRIPTION
Have a form view with a one2many field (e.g. displayed as a list) containing itself an x2many field (e.g. many2many_tags), with a dynamic context depending on the parent record (see the test for a specific situation).

Before this commit, the dynamic context on the inner x2many wasn't correctly evaluated, because when we evaluated it, the parent evalContext hadn't been computed yet (they were computed bottom-up) when the datapoints were created.

With this commit, we wait for all datapoints and evalContext to be properly set up before evaluating the static list dynamic contexts.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
