### PR TITLE
[IMP] pos_self_order: introduce combos

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -236,7 +236,7 @@ class PosSelfOrderController(http.Controller):
                         child_product,
                     )
                     newLines.append({
-                        'price_unit': price_unit,
+                        'price_unit': child_price_unit,
                         'price_subtotal': child_tax_results.get('total_excluded'),
                         'price_subtotal_incl': child_tax_results.get('total_included'),
                         'id': child.get('id'),

--- a/addons/pos_self_order/static/src/common/self_order_service.js
+++ b/addons/pos_self_order/static/src/common/self_order_service.js
@@ -4,6 +4,7 @@ import { ConnectionLostError, RPCError } from "@web/core/network/rpc_service";
 import { _t } from "@web/core/l10n/translation";
 import { formatMonetary } from "@web/views/fields/formatters";
 import { Product } from "@pos_self_order/common/models/product";
+import { Combo } from "@pos_self_order/common/models/combo";
 import { session } from "@web/session";
 import { getColor } from "@web/core/colors/colors";
 import { categorySorter } from "@pos_self_order/common/utils";
@@ -26,6 +27,7 @@ export class selfOrderCommon extends Reactive {
         this.color = getColor(this.company_color);
         this.priceLoading = false;
         this.productByIds = {};
+        this.comboByIds = {};
         this.productsGroupedByCategory = {};
         this.currentProduct = 0;
         this.lastEditedProductId = null;
@@ -36,6 +38,11 @@ export class selfOrderCommon extends Reactive {
                 .filter((c) => this.productsGroupedByCategory[c.name])
                 .sort((a, b) => categorySorter(a, b, this.iface_start_categ_id))
         );
+        this.combos = this.combos.map((c) => {
+            const combo = new Combo(c);
+            this.comboByIds[combo.id] = combo;
+            return combo;
+        });
     }
 
     initData() {

--- a/addons/pos_self_order/static/src/kiosk/self_order_kiosk_service.js
+++ b/addons/pos_self_order/static/src/kiosk/self_order_kiosk_service.js
@@ -3,7 +3,6 @@ import { useState } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { Order } from "@pos_self_order/common/models/order";
-import { Combo } from "@pos_self_order/common/models/combo";
 import { selfOrderCommon } from "@pos_self_order/common/self_order_service";
 
 export class selfOrder extends selfOrderCommon {
@@ -13,7 +12,6 @@ export class selfOrder extends selfOrderCommon {
     }
 
     async setup(...args) {
-        this.comboByIds = {};
 
         await super.setup(...args);
 
@@ -67,16 +65,6 @@ export class selfOrder extends selfOrderCommon {
 
     updateOrderFromServer(order) {
         this.currentOrder.updateDataFromServer(order);
-    }
-
-    initData() {
-        super.initData();
-
-        this.combos = this.combos.map((c) => {
-            const combo = new Combo(c);
-            this.comboByIds[combo.id] = combo;
-            return combo;
-        });
     }
 
     isSession() {

--- a/addons/pos_self_order/static/src/mobile/components/lines/lines.js
+++ b/addons/pos_self_order/static/src/mobile/components/lines/lines.js
@@ -16,6 +16,11 @@ export class Lines extends Component {
     get lines() {
         return this.props.order.lines;
     }
+    getPrice(line) {
+        return this.selfOrder.show_prices_with_tax_included
+            ? line.price_subtotal_incl
+            : line.price_subtotal;
+    }
 
     clickOnLine(line) {
         const order = this.props.order;

--- a/addons/pos_self_order/static/src/mobile/components/lines/lines.xml
+++ b/addons/pos_self_order/static/src/mobile/components/lines/lines.xml
@@ -14,7 +14,7 @@
                             <span class="text-primary fw-bolder small" t-esc="`${line.qty}x `" />
                             <span
                                 class="flex-grow-1 me-3 small text-muted"
-                                t-esc="selfOrder.formatMonetary(selfOrder.productByIds[line.product_id].prices)"
+                                t-esc="selfOrder.formatMonetary(getPrice(line) / line.qty)"
                                 />
                         </div>
                         <span
@@ -22,15 +22,18 @@
                             class="m-0 text-muted small break-line"
                             t-esc="lineName.attributes"
                             />
+                        <t t-set="comboParent" t-value="line.combo_parent_uuid and props.order.lines.find(l => l.uuid === line.combo_parent_uuid)" />
+                        <div t-if="comboParent" class="info ms-2 combo-parent-name">
+                            <i class="fa fa-th-large me-2" role="img" aria-label="Combo" title="Combo"/>
+                            <t t-esc="comboParent.full_product_name" />
+                        </div>
                         <div t-if="line.customer_note" class="d-inline-block m-0 text-muted small break-line">
                             <i class="fa fa-pencil-square-o" aria-hidden="true" />
                             <span t-esc="line.customer_note" class="ms-1" />
                         </div>
                     </div>
-                    <span
-                        t-attf-class="card-text small"
-                        t-esc="this.selfOrder.formatMonetary(line.qty * selfOrder.productByIds[line.product_id].prices)"
-                        />
+                    <span t-attf-class="card-text small"
+                        t-esc="selfOrder.formatMonetary(getPrice(line))"/>
                 </div>
             </div>
         </t>

--- a/addons/pos_self_order/static/src/mobile/pages/product_main_view/product_main_view.xml
+++ b/addons/pos_self_order/static/src/mobile/pages/product_main_view/product_main_view.xml
@@ -86,6 +86,24 @@
                             </div>
                         </div>
                     </t>
+                <div t-foreach="props.product.pos_combo_ids or []" t-as="combo_id" t-key="combo_id" class="mb-3">
+                        <t t-set="combo" t-value="selfOrder.comboByIds[combo_id]"/>
+                        <h3 class="py-1" t-esc="combo.name"/>
+                        <div t-foreach="combo.combo_line_ids" t-as="combo_line" t-key="combo_line.id" class="d-flex align-items-center form-control py-3">
+                            <input type="radio" class="form-check-input my-1 me-2"
+                                t-att-name="combo.name"
+                                t-attf-id="{{ combo.name }}_{{ combo_line.product_id[1] }}"
+                                t-att-value="combo_line.id"
+                                t-model="state.selectedCombos[combo.id]" />
+                            <label t-attf-for="{{ combo.name }}_{{ combo_line.product_id[1] }}" class="d-flex flex-grow-1">
+                                <div class="" t-esc="selfOrder.productByIds[combo_line.product_id[0]].name"/>
+                                <div class="ms-auto pe-3" t-if="combo_line.combo_price">
+                                    + <t t-esc="selfOrder.formatMonetary(combo_line.combo_price)" />
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+
                     <div t-if="selfOrder.ordering and (!disableAttributes || state.customer_note)">
                         <label class="form-label fw-bold" for="note">Add a note:</label>
                         <textarea class="form-control rounded bg-white" id="note" type="textarea" rows="1" placeholder="No onions please" t-model="state.customer_note" t-att-disabled="disableAttributes" />

--- a/addons/pos_self_order/static/tests/tours/self_order_after_meal_cart_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_after_meal_cart_tour.js
@@ -32,8 +32,8 @@ registry.category("web_tour.tours").add("self_order_after_meal_cart_tour", {
         // the cart and edited, the changes are made to the orderline clicked on.
         PosSelf.check.isOrderline("Office Chair Black", "138.58", ""),
         ...PosSelf.action.editOrderline("Office Chair Black", "138.58", "", 5, "no wheels"),
-        PosSelf.check.isOrderline("Office Chair Black", "692.90", "no wheels"),
-        ...PosSelf.action.editOrderline("Office Chair Black", "692.90", "no wheels", -4, "kidding"),
+        PosSelf.check.isOrderline("Office Chair Black", "692.88", "no wheels"),
+        ...PosSelf.action.editOrderline("Office Chair Black", "692.88", "no wheels", -4, "kidding"),
         PosSelf.check.isOrderline("Office Chair Black", "138.58", "kidding"),
 
         // Send the order to the server
@@ -69,8 +69,8 @@ registry.category("web_tour.tours").add("self_order_after_meal_cart_tour", {
         PosSelf.action.clickBack(),
         ...PosSelf.action.addProduct("Office Chair Black", 1, "kidding"),
         PosSelf.action.clickPrimaryBtn("Review"),
-        PosSelf.check.isOrderline("Office Chair Black", "277.16", "kidding"),
-        ...PosSelf.action.editSentOrderline("Office Chair Black", "277.16", "kidding", -1),
+        PosSelf.check.isOrderline("Office Chair Black", "277.15", "kidding"),
+        ...PosSelf.action.editSentOrderline("Office Chair Black", "277.15", "kidding", -1),
         PosSelf.check.isOrderline("Office Chair Black", "138.58", "kidding"),
         ...PosSelf.action.editSentOrderline("Office Chair Black", "138.58", "kidding", -1),
         PosSelf.check.isNotification("You cannot reduce the quantity"),
@@ -87,7 +87,7 @@ registry.category("web_tour.tours").add("self_order_after_meal_cart_tour", {
         }),
         PosSelf.action.clickPrimaryBtn("Review"),
         PosSelf.check.isOrderline("Desk Organizer", "5.87", "kidding", "M, Leather"),
-        PosSelf.check.isOrderline("Desk Organizer", "11.74", "okkk", "L, Custom"),
+        PosSelf.check.isOrderline("Desk Organizer", "11.73", "okkk", "L, Custom"),
 
         // Check if we can edit the product attributes, and if the changes are made to the orderline
         ...PosSelf.action.editOrderline("Desk Organizer", "5.87", "kidding", 0, "dav", {
@@ -95,7 +95,7 @@ registry.category("web_tour.tours").add("self_order_after_meal_cart_tour", {
             select: { name: "Fabric", value: "Custom" },
         }),
         PosSelf.check.isOrderline("Desk Organizer", "5.87", "dav", "S, Custom"),
-        PosSelf.check.isOrderline("Desk Organizer", "11.74", "okkk", "L, Custom"),
+        PosSelf.check.isOrderline("Desk Organizer", "11.73", "okkk", "L, Custom"),
         PosSelf.action.clickPrimaryBtn("Order"),
 
         PosSelf.check.isPrimaryBtn("My Orders"),


### PR DESCRIPTION
Using the POS app, one can buy a combo consisting of multiple products.

In this PR we implement this functionality in the `pos_self_order`.
A user can now navigate to a combo product, select each combo choice
and order the desired combo directly from the `pos_self_order` app.

In this commit we also change the values displayed in the orderlines
of the `pos_self_order`, such that they better reflect the values
that would be shown by the POS for the same respective orderlines.

Ex: when buying 5 units of an item that has unit price 138.58, the
POS ( and also the invoicing app, etc ) would display a total price
of 692.88. The self order now does the same, but before it was showing
692.90 for the same situation.

Task: 3437447




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
