### PR TITLE
[FIX] account: allow the creation of a new account.report from the UI again

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -236,7 +236,10 @@ class AccountReport(models.Model):
     @api.depends('name', 'country_id')
     def _compute_display_name(self):
         for report in self:
-            report.display_name = report.name + (f' ({report.country_id.code})' if report.country_id else '')
+            if report.name:
+                report.display_name = report.name + (f' ({report.country_id.code})' if report.country_id else '')
+            else:
+                report.display_name = False
 
 
 class AccountReportLine(models.Model):


### PR DESCRIPTION
Hitting the "new" button in the tree view (in enterprise) was crashing because of the changes introduced on the display name computation. It is now also computed on 'new' records, when no field is set at all: this caused this function to try concatenating None with an empty string.

