### PR TITLE
[FIX] prevent reconciliation between credit note and reversed move if in draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3724,7 +3724,7 @@ class AccountMove(models.Model):
                 wrong_lines.write({'partner_id': invoice.commercial_partner_id.id})
 
         # reconcile if state is in draft and move has reversal_entry_id set
-        draft_reverse_moves = to_post.filtered(lambda move: move.reversed_entry_id)
+        draft_reverse_moves = to_post.filtered(lambda move: move.reversed_entry_id and move.reversed_entry_id.state == 'posted')
 
         to_post.write({
             'state': 'posted',


### PR DESCRIPTION
The aim of this commit is to prevent reconciliation with credit note  to be triggered when a reversed move is reset to draft

Context: reconciliation between credit note and invoice (same for vendor bill)

Previous to this commit:
Post invoice
Create and post credit note
Reset to draft both the invoice and the credit note
Post (confirm) again the credit note
-> User error due to attempt of reconciliation between credit note and draft invoice

After this commit:
The credit note is posted but not reconciled when the original move is in draft 

task-3492197

