### PR TITLE
[FIX] web: apply correct limit when grouping list/kanban

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -294,6 +294,10 @@ export class RelationalModel extends Model {
         if (!config.isMonoRecord && this.root) {
             // always reset the offset to 0 when reloading from above
             config.offset = 0;
+            if (!!config.groupBy.length !== !!currentGroupBy.length) {
+                // from grouped to ungrouped or the other way around -> force the limit to be reset
+                delete config.limit;
+            }
         }
 
         return config;


### PR DESCRIPTION
Be in an ungrouped list or kanban view. The "limit" number of records is displayed (by default 80). Apply a group by. The same limit is applied for the number of groups, whereas there's a specific parameter ("groups_limit") for the number of groups to fetch and display. The same problem occurs the other way around (going from grouped to ungrouped), as in this case the groups_limit is kept when the view is no longer grouped.

This commit fixes the issue by forcing a reset of the limit when we go from grouped to ungrouped and from ungrouped to grouped.

We also add a test to ensure that the "groups_limit" is taken into account even when there're multiple groupbys, which wasn't the case in previous versions, but which is working as expected with the new model.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
