### PR TITLE
[FIX] mail: fix record deletion crash

### DIFF
--- a/addons/mail/static/src/core/common/record.js
+++ b/addons/mail/static/src/core/common/record.js
@@ -105,7 +105,7 @@ export class Record {
     Model;
 
     delete() {
-        delete this.Model.records[this.localId];
+        delete this.Model?.records[this.localId];
         this.Model = null;
     }
 


### PR DESCRIPTION
Before this commit, calling `record.delete` twice would result in a crash. This is due to `this.Model`being cleared once the delete is done. This commit skips the deletion if it was already done: calling delete will result in the desired state anyway.

This can be easily reproduced:
- Throttle your network
- Send a message on the discuss app
- A crash occurs