### PR TITLE
[FIX] loyalty: invalid program field when specifying rules/rewards on new programs

### DIFF
--- a/addons/loyalty/views/loyalty_reward_views.xml
+++ b/addons/loyalty/views/loyalty_reward_views.xml
@@ -67,7 +67,7 @@
         <field name="model">loyalty.reward</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="program_id"/>
+                <field name="program_id" invisible="1"/>
                 <field name="company_id"/>
                 <field name="currency_id"/>
                 <field name="description"/>

--- a/addons/loyalty/views/loyalty_rule_views.xml
+++ b/addons/loyalty/views/loyalty_rule_views.xml
@@ -51,7 +51,7 @@
         <field name="model">loyalty.rule</field>
         <field name="arch" type="xml">
             <kanban>
-                <field name="program_id"/>
+                <field name="program_id" invisible="1"/>
                 <field name="company_id"/>
                 <field name="currency_id"/>
                 <field name="product_domain"/>


### PR DESCRIPTION
Before this PR, users encountered an issue when attempting to add rules
to Discount and Loyalty programs. An undesired validation message would surface,
preventing them from saving their changes.

In this PR, the extraneous validation has been eliminated, enabling users to
successfully save and update their existing rules and rewards.

Task-3487478
