### PR TITLE
[IMP] mail: simplify link preview payload

### DIFF
--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -90,7 +90,7 @@ class LinkPreview(models.Model):
     def _link_preview_format(self):
         return [{
             'id': preview.id,
-            'message': {'id': preview.message_id.id},
+            'message_id': preview.message_id.id,
             'image_mimetype': preview.image_mimetype,
             'og_description': preview.og_description,
             'og_image': preview.og_image,

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -9,7 +9,7 @@ export class LinkPreview extends Record {
      * @returns {LinkPreview}
      */
     static insert(data) {
-        const message = this.store.Message.get(data.message.id);
+        const message = this.store.Message.get(data.message_id);
         let linkPreview = message?.linkPreviews.find((lp) => lp.id === data.id);
         if (linkPreview) {
             return Object.assign(linkPreview, data);
@@ -22,8 +22,8 @@ export class LinkPreview extends Record {
 
     /** @type {number} */
     id;
-    /** @type {Object} */
-    message;
+    /** @type {number} */
+    message_id;
     /** @type {string} */
     image_mimetype;
     /** @type {string} */

--- a/addons/mail/static/src/core/common/record.js
+++ b/addons/mail/static/src/core/common/record.js
@@ -105,7 +105,7 @@ export class Record {
     Model;
 
     delete() {
-        delete this.Model.records[this.localId];
+        delete this.Model?.records[this.localId];
         this.Model = null;
     }
 

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
@@ -13,7 +13,7 @@ patch(MockServer.prototype, {
     _mockMailLinkPreviewFormat(linkPreview) {
         return {
             id: linkPreview.id,
-            message: { id: linkPreview.message_id[0] },
+            message_id: linkPreview.message_id[0],
             image_mimetype: linkPreview.image_mimetype,
             og_description: linkPreview.og_description,
             og_image: linkPreview.og_image,

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -108,7 +108,7 @@ class TestLinkPreview(MailCommon):
                     'payload': {
                         'LinkPreview': [{
                             'id': link_preview.id,
-                            'message': {'id': message.id},
+                            'message_id': message.id,
                             'image_mimetype': False,
                             'og_description': self.og_description,
                             'og_image': self.og_image,


### PR DESCRIPTION
Before this PR the link preview formatter was creating an unnecessary complex object in the message key.
This PR simplify the payload by using a message_id key and remove the unnecessary object.
