### PR TITLE
 [IMP] mail: allow deletion of all the link preview at once

### DIFF
--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -23,9 +23,9 @@ class LinkPreviewController(http.Controller):
 
     @http.route("/mail/link_preview/delete", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
-    def mail_link_preview_delete(self, link_preview_id):
+    def mail_link_preview_delete(self, link_preview_ids):
         guest = request.env["mail.guest"]._get_guest_from_context()
-        link_preview_sudo = guest.env["mail.link.preview"].sudo().search([("id", "=", int(link_preview_id))])
+        link_preview_sudo = guest.env["mail.link.preview"].sudo().search([("id", "in", link_preview_ids)])
         if not link_preview_sudo:
             return
         if not link_preview_sudo.message_id.is_current_user_or_guest_author and not guest.env.user._is_admin():

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.js
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.js
@@ -1,6 +1,6 @@
 /* @odoo-module */
 
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
@@ -19,13 +19,27 @@ export class LinkPreviewConfirmDelete extends Component {
 
     setup() {
         this.rpc = useService("rpc");
+        this.store = useState(useService("mail.store"));
+    }
+
+    get message() {
+        return this.store.Message.get(this.props.linkPreview.message_id);
     }
 
     onClickOk() {
         this.rpc(
             "/mail/link_preview/delete",
-            { link_preview_id: this.props.linkPreview.id },
-            { shadow: true }
+            { link_preview_ids: [this.props.linkPreview.id] },
+            { silent: true }
+        );
+        this.props.close();
+    }
+
+    onClickDeleteAll() {
+        this.rpc(
+            "/mail/link_preview/delete",
+            { link_preview_ids: this.message.linkPreviews.map((lp) => lp.id) },
+            { silent: true }
         );
         this.props.close();
     }

--- a/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
+++ b/addons/mail/static/src/core/common/link_preview_confirm_delete.xml
@@ -5,7 +5,8 @@
             <p class="mx-3 mb-3">Do you really want to delete this preview?</p>
             <t t-component="props.LinkPreview" linkPreview="props.linkPreview" deletable="false"/>
             <t t-set-slot="footer">
-                <button class="btn btn-primary me-2" t-on-click="onClickOk">Ok</button>
+                <button class="btn btn-danger me-2" t-on-click="onClickOk">Delete</button>
+                <button t-if="message.linkPreviews.length > 1" class="btn btn-outline-danger me-2" t-on-click="onClickDeleteAll">Delete all previews</button>
                 <button class="btn btn-secondary me-2" t-on-click="onClickCancel">Cancel</button>
             </t>
         </Dialog>

--- a/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
+++ b/addons/mail/static/tests/helpers/mock_server/controllers/discuss.js
@@ -73,17 +73,19 @@ patch(MockServer.prototype, {
             return this._mockRouteMailLinkPreview(args.message_id, args.clear);
         }
         if (route === "/mail/link_preview/delete") {
-            const [linkPreview] = this.pyEnv["mail.link.preview"].searchRead([
-                ["id", "=", args.link_preview_id],
+            const linkPreviews = this.pyEnv["mail.link.preview"].searchRead([
+                ["id", "in", args.link_preview_ids],
             ]);
-            this.pyEnv["bus.bus"]._sendone(
-                this._mockMailMessage__busNotificationTarget(linkPreview.message_id[0]),
-                "mail.link.preview/delete",
-                {
-                    id: linkPreview.id,
-                    message_id: linkPreview.message_id[0],
-                }
-            );
+            for (const linkPreview of linkPreviews) {
+                this.pyEnv["bus.bus"]._sendone(
+                    this._mockMailMessage__busNotificationTarget(linkPreview.message_id[0]),
+                    "mail.link.preview/delete",
+                    {
+                        id: linkPreview.id,
+                        message_id: linkPreview.message_id[0],
+                    }
+                );
+            }
             return args;
         }
         if (route === "/mail/load_message_failures") {
@@ -287,11 +289,11 @@ patch(MockServer.prototype, {
                     ["message_id", "=", message_id],
                 ]);
                 this.pyEnv["bus.bus"]._sendone(
-                    this._mockMailMessage__busNotificationTarget(linkPreview.message_id[0]),
+                    this._mockMailMessage__busNotificationTarget(linkPreview.message_id),
                     "mail.link.preview/delete",
                     {
                         id: linkPreview.id,
-                        message_id: linkPreview.message_id[0],
+                        message_id: linkPreview.message_id,
                     }
                 );
             }

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_link_preview.js
@@ -13,7 +13,7 @@ patch(MockServer.prototype, {
     _mockMailLinkPreviewFormat(linkPreview) {
         return {
             id: linkPreview.id,
-            message_id: linkPreview.message_id[0],
+            message_id: linkPreview.message_id[0] || linkPreview.message_id,
             image_mimetype: linkPreview.image_mimetype,
             og_description: linkPreview.og_description,
             og_image: linkPreview.og_image,

--- a/addons/mail/static/tests/message/link_preview_test.js
+++ b/addons/mail/static/tests/message/link_preview_test.js
@@ -165,7 +165,7 @@ QUnit.test("Remove link preview Gif", async () => {
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
-    await click(".modal-footer button", { text: "Ok" });
+    await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });
 
@@ -189,7 +189,7 @@ QUnit.test("Remove link preview card", async () => {
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewCard button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
-    await click(".modal-footer button", { text: "Ok" });
+    await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewCard", { count: 0 });
 });
 
@@ -214,7 +214,7 @@ QUnit.test("Remove link preview video", async () => {
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewVideo button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
-    await click(".modal-footer button", { text: "Ok" });
+    await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewVideo", { count: 0 });
 });
 
@@ -237,7 +237,7 @@ QUnit.test("Remove link preview image", async () => {
     openDiscuss(channelId);
     await click(".o-mail-LinkPreviewImage button[aria-label='Remove']");
     await contains("p", { text: "Do you really want to delete this preview?" });
-    await click(".modal-footer button", { text: "Ok" });
+    await click(".modal-footer button", { text: "Delete" });
     await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });
 
@@ -260,7 +260,7 @@ QUnit.test("No crash on receiving link preview of non-known message", async (ass
     openDiscuss();
     env.services.rpc("/mail/link_preview", { message_id: messageId });
     assert.ok(true);
-    env.services.rpc("/mail/link_preview/delete", { link_preview_id: linkPreviewId });
+    env.services.rpc("/mail/link_preview/delete", { link_preview_ids: [linkPreviewId] });
     assert.ok(true);
 });
 
@@ -343,4 +343,35 @@ QUnit.test("Sending message with link preview URL should show a link preview car
     await insertText(".o-mail-Composer-input", "https://make-link-preview.com");
     await click("button:not([disabled])", { text: "Send" });
     await contains(".o-mail-LinkPreviewCard");
+});
+
+QUnit.test("Delete all link previews at once", async () => {
+    const pyEnv = await startServer();
+    const linkPreviewIds = pyEnv["mail.link.preview"].create([
+        {
+            og_description: "Description",
+            og_title: "Article title 1",
+            og_type: "article",
+            source_url: "https://www.odoo.com",
+        },
+        {
+            image_mimetype: "image/jpg",
+            source_url:
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Siberischer_tiger_de_edit02.jpg/290px-Siberischer_tiger_de_edit02.jpg",
+        },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({ name: "wololo" });
+    pyEnv["mail.message"].create({
+        body: "not empty",
+        link_preview_ids: linkPreviewIds,
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await click(".o-mail-LinkPreviewCard button[aria-label='Remove']");
+    await click(".modal-footer button", { text: "Delete all previews" });
+    await contains(".o-mail-LinkPreviewCard", { count: 0 });
+    await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });


### PR DESCRIPTION
Before this commit, when a message had many link previews,
deleting all of them required to delete one by one.

This commit improves this aspect by showing a "Delete All"
button in the dialog to delete all link previews at once.

task-3488054