### PR TITLE
[FIX] sale: avoid displaying address

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -303,11 +303,11 @@
                                placeholder="Type to find a customer..." readonly="state in ['cancel', 'sale']"/>
                         <field name="partner_invoice_id"
                               groups="account.group_delivery_invoice_address"
-                              context="{'default_type':'invoice'}"
+                              context="{'default_type':'invoice', 'show_address': False, 'show_vat': False}"
                               readonly="state == 'cancel' or locked"/>
                         <field name="partner_shipping_id"
                               groups="account.group_delivery_invoice_address"
-                              context="{'default_type':'delivery'}"
+                              context="{'default_type':'delivery', 'show_address': False, 'show_vat': False}"
                               readonly="state == 'cancel' or locked"/>
                     </group>
                     <group name="order_details">


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/122085, on the sale order form (with website_sale installed), changing the "Customer" changes the "Invoice Address" & "Delivery Address". But the latter are displayed with the partner name, but also with the full partner address. This last information makes the form uglier than before and are useless.

![image](https://github.com/odoo/odoo/assets/53175387/7ca27bdd-f09d-4d10-9228-c97b0d14613e)

The old `display_name` of `res.partner` was stored in the DB and did not depend on the context. Also, onchange calls add the context of the source field (the one being changed). In this case, `'show_address': 1` is added, and then `display_name` of `partner_invoice_id`/`partner_shipping_id` is also read with this context.

We cannot easily fix this in saas16-4 because it was not possible to change the read context of a particular field. With the new specification of onchange, we can override the read context on a particular field.
