### PR TITLE
[IMP] point_of_sale: change skip line color

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/orderline/orderline.js
@@ -38,7 +38,7 @@ export class Orderline extends Component {
             selected: this.props.line.selected,
             "has-change ps-2 text-success border-start border-success border-4":
                 this.props.line.hasChange && this.pos.config.module_pos_restaurant,
-            "skip-change ps-2 text-secondary border-start border-secondary border-4":
+            "skip-change ps-2 border-start border-secondary border-4":
                 this.props.line.skipChange && this.pos.config.module_pos_restaurant,
         };
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/orderline/orderline.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/orderline/orderline.scss
@@ -7,4 +7,9 @@
     &.selected {
         background-color: $o-component-active-bg;
     }
+
+    &.skip-change {
+        color: #7F82AC;
+        border-color: #7F82AC !important;
+    }
 }


### PR DESCRIPTION
Previously before the bootstrap refactoring the skip line color was `#7F82AC` which is a dark purple. After the refactoring the color was changed to `text-secondary` color which is a light gray.

This commit changes the color to `#7F82AC` again to keep the same behavior as before the refactoring.

Before:
![image](https://github.com/odoo/odoo/assets/63289800/5cc37076-1dc8-4095-9425-df69487cf7b0)

After:
![image](https://github.com/odoo/odoo/assets/63289800/f94e9500-1d28-4d72-be8a-068b82e550da)
