### PR TITLE
[IMP] account: Improve date algorithm.

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4217,7 +4217,13 @@ class AccountMove(models.Model):
                 if today.year > invoice_date.year:
                     return date(invoice_date.year, 12, 31)
                 else:
-                    return max(invoice_date, today)
+                    end_of_month = date_utils.end_of(invoice_date, 'month')
+                    date_to_return = min(end_of_month, today)
+                    rec = self.env['account.move'].search_fetch([('name', '=', highest_name)], ['date'], limit=1)
+                    if not rec:
+                        return date_to_return
+                    latest_invoice_date = rec.date
+                    return max(date_to_return, latest_invoice_date)
         return invoice_date
 
     def _get_violated_lock_dates(self, invoice_date, has_tax):


### PR DESCRIPTION
Problem
---------
The purpose of this task is refine a little the bill dates algorithm in some specific cases that escaped our attention.
Suppose the following setup :

- Lock date on June 30th 2021
- Annual Sequence on the Purchase Journal.
- Last posted invoice is in July !!
- Today is September 20th 2021
- 3 invoices to post :  
> - Vendor Bill A has Invoice date on July 7th 2021 
> - Vendor Bill B has invoice date on August 8th 2021 
> - Vendor Bill C has invoice date on September 9th 2021

All gets posted on 09/20/2021, no matter in which order user posts A, B and C.

Objective
---------
We want the following behavior.

A : 07/31/2021 / B : 08/31/2021 / C : 09/09/2021
A : 07/31/2021 / C : 09/09/2021 / B : 09/09/2021
B:  08/31/2021 / A : 08/31/2021 / C : 09/09/2021
B:  08/31/2021 / C : 09/09/2021 / A : 09/09/2021
C:  09/09/2021 / A : 09/09/2021 / B : 09/09/2021
C:  09/09/2021 / B : 09/09/2021 / A : 09/09/2021

Solution
---------
When computing accounting date:
- if there is a published bill in the journal, and that the latest move in that journal's accounting date is after the bill date of the bill currently being modified:
    - set the current bill's accounting date to the one of the previous
    move's accounting date.
- In any other case, set the bill's accounting date to: - the last day of the month, if the bill date is set a past month; - today otherwise.

task-2843106
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
