### PR TITLE
[FIX] sale: fix expected singelton in _compute_amount_to_invoice

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -600,7 +600,10 @@ class SaleOrder(models.Model):
         for order in self:
             order.amount_to_invoice = order.amount_total
             for invoice in order.invoice_ids.filtered(lambda x: x.state == 'posted'):
-                prices = sum(invoice.line_ids.filtered(lambda x: order in x.sale_line_ids.order_id).mapped('price_total'))
+                prices = sum(invoice.line_ids.filtered(
+                    lambda x: x.sale_line_ids.order_id.filtered(
+                        lambda y : y.id == order.id)
+                    ).mapped('price_total'))
                 invoice_amount_currency = invoice.currency_id._convert(
                     prices * -invoice.direction_sign,
                     order.currency_id,


### PR DESCRIPTION
### Issue:

A recent bugfix PR https://github.com/odoo/odoo/pull/131446 changed the compute behavior of the `_compute_amount_to_invoice` method. By doing so it inadvertently introduced a blocking issue for pre-16 databases migrated. Old subscriptions can't generate invoices (CRON or manual)

### Cause:

During the migration, records from the old `sale.subscrption` got recast into sales order records (`sale.order`) with the `recurrence_id` set. In practice, after the migration the original pre-16 SO that generated the original `sale.subscrption` records will now coexist with it's twin named in a local manner based on it's recurrence period. Example:
S00001 [original SO] and Annual-01 [recast SO having the relevant data for the subscription part of S00001]

In doing so, old posted invoices from S00001 will have their respective `account.move.line` records modified ad-hoc and set the `sale_line_ids` field to point now to the `sale.order.line` records of S00001 AND Annual-01. [in a invoice this resolves to `account.move.invoice_line_ids` > `account.move.line.sale_lines_ids` > `sale.order.line`] This keeps the tracebility and linkage between the newly migrated subscriptions.

In this context calling
`invoice.line_ids.filtered(lambda x: x.sale_line_ids.order_id.id == order.id)` will produce a `ValueError: Expected singleton: sale.order(ID1,ID2)` in `odoo/odoo/fields.py`.
Since multiple sales orders are linked, a recordset > 1 will be returned from the filtered method, which the ORM does not expect in this context.

### Steps to reproduce:

1) Create one Quote/SO with recurrence set
2) Follow workflow until you generate first invoice (let's call it "A" , state = posted) 3) Duplicate original quote (so same customer and products, but different sales.order.lines) 4) Confirm Quote but don't generate invoice (yet)
5) For the invoice "A" manually link the invoice lines to the equivalent sales.order.line from the 2nd quote
You need to use direct SQL queries
Example
```
INSERT INTO sale_order_line_invoice_rel
VALUES (ACCOUNT_MOVE_LINE_ID,SALE_ORDER_LINE_ID);
```

6) Try to generate an invoice for second quote

OPW-3486614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
