### PR TITLE
[PERF] project: add an index on `create_date`

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -139,7 +139,7 @@ class Task(models.Model):
         ('04_waiting_normal', 'Waiting'),
     ], string='State', copy=False, default='01_in_progress', required=True, compute='_compute_state', inverse='_inverse_state', readonly=False, store=True, index=True, recursive=True, tracking=True)
 
-    create_date = fields.Datetime("Created On", readonly=True)
+    create_date = fields.Datetime("Created On", readonly=True, index=True)
     write_date = fields.Datetime("Last Updated On", readonly=True)
     date_end = fields.Datetime(string='Ending Date', index=True, copy=False)
     date_assign = fields.Datetime(string='Assigning Date', copy=False, readonly=True,


### PR DESCRIPTION
## Description
In eedf37d6e286b995c47b946be1a6b66817094eff the index on `create_date` was removed, but it was still left on our production database. After recent analysis on the usage of the index over the span of 2 months (start July 2023 -> end of August 2023), this index was hit over *100M* times. It's heavily used in custom filters when grouping by `create_date`. So the goal of this PR is to add it back in standard code.

## Reference
task-3263544

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
