### PR TITLE
[FIX] mail: properly type static methods of discuss models

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -10,7 +10,14 @@ export class Attachment extends Record {
     static id = "id";
     /** @type {Object.<number, Attachment>} */
     static records = {};
-
+    /** @returns {Attachment} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Attachment} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {Attachment}

--- a/addons/mail/static/src/core/common/canned_response_model.js
+++ b/addons/mail/static/src/core/common/canned_response_model.js
@@ -6,6 +6,14 @@ export class CannedResponse extends Record {
     static id = "id";
     /** @type {Object.<number, CannedResponse>} */
     static records = {};
+    /** @returns {CannedResponse} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {CannedResponse} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {CannedResponse}

--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -13,6 +13,14 @@ export class ChannelMember extends Record {
     static id = "id";
     /** @type {Object.<number, ChannelMember>} */
     static records = {};
+    /** @returns {ChannelMember} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {ChannelMember} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object|Array} data
      * @returns {ChannelMember}

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -11,6 +11,14 @@ export class ChatWindow extends Record {
     static id = "threadLocalId";
     /** @type {ChatWindow[]} */
     static records = [];
+    /** @returns {ChatWindow} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {ChatWindow} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {ChatWindowData} [data]
      * @returns {ChatWindow}

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -8,6 +8,14 @@ import { OR, Record } from "@mail/core/common/record";
 
 export class Composer extends Record {
     static id = OR("threadLocalId", "messageLocalId");
+    /** @returns {Composer} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Composer} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {Composer}

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -14,6 +14,14 @@ export class Follower extends Record {
     static id = "id";
     /** @type {Object.<number, Follower>} */
     static records = {};
+    /** @returns {Follower} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Follower} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Data} data
      * @returns {Follower}

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -4,6 +4,14 @@ import { Record } from "@mail/core/common/record";
 
 export class LinkPreview extends Record {
     static id = "id";
+    /** @returns {LinkPreview} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {LinkPreview} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {LinkPreview}

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -16,6 +16,14 @@ export class Message extends Record {
     static id = "id";
     /** @type {Object.<number, Message>} */
     static records = {};
+    /** @returns {Message} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Message} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {Message}

--- a/addons/mail/static/src/core/common/message_reactions_model.js
+++ b/addons/mail/static/src/core/common/message_reactions_model.js
@@ -4,6 +4,14 @@ import { AND, Record } from "@mail/core/common/record";
 
 export class MessageReactions extends Record {
     static id = AND("messageId", "content");
+    /** @returns {MessageReactions} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {MessageReactions} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {MessageReactions}

--- a/addons/mail/static/src/core/common/notification_group_model.js
+++ b/addons/mail/static/src/core/common/notification_group_model.js
@@ -10,6 +10,14 @@ export class NotificationGroup extends Record {
     static id = "id";
     /** @type {NotificationGroup[]} */
     static records = [];
+    /** @returns {NotificationGroup} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {NotificationGroup} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {NotificationGroup}

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -8,6 +8,14 @@ export class Notification extends Record {
     static id = "id";
     /** @type {Object.<number, Notification>} */
     static records = {};
+    /** @returns {Notification} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Notification} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {Notification}

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -16,6 +16,14 @@ export class Persona extends Record {
     static id = AND("type", "id");
     /** @type {Object.<number, Persona>} */
     static records = {};
+    /** @returns {Persona} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Persona} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Data} data
      * @returns {Persona}

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -25,6 +25,14 @@ export class Thread extends Record {
     static id = AND("model", "id");
     /** @type {Object.<string, Thread>} */
     static records = {};
+    /** @returns {Thread} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Thread} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Thread.localId} localId
      * @returns {string}

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -37,7 +37,14 @@ export class Activity extends Record {
     static id = "id";
     /** @type {Object.<number, Activity>} */
     static records = {};
-
+    /** @returns {Activity} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {Activity} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Data} data
      * @param {Object} [param1]

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -6,6 +6,14 @@ export class RtcSession extends Record {
     static id = "id";
     /** @type {Object.<number, RtcSession>} */
     static records = {};
+    /** @returns {RtcSession} */
+    static new(data) {
+        return super.new(data);
+    }
+    /** @returns {RtcSession} */
+    static get(data) {
+        return super.get(data);
+    }
     /**
      * @param {Object} data
      * @returns {number, RtcSession}


### PR DESCRIPTION
Before this commit, static methods on discuss models like `.get()` or `.new()` where not properly documented.

The superclass `Record` documents `@returns`, but jsdoc failed to deduce these static methods return subclass instances. We tried to find a way to define things once in `Record` and let typedoc deduce things automatically without overriding in each models just for the sake of type. However typedoc still sucks in 2023 despite requests for improvements to support this specific case since 2016, 7 years ago.
