### PR TITLE
[REF] web, *: change name noReload to reload

### DIFF
--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -47,7 +47,7 @@ class PeppolSettingsButtons extends Component {
     }
 
     async _save () {
-        this.env.model.root.save({ noReload: true });
+        this.env.model.root.save({ reload: false });
     }
 
     showConfirmation(warning, methodName) {

--- a/addons/account_peppol/static/src/components/verification_code_widget/verification_code_widget.js
+++ b/addons/account_peppol/static/src/components/verification_code_widget/verification_code_widget.js
@@ -62,7 +62,7 @@ class VerificationCodeWidget extends Component {
     _save() {
         let verificationCode = [...this.inputs.map((i) => i.el.value)].join('');
         this.props.record.update({ account_peppol_verification_code: verificationCode });
-        this.env.model.root.save({ noReload: true });
+        this.env.model.root.save({ reload: false });
     }
 }
 

--- a/addons/auth_totp/wizard/auth_totp_wizard_views.xml
+++ b/addons/auth_totp/wizard/auth_totp_wizard_views.xml
@@ -40,7 +40,7 @@
 
                             <!-- Desktop version -->
                             <div class="text-center d-none d-md-block">
-                                <field name="qrcode" readonly="True" widget="image" options="{'no_reload': true }"/>
+                                <field name="qrcode" readonly="True" widget="image" options="{'reload': false }"/>
 
                                 <h3 class="fw-bold"><a data-bs-toggle="collapse"
                                    href="#collapseTotpSecret" role="button" aria-expanded="false"

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -217,7 +217,7 @@ export class DynamicGroupList extends DynamicList {
                 orderBy: this.orderBy,
             },
         };
-        this.model._updateConfig(this.config, { groups: nextConfigGroups }, { noReload: true });
+        this.model._updateConfig(this.config, { groups: nextConfigGroups }, { reload: false });
 
         const data = {
             count: 0,

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -77,7 +77,7 @@ export class DynamicList extends DataPoint {
         }
         const canProceed = await this.leaveEditMode();
         if (canProceed) {
-            this.model._updateConfig(record.config, { mode: "edit" }, { noReload: true });
+            this.model._updateConfig(record.config, { mode: "edit" }, { reload: false });
         }
         return canProceed;
     }
@@ -129,7 +129,7 @@ export class DynamicList extends DataPoint {
                 this.model._updateConfig(
                     this.editedRecord.config,
                     { mode: "readonly" },
-                    { noReload: true }
+                    { reload: false }
                 );
             } else {
                 return canProceed;
@@ -249,7 +249,7 @@ export class DynamicList extends DataPoint {
                 await this.model.orm.write(this.resModel, resIds, changes, { context });
             } catch (e) {
                 record._discard();
-                this.model._updateConfig(record.config, { mode: "readonly" }, { noReload: true });
+                this.model._updateConfig(record.config, { mode: "readonly" }, { reload: false });
                 throw e;
             }
             const records = await this.model._loadRecords({ ...this.config, resIds });
@@ -259,7 +259,7 @@ export class DynamicList extends DataPoint {
                 this.model._updateSimilarRecords(record, serverValues);
             }
             record._discard();
-            this.model._updateConfig(record.config, { mode: "readonly" }, { noReload: true });
+            this.model._updateConfig(record.config, { mode: "readonly" }, { reload: false });
         }
         this.model.hooks.onSavedMulti(validSelection);
         return true;

--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -80,7 +80,7 @@ export class Group extends DataPoint {
         } else {
             await this.list.load({ domain: this.config.initialDomain });
         }
-        this.model._updateConfig(this.config, { extraDomain: filter }, { noReload: true });
+        this.model._updateConfig(this.config, { extraDomain: filter }, { reload: false });
     }
 
     deleteRecords(records) {
@@ -94,7 +94,7 @@ export class Group extends DataPoint {
         this.model._updateConfig(
             this.config,
             { isFolded: !this.config.isFolded },
-            { noReload: true }
+            { reload: false }
         );
     }
 

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -170,7 +170,7 @@ export class Record extends DataPoint {
             if (resId) {
                 await this.model.load({ resId, resIds });
             } else {
-                this.model._updateConfig(this.config, { resId: false }, { noReload: true });
+                this.model._updateConfig(this.config, { resId: false }, { reload: false });
                 this.dirty = false;
                 this._changes = this._parseServerValues(this._getDefaultValues());
                 this._values = markRaw({});
@@ -261,7 +261,7 @@ export class Record extends DataPoint {
     urgentSave() {
         this.model._urgentSave = true;
         this.model.bus.trigger("WILL_SAVE_URGENTLY");
-        this._save({ noReload: true });
+        this._save({ reload: false });
         return this.isValid;
     }
 
@@ -821,14 +821,14 @@ export class Record extends DataPoint {
             {
                 activeFields: { ...this._activeFieldsToRestore },
             },
-            { noReload: true }
+            { reload: false }
         );
         this._activeFieldsToRestore = undefined;
     }
 
-    async _save({ noReload, onError, nextId } = {}) {
+    async _save({ reload = true, onError, nextId } = {}) {
         if (nextId) {
-            noReload = false;
+            reload = true;
         }
         // before saving, abandon new invalid, untouched records in x2manys
         for (const fieldName in this.activeFields) {
@@ -851,7 +851,7 @@ export class Record extends DataPoint {
             return false;
         }
         let fieldSpec = {};
-        if (!noReload) {
+        if (reload) {
             fieldSpec = getFieldsSpec(
                 this.activeFields,
                 this.fields,
@@ -883,9 +883,9 @@ export class Record extends DataPoint {
         if ((creation || nextId) && records.length) {
             const resId = records[0].id;
             const resIds = resId in this.resIds ? this.resIds : this.resIds.concat([resId]);
-            this.model._updateConfig(this.config, { resId, resIds }, { noReload: true });
+            this.model._updateConfig(this.config, { resId, resIds }, { reload: false });
         }
-        if (!noReload) {
+        if (reload) {
             if (!records.length) {
                 throw new FetchRecordError(records.map((r) => r.id));
             }
@@ -946,7 +946,7 @@ export class Record extends DataPoint {
     }
 
     _switchMode(mode) {
-        this.model._updateConfig(this.config, { mode }, { noReload: true });
+        this.model._updateConfig(this.config, { mode }, { reload: false });
         if (mode === "readonly") {
             this._invalidFields.clear();
         }

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -600,21 +600,21 @@ export class RelationalModel extends Model {
      * @param {Config} config
      * @param {Partial<Config>} patch
      * @param {Object} [options]
-     * @param {boolean} [options.noReload=false]
+     * @param {boolean} [options.reload=true]
      * @param {Function} [options.commit] Function to call once the data has been loaded
      */
-    async _updateConfig(config, patch, options = {}) {
+    async _updateConfig(config, patch, { reload = true, commit } = {}) {
         const tmpConfig = { ...config, ...patch };
         markRaw(tmpConfig.activeFields);
         markRaw(tmpConfig.fields);
 
         let data;
-        if (!options.noReload) {
+        if (reload) {
             data = await this._loadData(tmpConfig);
         }
         Object.assign(config, tmpConfig);
-        if (data && options.commit) {
-            options.commit(data);
+        if (data && commit) {
+            commit(data);
         }
     }
 

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -227,7 +227,7 @@ export class StaticList extends DataPoint {
                 if (this._extendedRecords.has(record.id)) {
                     // case 1.1: the record has already been extended
                     // -> simply store a savepoint
-                    this.model._updateConfig(record.config, config, { noReload: true });
+                    this.model._updateConfig(record.config, config, { reload: false });
                     record._addSavePoint();
                     return record;
                 }
@@ -247,7 +247,7 @@ export class StaticList extends DataPoint {
                     const resIds = [record.resId];
                     [data] = await this.model._loadRecords({ ...config, resIds }, evalContext);
                 }
-                this.model._updateConfig(record.config, config, { noReload: true });
+                this.model._updateConfig(record.config, config, { reload: false });
                 record._applyDefaultValues();
                 for (const fieldName in record.activeFields) {
                     if (["one2many", "many2many"].includes(record.fields[fieldName].type)) {
@@ -258,10 +258,10 @@ export class StaticList extends DataPoint {
                         };
                         for (const subRecord of Object.values(list._cache)) {
                             this.model._updateConfig(subRecord.config, patch, {
-                                noReload: true,
+                                reload: false,
                             });
                         }
-                        this.model._updateConfig(list.config, patch, { noReload: true });
+                        this.model._updateConfig(list.config, patch, { reload: false });
                     }
                 }
                 record._applyValues(data);
@@ -409,7 +409,7 @@ export class StaticList extends DataPoint {
                     this.model._updateConfig(
                         this.config,
                         { limit: this.limit - 1 },
-                        { noReload: true }
+                        { reload: false }
                     );
                     this._tmpIncreaseLimit--;
                 }
@@ -432,7 +432,7 @@ export class StaticList extends DataPoint {
             if (this.records.length > this.limit) {
                 this._tmpIncreaseLimit++;
                 const nextLimit = this.limit + 1;
-                this.model._updateConfig(this.config, { limit: nextLimit }, { noReload: true });
+                this.model._updateConfig(this.config, { limit: nextLimit }, { reload: false });
             }
             this._commands.push(command);
         } else {
@@ -736,7 +736,7 @@ export class StaticList extends DataPoint {
         this._unknownRecordCommands = [];
         const limit = this.limit - this._tmpIncreaseLimit;
         this._tmpIncreaseLimit = 0;
-        this.model._updateConfig(this.config, { limit }, { noReload: true });
+        this.model._updateConfig(this.config, { limit }, { reload: false });
         this.records = this._currentIds
             .slice(this.offset, this.limit)
             .map((resId) => this._cache[resId]);
@@ -806,7 +806,7 @@ export class StaticList extends DataPoint {
         }
         this.records = currentIds.map((id) => this._cache[id]);
         this._currentIds = nextCurrentIds;
-        await this.model._updateConfig(this.config, { limit, offset, orderBy }, { noReload: true });
+        await this.model._updateConfig(this.config, { limit, offset, orderBy }, { reload: false });
     }
 
     async _replaceWith(ids, { reload = false } = {}) {

--- a/addons/web/static/src/views/fields/image/image_field.js
+++ b/addons/web/static/src/views/fields/image/image_field.js
@@ -49,10 +49,11 @@ export class ImageField extends Component {
         acceptedFileExtensions: { type: String, optional: true },
         width: { type: Number, optional: true },
         height: { type: Number, optional: true },
-        noReload: { type: Boolean, optional: true },
+        reload: { type: Boolean, optional: true },
     };
     static defaultProps = {
         acceptedFileExtensions: "image/*",
+        reload: true,
     };
 
     setup() {
@@ -98,7 +99,7 @@ export class ImageField extends Component {
     }
 
     getUrl(previewFieldName) {
-        if (this.props.noReload && this.lastURL) {
+        if (!this.props.reload && this.lastURL) {
             return this.lastURL;
         }
         if (this.state.isValid && this.props.record.data[this.props.name]) {
@@ -241,7 +242,7 @@ export const imageField = {
         acceptedFileExtensions: options.accepted_file_extensions,
         width: options.size && Boolean(options.size[0]) ? options.size[0] : attrs.width,
         height: options.size && Boolean(options.size[1]) ? options.size[1] : attrs.height,
-        noReload: Boolean(options.no_reload),
+        reload: "reload" in options ? Boolean(options.reload) : true,
     }),
 };
 

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -74,7 +74,7 @@ export class Many2ManyTagsAvatarFieldPopover extends Many2ManyTagsAvatarField {
     }
 
     async _saveUpdate() {
-        await this.props.record.save({ noReload: true });
+        await this.props.record.save({ reload: false });
         // manual render to dirty record
         this.render();
         // update dropdown

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -331,7 +331,7 @@ export class FormController extends Component {
     async beforeLeave() {
         if (this.model.root.dirty) {
             return this.model.root.save({
-                noReload: true,
+                reload: false,
                 onError: this.onSaveError.bind(this),
             });
         }
@@ -479,7 +479,7 @@ export class FormController extends Component {
             if (clickParams.special === "save" && this.props.saveRecord) {
                 saved = await this.props.saveRecord(record, clickParams);
             } else {
-                const params = { noReload: this.env.inDialog && clickParams.close };
+                const params = { reload: !(this.env.inDialog && clickParams.close) };
                 if (!this.env.inDialog) {
                     params.onError = this.onSaveError.bind(this);
                 }

--- a/addons/web/static/src/views/kanban/kanban_record_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_record_quick_create.js
@@ -157,7 +157,7 @@ class KanbanQuickCreateController extends Component {
             }
         } else {
             await this.model.root.save({
-                noReload: true,
+                reload: false,
                 onError: (e) => this.showFormDialogInError(e),
             });
             resId = this.model.root.resId;

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -35,7 +35,7 @@ export class FormViewDialog extends Component {
                 this.props.close();
             },
             saveRecord: async (record, { saveAndNew }) => {
-                const saved = await record.save({ noReload: true });
+                const saved = await record.save({ reload: false });
                 if (saved) {
                     await this.props.onRecordSaved(record);
                     if (saveAndNew) {

--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -727,7 +727,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
-        "unique in url does not change on record change if no_reload option is set",
+        "unique in url does not change on record change if reload option is set to false",
         async (assert) => {
             const rec = serverData.models.partner.records.find((rec) => rec.id === 1);
             rec.document = "3 kb";
@@ -741,7 +741,7 @@ QUnit.module("Fields", (hooks) => {
                 serverData,
                 arch: `
                     <form>
-                        <field name="document" widget="image" required="1" options="{'no_reload': true}" />
+                        <field name="document" widget="image" required="1" options="{'reload': false}" />
                         <field name="write_date" />
                     </form>`,
             });


### PR DESCRIPTION
This commit change the name of the option noReload to reload, this is to
avoid having negative variables names for boolean. This is a general
known best practice, and in this case it's important to have a better
readability of the code (specially when a negation of a negative
variable occurs).