### PR TITLE
[MOV] l10n_au: move BSB bank support

### DIFF
--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -25,6 +25,7 @@ Also:
         'views/menuitems.xml',
         'views/report_invoice.xml',
         'views/res_company_views.xml',
+        'views/res_partner_bank_views.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_au/models/__init__.py
+++ b/addons/l10n_au/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import template_au
 from . import account_move
+from . import res_partner_bank

--- a/addons/l10n_au/models/res_partner_bank.py
+++ b/addons/l10n_au/models/res_partner_bank.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartnerBank(models.Model):
+    _inherit = "res.partner.bank"
+
+    aba_bsb = fields.Char(string='BSB', help='Bank State Branch code - needed if payment is to be made using ABA files')
+
+    @api.model
+    def _get_supported_account_types(self):
+        rslt = super(ResPartnerBank, self)._get_supported_account_types()
+        rslt.append(('aba', _('ABA')))
+        return rslt
+
+    @api.constrains('aba_bsb')
+    def _validate_aba_bsb(self):
+        for record in self:
+            if record.aba_bsb:
+                test_bsb = re.sub('( |-)', '', record.aba_bsb)
+                if len(test_bsb) != 6 or not test_bsb.isdigit():
+                    raise ValidationError(_('BSB is not valid (expected format is "NNN-NNN"). Please rectify.'))
+
+    @api.depends('acc_number')
+    def _compute_acc_type(self):
+        """ Criteria to be an ABA account:
+            - Spaces, hypens, digits are valid.
+            - Total length must be 9 or less.
+            - Cannot be only spaces, zeros or hyphens (must have at least one digit in range 1-9)
+        """
+        super()._compute_acc_type()
+        for rec in self:
+            if rec.acc_type == 'bank' and re.match(r"^(?=.*[1-9])[ \-\d]{0,9}$", rec.acc_number or ''):
+                rec.acc_type = 'aba'

--- a/addons/l10n_au/views/res_partner_bank_views.xml
+++ b/addons/l10n_au/views/res_partner_bank_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_bank_form" model="ir.ui.view">
+        <field name="name">aba.res.partner.bank.form</field>
+        <field name="model">res.partner.bank</field>
+        <field name='inherit_id' ref='base.view_partner_bank_form'/>
+        <field name="arch" type="xml">
+            <field name="acc_holder_name" position='after'>
+                <field name='aba_bsb'/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
BSB definition is now moved from enterprise (l10n_au_aba) to l10n_au.

BSB is not limited to ABA bank interactions.

As such, it is useful to define this and allow validation in l10n, making it available to users who are not using ABA files.

Enterprise PR: https://github.com/odoo/enterprise/pull/46914
Upgrade PR: https://github.com/odoo/upgrade/pull/5111