### PR TITLE
[IMP] l10n_xx: Fiscal country codes XML code cleanup

### DIFF
--- a/addons/l10n_ar/views/account_fiscal_position_view.xml
+++ b/addons/l10n_ar/views/account_fiscal_position_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
             <field name="auto_apply" position="after">
-                <field name="l10n_ar_afip_responsibility_type_ids" options="{'no_open': True, 'no_create': True}" invisible="'AR'.lower() not in (fiscal_country_codes or '').lower() or not auto_apply" groups="base.group_no_one" widget="many2many_tags"/>
+                <field name="l10n_ar_afip_responsibility_type_ids" options="{'no_open': True, 'no_create': True}" invisible="'AR' not in fiscal_country_codes or not auto_apply" groups="base.group_no_one" widget="many2many_tags"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_ar/views/res_currency_view.xml
+++ b/addons/l10n_ar/views/res_currency_view.xml
@@ -7,7 +7,7 @@
         <field name="model">res.currency</field>
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="l10n_ar_afip_code" invisible="'AR'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="l10n_ar_afip_code" invisible="'AR' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_ar/views/res_partner_view.xml
+++ b/addons/l10n_ar/views/res_partner_view.xml
@@ -19,7 +19,7 @@
         <field name="arch" type="xml">
 
             <xpath expr="//page[@name='accounting']/group" position="inside">
-                <group string="Accounting Documents" name="accounting_documents" invisible="'AR'.lower() not in (fiscal_country_codes or '').lower()">
+                <group string="Accounting Documents" name="accounting_documents" invisible="'AR' not in fiscal_country_codes">
                     <field name="l10n_ar_special_purchase_document_type_ids" widget="many2many_tags"/>
                 </group>
             </xpath>

--- a/addons/l10n_ar/views/uom_uom_view.xml
+++ b/addons/l10n_ar/views/uom_uom_view.xml
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
             <field name="rounding" position="after">
-                <field name="l10n_ar_afip_code" invisible="'AR'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="l10n_ar_afip_code" invisible="'AR' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_br/views/res_partner_views.xml
+++ b/addons/l10n_br/views/res_partner_views.xml
@@ -7,9 +7,9 @@
             <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vat']" position="after">
-                    <field name="l10n_br_ie_code" invisible="'BR'.lower() not in (fiscal_country_codes or '').lower()"/>
-                    <field name="l10n_br_im_code" invisible="'BR'.lower() not in (fiscal_country_codes or '').lower()"/>
-                    <field name="l10n_br_isuf_code" invisible="'BR'.lower() not in (fiscal_country_codes or '').lower()"/>
+                    <field name="l10n_br_ie_code" invisible="'BR' not in fiscal_country_codes"/>
+                    <field name="l10n_br_im_code" invisible="'BR' not in fiscal_country_codes"/>
+                    <field name="l10n_br_isuf_code" invisible="'BR' not in fiscal_country_codes"/>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_ca/views/res_partner_view.xml
+++ b/addons/l10n_ca/views/res_partner_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vat']" position="after">
-                    <field name="l10n_ca_pst" invisible="'CA'.lower() not in (fiscal_country_codes or '').lower()"/>
+                    <field name="l10n_ca_pst" invisible="'CA' not in fiscal_country_codes"/>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_cl/views/res_partner.xml
+++ b/addons/l10n_cl/views/res_partner.xml
@@ -16,8 +16,8 @@
                 <attribute name="placeholder">Region</attribute>
             </field>
             <field name="vat" position="after">
-                <field name="l10n_cl_sii_taxpayer_type" invisible="'CL'.lower() not in (fiscal_country_codes or '').lower()" readonly="parent_id"/>
-                <field name="l10n_cl_activity_description" placeholder="Activity Description" invisible="'CL'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="l10n_cl_sii_taxpayer_type" invisible="'CL' not in fiscal_country_codes" readonly="parent_id"/>
+                <field name="l10n_cl_activity_description" placeholder="Activity Description" invisible="'CL' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_cz/views/res_partner_views.xml
+++ b/addons/l10n_cz/views/res_partner_views.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
              <xpath expr="//field[@name='company_registry']" position="replace">
-                <field name="company_registry" invisible="'CZ'.lower() in (fiscal_country_codes or '').lower()"/>
+                <field name="company_registry" invisible="'CZ' not in fiscal_country_codes"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="company_registry" invisible="'CZ'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="company_registry" invisible="'CZ' not in fiscal_country_codes"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_eg_edi_eta/views/product_template_views.xml
+++ b/addons/l10n_eg_edi_eta/views/product_template_views.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="product.product_template_only_form_view"/>
             <field name="arch" type="xml">
                 <page name="invoicing" position="inside">
-                    <group name="l10n_eg_eta_edi" string="Egyptian Electronic Invoicing" invisible="'EG'.lower() not in (fiscal_country_codes or '').lower() or product_variant_count &gt; 1">
+                    <group name="l10n_eg_eta_edi" string="Egyptian Electronic Invoicing" invisible="'EG' not in fiscal_country_codes or product_variant_count &gt; 1">
                         <field name="l10n_eg_eta_code" help="ETA Field for GS1/EGS product codes. Please use the barcode field to store GS1/EGS ETA code if possible"/>
                     </group>
                 </page>

--- a/addons/l10n_eg_edi_eta/views/uom_uom_view.xml
+++ b/addons/l10n_eg_edi_eta/views/uom_uom_view.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="uom.product_uom_form_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='uom_type']" position="after">
-                    <field name="l10n_eg_unit_code_id" invisible="'EG'.lower() not in (fiscal_country_codes or '').lower()"/>
+                    <field name="l10n_eg_unit_code_id" invisible="'EG' not in fiscal_country_codes"/>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_fr/views/l10n_fr_view.xml
+++ b/addons/l10n_fr/views/l10n_fr_view.xml
@@ -23,7 +23,7 @@
             <field name="arch" type="xml">
             <data>
                  <xpath expr="//field[@name='ref']" position="after">
-                    <field name="siret" invisible="'FR'.lower() not in (fiscal_country_codes or '').lower() or not is_company"/>
+                    <field name="siret" invisible="'FR' not in fiscal_country_codes or not is_company"/>
                  </xpath>
             </data>
             </field>

--- a/addons/l10n_in/views/product_template_view.xml
+++ b/addons/l10n_in/views/product_template_view.xml
@@ -7,8 +7,8 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <field name="categ_id" position="after">
-                <field name="l10n_in_hsn_code" invisible="'IN'.lower() not in (fiscal_country_codes or '').lower()"/>
-                <field name="l10n_in_hsn_description" invisible="'IN'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="l10n_in_hsn_code" invisible="'IN' not in fiscal_country_codes"/>
+                <field name="l10n_in_hsn_description" invisible="'IN' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -11,7 +11,7 @@
                 <attribute name="required">l10n_in_gst_treatment in ['regular', 'composition', 'special_economic_zone', 'deemed_export']</attribute>
             </xpath>
             <xpath expr="//field[@name='vat']" position="before">
-                <field name="l10n_in_gst_treatment" invisible="'IN'.lower() not in (fiscal_country_codes or '').lower()" readonly="parent_id"/>
+                <field name="l10n_in_gst_treatment" invisible="'IN' not in fiscal_country_codes" readonly="parent_id"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
                 <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" />

--- a/addons/l10n_in/views/uom_uom_views.xml
+++ b/addons/l10n_in/views/uom_uom_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="uom.product_uom_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='category_id']" position="after">
-                <field name="l10n_in_code" invisible="'IN'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="l10n_in_code" invisible="'IN' not in fiscal_country_codes"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -29,9 +29,9 @@
         <field name="arch" type="xml">
         <data>
             <xpath expr="//field[@name='category_id']" position="after">
-                <field name="l10n_it_pec_email" invisible="'IT'.lower() not in (fiscal_country_codes or '').lower() or parent_id"/>
-                <field name="l10n_it_codice_fiscale" invisible="'IT'.lower() not in (fiscal_country_codes or '').lower() or parent_id"/>
-                <field name="l10n_it_pa_index" invisible="'IT'.lower() not in (fiscal_country_codes or '').lower() or parent_id"/>
+                <field name="l10n_it_pec_email" invisible="'IT' not in fiscal_country_codes or parent_id"/>
+                <field name="l10n_it_codice_fiscale" invisible="'IT' not in fiscal_country_codes or parent_id"/>
+                <field name="l10n_it_pa_index" invisible="'IT' not in fiscal_country_codes or parent_id"/>
             </xpath>
         </data>
         </field>

--- a/addons/l10n_ph/views/res_partner_views.xml
+++ b/addons/l10n_ph/views/res_partner_views.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="branch_code" invisible="'PH'.lower() not in (fiscal_country_codes or '').lower()"/>
-                <field name="first_name" invisible="'PH'.lower() not in (fiscal_country_codes or '').lower() or is_company"/>
-                <field name="middle_name" invisible="'PH'.lower() not in (fiscal_country_codes or '').lower() or is_company"/>
-                <field name="last_name" invisible="'PH'.lower() not in (fiscal_country_codes or '').lower() or is_company"/>
+                <field name="branch_code" invisible="'PH' not in fiscal_country_codes"/>
+                <field name="first_name" invisible="'PH' not in fiscal_country_codes or is_company"/>
+                <field name="middle_name" invisible="'PH' not in fiscal_country_codes or is_company"/>
+                <field name="last_name" invisible="'PH' not in fiscal_country_codes or is_company"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_ro/views/res_partner_view.xml
+++ b/addons/l10n_ro/views/res_partner_view.xml
@@ -6,7 +6,7 @@
 			<field name="model">res.partner</field>
 			<field name="arch" type="xml">
 				<field name="vat" position="after">
-					<field name="nrc" placeholder="e.g. J12/1234/2012" class="oe_inline" invisible="'RO'.lower() not in (fiscal_country_codes or '').lower()"/>
+					<field name="nrc" placeholder="e.g. J12/1234/2012" class="oe_inline" invisible="'RO' not in fiscal_country_codes"/>
                 </field>
 			</field>
 		</record>

--- a/addons/l10n_se/views/partner_view.xml
+++ b/addons/l10n_se/views/partner_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="arch" type="xml">
                 <group name="accounting_entries" position="after">
-                    <group string="Payment Options Sweden" name="payment_options" invisible="'SE'.lower() not in (fiscal_country_codes or '').lower()">
+                    <group string="Payment Options Sweden" name="payment_options" invisible="'SE' not in fiscal_country_codes">
                         <field name="l10n_se_check_vendor_ocr"/>
                         <field name="l10n_se_default_vendor_payment_ref"/>
                     </group>

--- a/addons/l10n_sg/views/res_partner_view.xml
+++ b/addons/l10n_sg/views/res_partner_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_partner_property_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vat']" position="before">
-                    <field name="l10n_sg_unique_entity_number" invisible="'SG'.lower() not in (fiscal_country_codes or '').lower()"/>
+                    <field name="l10n_sg_unique_entity_number" invisible="'SG' not in fiscal_country_codes"/>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_sk/views/res_partner_views.xml
+++ b/addons/l10n_sk/views/res_partner_views.xml
@@ -6,10 +6,10 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
              <xpath expr="//field[@name='company_registry']" position="replace">
-                <field name="company_registry" invisible="'SK'.lower() in (fiscal_country_codes or '').lower()"/>
+                <field name="company_registry" invisible="'SK' not in fiscal_country_codes"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="company_registry" invisible="'SK'.lower() not in (fiscal_country_codes or '').lower()"/>
+                <field name="company_registry" invisible="'SK' not in fiscal_country_codes"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Problem
---------
In master, XML attributes have been modifed from attrs={'invisible':...} to invisible=. During the conversion, the condition where not properly cleaned up.

Objective
---------
Clean up the XML attributes.

Solution
---------
Reduce conditions by removing unecessary elements:
    - `fiscal_country_codes` always returns at least an empty string.
    - All country codes are in capital letters, no need to `lower` them.

task-3493124
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
