### PR TITLE
[FIX] pos_self_order: fix combo header in kiosk

### DIFF
--- a/addons/pos_self_order/static/src/kiosk/template/kiosk_template.js
+++ b/addons/pos_self_order/static/src/kiosk/template/kiosk_template.js
@@ -39,10 +39,6 @@ export class KioskTemplate extends Component {
         });
     }
 
-    get isHeaderBanner() {
-        return this.selfOrder.kiosk_image_home;
-    }
-
     idleDetector() {
         clearTimeout(this.idleTimer);
         this.idleTimer = setTimeout(() => this.router.navigate("default"), 3 * 60 * 1000); // 5 minutes

--- a/addons/pos_self_order/static/src/kiosk/template/kiosk_template.xml
+++ b/addons/pos_self_order/static/src/kiosk/template/kiosk_template.xml
@@ -2,10 +2,10 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.KioskTemplate" owl="1">
         <div class="o_kiosk-template h-100">
-            <section class="header-section" t-attf-style="height: {{ isHeaderBanner ? props.headerHeight : '0' }}%;">
+            <section class="header-section" t-attf-style="height: {{ props.headerHeight }}%;">
                 <t t-slot="header" />
             </section>
-            <section class="content-section position-relative z-index-0" t-attf-style="height: {{ isHeaderBanner ? props.contentHeight : props.contentHeight + props.headerHeight }}%;">
+            <section class="content-section position-relative z-index-0" t-attf-style="height: {{ props.contentHeight }}%;">
                 <t t-slot="content" />
             </section>
             <section t-attf-class="position-relative p-3 bg-transparent z-index-1 {{ showShadow ? 'o_footer_shadow' : '' }}" t-attf-style="height: {{ props.footerHeight }}%;">


### PR DESCRIPTION
Previously, header height in pages was managed by `kiosk_template.js` and in the various other components via props. This caused a bug in the `combo.xml` page, as the header with steps and product names was not displayed.

Now the height of header, content and footer is managed entirely via the components and never via the template. This corrects the error in question.