### PR TITLE
[FIX] website_event: no cache of urls creating redirect loop

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -167,8 +167,14 @@ class WebsiteEventController(http.Controller):
             target_url = event.menu_id.child_id[0].url
         else:
             target_url = '/event/%s/register' % str(event.id)
+
+        unique_id = datetime.now().strftime('%H%M%S%f')
+        separator = '&' if '?' in target_url else '?'
+        target_url += '{}cache_bust={}'.format(separator, unique_id)
+
         if post.get('enable_editor') == '1':
-            target_url += '?enable_editor=1'
+            target_url += '&enable_editor=1'
+
         return request.redirect(target_url)
 
     @http.route(['''/event/<model("event.event"):event>/register'''], type='http', auth="public", website=True, sitemap=False)


### PR DESCRIPTION
Steps to reproduce:

- Install website_event.
- Create a new event with website menu activated.
- Fill a name like 'test' and render the website preview.
- Now go back to the form page again and change the name to anything.
- Get the website preview again, and go back to the form after it.
- Here put back the initial name and try to get the website_preview.

Issue:

The browser is caching the urls that we generate and trying to redirect to them, but in chrome this redirecting is not being handled properly and it's generating a loop of 301 redirects.

Solution:

One posible solution is to manually cache bust the urls so we prevent the browser from caching them and we do the proper request everytime.

Notice again, this issue is only present in Chrome.

opw-3246631