### PR TITLE
[FIX] web_editor: Avoid indexing empty field

### DIFF
--- a/addons/web_editor/models/ir_attachment.py
+++ b/addons/web_editor/models/ir_attachment.py
@@ -38,7 +38,7 @@ class IrAttachment(models.Model):
                 attachment.image_src = attachment.url
             else:
                 # Adding unique in URLs for cache-control
-                unique = attachment.checksum[:8]
+                unique = (attachment.checksum or attachment._compute_checksum(attachment.datas))[:8]
                 if attachment.url:
                     # For attachments-by-url, unique is used as a cachebuster. They
                     # currently do not leverage max-age headers.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Find an HTML-field, type "/" and select Image. If an attachment does not have "checksum" set, this fails with "TypeError: 'bool' object is not subscriptable".

Current behavior before PR:
Fail

Desired behavior after PR is merged:
Image can be selected and inserted




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
