### PR TITLE
[FIX] account: html in mail wrongly escaped

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4438,7 +4438,7 @@ class AccountMove(models.Model):
                 ]
         # Little hack: Inject the mail's subject in the body.
         if msg_dict.get('subject') and msg_dict.get('body'):
-            msg_dict['body'] = '<div><div><h3>%s</h3></div>%s</div>' % (msg_dict['subject'], msg_dict['body'])
+            msg_dict['body'] = Markup('<div><div><h3>%s</h3></div>%s</div>') % (msg_dict['subject'], msg_dict['body'])
 
         # Create the invoice.
         values = {


### PR DESCRIPTION
Current behaviour:
---
When sending an email to the vendor bills alias,
html in mail is being escaped.
ie: `<div> ` appears in chatter

Expected behaviour:
---
Html in mail should be rendered correctly

Steps to reproduce:
---
1. Install contacts,account_accountant
2. Create a working gmail server (imap)
3. Configure Odoo to use gmail server address
4. Replace admin email by gmail server address
5. Change odoo server alias domain to @gmail.com
6. Change vendor bills alias email by gmail server address
7. Send an email to gmail server address
8. A vendor bill should have appeared
9. `<div><div><h3>test</h3></div><div dir="ltr">test</div></div>`

Cause of the issue:
---
https://github.com/odoo/odoo/blob/e10e5ff3e20d30da9f4dc466ea5efbce2f3e63eb/addons/mail/models/mail_thread.py#L2079 Body was supposed to be Markup to avoid being escaped, but was str

opw-3439965

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
