### PR TITLE
[IMP] hr_holidays:  add missing employee information

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -300,10 +300,10 @@
         <field name="priority">32</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='employee_id']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='department_id']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//button[@name='action_validate']" position="attributes">
                 <attribute name="invisible">1</attribute>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -509,16 +509,16 @@
         <field name="priority">32</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='all_employee_ids']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='employee_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='department_id']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='holiday_type']" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath expr="//button[@name='action_approve']" position="attributes">
                 <attribute name="invisible">1</attribute>


### PR DESCRIPTION
Before this commit, In time off if we got to dashboard and open list view then information related to employee is missing.
In this commit, removed invisible attribute from field to show employee information.

task-3482508
