### PR TITLE
[FIX] web: correctly restore focus with ConfirmationDialog

### DIFF
--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -77,7 +77,19 @@ export function useActiveElement(refName) {
                 return () => {
                     uiService.deactivateElement(el);
                     el.removeEventListener("keydown", trapFocus);
-                    if (el.contains(document.activeElement)) {
+
+                    /**
+                     * In some cases, the current active element is not
+                     * anymore in el (e.g. with ConfirmationDialog, the
+                     * confirm button is disabled when clicked, so the
+                     * focus is lost). In that case, we also want to restore
+                     * the focus to the previous active element so we
+                     * check if the current active element is the body
+                     */
+                    if (
+                        el.contains(document.activeElement) ||
+                        document.activeElement === document.body
+                    ) {
                         oldActiveElement.focus();
                     }
                 };


### PR DESCRIPTION
When a dialog is closed, the focus is meant to be restored to the previous focused element.

Before this commit, it did not work for the ConfirmationDialog when the confirm button was clicked. This was because the focus was lost **before** the dialog was closed (because the confirm button is disabled when clicked), and thus the previous focused element was not in the el of the dialog anymore, and thus the focus was not restored.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
