### PR TITLE
[FIX] spreadsheet: add missing icon for download button

### DIFF
--- a/addons/spreadsheet/__manifest__.py
+++ b/addons/spreadsheet/__manifest__.py
@@ -61,6 +61,7 @@
             ('include', 'spreadsheet.dependencies'),
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js',
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet.xml',
+            'spreadsheet/static/src/o_spreadsheet/icons.xml',
             'spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss',
             'spreadsheet/static/src/o_spreadsheet/migration.js',
             'spreadsheet/static/src/o_spreadsheet/odoo_module.js',

--- a/addons/spreadsheet/static/src/o_spreadsheet/icons.xml
+++ b/addons/spreadsheet/static/src/o_spreadsheet/icons.xml
@@ -7,4 +7,9 @@
       />
     </svg>
   </t>
+  <t t-name="o-spreadsheet-Icon.DOWNLOAD">
+    <svg class="o-icon">
+      <path fill="currentColor" d="M2 10.5h1.5V15h11v-4.5H16v6H2M5.5 8H8V1h2v7h2.5L9 11.5"/>
+    </svg>
+  </t>
 </templates>

--- a/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
@@ -13,6 +13,7 @@ registries.topbarMenuRegistry.addChild("download_public_excel", ["file"], {
     name: _t("Download"),
     execute: (env) => env.downloadExcel(),
     isReadonlyAllowed: true,
+    icon: "o-spreadsheet-Icon.DOWNLOAD",
 });
 
 export class PublicReadonlySpreadsheet extends Component {


### PR DESCRIPTION
The icon was missing in the download menu item for portal users that access a shared spreadsheet.

Task: [3495200](https://www.odoo.com/web#menu_id=4720&cids=1&action=333&active_id=2328&model=project.task&view_type=form&id=3495200)
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
