### PR TITLE
[FIX] hr_recruitment : Fix window focus when opening applicant

### DIFF
--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -169,7 +169,7 @@
             <div class="oe_chatter">
                 <field name="message_follower_ids"/>
                 <field name="activity_ids"/>
-                <field name="message_ids" options="{'open_attachments': True}"/>
+                <field name="message_ids" options="{'open_attachments': False}"/>
             </div>
           </form>
         </field>


### PR DESCRIPTION
Currently when we open an applicant form, the navigator scrolls to the attachments instead of starting at the top of the window
task-3482397