### PR TITLE
[FIX] web: fix translations for duplicate records

### DIFF
--- a/addons/mail/static/src/views/web/form/form_controller.js
+++ b/addons/mail/static/src/views/web/form/form_controller.js
@@ -5,6 +5,7 @@ import { FormController } from "@web/views/form/form_controller";
 
 patch(FormController.prototype, {
     onWillLoadRoot(nextConfiguration) {
+        super.onWillLoadRoot(...arguments);
         const isSameThread =
             this.model.root?.resId === nextConfiguration.resId &&
             this.model.root?.resModel === nextConfiguration.resModel;

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -1091,6 +1091,24 @@ class Base(models.AbstractModel):
 
         return result
 
+    def web_override_translations(self, values):
+        """
+        This method is used to override all the modal translations of the given fields
+        with the provided value for each field.
+
+        :param values: dictionary of the translations to apply for each field name
+        ex: { "field_name": "new_value" }
+        """
+        self.ensure_one()
+        for field_name in values:
+            field = self._fields[field_name]
+            if field.translate is True:
+                translations = {lang: False for lang, _ in self.env['res.lang'].get_installed()}
+                translations['en_US'] = values[field_name]
+                translations[self.env.lang or 'en_US'] = values[field_name]
+                self.update_field_translations(field_name, translations)
+
+
 
 class ResCompany(models.Model):
     _inherit = 'res.company'

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -32,7 +32,7 @@
                         <CogMenu
                             getActiveIds="() => model.root.isNew ? [] : [model.root.resId]"
                             context="props.context"
-                            items="props.info.actionMenus ? actionMenuItems : {}"
+                            items="props.info.actionMenus ? this.actionMenuItems : {}"
                             isDomainSelected="model.root.isDomainSelected"
                             resModel="model.root.resModel"
                             domain="props.domain"

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -68,7 +68,7 @@ QUnit.module("Views", (hooks) => {
             models: {
                 partner: {
                     fields: {
-                        display_name: { string: "Displayed name", type: "char" },
+                        display_name: { string: "Displayed name", type: "char", translate: true },
                         foo: { string: "Foo", type: "char", default: "My little Foo Value" },
                         bar: { string: "Bar", type: "boolean" },
                         int_field: { string: "int_field", type: "integer", sortable: true },
@@ -4618,6 +4618,49 @@ QUnit.module("Views", (hooks) => {
 
         assert.verifySteps(["web_save"]);
     });
+
+    QUnit.test(
+        "editing a translatable field in a duplicate record overrides translations",
+        async function (assert) {
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: '<form><field name="display_name"/></form>',
+                resId: 1,
+                actionMenus: {},
+                async mockRPC(route, args) {
+                    if (args.method === "web_save") {
+                        assert.step("web_save");
+                    }
+                    if (args.method === "web_override_translations") {
+                        assert.deepEqual(args.args[1], { display_name: "first record (test)" });
+                        assert.step("web_override_translations");
+                        return true;
+                    }
+                },
+            });
+
+            assert.strictEqual(
+                target.querySelector(".o_control_panel .o_breadcrumb").textContent,
+                "first record",
+                "should have the display name of the record as title"
+            );
+
+            await toggleActionMenu(target);
+            await toggleMenuItem(target, "Duplicate");
+
+            assert.strictEqual(
+                target.querySelector(".o_control_panel .o_breadcrumb").textContent,
+                "first record (copy)",
+                "should have duplicated the record"
+            );
+            assert.containsOnce(target, ".o_form_editable");
+            await editInput(target, ".o_field_char input", "first record (test)");
+            await click(target, ".o_form_button_save");
+            assert.verifySteps(["web_save", "web_override_translations"]);
+        }
+    );
 
     QUnit.test("clicking on stat buttons in edit mode", async function (assert) {
         let count = 0;

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -18,6 +18,7 @@ from . import test_assets_xml
 from . import test_login
 from . import test_web_search_read
 from . import test_domain
+from . import test_translate
 from . import test_web_redirect
 from . import test_res_users
 from . import test_webmanifest

--- a/addons/web/tests/test_translate.py
+++ b/addons/web/tests/test_translate.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+class TestTranslationOverride(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.category = cls.env['res.partner.category'].create({'name': 'Reblochon'})
+        cls.custom = cls.env['ir.model.fields'].create({
+            'name': 'x_html_test',
+            'ttype': 'html',
+            'model_id': cls.category.id,
+            'translate': True,
+        })
+
+    def test_web_override_translations(self):
+        self.env['res.lang']._activate_lang('fr_FR')
+        categoryEN = self.category.with_context(lang='en_US')
+        categoryFR = self.category.with_context(lang='fr_FR')
+        customEN = self.custom.with_context(lang='en_US')
+        customFR = self.custom.with_context(lang='fr_FR')
+
+        self.category.web_override_translations({'name': 'commonName'})
+        self.assertEqual(categoryEN.name, 'commonName')
+        self.assertEqual(categoryFR.name, 'commonName')
+
+        # cannot void translations (incluiding en_US)
+        self.category.web_override_translations({'name': False})
+        self.assertEqual(categoryEN.name, 'commonName')
+        self.assertEqual(categoryFR.name, 'commonName')
+
+        # empty str is a valid translation
+        self.category.web_override_translations({'name': ''})
+        self.assertEqual(categoryEN.name, '')
+        self.assertEqual(categoryFR.name, '')
+
+        # translated html fields are not changed
+        self.custom.web_override_translations({'name': '<div>dont</div><div>change</div>'})
+        self.assertEqual(customEN.name, 'x_html_test')
+        self.assertEqual(customFR.name, 'x_html_test')


### PR DESCRIPTION
This commit ensures that changes in translated fields on a freshly duplicated record will apply to all translation even when the user language is not en_US.

Steps to reproduce:

- go to accounting -> configuration -> taxes in other language than en_US -open any record in form view
- duplicate the record
- change the name of the record and save
- ensure that the name is the same in all languages

task-3339736
