### PR TITLE
[FIX] base: Module category can reference itself as parent

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -25,7 +25,7 @@ import psycopg2
 import odoo
 from odoo import api, fields, models, modules, tools, _
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-from odoo.exceptions import AccessDenied, UserError
+from odoo.exceptions import AccessDenied, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools.parse_version import parse_version
 from odoo.tools.misc import topological_sort
@@ -111,6 +111,11 @@ class ModuleCategory(models.Model):
             xml_ids[data['res_id']].append("%s.%s" % (data['module'], data['name']))
         for cat in self:
             cat.xml_id = xml_ids.get(cat.id, [''])[0]
+
+    @api.constrains('parent_id')
+    def _check_parent_not_circular(self):
+        if not self._check_recursion():
+            raise ValidationError(_("Error ! You cannot create recursive categories."))
 
 class MyFilterMessages(Transform):
     """

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -49,3 +49,4 @@ from . import test_form_create
 from . import test_cloc
 from . import test_pdf
 from . import test_config_parameter
+from . import test_ir_module_category

--- a/odoo/addons/base/tests/test_ir_module_category.py
+++ b/odoo/addons/base/tests/test_ir_module_category.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+class TestModuleCategory(TransactionCase):
+
+    def test_parent_circular_dependencies(self):
+        Cats = self.env['ir.module.category']
+
+        def create(name, **kw):
+            return Cats.create(dict(kw, name=name))
+
+        category_a = create('A', parent_id=False)
+        category_b = create('B', parent_id=category_a.id)
+        category_c = create('C', parent_id=category_b.id)
+
+        with self.assertRaises(ValidationError):
+            category_a.write({'parent_id': category_c.id})
+        with self.assertRaises(ValidationError):
+            category_b.write({'parent_id': category_b.id})


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Update a module category to reference itself as parent
OR
- Update multiple module categories to create a circular dependency (A -> B -> A)

Current behavior before PR:
- Upgrade a module is impossible
- Un/Install a module is impossible
- Infinite loop: https://github.com/odoo/odoo/blob/14.0/odoo/addons/base/models/ir_module.py#L891

Desired behavior after PR is merged:
- Circular dependencies not possible
- Module can be upgrade and un/install



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
