### PR TITLE
[FIX] website: fix editor unable to open with filled date field

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1892,7 +1892,7 @@ const DatetimePickerUserValueWidget = InputUserValueWidget.extend({
      */
     async setValue() {
         await this._super(...arguments);
-        let dateTime = "";
+        let dateTime = null;
         if (this._value) {
             dateTime = DateTime.fromSeconds(parseInt(this._value))
             if (!dateTime.isValid) {

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -35,7 +35,7 @@ const { DateTime } = luxon;
                         el.closest(".s_website_form_field").dataset.type === "date"
                             ? formatDate
                             : formatDateTime;
-                        el.value = format(DateTime.fromSeconds(value));
+                        el.value = format(DateTime.fromSeconds(parseInt(value)));
                     }
                 });
             }
@@ -223,7 +223,7 @@ const { DateTime } = luxon;
                             el.closest(".s_website_form_field").dataset.type === "date"
                                 ? formatDate
                                 : formatDateTime;
-                        value = format(DateTime.fromSeconds(value));
+                        value = format(DateTime.fromSeconds(parseInt(value)));
                     }
                     el.value = value;
                 }

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -9,6 +9,7 @@ import "@website/js/editor/snippets.options";
 import { unique } from "@web/core/utils/arrays";
 import { _t } from "@web/core/l10n/translation";
 import { renderToElement } from "@web/core/utils/render";
+import { formatDate, formatDateTime } from "@web/core/l10n/dates";
 
 let currentActionName;
 
@@ -1067,7 +1068,10 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      * Select the date as value property and convert it to the right format
      */
     selectValueProperty: function (previewMode, value, params) {
-        this.$target[0].value = value ? moment.unix(value).format(params.format) : '';
+        const [target] = this.$target;
+        const field = target.closest(".s_website_form_date, .s_website_form_datetime");
+        const format = field.matches(".s_website_form_date") ? formatDate : formatDateTime;
+        target.value = value ? format(luxon.DateTime.fromSeconds(parseInt(value))) : "";
     },
     /**
      * Select the display of the multicheckbox field (vertical & horizontal)


### PR DESCRIPTION
In odoo/odoo#133349 some code in website was adapted to use the new datetime picker and luxon instead of tempusdominus and moment, but some conversions were improperly performed causing a crash that would prevent the website editor from opening. This commit fixes this issue and also formats the chosen default date/datetime correctly while within the editor.
