### PR TITLE
[REF] web: simplify assets loading

### DIFF
--- a/addons/mail/static/src/discuss/voice_message/common/voice_message_service.js
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_message_service.js
@@ -1,11 +1,11 @@
 /* @odoo-module */
 
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { memoize } from "@web/core/utils/functions";
 
 const loader = {
-    loadLamejs: memoize(() => getBundle("mail.assets_lamejs").then(loadBundle)),
+    loadLamejs: memoize(() => loadBundle("mail.assets_lamejs")),
 };
 
 export async function loadLamejs() {

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -5,7 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { initializeDesignTabCss } from "@mass_mailing/js/mass_mailing_design_constants"
 import { toInline, getCSSRules } from "@web_editor/js/backend/convert_inline";
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { renderToElement } from "@web/core/utils/render";
 import { useService } from "@web/core/utils/hooks";
 import { buildQuery } from "@web/legacy/js/core/rpc";
@@ -167,8 +167,7 @@ export class MassMailingHtmlField extends HtmlField {
     async startWysiwyg(...args) {
         await super.startWysiwyg(...args);
 
-        const assets = await getBundle("mass_mailing.assets_wysiwyg");
-        await loadBundle(assets);
+        await loadBundle("mass_mailing.assets_wysiwyg");
 
         if (status(this) === "destroyed") {
             return;

--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -2,7 +2,7 @@
 
 import { Chrome } from "@point_of_sale/app/pos_app";
 import { Loader } from "@point_of_sale/app/loader/loader";
-import { setLoadXmlDefaultApp, templates } from "@web/core/assets";
+import { templates } from "@web/core/assets";
 import { App, mount, reactive, whenReady, Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { hasTouch } from "@web/core/browser/feature_detection";
@@ -55,7 +55,6 @@ whenReady(() => {
         props: { disableLoader: () => (loader.isShown = false) },
     });
     renderToString.app = app;
-    setLoadXmlDefaultApp(app);
     const root = await app.mount(document.body);
     const classList = document.body.classList;
     if (localization.direction === "rtl") {

--- a/addons/pos_self_order/static/src/kiosk/self_order_kiosk_index.js
+++ b/addons/pos_self_order/static/src/kiosk/self_order_kiosk_index.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 import { Component, whenReady, App } from "@odoo/owl";
 import { makeEnv, startServices } from "@web/env";
-import { setLoadXmlDefaultApp, templates } from "@web/core/assets";
+import { templates } from "@web/core/assets";
 import { _t } from "@web/core/l10n/translation";
 import { LandingPage } from "@pos_self_order/kiosk/pages/landing_page/landing_page";
 import { EatingLocation } from "@pos_self_order/kiosk/pages/eating_location/eating_location";
@@ -51,7 +51,6 @@ export async function createPublicRoot() {
         translateFn: _t,
         translatableAttributes: ["data-tooltip"],
     });
-    setLoadXmlDefaultApp(app);
     return app.mount(document.body);
 }
 createPublicRoot();

--- a/addons/pos_self_order/static/src/mobile/self_order_root.js
+++ b/addons/pos_self_order/static/src/mobile/self_order_root.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 import { Component, whenReady, App } from "@odoo/owl";
 import { makeEnv, startServices } from "@web/env";
-import { setLoadXmlDefaultApp, templates } from "@web/core/assets";
+import { templates } from "@web/core/assets";
 import { _t } from "@web/core/l10n/translation";
 import { LandingPage } from "@pos_self_order/mobile/pages/landing_page/landing_page";
 import { NavBar } from "@pos_self_order/mobile/components/navbar/navbar";
@@ -54,7 +54,6 @@ export async function createPublicRoot() {
         translateFn: _t,
         translatableAttributes: ["data-tooltip"],
     });
-    setLoadXmlDefaultApp(app);
     return app.mount(document.body);
 }
 createPublicRoot();

--- a/addons/spreadsheet/static/src/assets_backend/spreadsheet_action_loader.js
+++ b/addons/spreadsheet/static/src/assets_backend/spreadsheet_action_loader.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { sprintf } from "@web/core/utils/strings";
 import { loadSpreadsheetDependencies } from "./helpers";
 
@@ -16,8 +16,7 @@ const actionRegistry = registry.category("actions");
  */
 export async function loadSpreadsheetAction(env, actionName, actionLazyLoader) {
     await loadSpreadsheetDependencies();
-    const desc = await getBundle("spreadsheet.o_spreadsheet");
-    await loadBundle(desc);
+    await loadBundle("spreadsheet.o_spreadsheet");
 
     if (actionRegistry.get(actionName) === actionLazyLoader) {
         // At this point, the real spreadsheet client action should be loaded and have

--- a/addons/spreadsheet/static/src/public_readonly_app/main.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/main.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 import { App, whenReady } from "@odoo/owl";
 import { PublicReadonlySpreadsheet } from "./public_readonly";
-import { setLoadXmlDefaultApp, templates } from "@web/core/assets";
+import { templates } from "@web/core/assets";
 import { makeEnv, startServices } from "@web/env";
 import { session } from "@web/session";
 import { _t } from "@web/core/l10n/translation";
@@ -26,7 +26,6 @@ import { _t } from "@web/core/l10n/translation";
         warnIfNoStaticProps: env.debug,
         translatableAttributes: ["data-tooltip"],
     });
-    setLoadXmlDefaultApp(app);
     const root = await app.mount(document.getElementById("spreadsheet-mount-anchor"));
     odoo.__WOWL_DEBUG__ = { root };
     odoo.isReady = true;

--- a/addons/web/static/src/core/code_editor/code_editor.js
+++ b/addons/web/static/src/core/code_editor/code_editor.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 import { Component, onWillDestroy, onWillStart, useEffect, useRef } from "@odoo/owl";
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { useDebounced } from "@web/core/utils/timing";
 
 function onResized(ref, callback) {
@@ -59,7 +59,7 @@ export class CodeEditor extends Component {
     setup() {
         this.editorRef = useRef("editorRef");
 
-        onWillStart(async () => loadBundle(await getBundle("web.ace_lib")));
+        onWillStart(async () => await loadBundle("web.ace_lib"));
 
         const sessions = {};
         useEffect(

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -15,11 +15,10 @@ import {
     useState,
 } from "@odoo/owl";
 
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
-import { memoize } from "@web/core/utils/functions";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { useService } from "@web/core/utils/hooks";
 
@@ -107,7 +106,7 @@ export function useEmojiPicker(ref, props, options = {}) {
 }
 
 export const loader = {
-    loadEmoji: memoize(() => getBundle("web.assets_emoji").then(loadBundle)),
+    loadEmoji: () => loadBundle("web.assets_emoji"),
 };
 
 /**

--- a/addons/web/static/src/core/errors/error_utils.js
+++ b/addons/web/static/src/core/errors/error_utils.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { _loadJS } from "../assets"; // use the real, non patched (in tests), loadJS
+import { loadJS } from "../assets"; // use the real, non patched (in tests), loadJS
 import { isBrowserChrome } from "../browser/feature_detection";
 
 /** @typedef {import("./error_service").UncaughtError} UncaughtError */
@@ -147,7 +147,7 @@ export function formatTraceback(error) {
 export async function annotateTraceback(error) {
     const traceback = formatTraceback(error);
     try {
-        await _loadJS("/web/static/lib/stacktracejs/stacktrace.js");
+        await loadJS("/web/static/lib/stacktracejs/stacktrace.js");
     } catch {
         return traceback;
     }

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -17,7 +17,7 @@ import {
 import { standaloneAdapter } from "@web/legacy/js/owl_compatibility";
 
 import { makeEnv, startServices } from "@web/env";
-import { setLoadXmlDefaultApp, loadJS, templates } from '@web/core/assets';
+import { loadJS, templates } from '@web/core/assets';
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { browser } from '@web/core/browser/browser';
 import { jsonrpc } from '@web/core/network/rpc_service';
@@ -405,7 +405,6 @@ export async function createPublicRoot(RootWidget) {
         translatableAttributes: ["data-tooltip"],
     });
     renderToString.app = app;
-    setLoadXmlDefaultApp(app);
     const language = lang || browser.navigator.language;
     const locale = language === "sr@latin" ? "sr-Latn-RS" : language.replace(/_/g, "-");
     Settings.defaultLocale = locale;

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -6,7 +6,7 @@ import { mapLegacyEnvToWowlEnv } from "./legacy/utils";
 import { localization } from "@web/core/l10n/localization";
 import { session } from "@web/session";
 import { renderToString } from "./core/utils/render";
-import { setLoadXmlDefaultApp, templates } from "@web/core/assets";
+import { templates } from "@web/core/assets";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { _t } from "@web/core/l10n/translation";
 import { App, whenReady } from "@odoo/owl";
@@ -46,7 +46,6 @@ export async function startWebClient(Webclient) {
         translateFn: _t,
     });
     renderToString.app = app;
-    setLoadXmlDefaultApp(app);
     const root = await app.mount(document.body);
     const classList = document.body.classList;
     if (localization.direction === "rtl") {

--- a/addons/web/static/tests/legacy/helpers/test_env.js
+++ b/addons/web/static/tests/legacy/helpers/test_env.js
@@ -2,7 +2,7 @@
 
     import Bus from "@web/legacy/js/core/bus";
     import { buildQuery } from "@web/legacy/js/core/rpc";
-    import { templates, setLoadXmlDefaultApp } from "@web/core/assets";
+    import { templates } from "@web/core/assets";
     import { renderToString } from "@web/core/utils/render";
     const { App, Component } = owl;
 
@@ -21,7 +21,6 @@
         if (!app) {
             app = new App(null, { templates, test: true });
             renderToString.app = app;
-            setLoadXmlDefaultApp(app);
         }
 
         function rpc(route, params, options) {

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -260,14 +260,8 @@ function removeUnwantedAttrsFromTemplates(attrs) {
 }
 
 function patchAssets() {
-    const { loadXML, getBundle, loadJS, loadCSS } = assets;
+    const { getBundle, loadJS, loadCSS } = assets;
     patch(assets, {
-        loadXML: function (templates) {
-            console.log("%c[assets] fetch XML ressource", "color: #66e; font-weight: bold;");
-            // Clean up new templates that might be added later.
-            loadXML(templates);
-            removeUnwantedAttrsFromTemplates(["alt", "src"]);
-        },
         getBundle: memoize(async function (xmlID) {
             console.log(
                 "%c[assets] fetch libs from xmlID: " + xmlID,

--- a/addons/web_editor/static/src/js/frontend/loadWysiwygFromTextarea.js
+++ b/addons/web_editor/static/src/js/frontend/loadWysiwygFromTextarea.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { useWowlService } from '@web/legacy/utils';
 import { requireLegacyModule } from '@web_editor/js/frontend/loader';
 
@@ -18,8 +18,7 @@ export async function loadWysiwygFromTextarea(parent, textarea, options) {
 
     const { ComponentWrapper } = await requireLegacyModule('@web/legacy/js/owl_compatibility')
     const { Wysiwyg } = await requireLegacyModule('@web_editor/js/wysiwyg/wysiwyg', async () => {
-        const bundle = await getBundle('web_editor.assets_wysiwyg');
-        await loadBundle(bundle);
+        await loadBundle("web_editor.assets_wysiwyg");
     });
     let wysiwyg;
     class LegacyWysiwyg extends Wysiwyg {

--- a/addons/web_editor/static/src/js/frontend/loader.js
+++ b/addons/web_editor/static/src/js/frontend/loader.js
@@ -1,13 +1,10 @@
 /** @odoo-module **/
 
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 
-export async function loadLegacyWysiwygAssets(additionnalAssets=[]) {
-    const xmlids = ['web_editor.assets_legacy_wysiwyg', ...additionnalAssets];
-    for (const xmlid of xmlids) {
-        const assets = await getBundle(xmlid);
-        await loadBundle(assets);
-    }
+export async function loadLegacyWysiwygAssets(additionnalAssets = []) {
+    const xmlids = ["web_editor.assets_legacy_wysiwyg", ...additionnalAssets];
+    await loadBundle({ assetLibs: xmlids });
 }
 
 export async function requireLegacyModule(moduleName, loadCallback = () => {}) {

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -381,11 +381,10 @@ class AssetsBundle(object):
                     *  Templates                               *
                     *******************************************/
 
-                    odoo.define('{self.name}.bundle.xml', ['@web/core/assets'], function(require){{
+                    odoo.define('{self.name}.bundle.xml', ['@web/core/registry'], function(require){{
                         'use strict';
-                        const {{ loadXML }} = require('@web/core/assets');
-                        const templates = `{templates}`;
-                        return loadXML(templates);
+                        const {{ registry }} = require('@web/core/registry');
+                        registry.category(`xml_templates`).add(`{self.name}`, `{templates}`);
                     }});""")
 
             if is_minified:


### PR DESCRIPTION
In this commit, the loadXML function has been removed. We use registry with xml_templates to load XML templates for OWL Apps.

task-3266441

PR Enterprise : https://github.com/odoo/enterprise/pull/47001