### PR TITLE
[FIX] web: always read m2o display_name in studio mode

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -340,7 +340,7 @@ export function getFieldsSpec(
         // M2O
         if (fields[fieldName].type === "many2one") {
             fieldsSpec[fieldName].fields = {};
-            if (invisible !== "True" && invisible !== "1") {
+            if ((invisible !== "True" && invisible !== "1") || evalContext.studio) {
                 fieldsSpec[fieldName].fields.display_name = {};
             }
         }


### PR DESCRIPTION
Before this commit, the display_name wasn't read if the field was invisible. So, when displaying invisible fields in studio mode a traceback was popping up.

Now, if you are in studio mode, the display_name is read, even for the invisible fields.

TASK-ID: 3453701

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
