### PR TITLE
[FIX] stock: reserve kit components in immediate transfer

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -395,6 +395,7 @@ class StockMove(models.Model):
             if len(moves) > 1:
                 return
             if move.reserved_availability < move.quantity_done and move.state not in ['done', 'cancel']:
+                move.product_uom_qty = move.quantity_done
                 move._action_assign(force_qty=move.quantity_done)
             move._set_quantity_done(quantity)
 


### PR DESCRIPTION
Steps to reproduce:
- Create a kit with multiple tracked components
- Update on hand quantity (create lots) for the components
- Create an immediate transfer

Bug:
lots are not assigned on the components because the stock move of the kit is replaced by its components which have a quantity_done set but not product_qty which is checked when assigning the moves

opw-3447102

