### PR TITLE
[FIX] pos_self_order: fix combo price when changing combo quantity

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -223,7 +223,7 @@ class PosSelfOrderController(http.Controller):
                     )
                     unit_price_by_id[child['uuid']] = pricelist._get_product_price(product, quantity=line.get('qty')) if pricelist else product.lst_price
                     total_price += tax_results.get('total_included') if pos_config.iface_tax_included == 'total' else tax_results.get('total_excluded')
-                ratio = (price_unit / total_price)
+                ratio = (price_unit * line.get('qty') / total_price)
                 for child in children:
                     child_line_combo = pos_config.env['pos.combo'].browse(int(child.get('combo_id')))
                     child_line_combo_line = child_line_combo.combo_line_ids.filtered(lambda l: l.product_id.id == child.get('product_id'))[0]


### PR DESCRIPTION
When changing the quantity of a combo, the price was not correctly updated due to a miscomputation in the backend.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
