### PR TITLE
[FIX] base: writing selection values with server actions

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -801,7 +801,7 @@ class IrActionsServer(models.Model):
     def _set_selection_value(self):
         for action in self.filtered(lambda action: action.value_field_to_show == 'selection_value'):
             if action.selection_value:
-                action.value = action.selection_value.name
+                action.value = action.selection_value.value
 
     def _eval_value(self, eval_context=None):
         result = {}


### PR DESCRIPTION
Server actions that 'update the record' have a mechanism to allow users to easily select a selection value if the field they want to update is a selection field (instead of having to type the technical value directly).

Before this commit, this mechanism incorrectly stored the selection's name instead of the value (e.g. 'Done' instead of '01_done'), making the write crash when the action was run.
