### PR TITLE
[IMP] account: hide amount in currency

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1122,7 +1122,8 @@
                                                column_invisible="context.get('view_no_maturity')"/>
                                         <field name="amount_currency"
                                                groups="base.group_multi_currency"
-                                               optional="hide"/>
+                                               optional="hide"
+                                               column_invisible="parent.currency_id == parent.company_currency_id"/>
                                         <field name="currency_id" options="{'no_create': True}"
                                                optional="hide" groups="base.group_multi_currency"
                                                column_invisible="parent.move_type != 'entry'"/>


### PR DESCRIPTION
Before: in the Journal Items page in an invoice, the Amount in Currency was shown even if the amount is in the same currency as the company.

Now: only shown if the currency is different from that of the company.

task-3491419
