### PR TITLE
[FIX] pos_self_order: add sequence to demo data sessions

### DIFF
--- a/addons/pos_self_order/__init__.py
+++ b/addons/pos_self_order/__init__.py
@@ -3,3 +3,8 @@
 from . import controllers
 from . import models
 from . import tests
+
+def _post_self_order_post_init(env):
+    sessions = env['pos.session'].search([('state', '!=', 'closed')])
+    if len(sessions) > 0:
+        env['pos.session']._create_pos_self_sessions_sequence(sessions)

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -74,5 +74,6 @@
             "pos_self_order/static/tests/tours/**/*",
         ],
     },
+    'post_init_hook': '_post_self_order_post_init',
     "license": "LGPL-3",
 }

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -10,6 +10,11 @@ class PosSession(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         sessions = super(PosSession, self).create(vals_list)
+        sessions = self._create_pos_self_sessions_sequence(sessions)
+        return sessions
+
+    @api.model
+    def _create_pos_self_sessions_sequence(self, sessions):
         date_string = fields.Date.today().isoformat()
         ir_sequence = self.env['ir.sequence'].sudo().search([('code', '=', f'pos.order_{date_string}')])
         company_id = self.env.company.id


### PR DESCRIPTION
The demo data sessions were not having the self needed sequence, so when the user tried to use the demo sessions in the self, the sequence was not found and the normal flows were not successful.

This commit adds a new post_init_hook to the pos_self_order module to add the sequence to the demo data sessions.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
