### PR TITLE
[FIX] point_of_sale: fix `restrict categories` bug

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -663,7 +663,7 @@ class PosConfig(models.Model):
             ('available_in_pos', '=', True),
             ('sale_ok', '=', True),
         ]
-        if self.iface_available_categ_ids:
+        if self.limit_categories and self.iface_available_categ_ids:
             domain.append(('pos_categ_ids', 'in', self.iface_available_categ_ids.ids))
         if self.iface_tipproduct:
             domain = OR([domain, [('id', '=', self.tip_product_id.id)]])


### PR DESCRIPTION
The products are not correctly loaded in the POS because of a bug regarding the `Restrict Categories` feature.

Steps to reproduce:

1. Create a `pos config` with `Restrict Categories` set to: `categ1` and `categ2`

2. Disable `Restrict Categories`

3. Open the POS and notice that although all the categories are present in the category selector, only the products from `categ1` and `categ2` are loaded. 

Task: 3497308






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
