### PR TITLE
[IMP] web: datetime picker support for custom invalidity/class per day

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -19,9 +19,10 @@ import { ensureArray } from "../utils/arrays";
  * @property {string} id
  * @property {boolean} includesToday
  * @property {boolean} isOutOfRange
- * @property {boolean} isInvalid
+ * @property {boolean} isValid
  * @property {string} label
  * @property {DateRange} range
+ * @property {string} extraClass
  *
  * @typedef {"today" | NullableDateTime} DateLimit
  *
@@ -41,7 +42,9 @@ import { ensureArray } from "../utils/arrays";
  *  rounding minutes without displaying seconds.
  * @property {{ buttons?: any }} [slots]
  * @property {"date" | "datetime"} [type]
- * @property {NullableDateTime | NullableDateRange} value
+ * @property {NullableDateTime | NullableDateRange} [value]
+ * @property {(date: DateTime) => boolean} [isDateValid]
+ * @property {(date: DateTime) => string} [dayCellClass]
  *
  * @typedef {DateItem | MonthItem} Item
  *
@@ -118,18 +121,20 @@ const parseLimitDate = (value, defaultValue) =>
 /**
  * @param {Object} params
  * @param {boolean} [params.isOutOfRange=false]
- * @param {boolean} [params.isInvalid=false]
+ * @param {boolean} [params.isValid=true]
  * @param {keyof DateTime} params.label
+ * @param {string} [params.extraClass]
  * @param {[DateTime, DateTime]} params.range
  * @returns {DateItem}
  */
-const toDateItem = ({ isOutOfRange = false, isInvalid = false, label, range }) => ({
+const toDateItem = ({ isOutOfRange = false, isValid = true, label, range, extraClass }) => ({
     id: range[0].toISODate(),
     includesToday: isInRange(today(), range),
     isOutOfRange,
-    isInvalid,
+    isValid,
     label: String(range[0][label]),
     range,
+    extraClass,
 });
 
 /**
@@ -165,7 +170,10 @@ const PRECISION_LEVELS = new Map()
             }
             return titles;
         },
-        getItems: (date, { additionalMonth, maxDate, minDate, showWeekNumbers }) => {
+        getItems: (
+            date,
+            { additionalMonth, maxDate, minDate, showWeekNumbers, isDateValid, dayCellClass }
+        ) => {
             const startDates = [date];
             if (additionalMonth) {
                 startDates.push(date.plus({ month: 1 }));
@@ -185,9 +193,10 @@ const PRECISION_LEVELS = new Map()
                         const range = [day, day.endOf("day")];
                         const dayItem = toDateItem({
                             isOutOfRange: !isInRange(day, monthRange),
-                            isInvalid: !isInRange(range, [minDate, maxDate]),
+                            isValid: isInRange(range, [minDate, maxDate]) && isDateValid?.(day),
                             label: "day",
                             range,
+                            extraClass: dayCellClass?.(day) || "",
                         });
                         weekDayItems.push(dayItem);
                         if (d === 6) {
@@ -227,7 +236,7 @@ const PRECISION_LEVELS = new Map()
                 const startOfMonth = startOfYear.plus({ month: i });
                 const range = [startOfMonth, startOfMonth.endOf("month")];
                 return toDateItem({
-                    isInvalid: !isInRange(range, [minDate, maxDate]),
+                    isValid: isInRange(range, [minDate, maxDate]),
                     label: "monthShort",
                     range,
                 });
@@ -247,7 +256,7 @@ const PRECISION_LEVELS = new Map()
                 const range = [startOfYear, startOfYear.endOf("year")];
                 return toDateItem({
                     isOutOfRange: i < 0 || i >= GRID_COUNT,
-                    isInvalid: !isInRange(range, [minDate, maxDate]),
+                    isValid: isInRange(range, [minDate, maxDate]),
                     label: "year",
                     range,
                 });
@@ -268,7 +277,7 @@ const PRECISION_LEVELS = new Map()
                 return toDateItem({
                     label: "year",
                     isOutOfRange: i < 0 || i >= GRID_COUNT,
-                    isInvalid: !isInRange(range, [minDate, maxDate]),
+                    isValid: isInRange(range, [minDate, maxDate]),
                     range,
                 });
             });
@@ -310,6 +319,8 @@ export class DateTimePicker extends Component {
             ],
             optional: true,
         },
+        isDateValid: { type: Function, optional: true },
+        dayCellClass: { type: Function, optional: true },
     };
 
     static defaultProps = {
@@ -425,6 +436,8 @@ export class DateTimePicker extends Component {
             maxDate: this.maxDate,
             minDate: this.minDate,
             showWeekNumbers: !this.props.range,
+            isDateValid: this.props.isDateValid,
+            dayCellClass: this.props.dayCellClass,
         };
         const referenceDate = this.state.focusDate;
         this.title = precision.getTitle(referenceDate, getterParams);
@@ -684,7 +697,7 @@ export class DateTimePicker extends Component {
      * @param {DateItem} dateItem
      */
     zoomOrSelect(dateItem) {
-        if (dateItem.isInvalid) {
+        if (!dateItem.isValid) {
             // Invalid item
             return;
         }

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -36,9 +36,10 @@
                                     o_highlight_end: arInfo.isHighlightEnd,
                                     o_current: arInfo.isCurrent,
                                     o_today: itemInfo.includesToday,
-                                    o_out_of_range: itemInfo.isOutOfRange or itemInfo.isInvalid,
+                                    o_out_of_range: itemInfo.isOutOfRange or !itemInfo.isValid,
+                                    [itemInfo.extraClass]: true,
                                 }"
-                                t-att-disabled="itemInfo.isInvalid"
+                                t-att-disabled="!itemInfo.isValid"
                                 t-on-pointerenter="() => (state.hoveredDate = itemInfo.range[0])"
                                 t-on-click="() => this.zoomOrSelect(itemInfo)"
                             >
@@ -104,9 +105,9 @@
                         o_highlight_start: arInfo.isHighlightStart,
                         o_highlight_end: arInfo.isHighlightEnd,
                         o_today: itemInfo.includesToday,
-                        o_out_of_range: itemInfo.isOutOfRange or itemInfo.isInvalid,
+                        o_out_of_range: itemInfo.isOutOfRange or !itemInfo.isValid,
                     }"
-                    t-att-disabled="itemInfo.isInvalid"
+                    t-att-disabled="!itemInfo.isValid"
                     t-on-click="() => this.zoomOrSelect(itemInfo)"
                 >
                     <span t-esc="itemInfo.label" class="z-index-1" />

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -315,6 +315,9 @@ export const datetimePickerService = {
                  * @param {DateTime} value
                  */
                 const updateInput = (el, value) => {
+                    if (!el) {
+                        return;
+                    }
                     const [formattedValue] = safeConvert("format", value);
                     el.value = formattedValue || "";
                 };
@@ -443,17 +446,16 @@ export const datetimePickerService = {
                             ensureArray(pickerProps.value),
                             true
                         )) {
+                            updateInput(el, value);
                             if (el && !el.disabled && !el.readOnly) {
                                 cleanups.push(addListener(el, "change", onInputChange));
                                 cleanups.push(addListener(el, "click", onInputClick));
                                 cleanups.push(addListener(el, "focus", onInputFocus));
                                 cleanups.push(addListener(el, "keydown", onInputKeydown));
-
-                                updateInput(el, value);
                                 editableInputs++;
                             }
                         }
-                        if (!editableInputs) {
+                        if (!editableInputs && popover.isOpen) {
                             saveAndClose();
                         }
                         return () => cleanups.forEach((cleanup) => cleanup());

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -81,7 +81,7 @@ const dateCache = new WeakMap();
 /** @type {WeakMap<DateTime, string>} */
 const dateTimeCache = new WeakMap();
 
-class ConversionError extends Error {
+export class ConversionError extends Error {
     name = "ConversionError";
 }
 

--- a/addons/web/static/tests/core/datetime/datetime_picker_tests.js
+++ b/addons/web/static/tests/core/datetime/datetime_picker_tests.js
@@ -1000,6 +1000,53 @@ QUnit.module("Components", ({ beforeEach }) => {
         }
     );
 
+    QUnit.test("custom invalidity function", async (assert) => {
+        await mountPicker({
+            type: "date",
+            // make weekends invalid
+            isDateValid: (date) => date.weekday <= 5,
+        });
+
+        assertDateTimePicker({
+            title: "April 2023",
+            date: [
+                {
+                    cells: [
+                        [-26, -27, -28, -29, -30, -31, -1],
+                        [-2, 3, 4, 5, 6, 7, -8],
+                        [-9, 10, 11, 12, 13, 14, -15],
+                        [-16, 17, 18, 19, 20, 21, -22],
+                        [-23, 24, "25", 26, 27, 28, -29],
+                        [-30, -1, -2, -3, -4, -5, -6],
+                    ],
+                },
+            ],
+        });
+    });
+
+    QUnit.test("custom date cell class function", async (assert) => {
+        await mountPicker({
+            type: "date",
+            // give special class to weekends
+            dayCellClass: (date) => (date.weekday >= 6 ? "o_weekend" : ""),
+        });
+
+        assert.deepEqual(getTexts(".o_weekend"), [
+            "26",
+            "1",
+            "2",
+            "8",
+            "9",
+            "15",
+            "16",
+            "22",
+            "23",
+            "29",
+            "30",
+            "6",
+        ]);
+    });
+
     QUnit.test("single value, select date", async (assert) => {
         await mountPicker({
             value: DateTime.fromObject({ day: 30, hour: 8, minute: 43 }),


### PR DESCRIPTION
This commit allows users of the datetime picker service to pass functions that will be called to check the validity of specific days or that generate a class for a given day. This can be useful in some contexts for example when you want to prevent the user from selecting days on the weekend for certain operations, or to highlight some days where a given product is not in stock.

Enterprise: https://github.com/odoo/enterprise/pull/47061