### PR TITLE
[IMP] stock{_dropshipping},mrp,repair: remove onchange('code') from stock_picking_type

### DIFF
--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -49,8 +49,9 @@ class StockPickingType(models.Model):
     @api.depends('default_location_src_id', 'default_location_dest_id')
     def _compute_warehouse_id(self):
         super()._compute_warehouse_id()
-        if self.default_location_src_id.usage == 'supplier' and self.default_location_dest_id.usage == 'customer':
-            self.warehouse_id = False
+        for picking_type in self:
+            if picking_type.default_location_src_id.usage == 'supplier' and picking_type.default_location_dest_id.usage == 'customer':
+                picking_type.warehouse_id = False
 
     @api.depends('code')
     def _compute_show_picking_type(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Legacy code still use 'onchange' on the 'stock.picking.type' field code to compute the different xxx_location_id.
As it is no more viable, this commit replace all these onchange by compute methods.
These changes also has a side effect as some already existing compute methods may now get a set of 'stock.picking.type' in input, such that these methods are also updated to handle this case.

Current behavior before PR:
 - default value assignation of default_location_xxx_id  fields in 'stock.picking.type'  is triggered by an 'onchange' 
 - some compute methods handle one picking_type at a time
 
Desired behavior after PR is merged:
 - default value assignation of default_location_xxx_id  fields in 'stock.picking.type'  is triggered by a 'compute' 
-  compute methods handle one or multiple picking_type at a time


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
