### PR TITLE
[FIX] web_editor: remove regex look-behind for browser support

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -562,7 +562,7 @@ export class Link extends Component {
         const allBtnColorPrefixes = /(^|\s+)(bg|text|border)(-[a-z0-9_-]*)?/gi;
         const allBtnClassSuffixes = /(^|\s+)btn(-[a-z0-9_-]*)?/gi;
         const allBtnShapes = /\s*(rounded-circle|flat)\s*/gi;
-        const btnMarginBottom = /(?<!\S)mb-2(?!\S)/i;
+        const btnMarginBottom = /(^|\s+)mb-2(\s+|$)/i;
         this.state.className = this.state.iniClassName
             .replace(allBtnColorPrefixes, ' ')
             .replace(allBtnClassSuffixes, ' ')


### PR DESCRIPTION
Commit [1] used a regex with positive and negative look-behind assertions, which is not supported before Safari 16.4 [2]. This commit rewrites the regex with a more widely supported syntax.

[1]: https://www.github.com/odoo/odoo/commit/73317cb
[2]: https://caniuse.com/js-regexp-lookbehind

task-3497427