### PR TITLE
[IMP] mail, bus: Recover RTC call when a browser tab is closed

### DIFF
--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -26,6 +26,11 @@ let multiTabId = 0;
 export const multiTabService = {
     start() {
         const bus = new EventBus();
+        let broadcastChannel = null;
+        if (browser.BroadcastChannel) {
+            broadcastChannel = new browser.BroadcastChannel("multi.tab.service");
+            broadcastChannel.onmessage = ({ data }) => bus.trigger(data.type, data.payload);
+        }
 
         // CONSTANTS
         const TAB_HEARTBEAT_PERIOD = 10000; // 10 seconds
@@ -178,6 +183,7 @@ export const multiTabService = {
             get currentTabId() {
                 return tabId;
             },
+            startElection,
             /**
              * Determine whether or not this tab is the main one.
              *
@@ -216,8 +222,8 @@ export const multiTabService = {
             removeSharedValue(key) {
                 browser.localStorage.removeItem(generateLocalStorageKey(key));
             },
-            forceElection() {
-                return startElection();
+            broadcast(type, payload) {
+                broadcastChannel?.postMessage({ type, payload });
             },
         };
     },

--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -96,6 +96,16 @@ export const multiTabService = {
             }
         }
 
+        function getAnyOtherTabId() {
+            const lastPresenceByTab = getItemFromStorage("lastPresenceByTab", {});
+            for (const tab of Object.entries(lastPresenceByTab)) {
+                if (tab[0] === tabId) {
+                    continue;
+                }
+                return tab[0];
+            }
+        }
+
         function heartbeat() {
             const now = new Date().getTime();
             let heartbeatValue = getItemFromStorage("heartbeat", 0);
@@ -183,7 +193,7 @@ export const multiTabService = {
             get currentTabId() {
                 return tabId;
             },
-            startElection,
+            getAnyOtherTabId,
             /**
              * Determine whether or not this tab is the main one.
              *

--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -216,6 +216,9 @@ export const multiTabService = {
             removeSharedValue(key) {
                 browser.localStorage.removeItem(generateLocalStorageKey(key));
             },
+            forceElection() {
+                return startElection();
+            },
         };
     },
 };

--- a/addons/bus/static/tests/legacy/multi_tab_service_tests.js
+++ b/addons/bus/static/tests/legacy/multi_tab_service_tests.js
@@ -93,3 +93,21 @@ QUnit.test("multi tab triggers become_master", async function (assert) {
     await nextTick();
     assert.verifySteps(["become_main_tab"]);
 });
+
+QUnit.test("BroadcastChannel correctly notifies subscribers", async function (assert) {
+    assert.expect(2);
+    addBusServicesToRegistry();
+    const firstTabEnv = await makeTestEnv();
+    const secondTabEnv = await makeTestEnv();
+    secondTabEnv.services["multi_tab"].bus.addEventListener("bus/notify", ({ detail }) => {
+        assert.step(detail.notification);
+    });
+    firstTabEnv.services["multi_tab"].broadcast("bus/notify", {
+        notification: "notification",
+    });
+    firstTabEnv.services["multi_tab"].broadcast("bus/do_not_notify", {
+        notification: "notification",
+    });
+    await nextTick();
+    assert.verifySteps(["notification"]);
+});

--- a/addons/hr/static/tests/web/m2x_avatar_user_tests.js
+++ b/addons/hr/static/tests/web/m2x_avatar_user_tests.js
@@ -30,6 +30,7 @@ const fakeMultiTab = {
             },
             setSharedValue(key, value) {},
             removeSharedValue(key) {},
+            broadcast() {},
         };
     },
 };

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -69,7 +69,7 @@ export class Activity extends Record {
         if (broadcast) {
             this.store.env.services["multi_tab"].broadcast(
                 "mail.activity/insert",
-                this.store.env.services["mail.activity"]._serialize(activity)
+                activity.serialize()
             );
         }
         return activity;

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -67,10 +67,10 @@ export class Activity extends Record {
         }
         assignDefined(activity, data);
         if (broadcast) {
-            this.store.activityBroadcastChannel?.postMessage({
-                type: "INSERT",
-                payload: activity.serialize(),
-            });
+            this.store.env.services["multi_tab"].broadcast(
+                "mail.activity/insert",
+                this.store.env.services["mail.activity"]._serialize(activity)
+            );
         }
         return activity;
     }
@@ -171,9 +171,9 @@ export class Activity extends Record {
             attachment_ids: attachmentIds,
             feedback: this.feedback,
         });
-        this.store.activityBroadcastChannel?.postMessage({
-            type: "RELOAD_CHATTER",
-            payload: { id: this.res_id, model: this.res_model },
+        this.store.env.services["multi_tab"].broadcast("mail.activity/reload_chatter", {
+            id: this.res_id,
+            model: this.res_model,
         });
     }
 
@@ -184,9 +184,9 @@ export class Activity extends Record {
             [[this.id]],
             { feedback: this.feedback }
         );
-        this.activityBroadcastChannel?.postMessage({
-            type: "RELOAD_CHATTER",
-            payload: { id: this.res_id, model: this.res_model },
+        this.store.env.services["multi_tab"].broadcast("mail.activity/reload_chatter", {
+            id: this.res_id,
+            model: this.res_model,
         });
         return action;
     }
@@ -194,9 +194,8 @@ export class Activity extends Record {
     remove({ broadcast = true } = {}) {
         this.delete();
         if (broadcast) {
-            this.activityBroadcastChannel?.postMessage({
-                type: "DELETE",
-                payload: { id: this.id },
+            this.store.env.services["multi_tab"].broadcast("mail.activity/delete", {
+                id: this.res_id,
             });
         }
     }

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -28,21 +28,29 @@ const StorePatch = {
     },
     onStarted() {
         super.onStarted(...arguments);
-        debugger;
-        this.multiTab.bus.addEventListener("mail.activity/insert", ({ detail }) => {
-            this.store.Activity.insert(detail, { broadcast: false, html: true });
-        });
-        this.multiTab.bus.addEventListener("mail.activity/delete", ({ detail }) => {
-            const activity = this.store.Activity.insert(detail, { broadcast: false });
-            this.delete(activity, { broadcast: false });
-        });
-        this.multiTab.bus.addEventListener("mail.activity/reload_chatter", ({ detail }) => {
-            const thread = this.store.Thread.insert({
-                model: detail.model,
-                id: detail.id,
-            });
-            this.env.services["mail.thread"].fetchNewMessages(thread);
-        });
+        this.env.services["multi_tab"].bus.addEventListener(
+            "mail.activity/insert",
+            ({ detail }) => {
+                this.store.Activity.insert(detail, { broadcast: false, html: true });
+            }
+        );
+        this.env.services["multi_tab"].bus.addEventListener(
+            "mail.activity/delete",
+            ({ detail }) => {
+                const activity = this.store.Activity.insert(detail, { broadcast: false });
+                activity.delete({ broadcast: false });
+            }
+        );
+        this.env.services["multi_tab"].bus.addEventListener(
+            "mail.activity/reload_chatter",
+            ({ detail }) => {
+                const thread = this.store.Thread.insert({
+                    model: detail.model,
+                    id: detail.id,
+                });
+                thread.fetchNewMessages();
+            }
+        );
     },
     get initMessagingParams() {
         return {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -4,40 +4,40 @@
     <t t-name="discuss.CallActionList">
         <div class="o-discuss-CallActionList d-flex justify-content-center" t-attf-class="{{ className }}" t-ref="root">
             <div class="d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
-                <t t-if="isOfActiveCall and rtc.state.selfSession">
-                    <t t-if="rtc.state?.selfSession.isMute" t-set="micText">Unmute</t>
+                <t t-if="!props.thread.rtcInvitingSession">
+                    <t t-if="this.rtcState.selfSession.isMute" t-set="micText">Unmute</t>
                     <t t-else="" t-set="micText">Mute</t>
                     <button class="btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{ 'p-2': isSmall, 'p-3': !isSmall }"
                         t-att-aria-label="micText"
                         t-att-title="micText"
-                        t-on-click="onClickMicrophone">
+                        t-on-click="onClickCallAction.bind(this, 'microphone')">
                         <div class="fa-stack">
                             <i class="fa fa-stack-1x" t-att-class="{
                                 'fa-lg': !isSmall,
-                                'fa-microphone': !rtc.state.selfSession.isMute,
-                                'fa-microphone-slash': rtc.state.selfSession.isMute,
-                                'text-danger': rtc.state.selfSession.isMute,
+                                'fa-microphone': !this.rtcState.selfSession.isMute,
+                                'fa-microphone-slash': this.rtcState.selfSession.isMute,
+                                'text-danger': this.rtcState.selfSession.isMute,
                             }"/>
                         </div>
                     </button>
-                    <t t-if="rtc.state?.selfSession.isDeaf" t-set="headphoneText">Undeafen</t>
+                    <t t-if="this.rtcState.selfSession.isDeaf" t-set="headphoneText">Undeafen</t>
                     <t t-else="" t-set="headphoneText">Deafen</t>
                     <button class="btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{ 'p-2': isSmall, 'p-3': !isSmall }"
                         t-att-aria-label="headphoneText"
                         t-att-title="headphoneText"
-                        t-on-click="onClickDeafen">
+                        t-on-click="onClickCallAction.bind(this, 'deaf')">
                         <div class="fa-stack">
                             <i class="fa fa-stack-1x" t-att-class="{
                                 'fa-lg': !isSmall,
-                                'fa-headphones': !rtc.state.selfSession.isDeaf,
-                                'fa-deaf': rtc.state.selfSession.isDeaf,
-                                'text-danger': rtc.state.selfSession.isDeaf,
+                                'fa-headphones': !this.rtcState.selfSession.isDeaf,
+                                'fa-deaf': this.rtcState.selfSession.isDeaf,
+                                'text-danger': this.rtcState.selfSession.isDeaf,
                             }"/>
                         </div>
                     </button>
-                    <t t-if="rtc.state.sendCamera" t-set="cameraText">Stop camera</t>
+                    <t t-if="rtcState.sendCamera" t-set="cameraText">Stop camera</t>
                     <t t-else="" t-set="cameraText">Turn camera on</t>
                     <button class="btn d-flex m-1 border-0 rounded-circle shadow-none opacity-100 opacity-75-hover"
                         t-att-class="{
@@ -46,9 +46,9 @@
                         }"
                         t-att-aria-label="cameraText"
                         t-att-title="cameraText"
-                        t-on-click="() => this.rtc.toggleVideo('camera')">
+                        t-on-click="onClickCallAction.bind(this, 'camera')">
                         <div class="fa-stack">
-                            <i class="fa fa-video-camera fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall, 'text-success': rtc.state.sendCamera }"/>
+                            <i class="fa fa-video-camera fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall, 'text-success': rtcState.sendCamera }"/>
                         </div>
                     </button>
                     <Dropdown position="'top-end'" menuClass="'d-flex flex-column py-0'">
@@ -75,11 +75,12 @@
                         <i class="fa fa-times fa-stack-1x" t-att-class="{ 'fa-lg': !isSmall }"/>
                     </div>
                 </button>
-                <t t-if="props.thread.eq(rtc.state.channel)" t-set="callText">Disconnect</t>
+                <t t-set="isActive" t-value="isOfActiveCall || !!rtc.sharedState.channelId"/>
+                <t t-if="isActive" t-set="callText">Disconnect</t>
                 <t t-else="" t-set="callText">Join Call</t>
                 <button class="btn d-flex m-1 border-0 rounded-circle shadow-none"
                     t-att-aria-label="callText"
-                    t-att-class="{ 'btn-danger': isOfActiveCall, 'p-2': isSmall, 'p-3': !isSmall, 'btn-success': !isOfActiveCall }"
+                    t-att-class="{ 'btn-danger': isActive, 'p-2': isSmall, 'p-3': !isSmall, 'btn-success': !isActive }"
                     t-att-disabled="rtc.state.hasPendingRequest"
                     t-att-title="callText"
                     t-on-click="onClickToggleAudioCall">

--- a/addons/mail/static/src/discuss/call/common/call_menu.js
+++ b/addons/mail/static/src/discuss/call/common/call_menu.js
@@ -9,6 +9,22 @@ export class CallMenu extends Component {
     setup() {
         super.setup();
         this.rtc = useState(useService("discuss.rtc"));
+        this.store = useState(useService("mail.store"));
+    }
+
+    get rtcState() {
+        return this.rtc.state.channel ? this.rtc.state : this.rtc.sharedState;
+    }
+    
+    get rtcChannel() {
+        let channel = this.rtcState.channel;
+        if (!channel) {
+            channel = this.store.Thread.get({
+                model: "discuss.channel",
+                id: this.rtcState.channelId
+            });
+        }
+        return channel;
     }
 }
 

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -3,19 +3,19 @@
 
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.state.channel" class="px-3 user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="() => this.rtc.state.channel.open()">
+            <button t-if="rtcChannel" class="px-3 user-select-none dropdown-toggle o-no-caret o-dropdown--narrow" t-att-title="buttonTitle" role="button" t-on-click="() => this.rtcChannel.open()">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center">
                     <span class="position-relative me-2">
                         <i class="fa me-2" t-att-class="{
-                            'fa-microphone': !rtc.state.sendCamera and !rtc.state.sendScreen,
-                            'fa-video-camera': rtc.state.sendCamera,
-                            'fa-desktop': rtc.state.sendScreen,
+                            'fa-microphone': !rtcState.sendCamera and !rtcState.sendScreen,
+                            'fa-video-camera': rtcState.sendCamera,
+                            'fa-desktop': rtcState.sendScreen,
                         }"/>
                         <small class="position-absolute top-0 end-0 bottom-0 mt-n3 pt-1">
                             <i class="o-discuss-CallMenu-dot fa fa-circle text-warning small"/>
                         </small>
                     </span>
-                    <em class="text-truncate" t-esc="rtc.state.channel.displayName"/>
+                    <em class="text-truncate" t-esc="rtcChannel.displayName"/>
                 </div>
             </button>
         </div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -27,7 +27,7 @@
                         'o-isInvitation': !rtcSession,
                         }"
                         class="h-100 rounded-circle border-5 o_object_fit_cover"
-                        t-att-src="channelMember.persona.avatarUrl"
+                        t-att-src="channelMember?.persona?.avatarUrl"
                         draggable="false"
                 />
             </div>
@@ -48,6 +48,9 @@
                     </span>
                     <span t-if="rtcSession.isDeaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="deaf" aria-label="deaf">
                         <i class="fa fa-deaf"/>
+                    </span>
+                    <span t-if="rtcSession.isCameraOn and !hasVideo" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="camera" aria-label="camera">
+                        <i class="fa fa-video-camera"/>
                     </span>
                     <span t-if="hasMediaError" class="o-discuss-CallParticipantCard-overlay-replayButton d-flex flex-column justify-content-center me-1 p-2 rounded-circle" title="media player Error" t-on-click.stop="onClickReplay">
                         <i t-if="rootHover.isHover" class="fa fa-repeat text-danger"/>

--- a/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
@@ -30,6 +30,7 @@ const fakeMultiTab = {
             },
             setSharedValue(key, value) {},
             removeSharedValue(key) {},
+            broadcast() {},
         };
     },
 };


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Even if you have multiple browser tabs open, closing a tab removes you from your potentially ongoing RTC call.
This is sad because that may not be your intention to cut the call short and there are idle tabs that could carry over.

Current behavior before PR:
Closing a tab remove you from the call.

Desired behavior after PR is merged:
If one or more tabs are open, the elected tab will join the call that you just left.

<hr/>

Closing a tab removes you from your potentially ongoing RTC call.

This commits ensure that browser tabs with the same origin are notified and the elected tab will instantly join the call if possible.

Task-3244140

[Enterprise PR](https://github.com/odoo/enterprise/pull/61648)
