### PR TITLE
[FIX] survey: resolve the traceback for matrix question type

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -1013,7 +1013,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
                 if (this.options.questionsLayout === 'page_per_question') {
                     var subQuestionsIds = $matrixBtn.closest('table').data('subQuestions');
                     var completedQuestions = [];
-                    subQuestionsIds.forEach(function (id) {
+                    subQuestionsIds.forEach((id) => {
                         if (this.$('tr#' + id).find('input:checked').length !== 0) {
                             completedQuestions.push(id);
                         }


### PR DESCRIPTION
Steps to reproduce:
- Create a survey with matrix-type questions.
- Test the survey.
- Click on the given option, and it gives a trackback.

Issue:
- The issue occurs because the scope of `this` keyword is unavailable.

Task: 3485467

