### PR TITLE
[IMP] core: add SQL wrapper

### DIFF
--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -41,6 +41,7 @@ from . import test_res_config
 from . import test_res_lang
 from . import test_search
 from . import test_split_table
+from . import test_sql
 from . import test_translate
 # from . import test_uninstall  # loop
 from . import test_user_has_group

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1229,7 +1229,7 @@ class TestQueries(TransactionCase):
             SELECT COUNT(*) FROM (
                 SELECT FROM "res_partner"
                 WHERE (("res_partner"."active" = %s) AND ("res_partner"."name"::text LIKE %s))
-                LIMIT 1
+                LIMIT %s
             ) t
         ''']):
             Model.search_count([('name', 'like', 'foo')], limit=1)
@@ -1294,7 +1294,7 @@ class TestQueries(TransactionCase):
                 OR ("ir_model"."model"::text ILIKE %s)
             )
             ORDER BY "ir_model"."model"
-            LIMIT 100
+            LIMIT %s
         ''']):
             Model.name_search('foo')
 
@@ -1306,7 +1306,7 @@ class TestQueries(TransactionCase):
                 AND (("ir_model"."model"::text NOT ILIKE %s) OR "ir_model"."model" IS NULL)
             )
             ORDER BY "ir_model"."model"
-            LIMIT 100
+            LIMIT %s
         ''']):
             Model.name_search('foo', operator='not ilike')
 
@@ -1426,7 +1426,7 @@ class TestMany2one(TransactionCase):
                 FROM "res_company"
                 WHERE (("res_company"."active" = %s) AND ("res_company"."name"::text LIKE %s))
                 ORDER BY "res_company"."id"
-                LIMIT 1
+                LIMIT %s
             ))
             ORDER BY "res_partner"."complete_name"asc,"res_partner"."id"desc
         ''']):

--- a/odoo/addons/base/tests/test_osv.py
+++ b/odoo/addons/base/tests/test_osv.py
@@ -50,12 +50,12 @@ class QueryTestCase(BaseCase):
         alias = query.left_join("product_template__categ_id", "user_id", "res_user", "id", "user_id")
         self.assertEqual(alias, 'product_template__categ_id__user_id')
         # additional implicit join
-        query.add_table('account.account')
+        query.add_table('account_account')
         query.add_where("product_category.expense_account_id = account_account.id")
 
         from_clause, where_clause, where_params = query.get_sql()
         self.assertEqual(from_clause,
-            '"product_product", "product_template", "account.account" JOIN "product_category" AS "product_template__categ_id" ON ("product_template"."categ_id" = "product_template__categ_id"."id") LEFT JOIN "res_user" AS "product_template__categ_id__user_id" ON ("product_template__categ_id"."user_id" = "product_template__categ_id__user_id"."id")')
+            '"product_product", "product_template", "account_account" JOIN "product_category" AS "product_template__categ_id" ON ("product_template"."categ_id" = "product_template__categ_id"."id") LEFT JOIN "res_user" AS "product_template__categ_id__user_id" ON ("product_template__categ_id"."user_id" = "product_template__categ_id__user_id"."id")')
         self.assertEqual(where_clause, "product_product.template_id = product_template.id AND product_category.expense_account_id = account_account.id")
 
     def test_raise_missing_lhs(self):

--- a/odoo/addons/base/tests/test_sql.py
+++ b/odoo/addons/base/tests/test_sql.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import BaseCase
+from odoo.tools import SQL
+
+
+class TestSQL(BaseCase):
+
+    def test_sql_empty(self):
+        sql = SQL()
+        self.assertEqual(sql.code, "")
+        self.assertEqual(sql.params, [])
+
+    def test_sql_bool(self):
+        self.assertFalse(SQL())
+        self.assertFalse(SQL(""))
+        self.assertTrue(SQL("anything"))
+        self.assertTrue(SQL("%s", 42))
+
+    def test_sql_with_no_parameter(self):
+        sql = SQL("SELECT id FROM table WHERE foo=bar")
+        self.assertEqual(sql.code, "SELECT id FROM table WHERE foo=bar")
+        self.assertEqual(sql.params, [])
+
+    def test_sql_with_literal_parameters(self):
+        sql = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
+        self.assertEqual(sql.code, "SELECT id FROM table WHERE foo=%s AND bar=%s")
+        self.assertEqual(sql.params, [42, 'baz'])
+
+    def test_sql_with_wrong_pattern(self):
+        with self.assertRaises(TypeError):
+            SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42)
+
+        with self.assertRaises(TypeError):
+            SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 1, 2, 3)
+
+    def test_sql_equality(self):
+        sql1 = SQL("SELECT id FROM table WHERE foo=%s", 42)
+        sql2 = SQL("SELECT id FROM table WHERE foo=%s", 42)
+        self.assertEqual(sql1, sql2)
+
+        sql1 = SQL("SELECT id FROM table WHERE foo=%s", 42)
+        sql2 = SQL("SELECT id FROM table WHERE bar=%s", 42)
+        self.assertNotEqual(sql1, sql2)
+
+        sql1 = SQL("SELECT id FROM table WHERE foo=%s", 42)
+        sql2 = SQL("SELECT id FROM table WHERE foo=%s", 421)
+        self.assertNotEqual(sql1, sql2)
+
+    def test_sql_idempotence(self):
+        sql1 = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
+        sql2 = SQL(sql1)
+        self.assertIs(sql1, sql2)
+
+    def test_sql_unpacking(self):
+        sql = SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 42, 'baz')
+        string, params = sql
+        self.assertEqual(string, "SELECT id FROM table WHERE foo=%s AND bar=%s")
+        self.assertEqual(params, [42, 'baz'])
+
+    def test_sql_join(self):
+        sql = SQL(" AND ").join([])
+        self.assertEqual(sql.code, "")
+        self.assertEqual(sql.params, [])
+        self.assertEqual(sql, SQL(""))
+
+        sql = SQL(" AND ").join([SQL("foo=%s", 1)])
+        self.assertEqual(sql.code, "foo=%s")
+        self.assertEqual(sql.params, [1])
+
+        sql = SQL(" AND ").join([
+            SQL("foo=%s", 1),
+            SQL("bar=%s", 2),
+            SQL("baz=%s", 3),
+        ])
+        self.assertEqual(sql.code, "foo=%s AND bar=%s AND baz=%s")
+        self.assertEqual(sql.params, [1, 2, 3])
+
+        sql = SQL(", ").join([1, 2, 3])
+        self.assertEqual(sql.code, "%s, %s, %s")
+        self.assertEqual(sql.params, [1, 2, 3])
+
+    def test_sql_identifier(self):
+        sql = SQL.identifier('foo')
+        self.assertEqual(sql.code, '"foo"')
+        self.assertEqual(sql.params, [])
+
+        sql = SQL.identifier('foo', 'bar')
+        self.assertEqual(sql.code, '"foo"."bar"')
+        self.assertEqual(sql.params, [])
+
+        with self.assertRaises(AssertionError):
+            sql = SQL.identifier('foo"')
+
+        with self.assertRaises(AssertionError):
+            sql = SQL.identifier('(SELECT 42)')
+
+        with self.assertRaises(AssertionError):
+            sql = SQL.identifier('foo', 'ba"r')
+
+    def test_sql_with_sql_parameters(self):
+        sql = SQL("SELECT id FROM table WHERE foo=%s AND %s", 1, SQL("bar=%s", 2))
+        self.assertEqual(sql.code, "SELECT id FROM table WHERE foo=%s AND bar=%s")
+        self.assertEqual(sql.params, [1, 2])
+        self.assertEqual(sql, SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 1, 2))
+
+        sql = SQL("SELECT id FROM table WHERE %s AND bar=%s", SQL("foo=%s", 1), 2)
+        self.assertEqual(sql.code, "SELECT id FROM table WHERE foo=%s AND bar=%s")
+        self.assertEqual(sql.params, [1, 2])
+        self.assertEqual(sql, SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 1, 2))
+
+        sql = SQL("SELECT id FROM table WHERE %s AND %s", SQL("foo=%s", 1), SQL("bar=%s", 2))
+        self.assertEqual(sql.code, "SELECT id FROM table WHERE foo=%s AND bar=%s")
+        self.assertEqual(sql.params, [1, 2])
+        self.assertEqual(sql, SQL("SELECT id FROM table WHERE foo=%s AND bar=%s", 1, 2))
+
+    def test_complex_sql(self):
+        sql = SQL(
+            "SELECT %s FROM %s WHERE %s",
+            SQL.identifier('id'),
+            SQL.identifier('table'),
+            SQL(" AND ").join([
+                SQL("%s=%s", SQL.identifier('table', 'foo'), 1),
+                SQL("%s=%s", SQL.identifier('table', 'bar'), 2),
+            ]),
+        )
+        self.assertEqual(sql.code, 'SELECT "id" FROM "table" WHERE "table"."foo"=%s AND "table"."bar"=%s')
+        self.assertEqual(sql.params, [1, 2])
+        self.assertEqual(sql, SQL('SELECT "id" FROM "table" WHERE "table"."foo"=%s AND "table"."bar"=%s', 1, 2))
+        self.assertEqual(
+            repr(sql),
+            """SQL('SELECT "id" FROM "table" WHERE "table"."foo"=%s AND "table"."bar"=%s', 1, 2)"""
+        )

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -305,7 +305,7 @@ class PropertiesCase(TestPropertiesMixin):
             # check the many2one existence
             ''' SELECT "test_new_api_partner"."id"
                 FROM "test_new_api_partner"
-                WHERE "test_new_api_partner".id IN %s
+                WHERE "test_new_api_partner"."id" IN %s
             ''',
             ''' SELECT "test_new_api_partner"."id",
                        "test_new_api_partner"."name",
@@ -2015,7 +2015,7 @@ class PropertiesSearchCase(TestPropertiesMixin):
                     self.env['test_new_api.message'].search(domain=[], order=order)
 
 
-class PropertiesGroupByCase(PropertiesCase):
+class PropertiesGroupByCase(TestPropertiesMixin):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -26,7 +26,7 @@ from .. import SUPERUSER_ID
 from odoo.sql_db import TestCursor
 from odoo.tools import (
     config, existing_tables, lazy_classproperty,
-    lazy_property, sql, Collector, OrderedSet,
+    lazy_property, sql, Collector, OrderedSet, SQL,
     format_frame
 )
 from odoo.tools.func import locked
@@ -797,9 +797,11 @@ class Registry(Mapping):
 
             for sequence_name in sequence_names:
                 if sequence_name not in existing_sequences:
-                    _sequence_name = sql.Identifier(sequence_name)  # even if sequence_name should be safe, will avoid flagging the sql_injection linter
-                    cr.execute(sql.SQL("CREATE SEQUENCE {} INCREMENT BY 1 START WITH 1").format(_sequence_name))
-                    cr.execute("SELECT nextval(%s)", [sequence_name])
+                    cr.execute(SQL(
+                        "CREATE SEQUENCE %s INCREMENT BY 1 START WITH 1",
+                        SQL.identifier(sequence_name),
+                    ))
+                    cr.execute(SQL("SELECT nextval(%s)", sequence_name))
 
             db_registry_sequence, db_cache_sequences = self.get_sequences(cr)
             self.registry_sequence = db_registry_sequence

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1440,12 +1440,14 @@ class expression(object):
             params = []
 
         elif operator == 'inselect':
-            query = '(%s."%s" in (%s))' % (table_alias, left, right[0])
-            params = list(right[1])
+            subquery, subparams = right
+            query = '(%s."%s" in (%s))' % (table_alias, left, subquery)
+            params = list(subparams)
 
         elif operator == 'not inselect':
-            query = '(%s."%s" not in (%s))' % (table_alias, left, right[0])
-            params = list(right[1])
+            subquery, subparams = right
+            query = '(%s."%s" not in (%s))' % (table_alias, left, subquery)
+            params = list(subparams)
 
         elif operator in ['in', 'not in']:
             # Two cases: right is a boolean or a list. The boolean case is an

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -52,7 +52,7 @@ from odoo.exceptions import AccessError
 from odoo.modules.registry import Registry
 from odoo.service import security
 from odoo.sql_db import BaseCursor, Cursor
-from odoo.tools import float_compare, single_email_re, profiler, lower_logging
+from odoo.tools import float_compare, single_email_re, profiler, lower_logging, SQL
 from odoo.tools.misc import find_in_path, mute_logger
 
 from . import case
@@ -465,7 +465,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
         actual_queries = []
 
         def execute(self, query, params=None, log_exceptions=None):
-            actual_queries.append(query)
+            actual_queries.append(query.code if isinstance(query, SQL) else query)
             return Cursor_execute(self, query, params, log_exceptions)
 
         def get_unaccent_wrapper(cr):


### PR DESCRIPTION
We introduce a new class of objects to wrap SQL code together with its parameters.  It is designed to be easily composable and to discourage SQL injections.  Its API is similar to the methods of module `logging`: the code is a format string, and the positional parameters are meant to be merged into it using the string formatting operator.
```py
# default and increment are parameters of the SQL code in first argument
term = SQL("COALESCE(value, %s) + %s", default, increment)

# term can safely be injected into another SQL, besides regular parameters
query = SQL("SELECT %s FROM mytable WHERE id = %s", term, id_)
```    
The SQL wrapper can return the final SQL code string as `query.code`, and the corresponding parameters as `query.params` (`list`).  The cursor method `execute()` can now take an `SQL` object, and execute it just like
```py    
cr.execute(query.code, query.params)
```    
It is quite easy to make SQL objects safe against SQL injections: if the code is a string literal, then the SQL object is guaranteed safe, provided the SQL objects within its parameters are themselves safe.