### PR TITLE
[IMP] point_of_sale,pos_restaurant: primary btn payment, order & review

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -377,11 +377,8 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
     get showProductReminder() {
         return this.currentOrder.get_selected_orderline() && this.selectedOrderlineQuantity;
     }
-    primaryPayButton() {
+    get primaryPayButton() {
         return !this.currentOrder.is_empty();
-    }
-    primaryReviewButton() {
-        return !this.primaryPayButton() && !this.currentOrder.is_empty();
     }
     // FIXME POSREF this is dead code, check if we need the business logic that's left in here
     // If we do it should be in the model.

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -50,11 +50,11 @@
                         <span><t t-esc="selectedOrderlineQuantity"/> <t t-esc="selectedOrderlineDisplayName"/> <t t-esc="selectedOrderlineTotal"/></span>
                     </div>
                     <div class="switchpane d-flex">
-                        <button class="btn-switchpane pay-button btn btn-primary w-50 rounded-0 fw-bolder" t-att-class="{'primary': primaryPayButton(), 'secondary': !primaryPayButton()}" t-on-click="() => currentOrder.pay()">
+                        <button class="btn-switchpane pay-button btn w-50 rounded-0 fw-bolder" t-attf-class="{{ primaryPayButton ? 'btn-primary' : 'btn-secondary' }}" t-on-click="() => currentOrder.pay()">
                             <span class="fs-1 d-block">Pay</span>
                             <span><t t-esc="total" /></span>
                         </button>
-                        <button class="btn-switchpane btn btn-secondary w-50 rounded-0 fw-bolder" t-att-class="{'primary': primaryReviewButton(), 'secondary': !primaryReviewButton()}" t-on-click="switchPane">
+                        <button class="btn-switchpane btn w-50 btn-secondary rounded-0 fw-bolder review-button" t-on-click="switchPane">
                             <span class="fs-1 d-block">Review</span>
                             <span><t t-esc="items"/> items</span>
                         </button>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -114,7 +114,7 @@
                         <button class="btn-switchpane load-order-button primary btn btn-primary rounded-0 w-50 fw-bolder py-3" t-if="!isOrderSynced" t-on-click="() => this._setOrder(_selectedSyncedOrder)">
                             <span class="fs-1 d-block">Load Order</span>
                         </button>
-                        <button class="btn-switchpane flex-fill btn rounded-0 fw-bolder secondary" t-att-class="{'btn-primary': isOrderSynced, 'btn-secondary': !isOrderSynced}" t-on-click="switchPane">
+                        <button class="btn-switchpane flex-fill btn rounded-0 fw-bolder secondary review-button" t-att-class="{'btn-primary': isOrderSynced, 'btn-secondary': !isOrderSynced}" t-on-click="switchPane">
                             <span class="fs-1 d-block">Review</span>
                         </button>
                     </div>

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1763,6 +1763,7 @@ export class Order extends PosModel {
         const oldChanges = this.lastOrderPrepaChange;
         const changes = {};
         let changesCount = 0;
+        let changeAbsCount = 0;
 
         // Compares the orderlines of the order with the last ones sent.
         // When one of them has changed, we add the change.
@@ -1790,6 +1791,7 @@ export class Order extends PosModel {
                         note: note,
                     };
                     changesCount += quantityDiff;
+                    changeAbsCount += Math.abs(quantityDiff);
 
                     if (!orderline.skipChange) {
                         orderline.setHasChange(true);
@@ -1821,6 +1823,7 @@ export class Order extends PosModel {
         }
 
         return {
+            nbrOfChanges: changeAbsCount,
             orderlines: changes,
             count: changesCount,
         };

--- a/addons/point_of_sale/static/tests/tours/acceptance_tour.js
+++ b/addons/point_of_sale/static/tests/tours/acceptance_tour.js
@@ -13,7 +13,7 @@ function add_product_to_order(product_name) {
         },
         {
             content: "click review button",
-            trigger: ".btn-switchpane:contains('Review')",
+            trigger: ".btn-switchpane.review-button",
             mobile: true,
         },
         ...Order.hasLine({ productName: product_name }),
@@ -29,7 +29,7 @@ function set_fiscal_position_on_order(fp_name) {
     return [
         {
             content: "click review button",
-            trigger: ".btn-switchpane:contains('Review')",
+            trigger: ".btn-switchpane.review-button",
             mobile: true,
         },
         {
@@ -96,7 +96,7 @@ function press_product_numpad(val) {
     return [
         {
             content: "click review button",
-            trigger: ".btn-switchpane:contains('Review')",
+            trigger: ".btn-switchpane.review-button",
             mobile: true,
         },
         Numpad.click(val),
@@ -123,7 +123,7 @@ function selected_orderline_has({ product, price = null, quantity = null }) {
     const result = [
         {
             content: "click review button",
-            trigger: ".btn-switchpane:contains('Review')",
+            trigger: ".btn-switchpane.review-button",
             mobile: true,
         },
     ];
@@ -140,7 +140,7 @@ function verify_order_total(total_str) {
     return [
         {
             content: "click review button",
-            trigger: ".btn-switchpane:contains('Review')",
+            trigger: ".btn-switchpane.review-button",
             mobile: true,
         },
         Order.hasTotal(total_str),

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -9,7 +9,7 @@ export function adaptForMobile(steps) {
     return [
         {
             content: "click review button",
-            trigger: ".btn-switchpane:contains('Review')",
+            trigger: ".btn-switchpane.review-button",
             mobile: true,
         },
         ...[steps].flat(),
@@ -114,7 +114,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -147,7 +147,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -165,7 +165,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -208,7 +208,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -288,22 +288,22 @@ class Do {
     clickLotIcon() {
         return [
             {
-                content: 'click lot icon',
-                trigger: '.line-lot-icon',
+                content: "click lot icon",
+                trigger: ".line-lot-icon",
             },
         ];
     }
     enterLotNumber(number) {
         return [
             {
-                content: 'enter lot number',
-                trigger: '.list-line-input:first()',
-                run: 'text ' + number,
+                content: "enter lot number",
+                trigger: ".list-line-input:first()",
+                run: "text " + number,
             },
             {
-                content: 'click validate lot number',
-                trigger: '.popup .button.confirm',
-            }
+                content: "click validate lot number",
+                trigger: ".popup .button.confirm",
+            },
         ];
     }
 }
@@ -397,7 +397,7 @@ class Check {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -432,7 +432,7 @@ class Check {
     checkFirstLotNumber(number) {
         return [
             {
-                content: 'Check lot number',
+                content: "Check lot number",
                 trigger: `.popup-input:propValue(${number})`,
                 run: () => {}, // it's a check
             },

--- a/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
@@ -29,7 +29,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
         ];
@@ -53,7 +53,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -125,7 +125,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {
@@ -149,7 +149,7 @@ class Do {
         return [
             {
                 content: "click review button",
-                trigger: ".btn-switchpane:contains('Review')",
+                trigger: ".btn-switchpane.review-button",
                 mobile: true,
             },
             {

--- a/addons/point_of_sale/static/tests/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pricelist_tour.js
@@ -106,7 +106,7 @@ steps = steps.concat([
     ...ProductScreen.do.clickHomeCategory(),
     {
         content: "click review button",
-        trigger: ".btn-switchpane:contains('Review')",
+        trigger: ".btn-switchpane.review-button",
         mobile: true,
     },
     {
@@ -190,7 +190,7 @@ steps = steps.concat([
     },
     {
         content: "click review button",
-        trigger: ".btn-switchpane:contains('Review')",
+        trigger: ".btn-switchpane.review-button",
         mobile: true,
     },
     ...Order.hasLine({ productName: "Wall Shelf", quantity: "1.0", withClass: ".selected" }),
@@ -222,7 +222,7 @@ steps = steps.concat([
     },
     {
         content: "click review button",
-        trigger: ".btn-switchpane:contains('Review')",
+        trigger: ".btn-switchpane.review-button",
         mobile: true,
     },
     ...Order.hasLine({ productName: "Small Shelf", quantity: "1.0", withClass: ".selected" }),

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.xml
@@ -15,9 +15,7 @@
                 <i class="fa fa-cutlery"></i>
                 Order
                 <div class="break-line">
-                    <t t-foreach="categoryCount" t-as="category" t-key="category[0]">
-                        <t t-esc="category[1]"/> <t t-esc="category[0]"/> | 
-                    </t>
+                    <t t-esc="categoryCount" />
                 </div>
             </button>
         </xpath>

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
@@ -27,17 +27,26 @@ patch(ProductScreen.prototype, {
             this.pos.get_order().get_selected_orderline().get_display_price()
         );
     },
+    get nbrOfChanges() {
+        return this.currentOrder.getOrderChanges().nbrOfChanges;
+    },
     get swapButton() {
         return this.pos.config.module_pos_restaurant && this.pos.orderPreparationCategories.size;
     },
     submitOrder() {
         this.pos.sendOrderInPreparation(this.pos.get_order());
     },
-    primaryPayButton() {
+    get primaryReviewButton() {
         return (
-            !this.currentOrder.is_empty() &&
-            ((!this.swapButton && super.primaryPayButton(...arguments)) ||
-                (this.swapButton && this.pos.get_order().getOrderChanges().count > 0))
+            !this.primaryOrderButton &&
+            !this.pos.get_order().is_empty() &&
+            this.pos.config.module_pos_restaurant
+        );
+    },
+    get primaryOrderButton() {
+        return (
+            this.pos.get_order().getOrderChanges().nbrOfChanges !== 0 &&
+            this.pos.config.module_pos_restaurant
         );
     },
 });

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.xml
@@ -5,22 +5,29 @@
         <xpath expr="//button[hasclass('pay-button')]" position="replace">
             <button
                 t-if="this.swapButton"
-                class="btn-switchpane btn btn-primary flex-fill rounded-0 fw-bolder py-3"
+                class="btn-switchpane btn flex-fill rounded-0 fw-bolder py-3"
                 t-on-click="submitOrder"
-                t-att-class="{'primary': primaryPayButton(), 'secondary': !primaryPayButton()}">
+                t-attf-class="{{ primaryOrderButton ? 'btn-primary' : 'btn-secondary' }}">
                 <!-- Replace the payment button by the order button -->
                 <span class="fs-1 d-block">Order</span>
-                <span><t t-esc="total"/></span>
+                <span><t t-esc="nbrOfChanges"/> changes</span>
             </button>
             <t t-else="">
-                <button 
-                    class="btn-switchpane btn btn-primary flex-fill rounded-0 fw-bolder py-3" 
-                    t-att-class="{'primary': primaryPayButton(), 'secondary': !primaryPayButton()}"
+                <button
+                    class="btn-switchpane btn flex-fill rounded-0 fw-bolder py-3"
+                    t-attf-class="{{ primaryPayButton ? 'btn-primary' : 'btn-secondary' }}"
                     t-on-click="() => currentOrder.pay()">
                     <span class="fs-1 d-block">Pay</span>
                     <span><t t-esc="total" /></span>
                 </button>
             </t>
+        </xpath>
+        <xpath expr="//button[hasclass('review-button')]" position="replace">
+            <button class="btn-switchpane btn w-50 rounded-0 fw-bolder review-button" t-attf-class="{{ primaryReviewButton ? 'btn-primary' : 'btn-secondary' }}" t-on-click="switchPane">
+                <span class="fs-1 d-block">Payment</span>
+                <span t-if="this.swapButton"><t t-esc="total" /></span>
+                <span t-else=""><t t-esc="items"/> items</span>
+            </button>
         </xpath>
         <xpath expr="//Orderline" position="attributes">
             <attribute name="t-on-dblclick">

--- a/addons/pos_restaurant/static/src/overrides/models/pos_bus.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_bus.js
@@ -27,7 +27,7 @@ patch(PosBus.prototype, {
     dispatch(message) {
         super.dispatch(...arguments);
 
-        if (message.type === "TABLE_ORDER_COUNT") {
+        if (message.type === "TABLE_ORDER_COUNT" && this.pos.config.module_pos_restaurant) {
             this.ws_syncTableCount(message.payload);
         }
     },


### PR DESCRIPTION
Previously, the order, review and pay buttons were in btn-primary at the same time, or not at the right time.

Changes have been made to the current behavior:
- If there is no order line, both buttons are gray
- if something needs to be sent, the Command button takes priority
- if nothing is to be sent, the Payment button takes priority

A fix has also been made to the number of items to be sent to the kitchen, both for the category list and for the number of products. The number of products per category was erroneous, so the number of products has been changed to an absolute value.