### PR TITLE
[FIX] survey: fix duplicate timer

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -475,7 +475,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
             }
 
             // Start datetime pickers
-            self.trigger_up("widgets_start_request");
+            self.trigger_up("widgets_start_request", { $target: this.$el.find('.o_survey_form_date') });
             if (this.options.isStartScreen || (options && options.initTimer)) {
                 this._initTimer();
                 this.options.isStartScreen = false;


### PR DESCRIPTION
This commit fix a bug introduced by 910897fc97d87b08f01627094ec8c159f5267628 which displayed two timers when starting a survey.

Task-3497526




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
