### PR TITLE
[FIX] pos_gift_card: Gift Cards' Balance

### DIFF
--- a/addons/pos_gift_card/models/gift_card.py
+++ b/addons/pos_gift_card/models/gift_card.py
@@ -29,7 +29,7 @@ class GiftCard(models.Model):
                 balance -= sum(
                     confirmed_line.mapped(
                         lambda line: line.currency_id._convert(
-                            line.price_unit,
+                            line.price_subtotal_incl,
                             record.currency_id,
                             record.env.company,
                             line.create_date,


### PR DESCRIPTION
The method `_compute_balance` doesn't take into account the actual quantity of the line, so if you have `qty == 0` or `qty == 99`, the result will be the same if it was `qty == 1`, which results for example:
- Gift Card with $100, balance is $100
- Order with:
    - A product with a subtotal of $100
    - Gift card line applied, `price_unit` of $100, then there was a change in the `qty` to 0, and `price_subtotal_incl` is 0.
    - Total of the Order $100
- Results in a Gift Card's balance was affected and is $0 and can't be used again.

Now the same example above has a result where the Gift Card's balance isn't affected and is still $100 and can be used again.

Here is the Video with the Current Behavior: 
https://youtu.be/nsvlDwKosLo

Replicated in Runbot:
https://50541124-15-0-all.runbot158.odoo.com/web?debug=1#cids=1&action=menu

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
