### PR TITLE
[FIX] mrp_subcontracting: the move lines on backorder will not be created with qty_done = qty_reserved

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -74,7 +74,7 @@ class StockPicking(models.Model):
             # _split_production can set the qty_done, but not split it.
             # Remove the qty_done potentially set by a previous split to prevent any issue.
             production.move_line_raw_ids.filtered(lambda sml: sml.state not in ['done', 'cancel']).write({'qty_done': 0})
-            productions = production._split_productions({production: amounts}, set_consumed_qty=True)
+            productions = production._split_productions({production: amounts})
             for production, move_line in zip(productions, move.move_line_ids):
                 if move_line.lot_id:
                     production.lot_producing_id = move_line.lot_id


### PR DESCRIPTION
### Before this PR

Steps to reproduce the issue:
- Create a BOM subcontracting with more than 3 quantity
- Create a Purchase 
- The Subcontracting production is created 
- Confirm quantity 1 on receipt linked to subcontracting
- The move lines on new backorder will contain consumed = reserved
- Try to confirm quantity 1 on the receipt linked to subcontracting
- All the remaining reserved components will be confirmed instead the required ones


### After this PR
No set quantity consumed will be passed when creating backorder but the quantity of components used will be correctly set 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
