### PR TITLE
[FIX] test_base_automation: fix failing tour

### DIFF
--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -99,7 +99,9 @@ registry.category("web_tour.tours").add("test_base_automation", {
             content: "Open update select",
             trigger: ".modal-content .o_form_button_save",
         },
-        ...stepUtils.saveForm(),
+        ...stepUtils.saveForm({
+            extra_trigger: ".o-overlay-container:not(:has(.modal-content))",
+        }),
     ],
 });
 


### PR DESCRIPTION
This commit fixes a tour that is failing undeterministically.

- Before The tour was saving a form dialog just before saving the main form. Sometimes, these two steps were too fast, leading for the second one not performing the main form save action.

- After The second step now awaits that the modal is closed before running.
  This element is the kanban record saved by the form dialog.

Fixes runbot error 24576