### PR TITLE
[FIX] mail, im_livechat: fix website livechat chatbot flow tour 

### DIFF
--- a/addons/im_livechat/static/src/embed/core/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/core/message_model_patch.js
@@ -8,9 +8,10 @@ import { patch } from "@web/core/utils/patch";
 
 patch(Message, {
     insert(data) {
+        const chatbotStep = this.store.Message.get(data)?.chatbotStep;
         const message = super.insert(data);
         if (data.chatbotStep) {
-            message.chatbotStep = new ChatbotStep(data.chatbotStep);
+            message.chatbotStep = new ChatbotStep({ ...chatbotStep, ...data.chatbotStep });
         }
         return message;
     },


### PR DESCRIPTION
This commit fixes the "website_livechat_chatbot_flow_tour" which was
nondeterministic. This was due to the message service update which was
assigning data blindly based on the payload instead of handling it
properly. This is solved by enriching the chatbot step instead of
overwriting it.

runbot-24625