### PR TITLE
[IMP] payment: remove create from payment provider form

### DIFF
--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -5,7 +5,7 @@
         <field name="name">payment.provider.form</field>
         <field name="model">payment.provider</field>
         <field name="arch" type="xml">
-            <form string="Payment provider">
+            <form string="Payment provider" create="0">
                 <field name="company_id" invisible="1"/>
                 <field name="is_published" invisible="1"/>
                 <field name="main_currency_id" invisible="1"/>
@@ -59,10 +59,6 @@
                             <a invisible="not module_to_buy" href="https://odoo.com/pricing?utm_source=db&amp;utm_medium=module" target="_blank" class="btn btn-info" role="button">Upgrade</a>
                             <button invisible="module_to_buy" type="object" class="btn btn-primary" name="button_immediate_install" string="Install"/>
                         </div>
-                    </div>
-                    <div id="provider_creation_warning" invisible="id" class="alert alert-warning" role="alert">
-                        <strong>Warning</strong> Creating a payment provider from the <em>CREATE</em> button is not supported.
-                        Please use the <em>Duplicate</em> action instead.
                     </div>
                     <group>
                         <group name="payment_state" invisible="module_state not in ('installed', False)">

--- a/addons/payment_alipay/views/payment_provider_views.xml
+++ b/addons/payment_alipay/views/payment_provider_views.xml
@@ -6,7 +6,7 @@
         <field name="model">payment.provider</field>
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+            <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div class="alert alert-danger"
                      role="alert"
                      invisible="code != 'alipay'">

--- a/addons/payment_ogone/views/payment_provider_views.xml
+++ b/addons/payment_ogone/views/payment_provider_views.xml
@@ -6,7 +6,7 @@
         <field name="model">payment.provider</field>
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+            <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div class="alert alert-danger"
                      role="alert"
                      invisible="code != 'ogone'">

--- a/addons/payment_payulatam/views/payment_provider_views.xml
+++ b/addons/payment_payulatam/views/payment_provider_views.xml
@@ -6,7 +6,7 @@
         <field name="model">payment.provider</field>
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+            <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div class="alert alert-danger"
                      role="alert"
                      invisible="code != 'payulatam'">

--- a/addons/payment_payumoney/views/payment_provider_views.xml
+++ b/addons/payment_payumoney/views/payment_provider_views.xml
@@ -6,7 +6,7 @@
         <field name="model">payment.provider</field>
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='provider_creation_warning']" position="after">
+            <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div class="alert alert-danger"
                      role="alert"
                      invisible="code != 'payumoney'">


### PR DESCRIPTION
before this commit, the create/new button is shown in the payment provider form, where us it is removed in the kanban and tree

after this commit, the create/new button will be removed from the form and users can use duplicate option to create new provider


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
