### PR TITLE
[FIX] test_base_automation: fix a failing tour

### DIFF
--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -223,7 +223,7 @@ class BaseAutomationTestUi(HttpCase):
             "model_id": model.id,
         }
         automation.write(
-            {"action_server_ids": [Command.create(dict(action, name=action["name"] + f" {i}")) for i in range(3)]}
+            {"action_server_ids": [Command.create(dict(action, name=action["name"] + f" {i}", sequence=i)) for i in range(3)]}
         )
         self.assertEqual(
             automation.action_server_ids.mapped("name"),


### PR DESCRIPTION
This commit fixes an undeterministically failing tour. `test_form_view_resequence_actions`

*Reason*
This test tour prepares some data before running the test. The data preparation missed to specify the sequence of the actions.

*Fix*
The sequence is now set in the data preparation.
This reflects the way the form view would create the actions if they were created through user input.

See the `canResequence` part in `_createNewRecordDatapoint` inside `@web/model/relational_model/static_list`

Fixes runbot error 24578
