### PR TITLE
[FIX] hr_holidays: delete holiday from calendar view

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -78,18 +78,18 @@ export class TimeOffCalendarController extends CalendarController {
     }
 
     deleteRecord(record) {
-        if (!record.can_cancel) {
+        if (!record.data.can_cancel) {
             this.displayDialog(ConfirmationDialog, {
                 title: _t("Confirmation"),
                 body: _t("Are you sure you want to delete this record?"),
                 confirm: async () => {
-                    await this.model.unlinkRecord(record.id);
+                    await this.model.unlinkRecord(record.resId);
                     this.env.timeOffBus.trigger('update_dashboard');
                 },
                 cancel: () => {},
             });
         } else {
-            this.leaveCancelWizard(record.id, () => {
+            this.leaveCancelWizard(record.resId, () => {
                 this.model.load();
                 this.env.timeOffBus.trigger('update_dashboard');
             });
@@ -125,5 +125,6 @@ TimeOffCalendarController.components = {
     Dropdown,
     DropdownItem,
     FilterPanel: TimeOffCalendarFilterPanel,
-}
-TimeOffCalendarController.template = "hr_holidays.CalendarController"
+};
+
+TimeOffCalendarController.template = "hr_holidays.CalendarController";

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -40,7 +40,7 @@ export class TimeOffDialogFormController extends FormController {
     }
 
     deleteRecord() {
-        this.props.onRecordDeleted(this.record.data)
+        this.props.onRecordDeleted(this.record);
         this.props.onCancelLeave();
         if (this.record.data.can_cancel) {
             this.leaveCancelWizard(this.record.resId, () => {


### PR DESCRIPTION
Reason:
Since the change to RelationalModel, the id is no longer present in the record data by default.

Steps to reproduce the bug:
1. Create a new leave and save it (and keep it unapproved)
2. Click on your newly created leave, click delete and confirm
> Odoo Client Error
(unlinkRecord is called with an undefined value for recordId)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
