### PR TITLE
[IMP] website_event: change attrs to invisible attribute

### DIFF
--- a/addons/website_event/views/event_registration_views.xml
+++ b/addons/website_event/views/event_registration_views.xml
@@ -49,10 +49,10 @@
                                                 </strong>
                                             </div>
                                             <field name="value_answer_id"
-                                                attrs="{'invisible': [('question_type', '!=', 'simple_choice')]}"
+                                                invisible="question_type != 'simple_choice'"
                                                 domain="[('question_id', '=', question_id)]" options="{'no_create': True}"/>
                                             <field name="value_text_box"
-                                                attrs="{'invisible': [('question_type', '=', 'simple_choice')]}"/>
+                                                invisible="question_type == 'simple_choice'"/>
                                         </div>
                                     </t>
                                 </templates>


### PR DESCRIPTION
since 17.0 attrs is no more used, replacing the existing usage with invisible attribute

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
