### PR TITLE
[FIX] account: fix drag and drop on journals

### DIFF
--- a/addons/account/static/src/components/bills_upload/bills_upload.js
+++ b/addons/account/static/src/components/bills_upload/bills_upload.js
@@ -96,7 +96,7 @@ export class AccountDropZone extends Component {
     }
 
     onDrop(ev) {
-        const selector = '.account_file_uploader.o_input_file.o_hidden';
+        const selector = '.account_file_uploader.o_input_file';
         // look for the closest uploader Input as it may have a context
         let uploadInput = ev.target.closest('.o_drop_area').parentElement.querySelector(selector) || document.querySelector(selector);
         let files = ev.dataTransfer ? ev.dataTransfer.files : false;


### PR DESCRIPTION
When trying to drop an invoice on a journal on the journal dashboard, it fails with a message "Could not upload files". The issue is that commit 6f95be6884a59665ca7d8a809e7aaa17695fa9b0 changed a CSS class where the upload functionality depended on, making it fail.

This commit fixes this issue by adapting the CSS selector of the upload field.

[task-3496997](https://www.odoo.com/web#id=3496997&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
