### PR TITLE
[IMP] account_report: new option for favorite filters

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -127,6 +127,10 @@ class AccountReport(models.Model):
         string="Filter Multivat",
         compute=lambda x: x._compute_report_option_filter('filter_fiscal_position'), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
+    filter_aml_ir_filters = fields.Boolean(
+        string="Favorite Filters", help="If activated, user-defined filters on journal items can be selected on this report",
+        compute=lambda x: x._compute_report_option_filter('filter_aml_ir_filters'), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
+    )
 
     def _compute_report_option_filter(self, field_name, default_value=False):
         # We don't depend on the different filter fields on the root report, as we don't want a manual change on it to be reflected on all the reports


### PR DESCRIPTION
Adds a new boolean field on accounting report to enable the user to select user-defined filter on accounting reports. If activated, the user can visualize its own favorite filter (defined on journal items list view) on a new option selector on top of accounting reports (see enterprise commit). When selected, the domain of the user-defined filter is added to other selected options' domain.

task-3444246




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
