### PR TITLE
[FIX] website: fix the outline hover effect

### DIFF
--- a/addons/website/static/src/svg/hover_effects.svg
+++ b/addons/website/static/src/svg/hover_effects.svg
@@ -142,7 +142,7 @@
             <animate
                 xlink:href="#shapeBorder"
                 attributeName="stroke-width"
-                values="1;hover_effect_stroke_width"
+                values="0;hover_effect_stroke_width"
                 keyTimes="0;1"
                 keySplines="0.5 0 0.5 1"
                 dur="0.3"


### PR DESCRIPTION
Before this commit, there was a 1 pixel border around the image that remained visible after the "outline" hover effect mouse out animation was triggered.

This happened due to a typo where the initial value for the "outline" animation was set to 1 pixel instead of 0 pixels.

task-3495241