### PR TITLE
[IMP] website_blog: improve help center

### DIFF
--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -14,7 +14,7 @@ class TestBlogPerformance(UtilPerf):
 
     def test_10_perf_sql_blog_standard_data(self):
         self.assertEqual(self._get_url_hot_query('/blog'), 11)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 24)
+        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 26)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -27,9 +27,9 @@ class TestBlogPerformance(UtilPerf):
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
         self.assertEqual(self._get_url_hot_query('/blog'), 11)
-        self.assertEqual(self._get_url_hot_query('/blog', cache=False), 31)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url), 16)
-        self.assertEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 18)
+        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 33)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 16)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 20)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']


### PR DESCRIPTION
This commit adapts website_blog tests to change in website_helpdesk. The method _compute_visible of model website.menu is modified to display help team menus to backend user, even if they are unpublished. This potentially add extra requests when rendering a website page. Therefore, the performance tests are adapted accordingly.

task-3186564