### PR TITLE
[FIX] survey: get user input lines

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -786,7 +786,7 @@ class Survey(http.Controller):
 
         # Get the matching user input lines
         user_inputs_query = request.env['survey.user_input'].sudo()._search(user_input_domain)
-        user_input_lines = request.env['survey.user_input.line'].search([('user_input_id', 'in', user_inputs_query)])
+        user_input_lines = request.env['survey.user_input.line'].sudo().search([('user_input_id', 'in', user_inputs_query)])
 
         return user_input_lines, search_filters
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create an appraisal;
- add yourself and an user (employee) as the manager;
- make sure the user has no group defined for the appraisal;
- ask a feedback from this employee (and respond to it);
- with this employee go to feedback survey;

Issue:
------
The employee can't see the survey responses
even if he is the appraisal manager.

Cause:
------
The record rule:

```xml
<record id="survey.survey_user_input_line_rule_survey_user_read" model="ir.rule">
    <field name="name">Survey user input line: officer: read all non private</field>
    <field name="domain_force">[('survey_id.is_appraisal', '=', False)]</field>
</record>
```

Force this user to read surveys that are not for appraisals.

Solution:
---------
Add a `sudo` when using the `survey.user_input.line` model to get data. In this case, it is the domain built beforehand that must be used to filter.

Furthermore, if we cannot get access to this information, we are stopped before.

opw-3499036