### PR TITLE
[REF] spreadsheet_dashboard: use web_search_read to load dashboards

### DIFF
--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action_test.js
@@ -80,8 +80,11 @@ QUnit.test("can switch spreadsheet", async (assert) => {
 QUnit.test("display no dashboard message", async (assert) => {
     await createSpreadsheetDashboard({
         mockRPC: function (route, { model, method, args }) {
-            if (method === "search_read" && model === "spreadsheet.dashboard.group") {
-                return [];
+            if (method === "web_search_read" && model === "spreadsheet.dashboard.group") {
+                return {
+                    records: [],
+                    length: 0,
+                };
             }
         },
     });


### PR DESCRIPTION
Previously, the dashboard action needed two RPC calls to be ready:
1. load the dashboard groups (with the dashboards ids in the groups)
2. load the dashboard display names

Now, with the new `web_search_read` we can load both at the same time, saving one http request.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
