### PR TITLE
Master change semantic traversing many2one ryv

### DIFF
--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -86,7 +86,7 @@ class TestProject(TestCommonSaleTimesheet):
             'stage_id': done_stage.id,
         })
         self.env.flush_all()
-        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', False)]}), employee_mapping.sale_line_id)
+        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id', '!=', False), ('stage_id.fold', '=', False)]}), employee_mapping.sale_line_id)
         self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', True)]}), task.sale_line_id | employee_mapping.sale_line_id)
 
         task2 = self.env['project.task'].create({
@@ -96,7 +96,7 @@ class TestProject(TestCommonSaleTimesheet):
             'stage_id': new_stage.id,
         })
 
-        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', False)]}), task2.sale_line_id | employee_mapping.sale_line_id)
+        self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id', '!=', False), ('stage_id.fold', '=', False)]}), task2.sale_line_id | employee_mapping.sale_line_id)
         self.assertEqual(self.project_global._fetch_sale_order_items({'project.task': [('stage_id.fold', '=', True)]}), task.sale_line_id | employee_mapping.sale_line_id)
 
         self.project_global.allow_billable = False

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5978,6 +5978,7 @@ class BaseModel(metaclass=MetaModel):
             return self
 
         stack = []
+        domain = expression.domain_combine_anies(domain, self)
         for leaf in reversed(domain):
             if leaf == '|':
                 stack.append(stack.pop() | stack.pop())


### PR DESCRIPTION
## Rational

There are lot of semantic inconsistency between `filtered_domain` and `search`. Because the same ir.rule domain in ensured in both case (sometime we check the security in python, sometime we apply the ir.rule on the search query), it is important to have the same semantic. Moreover, it blocks https://github.com/odoo/odoo/pull/127353 , because the domain returned `[('<related_path', '=', False)]` is not consistent between the `search` result, and the `groupby` on related semantic.

### Semantic differences

*many2one* is no-required many2one field. (When the *many2one*, there are no semantic difference)
*field* is any type of store field (columned)

#### Leaf like `('many2one.field', '=', False)`:
- Python (`records.filtered(lambda r: not r.many2one.field)`): *many2one* is **not** set OR *many2one*.*field* is **not** set
- `search`/`filtered_domain`: *many2one* is set AND *many2one*.*field* is **not** set

#### Leaf like `('many2one.field', '!=', 'value')` ('!=' can be change with 'not like'/'not ilike'/'not in'):
- Python (`records.filtered(lambda r: r.many2one.field != 'value')`)/`filtered_domain`: *many2one* is **not** set OR *many2one*.*field* != 'value'
- `search`: *many2one* is set AND *many2one*.*field* != 'value'

#### Leaf like ` ('many2one.field', '!=', False)`:
- Python (`records.filtered(lambda r: r.many2one.field)`)/`search`: *many2one* is set AND *many2one*.*field* is set
- `filtered_domain`: *many2one* is **not** set OR *many2one*.*field* is set

### related_field
For *related_field* with `related='many2one.field'`, same result than above excepted the first one: 
#### Leaf like `('related_field', '=', False)`:
- Python (`records.filtered(lambda r: not r.related_field)`)/`filtered_domain`: *many2one* is **not** set OR *many2one*.*field* is **not** set
- `search`: *many2one* is set AND *many2one*.*field* is **not** set
