### PR TITLE
[FIX] web_editor: fix misaligned colorpicker top arrow

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -1268,7 +1268,7 @@
                 .o_we_color_preview {
                     border: 2px solid $o-we-accent;
                 }
-                .o_we_dropdown_caret {
+                span.o_we_dropdown_caret {
                     &::before, &::after {
                         right: $o-we-sidebar-content-field-colorpicker-size / 2;
                     }


### PR DESCRIPTION
Since this commit [1], the top arrow (or "dropdown caret") in the
colorpicker selector has become misaligned.

This happened because we modified the default CSS rule for "we-select"
and made it more important (by adding a class to it). As a result, it
now overrides the rule for the colorpicker we-select.

To fix this, we add a selector component to the rule for the color
picker's top arrow to make it more relevant. This ensures it takes
priority over the default rule.

[1]:https://github.com/odoo/odoo/commit/b7b05a2d1c1d54380364e7a7d10a7e6a69bce27e

task-3475043