### PR TITLE
[FIX] web_editor: ensures images are saved

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -919,6 +919,7 @@ const Wysiwyg = Widget.extend({
                         name: (el.dataset.fileName ? el.dataset.fileName : null),
                     },
                 });
+                this.odooEditor.observerUnactive('saveModifiedImages');
                 if (isBackground) {
                     const parts = weUtils.backgroundImageCssToParts($(el).css('background-image'));
                     parts.url = `url('${newAttachmentSrc}')`;
@@ -928,6 +929,7 @@ const Wysiwyg = Widget.extend({
                 } else {
                     el.setAttribute('src', newAttachmentSrc);
                 }
+                this.odooEditor.observerActive('saveModifiedImages');
             });
             return Promise.all(proms);
         });


### PR DESCRIPTION
__Current behavior before commit:__
Sometimes, when modifying an image on the website, it won't be saved.

When we hit **save** on the website editor, the [cleanForSave][1] method will [at some point][2] activate a `MutationObserver`. This observer reverts all modifications made after 100ms by calling [historyStep][3].

The method `saveModifiedImages` sends the **src** attribute of the modified `<img>` to the server. At that moment it is in base64 and it will be converted to an url returned by the server response. However `saveModifiedImages` is called after `cleanForSave`. Therefore the previously mentionned observer will revert this change 100ms after.

Each edited block on the website is saved with an independent request. Provided that the first one takes more than 100ms to be executed and that the second one contains the image to be saved, then when this second request is sent, the oberver would already have changed back the **src** attribute to the base64 representation. The server will then fail to save it.

__Description of the fix:__
Disable the observer when the src attibute is modified. This way it won't be reverted.

__Steps to reproduce the issue on runbot:__
1. Go to a page where there is multiple blocks to save. (e.g. `/forum`, the bug does not occur in the homepage because it is saved as one block)
1. Make sure there is at least 2 forums to have the list of them on the page
1. Edit the title of the first forum
1. Change the image of the second forum
1. Throttle your network in the chrome dev tools to have a latency of severals hundreds of milliseconds
1. Save the website
1. The image is not saved

[Video][4]

opw-3489060

[1]: https://github.com/odoo/odoo/blob/3bee8aa5bbcada4baba31100678ca7907be5d663/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js#L858
[2]: https://github.com/odoo/odoo/blob/3bee8aa5bbcada4baba31100678ca7907be5d663/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js#L507
[3]: https://github.com/odoo/odoo/blob/3bee8aa5bbcada4baba31100678ca7907be5d663/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js#L514
[4]: https://watch.screencastify.com/v/zLUtGT27hzraCuxJLzK0