### PR TITLE
[FIX] point_of_sale: handle parse-error if reinstall point_of_sale module

### DIFF
--- a/addons/point_of_sale/__init__.py
+++ b/addons/point_of_sale/__init__.py
@@ -5,3 +5,11 @@ from . import models
 from . import controllers
 from . import report
 from . import wizard
+
+
+def uninstall_hook(env):
+    warehouses = env['stock.warehouse'].sudo().search([('pos_type_id', '!=', False)])
+    for warehouse in warehouses:
+        sequence_data = warehouse._get_sequence_values()
+        if sequence_data and sequence_data.get('pos_type_id'):
+            env['ir.sequence'].sudo().search([('prefix', '=', sequence_data['pos_type_id']['prefix'])]).unlink()

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -8,6 +8,7 @@
     'sequence': 40,
     'summary': 'User-friendly PoS interface for shops and restaurants',
     'depends': ['stock_account', 'barcodes', 'web_editor', 'digest'],
+    'uninstall_hook': 'uninstall_hook',
     'data': [
         'security/point_of_sale_security.xml',
         'security/ir.model.access.csv',


### PR DESCRIPTION
When users try to reinstall the "point_of_sale" module, a traceback will be generated.

Tracebak:
```UserError: Sequences bizz Picking POS already exist.
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 279, in _tag_function
    _eval_xml(self, rec, env)
  File "odoo/tools/convert.py", line 204, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "addons/point_of_sale/models/stock_warehouse.py", line 50, in _create_missing_pos_picking_types
    new_vals = warehouse._create_or_update_sequences_and_picking_types()
  File "addons/stock/models/stock_warehouse.py", line 348, in _create_or_update_sequences_and_picking_types
    warehouse_data[picking_type] = PickingType.create(values).id
  File "<decorator-gen-209>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/stock/models/stock_picking.py", line 122, in create
    return super().create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4261, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4535, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "odoo/models.py", line 1454, in _validate_fields
    check(self)
  File "addons/stock/models/stock_picking.py", line 286, in _check_sequence_code
    raise UserError(_("Sequences %s already exist.",
ParseError: while parsing /home/odoo/src/odoo/saas-16.4/addons/point_of_sale/data/point_of_sale_data.xml:4, somewhere inside
<function model="stock.warehouse" name="_create_missing_pos_picking_types"/>
  File "odoo/modules/registry.py", line 105, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

This is because duplicate sequence records exist and raise the ParseError.

code reference:
https://github.com/odoo/odoo/blob/217c8cd0bd7c546de7ad2587b605c58c3fc9378c/addons/stock/models/stock_picking.py#L284
https://github.com/odoo/odoo/blob/saas-16.3/addons/point_of_sale/data/point_of_sale_data.xml#L4C49-L4C82

sentry-4452246611