### PR TITLE
[IMP] web: mark field as invalid if onchange returns error

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1022,6 +1022,12 @@ export class Record extends DataPoint {
                 changes: localChanges,
                 fieldNames: onChangeFields,
                 evalContext: this.evalContext,
+                onError: (e) => {
+                    for (const fieldName in localChanges) {
+                        this._setInvalidField(fieldName);
+                    }
+                    throw e;
+                },
             });
             Object.assign(changes, this._parseServerValues(otherChanges, this.data));
         }

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -8923,7 +8923,7 @@ QUnit.module("Fields", (hooks) => {
     );
 
     QUnit.test("display correct value after validation error", async function (assert) {
-        assert.expect(4);
+        assert.expect(5);
 
         /*
          * By-pass QUnit's and test's error handling because the error service needs to be active
@@ -9002,10 +9002,8 @@ QUnit.module("Fields", (hooks) => {
         await editInput(target, ".o_field_widget[name=turtle_foo] input", "pinky");
         await click(target, ".o_form_view");
         assert.strictEqual(target.querySelector(".o_data_row .o_data_cell").textContent, "foo");
-
-        // we make sure here that when we save, the values are the current
-        // values displayed in the field.
-        await clickSave(target);
+        assert.hasClass(target.querySelector(".o_field_widget[name=turtles]"), "o_field_invalid");
+        assert.ok(target.querySelector(".o_form_button_save").disabled);
     });
 
     QUnit.test("propagate context to sub views without default_* keys", async function (assert) {


### PR DESCRIPTION
Before this commit, if an onchange returned an error, the faulty value was kept in the UI and there was no feedback given to the user besides the error being displayed in a dialog. However, the former value was still the one stored in the model, which produced a discrepancy between model and UI.

This commit tackles the issue by marking the field as invalid in this case (like when you input letters inside a numeric field). That way, the value in the model is still different from the one in the UI, but the field is stored in the list of invalid fields, it is displayed in red, and the view can't be saved (it can be discarded though).

Task~3498849 (master version, which differs from 16.0, see [1])

[1] odoo/odoo#134792

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
