### PR TITLE
[IMP] web: sample server: support of array_agg

### DIFF
--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -170,9 +170,11 @@ export class SampleServer {
      */
     _aggregateFields(measures, records) {
         const values = {};
-        for (const { fieldName, type } of measures) {
+        for (const { fieldName, type, aggregateFunction } of measures) {
             if (["float", "integer", "monetary"].includes(type)) {
-                if (records.length) {
+                if (aggregateFunction === "array_agg") {
+                    values[fieldName] = (records || []).map((r) => r[fieldName]);
+                } else if (records.length) {
                     let value = 0;
                     for (const record of records) {
                         value += record[fieldName];
@@ -479,7 +481,7 @@ export class SampleServer {
                 type &&
                 (type !== "many2one" || aggregateFunction !== "count_distinct")
             ) {
-                measures.push({ fieldName: fName, type });
+                measures.push({ fieldName: fName, type, aggregateFunction });
             }
         }
 

--- a/addons/web/static/tests/model/sample_server_tests.js
+++ b/addons/web/static/tests/model/sample_server_tests.js
@@ -534,6 +534,21 @@ QUnit.module(
             assert.strictEqual(result.length, MAIN_RECORDSET_SIZE);
         });
 
+        QUnit.test("partial support of array_agg", async function (assert) {
+            fields["res.users"].id = { type: "integer", name: "ID" };
+            const server = new DeterministicSampleServer("res.users", fields["res.users"]);
+            const result = await server.mockRpc({
+                method: "read_group",
+                model: "res.users",
+                fields: ["unused_label:array_agg(id)"],
+                groupBy: [],
+                lazy: false,
+            });
+            assert.strictEqual(result.length, 1);
+            const ids = new Array(16).fill(0).map((_, index) => index + 1);
+            assert.deepEqual(result[0].id, ids);
+        });
+
         // To be implemented if needed
         // QUnit.test("Send 'read_progress_bar' RPC", async function (assert) { ... });
     }


### PR DESCRIPTION
In SampleServer, we make _mockReadGroup support array_agg (at least for
the field id).
