### PR TITLE
[IMP] account{_peppol}: auto fill customer reference

### DIFF
--- a/addons/account_peppol/tests/__init__.py
+++ b/addons/account_peppol/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_peppol_account_move
 from . import test_peppol_messages
 from . import test_peppol_participant

--- a/addons/account_peppol/tests/test_peppol_account_move.py
+++ b/addons/account_peppol/tests/test_peppol_account_move.py
@@ -1,0 +1,23 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPeppolAccountMove(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.company_data['company'].is_account_peppol_participant = True
+        cls.invoice = cls.init_invoice('out_invoice', products=cls.product_a)
+
+    def test_peppol_invoice_set_customer_ref(self):
+        self.assertFalse(self.invoice.ref)
+        self.invoice.action_post()
+        self.assertEqual(self.invoice.ref, self.invoice.payment_reference)
+
+    def test_peppol_invoice_keep_customer_ref(self):
+        self.invoice.ref = 'MYREF'
+        self.invoice.action_post()
+        self.assertEqual(self.invoice.ref, 'MYREF')


### PR DESCRIPTION
For PEPPOL, the Customer Reference field on invoices is a required field. In Odoo it can be blank when creating an invoice from scratch. In order to avoid errors when sending PEPPOL invoices, we want to prefill the Customer Reference with the Payment Reference by default.

[task-3499548](https://www.odoo.com/web#id=3499548&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
