### PR TITLE
[FIX] account_edi_ubl_cii: handle 0 basis_qty and None attachement_name

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -319,7 +319,7 @@ class AccountEdiCommon(models.AbstractModel):
                 # Normalize the name of the file : some e-fff emitters put the full path of the file
                 # (Windows or Linux style) and/or the name of the xml instead of the pdf.
                 # Get only the filename with a pdf extension.
-                name = attachment_name.text.split('\\')[-1].split('/')[-1].split('.')[0] + '.pdf'
+                name = (attachment_name.text or 'invoice').split('\\')[-1].split('/')[-1].split('.')[0] + '.pdf'
                 attachment = self.env['ir.attachment'].create({
                     'name': name,
                     'res_id': invoice.id,
@@ -535,7 +535,7 @@ class AccountEdiCommon(models.AbstractModel):
         for xpath in xpath_dict['basis_qty']:
             basis_quantity_node = tree.find(xpath)
             if basis_quantity_node is not None:
-                basis_qty = float(basis_quantity_node.text)
+                basis_qty = float(basis_quantity_node.text) or 1
 
         # gross_price_unit (optional)
         gross_price_unit = None


### PR DESCRIPTION
When parsed, if the attachment has a basis quantity of zero, it creates an error, because it is used in a division. The condition that checks whether is computed
should be done only if this variable is none.

The code does not handle if `attachement_name.text` is None, which can be caused by an orphan ID tag (e.i. "<cbc:ID />") , in the xml of the pdf.

opw-3470969

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
