### PR TITLE
[MERGE] (test_)mail, various: prepare MC environment for mail tests

### DIFF
--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -17,7 +17,6 @@ class TestDigest(TestDigestCommon):
     @classmethod
     def setUpClass(cls):
         super(TestDigest, cls).setUpClass()
-        cls._activate_multi_company()
 
         # clean messages
         cls.env['mail.message'].search([

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1094,6 +1094,9 @@ class MailCommon(common.TransactionCase, MailCase):
         cls.user_root = cls.env.ref('base.user_root')
         cls.partner_root = cls.user_root.partner_id
 
+        # setup MC environment
+        cls._activate_multi_company()
+
         # give default values for all email aliases and domain
         cls._init_mail_gateway()
         cls._init_mail_servers()
@@ -1162,6 +1165,9 @@ class MailCommon(common.TransactionCase, MailCase):
             'currency_id': cls.env.ref('base.CAD').id,
             'email': 'company_2@test.example.com',
             'name': 'Company 2',
+        })
+        cls.company_3 = cls.env['res.company'].create({
+            'name': 'ELIT',
         })
         cls.user_admin.write({'company_ids': [(4, cls.company_2.id)]})
 

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -550,7 +550,6 @@ class TestChannelInternals(MailCommon):
         self.assertEqual(self.user_employee.with_user(self.user_employee)._init_messaging()['starred_counter'], 1)
 
     def test_multi_company_chat(self):
-        self._activate_multi_company()
         self.assertEqual(self.env.user.company_id, self.company_admin)
 
         with self.with_user('employee'):

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -19,7 +19,6 @@ class TestPartner(MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._activate_multi_company()
 
         cls.samples = [
             ('"Raoul Grosbedon" <raoul@chirurgiens-dentistes.fr> ', 'Raoul Grosbedon', 'raoul@chirurgiens-dentistes.fr'),
@@ -34,7 +33,6 @@ class TestPartner(MailCommon):
             # multi email
             ('"Multi Email" <multi.email@example.com>, multi.email.2@example.com', 'Multi Email', 'multi.email@example.com')
         ]
-
     @contextmanager
     def mockPartnerCalls(self):
         _original_create = Partner.create

--- a/addons/mail_group/tests/common.py
+++ b/addons/mail_group/tests/common.py
@@ -55,8 +55,6 @@ class TestMailListCommon(MailCommon):
         })
         cls.test_group_valid_members = cls.test_group_member_1 + cls.test_group_member_2 + cls.test_group_member_4_emp
 
-        cls._init_mail_gateway()
-
         # Create some messages
         cls.test_group_msg_1_pending = cls.env['mail.group.message'].create({
             'subject': 'Test message pending',

--- a/addons/portal/tests/test_portal_wizard.py
+++ b/addons/portal/tests/test_portal_wizard.py
@@ -158,8 +158,8 @@ class TestPortalWizard(MailCommon):
             portal_user.action_revoke_access()
 
     def test_portal_wizard_multi_company(self):
-        company_1 = self.env['res.company'].search([], limit=1)
-        company_2 = self.env['res.company'].create({'name': 'Company 2'})
+        company_1 = self.company_admin
+        company_2 = self.company_2
 
         partner_company_2 = self.env['res.partner'].with_company(company_2).create({
             'name': 'Testing Partner',

--- a/addons/test_crm_full/tests/common.py
+++ b/addons/test_crm_full/tests/common.py
@@ -13,7 +13,6 @@ class TestCrmFullCommon(TestCrmCommon, MockIAPReveal, MockVisitor):
     @classmethod
     def setUpClass(cls):
         super(TestCrmFullCommon, cls).setUpClass()
-        cls._init_mail_gateway()
         cls._activate_multi_company()
 
         # Context data: dates

--- a/addons/test_event_full/tests/common.py
+++ b/addons/test_event_full/tests/common.py
@@ -15,7 +15,6 @@ class TestEventFullCommon(EventCrmCase, TestSalesCommon, MockVisitor):
     @classmethod
     def setUpClass(cls):
         super(TestEventFullCommon, cls).setUpClass()
-        cls._init_mail_gateway()
 
         # Context data: dates
         # ------------------------------------------------------------

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -17,7 +17,6 @@ class TestMailAliasCommon(MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._activate_multi_company()
 
         cls.test_alias_mc = cls.env['mail.alias'].create({
             'alias_model_id': cls.env['ir.model']._get('mail.test.container.mc').id,

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -152,7 +152,6 @@ class TestMailgateway(MailCommon):
     @classmethod
     def setUpClass(cls):
         super(TestMailgateway, cls).setUpClass()
-        cls._activate_multi_company()
 
         cls.mail_test_gateway_model = cls.env['ir.model']._get('mail.test.gateway')
         cls.email_from = '"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>'

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -21,7 +21,6 @@ class TestMailMCCommon(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._activate_multi_company()
 
         cls.test_model = cls.env['ir.model']._get('mail.test.gateway')
         cls.email_from = '"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>'
@@ -37,7 +36,6 @@ class TestMailMCCommon(MailCommon, TestRecipients):
              'company_id': cls.user_employee_c2.company_id.id},
         ])
 
-        cls.company_3 = cls.env['res.company'].create({'name': 'ELIT'})
         cls.partner_1 = cls.env['res.partner'].with_context(cls._test_context).create({
             'name': 'Valid Lelitre',
             'email': 'valid.lelitre@agrolait.com',
@@ -437,11 +435,6 @@ class TestMultiCompanySetup(TestMailMCCommon):
 
 @tagged('-at_install', 'post_install', 'multi_company')
 class TestMultiCompanyRedirect(MailCommon, HttpCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestMultiCompanyRedirect, cls).setUpClass()
-        cls._activate_multi_company()
 
     def test_redirect_to_records(self):
         """ Test mail/view redirection in MC environment, notably cids being

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1632,7 +1632,6 @@ class TestMessagePostLang(MailCommon, TestRecipients):
             'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)],
         })
 
-        cls._activate_multi_company()
         cls._activate_multi_lang(test_record=cls.test_records[0], test_template=cls.test_template)
 
         cls.partner_2.write({'lang': 'es_ES'})

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -423,8 +423,6 @@ class TestTrackingMonetary(MailCommon):
     def setUp(self):
         super(TestTrackingMonetary, self).setUp()
 
-        self._activate_multi_company()
-
         record = self.env['mail.test.track.monetary'].with_user(self.user_employee).with_context(self._test_context).create({
             'company_id': self.user_employee.company_id.id,
         })


### PR DESCRIPTION
Purpose of this merge is to further cleanup and prepare tests for
multi-company enabled aliases, notably

  * activate multi-company environment by default in all mail tests;
  * avoid multiple init of gateway parameters;
  * fix leftover of bad alias management;

Followup of odoo/odoo# 130768 and odoo/enterprise# 45204

Followup of Task-3453577 (TestMail: Update Alias/Gateway tests for MC)
Followup of Task-3453343 (Mail: Cleanup Alias Usage)
Prepares Task-36879 (Mail: Support MultiCompany Aliases)