### PR TITLE
[FIX] web: allow overriding number of cols in form groups

### DIFF
--- a/addons/web/static/src/views/form/form_group/form_group.xml
+++ b/addons/web/static/src/views/form/form_group/form_group.xml
@@ -12,7 +12,8 @@
 </t>
 
 <t t-name="web.Form.InnerGroup" owl="1">
-    <div t-attf-class="{{ allClasses }}" class="o_inner_group grid" t-att-style="props.style">
+    <div t-attf-class="{{ allClasses }}" class="o_inner_group grid"
+        t-attf-style="grid-template-columns: repeat({{ props.maxCols >> 1 }}, fit-content(150px) 1fr); {{ props.style }}">
         <div t-if="props.slots and props.slots.title" t-attf-class="g-col-sm-{{ props.maxCols }}">
             <t t-slot="title" />
         </div>

--- a/addons/web/static/tests/qunit.js
+++ b/addons/web/static/tests/qunit.js
@@ -178,6 +178,44 @@ export function setupQUnit() {
     }
 
     /**
+     * Checks that the target element (described by widget/jquery or html element)
+     * - exists
+     * - is unique
+     * - has the given attribute with the proper value
+     *
+     * @param {Widget|jQuery|HTMLElement|Component} w
+     * @param {string} attr
+     * @param {string} value
+     * @param {string} [msg]
+     */
+    function hasStyleValue(target, prop, value, msg) {
+        let $el;
+        if (target._widgetRenderAndInsert) {
+            $el = target.$el; // legacy widget
+        } else if (target instanceof Component) {
+            if (!target.el) {
+                throw new Error(
+                    `hasStyle assert with property '${prop}' called on an unmounted component`
+                );
+            }
+            $el = $(target.el);
+        } else {
+            $el = target instanceof HTMLElement ? $(target) : target;
+        }
+
+        if ($el.length !== 1) {
+            const descr = `hasStyleValue (${prop}: ${value})`;
+            QUnit.assert.ok(
+                false,
+                `Assertion '${descr}' targets ${$el.length} elements instead of 1`
+            );
+        } else {
+            msg = msg || `attribute '${prop}' of target should be '${value}'`;
+            QUnit.assert.strictEqual($el[0].style[prop], value, msg);
+        }
+    }
+
+    /**
      * Helper function, to check if a given element
      * - is unique (if it is a jquery node set)
      * - is (or not) visible
@@ -212,6 +250,7 @@ export function setupQUnit() {
     QUnit.assert.doesNotHaveClass = doesNotHaveClass;
     QUnit.assert.hasClass = hasClass;
     QUnit.assert.hasAttrValue = hasAttrValue;
+    QUnit.assert.hasStyleValue = hasStyleValue;
     QUnit.assert.isVisible = isVisible;
     QUnit.assert.isNotVisible = isNotVisible;
 

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -276,10 +276,10 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(target, "label:contains(Foo)");
         assert.containsOnce(target, ".o_field_char input");
         assert.strictEqual(target.querySelector(".o_field_char input").value, "blip");
-        assert.hasAttrValue(
+        assert.hasStyleValue(
             target.querySelector(".o_group .o_inner_group"),
-            "style",
-            "background-color: red",
+            "background-color",
+            "red",
             "should apply style attribute on groups"
         );
         assert.hasAttrValue(
@@ -13243,7 +13243,9 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("containing a nested x2many list view should not overflow", async function (assert) {
         serverData.models.partner_type.records.push({
-            id: 3, display_name: 'very'.repeat(30) + '_long_name', color: 10,
+            id: 3,
+            display_name: "very".repeat(30) + "_long_name",
+            color: 10,
         });
 
         const record = serverData.models.partner.records[0];
@@ -13272,11 +13274,42 @@ QUnit.module("Views", (hooks) => {
             </form>`,
         });
 
-        const table = target.querySelector('table');
-        const group = target.querySelector('.o_inner_group:last-child');
+        const table = target.querySelector("table");
+        const group = target.querySelector(".o_inner_group:last-child");
 
         assert.equal(group.clientWidth, group.scrollWidth);
-        table.style.tableLayout = 'auto';
+        table.style.tableLayout = "auto";
         assert.ok(group.clientWidth < group.scrollWidth);
+    });
+
+    QUnit.test("group with a col attribute", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <sheet>
+                        <group col="4">
+                            <!-- InnerGroup -->
+                            <field name="foo"/>
+                            <field name="bar"/>
+                            <field name="qux"/>
+                        </group>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+
+        const foo = target.querySelector("label[for=foo]").getBoundingClientRect();
+        const bar = target.querySelector("label[for=bar]").getBoundingClientRect();
+        const qux = target.querySelector("label[for=qux]").getBoundingClientRect();
+
+        // Check that bar is positioned to the right of foo
+        assert.ok(foo.x < bar.x);
+        assert.strictEqual(foo.y, bar.y);
+        // Check that qux is postioned under foo
+        assert.strictEqual(foo.x, qux.x);
+        assert.ok(foo.y < qux.y);
     });
 });


### PR DESCRIPTION
Group tags can be used in form views to allow tabular layouts of fields, by default these groups are organised into two columns. However, this value can be overridden, using the `col` attribute. Since the refactor in [commit 1] using the css grid system, this attribute no longer works, resulting in the default two-column layout (field label + actual field). The number of columns can still be forced by including an element having a `colspan` equal to the desired number of columns.

This commit aims to restore the behavior of the `col` attribute from before the mentioned commit, as described in the docs:

The number of columns in a group can be customized using the `col` attribute, the number of columns taken by an element can be customized using `colspan`.

To this purpose, a `grid-template-columns` css property reflecting the number of columns in the layout is included (only even values are supported, as odd and even columns are styled differently).