### PR TITLE
[FIX] project,sale_timesheet: fix profitability section visibility

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -758,14 +758,16 @@ class Project(models.Model):
         self.ensure_one()
         if not self.user_has_groups('project.group_project_user'):
             return {}
+        show_profitability = self._show_profitability()
         panel_data = {
             'user': self._get_user_values(),
             'buttons': sorted(self._get_stat_buttons(), key=lambda k: k['sequence']),
             'currency_id': self.currency_id.id,
+            'show_project_profitability_helper': show_profitability and self._show_profitability_helper(),
         }
         if self.allow_milestones:
             panel_data['milestones'] = self._get_milestones()
-        if self._show_profitability():
+        if show_profitability:
             profitability_items = self._get_profitability_items()
             if self._get_profitability_sequence_per_invoice_type() and profitability_items and 'revenues' in profitability_items and 'costs' in profitability_items:  # sort the data values
                 profitability_items['revenues']['data'] = sorted(profitability_items['revenues']['data'], key=lambda k: k['sequence'])
@@ -798,6 +800,9 @@ class Project(models.Model):
     def _show_profitability(self):
         self.ensure_one()
         return True
+
+    def _show_profitability_helper(self):
+        return self.user_has_groups('analytic.group_analytic_accounting')
 
     def _get_profitability_aal_domain(self):
         return [('account_id', 'in', self.analytic_account_id.ids)]

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.xml
@@ -37,7 +37,7 @@
             </ProjectRightSidePanelSection>
             <ProjectRightSidePanelSection
                 name="'profitability'"
-                show="!!this.state.data.profitability_items"
+                show="showProfitability or state.data.show_project_profitability_helper"
                 dataClassName="'py-3'"
             >
                 <t t-set-slot="title">
@@ -50,7 +50,7 @@
                     formatMonetary="formatMonetary.bind(this)"
                     onClick="(params) => this.onProjectActionClick(params)"
                 />
-                <span t-else="" class="text-muted fst-italic">
+                <span t-elif="state.data.show_project_profitability_helper" class="text-muted fst-italic">
                     Track project costs, revenues, and margin by setting the analytic account associated with the project on relevant documents.
                 </span>
             </ProjectRightSidePanelSection>

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -392,6 +392,9 @@ class Project(models.Model):
         self.ensure_one()
         return self.allow_billable and super()._show_profitability()
 
+    def _show_profitability_helper(self):
+        return True
+
     def _get_profitability_labels(self):
         return {
             **super()._get_profitability_labels(),


### PR DESCRIPTION
Steps:
- Install project & accounting
- Open project
- Open project.update
- There is profitability section
- Go to accounting module configuration,settings
- Analytic accounting field true or false

Issue:
- Analytic accounting feature true or false the profitability section always visible in project.update

Cause:
- There is no condition for profitability section visibility

Fix:
- Added  required conditions for profitability section visibility

Task-3484413
