### PR TITLE
[IMP] core: check field groups for search domain and order

### DIFF
--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -95,7 +95,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
 
         # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=583):  # crm 582
+            with self.assertQueryCount(user_sales_manager=584):  # crm 582
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign

--- a/odoo/addons/test_access_rights/models.py
+++ b/odoo/addons/test_access_rights/models.py
@@ -9,6 +9,7 @@ class SomeObj(models.Model):
 
     val = fields.Integer()
     categ_id = fields.Many2one('test_access_right.obj_categ')
+    parent_id = fields.Many2one('test_access_right.some_obj')
     company_id = fields.Many2one('res.company')
     forbidden = fields.Integer(
         groups='test_access_rights.test_group,!base.group_no_one,!base.group_public',

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5190,10 +5190,6 @@ class BaseModel(metaclass=MetaModel):
             # return the model found by traversing all fields (used in collect_from_domain)
             return model
 
-        # also take into account the fields in the record rules
-        domain = list(domain) + (self.env['ir.rule']._compute_domain(self._name, 'read') or [])
-        collect_from_domain(self, domain)
-
         # flush the order fields
         if order:
             for order_part in order.split(','):
@@ -5205,8 +5201,18 @@ class BaseModel(metaclass=MetaModel):
                         comodel = self.env[field.comodel_name]
                         comodel._flush_search([], order=comodel._order, seen=seen)
 
-        if self._active_name:
+        if self._active_name and self.env.context.get('active_test', True):
             to_flush[self._name].add(self._active_name)
+
+        collect_from_domain(self, domain)
+
+        # Check access of fields with groups
+        for model_name, field_names in to_flush.items():
+            self.env[model_name].check_field_access_rights('read', field_names)
+
+        # also take into account the fields in the record rules
+        if ir_rule_domain := self.env['ir.rule']._compute_domain(self._name, 'read'):
+            collect_from_domain(self, ir_rule_domain)
 
         # flush model dependencies (recursively)
         if self._depends:


### PR DESCRIPTION
#### [IMP] core: check field groups for search domain and order
In order to boost the read security of groups on field, we now
check groups of field used in search domain and search order.


#### [FIX] mail: allow searching on message_partner_ids for portal

Because we now check groups in the domain, some searches raise
`AccessError` when using `message_partner_ids` in the domain for the
portal user:
- https://github.com/odoo/odoo/blob/4d1a1f1c99d6055b60921ce464b72f0f4d9bbfe2/addons/sale/controllers/portal.py#L35
- https://github.com/odoo/odoo/blob/4d1a1f1c99d6055b60921ce464b72f0f4d9bbfe2/addons/sale/controllers/portal.py#L41
- https://github.com/odoo/odoo/blob/ba1a5509fa49fd846739252d16083dd8cb334b53/addons/website_forum/models/forum_post.py#L831
- https://github.com/odoo/odoo/blob/86b43bcfa6c9a5b6ac1b3ac9ba0c308f1169ea3b/addons/hr_timesheet/models/hr_timesheet.py#L41

Since there are many invalid domains and it is impossible to sudo only
part of the domain, it is easier to override `_flush_search` to allow
`message_partner_ids` in search domain leafs with some restriction.


https://github.com/odoo/enterprise/pull/47822