### PR TITLE
[FIX] point_of_sale: inconsistant ui when popup

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.OrderSummary">
-        <div class="summary clearfix sticky-top w-100 py-2 px-3 bg-200 bg-opacity-50 text-end fw-bolder">
+        <div class="summary clearfix w-100 py-2 px-3 bg-200 bg-opacity-50 text-end fw-bolder">
             <t t-set="_total" t-value="getTotal()" />
             <t t-set="_tax" t-value="getTax()" />
             <div class="line">

--- a/addons/pos_loyalty/static/src/overrides/components/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/order_summary/order_summary.xml
@@ -5,7 +5,7 @@
             <t t-set="_loyaltyStats" t-value="getLoyaltyPoints()"/>
             <t t-foreach="_loyaltyStats" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">
                 <t t-if="_loyaltyStat.points.won || _loyaltyStat.points.spent">
-                    <div class="summary clearfix sticky-top w-100 border-top text-end fw-bolder">
+                    <div class="summary clearfix w-100 border-top text-end fw-bolder">
                         <div class='d-flex flex-column px-3 py-2 bg-200 text-start'>
                             <div class="loyalty-points-title text-center mb-1">
                                 <t t-esc="_loyaltyStat.points.name"/>


### PR DESCRIPTION
This commit fixes the ui of the pos. When a popup was open in pos2 ui elements were rendered at the same level as the popup.


![2023-09-12_10-26](https://github.com/odoo/odoo/assets/33456800/b2605cce-502e-4578-a74f-6ebb82d52c26)
