### PR TITLE
[FIX] website_blog: post published notification full url

### DIFF
--- a/addons/website_blog/data/mail_templates.xml
+++ b/addons/website_blog/data/mail_templates.xml
@@ -3,7 +3,7 @@
     <template id="blog_post_template_new_post">
         <p>A new post <t t-esc="post.name" /> has been published on the <t t-esc="object.name" /> blog. Click here to access the blog :</p>
         <p style="margin-left: 30px; margin-top: 10 px; margin-bottom: 10px;">
-            <a t-attf-href="/blog/#{slug(object)}/#{slug(post)}"
+            <a t-attf-href="#{object.get_base_url() or ''}/blog/#{slug(object)}/#{slug(post)}"
                 style="padding: 5px 10px; font-size: 12px; line-height: 18px; color: #FFFFFF; border-color:#875A7B; text-decoration: none; display: inline-block; margin-bottom: 0px; font-weight: 400; text-align: center; vertical-align: middle; cursor: pointer;background-color: #875A7B; border: 1px solid #875A7B; border-radius:3px">
                 Access post
             </a>


### PR DESCRIPTION
forwarding #91251

We should ensure that the link has the proper url link or we could get missleading notifications where the link drive the suscribed partners to 404 as the url isn't the right one. This is very typical in multiwebsite environment or even when a backend and a frontend url co-exist and we want to notify just the public one.

cc @Tecnativa TT45002

Steps to reproduce:

- Assign a website to a blog
- Set a url to that website different from the one in backend (param web.base.url)

Current behavior before PR:

- When a that blog posts get published the notification to the blog subscribers arrive as an addres for base_url.
- We could event get a 404 or a 403 when base_url is used for another website or in another company.

Desired behavior after PR is merged:

- The notified post links go with their proper base urls


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
