### PR TITLE
Viewtiverse: remove context dependencies

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -14,12 +14,6 @@ class AccruedExpenseRevenue(models.TransientModel):
     _description = 'Accrued Orders Wizard'
     _check_company_auto = True
 
-    def _get_account_domain(self):
-        if self.env.context.get('active_model') == 'purchase.order':
-            return [('account_type', '=', 'liability_current')]
-        else:
-            return [('account_type', '=', 'asset_current')]
-
     def _get_default_company(self):
         if not self._context.get('active_model'):
             return
@@ -56,7 +50,7 @@ class AccruedExpenseRevenue(models.TransientModel):
         required=True,
         string='Accrual Account',
         check_company=True,
-        domain=_get_account_domain,
+        domain="[('account_type', '=', 'liability_current')] if context.get('active_model') == 'purchase.order' else [('account_type', '=', 'asset_current')]",
     )
     preview_data = fields.Text(compute='_compute_preview_data')
     display_amount = fields.Boolean(compute='_compute_display_amount')

--- a/addons/base_import/static/src/import_records/import_records.js
+++ b/addons/base_import/static/src/import_records/import_records.js
@@ -3,6 +3,7 @@
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { archParseBoolean } from "@web/views/utils";
 import { Component } from "@odoo/owl";
 import { STATIC_ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
 
@@ -43,8 +44,8 @@ export const importRecordsItem = {
         !isSmall &&
         config.actionType === "ir.actions.act_window" &&
         ["kanban", "list"].includes(config.viewType) &&
-        !!JSON.parse(config.viewArch.getAttribute("import") || "1") &&
-        !!JSON.parse(config.viewArch.getAttribute("create") || "1"),
+        archParseBoolean(config.viewArch.getAttribute("import"), true) &&
+        archParseBoolean(config.viewArch.getAttribute("create"), true),
 };
 
 cogMenuRegistry.add("import-menu", importRecordsItem, { sequence: 1 });

--- a/addons/board/models/board.py
+++ b/addons/board/models/board.py
@@ -36,13 +36,6 @@ class Board(models.AbstractModel):
         return res
 
     @api.model
-    def get_views(self, views, options=None):
-        res = super().get_views(views, options)
-        for view in res['views'].values():
-            view['toolbar'] = {'print': [], 'action': [], 'relate': []}
-        return res
-
-    @api.model
     def _arch_preprocessing(self, arch):
         from lxml import etree
 

--- a/addons/board/views/board_views.xml
+++ b/addons/board/views/board_views.xml
@@ -20,6 +20,7 @@
             <field name="name">My Dashboard</field>
             <field name="res_model">board.board</field>
             <field name="view_mode">form</field>
+            <field name="context">{'disable_toolbar': True}</field>
             <field name="usage">menu</field>
             <field name="view_id" ref="board_my_dash_view"/>
         </record> 

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -68,7 +68,7 @@ class Channel(models.Model):
     channel_member_ids = fields.One2many(
         'discuss.channel.member', 'channel_id', string='Members',
         groups='base.group_user')
-    pinned_message_ids = fields.One2many('mail.message', 'res_id', domain=lambda self: [('model', '=', 'discuss.channel'), ('pinned_at', '!=', False)], string='Pinned Messages')
+    pinned_message_ids = fields.One2many('mail.message', 'res_id', domain=[('model', '=', 'discuss.channel'), ('pinned_at', '!=', False)], string='Pinned Messages')
     rtc_session_ids = fields.One2many('discuss.channel.rtc.session', 'channel_id', groups="base.group_system")
     is_member = fields.Boolean('Is Member', compute='_compute_is_member', search='_search_is_member')
     member_count = fields.Integer(string="Member Count", compute='_compute_member_count', compute_sudo=True)

--- a/addons/membership/models/product.py
+++ b/addons/membership/models/product.py
@@ -16,12 +16,3 @@ class Product(models.Model):
     _sql_constraints = [
         ('membership_date_greater', 'check(membership_date_to >= membership_date_from)', 'Error! Ending Date cannot be set before Beginning Date.')
     ]
-
-    @api.model
-    def get_view(self, view_id=None, view_type='form', **options):
-        if self._context.get('product') == 'membership_product':
-            if view_type == 'form':
-                view_id = self.env.ref('membership.membership_products_form').id
-            else:
-                view_id = self.env.ref('membership.membership_products_tree').id
-        return super().get_view(view_id, view_type, **options)

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -350,7 +350,7 @@ class MrpWorkcenterProductivityLoss(models.Model):
     name = fields.Char('Blocking Reason', required=True, translate=True)
     sequence = fields.Integer('Sequence', default=1)
     manual = fields.Boolean('Is a Blocking Reason', default=True)
-    loss_id = fields.Many2one('mrp.workcenter.productivity.loss.type', domain=([('loss_type', 'in', ['quality', 'availability'])]), string='Category')
+    loss_id = fields.Many2one('mrp.workcenter.productivity.loss.type', domain=[('loss_type', 'in', ['quality', 'availability'])], string='Category')
     loss_type = fields.Selection(string='Effectiveness Category', related='loss_id.loss_type', store=True, readonly=False)
 
     def _convert_to_duration(self, date_start, date_stop, workcenter=False):

--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -18,14 +18,6 @@ class SupplierInfo(models.Model):
                 product_id = self.env[model].browse(active_id).exists()
         return product_id
 
-    def _domain_product_id(self):
-        domain = "product_tmpl_id and [('product_tmpl_id', '=', product_tmpl_id)] or []"
-        if self.env.context.get('base_model_name') == 'product.template':
-            domain = "[('product_tmpl_id', '=', parent.id)]"
-        elif self.env.context.get('base_model_name') == 'product.product':
-            domain = "[('product_tmpl_id', '=', parent.product_tmpl_id)]"
-        return domain
-
     partner_id = fields.Many2one(
         'res.partner', 'Vendor',
         ondelete='cascade', required=True,
@@ -58,7 +50,10 @@ class SupplierInfo(models.Model):
     date_end = fields.Date('End Date', help="End date for this vendor price")
     product_id = fields.Many2one(
         'product.product', 'Product Variant', check_company=True,
-        domain=_domain_product_id, default=_default_product_id,
+        domain="[('product_tmpl_id', '=', parent.id)] if context.get('base_model_name') == 'product.template' else"
+            " [('product_tmpl_id', '=', parent.product_tmpl_id)] if context.get('base_model_name') == 'product.product' else"
+            " [('product_tmpl_id', '=', product_tmpl_id)] if product_tmpl_id else []",
+        default=_default_product_id,
         help="If not set, the vendor price will apply to all variants of this product.")
     product_tmpl_id = fields.Many2one(
         'product.template', 'Product Template', check_company=True,

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -26,7 +26,9 @@ class StockLot(models.Model):
     ref = fields.Char('Internal Reference', help="Internal reference number in case it differs from the manufacturer's lot/serial number")
     product_id = fields.Many2one(
         'product.product', 'Product', index=True,
-        domain=lambda self: self._domain_product_id(), required=True, check_company=True)
+        domain=("[('tracking', '!=', 'none'), ('type', '=', 'product')] +"
+            " ([('product_tmpl_id', '=', context['default_product_tmpl_id'])] if context.get('default_product_tmpl_id') else [])"),
+        required=True, check_company=True)
     product_uom_id = fields.Many2one(
         'uom.uom', 'Unit of Measure',
         related='product_id.uom_id', store=True)
@@ -92,17 +94,6 @@ class StockLot(models.Model):
             error_message_lines.append(_(" - Product: %s, Serial Number: %s", product.display_name, name))
         if error_message_lines:
             raise ValidationError(_('The combination of serial number and product must be unique across a company.\nFollowing combination contains duplicates:\n') + '\n'.join(error_message_lines))
-
-    def _domain_product_id(self):
-        domain = [
-            "('tracking', '!=', 'none')",
-            "('type', '=', 'product')",
-        ]
-        if self.env.context.get('default_product_tmpl_id'):
-            domain.insert(0,
-                ("('product_tmpl_id', '=', %s)" % self.env.context['default_product_tmpl_id'])
-            )
-        return '[' + ', '.join(domain) + ']'
 
     def _check_create(self):
         active_picking_id = self.env.context.get('active_picking_id', False)

--- a/addons/stock/models/stock_storage_category.py
+++ b/addons/stock/models/stock_storage_category.py
@@ -51,19 +51,11 @@ class StorageCategoryProductCapacity(models.Model):
     _check_company_auto = True
     _order = "storage_category_id"
 
-    @api.model
-    def _domain_product_id(self):
-        domain = "('type', '=', 'product')"
-        if self.env.context.get('active_model') == 'product.template':
-            product_template_id = self.env.context.get('active_id', False)
-            domain = f"('product_tmpl_id', '=', {product_template_id})"
-        elif self.env.context.get('default_product_id', False):
-            product_id = self.env.context.get('default_product_id', False)
-            domain = f"('id', '=', {product_id})"
-        return f"[{domain}]"
-
     storage_category_id = fields.Many2one('stock.storage.category', ondelete='cascade', required=True, index=True)
-    product_id = fields.Many2one('product.product', 'Product', domain=lambda self: self._domain_product_id(), ondelete='cascade', check_company=True)
+    product_id = fields.Many2one('product.product', 'Product', ondelete='cascade', check_company=True,
+        domain=("[('product_tmpl_id', '=', context.get('active_id', False))] if context.get('active_model') == 'product.template' else"
+            " [('id', '=', context.get('default_product_id', False))] if context.get('default_product_id') else"
+            " [('type', '=', 'product')]"))
     package_type_id = fields.Many2one('stock.package.type', 'Package Type', ondelete='cascade', check_company=True)
     quantity = fields.Float('Quantity', required=True)
     product_uom_id = fields.Many2one(related='product_id.uom_id')

--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -139,7 +139,7 @@ export class Domain {
             try {
                 rawAST = typeof descr === "string" ? parseExpr(descr) : toAST(descr);
             } catch (error) {
-                throw new InvalidDomainError(`Invalid domain representation`, {
+                throw new InvalidDomainError(`Invalid domain representation: ${descr.toString()}`, {
                     cause: error,
                 });
             }

--- a/addons/web/static/src/core/utils/xml.js
+++ b/addons/web/static/src/core/utils/xml.js
@@ -1,11 +1,10 @@
 /** @odoo-module **/
 
-import { nbsp } from "@web/core/utils/strings";
-
 /**
  * XML document to create new elements from. The fact that this is a "text/xml"
  * document ensures that tagNames and attribute names are case sensitive.
  */
+const serializer = new XMLSerializer();
 const parser = new DOMParser();
 const xmlDocument = parser.parseFromString("<templates/>", "text/xml");
 
@@ -13,13 +12,29 @@ function hasParsingError(parsedDocument) {
     return parsedDocument.getElementsByTagName("parsererror").length > 0;
 }
 
-export class XMLParser {
-    /**
-     * to override. Should return the parsed content of the arch.
-     * It can call the visitArch function if desired
-     */
-    parse() {}
+/**
+ * @param {string} str
+ * @returns {Element}
+ */
+export function parseXML(str) {
+    const xml = parser.parseFromString(str, "text/xml");
+    if (hasParsingError(xml)) {
+        throw new Error(
+            `An error occured while parsing ${str}: ${xml.getElementsByTagName("parsererror")}`
+        );
+    }
+    return xml.documentElement;
+}
 
+/**
+ * @param {Element} xml
+ * @returns {string}
+ */
+export function serializeXML(xml) {
+    return serializer.serializeToString(xml);
+}
+
+export class XMLParser {
     /**
      * @param {Element | string} xml
      * @param {(el: Element, visitChildren: () => any) => any} callback
@@ -45,18 +60,11 @@ export class XMLParser {
     }
 
     /**
-     * @param {string} arch
+     * @param {string} str
      * @returns {Element}
      */
-    parseXML(arch) {
-        const cleanedArch = arch.replace(/&amp;nbsp;/g, nbsp);
-        const xml = parser.parseFromString(cleanedArch, "text/xml");
-        if (hasParsingError(xml)) {
-            throw new Error(
-                `An error occured while parsing ${arch}: ${xml.getElementsByTagName("parsererror")}`
-            );
-        }
-        return xml.documentElement;
+    parseXML(str) {
+        return parseXML(str);
     }
 }
 

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { ColorList } from "@web/core/colorlist/colorlist";
 import { Domain } from "@web/core/domain";
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import {
     Many2XAutocomplete,
@@ -280,7 +281,7 @@ export const many2ManyTagsField = {
     },
     extractProps({ attrs, options, string }, dynamicInfo) {
         const noCreate = Boolean(options.no_create);
-        const canCreate = attrs.can_create && Boolean(JSON.parse(attrs.can_create)) && !noCreate;
+        const canCreate = attrs.can_create && evaluateBooleanExpr(attrs.can_create) && !noCreate;
         const noQuickCreate = Boolean(options.no_quick_create);
         const noCreateEdit = Boolean(options.no_create_edit);
         return {

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -341,12 +341,12 @@ export const many2OneField = {
     supportedTypes: ["many2one"],
     extractProps({ attrs, context, decorations, options, string }, dynamicInfo) {
         const canCreate =
-            attrs.can_create && Boolean(JSON.parse(attrs.can_create)) && !options.no_create;
+            attrs.can_create && evaluateBooleanExpr(attrs.can_create) && !options.no_create;
         return {
             placeholder: attrs.placeholder,
             canOpen: !options.no_open,
             canCreate,
-            canWrite: attrs.can_write && Boolean(JSON.parse(attrs.can_write)),
+            canWrite: attrs.can_write && evaluateBooleanExpr(attrs.can_write),
             canQuickCreate: canCreate && !options.no_quick_create,
             canCreateEdit: canCreate && !options.no_create_edit,
             context: context,

--- a/addons/web/static/src/views/view.js
+++ b/addons/web/static/src/views/view.js
@@ -5,6 +5,8 @@ import { registry } from "@web/core/registry";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { useService } from "@web/core/utils/hooks";
 import { deepCopy, pick } from "@web/core/utils/objects";
+import { nbsp } from "@web/core/utils/strings";
+import { parseXML, serializeXML } from "@web/core/utils/xml";
 import { extractLayoutComponents } from "@web/search/layout";
 import { WithSearch } from "@web/search/with_search/with_search";
 import { OnboardingBanner } from "@web/views/onboarding_banner";
@@ -159,6 +161,7 @@ const STANDARD_PROPS = [
     "searchModel",
 ];
 
+const ACTIONS = ["create", "delete", "edit", "group_create", "group_delete", "group_edit"];
 export class View extends Component {
     setup() {
         const { arch, fields, resModel, searchViewArch, searchViewFields, type } = this.props;
@@ -274,9 +277,13 @@ export class View extends Component {
             actionMenus = viewDescription.actionMenus;
         }
 
-        const parser = new DOMParser();
-        const xml = parser.parseFromString(arch, "text/xml");
-        const rootNode = xml.documentElement;
+        const rootNode = parseXML(arch.replace(/&amp;nbsp;/g, nbsp));
+        for (const action of ACTIONS) {
+            if (action in this.props.context && !this.props.context[action]) {
+                rootNode.setAttribute(action, "0");
+            }
+        }
+        arch = serializeXML(rootNode);
 
         let subType = rootNode.getAttribute("js_class");
         const bannerRoute = rootNode.getAttribute("banner_route");

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -331,16 +331,6 @@ export class MockServer {
         const editableView = editable && this._editableNode(doc, modelName);
         const onchangeAbleView = this._onchangeAbleView(doc);
         const inFormView = doc.tagName === "form";
-        // mock _postprocess_access_rights
-        const isBaseModel = !context.base_model_name || modelName === context.base_model_name;
-        const views = ["kanban", "tree", "form", "gantt", "activity"];
-        if (isBaseModel && views.indexOf(doc.tagName) !== -1) {
-            for (const action of ["create", "delete", "edit", "write"]) {
-                if (!doc.getAttribute(action) && action in context && !context[action]) {
-                    doc.setAttribute(action, "false");
-                }
-            }
-        }
 
         traverseElementTree(doc, (node) => {
             if (node.nodeType === Node.TEXT_NODE) {

--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -1053,7 +1053,7 @@ QUnit.module("Fields", (hooks) => {
             serverData,
             arch: `
                 <form>
-                    <field name="timmy" widget="many2many" can_create="false" can_write="false"/>
+                    <field name="timmy" widget="many2many" can_create="False" can_write="False"/>
                 </form>`,
             mockRPC(route, args) {
                 if (

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -880,20 +880,21 @@ QUnit.module("Fields", (hooks) => {
                 },
                 mockRPC(route, { method, kwargs }) {
                     if (method === "get_views") {
-                        assert.step(method);
-                        if (kwargs.context.default_name === "ABC") {
-                            assert.strictEqual(kwargs.context.form_view_ref, undefined);
-                        } else {
-                            assert.strictEqual(kwargs.context.form_view_ref, "test_form_view");
-                        }
+                        assert.step(
+                            JSON.stringify([
+                                method,
+                                kwargs.context.default_name,
+                                kwargs.context.form_view_ref,
+                            ])
+                        );
                     }
                 },
             });
 
-            assert.verifySteps(["get_views"]);
+            assert.verifySteps(['["get_views",null,"test_form_view"]']);
             await editInput(target, ".o_field_widget[name=trululu] input", "ABC");
             await click(target, ".o_field_widget[name=trululu] .o_m2o_dropdown_option_create_edit");
-            assert.verifySteps(["get_views"]);
+            assert.verifySteps(['["get_views",null,null]']);
         }
     );
 
@@ -1905,7 +1906,7 @@ QUnit.module("Fields", (hooks) => {
                         </field>
                     </sheet>
                 </form>`,
-            mockRPC(route, { method, args}) {
+            mockRPC(route, { method, args }) {
                 if (method === "read" && args[1].length === 1 && args[1][0] === "display_name") {
                     throw new Error("read(['display_name']) should not be called");
                 }
@@ -1945,7 +1946,11 @@ QUnit.module("Fields", (hooks) => {
                         </sheet>
                     </form>`,
                 mockRPC(route, { method, args }) {
-                    if (method === "read" && args[1].length === 1 && args[1][0] === "display_name") {
+                    if (
+                        method === "read" &&
+                        args[1].length === 1 &&
+                        args[1][0] === "display_name"
+                    ) {
                         throw new Error("read(['display_name']) should not be called");
                     }
                 },

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -11445,9 +11445,11 @@ QUnit.module("Views", (hooks) => {
             serverData,
             arch: '<tree editable="top"><field name="foo"/></tree>',
             mockRPC(route, args) {
-                const context = args.kwargs.context;
-                assert.strictEqual(context.active_field, 2, "context should be correct");
-                assert.strictEqual(context.someKey, "some value", "context should be correct");
+                if (args.method !== "get_views") {
+                    const context = args.kwargs.context;
+                    assert.strictEqual(context.active_field, 2, "context should be correct");
+                    assert.strictEqual(context.someKey, "some value", "context should be correct");
+                }
             },
             context: { active_field: 2 },
         });
@@ -19508,7 +19510,7 @@ QUnit.module("Views", (hooks) => {
         const wc = await createWebClient({ serverData, mockRPC });
         await doAction(wc, 1);
         assert.verifySteps([
-            `foo: get_views: {"lang":"en","uid":7,"tz":"taht","tree_view_ref":"foo_view_ref","search_default_bar":true}`,
+            `foo: get_views: {"lang":"en","uid":7,"tz":"taht","tree_view_ref":"foo_view_ref"}`,
             `foo: web_search_read: {"lang":"en","uid":7,"tz":"taht","bin_size":true,"tree_view_ref":"foo_view_ref"}`,
         ]);
 

--- a/addons/web/static/tests/views/view_dialogs/form_view_dialog_tests.js
+++ b/addons/web/static/tests/views/view_dialogs/form_view_dialog_tests.js
@@ -234,7 +234,6 @@ QUnit.module("ViewDialogs", (hooks) => {
                     assert.deepEqual(
                         args.kwargs.context,
                         {
-                            base_model_name: "instrument",
                             lang: "en",
                             tree_view_ref: "some_other_tree_view",
                             tz: "taht",

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -74,7 +74,7 @@ class Post(models.Model):
     self_reply = fields.Boolean('Reply to own question', compute='_compute_self_reply', store=True)
     child_ids = fields.One2many(
         'forum.post', 'parent_id', string='Post Answers',
-        domain=lambda self: [('forum_id', 'in', self.forum_id.ids)])
+        domain="[('forum_id', '=', forum_id)]")
     child_count = fields.Integer('Answers', compute='_compute_child_count', store=True)
     uid_has_answered = fields.Boolean('Has Answered', compute='_compute_uid_has_answered')
     has_validated_answer = fields.Boolean(

--- a/odoo/addons/base/tests/test_acl.py
+++ b/odoo/addons/base/tests/test_acl.py
@@ -148,7 +148,7 @@ class TestACL(TransactionCaseWithUserDemo):
 
         # demo not part of the group_system, create edit and delete must be False
         for method in methods:
-            self.assertEqual(view_arch.get(method), 'false')
+            self.assertEqual(view_arch.get(method), 'False')
 
         # demo part of the group_system, create edit and delete must not be specified
         company = self.env['res.company'].with_user(self.env.ref("base.user_admin"))
@@ -168,14 +168,14 @@ class TestACL(TransactionCaseWithUserDemo):
         field_node = view_arch.xpath("//field[@name='currency_id']")
         self.assertTrue(len(field_node), "currency_id field should be in company from view")
         for method in methods:
-            self.assertEqual(field_node[0].get('can_' + method), 'false')
+            self.assertEqual(field_node[0].get('can_' + method), 'False')
 
         company = self.env['res.company'].with_user(self.env.ref("base.user_admin"))
         company_view = company.get_view(False, 'form')
         view_arch = etree.fromstring(company_view['arch'])
         field_node = view_arch.xpath("//field[@name='currency_id']")
         for method in methods:
-            self.assertEqual(field_node[0].get('can_' + method), 'true')
+            self.assertEqual(field_node[0].get('can_' + method), 'True')
 
     def test_get_views_fields(self):
         """ Tests fields restricted to group_system are not passed when calling `get_views` as demo

--- a/odoo/addons/base/wizard/base_module_upgrade.py
+++ b/odoo/addons/base/wizard/base_module_upgrade.py
@@ -28,9 +28,6 @@ class BaseModuleUpgrade(models.TransientModel):
         if view_type != 'form':
             return res
 
-        if not(self._context.get('active_model') and self._context.get('active_id')):
-            return res
-
         if not self.get_module_list():
             res['arch'] = '''<form string="Upgrade Completed">
                                 <separator string="Upgrade Completed" colspan="4"/>

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2892,7 +2892,7 @@ class _Relational(Field):
             else:
                 cid = "id" if self.model_name == "res.company" else "company_id"
             company_domain = env[self.comodel_name]._check_company_domain(companies=unquote(cid))
-            return f"({cid} and {company_domain} or []) + ({domain})"
+            return f"({cid} and {company_domain} or []) + ({domain or []})"
         return domain
 
 
@@ -2904,7 +2904,8 @@ class Many2one(_Relational):
         ``Mandatory`` except for related or extended fields.
 
     :param domain: an optional domain to set on candidate values on the
-        client side (domain or string)
+        client side (domain or a python expression that will be evaluated
+        to provide domain)
 
     :param dict context: an optional context to use on the client side when
         handling that field
@@ -4313,7 +4314,8 @@ class One2many(_RelationalMulti):
         ``comodel_name``
 
     :param domain: an optional domain to set on candidate values on the
-        client side (domain or string)
+        client side (domain or a python expression that will be evaluated
+        to provide domain)
 
     :param dict context: an optional context to use on the client side when
         handling that field
@@ -4617,7 +4619,8 @@ class Many2many(_RelationalMulti):
     - at least one field belongs to a model with ``_auto = False``.
 
     :param domain: an optional domain to set on candidate values on the
-        client side (domain or string)
+        client side (domain or a python expression that will be evaluated
+        to provide domain)
 
     :param dict context: an optional context to use on the client side when
         handling that field

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -54,10 +54,10 @@ def get_domain_value_names(domain):
             (1, '=', 1),
             bool(context.get('c')),
         ]
-        returns {'parent', 'parent.truc', 'context'}
+        returns {'id', 'field_a', 'field_b'}, {'parent', 'parent.truc', 'context'}
 
     :param domain: list(tuple) or str
-    :return: set(str)
+    :return: set(str), set(str)
     """
     contextual_values = set()
     field_names = set()


### PR DESCRIPTION
In this viewtiverse, the heroes remove the context dependencies for
`get_views`, from the views and python fields (such as domain). To reduce
inconsistencies and the number of rpc.

Current issues:
* There may be inconsistencies in views at the JavaScript level. Some
overrides modify the behavior of get_views or domains on fields via
context keys, therefore by changing the action, the rendering may be
different. However, these views are cached. However, the cache key
(Javascript) does not reflect the entire context, and requires additional
post-processing from the server.
* Multiple rpc for the same rendering. get_views being dependent on the
context, as soon as it changes, a new rpc is performed. In most cases,
when JavaScript needs the same view, there is no change depending on the
context, the rpc is useless.
* Inconsistency when rendering subviews, some views could be different
depending on the context, this context can be modified in the view itself
via the context attributes. However, the JavaScript client does not redo
an rpc for each change of these sub-contexts. Therefore the result may be
inconsistent.

Solution:
Limit as much as possible the number of context keys provided when calling
get_views, and use the context provided as a cache key. The authorized
keys are 'lang' and '*_view_ref'. For the cache key, options are added in
the get_views method.
Instead of using the context, it is inserted into python expressions.
This will be evaluated by JavaScript and thus avoids inconsistencies.

task-3414108
task-3414068