### PR TITLE
[FIX] web_editor: page getting crash

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3208,6 +3208,9 @@ export class OdooEditor extends EventTarget {
         this.toolbar.classList.toggle('d-none', false);
         this.toolbar.style.maxWidth = window.innerWidth - OFFSET * 2 + 'px';
         const sel = this.document.getSelection();
+        if (!sel || !sel.rangeCount) {
+            return;
+        }
         const range = sel.getRangeAt(0);
         const isSelForward =
             sel.anchorNode === range.startContainer && sel.anchorOffset === range.startOffset;


### PR DESCRIPTION
**Current behavior before PR:**

selecting text after banner to inside the banner and apply color gives traceback
because the selection is null or rangeCount of selection is 0.

**Desired behavior after PR is merged:**

Now after adding check for selection and rangeCount selecting text after banner
to inside the banner and apply color will not give traceback.

task-3500897


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
