### PR TITLE
[IMP] account: enable index scan on AML

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1355,6 +1355,9 @@ class AccountMoveLine(models.Model):
         """
         create_index(self._cr, 'account_move_line_partner_id_ref_idx', 'account_move_line', ["partner_id", "ref"])
         create_index(self._cr, 'account_move_line_date_name_id_idx', 'account_move_line', ["date desc", "move_name desc", "id"])
+        # Match exactly how the ORM converts domains to ensure the query planner uses it
+        create_index(self._cr, 'account_move_line__unreconciled_index', 'account_move_line', ['account_id', 'partner_id'],
+                     where="(reconciled IS NULL OR reconciled = false OR reconciled IS NOT true) AND parent_state = 'posted'")
         super().init()
 
     def default_get(self, fields_list):


### PR DESCRIPTION
The corresponding enterprise PR enables sorting account move lines on the bank recon by matching amount. Unfortunately there is a significant performance impact when enabling this ORDER BY (~300 ms -> ~2600 ms tested on a large db)

In order to optimise the above, we slightly modify the domains used so that the existing index `account_move_line__unreconciled_index` is used. This is not yet tested on a large DB (due to the index change), however observations on a populated database indicate an improvement: 
without index: 80ms
with index: 30ms

