### PR TITLE
[IMP] account_edi_ubl_cii: always set customer reference

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -491,7 +491,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         sales_order_id = 'sale_line_ids' in invoice.invoice_line_ids._fields \
                          and ",".join(invoice.invoice_line_ids.sale_line_ids.order_id.mapped('name'))
         # OrderReference/ID (order_reference) is mandatory inside the OrderReference node !
-        order_reference = invoice.ref or invoice.name if sales_order_id else invoice.ref
+        order_reference = invoice.ref or invoice.name
 
         vals = {
             'builder': self,

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -9,6 +9,9 @@
   <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
   <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
   <cbc:BuyerReference>Mohammed Ali</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>INV/2023/00034</cbc:ID>
+  </cac:OrderReference>
   <cac:AdditionalDocumentReference>
     <cbc:ID>QR</cbc:ID>
     <cac:Attachment>

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -12,6 +12,9 @@
     <cbc:DocumentCurrencyCode>SAR</cbc:DocumentCurrencyCode>
     <cbc:TaxCurrencyCode>SAR</cbc:TaxCurrencyCode>
     <cbc:BuyerReference>Azure Interior</cbc:BuyerReference>
+    <cac:OrderReference>
+        <cbc:ID>INV/2022/00014</cbc:ID>
+    </cac:OrderReference>
     <cac:AdditionalDocumentReference>
         <cbc:ID>PIH</cbc:ID>
         <cac:Attachment>


### PR DESCRIPTION
For PEPPOL, the Customer Reference field on invoices is a required field. In Odoo it can be blank when creating an invoice from scratch. In order to avoid errors when sending PEPPOL invoices, we want to set the Customer Reference to the invoice name when no reference was provided.

[task-3499548](https://www.odoo.com/web#id=3499548&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
