### PR TITLE
[IMP] product,website_sale(_product_configurator): allow extra-options

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -1,0 +1,60 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from "@website_sale/js/tours/tour_utils";
+
+// This tour relies on a data created from the python test.
+registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
+    test: true,
+    url: '/shop?search=Product Multi',
+    steps: () => [
+    {
+        content: "select Product",
+        trigger: '.oe_product_cart a:containsExact("Product Multi")',
+    },
+    {
+        content: "check price",
+        trigger: '.oe_currency_value:contains("750")',
+        run: function () {},
+    },
+    {
+        content: 'click on the first option to select it',
+        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 1"]',
+    },
+    {
+        content: 'click on the third option to select it',
+        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"]',
+    },
+    {
+        content: 'check combination is not possible',
+        trigger: '.js_main_product.css_not_available .css_not_available_msg:contains("This combination does not exist.")'
+    },
+    {
+        content: "check add to cart not possible",
+        trigger: '#add_to_cart.disabled',
+        run: function () {},
+    },
+    {
+        content: 'click on the third option to unselect it',
+        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 3"]',
+    },
+    {
+        content: 'click on the second option to select it',
+        trigger: 'input[data-attribute_name="Options"][data-value_name="Option 2"]',
+    },
+    {
+        content: "check price of options is correct",
+        trigger: '.oe_currency_value:contains("753")',
+        run: function () {},
+    },
+    {
+        content: "add to cart",
+        trigger: 'a:contains(ADD TO CART)',
+    },
+        tourUtils.goToCart(),
+    {
+        content: "check price is correct",
+        trigger: '.td-product_name:contains("Options: Option 1, Option 2")',
+        run: function () {},
+    },
+]});

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -859,7 +859,7 @@
                                         </t>
                                     </select>
                                 </t>
-                                <t t-if="a.display_type == 'radio' or a.display_type == 'pills'">
+                                <t t-if="a.display_type in ('radio', 'pills', 'multi')">
                                     <div class="flex-column mb-3">
                                         <t t-foreach="a.value_ids" t-as="v">
                                             <div class="form-check mb-1">
@@ -1033,12 +1033,9 @@
                                         <input type="hidden" class="product_id" name="product_id" t-att-value="product_variant.id" />
                                         <input type="hidden" class="product_template_id" name="product_template_id" t-att-value="product.id" />
                                         <input t-if="product.public_categ_ids.ids" type="hidden" class="product_category_id" name="product_category_id" t-att-value="product.public_categ_ids.ids[0]" />
-                                        <t t-if="combination" t-call="website_sale.variants">
+                                        <t t-call="website_sale.variants">
                                             <t t-set="ul_class" t-valuef="flex-column" />
                                             <t t-set="parent_combination" t-value="None" />
-                                        </t>
-                                        <t t-else="">
-                                            <ul class="d-none js_add_cart_variants mb-0" t-att-data-attribute_exclusions="{'exclusions: []'}"/>
                                         </t>
                                     </t>
                                     <p t-if="True" class="css_not_available_msg alert alert-warning">This combination does not exist.</p>

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -36,13 +36,13 @@
                         </select>
                     </t>
 
-                    <t t-if="ptal.attribute_id.display_type == 'radio'">
+                    <t t-elif="ptal.attribute_id.display_type in ('radio', 'multi')">
                         <ul t-att-data-attribute_id="ptal.attribute_id.id" t-attf-class="list-inline list-unstyled o_wsale_product_attribute #{'d-none' if single_and_custom else ''}">
                             <t t-foreach="ptal.product_template_value_ids._only_active()" t-as="ptav">
                                 <li class="list-inline-item mb-3 js_attribute_value" style="margin: 0;">
                                     <label class="col-form-label">
                                         <div class="form-check">
-                                            <input type="radio"
+                                            <input t-att-type="'radio' if ptal.attribute_id.display_type == 'radio' else 'checkbox'"
                                                 t-attf-class="form-check-input js_variant_change #{ptal.attribute_id.create_variant}"
                                                 t-att-checked="ptav in combination"
                                                 t-att-name="'ptal-%s' % ptal.id"
@@ -52,7 +52,7 @@
                                                 t-att-data-attribute_name="ptav.attribute_id.name"
                                                 t-att-data-is_custom="ptav.is_custom"
                                                 t-att-data-is_single="single"
-                                                t-att-data-is_single_and_custom="single_and_custom" />
+                                                t-att-data-is_single_and_custom="single_and_custom"/>
                                             <div class="radio_input_value form-check-label">
                                                 <span t-field="ptav.name"/>
                                                 <t t-call="website_sale.badge_extra_price"/>
@@ -64,7 +64,7 @@
                         </ul>
                     </t>
 
-                    <t t-if="ptal.attribute_id.display_type == 'pills'">
+                    <t t-elif="ptal.attribute_id.display_type == 'pills'">
                         <ul t-att-data-attribute_id="ptal.attribute_id.id"
                             t-attf-class="btn-group-toggle list-inline list-unstyled o_wsale_product_attribute #{'d-none' if single_and_custom else ''}"
                             data-bs-toggle="buttons">
@@ -92,7 +92,7 @@
                         </ul>
                     </t>
 
-                    <t t-if="ptal.attribute_id.display_type == 'color'">
+                    <t t-elif="ptal.attribute_id.display_type == 'color'">
                         <ul t-att-data-attribute_id="ptal.attribute_id.id" t-attf-class="list-inline o_wsale_product_attribute #{'d-none' if single_and_custom else ''}">
                             <li t-foreach="ptal.product_template_value_ids._only_active()" t-as="ptav" class="list-inline-item me-1">
                                 <label t-attf-style="background-color:#{ptav.html_color or ptav.product_attribute_value_id.name if not ptav.is_custom else ''}"

--- a/addons/website_sale_product_configurator/static/src/js/sale_product_configurator_modal.js
+++ b/addons/website_sale_product_configurator/static/src/js/sale_product_configurator_modal.js
@@ -257,9 +257,15 @@ export const OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, 
 
             $.each(this.rootProduct.no_variant_attribute_values, function () {
                 if (this.is_custom !== 'True') {
-                    $updatedDescription.append($('<div>', {
-                        text: this.attribute_name + ': ' + this.attribute_value_name
-                    }));
+                    var $currentDescription = $updatedDescription.find(`div[name=ptal-${this.id}]`);
+                    if ($currentDescription?.length > 0) { // one row per multicheckbox
+                        $currentDescription.text($currentDescription.text() + ', ' + this.attribute_value_name);
+                    } else {
+                        $updatedDescription.append($('<div>', {
+                            text: this.attribute_name + ': ' + this.attribute_value_name,
+                            name: `ptal-${this.id}`,
+                        }));
+                    }
                 }
             });
 
@@ -356,9 +362,15 @@ export const OptionalProductsModal = Dialog.extend(ServicesMixin, VariantMixin, 
 
             $.each(noVariantAttributeValues, function (){
                 if (this.is_custom !== 'True'){
-                    $customAttributeValuesDescription.append($('<div>', {
-                        text: this.attribute_name + ': ' + this.attribute_value_name
-                    }));
+                    var $currentDescription = $customAttributeValuesDescription.find(`div[name=ptal-${this.id}]`);
+                    if ($currentDescription?.length > 0) { // one row per multicheckbox
+                        $currentDescription.text($currentDescription.text() + ', ' + this.attribute_value_name);
+                    } else {
+                        $customAttributeValuesDescription.append($('<div>', {
+                            text: this.attribute_name + ': ' + this.attribute_value_name,
+                            name: `ptal-${this.id}`,
+                        }));
+                    }
                 }
             });
 


### PR DESCRIPTION
[A previous commit](https://github.com/odoo/odoo/commit/5ca1da8ab33d4dd6a9ed0b6737e5d19f1a3ac9d2) introduces a new attribute `display_type`, `multi`, which allows users to define extra-options to products. But this option was only available in Sales.

This commit allows eCommerce users to use this new attribute in the online shop.

task-3497046
