### PR TITLE
[IMP] account: Better UX during account_accoutant_tour

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -75,8 +75,7 @@ registry.category("web_tour.tours").add('account_tour', {
     {
         trigger: "button[name=action_post]",
         extra_trigger: "button.o_form_button_create",
-        content: _t("Once your invoice is ready, confirm it."),
-        position: "bottom",
+        content: _t("After the data extraction, check and validate the bill. If no vendor has been found, add one before validating."),
     }, {
         trigger: "button[name=action_invoice_sent]",
         extra_trigger: "[name=move_type] [raw-value=out_invoice]",

--- a/addons/account/wizard/account_tour_upload_bill.py
+++ b/addons/account/wizard/account_tour_upload_bill.py
@@ -54,7 +54,9 @@ class AccountTourUploadBill(models.TransientModel):
 
         values = [('sample', _('Try a sample vendor bill')), ('upload', _('Upload your own bill'))]
         if journal_alias.alias_name and journal_alias.alias_domain:
-            values.append(('email', _('Or send a bill to %s@%s', journal_alias.alias_name, journal_alias.alias_domain)))
+            values.append(('email', _('Send a bill to \n%s@%s', journal_alias.alias_name, journal_alias.alias_domain)))
+        else:
+            values.append(('email_no_alias', _('Send a bill by email')))
         return values
 
     def _action_list_view_bill(self, bill_ids=[]):
@@ -122,7 +124,10 @@ class AccountTourUploadBill(models.TransientModel):
 
             return self._action_list_view_bill(bill.ids)
         else:
-            email_alias = '%s@%s' % (purchase_journal.alias_name, purchase_journal.alias_domain)
+            if self.selection == 'email':
+                email_alias = '%s@%s' % (purchase_journal.alias_name, purchase_journal.alias_domain)
+            else:
+                email_alias = ''
             new_wizard = self.env['account.tour.upload.bill.email.confirm'].create({'email_alias': email_alias})
             view_id = self.env.ref('account.account_tour_upload_bill_email_confirm').id
 

--- a/addons/account/wizard/account_tour_upload_bill.xml
+++ b/addons/account/wizard/account_tour_upload_bill.xml
@@ -28,13 +28,17 @@
             <field name="model">account.tour.upload.bill.email.confirm</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="email_alias" invisible="1"/>
                     <sheet>
-                        <p>Send your email to <field name="email_alias" class="oe_inline"/> with a pdf of an invoice as attachment.</p>
-                        <p>Once done, press continue.</p>
+                        <p invisible="not email_alias">Send your email to <field name="email_alias" class="oe_inline" widget="email"/> with a pdf of an invoice as attachment.</p>
+                        <p invisible="not email_alias">Once done, press continue.</p>
+                        <p invisible="email_alias">Configure your email server first and send your bill by email.</p>
+                        <a type='action' name='%(action_open_settings)d' class="btn btn-link" role="button" invisible="email_alias"><i class="oi oi-fw o_button_icon oi-arrow-right"/> Configure Email Servers</a>
                     </sheet>
                     <footer>
-                        <button string="Continue" type="object" name="apply" class="btn-primary" data-hotkey="q"/>
-                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                        <button string="Continue" type="object" name="apply" class="btn-primary" data-hotkey="q" invisible="not email_alias"/>
+                        <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" invisible="not email_alias"/>
+                        <button string="Close" class="btn-secondary" special="cancel" data-hotkey="x" invisible="email_alias"/>
                     </footer>
                </form>
             </field>


### PR DESCRIPTION
Description of the issue/feature this commit addresses:

The current onboarding account tour is sometimes broken. The purpose of this commit is to fix it and make it run smoothly.

---

Desired behavior after the commit is merged :

This commit modifies the onboarding account tour to clarify the messages that are shown, add messages to certain steps and try to make it impossible for the user to be lost during its entierty.

Adding this improvement, the onboarding account tour better fills its purpose.

---

Enterprise PR : https://github.com/odoo/enterprise/pull/47306

task-3375344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
