### PR TITLE
[FIX] web_editor: record info in media dialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1279,13 +1279,17 @@ const Wysiwyg = Widget.extend({
         const restoreSelection = preserveCursor(this.odooEditor.document);
 
         const $editable = $(OdooEditorLib.closestElement(range.startContainer, '.o_editable') || this.odooEditor.editable);
-        const model = $editable.data('oe-model');
+        let model = $editable.data('oe-model');
+        let resId = $editable.data('oe-id');
+        if (!model) {
+            ({ res_model: model, res_id: resId } = this.options.recordInfo);
+        }
         const field = $editable.data('oe-field');
         const type = $editable.data('oe-type');
 
         this.mediaDialogWrapper = new ComponentWrapper(this, MediaDialogWrapper, {
             resModel: model,
-            resId: $editable.data('oe-id'),
+            resId: resId,
             domain: $editable.data('oe-media-domain'),
             useMediaLibrary: !!(field && (model === 'ir.ui.view' && field === 'arch' || type === 'html')),
             media: params.node,


### PR DESCRIPTION
When opening the media dialog, the record's model and id are obtained from the editable's Jquery dataset. This works fine both for the single editable case (ex: task description) and the multiple editables case, provided that each editable carries such information in the dataset (ex: website).

However, before this commit, the record information was not correctly obtained when the editor was used by mass_mailing. The snippets provide multiple editables, but those do not contain the record's model and id in its Jquery dataset.

This leads to the creation of public attachments instead of private ones when uploading images via the media dialog. Ultimately, this results in sharing uploaded images across different records, which is undesirable.

This commit addresses such case by using the Wysiwyg's record info (which comes from the HtmlField's props) as a fallback when such data is not present in the editable.

opw-3340212
task-3502797
