### PR TITLE
[IMP] l10n_dk: force lock of sales and purchase entries

### DIFF
--- a/addons/l10n_dk/__manifest__.py
+++ b/addons/l10n_dk/__manifest__.py
@@ -96,6 +96,7 @@ Produkt setup:
     'data': [
         'data/account_account_tags.xml',
         'data/account_tax_report_data.xml',
+        'views/account_journal_views.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_dk/models/account_journal.py
+++ b/addons/l10n_dk/models/account_journal.py
@@ -19,3 +19,23 @@ class AccountJournal(models.Model):
             account_vals['tag_ids'].append((4, self.env.ref('l10n_dk.account_tag_liquidity').id))
 
         return account_vals
+
+    def create(self, vals_list):
+        # EXTENDS account
+        journals = super().create(vals_list)
+        for journal in journals:
+            if journal.type in ('sale', 'purchase') and journal.country_code == 'DK':
+                # For Denmark we force hashing the entries for sales and purchase journals.
+                journal.restrict_mode_hash_table = True
+        return journals
+
+    def write(self, vals):
+        # EXTENDS account
+        if 'restrict_mode_hash_table' in vals and not vals['restrict_mode_hash_table']:
+            for journal in self:
+                if journal.country_code == 'DK' and journal.type in ('sale', 'purchase'):
+                    # For Denmark we force hashing the entries for sales and purchase journals.
+                    del vals['restrict_mode_hash_table']
+                    break
+        res = super().write(vals)
+        return res

--- a/addons/l10n_dk/views/account_journal_views.xml
+++ b/addons/l10n_dk/views/account_journal_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_journal_form_inherit_l10n_dk" model="ir.ui.view">
+        <field name="name">account.journal.view.form.inherit</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <field name="restrict_mode_hash_table" position="attributes">
+                <attribute name="readonly">type in ('sale', 'purchase') and country_code == 'DK'</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Following new regulations in Denmark, we need to prevent users from modifying posted entries in sales and purchase journals.

By using a forced hash on the journals we do just that.

[task-3497062](https://www.odoo.com/web#id=3497062&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
