### PR TITLE
[IMP] web,*: remove assets_backend_prod_only

### DIFF
--- a/addons/bus/tests/test_assetsbundle.py
+++ b/addons/bus/tests/test_assetsbundle.py
@@ -16,7 +16,7 @@ class BusWebTests(odoo.tests.HttpCase):
         """
         db_name = self.env.registry.db_name
         # start from a clean slate
-        self.env['ir.attachment'].search([('name', 'ilike', 'web.assets_backend%')]).unlink()
+        self.env['ir.attachment'].search([('name', 'ilike', 'web.assets_web%')]).unlink()
         self.env.registry.clear_cache()
 
         sendones = []

--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -67,7 +67,7 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
             # Don't include dark mode files in light mode
             ('remove', 'hr_holidays/static/src/**/*.dark.scss'),
         ],
-        "web.dark_mode_assets_backend": [
+        "web.assets_web_dark": [
             'hr_holidays/static/src/**/*.dark.scss',
         ],
         'web.tests_assets': [

--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -132,7 +132,6 @@ Help your customers with this chat, and analyse their feedback.
             'im_livechat/static/src/embed/external/**/*',
         ],
         'im_livechat.embed_test_assets': [
-            ('include', 'web.assets_backend'),
             ('include', 'web.tests_assets'),
             ('remove', 'web/static/tests/mock_server_tests.js'),
             ('remove', 'im_livechat/static/**'),

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -143,7 +143,7 @@ For more specific needs, you may also assign custom-defined actions
             ('remove', 'mail/static/src/discuss/**/*.dark.scss'),
             'mail/static/src/views/fields/**/*',
         ],
-        "web.dark_mode_assets_backend": [
+        "web.assets_web_dark": [
             'mail/static/src/**/*.dark.scss',
         ],
         'mail.assets_discuss_public_test_tours': [

--- a/addons/spreadsheet/__manifest__.py
+++ b/addons/spreadsheet/__manifest__.py
@@ -75,7 +75,7 @@
             ('remove', 'spreadsheet/static/src/public_readonly_app/**/*.scss'),
             ('remove', 'spreadsheet/static/src/**/*.dark.scss'),
         ],
-        "web.dark_mode_assets_backend": [
+        "web.assets_web_dark": [
             'spreadsheet/static/src/**/*.dark.scss',
         ],
         'web.qunit_suite_tests': [

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -100,7 +100,7 @@ sent mails with personal token for the invitation of the survey.
             'survey/static/src/scss/survey_templates_results.scss',
             'survey/static/src/js/tours/survey_tour.js',
         ],
-        "web.dark_mode_assets_backend": [
+        "web.assets_web_dark": [
             'survey/static/src/scss/*.dark.scss',
         ],
         'web.assets_tests': [

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -154,6 +154,12 @@ This module provides the core of the Odoo Web Client.
             # Don't include dark mode files in light mode
             ('remove', 'web/static/src/**/*.dark.scss'),
         ],
+        'web.assets_web': [
+            ('include', 'web.assets_backend'),
+            'web/static/src/main.js',
+            'web/static/src/legacy/legacy_setup.js',
+            'web/static/src/start.js',
+        ],
         'web.assets_frontend_minimal': [
             'web/static/src/legacy/js/promise_extension.js',
             'web/static/src/module_loader.js',
@@ -280,11 +286,6 @@ This module provides the core of the Odoo Web Client.
             ('remove', 'web/static/src/legacy/js/core/cookie_utils.js'),
             ('remove', 'web/static/src/legacy/js/public/lazyloader.js'),
         ],
-        'web.assets_backend_prod_only': [
-            'web/static/src/main.js',
-            'web/static/src/start.js',
-            'web/static/src/legacy/legacy_setup.js',
-        ],
         # Optional Bundle for PDFJS lib
         # Since PDFJS is quite huge (80000≈ lines), please only load it when it is necessary.
         # For now, it is only use to display the PDF slide Viewer during an embed.
@@ -351,8 +352,8 @@ This module provides the core of the Odoo Web Client.
         # ---------------------------------------------------------------------
         # COLOR SCHEME BUNDLES
         # ---------------------------------------------------------------------
-        "web.dark_mode_assets_backend": [
-            ('include', 'web.assets_backend'),
+        "web.assets_web_dark": [
+            ('include', 'web.assets_web'),
             'web/static/src/**/*.dark.scss',
         ],
 
@@ -439,6 +440,8 @@ This module provides the core of the Odoo Web Client.
             'web/static/tests/ignore_missing_deps_stop.js',
         ],
         'web.tests_assets': [
+            ('include', 'web.assets_backend'),
+
             'web/static/tests/patch_translations.js',
             'web/static/lib/qunit/qunit-2.9.1.css',
             'web/static/lib/qunit/qunit-2.9.1.js',

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -217,8 +217,6 @@
             <t t-set="html_data" t-value="{'style': 'height: 100%;'}"/>
             <t t-set="title">Web Tests</t>
             <t t-set="head">
-                <t t-call-assets="web.assets_backend"/>
-
                 <t t-call="web.test_helpers"/>
 
                 <t t-call-assets="web.qunit_suite_tests" t-js="false"/>
@@ -235,8 +233,6 @@
             <t t-set="title">Web Mobile Tests</t>
             <t t-set="head">
                 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
-
-                <t t-call-assets="web.assets_backend"/>
 
                 <t t-call="web.test_helpers"/>
 
@@ -274,12 +270,11 @@
                     }
                 </script>
                 <t t-if="request.httprequest.cookies.get('color_scheme') == 'dark'">
-                    <t t-call-assets="web.dark_mode_assets_backend"/>
+                    <t t-call-assets="web.assets_web_dark"/>
                 </t>
                 <t t-else="">
-                    <t t-call-assets="web.assets_backend"/>
+                    <t t-call-assets="web.assets_web"/>
                 </t>
-                <t t-call-assets="web.assets_backend_prod_only" t-css="false"/>
                 <t t-call="web.conditional_assets_tests"/>
             </t>
             <t t-set="head" t-value="head_web + (head or '')"/>

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -201,7 +201,7 @@ Odoo Web Editor widget.
 
             ('include', 'web_editor.assets_wysiwyg'),
         ],
-        "web.dark_mode_assets_backend": [
+        "web.assets_web_dark": [
             'web_editor/static/src/scss/odoo-editor/powerbox.dark.scss',
             'web_editor/static/src/scss/odoo-editor/tablepicker.dark.scss',
             'web_editor/static/src/scss/odoo-editor/tableui.dark.scss',

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -188,7 +188,7 @@
             # Don't include dark mode files in light mode
             ('remove', 'website/static/src/client_actions/*/*.dark.scss'),
         ],
-        "web.dark_mode_assets_backend": [
+        "web.assets_web_dark": [
             'website/static/src/components/dialog/*.dark.scss',
             'website/static/src/scss/website.backend.dark.scss',
             'website/static/src/client_actions/*/*.dark.scss',

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -55,7 +55,7 @@ class AssetsBundle(object):
     rx_preprocess_imports = re.compile("""(@import\s?['"]([^'"]+)['"](;?))""")
     rx_css_split = re.compile("\/\*\! ([a-f0-9-]+) \*\/")
 
-    TRACKED_BUNDLES = ['web.assets_backend']
+    TRACKED_BUNDLES = ['web.assets_web']
 
     def __init__(self, name, files, external_assets=(), env=None, css=True, js=True, debug_assets=False, rtl=False, assets_params=None):
         """


### PR DESCRIPTION
This commit reworks a little bit the backend assets to remove a bundle and thus save a call at webclient startup. The bundle "assets_backend_prod_only" existed only to allow to add files in production, but not in the tests (typically, the file that spawns the webclient).

This commit introduces a new bundle "web.assets_web" that contains "assets_backend" and the few files that we only want in production. In the /web page, we now load "assets_web" instead of "assets_backend" and "assets_backend_prod_only". In the /web/tests page, we keep loading "assets_backend", which is now directly included into "web.tests_assets".

For the sake of consistency, this commit also renames the dark mode bundle "dark_mode_assets_backend" into "assets_web_dark".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
