### PR TITLE
[FIX] mail: do not autoscroll attachment box when initially open

### DIFF
--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -99,6 +99,7 @@ export class Chatter extends Component {
             composerType: false,
             isAttachmentBoxOpened: this.props.isAttachmentBoxVisibleInitially,
             jumpThreadPresent: 0,
+            scrollToAttachments: 0,
             showActivities: true,
             showAttachmentLoading: false,
             /** @type {import("@mail/core/common/thread_model").Thread} */
@@ -174,12 +175,12 @@ export class Chatter extends Component {
             () => [this.attachments]
         );
         useEffect(
-            (opened) => {
-                if (opened) {
+            () => {
+                if (this.state.scrollToAttachments > 0) {
                     this.attachmentBox.el.scrollIntoView({ block: "center" });
                 }
             },
-            () => [this.state.isAttachmentBoxOpened]
+            () => [this.state.scrollToAttachments]
         );
         useEffect(
             () => {
@@ -394,6 +395,9 @@ export class Chatter extends Component {
             return;
         }
         this.state.isAttachmentBoxOpened = !this.state.isAttachmentBoxOpened;
+        if (this.state.isAttachmentBoxOpened) {
+            this.state.scrollToAttachments++;
+        }
     }
 
     async onClickAttachFile(ev) {


### PR DESCRIPTION
Before this commit, when a form view choose to open attachment box initially and chatter is at bottom, opening the form view was scrolling down to the attachment box.

The auto-scroll to opened attachment box is desirable when the user explicitly interact with the attachment button, to show the attachments. However, it should not be triggered when opening the form.

This commit fixes the issue by limiting auto-scroll to attachment box only when explicitly chosen by the user.

Before (scroll to attachment box):
![before](https://github.com/odoo/odoo/assets/6569390/0b0053f7-f265-4b5c-8f1c-8185966ca71f)

After (stay at top of form view)
![after](https://github.com/odoo/odoo/assets/6569390/945ae795-47aa-4386-8173-5b101edcb181)

