### PR TITLE
[FIX] web: trackback when formatFloat value is undefined

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { getBorderWhite, DEFAULT_BG, getColor, hexToRGBA } from "@web/core/colors/colors";
-import { formatFloat } from "@web/core/utils/numbers";
+import { formatFloat } from "@web/views/fields/formatters";
 import { SEP } from "./graph_model";
 import { sortBy } from "@web/core/utils/arrays";
 import { loadJS } from "@web/core/assets";


### PR DESCRIPTION
steps to produce:
- when measure field value set null if value is zero
- try to open cohort view measure
- trackback occurs 'value.toFixed is not a function'

Fix:
This PR, fixes the trackback when the measure value is null or undefined. It occurs when the measure field value is null in a particular condition.

task: 3502869

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
