### PR TITLE
[FIX] web: relatedFields with column_invisible

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -264,10 +264,18 @@ export function extractFieldsFromArchInfo({ fieldNodes, widgetNodes }, fields) {
                             fieldNode.views.default,
                             fieldNode.views.default.fields
                         );
-                        activeField.related.activeFields = {
-                            ...defaultArchInfo.activeFields,
-                            ...activeField.related.activeFields,
-                        };
+                        for (const fieldName in defaultArchInfo.activeFields) {
+                            if (fieldName in activeField.related.activeFields) {
+                                patchActiveFields(
+                                    activeField.related.activeFields[fieldName],
+                                    defaultArchInfo.activeFields[fieldName]
+                                );
+                            } else {
+                                activeField.related.activeFields[fieldName] = {
+                                    ...defaultArchInfo.activeFields[fieldName],
+                                };
+                            }
+                        }
                         activeField.related.fields = Object.assign(
                             {},
                             defaultArchInfo.fields,

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -14096,6 +14096,60 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test(
+        "custom x2many with a m2o in relatedFields and column_invisible",
+        async function (assert) {
+            class MyField extends X2ManyField {}
+            fieldRegistry.add("my_widget", {
+                ...x2ManyField,
+                component: MyField,
+                relatedFields: [{ name: "trululu", type: "many2one", relation: "partner" }],
+            });
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                <form>
+                    <field name="p" widget='my_widget'>
+                        <tree editable="bottom" >
+                            <field name="foo"/>
+                            <field name="trululu" column_invisible="True"/>
+                        </tree>
+                    </field>
+                </form>`,
+                resId: 2,
+                mockRPC(route, args) {
+                    if (args.method === "web_read") {
+                        assert.step("web_read");
+                        assert.deepEqual(args.kwargs.specification.p.fields, {
+                            trululu: { fields: { display_name: {} } },
+                            foo: {},
+                        });
+                    } else if (args.method === "write") {
+                        assert.step("write");
+                        assert.deepEqual(args.args[1].p[0][2], {
+                            foo: "new record",
+                            int_field: 0,
+                        });
+                    } else if (args.method === "web_save") {
+                        assert.step("web_save");
+                        assert.deepEqual(args.kwargs.specification.p.fields, {
+                            trululu: { fields: { display_name: {} } },
+                            foo: {},
+                        });
+                    }
+                },
+            });
+
+            await addRow(target);
+            await editInput(target, ".o_data_row [name='foo'] input", "new record");
+            await clickSave(target);
+            assert.verifySteps(["web_read", "web_save"]);
+        }
+    );
+
+    QUnit.test(
         "custom x2many with relatedFields and list view not inline",
         async function (assert) {
             class MyField extends X2ManyField {}


### PR DESCRIPTION
Before to this commit, the activeFields of the fields in the x2many arch were not merged with those of the relatedFields.

Problem:
When I have a custom x2many field that contains a many2one "x" field in its relatedFields and this field is also present in the arch with column_invisible="True". The field is considered invisible because its presence in relatedFields is ignored.

Solution:
Merge the field description in the arch with that in relatedFields.

Before:
Only the "id" of the many2one field is present in "web_read".

After:
The "id" and "display_name" of the many2one are present in "web_read".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
