### PR TITLE
[IMP] spreadsheet: Allow Odoo Chart domain edition

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -111,11 +111,13 @@ export default class OdooChartCorePlugin extends CorePlugin {
      * @returns {string}
      */
     getOdooChartDisplayName(chartId) {
-        return this.getters.getChart(chartId).title;
+        return `(#${this.getOdooChartIds().indexOf(chartId) + 1}) ${
+            this.getters.getChart(chartId).title
+        }`;
     }
 
     /**
-     * Import the pivots
+     * Import the charts
      *
      * @param {Object} data
      */
@@ -131,7 +133,7 @@ export default class OdooChartCorePlugin extends CorePlugin {
         }
     }
     /**
-     * Export the pivots
+     * Export the chart
      *
      * @param {Object} data
      */
@@ -154,7 +156,7 @@ export default class OdooChartCorePlugin extends CorePlugin {
     // -------------------------------------------------------------------------
 
     /**
-     * Get the current pivotFieldMatching of a chart
+     * Get the current odooChartFieldMatching of a chart
      *
      * @param {string} chartId
      * @param {string} filterId
@@ -164,7 +166,7 @@ export default class OdooChartCorePlugin extends CorePlugin {
     }
 
     /**
-     * Sets the current pivotFieldMatching of a chart
+     * Sets the current odooChartFieldMatching of a chart
      *
      * @param {string} filterId
      * @param {Record<string,FieldMatching>} chartFieldMatches

--- a/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
+++ b/addons/spreadsheet/static/src/data_sources/odoo_views_data_source.js
@@ -98,6 +98,14 @@ export class OdooViewsDataSource extends LoadableDataSource {
     }
 
     /**
+     * Get the current domain as a string
+     * @returns { string }
+     */
+    getInitialDomainString() {
+        return new Domain(this._initialSearchParams.domain).toString();
+    }
+
+    /**
      *
      * @param {string} domain
      */

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -410,11 +410,10 @@ export default class PivotUIPlugin extends spreadsheet.UIPlugin {
 
     /**
      * @param {string} pisvotId
-     * @param {PivotDefinition=} definition
      */
-    _setupPivotDataSource(pivotId, definition) {
+    _setupPivotDataSource(pivotId) {
         const dataSourceId = this.getPivotDataSourceId(pivotId);
-        definition = definition || this.getters.getPivotModelDefinition(pivotId);
+        const definition = this.getters.getPivotModelDefinition(pivotId);
         if (!this.dataSources.contains(dataSourceId)) {
             this.dataSources.add(dataSourceId, PivotDataSource, definition);
         }


### PR DESCRIPTION
## Task Description:

This PR aims to add the possibility to edit the evaluation domain of
an Odoo chart, the same way it can currently be done for other
datasources like `List` or `Pivot`. This revision ensures that the chart
datasources are properly reloaded their domain update.

Task: 3384872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
