### PR TITLE
[IMP] project_todo: improve todo title color and eliminate hover flicker

### DIFF
--- a/addons/project_todo/static/src/components/todo_editable_breadcrumb_name/todo_editable_breadcrumb_name.scss
+++ b/addons/project_todo/static/src/components/todo_editable_breadcrumb_name/todo_editable_breadcrumb_name.scss
@@ -4,7 +4,13 @@
     overflow: hidden;
     border: none;
     padding: 0px 5px 0px 2px;
-    color: $o-brand-secondary;
+    color: $o-gray-700;
+    border-bottom: $input-border-width solid transparent;
+    transition: border-color 0.3s;
+
+    &:hover {
+        border-bottom-color: $o-brand-primary;
+    }
 
     &:focus {
         outline: 1px solid #ccc;
@@ -25,6 +31,3 @@
     }
 }
 
-.o_todo_breadcrumb_name_input:hover {
-    border-bottom: $input-border-width solid $o-brand-primary;
-}


### PR DESCRIPTION
Before this PR, in the form view of todo the title was light grey and there was a small flicker when hovering the title.

In this PR, the color of the title is changed to dark grey and flicker is eliminated.

Task-347920

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
