### PR TITLE
[FIX] im_livechat: fix history command

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -85,7 +85,7 @@ class DiscussChannel(models.Model):
         return msg
 
     def execute_command_history(self, **kwargs):
-        self.env['bus.bus']._sendone(self.uuid, 'im_livechat.history_command', {'id': self.id})
+        self.env['bus.bus']._sendone(self, 'im_livechat.history_command', {'id': self.id})
 
     def _send_history_message(self, pid, page_history):
         message_body = _('No history found')


### PR DESCRIPTION
Before this commit, executing the `/history` command in a livechat would do nothing. Indeed, the message was sent on the wrong target through the bus so the history request was never received by the visitor client. This commit fixes the issue by sending the notification on the channel instead of the channel uuid.
