### PR TITLE
[FIX] multi_edit: fix silence exception when save multi records

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -1664,8 +1664,9 @@ class DynamicList extends DataPoint {
                         await Promise.all(validSelection.map((record) => record.load()));
                         record.switchMode("readonly");
                         this.model.notify();
-                    } catch (_) {
+                    } catch (e) {
                         record.discard();
+                        throw e;
                     }
                     validSelection.forEach((record) => {
                         record.selected = false;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- When using multi edit feature on list view to update multiple records and there is exception, the system doesn't display the error message but just uncheck selected records. 
- This is confusing as it looks like records have been updated successfully but actually not. The user doesn't know what is the error to fix.

Current behavior before PR:
- When using multi edit feature on list view to update multiple records and there is exception, the system doesn't display the error message. 

Desired behavior after PR is merged:
- When using multi edit feature on list view to update multiple records and there is exception, the system displays the error message. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
