### PR TITLE
[FIX] pos_paytm: resolved issue of not receiving expected Paytm Error

### DIFF
--- a/addons/pos_paytm/static/src/js/payment_paytm.js
+++ b/addons/pos_paytm/static/src/js/payment_paytm.js
@@ -1,5 +1,6 @@
 /** @odoo-module */
 
+import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/payment/payment_interface";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 
@@ -84,7 +85,7 @@ export class PaymentPaytm extends PaymentInterface {
                 }
                 let resultCode = data?.resultCode;
                 if (resultCode === 'S' && data?.merchantReferenceNo != referenceId){
-                    throw this.env._t("Reference number mismatched");
+                    throw _t("Reference number mismatched");
                 } else if (resultCode === 'S') {
                     paymentLine.paytm_authcode = data?.authCode;
                     paymentLine.paytm_issuer_card_no = data?.issuerMaskCardNo;
@@ -151,9 +152,8 @@ export class PaymentPaytm extends PaymentInterface {
         localStorage.setItem(uid, ++retry);
     }
     _showError(error_msg, title) {
-        var self = this;
-        self.env.services.popup.add(ErrorPopup, {
-            title: title || self.env._t('PayTM Error'),
+        this.env.services.popup.add(ErrorPopup, {
+            title: title || _t('PayTM Error'),
             body: error_msg,
         });
     }


### PR DESCRIPTION
Before this commit:
    While using Paytm Terminal the expected behaviour is to get the expected error
    message from Paytm but unexpectedly the cashier is getting
    TypeError: this.env._t is not a function
    
After this commit:
    The issue has been fixed, and the cashier will now receive the correct error
    message from Paytm


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
