### PR TITLE
[FIX] survey:  remove 'New' button for creating suggested value

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -314,13 +314,13 @@
         <field name="name">survey.question.answer.view.form</field>
         <field name="model">survey.question.answer</field>
         <field name="arch" type="xml">
-            <form string="Question Answer Form">
+            <form string="Question Answer Form" create="false">
                 <sheet>
                     <field name="question_type" invisible="1"/>
                     <group>
                         <group>
                             <field name="scoring_type" invisible="1"/>
-                            <field name="question_id"/>
+                            <field name="question_id" required="1"/>
                             <field name="is_correct" invisible="scoring_type == 'no_scoring'"/>
                             <field name="answer_score" invisible="scoring_type == 'no_scoring' or question_type == 'matrix'"/>
                             <field name="value_image"/>


### PR DESCRIPTION
**Before this PR**:
Users could create new suggested values using the 'New' button. However, this didn't align with the typical user flow of creating and assigning suggested values to questions.

**After this PR**:
The 'New' button has been removed, eliminating the option to create a new suggested values.

**Task**-3495142