### PR TITLE
[FIX] various: update query counters to runbot state

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -24,7 +24,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=627):  # crm 537 / com 541 / ent 536
+        with self.assertQueryCount(user_sales_manager=605):  # crm 605 / com 605 / ent 605
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -42,7 +42,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=581):  # crm 521 / com 516 / ent 516
+        with self.assertQueryCount(user_sales_manager=581):  # crm 579 / com 581 / ent 581
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)
@@ -167,7 +167,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         user_ids = self.assign_users.ids
 
         # randomness: at least 1 query
-        with self.assertQueryCount(user_sales_manager=1798):  # crm 1410 / com 1677 / ent 1685
+        with self.assertQueryCount(user_sales_manager=1798):  # crm 1503 / com 1790 / ent 1798
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -50,7 +50,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
             self.env['res.users'].has_group('base.group_user')  # warmup the cache to avoid inconsistency between community an enterprise
-            with self.assertQueryCount(user_sales_manager=1266):  # crm 1187
+            with self.assertQueryCount(user_sales_manager=1166):  # crm 1160 / com 1165
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -95,7 +95,7 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
 
         # randomness: at least 1 query
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=585):  # crm 584
+            with self.assertQueryCount(user_sales_manager=583):  # crm 582
                 self.env['crm.team'].browse(self.sales_teams.ids)._action_assign_leads(work_days=2)
 
         # teams assign
@@ -176,9 +176,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
-        # randomness
+        # randomness: add 2 queries
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=6280):  # crm 6226 / com 6212 / ent 6214
+            with self.assertQueryCount(user_sales_manager=6066):  # crm 6048 / com 6052 / ent 6054
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads(work_days=30)
 
         # teams assign

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -74,7 +74,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         })
         partner_model = self.env.ref('base.model_res_partner')
         partner = self.env['res.partner'].search([], limit=1)
-        with self.assertQueryCount(__system__=616):
+        with self.assertQueryCount(__system__=615):
             events = self.env['calendar.event'].create([{
                 'name': "Event %s" % (i),
                 'start': datetime(2020, 1, 15, 8, 0),
@@ -89,7 +89,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
 
             events._sync_odoo2google(self.google_service)
 
-        with self.assertQueryCount(__system__=127):
+        with self.assertQueryCount(__system__=27):
             events.unlink()
 
 

--- a/addons/hr_timesheet/tests/test_performance.py
+++ b/addons/hr_timesheet/tests/test_performance.py
@@ -13,7 +13,7 @@ class TestPerformanceTimesheet(TestCommonTimesheet):
         } for i in range(17) for project in projects])
         self.env.invalidate_all()
         self.env.registry.clear_cache()
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(5):
             self.env['account.analytic.line']._timesheet_preprocess([
                 {'task_id': task.id} for task in tasks for _i in range(10)
             ])

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=100, admin=103):
+        with self.assertQueryCount(__system__=100, admin=103):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 
@@ -111,7 +111,7 @@ class TestWorkEntryHolidaysPerformancesBigData(TestWorkEntryHolidaysBase):
     def test_work_entries_generation_perf(self):
         # Test Case 7: Try to generate work entries for
         # a hundred employees over a month
-        with self.assertQueryCount(__system__=2607, admin=2807):
+        with self.assertQueryCount(__system__=407, admin=2807):  # com: 402 / 2807
             work_entries = self.contracts.generate_work_entries(date(2020, 7, 1), date(2020, 8, 31))
 
         # Original work entries to generate when we don't adapt date_generated_from and

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1093,7 +1093,10 @@ class MailCommon(common.TransactionCase, MailCase):
         cls.user_admin = cls.env.ref('base.user_admin')
         cls.partner_admin = cls.env.ref('base.partner_admin')
         cls.company_admin = cls.user_admin.company_id
-        cls.company_admin.write({'email': 'company@example.com'})
+        cls.company_admin.write({
+            'email': 'your.company@example.com',  # ensure email for various fallbacks
+            'name': 'YourTestCompany',  # force for reply_to computation
+        })
         with patch.object(Users, '_notify_security_setting_update', side_effect=lambda *args, **kwargs: None):
             cls.user_admin.write({
                 'country_id': cls.env.ref('base.be').id,

--- a/addons/mail/tests/mail_tracking_duration_testing.py
+++ b/addons/mail/tests/mail_tracking_duration_testing.py
@@ -192,5 +192,5 @@ class TestMailTrackingDurationMixin(MailCommon):
         self.flush_tracking()
         batch[self.track_duration_field] = self.stage_2.id
 
-        with self.assertQueryCount(3):
+        with self.assertQueryCount(2):
             batch._compute_duration_tracking()

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -104,9 +104,9 @@ class TestPartner(MailCommon):
             change_messages = partner.message_ids - original_messages
             self.assertEqual(len(change_messages), 1)
             tracking_values = change_messages.tracking_value_ids
-            self.assertIn('YourCompany, Some Street Name, Some City Name CA 94134, United States',
+            self.assertIn(f'{self.env.company.name}, Some Street Name, Some City Name CA 94134, United States',
                           tracking_values._get_old_display_value())
-            self.assertIn('YourCompany, Some Other Street Name, Some Other City Name CA 94134, United States',
+            self.assertIn(f'{self.env.company.name}, Some Other Street Name, Some Other City Name CA 94134, United States',
                           tracking_values._get_new_display_value())
             # none of the address fields are logged at the same time
             self.assertEqual(set(), set(partner._address_fields()) & set(tracking_values.sudo().field.mapped('name')))

--- a/addons/sale_stock/tests/test_create_perf.py
+++ b/addons/sale_stock/tests/test_create_perf.py
@@ -96,7 +96,7 @@ class TestPERF(common.TransactionCase):
         # + 2 SQL insert
         # + 2 queries to get analytic default tags
         # + 9 follower queries ?
-        with self.assertQueryCount(admin=49):
+        with self.assertQueryCount(admin=49):  # com 46
             self.env['sale.order'].create([{
                 'partner_id': self.partners[0].id,
                 'user_id': self.salesmans[0].id,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1044,4 +1044,4 @@ class TestDiscussFullPerformance(HttpCase):
             Returns the expected query count.
             The point of having a separate getter is to allow it to be overriden.
         """
-        return 71
+        return 59

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -330,7 +330,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=17, employee=17):  # com+tm 15/15
+        with self.assertQueryCount(admin=17, employee=17):  # com+tm 16/16
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications
@@ -387,7 +387,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=9, employee=9):
+        with self.assertQueryCount(admin=7, employee=7):
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -401,7 +401,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=54, employee=54):  # tm+com 46/46
+        with self.assertQueryCount(admin=54, employee=54):  # tm+com 53/53
             composer._action_send_mail()
 
         # notifications
@@ -423,7 +423,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=138, employee=131), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=128, employee=131), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)
@@ -455,7 +455,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
         test_template.write({'attachment_ids': [(5, 0)]})
 
-        with self.assertQueryCount(admin=26, employee=26):  # tm 15/15 / com 23/23
+        with self.assertQueryCount(admin=26, employee=26):  # tm 15/15 / com 25/25
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -479,7 +479,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def test_mail_composer_w_template_attachments(self):
         test_record, test_template = self._create_test_records()
 
-        with self.assertQueryCount(admin=27, employee=27):  # tm 15/15 / com 23/23
+        with self.assertQueryCount(admin=27, employee=27):  # tm 16/16 / com 26/26
             composer = self.env['mail.compose.message'].with_context({
                 'default_composition_mode': 'comment',
                 'default_model': test_record._name,
@@ -508,7 +508,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=37, employee=37):  # tm 28/28 / com 36/36
+        with self.assertQueryCount(admin=33, employee=33):  # tm 22/22 / com 32/32
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -538,7 +538,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=36, employee=36):  # tm 27/27 / com 35/35
+        with self.assertQueryCount(admin=33, employee=33):  # tm 22/22 / com 32/32
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -585,7 +585,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=23, employee=23):  # com 19/9
+        with self.assertQueryCount(admin=23, employee=23):
             record.write({
                 'user_id': self.user_test_inbox.id,
             })
@@ -739,7 +739,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             self.assertEqual(
                 reply_to[record.id],
                 formataddr((
-                    record.name,
+                    f"{record.env.company.name} {record.name}",
                     f"{record.alias_name}@{self.alias_domain}"
                 ))
             )

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -91,7 +91,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         record_ticket = self.env['mail.test.ticket.mc'].browse(self.record_ticket.ids)
         attachments = self.env['ir.attachment'].create(self.test_attachments_vals)
 
-        with self.assertQueryCount(employee=96):  # test_mail_full: 88
+        with self.assertQueryCount(employee=96):  # test_mail_full: 95
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -47,7 +47,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1524, marketing=1525):
+        with self.assertQueryCount(__system__=1523, marketing=1524):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -90,7 +90,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1597, marketing=1598):
+        with self.assertQueryCount(__system__=1595, marketing=1596):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/addons/website_slides/tests/test_gamification_karma.py
+++ b/addons/website_slides/tests/test_gamification_karma.py
@@ -128,7 +128,7 @@ class TestKarmaGain(common.SlidesCase):
         self.assertEqual(len(channel_partners), 4)
 
         # Set courses as completed and update karma
-        with self.assertQueryCount(53):
+        with self.assertQueryCount(50):  # com 49
             channel_partners._post_completion_update_hook()
 
         computed_karma = self.channel.karma_gen_channel_finish + self.channel_2.karma_gen_channel_finish
@@ -147,7 +147,7 @@ class TestKarmaGain(common.SlidesCase):
             self.assertEqual(user_trackings[1].origin_ref, self.channel)
 
         # now, remove the membership in batch, on multiple users - karma should not move as we only archive membership
-        with self.assertQueryCount(43):
+        with self.assertQueryCount(10):
             (self.channel | self.channel_2)._remove_membership(users.partner_id.ids)
 
         for user in users:

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -456,11 +456,7 @@ class TestUsersGroupWarning(TransactionCase):
         warning should be there since 'Sales: Administrator' is required when
         user is having 'Field Service: Administrator'. When user reverts the
         changes, warning should disappear. """
-        # 97 requests if only base is installed
-        # 412 runbot community
-        # 549 runbot enterprise
-        with self.assertQueryCount(__system__=436), \
-             Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
+        with Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
             UserForm[self.sales_categ_field] = False
             self.assertEqual(
                 UserForm.user_group_warning,
@@ -475,11 +471,7 @@ class TestUsersGroupWarning(TransactionCase):
         should be there since 'Sales: Administrator' is required when user is
         having 'Field Service: Administrator'. When user reverts the changes,
         warning should disappear. """
-        # 97 requests if only base is installed
-        # 412 runbot community
-        # 549 runbot enterprise
-        with self.assertQueryCount(__system__=437), \
-             Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
+        with Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
             UserForm[self.sales_categ_field] = self.group_sales_user.id
             self.assertEqual(
                 UserForm.user_group_warning,
@@ -496,11 +488,7 @@ class TestUsersGroupWarning(TransactionCase):
         are required when user is havning 'Field Service: Administrator'.
         When user reverts the changes For 'Sales: Administrator', warning
         should disappear for Sales Access."""
-        # 101 requests if only base is installed
-        # 416 runbot community
-        # 553 runbot enterprise
-        with self.assertQueryCount(__system__=438), \
-             Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
+        with Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
             UserForm[self.sales_categ_field] = self.group_sales_user.id
             UserForm[self.project_categ_field] = self.group_project_user.id
             self.assertTrue(
@@ -520,11 +508,7 @@ class TestUsersGroupWarning(TransactionCase):
         'Timesheets: User: all timesheets' is at least required when user is
         having 'Project: Administrator'. When user reverts the changes For
         'Timesheets: User: all timesheets', warning should disappear."""
-        # 98 requests if only base is installed
-        # 413 runbot community
-        # 550 runbot enterprise
-        with self.assertQueryCount(__system__=437), \
-             Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
+        with Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
             UserForm[self.timesheets_categ_field] = self.group_timesheets_user_own_timesheet.id
             self.assertEqual(
                 UserForm.user_group_warning,
@@ -538,11 +522,7 @@ class TestUsersGroupWarning(TransactionCase):
         """ User changes 'Field Service: User' from 'Field Service: Administrator'.
         The warning should not be there since 'Field Service: User' is not affected
         by any other groups."""
-        # 83 requests if only base is installed
-        # 397 runbot community
-        # 534 runbot enterprise
-        with self.assertQueryCount(__system__=420), \
-             Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
+        with Form(self.test_group_user.with_context(show_user_group_warning=True), view='base.view_users_form') as UserForm:
             UserForm[self.field_service_categ_field] = self.group_field_service_user.id
             self.assertFalse(UserForm.user_group_warning)
 

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -318,7 +318,7 @@ class TestViewInheritance(ViewCase):
         _, _, counter = get_cache_key_counter(self.env['ir.model.data']._xmlid_lookup, 'base.action_ui_view')
         hit, miss = counter.hit, counter.miss
 
-        with self.assertQueryCount(8):
+        with self.assertQueryCount(7):
             base_view = self.assertValid("""
                 <form string="View">
                     <header>
@@ -332,7 +332,7 @@ class TestViewInheritance(ViewCase):
         self.assertEqual(counter.hit, hit)
         self.assertEqual(counter.miss, miss + 2)
 
-        with self.assertQueryCount(7):
+        with self.assertQueryCount(6):
             self.assertValid("""
                 <field name="name" position="replace"/>
             """, inherit_id=base_view.id)
@@ -343,7 +343,7 @@ class TestViewInheritance(ViewCase):
         _, _, counter = get_cache_key_counter(self.env['ir.model.data']._xmlid_lookup, 'base.group_system')
         hit, miss = counter.hit, counter.miss
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(4):
             base_view = self.assertValid("""
                 <form string="View">
                     <field name="name" groups="base.group_system"/>
@@ -354,7 +354,7 @@ class TestViewInheritance(ViewCase):
         self.assertEqual(counter.hit, hit)
         self.assertEqual(counter.miss, miss + 1)
 
-        with self.assertQueryCount(5):
+        with self.assertQueryCount(4):
             self.assertValid("""
                 <field name="name" position="replace">
                     <field name="key" groups="base.group_system"/>

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -1402,7 +1402,7 @@ class PropertiesCase(TestPropertiesMixin):
         """If we change the definition record, the onchange of the properties field must be triggered."""
         message_form = Form(self.env['test_new_api.message'])
 
-        with self.assertQueryCount(10):
+        with self.assertQueryCount(8):
             message_form.discussion = self.discussion_1
             message_form.author = self.user
 


### PR DESCRIPTION
Update (some) query counters according to runbot state.

Prepares Task-36879 (Mail: Support MultiCompany Aliases)