### PR TITLE
[FIX] core: remove unnecessary `ast.unparse`

### DIFF
--- a/odoo/tests/form.py
+++ b/odoo/tests/form.py
@@ -973,8 +973,8 @@ def get_static_context(context_str):
     result = {}
     for key_ast, val_ast in zip(context_ast.keys, context_ast.values):
         try:
-            key = ast.literal_eval(ast.unparse(key_ast))
-            val = ast.literal_eval(ast.unparse(val_ast))
+            key = ast.literal_eval(key_ast)
+            val = ast.literal_eval(val_ast)
             result[key] = val
         except ValueError:
             pass


### PR DESCRIPTION
Only available in Python 3.9, and for now at least Odoo remains committed to supporting Python 3.8.

And it's not actually necessary: `literal_eval` supports ast node input, because internally it just `ast.parse`s the input then evaluates it, giving it an AST node just skips the parse step.
