### PR TITLE
[FIX] web_editor: traceback when clicking button in table

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4908,7 +4908,7 @@ export class OdooEditor extends EventTarget {
         }
     }
     _onTableMenuTogglerClick(ev) {
-        const uiWrapper = closestElement(ev.target, '.o_table_ui');
+        const uiWrapper = ev.target.closest('.o_table_ui');
         uiWrapper.classList.toggle('o_open');
         if (uiWrapper.classList.contains('o_column_ui')) {
             const columnIndex = getColumnIndex(this._columnUiTarget);


### PR DESCRIPTION
**Current behaviour before commit:**

In table, when clicking table menu icon it throws
traceback.

**Desired behaviour after commit:**

Now, clicking table menu icon opens table menu
without any traceback.

task-3503806




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
