### PR TITLE
[FIX] core: fix like domain with trailing escape

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -730,6 +730,25 @@ class TestExpression(SavepointCaseWithUserDemo):
         countries = self._search(Country, [('name', '=ilike', 'z%')])
         self.assertTrue(len(countries) == 2, "Must match only countries with names starting with Z (currently 2)")
 
+    def test_like_escape(self):
+        # check that =like/=ilike expressions are working on an untranslated field
+        Partner = self.env['res.partner']
+        Partner.create([
+            {'name': 'test_like_escape'},
+            {'name': 'test_like_escape\\'},
+            {'name': 'test_like_escape%'},
+            {'name': 'test_like_escape2'},
+            {'name': 'test_like_escape%2'}
+        ])
+        # the trailing escape character '\' should be ignored
+        partner = Partner.search([('name', '=ilike', 'Test_Like_Escape\\')])
+        self.assertEqual(partner.name, 'test_like_escape', "Must match only 'test_like_escape'")
+        partner = Partner.search([('name', '=ilike', 'Test_Like_Escape\\\\')])
+        self.assertEqual(partner.name, 'test_like_escape\\', "Must match only 'test_like_escape\\'")
+        # the trailing escape character '\' should be ignored
+        partners = Partner.search([('name', 'ilike', 'Test_Like_Escape\\')])
+        self.assertEqual(len(partners), 5, "Must match all test_like_escape partners'")
+
     def test_translate_search(self):
         Country = self.env['res.country']
         belgium = self.env.ref('base.be')

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -943,6 +943,9 @@ class expression(object):
 
                 elif field.translate is True and right:
                     need_wildcard = operator in ('like', 'ilike', 'not like', 'not ilike')
+                    if operator.endswith('like') and isinstance(right, str) and (len(right) - len(right.rstrip('\\'))) % 2:
+                        # PostgreSQL LIKE pattern must not end with escape character
+                        right = right[:-1]
                     sql_operator = {'=like': 'like', '=ilike': 'ilike'}.get(operator, operator)
                     if need_wildcard:
                         right = '%%%s%%' % right
@@ -1063,6 +1066,9 @@ class expression(object):
 
         else:
             need_wildcard = operator in ('like', 'ilike', 'not like', 'not ilike')
+            if operator.endswith('like') and isinstance(right, str) and (len(right) - len(right.rstrip('\\'))) % 2:
+                # PostgreSQL LIKE pattern must not end with escape character
+                right = right[:-1]
             sql_operator = {'=like': 'like', '=ilike': 'ilike'}.get(operator, operator)
             cast = '::text' if  sql_operator.endswith('like') else ''
 


### PR DESCRIPTION
before this commit:
for python domain
    `[('name', 'ilike', 'a\\')]`
the sql would be
    `"name" ILIKE '%a\%'`
where the wildcard character `%` is escaped by the `\`

for python domain
    `[('name', '=ilike', 'a\\')]`
the sql would be
    `"name" ILIKE 'a\'`
which will trigger error
ERROR: LIKE pattern must not end with escape character

Reproduce the problem
Go to Settings > Companies > New a Company
In address fill 'state' field with value 'k\'
ERROR: LIKE pattern must not end with escape character

after this commit:
Since the search bar may auto search before user confirms, some incomplete domain may be sent to the server. Instead of raising error, we choose to drop the trailing escape character for 'like' relevant operators

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
