### PR TITLE
[IMP] enable to drop inner content snippets on grid dropzones 

### DIFF
--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -79,16 +79,20 @@ class IrQWeb(models.AbstractModel):
         view = self.env['ir.ui.view']._get(key).sudo()
         name = el.attrib.pop('string', view.name)
         thumbnail = el.attrib.pop('t-thumbnail', "oe-thumbnail")
+        height_grid = el.attrib.pop('t-height-grid', '')
+        width_grid = el.attrib.pop('t-width-grid', '')
         # Forbid sanitize contains the specific reason:
         # - "true": always forbid
         # - "form": forbid if forms are sanitized
         forbid_sanitize = el.attrib.pop('t-forbid-sanitize', None)
-        div = '<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s" %s>' % (
+        div = '<div name="%s" data-oe-type="snippet" data-oe-thumbnail="%s" data-oe-snippet-id="%s" data-oe-keywords="%s" %s %s %s>' % (
             escape(pycompat.to_text(name)),
             escape(pycompat.to_text(thumbnail)),
             escape(pycompat.to_text(view.id)),
             escape(pycompat.to_text(el.findtext('keywords'))),
             f'data-oe-forbid-sanitize="{forbid_sanitize}"' if forbid_sanitize else '',
+            f'data-oe-height-grid="{height_grid}"' if height_grid else '',
+            f'data-oe-width-grid="{width_grid}"' if width_grid else '',
         )
         self._append_text(div, compile_context)
         code = self._compile_node(el, compile_context, indent)

--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -280,7 +280,8 @@ export function _convertColumnToGrid(rowEl, columnEl, columnWidth, columnHeight)
 
     // Computing the column and row spans.
     const gridProp = _getGridProperties(rowEl);
-    const columnColCount = Math.round((columnWidth + gridProp.columnGap) / (gridProp.columnSize + gridProp.columnGap));
+    // As the number of column can not exceed 12.
+    const columnColCount = Math.min(12, Math.round((columnWidth + gridProp.columnGap) / (gridProp.columnSize + gridProp.columnGap)));
     const columnRowCount = Math.ceil((columnHeight + gridProp.rowGap) / (gridProp.rowSize + gridProp.rowGap));
 
     // Removing the padding and offset classes.

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -36,10 +36,387 @@ var globalSelector = {
     is: () => false,
 };
 
+const dragAndDropCommonMenuEditor = Widget.extend({
+   /**
+     * Checks if an "over" dropzone event happens after an other "over" without
+     * an "out" between them. If it is the case, escapes the previous dropzone.
+     *
+     * @private
+     * @param {Element} currentDropzoneEl - The dropzone over which the target
+     * currently is.
+     */
+   _checkAndEscapePreviousDropzone(currentDropzoneEl) {
+        // Checking if the "out" event happened before this "over": if
+        // `self.dragState.currentDropzoneEl` exists, "out" didn't happen
+        // because it deletes it. We are therefore in the case of an "over"
+        // after an "over" and we need to escape the previous dropzone first.
+        if (this.dragState.currentDropzoneEl) {
+            const previousDropzoneEl = this.dragState.currentDropzoneEl;
+            const rowEl = previousDropzoneEl.parentNode;
+
+            if (rowEl.classList.contains("o_grid_mode")) {
+                this.handleDragMove = false;
+                const fromGridToGrid = currentDropzoneEl.classList.contains("oe_grid_zone");
+                if (fromGridToGrid) {
+                    // If we went from a grid dropzone to another grid one.
+                    rowEl.style.removeProperty("position");
+                } else {
+                    // If we went from a grid dropzone to a normal one.
+                    gridUtils._gridCleanUp(rowEl, this.draggedItemEl);
+                    this.draggedItemEl.style.removeProperty("z-index");
+                }
+
+                // Removing the drag helper and the background grid and
+                // resizing the grid and the dropzone.
+                this.dragState.dragHelperEl.remove();
+                this.dragState.backgroundGridEl.remove();
+                this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+                gridUtils._resizeGrid(rowEl);
+                this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+                const rowCount = parseInt(rowEl.dataset.rowCount);
+                previousDropzoneEl.style.gridRowEnd = Math.max(rowCount + 1, 1);
+            }
+            previousDropzoneEl.classList.remove("invisible");
+        }
+   },
+    /**
+     * Removes the grid properties from the grid item. Needed for example if the
+     * target has been dragged over a grid zone but is finally dropped in a
+     * non-grid zone.
+     *
+     * @private
+     */
+    _cleanItemFromGridCharacteristics() {
+        this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+        const gridSizeClasses = this.draggedItemEl.className.match(/(g-col-lg|g-height)-[0-9]+/g);
+        this.draggedItemEl.classList.remove("o_grid_item", "o_grid_item_image", "o_grid_item_image_contain", ...gridSizeClasses);
+        this.draggedItemEl.style.removeProperty("z-index");
+        this.draggedItemEl.style.removeProperty("grid-area");
+        this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+    },
+    /**
+     * Cleans the state of the drag and drop process.
+     *
+     * @private
+     */
+    _clearDragAndDropState() {
+        delete this.dragState;
+        delete this.draggedItemEl;
+    },
+    /**
+     * Removes the grid and updates the item style and property according to the
+     * dropzone on which it was dropped.
+     *
+     * @private
+     */
+    _dragAndDropStopGrid() {
+        const rowEl = this.draggedItemEl.parentNode;
+        if (rowEl && rowEl.classList.contains("o_grid_mode")) {
+            // Case when dropping the column in a grid.
+
+            // Defining the column grid area with its position.
+            const gridProp = gridUtils._getGridProperties(rowEl);
+
+            const top = parseFloat(this.draggedItemEl.style.top);
+            const left = parseFloat(this.draggedItemEl.style.left);
+
+            const rowStart = Math.round(top / (gridProp.rowSize + gridProp.rowGap)) + 1;
+            const columnStart = Math.round(left / (gridProp.columnSize + gridProp.columnGap)) + 1;
+            const rowEnd = rowStart + this.dragState.columnRowCount;
+            const columnEnd = columnStart + this.dragState.columnColCount;
+
+            this.draggedItemEl.style.gridArea = `${rowStart} / ${columnStart} / ${rowEnd} / ${columnEnd}`;
+
+            this._removeGridAndDragHelper(rowEl);
+        } else if (this.draggedItemEl.classList.contains("o_grid_item") && this.dropped) {
+            // Case when dropping a grid item in a non-grid dropzone.
+            this._cleanItemFromGridCharacteristics();
+        }
+    },
+    /**
+     * Places the item on the grid if dropzoneEl is a grid dropzone or cleans
+     * the item if it has grid characteristics but is finally dropped in a
+     * non-grid dropzone. Needed when the item is dropped near a dropzone.
+     *
+     * @private
+     * @param {Element} dropzoneEl - The dropzone on which the item will finally
+     * be dropped.
+     */
+    _droppedNear(dropzoneEl) {
+        if (dropzoneEl.classList.contains("oe_grid_zone")) {
+            // Case when a column is dropped near a grid.
+            const rowEl = dropzoneEl.parentNode;
+
+            // If the column does not come from a snippet in grid mode, convert
+            // it.
+            if (!this.draggedItemEl.classList.contains("o_grid_item")) {
+                this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+                const spans = gridUtils._convertColumnToGrid(rowEl, this.draggedItemEl, this.dragState.columnWidth, this.dragState.columnHeight);
+                this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+                this.dragState.columnColCount = spans.columnColCount;
+                this.dragState.columnRowCount = spans.columnRowCount;
+            }
+
+            // Placing it in the top left corner.
+            this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+            this.draggedItemEl.style.gridArea = `1 / 1 / ${1 + this.dragState.columnRowCount} / ${1 + this.dragState.columnColCount}`;
+            const rowCount = Math.max(rowEl.dataset.rowCount, this.dragState.columnRowCount);
+            rowEl.dataset.rowCount = rowCount;
+            this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+
+            // Setting the grid item z-index.
+            if (rowEl === this.dragState.startingGrid) {
+                this.draggedItemEl.style.zIndex = this.dragState.startingZIndex;
+            } else {
+                gridUtils._setElementToMaxZindex(this.draggedItemEl, rowEl);
+            }
+        } else if (this.draggedItemEl.classList.contains("o_grid_item")) {
+            // Case when a grid column is dropped near a non-grid dropzone.
+            this._cleanItemFromGridCharacteristics();
+        }
+        this.dropped = true;
+    },
+    /**
+     * Removes the siblings/children that would add a dropzone as direct child
+     * of a grid area and make a dedicated set out of the identified grid areas.
+     *
+     * @private
+     * @param {jQuery} $selectorSiblings - Elements that must have siblings drop
+     * zones.
+     * @param {jQuery} $selectorChildren - Elements that must have child drop
+     * zones between each of existing child.
+     * @return {Object} Elements that are in grid mode and for which a grid
+     * dropzone needs to be inserted.
+     */
+    _filterOutSelectorsGrids($selectorSiblings, $selectorChildren) {
+        const selectorGrids = new Set();
+        const filterOutSelectorGrids = ($selectorItems, getDropzoneParent) => {
+            if (!$selectorItems) {
+                return;
+            }
+            // Looping backwards because elements are removed, so the indexes
+            // are not lost.
+            for (let i = $selectorItems.length - 1; i >= 0; i--) {
+                const el = getDropzoneParent($selectorItems[i]);
+                if (el.classList.contains("o_grid_mode")) {
+                    $selectorItems.splice(i, 1);
+                    selectorGrids.add(el);
+                }
+            }
+        };
+        filterOutSelectorGrids($selectorSiblings, el => el.parentElement);
+        filterOutSelectorGrids($selectorChildren, el => el);
+        return selectorGrids;
+    },
+    /**
+     * Converts the dragged item to a grid item if needed and creates the
+     * background grid and the drag helper.
+     *
+     * @private
+     * @param {Element} dropzoneEl - The grid dropzone over which the target
+     * currently is.
+     */
+    _initDragOverGrid(dropzoneEl) {
+        const rowEl = dropzoneEl.parentNode;
+
+        // If the column doesn't come from a grid mode snippet.
+        if (!this.draggedItemEl.classList.contains("o_grid_item")) {
+            // Converting the column to grid.
+            this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+            const spans = gridUtils._convertColumnToGrid(rowEl, this.draggedItemEl, this.dragState.columnWidth, this.dragState.columnHeight);
+            this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+
+            // Storing the column spans.
+            this.dragState.columnColCount = spans.columnColCount;
+            this.dragState.columnRowCount = spans.columnRowCount;
+        }
+        const columnColCount = this.dragState.columnColCount;
+        const columnRowCount = this.dragState.columnRowCount;
+
+        // Creating the drag helper.
+        const dragHelperEl = document.createElement("div");
+        dragHelperEl.classList.add("o_we_drag_helper");
+        dragHelperEl.style.gridArea = `1 / 1 / ${1 + columnRowCount} / ${1 + columnColCount}`;
+        rowEl.append(dragHelperEl);
+
+        // Creating the background grid and updating the dropzone (in the case
+        // where the column over the dropzone is bigger than the grid).
+        const backgroundGridEl = gridUtils._addBackgroundGrid(rowEl, columnRowCount);
+        const rowCount = Math.max(rowEl.dataset.rowCount, columnRowCount);
+        dropzoneEl.style.gridRowEnd = rowCount + 1;
+
+        this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+        // Setting the moving grid item, the background grid and the drag helper
+        // z-indexes. The grid item z-index is set to its original one if we are
+        // in its starting grid, or to the maximum z-index of the grid
+        // otherwise.
+        if (rowEl === this.dragState.startingGrid) {
+            this.draggedItemEl.style.zIndex = this.dragState.startingZIndex;
+        } else {
+            gridUtils._setElementToMaxZindex(this.draggedItemEl, rowEl);
+        }
+        gridUtils._setElementToMaxZindex(backgroundGridEl, rowEl);
+        gridUtils._setElementToMaxZindex(dragHelperEl, rowEl);
+
+        // Setting the column height and width to keep its size when the
+        // grid-area is removed (as it prevents it from moving with the mouse).
+        const gridProp = gridUtils._getGridProperties(rowEl);
+        const columnHeight = columnRowCount * (gridProp.rowSize + gridProp.rowGap) - gridProp.rowGap;
+        const columnWidth = columnColCount * (gridProp.columnSize + gridProp.columnGap) - gridProp.columnGap;
+        this.draggedItemEl.style.height = columnHeight + "px";
+        this.draggedItemEl.style.width = columnWidth + "px";
+        this.draggedItemEl.style.position = "absolute";
+        this.draggedItemEl.style.removeProperty("grid-area");
+        rowEl.style.position = "relative";
+        this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+
+        // Storing useful information.
+        this.dragState.startingHeight = rowEl.clientHeight;
+        this.dragState.currentHeight = rowEl.clientHeight;
+        this.dragState.dragHelperEl = dragHelperEl;
+        this.dragState.backgroundGridEl = backgroundGridEl;
+        this.handleDragMove = true;
+    },
+    /**
+     * Initializes the state of the drag and drop.
+     *
+     * @private
+     * @param {Element} targetEl - The element that is currently being dragged.
+     */
+    _initializeDragAndDropState(targetEl) {
+        this.dragState = {};
+        this.draggedItemEl = targetEl;
+    },
+    /**
+     * Places a column in a grid at mouse move.
+     *
+     * @private
+     * @param {Event} ev
+     */
+    _onDragMove(ev) {
+        const columnEl = this.draggedItemEl;
+        const rowEl = columnEl.parentNode;
+
+        // Computing the rowEl position.
+        const rowElTop = rowEl.getBoundingClientRect().top;
+        const rowElLeft = rowEl.getBoundingClientRect().left;
+
+        // Getting the column dimensions.
+        const borderWidth = parseFloat(window.getComputedStyle(columnEl).borderWidth);
+        const columnHeight = columnEl.clientHeight + 2 * borderWidth;
+        const columnWidth = columnEl.clientWidth + 2 * borderWidth;
+        const columnMiddle = columnWidth / 2;
+
+        // Placing the column where the mouse is.
+        const top = ev.pageY - rowElTop;
+        const bottom = top + columnHeight;
+        let left = ev.pageX - rowElLeft - columnMiddle;
+
+        // Horizontal overflow.
+        left = clamp(left, 0, rowEl.clientWidth - columnWidth);
+
+        columnEl.style.top = top + "px";
+        columnEl.style.left = left + "px";
+
+        // Computing the drag helper corresponding grid area.
+        const gridProp = gridUtils._getGridProperties(rowEl);
+
+        const rowStart = Math.round(top / (gridProp.rowSize + gridProp.rowGap)) + 1;
+        const columnStart = Math.round(left / (gridProp.columnSize + gridProp.columnGap)) + 1;
+        const rowEnd = rowStart + this.dragState.columnRowCount;
+        const columnEnd = columnStart + this.dragState.columnColCount;
+
+        const dragHelperEl = this.dragState.dragHelperEl;
+        if (parseInt(dragHelperEl.style.gridRowStart) !== rowStart) {
+            dragHelperEl.style.gridRowStart = rowStart;
+            dragHelperEl.style.gridRowEnd = rowEnd;
+        }
+
+        if (parseInt(dragHelperEl.style.gridColumnStart) !== columnStart) {
+            dragHelperEl.style.gridColumnStart = columnStart;
+            dragHelperEl.style.gridColumnEnd = columnEnd;
+        }
+
+        // Vertical overflow/underflow.
+        // Updating the reference heights, the dropzone and the background grid.
+        const startingHeight = this.dragState.startingHeight;
+        const currentHeight = this.dragState.currentHeight;
+        const backgroundGridEl = this.dragState.backgroundGridEl;
+        const dropzoneEl = this.dragState.currentDropzoneEl;
+        const rowOverflow = Math.round((bottom - currentHeight) / (gridProp.rowSize + gridProp.rowGap));
+        const updateRows = bottom > currentHeight || bottom <= currentHeight && bottom > startingHeight;
+        const rowCount = Math.max(rowEl.dataset.rowCount, this.dragState.columnRowCount);
+        const maxRowEnd = rowCount + gridUtils.additionalRowLimit + 1;
+        if (Math.abs(rowOverflow) >= 1 && updateRows) {
+            if (rowEnd <= maxRowEnd) {
+                const dropzoneEnd = parseInt(dropzoneEl.style.gridRowEnd);
+                dropzoneEl.style.gridRowEnd = dropzoneEnd + rowOverflow;
+                backgroundGridEl.style.gridRowEnd = dropzoneEnd + rowOverflow;
+                this.dragState.currentHeight += rowOverflow * (gridProp.rowSize + gridProp.rowGap);
+            } else {
+                // Don't add new rows if we have reached the limit.
+                dropzoneEl.style.gridRowEnd = maxRowEnd;
+                backgroundGridEl.style.gridRowEnd = maxRowEnd;
+                this.dragState.currentHeight = (maxRowEnd - 1) * (gridProp.rowSize + gridProp.rowGap) - gridProp.rowGap;
+            }
+        }
+    },
+    /**
+     * Removes the grid if needed when a dropzone is being exit.
+     *
+     * @private
+     * @param {Element} dropzoneEl - The dropzone that is being exit.
+     */
+    _outOfZone(dropzoneEl) {
+        const rowEl = dropzoneEl.parentNode;
+        if (rowEl.classList.contains("o_grid_mode")) {
+            // Cleaning.
+            this._removeGridAndDragHelper(rowEl);
+            this.draggedItemEl.style.removeProperty("z-index");
+            const rowCount = parseInt(rowEl.dataset.rowCount);
+            dropzoneEl.style.gridRowEnd = Math.max(rowCount + 1, 1);
+        }
+        delete this.dragState.currentDropzoneEl;
+    },
+    /**
+     * Removes the grid and the drag helper.
+     *
+     * @private
+     * @param {Element} rowEl
+     */
+    _removeGridAndDragHelper(rowEl) {
+        gridUtils._gridCleanUp(rowEl, this.draggedItemEl);
+        // Removing the drag helper and the background grid and resizing the
+        // grid and the dropzone.
+        this.dragState.dragHelperEl.remove();
+        this.dragState.backgroundGridEl.remove();
+        this.options.wysiwyg.odooEditor.observerActive("dragAndDropMoveSnippet");
+        gridUtils._resizeGrid(rowEl);
+        this.options.wysiwyg.odooEditor.observerUnactive("dragAndDropMoveSnippet");
+        this.handleDragMove = false;
+    },
+    /**
+     * Stores the dragged item width and height.
+     * @private
+     */
+    _storeItemWidthAndHeight() {
+        const isImageColumn = gridUtils._checkIfImageColumn(this.draggedItemEl);
+        if (isImageColumn) {
+            // Store the image width and height if the column only
+            // contains an image.
+            const imageEl = this.draggedItemEl.querySelector("img");
+            this.dragState.columnWidth = parseFloat(imageEl.scrollWidth);
+            this.dragState.columnHeight = parseFloat(imageEl.scrollHeight);
+        } else {
+            this.dragState.columnWidth = parseFloat(this.draggedItemEl.scrollWidth);
+            this.dragState.columnHeight = parseFloat(this.draggedItemEl.scrollHeight);
+        }
+    },
+});
 /**
  * Management of the overlay and option list for a snippet.
  */
-var SnippetEditor = Widget.extend({
+var SnippetEditor = dragAndDropCommonMenuEditor.extend({
     template: 'web_editor.snippet_overlay',
     events: {
         'click .oe_snippet_remove': '_onRemoveClick',
@@ -126,6 +503,11 @@ var SnippetEditor = Widget.extend({
                         return $clone;
                     },
                     start: this._onDragAndDropStart.bind(this),
+                    drag: (ev) => {
+                        if (this.handleDragMove) {
+                            this._onDragMove(ev);
+                        }
+                    },
                     stop: (...args) => {
                         // Delay our stop handler so that some wysiwyg handlers
                         // which occur on mouseup (and are themself delayed) are
@@ -859,44 +1241,6 @@ var SnippetEditor = Widget.extend({
         return result;
     },
     /**
-     * Called when an "over" dropzone event happens after an other "over"
-     * without an "out" between them. It escapes the previous dropzone.
-     *
-     * @private
-     * @param {Object} self
-     *      the same `self` variable as when we are in `_onDragAndDropStart`
-     * @param {Element} currentDropzoneEl
-     *      the dropzone over which we are currently dragging
-     */
-    _outPreviousDropzone(self, currentDropzoneEl) {
-        const previousDropzoneEl = this;
-        const rowEl = previousDropzoneEl.parentNode;
-
-        if (rowEl.classList.contains('o_grid_mode')) {
-            self.$body[0].removeEventListener('mousemove', self.onDragMove, false);
-            const fromGridToGrid = currentDropzoneEl.classList.contains('oe_grid_zone');
-            if (fromGridToGrid) {
-                // If we went from a grid dropzone to an other grid one.
-                rowEl.style.removeProperty('position');
-            } else {
-                // If we went from a grid dropzone to a normal one.
-                gridUtils._gridCleanUp(rowEl, self.$target[0]);
-                self.$target[0].style.removeProperty('z-index');
-            }
-
-            // Removing the drag helper and the background grid and
-            // resizing the grid and the dropzone.
-            self.dragState.dragHelperEl.remove();
-            self.dragState.backgroundGridEl.remove();
-            self.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-            gridUtils._resizeGrid(rowEl);
-            self.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-            const rowCount = parseInt(rowEl.dataset.rowCount);
-            previousDropzoneEl.style.gridRowEnd = Math.max(rowCount + 1, 1);
-        }
-        previousDropzoneEl.classList.remove('invisible');
-    },
-    /**
      * Changes some behaviors before the drag and drop.
      *
      * @private
@@ -932,7 +1276,7 @@ var SnippetEditor = Widget.extend({
         this.trigger_up('drag_and_drop_start');
         this.options.wysiwyg.odooEditor.automaticStepUnactive();
         var self = this;
-        this.dragState = {};
+        this._initializeDragAndDropState(this.$target[0]);
         const rowEl = this.$target[0].parentNode;
         this.dragState.overFirstDropzone = true;
 
@@ -993,17 +1337,7 @@ var SnippetEditor = Widget.extend({
                 // If the column comes from a snippet that doesn't toggle the
                 // grid mode on drag, store its width and height to use them
                 // when the column goes over a grid dropzone.
-                const isImageColumn = gridUtils._checkIfImageColumn(this.$target[0]);
-                if (isImageColumn) {
-                    // Store the image width and height if the column only
-                    // contains an image.
-                    const imageEl = this.$target[0].querySelector('img');
-                    this.dragState.columnWidth = parseFloat(imageEl.scrollWidth);
-                    this.dragState.columnHeight = parseFloat(imageEl.scrollHeight);
-                } else {
-                    this.dragState.columnWidth = parseFloat(this.$target[0].scrollWidth);
-                    this.dragState.columnHeight = parseFloat(this.$target[0].scrollHeight);
-                }
+                this._storeItemWidthAndHeight();
             }
             // Storing the starting top position of the column.
             this.dragState.columnTop = this.$target[0].getBoundingClientRect().top;
@@ -1072,26 +1406,7 @@ var SnippetEditor = Widget.extend({
 
         const canBeSanitizedUnless = this._canBeSanitizedUnless(this.$target[0]);
 
-        // Remove the siblings/children that would add a dropzone as direct
-        // child of a grid area and make a dedicated set out of the identified
-        // grid areas.
-        const selectorGrids = new Set();
-        const filterOutSelectorGrids = ($selectorItems, getDropzoneParent) => {
-            if (!$selectorItems) {
-                return;
-            }
-            // Looping backwards because elements are removed, so the
-            // indexes are not lost.
-            for (let i = $selectorItems.length - 1; i >= 0; i--) {
-                const el = getDropzoneParent($selectorItems[i]);
-                if (el.classList.contains('o_grid_mode')) {
-                    $selectorItems.splice(i, 1);
-                    selectorGrids.add(el);
-                }
-            }
-        };
-        filterOutSelectorGrids($selectorSiblings, el => el.parentElement);
-        filterOutSelectorGrids($selectorChildren, el => el);
+        const selectorGrids = self._filterOutSelectorsGrids($selectorSiblings, $selectorChildren);
 
         this.trigger_up('activate_snippet', {$snippet: this.$target.parent()});
         this.trigger_up('activate_insertion_zones', {
@@ -1138,86 +1453,17 @@ var SnippetEditor = Widget.extend({
                 const $dropzone = $(this).first().after(self.$target);
                 $dropzone.addClass('invisible');
 
-                // Checking if the "out" event happened before this "over": if
-                // `self.dragState.currentDropzoneEl` exists, "out" didn't
-                // happen because it deletes it. We are therefore in the case
-                // of an "over" after an "over" and we need to escape the
-                // previous dropzone first.
-                if (self.dragState.currentDropzoneEl) {
-                    self._outPreviousDropzone.apply(self.dragState.currentDropzoneEl, [self, $dropzone[0]]);
-                }
+                self._checkAndEscapePreviousDropzone($dropzone[0]);
                 self.dragState.currentDropzoneEl = $dropzone[0];
 
                 if ($dropzone[0].classList.contains('oe_grid_zone')) {
                     // Case where the column we are dragging is over a grid
                     // dropzone.
-                    const rowEl = $dropzone[0].parentNode;
-
-                    // If the column doesn't come from a grid mode snippet.
-                    if (!self.$target[0].classList.contains('o_grid_item')) {
-                        // Converting the column to grid.
-                        self.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                        const spans = gridUtils._convertColumnToGrid(rowEl, self.$target[0], self.dragState.columnWidth, self.dragState.columnHeight);
-                        self.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-                        columnColCount = spans.columnColCount;
-                        columnRowCount = spans.columnRowCount;
-
-                        // Storing the column spans.
-                        self.dragState.columnColCount = columnColCount;
-                        self.dragState.columnRowCount = columnRowCount;
-                    }
-
-                    // Creating the drag helper.
-                    const dragHelperEl = document.createElement('div');
-                    dragHelperEl.classList.add('o_we_drag_helper');
-                    dragHelperEl.style.gridArea = `1 / 1 / ${1 + columnRowCount} / ${1 + columnColCount}`;
-                    rowEl.append(dragHelperEl);
-
-                    // Creating the background grid and updating the dropzone
-                    // (in the case where the column over the dropzone is
-                    // bigger than the grid).
-                    const backgroundGridEl = gridUtils._addBackgroundGrid(rowEl, columnRowCount);
-                    const rowCount = Math.max(rowEl.dataset.rowCount, columnRowCount);
-                    $dropzone[0].style.gridRowEnd = rowCount + 1;
-
-                    self.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                    // Setting the moving grid item, the background grid and
-                    // the drag helper z-indexes. The grid item z-index is set
-                    // to its original one if we are in its starting grid, or
-                    // to the maximum z-index of the grid otherwise.
-                    if (rowEl === self.dragState.startingGrid) {
-                        self.$target[0].style.zIndex = self.dragState.startingZIndex;
-                    } else {
-                        gridUtils._setElementToMaxZindex(self.$target[0], rowEl);
-                    }
-                    gridUtils._setElementToMaxZindex(backgroundGridEl, rowEl);
-                    gridUtils._setElementToMaxZindex(dragHelperEl, rowEl);
-
-                    // Setting the column height and width to keep its size
-                    // when the grid-area is removed (as it prevents it from
-                    // moving with the mouse).
-                    const gridProp = gridUtils._getGridProperties(rowEl);
-                    const columnHeight = columnRowCount * (gridProp.rowSize + gridProp.rowGap) - gridProp.rowGap;
-                    const columnWidth = columnColCount * (gridProp.columnSize + gridProp.columnGap) - gridProp.columnGap;
-                    self.$target[0].style.height = columnHeight + 'px';
-                    self.$target[0].style.width = columnWidth + 'px';
-                    self.$target[0].style.position = 'absolute';
-                    self.$target[0].style.removeProperty('grid-area');
-                    rowEl.style.position = 'relative';
-                    self.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-
-                    // Storing useful information and adding an event listener.
-                    self.dragState.startingHeight = rowEl.clientHeight;
-                    self.dragState.currentHeight = rowEl.clientHeight;
-                    self.dragState.dragHelperEl = dragHelperEl;
-                    self.dragState.backgroundGridEl = backgroundGridEl;
-                    self.onDragMove = self._onDragMove.bind(self);
-                    self.$body[0].addEventListener('mousemove', self.onDragMove, false);
+                    self._initDragOverGrid($dropzone[0]);
                 }
             },
             out: function () {
                 const dropzoneEl = this;
-                const rowEl = dropzoneEl.parentNode;
 
                 // Checking if the "out" event happens right after the "over"
                 // of the same dropzone. If it is not the case, we don't do
@@ -1226,22 +1472,7 @@ var SnippetEditor = Widget.extend({
                 const sameDropzoneAsCurrent = self.dragState.currentDropzoneEl === dropzoneEl;
 
                 if (sameDropzoneAsCurrent) {
-                    if (rowEl.classList.contains('o_grid_mode')) {
-                        // Removing the listener + cleaning.
-                        self.$body[0].removeEventListener('mousemove', self.onDragMove, false);
-                        gridUtils._gridCleanUp(rowEl, self.$target[0]);
-                        self.$target[0].style.removeProperty('z-index');
-
-                        // Removing the drag helper and the background grid and
-                        // resizing the grid and the dropzone.
-                        self.dragState.dragHelperEl.remove();
-                        self.dragState.backgroundGridEl.remove();
-                        self.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                        gridUtils._resizeGrid(rowEl);
-                        self.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-                        const rowCount = parseInt(rowEl.dataset.rowCount);
-                        dropzoneEl.style.gridRowEnd = Math.max(rowCount + 1, 1);
-                    }
+                    self._outOfZone(dropzoneEl);
 
                     var prev = self.$target.prev();
                     if (this === prev[0]) {
@@ -1249,8 +1480,6 @@ var SnippetEditor = Widget.extend({
                         self.$target.detach();
                         $(this).removeClass('invisible');
                     }
-
-                    delete self.dragState.currentDropzoneEl;
                 }
             },
         });
@@ -1274,43 +1503,7 @@ var SnippetEditor = Widget.extend({
         this.options.wysiwyg.odooEditor.automaticStepSkipStack();
         this.options.wysiwyg.odooEditor.unbreakableStepUnactive();
 
-        const rowEl = this.$target[0].parentNode;
-        if (rowEl && rowEl.classList.contains('o_grid_mode')) {
-            // Case when dropping the column in a grid.
-
-            // Removing the event listener.
-            this.$body[0].removeEventListener('mousemove', this.onDragMove, false);
-
-            // Defining the column grid area with its position.
-            const gridProp = gridUtils._getGridProperties(rowEl);
-
-            const top = parseFloat(this.$target[0].style.top);
-            const left = parseFloat(this.$target[0].style.left);
-
-            const rowStart = Math.round(top / (gridProp.rowSize + gridProp.rowGap)) + 1;
-            const columnStart = Math.round(left / (gridProp.columnSize + gridProp.columnGap)) + 1;
-            const rowEnd = rowStart + this.dragState.columnRowCount;
-            const columnEnd = columnStart + this.dragState.columnColCount;
-
-            this.$target[0].style.gridArea = `${rowStart} / ${columnStart} / ${rowEnd} / ${columnEnd}`;
-
-            // Cleaning, removing the drag helper and the background grid and
-            // resizing the grid.
-            gridUtils._gridCleanUp(rowEl, this.$target[0]);
-            this.dragState.dragHelperEl.remove();
-            this.dragState.backgroundGridEl.remove();
-            this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-            gridUtils._resizeGrid(rowEl);
-            this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-        } else if (this.$target[0].classList.contains('o_grid_item') && this.dropped) {
-            // Case when dropping a grid item in a non-grid dropzone.
-            this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-            const gridSizeClasses = this.$target[0].className.match(/(g-col-lg|g-height)-[0-9]+/g);
-            this.$target[0].classList.remove('o_grid_item', 'o_grid_item_image', 'o_grid_item_image_contain', ...gridSizeClasses);
-            this.$target[0].style.removeProperty('z-index');
-            this.$target[0].style.removeProperty('grid-area');
-            this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-        }
+        this._dragAndDropStopGrid();
 
         // TODO lot of this is duplicated code of the d&d feature of snippets
         if (!this.dropped) {
@@ -1320,47 +1513,7 @@ var SnippetEditor = Widget.extend({
             if ($el.length) {
                 $el.after(this.$target);
                 // If the column is not dropped inside a dropzone.
-                if ($el[0].classList.contains('oe_grid_zone')) {
-                    // Case when a column is dropped near a grid.
-                    const rowEl = $el[0].parentNode;
-
-                    // If the column doesn't come from a snippet in grid mode,
-                    // convert it.
-                    if (!this.$target[0].classList.contains('o_grid_item')) {
-                        this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                        const spans = gridUtils._convertColumnToGrid(rowEl, this.$target[0], this.dragState.columnWidth, this.dragState.columnHeight);
-                        this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-                        this.dragState.columnColCount = spans.columnColCount;
-                        this.dragState.columnRowCount = spans.columnRowCount;
-                    }
-
-                    // Placing it in the top left corner.
-                    this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                    this.$target[0].style.gridArea = `1 / 1 / ${1 + this.dragState.columnRowCount} / ${1 + this.dragState.columnColCount}`;
-                    const rowCount = Math.max(rowEl.dataset.rowCount, this.dragState.columnRowCount);
-                    rowEl.dataset.rowCount = rowCount;
-                    this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-
-                    // Setting the grid item z-index.
-                    if (rowEl === this.dragState.startingGrid) {
-                        this.$target[0].style.zIndex = this.dragState.startingZIndex;
-                    } else {
-                        gridUtils._setElementToMaxZindex(this.$target[0], rowEl);
-                    }
-                } else {
-                    if (this.$target[0].classList.contains('o_grid_item')) {
-                        // Case when a grid column is dropped near a non-grid
-                        // dropzone.
-                        this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                        const gridSizeClasses = this.$target[0].className.match(/(g-col-lg|g-height)-[0-9]+/g);
-                        this.$target[0].classList.remove('o_grid_item', 'o_grid_item_image', 'o_grid_item_image_contain', ...gridSizeClasses);
-                        this.$target[0].style.removeProperty('z-index');
-                        this.$target[0].style.removeProperty('grid-area');
-                        this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
-                    }
-                }
-
-                this.dropped = true;
+                this._droppedNear($el[0]);
             }
         }
 
@@ -1425,7 +1578,7 @@ var SnippetEditor = Widget.extend({
         this.dragState.restore();
 
         delete this.$dropZones;
-        delete this.dragState;
+        this._clearDragAndDropState();
     },
     /**
      * @private
@@ -1584,80 +1737,6 @@ var SnippetEditor = Widget.extend({
         const rowEl = this.$target[0].parentNode;
         gridUtils._setElementToMaxZindex(this.$target[0], rowEl);
     },
-    /**
-     * Called when the mouse is moved to place a column in a grid.
-     *
-     * @private
-     * @param {Event} ev
-     */
-    _onDragMove(ev) {
-        const columnEl = this.$target[0];
-        const rowEl = columnEl.parentNode;
-
-        // Computing the rowEl position.
-        const rowElTop = rowEl.getBoundingClientRect().top;
-        const rowElLeft = rowEl.getBoundingClientRect().left;
-
-        // Getting the column dimensions.
-        const borderWidth = parseFloat(window.getComputedStyle(columnEl).borderWidth);
-        const columnHeight = columnEl.clientHeight + 2 * borderWidth;
-        const columnWidth = columnEl.clientWidth + 2 * borderWidth;
-        const columnMiddle = columnWidth / 2;
-
-        // Placing the column where the mouse is.
-        const top = ev.pageY - rowElTop;
-        const bottom = top + columnHeight;
-        let left = ev.pageX - rowElLeft - columnMiddle;
-
-        // Horizontal overflow.
-        left = clamp(left, 0, rowEl.clientWidth - columnWidth);
-
-        columnEl.style.top = top + 'px';
-        columnEl.style.left = left + 'px';
-
-        // Computing the drag helper corresponding grid area.
-        const gridProp = gridUtils._getGridProperties(rowEl);
-
-        const rowStart = Math.round(top / (gridProp.rowSize + gridProp.rowGap)) + 1;
-        const columnStart = Math.round(left / (gridProp.columnSize + gridProp.columnGap)) + 1;
-        const rowEnd = rowStart + this.dragState.columnRowCount;
-        const columnEnd = columnStart + this.dragState.columnColCount;
-
-        const dragHelperEl = this.dragState.dragHelperEl;
-        if (parseInt(dragHelperEl.style.gridRowStart) !== rowStart) {
-            dragHelperEl.style.gridRowStart = rowStart;
-            dragHelperEl.style.gridRowEnd = rowEnd;
-        }
-
-        if (parseInt(dragHelperEl.style.gridColumnStart) !== columnStart) {
-            dragHelperEl.style.gridColumnStart = columnStart;
-            dragHelperEl.style.gridColumnEnd = columnEnd;
-        }
-
-        // Vertical overflow/underflow.
-        // Updating the reference heights, the dropzone and the background grid.
-        const startingHeight = this.dragState.startingHeight;
-        const currentHeight = this.dragState.currentHeight;
-        const backgroundGridEl = this.dragState.backgroundGridEl;
-        const dropzoneEl = this.dragState.currentDropzoneEl;
-        const rowOverflow = Math.round((bottom - currentHeight) / (gridProp.rowSize + gridProp.rowGap));
-        const updateRows = bottom > currentHeight || bottom <= currentHeight && bottom > startingHeight;
-        const rowCount = Math.max(rowEl.dataset.rowCount, this.dragState.columnRowCount);
-        const maxRowEnd = rowCount + gridUtils.additionalRowLimit + 1;
-        if (Math.abs(rowOverflow) >= 1 && updateRows) {
-            if (rowEnd <= maxRowEnd) {
-                const dropzoneEnd = parseInt(dropzoneEl.style.gridRowEnd);
-                dropzoneEl.style.gridRowEnd = dropzoneEnd + rowOverflow;
-                backgroundGridEl.style.gridRowEnd = dropzoneEnd + rowOverflow;
-                this.dragState.currentHeight += rowOverflow * (gridProp.rowSize + gridProp.rowGap);
-            } else {
-                // Don't add new rows if we have reached the limit.
-                dropzoneEl.style.gridRowEnd = maxRowEnd;
-                backgroundGridEl.style.gridRowEnd = maxRowEnd;
-                this.dragState.currentHeight = (maxRowEnd - 1) * (gridProp.rowSize + gridProp.rowGap) - gridProp.rowGap;
-            }
-        }
-    }
 });
 
 /**

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -4608,12 +4608,13 @@ registry.sizing = SnippetOptionWidget.extend({
 
             // Hiding/showing the arrows.
             if (isGrid) {
-                const moveLeftArrowEl = this.$overlay[0].querySelector('.fa-angle-left');
-                const moveRightArrowEl = this.$overlay[0].querySelector('.fa-angle-right');
-                const showLeft = await this._computeWidgetVisibility('move_left_opt');
-                const showRight = await this._computeWidgetVisibility('move_right_opt');
-                moveLeftArrowEl.classList.toggle('d-none', !showLeft);
-                moveRightArrowEl.classList.toggle('d-none', !showRight);
+                for (const direction in ["left", "right", "up", "down"]) {
+                    const moveArrowEl = this.$overlay[0].querySelector(`.fa-angle-${direction}`);
+                    if (moveArrowEl) {
+                        const showArrow = await this._computeWidgetVisibility(`move_${direction}_opt`);
+                        moveArrowEl.classList.toggle("d-none", !showArrow);
+                    }
+                }
             }
 
             // Show/hide the buttons to send back/front a grid item.

--- a/addons/website/views/snippets/s_timeline.xml
+++ b/addons/website/views/snippets/s_timeline.xml
@@ -71,9 +71,7 @@
             <we-colorpicker string="Line Color" data-select-style="true" data-css-property="border-color" data-color-prefix="border-" data-apply-to=".s_timeline_line"/>
         </div>
     </xpath>
-    <xpath expr="//div[@data-js='SnippetMove'][contains(@data-selector,'section')]" position="attributes">
-        <attribute name="data-selector" add=".s_timeline_row" separator=","/>
-    </xpath>
+    <xpath expr="//*[@t-set='prev_and_next_arrow_selector']" position="inside">, .s_timeline_row</xpath>
 </template>
 
 <record id="website.s_timeline_000_scss" model="ir.asset">

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -662,7 +662,7 @@
         data-exclude=".s_col_no_resize.row > div, .s_col_no_resize"/>
 
     <div data-js="sizing_grid"
-        data-selector=".row > div"
+        data-selector=".row > div, .row > .o_grid_item"
         data-drop-near=".row.o_grid_mode > div"
         data-exclude=".s_col_no_resize.row > div, .s_col_no_resize"/>
 
@@ -677,7 +677,7 @@
     <div id="so_content_addition"
         t-att-data-selector="so_content_addition_selector"
         t-attf-data-drop-near="p, h1, h2, h3, ul, ol, .row > div:not(.o_grid_item_image) > img, #{so_content_addition_selector}"
-        data-drop-in="nav"/>
+        data-drop-in="nav, .row.o_grid_mode"/>
 
     <div data-js="SnippetSave"
         data-selector="[data-snippet]"

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -592,13 +592,14 @@
     </div>
 
     <!-- Move snippets around -->
-    <div data-js="SnippetMove" data-selector="section, .accordion > .card, .s_showcase .row:not(.s_col_no_resize) > div" data-no-scroll=".accordion > .card">
+    <t t-set="prev_and_next_arrow_selector" t-translation="off">section, .accordion > .card, .s_showcase .row:not(.s_col_no_resize) > div</t>
+    <div data-js="SnippetMove" t-att-data-selector="prev_and_next_arrow_selector" data-no-scroll=".accordion > .card">
         <we-button class="fa fa-fw fa-angle-up" data-move-snippet="prev" data-no-preview="true" data-name="move_up_opt"/>
         <we-button class="fa fa-fw fa-angle-down" data-move-snippet="next" data-no-preview="true" data-name="move_down_opt"/>
     </div>
     <div data-js="SnippetMove"
-         data-selector=".row:not(.s_col_no_resize) > div, .nav-item"
-         data-exclude=".s_showcase .row > div"
+         data-selector=".row:not(.s_col_no_resize) > div, .nav-item, .o_grid_item"
+         t-attf-data-exclude=".s_showcase .row > div, #{prev_and_next_arrow_selector}"
          data-name="move_horizontally_opt">
         <we-button class="fa fa-fw fa-angle-left" data-move-snippet="prev" data-no-preview="true" data-name="move_left_opt"/>
         <we-button class="fa fa-fw fa-angle-right" data-move-snippet="next" data-no-preview="true" data-name="move_right_opt"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -109,7 +109,7 @@
             <div id="snippet_effect" class="o_panel">
                 <div class="o_panel_header">Dynamic Content</div>
                 <div class="o_panel_body">
-                    <t t-snippet="website.s_website_form" string="Form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" t-forbid-sanitize="form"/>
+                    <t t-snippet="website.s_website_form" string="Form" t-thumbnail="/website/static/src/img/snippets_thumbs/s_website_form.svg" t-forbid-sanitize="form" t-height-grid = "9"/>
                     <t t-set="google_maps_api_key" t-value="request.env['website'].get_current_website().google_maps_api_key"/>
                     <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" string="Map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg"/>
                     <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" string="Map" t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg"/>
@@ -123,13 +123,13 @@
                     <t id="mass_mailing_newsletter_block_hook"/>
                     <t id="mass_mailing_newsletter_popup_hook"/>
                     <t t-snippet="website.s_popup" string="Popup" t-thumbnail="/website/static/src/img/snippets_thumbs/s_popup.svg"/>
-                    <t t-snippet="website.s_facebook_page" string="Facebook" t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg"/>
-                    <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg">
+                    <t t-snippet="website.s_facebook_page" string="Facebook" t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg" t-height-grid="2" t-width-grid = "5"/>
+                    <t t-snippet="website.s_countdown" string="Countdown" t-thumbnail="/website/static/src/img/snippets_thumbs/s_countdown.svg" t-height-grid="4">
                         <keywords>celebration, launch</keywords>
                     </t>
                     <t id="mail_group_hook"/>
                     <t id="twitter_favorite_tweets_hook"/>
-                    <t t-snippet="website.s_embed_code" string="Embed Code" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" t-forbid-sanitize="true"/>
+                    <t t-snippet="website.s_embed_code" string="Embed Code" t-thumbnail="/website/static/src/img/snippets_thumbs/s_embed_code.svg" t-forbid-sanitize="true" t-height-grid="1"/>
                     <t id="snippet_donation_hook"/>
                 </div>
             </div>
@@ -150,10 +150,10 @@
                     <t t-snippet="website.s_searchbar_input" string="Search" t-thumbnail="/website/static/src/img/snippets_thumbs/s_searchbar_inline.svg" t-forbid-sanitize="form"/>
                     <t id="mass_mailing_newsletter_hook"/>
                     <t t-snippet="website.s_text_highlight" string="Text Highlight" t-thumbnail="/website/static/src/img/snippets_thumbs/s_text_highlight.svg"/>
-                    <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg">
+                    <t t-snippet="website.s_chart" string="Chart" t-thumbnail="/website/static/src/img/snippets_thumbs/s_chart.svg" t-height-grid= "8" t-width-grid = "7">
                         <keywords>chart, table, diagram, pie</keywords>
                     </t>
-                    <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg">
+                    <t t-snippet="website.s_progress_bar" string="Progress Bar" t-thumbnail="/website/static/src/img/snippets_thumbs/s_progress_bar.svg" t-height-grid="2">
                         <keywords>evolution, growth</keywords>
                     </t>
                     <t t-snippet="website.s_badge" string="Badge" t-thumbnail="/website/static/src/img/snippets_thumbs/s_badge.svg"/>


### PR DESCRIPTION
[IMP] web_editor: extract code that will be common for the snippet menu

The goal of this commit is to extract in `dragAndDropCommonMenuEditor`
the logic related to the drag and drop of the `SnippetEditor` that will
be common for the `SnippetsMenu`.

Here are the few adaptations added by this commit:
- Use of the `drag` event instead of an event listener to handle the
drag move.
- Creation of the `_cleanItemFromGridCharacteristics()` function to
handle the common part of `_droppedNear()` and ` _dragAndDropStopGrid()`
- Creation of the `_removeGridAndDragHelper()` function to handle the
common part of `_dragAndDropStopGrid()` and `_outOfZone()`.

task-3369611

-----------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] web_editor: associate code that have the same purpose

The goal of this commit is to gather two parts of the code that have the
same purpose; [1] and [2]. The goal of both commits is to handle the
case where an "over" event happens after another "over" event. Instead
of having "over" > "out" > "over", there is an "over" > "over" > "out".
This could happen when going really fast from a dropzone to another or
when the dropzones are glued to each other.
This commit removes the check of the `_checkAndEscapePreviousDropzone()`
to see if there is an "over" after an "over" as the logic related to
this function has been moved in a place where we know that it is already
the case.

[1]: https://github.com/odoo/odoo/commit/fed5854e32bcddf8b14b8311b2fe542eed990f77
[2]: https://github.com/odoo/odoo/commit/3749d6d66c8cc49fd6613c8a8b6889ca5150fe99

task-3369611

-----------------------------------------------------------------------------------------------------------------------------------------------------
[IMP] web_editor,*: enable to drop inner content on grid dropzones
*website

The goal of this commit is to be able to drag an "Inner content" snippet
as a grid element inside snippets that are in grid mode. To do so,
`.row.o_grid_mode` has been added as `data-drop-in` for those snippets
and the already existing logic of the "move" option of the
`SnippetEditor` has been reused for the `SnippetsMenu`. Here are
additional features added to the existing logic:
- For the drag and drop of a snippet that is already on the page, the
storage of the snippet width and height is always done (before this
commit, it was only the case if the snippet parent node had the `row`
class). Indeed, now, a snippet can start in a non-grid dropzone and then
be dragged over a grid dropzone where the `columnWidth` and
`columnHeight` parameters are needed.
- A condition has been added at the `out` of the dropzone to reactivate
the grid if needed. A typical case of this situation is a snippet that
is first dragged over a grid dropzone (let's call it "a"), then over a
non-grid dropzone ("b") inside of "a" and finally over "a". Because "b"
is inside of "a", the `over` event will not be triggered when the
snippet is dragged from "b" to "a" but the grid has to be reactivated.
- `important` has been added when setting the `width` and `height` of an
element inside a grid dropzone. Indeed, the snippet element could have
Bootstrap classes that impact the size of those elements (for example
`w-100`) but they should not be considered in a grid zone.
- When dropping the snippet on the website page, the `col-lg-` class is
removed if the snippet is not a direct child of a `.row` element.
- A hack has been used for the drag and drop of a snippet from the right
panel. When the snippet is dragged over a grid dropzone, we somehow need
to get its `width` and `height` to compute the number of rows and
columns needed inside the grid zone. To do so, the snippet can not be
inserted on the grid as it will try to fit in only one box. The hack is
to insert the snippet outside of the grid to get its "normal" `width`
and `height` and then on the grid again as the number of rows and
columns can now be determined. Note that this is not relevant for the
drag and drop of a snippet that is already on the page as we can
directly get its `width` and `height`.
- The grid dropzones are only activated if the user is not using the
mobile view.
- The `updateUIVisibility()` function has been adapted in order to work
with grid items that do not have a "move left" or "move right" arrow
(for example, the "Form" snippet if it is dropped inside a grid
dropzone).

task-3369611

-----------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] *: set the correct grid dimension of dynamically build snippets
*web_editor, website

To compute the size of an item, the `_storeGridItemWidthAndHeight()`
function first inserts it on the DOM and then measures its size. The
problem is that some snippets are built dynamically (for example, the
"Chart" or the "Form" snippet) leading this function to not correctly
set the size of such items. To solve the problem, the
`data-oe-width-grid` and `data-oe-height-grid` attributes of such
snippets are used to store the size that the item will have on the grid.

task-3369611

-----------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] website: add move arrows for all grid items in mobile view

Before this commit, some snippets did not have the "move left" and "move
right" arrows when clicking on them in mobile view ("Badge" for
example). This commit adds those moving arrows for all grid items that
do not already have the "move up" or "move down" arrows.

task-3369611