### PR TITLE
[FIX] im_livechat: fix livechat service thread getter

### DIFF
--- a/addons/im_livechat/static/src/embed/core/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/core/livechat_service.js
@@ -257,7 +257,9 @@ export class LivechatService {
      * @returns {import("@mail/core/common/thread_model").Thread|undefined}
      */
     get thread() {
-        return Object.values(this.store.Thread.records).find(({ type }) => type === "livechat");
+        return Object.values(this.store.Thread.records).find(
+            ({ id, type }) => type === "livechat" && id === this.sessionCookie?.id
+        );
     }
 
     get visitorUid() {


### PR DESCRIPTION
The livechat service thread getter relies on the thread type to find the current livechat thread. Since guest could have many channels it is incomplete, the id should also be checked. This PR fixes this issue.