### PR TITLE
[FIX] crm_iap_mine: fix the tour

### DIFF
--- a/addons/crm_iap_mine/static/src/js/tours/crm_iap_lead.js
+++ b/addons/crm_iap_mine/static/src/js/tours/crm_iap_lead.js
@@ -13,7 +13,7 @@ patch(registry.category("web_tour.tours").get("crm_tour"), {
         const DragOppToWonStepIndex = originalSteps.findIndex(
             (step) => step.id === "drag_opportunity_to_won_step"
         );
-        return originalSteps.splice(
+        originalSteps.splice(
             DragOppToWonStepIndex + 1,
             0,
             {
@@ -45,5 +45,6 @@ patch(registry.category("web_tour.tours").get("crm_tour"), {
                 },
             }
         );
+        return originalSteps
     },
 });


### PR DESCRIPTION
Before this commit,
When we start the CRM tour it ends up with one step.

Reason:
after this PR https://github.com/odoo/odoo/pull/125716 the `steps` become empty when
splice() method returns an empty array if nothing was removed from the given array
which caused an issue.

After this commit,
The tour will run successfully.

Task:- 3495911