### PR TITLE
[FIX] website_livechat:tests: fix chatbot ui tour nightly build fail

### DIFF
--- a/addons/im_livechat/static/src/embed/core/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/core/livechat_service.js
@@ -258,7 +258,8 @@ export class LivechatService {
      */
     get thread() {
         return Object.values(this.store.Thread.records).find(
-            ({ id, type }) => type === "livechat" && id === this.sessionCookie?.id
+            ({ id, type }) =>
+                type === "livechat" && id === (this.sessionCookie?.id ?? this.TEMPORARY_ID)
         );
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/135378

Commit above fixed a potential issue where guests may eventually have many livechats, so finding the livechat thread just by `type: livechat` is not enough. To be more specific, it relies on livechat session stored in cookie.

However, when there's no livechat session, there's no id stored in cookie. The livechat thread uses a `TEMPORARY_ID`. Fix above forgot to handle this part, thus the getter was failing when there's no persistent livechat session.
