### PR TITLE
[IMP] stock: generate moves at package level creation in case of picking already confirmed

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -851,7 +851,7 @@ class Picking(models.Model):
 
     def action_confirm(self):
         self._check_company()
-        self.mapped('package_level_ids').filtered(lambda pl: pl.state == 'draft' and not pl.move_ids)._generate_moves()
+        self.mapped('package_level_ids')._generate_moves()
         # call `_action_confirm` on every draft move
         self.move_ids.filtered(lambda move: move.state == 'draft')._action_confirm()
 


### PR DESCRIPTION
### Before this PR:
If you create a package level when the stock picking is not in state 'draft' , the moves are not created because the generate moves is only called when doing action_confirm on the stock picking.
I guess this is a unhandled case. 
If now you create a package level with a package, this will not be reserved if you create after validation. But IMHO the package should be reserved in this case 

### After this PR:
If you create a package level and the stock picking is already confirmed, the generate_moves is called on package level creation.
If the stock picking is already in confirmed state, the action_confirm is called after the generate_moves


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
