### PR TITLE
[FIX] mail: access right issues on read-only documents

### DIFF
--- a/addons/mail/static/src/composer/composer.xml
+++ b/addons/mail/static/src/composer/composer.xml
@@ -49,6 +49,7 @@
                             t-model="props.composer.textInputContent"
                             t-att-placeholder="placeholder"
                             t-att-readOnly="!state.active"
+                            t-att-disabled="threadService.isReadonly(this.thread)"
                         />
                         <!--
                              This is an invisible textarea used to compute the composer
@@ -63,6 +64,7 @@
                         />
                     </div>
                     <div class="o-mail-Composer-actions d-flex bg-view"
+                        t-if="!threadService.isReadonly(this.thread)"
                         t-att-class="{
                             'ms-1': compact and ui.isSmall,
                             'mx-1 me-2': compact and !ui.isSmall,
@@ -80,7 +82,7 @@
                         </div>
                         <button t-if="thread and thread.type === 'chatter'" class="o-mail-Composer-fullComposer btn fa fa-expand m-1 border-0 rounded-pill" title="Full composer" aria-label="Full composer" type="button" t-on-click="onClickFullComposer"/>
                     </div>
-                    <t t-if="!extended" t-call="mail.Composer.sendButton"/>
+                    <t t-if="!extended and !threadService.isReadonly(this.thread)" t-call="mail.Composer.sendButton"/>
                 </div>
                 <div t-if="extended and !props.composer.message" class="d-flex align-items-center mt-2 gap-2">
                     <t t-call="mail.Composer.sendButton"/>

--- a/addons/mail/static/src/core_ui/message.js
+++ b/addons/mail/static/src/core_ui/message.js
@@ -255,7 +255,11 @@ export class Message extends Component {
     }
 
     get canReplyTo() {
-        return this.message.originThread?.allowReplies && this.props.messageToReplyTo;
+        return (
+            this.message.originThread?.allowReplies &&
+            this.props.messageToReplyTo &&
+            !this.threadService.isReadonly(this.message.originThread)
+        );
     }
 
     /**

--- a/addons/mail/static/src/web/chatter.js
+++ b/addons/mail/static/src/web/chatter.js
@@ -220,6 +220,10 @@ export class Chatter extends Component {
         return !this.props.threadId || !this.state.thread.hasReadAccess;
     }
 
+    get isReadonly() {
+        return this.threadService.isReadonly(this.state.thread, false) && this.props.threadId;
+    }
+
     get attachments() {
         return this.state.thread?.attachments ?? [];
     }

--- a/addons/mail/static/src/web/chatter.xml
+++ b/addons/mail/static/src/web/chatter.xml
@@ -10,23 +10,23 @@
                     'btn-secondary': state.composerType === 'note',
                     'active': state.composerType === 'message',
                     'my-2': !props.compactHeight
-                }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
+                }" t-att-disabled="isReadonly" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                     Send message
                 </button>
                 <button t-if="props.hasMessageList" class="o-mail-Chatter-logNote btn text-nowrap me-2" t-att-class="{
                     'btn-primary active': state.composerType === 'note',
                     'btn-secondary': state.composerType !== 'note',
                     'my-2': !props.compactHeight
-                }" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                }" t-att-disabled="isReadonly" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                     Log note
                 </button>
                 <div class="flex-grow-1 d-flex">
-                    <button t-if="props.hasActivities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" data-hotkey="shift+a" t-on-click="scheduleActivity">
+                    <button t-if="props.hasActivities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap" t-att-class="{ 'my-2': !props.compactHeight }" t-att-disabled="isReadonly" data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <i class="fa fa-clock-o me-1"/>
                         <span>Activities</span>
                     </button>
                     <span class="o-mail-Chatter-topbarGrow flex-grow-1 pe-2"/>
-                    <FileUploader t-if="attachments.length === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
+                    <FileUploader t-if="attachments.length === 0 and state.thread.hasWriteAccess" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                         <t t-set-slot="toggler">
                             <t t-call="mail.Chatter.attachFiles"/>
                         </t>
@@ -153,7 +153,7 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles" owl="1">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-att-disabled="!state.thread.hasWriteAccess and attachments.length === 0" t-on-click="onClickAddAttachments">
         <i class="fa fa-paperclip fa-lg me-1"/>
         <span t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/web/composer_patch.js
+++ b/addons/mail/static/src/web/composer_patch.js
@@ -7,7 +7,9 @@ import { patch } from "@web/core/utils/patch";
 patch(Composer.prototype, "web", {
     get placeholder() {
         if (this.thread && this.thread.model !== "discuss.channel") {
-            if (this.props.type === "message") {
+            if (this.threadService.isReadonly(this.thread)) {
+                return _t("You don't have the rights to post on this Document...");
+            } else if (this.props.type === "message") {
                 return _t("Send a message to followers...");
             } else {
                 return _t("Log an internal note...");


### PR DESCRIPTION
**Current behavior before PR:**

Access Right Error raises on a read-only document when a user tries to post a message, update followers in the follower's menu or upload an attachment.

**Desired behavior after PR is merged:**

Disabled messaging buttons which would cause an Access Right Error for such cases.

Task-3062266

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
