### PR TITLE
[FIX] web_editor: reset MoveNodePlugin when switching record

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/MoveNodePlugin.js
+++ b/addons/web_editor/static/src/js/wysiwyg/MoveNodePlugin.js
@@ -93,7 +93,14 @@ export class MoveNodePlugin {
                 this._resetHooksNextMousemove = true;
             } else {
                 this._visibleMovableElements.delete(element);
-                this._elementHookMap.get(element).style.display = `none`;
+                const hookElement = this._elementHookMap.get(element);
+                if (hookElement) {
+                    // If hookElement is undefined, it means that this callback
+                    // was called after a new element was inserted in the
+                    // editable, but before the next _updateHooks. The hook will
+                    // be created when that happens.
+                    hookElement.style.display = `none`;
+                }
             }
         }
     }
@@ -186,10 +193,7 @@ export class MoveNodePlugin {
     }
     _getMovableElements() {
         return [...new Set([...this._editable.querySelectorAll(ALLOWED_ELEMENTS)])]
-            .filter((node) =>
-                node.parentElement && node.parentElement.isContentEditable &&
-                isNodeMovable(node)
-            );
+            .filter((node) => isNodeMovable(node));
     }
     _getDroppableElements(draggableNode) {
         return this._getMovableElements().filter((node) =>


### PR DESCRIPTION
How to reproduce:
- open a record with an html_field (i.e. todo or a Knowledge article)
- switch back and forth with the pager or the knowledge sidebar between 2
  records

Current behavior:
- traceback `this._elementHookMap.get(element)` is undefined

Expected behavior:
- no traceback

Technical explanation:

When changing the editable content (i.e. `resetContent` when changing record),
there is no guarantee that `_intersectionObserverCallback`
(intersectionObserver) won't be called before `_updateHooks` (mouseMove/resize
after a mutation occured).

This is an issue because `this._elementHookMap` may not yet have a hook element
related to the editable element which stops intersecting the document.
If such a case occurs, the next `_updateHooks` should be called when the
mutationObserver flags `_resetHooksNextMouseMove` to `true` and then after the
next `mouseMove`  (or after the next resize).

Ignore the hook style update if there is currently no hook for an element which
stops intersecting.

Remove a redundant check in `_getMovableElements`

task-3506666
