### PR TITLE
[FIX] project: Fix portal view conditional assets tests

### DIFF
--- a/addons/project/views/project_sharing_project_task_templates.xml
+++ b/addons/project/views/project_sharing_project_task_templates.xml
@@ -25,7 +25,6 @@
                 </script>
                 <base target="_parent"/>
                 <t t-call-assets="project.webclient"/>
-                <t t-call="web.conditional_assets_tests"/>
             </t>
             <t t-set="head" t-value="head_project_sharing + (head or '')"/>
             <t t-set="body_classname" t-value="'o_web_client o_project_sharing'"/>


### PR DESCRIPTION
Step to reproduce:
Go on [URL]/my/projects/[ID]/project_sharing with the assets tests activated.

The project.webclient doesn't load the whole backend assets that tests depend on, so the dependencies for the tours have to be ignored.
The tour didn't crash because the content of the iframe was present (below the traceback message)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
