### PR TITLE
[FIX] auth_oauth: raise badrequest on missing state

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -122,7 +122,13 @@ class OAuthController(http.Controller):
     @http.route('/auth_oauth/signin', type='http', auth='none')
     @fragment_to_query_string
     def signin(self, **kw):
-        state = json.loads(kw['state'])
+        st = kw.get('state')
+        if not(st or isinstance(st, str)):
+            return BadRequest()
+        try:
+            state = json.loads(st)
+        except json.decoder.JSONDecodeError:
+            return BadRequest()
         dbname = state['d']
         if not http.db_filter([dbname]):
             return BadRequest()


### PR DESCRIPTION
When the user tries to log in with `odoo.com` or any other third-party app this traceback may appear.

See Traceback
```
KeyError: 'state'
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1851, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/auth_oauth/controllers/main.py", line 47, in wrapper
    return func(self, *a, **kw)
  File "addons/auth_oauth/controllers/main.py", line 125, in signin
    state = json.loads(kw['state'])
```

This commit will solve the above issue by raising the `BadRequest` if the `state` is not available in `kw`.

Sentry-4476285288