### PR TITLE
[FIX] crm_iap_mine: Correction of industries used for lead generation

### DIFF
--- a/addons/crm_iap_mine/__manifest__.py
+++ b/addons/crm_iap_mine/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Lead Generation',
     'summary': 'Generate Leads/Opportunities based on country, industries, size, etc.',
     'category': 'Sales/CRM',
-    'version': '1.2',
+    'version': '1.3',
     'depends': [
         'iap_crm',
         'iap_mail',

--- a/addons/crm_iap_mine/data/crm.iap.lead.industry.csv
+++ b/addons/crm_iap_mine/data/crm.iap.lead.industry.csv
@@ -1,24 +1,66 @@
-"id",name,reveal_ids,sequence
-"crm_iap_mine_industry_30_155","Consumer Discretionary","30,155",1
-"crm_iap_mine_industry_33","Consumer Staples","33",4
-"crm_iap_mine_industry_69_157","Banks & Insurance","69,157",2
-"crm_iap_mine_industry_86","Media","86",7
-"crm_iap_mine_industry_114","Real Estate","114",21
-"crm_iap_mine_industry_136","Transportation","136",16
-"crm_iap_mine_industry_138_156","Energy & Utilities ","138",22
-"crm_iap_mine_industry_148","Materials","148",17
-"crm_iap_mine_industry_149","Telecommunication Services","149",20
-"crm_iap_mine_industry_150_151","Consumer Services","150,151",9
-"crm_iap_mine_industry_152","Retailing","152",3
-"crm_iap_mine_industry_153_154","Food, Beverage & Tobacco","153,154",12
-"crm_iap_mine_industry_158_159","Diversified Financials & Financial Services","158,159",15
-"crm_iap_mine_industry_160","Health Care Equipment & Services","160",11
-"crm_iap_mine_industry_161","Pharmaceuticals, Biotechnology & Life Sciences","161",13
-"crm_iap_mine_industry_162","Capital Goods","162",6
-"crm_iap_mine_industry_163","Commercial & Professional Services","163",5
-"crm_iap_mine_industry_165","Software & Services","165",8
-"crm_iap_mine_industry_166","Technology Hardware & Equipment","166",19
-"crm_iap_mine_industry_167","Construction Materials","167",23
-"crm_iap_mine_industry_168","Independent Power and Renewable Electricity Producers","168",14
-"crm_iap_mine_industry_238","Automobiles & Components","238",18
-"crm_iap_mine_industry_239","Consumer Durables & Apparel","239",10
+id,name
+crm_iap_mine_industry_1,Aerospace & Defense
+crm_iap_mine_industry_2,Air Freight & Logistics
+crm_iap_mine_industry_3,Airlines
+crm_iap_mine_industry_4,Automotive
+crm_iap_mine_industry_5,Banks
+crm_iap_mine_industry_6,Beverages
+crm_iap_mine_industry_7,Biotechnology
+crm_iap_mine_industry_8,Building Materials
+crm_iap_mine_industry_9,Capital Goods
+crm_iap_mine_industry_10,Capital Markets
+crm_iap_mine_industry_11,Chemicals
+crm_iap_mine_industry_12,Commercial Services & Supplies
+crm_iap_mine_industry_13,Communications Equipment
+crm_iap_mine_industry_14,Construction & Engineering
+crm_iap_mine_industry_15,Consumer Discretionary
+crm_iap_mine_industry_16,Consumer Goods
+crm_iap_mine_industry_17,Consumer Services
+crm_iap_mine_industry_18,Consumer Staples
+crm_iap_mine_industry_19,Containers & Packaging
+crm_iap_mine_industry_20,Distributors
+crm_iap_mine_industry_21,Diversified Consumer Services
+crm_iap_mine_industry_22,Diversified Financial Services
+crm_iap_mine_industry_23,Diversified Telecommunication Services
+crm_iap_mine_industry_24,Education Services
+crm_iap_mine_industry_25,Electric Utilities
+crm_iap_mine_industry_26,Electrical Equipment
+crm_iap_mine_industry_27,"Electronic Equipment, Instruments & Components"
+crm_iap_mine_industry_28,Family Services
+crm_iap_mine_industry_29,Food & Staples Retailing
+crm_iap_mine_industry_30,Food Products
+crm_iap_mine_industry_31,Gas Utilities
+crm_iap_mine_industry_32,Health Care Equipment & Supplies
+crm_iap_mine_industry_33,Health Care Providers & Services
+crm_iap_mine_industry_34,"Hotels, Restaurants & Leisure"
+crm_iap_mine_industry_35,Household Durables
+crm_iap_mine_industry_36,IT Services
+crm_iap_mine_industry_37,Industrial Conglomerates
+crm_iap_mine_industry_38,Industrials
+crm_iap_mine_industry_39,Insurance
+crm_iap_mine_industry_40,Internet Software & Services
+crm_iap_mine_industry_41,Leisure Products
+crm_iap_mine_industry_42,Life Sciences Tools & Services
+crm_iap_mine_industry_43,Machinery
+crm_iap_mine_industry_44,Marine
+crm_iap_mine_industry_45,Media
+crm_iap_mine_industry_46,Metals & Mining
+crm_iap_mine_industry_47,Paper & Forest Products
+crm_iap_mine_industry_48,Personal Products
+crm_iap_mine_industry_49,Pharmaceuticals
+crm_iap_mine_industry_50,Professional Services
+crm_iap_mine_industry_51,Real Estate
+crm_iap_mine_industry_52,Renewable Electricity
+crm_iap_mine_industry_53,Retailing
+crm_iap_mine_industry_54,Road & Rail
+crm_iap_mine_industry_55,Semiconductors & Semiconductor Equipment
+crm_iap_mine_industry_56,Software
+crm_iap_mine_industry_57,Specialized Consumer Services
+crm_iap_mine_industry_58,Specialty Retail
+crm_iap_mine_industry_59,"Technology Hardware, Storage & Peripherals"
+crm_iap_mine_industry_60,"Textiles, Apparel & Luxury Goods"
+crm_iap_mine_industry_61,Tobacco
+crm_iap_mine_industry_62,Trading Companies & Distributors
+crm_iap_mine_industry_63,Transportation
+crm_iap_mine_industry_64,Utilities
+crm_iap_mine_industry_65,Wireless Telecommunication Services

--- a/addons/crm_iap_mine/models/crm_iap_lead_industry.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_industry.py
@@ -8,12 +8,10 @@ class CrmIapLeadIndustry(models.Model):
     """ Industry Tags of Acquisition Rules """
     _name = 'crm.iap.lead.industry'
     _description = 'CRM IAP Lead Industry'
-    _order = 'sequence,id'
+    _order = 'name'
 
     name = fields.Char(string='Industry', required=True, translate=True)
-    reveal_ids = fields.Char(required=True) # The list of reveal_ids for this industry, separated with ','
     color = fields.Integer(string='Color Index')
-    sequence = fields.Integer('Sequence')
 
     _sql_constraints = [
         ('name_uniq', 'unique (name)', 'Industry name already exists!'),

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -211,15 +211,9 @@ class CRMLeadMiningRequest(models.Model):
             payload.update({'company_size_min': self.company_size_min,
                             'company_size_max': self.company_size_max})
         if self.industry_ids:
-            # accumulate all reveal_ids (separated by ',') into one list
-            # eg: 3 records with values: "175,176", "177" and "190,191"
-            # will become ['175','176','177','190','191']
-            all_industry_ids = [
-                reveal_id.strip()
-                for reveal_ids in self.mapped('industry_ids.reveal_ids')
-                for reveal_id in reveal_ids.split(',')
-            ]
-            payload['industry_ids'] = all_industry_ids
+            # return a list of all industry names
+            payload['industry_names'] = self.industry_ids.mapped('name')
+
         if self.search_type == 'people':
             payload.update({'contact_number': self.contact_number,
                             'contact_filter_type': self.contact_filter_type})
@@ -259,7 +253,7 @@ class CRMLeadMiningRequest(models.Model):
             raise UserError(_("Your request could not be executed: %s", e))
 
     def _iap_contact_mining(self, params, timeout=300):
-        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/iap/clearbit/2/lead_mining_request'
+        endpoint = self.env['ir.config_parameter'].sudo().get_param('reveal.endpoint', DEFAULT_ENDPOINT) + '/api/directory/2/lead/mining_request'
         return iap_tools.iap_jsonrpc(endpoint, params=params, timeout=timeout)
 
     def _create_leads_from_response(self, result):

--- a/addons/website_crm_iap_reveal/__manifest__.py
+++ b/addons/website_crm_iap_reveal/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Lead Generation From Website Visits',
     'summary': 'Generate Leads/Opportunities from your website\'s traffic',
-    'version': '1.1',
+    'version': '1.2',
     'category': 'Sales/CRM',
     'depends': [
         'iap_crm',

--- a/addons/website_crm_iap_reveal/models/crm_reveal_rule.py
+++ b/addons/website_crm_iap_reveal/models/crm_reveal_rule.py
@@ -36,7 +36,7 @@ class CRMRevealRule(models.Model):
                                    'Rules with a lower sequence number will be processed first.')
 
     # Company Criteria Filter
-    industry_tag_ids = fields.Many2many('crm.iap.lead.industry', string='Industries', help='Leave empty to always match. Odoo will not create lead if no match')
+    industry_ids = fields.Many2many('crm.iap.lead.industry', string='Industries', help='Leave empty to always match. Odoo will not create lead if no match')
     filter_on_size = fields.Boolean(string="Filter on Size", default=True, help="Filter companies based on their size.")
     company_size_min = fields.Integer(string='Company Size', default=0)
     company_size_max = fields.Integer(default=1000)
@@ -284,14 +284,7 @@ class CRMRevealRule(models.Model):
         company_country = self.env.company.country_id
         rule_payload = {}
         for rule in self:
-            # accumulate all reveal_ids (separated by ',') into one list
-            # eg: 3 records with values: "175,176", "177" and "190,191"
-            # will become ['175','176','177','190','191']
-            reveal_ids = [
-                reveal_id.strip()
-                for reveal_ids in rule.mapped('industry_tag_ids.reveal_ids')
-                for reveal_id in reveal_ids.split(',')
-            ]
+            industry_names = self.industry_ids.mapped('name')
             data = {
                 'rule_id': rule.id,
                 'lead_for': rule.lead_for,
@@ -299,7 +292,7 @@ class CRMRevealRule(models.Model):
                 'filter_on_size': rule.filter_on_size,
                 'company_size_min': rule.company_size_min,
                 'company_size_max': rule.company_size_max,
-                'industry_tags': reveal_ids,
+                'industry_names': industry_names,
                 'user_country': company_country and company_country.code or False
             }
             if rule.lead_for == 'people':

--- a/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
+++ b/addons/website_crm_iap_reveal/tests/test_lead_reveal.py
@@ -14,7 +14,7 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
         super(TestLeadMine, cls).setUpClass()
         cls.registry.enter_test_mode(cls.cr)
 
-        cls.test_industry_tags = cls.env.ref('crm_iap_mine.crm_iap_mine_industry_33') + cls.env.ref('crm_iap_mine.crm_iap_mine_industry_148')
+        cls.test_industry_ids = cls.env.ref('crm_iap_mine.crm_iap_mine_industry_33') + cls.env.ref('crm_iap_mine.crm_iap_mine_industry_8')
         cls.test_roles = cls.env.ref('crm_iap_mine.crm_iap_mine_role_11') + cls.env.ref('crm_iap_mine.crm_iap_mine_role_19')
         cls.test_seniority = cls.env.ref('crm_iap_mine.crm_iap_mine_seniority_2')
 
@@ -25,7 +25,7 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
         cls.test_request_1 = cls.env['crm.reveal.rule'].create({
             'contact_filter_type': 'role',
             'extra_contacts': 3,
-            'industry_tag_ids': cls.test_industry_tags.ids,
+            'industry_ids': cls.test_industry_ids.ids,
             'lead_for': 'people',
             'lead_type': 'lead',
             'name': 'Test Reveal People',
@@ -40,7 +40,7 @@ class TestLeadMine(TestCrmCommon, MockIAPReveal):
         })
         cls.test_request_2 = cls.env['crm.reveal.rule'].create({
             'contact_filter_type': 'role',
-            'industry_tag_ids': cls.test_industry_tags.ids,
+            'industry_ids': cls.test_industry_ids.ids,
             'lead_for': 'companies',
             'lead_type': 'opportunity',
             'name': 'Test Reveal Companies',

--- a/addons/website_crm_iap_reveal/views/crm_reveal_views.xml
+++ b/addons/website_crm_iap_reveal/views/crm_reveal_views.xml
@@ -52,7 +52,7 @@
                     </div>
                     <group>
                         <group string="Opportunity Generation Conditions">
-                            <field name="industry_tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True, 'no_quick_create': True}"/>
+                            <field name="industry_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True, 'no_quick_create': True}"/>
                             <field name="filter_on_size"/>
                             <label for="company_size_min" invisible="not filter_on_size"/>
                             <div invisible="not filter_on_size">


### PR DESCRIPTION
The values used in the industry to obtain lead generations did not align with those of our provider. This posed a problem, as it meant that some queries inevitably returned zero leads.

Description of the issue/feature this PR addresses:
When a lead mining request was made using the lead generation tool, several industry categories returned no results when selected, even for countries such as the USA.

Current behavior before PR:
The user's query returned industry ids that did not match up correctly with the keywords used in the lead search.

Desired behavior after PR is merged:
Now users will be able to choose their industry from a revised list. In addition, the query sent will now contain the name of the industry rather than an id.

Linked to the following Upgrade PR : https://github.com/odoo/upgrade/pull/5150
Linked to the following IAP PR : https://github.com/odoo/iap-apps/pull/696
Task ID : 3349531

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
