### PR TITLE
[FIX] base: prevent from updating sequence's company

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -28143,6 +28143,14 @@ msgid ""
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_sequence.py:0
+#, python-format
+msgid ""
+"You can not change the company of an existing sequence. Please create a new "
+"one instead."
+msgstr ""
+
+#. module: base
 #: code:addons/base/models/res_partner.py:0
 #, python-format
 msgid "You can not create recursive tags."

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -164,6 +164,8 @@ class IrSequence(models.Model):
         return super(IrSequence, self).unlink()
 
     def write(self, values):
+        if values.get('company_id') and any(seq.company_id.id != values['company_id'] for seq in self):
+            raise UserError(_('You can not change the company of an existing sequence. Please create a new one instead.'))
         new_implementation = values.get('implementation')
         for seq in self:
             # 4 cases: we test the previous impl. against the new one.


### PR DESCRIPTION
We should not change the company of an existing sequence. Else, it
could lead to some inconsistencies: suppose a record that belongs to
company C01 and has a sequence S. It would mean that the user can
set the company of S to C02.

It should only be possible to remove the company of such sequence.

OPW-3501199