### PR TITLE
[FIX] sale(_timesheet): take super's domain into account for aal.so_line

### DIFF
--- a/addons/sale/models/analytic.py
+++ b/addons/sale/models/analytic.py
@@ -7,13 +7,20 @@ from odoo import fields, models
 class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
 
+    allowed_so_line_ids = fields.Many2many('sale.order.line', compute='_compute_allowed_so_line_ids')
+    so_line = fields.Many2one('sale.order.line', string='Sales Order Item', domain="[('id', 'in', allowed_so_line_ids)]")
+
     def _default_sale_line_domain(self):
         """ This is only used for delivered quantity of SO line based on analytic line, and timesheet
             (see sale_timesheet). This can be override to allow further customization.
         """
+        self.ensure_one()
         return [('qty_delivered_method', '=', 'analytic')]
 
-    so_line = fields.Many2one('sale.order.line', string='Sales Order Item', domain=lambda self: self._default_sale_line_domain())
+    def _compute_allowed_so_line_ids(self):
+        for timesheet in self:
+            domain = timesheet._default_sale_line_domain()
+            timesheet.allowed_so_line_ids = self.env['sale.order.line'].search(domain)
 
 
 class AccountAnalyticApplicability(models.Model):

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -21,21 +21,28 @@ TIMESHEET_INVOICE_TYPES = [
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
-    def _default_sale_line_domain(self):
-        domain = super(AccountAnalyticLine, self)._default_sale_line_domain()
-        return expression.OR([domain, [('qty_delivered_method', '=', 'timesheet')]])
-
     timesheet_invoice_type = fields.Selection(TIMESHEET_INVOICE_TYPES, string="Billable Type",
             compute='_compute_timesheet_invoice_type', compute_sudo=True, store=True, readonly=True)
     commercial_partner_id = fields.Many2one('res.partner', compute="_compute_commercial_partner")
     timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet")
     so_line = fields.Many2one(compute="_compute_so_line", store=True, readonly=False,
-        domain="[('is_service', '=', True), ('is_expense', '=', False), ('state', '=', 'sale'), ('order_partner_id', 'child_of', commercial_partner_id)]",
         help="Sales order item to which the time spent will be added in order to be invoiced to your customer. Remove the sales order item for the timesheet entry to be non-billable.")
     # we needed to store it only in order to be able to groupby in the portal
     order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=True, index=True)
     is_so_line_edited = fields.Boolean("Is Sales Order Item Manually Edited")
     allow_billable = fields.Boolean(related="project_id.allow_billable")
+
+    def _default_sale_line_domain(self):
+        return expression.OR([[
+            ('is_service', '=', True),
+            ('is_expense', '=', False),
+            ('state', '=', 'sale'),
+            ('order_partner_id', 'child_of', self.commercial_partner_id.ids)
+        ], super()._default_sale_line_domain()])
+
+    @api.depends('commercial_partner_id')
+    def _compute_allowed_so_line_ids(self):
+        super()._compute_allowed_so_line_ids()
 
     @api.depends('project_id.partner_id.commercial_partner_id', 'task_id.partner_id.commercial_partner_id')
     def _compute_commercial_partner(self):

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -42,6 +42,7 @@
                 <field name="commercial_partner_id" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="allow_billable" column_invisible="True" groups="sales_team.group_sale_salesman"/>
+                <field name="allowed_so_line_ids" invisible="1"/>
                 <field name="so_line" widget="so_line_field" optional="show" options="{'no_create': True, 'no_open': True}" context="{'create': False, 'edit': False, 'delete': False}" invisible="not allow_billable" readonly="readonly_timesheet" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
@@ -56,6 +57,7 @@
                 <field name="commercial_partner_id" invisible="1" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" invisible="1" groups="sales_team.group_sale_salesman"/>
                 <field name="allow_billable" invisible="1" groups="sales_team.group_sale_salesman"/>
+                <field name="allowed_so_line_ids" invisible="1"/>
                 <field name="so_line" widget="so_line_field" options='{"no_create": True}' context="{'create': False, 'edit': False, 'delete': False, 'with_price_unit': True}" invisible="not allow_billable" readonly="readonly_timesheet" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
             <xpath expr="//group" position="before">


### PR DESCRIPTION
The model `account.analytic.line` has a field `so_line`. In module `sale`, this field has a domain, which is defined in `_default_sale_line_domain()`.

In module `sale_timesheet`, we override the method to add another condition to super's.

The issue is that we also add the arg `dommain=...`, in the field definition, which totally overrides both methods.

Moreover, it is impossible to just move that domain in the method, because it has to depend on `self.commercial_partner_id`, but the method is static.

The solution is to:
- Keep `_default_sale_line_domain()` in both modules, but not call it directly from the field.
- Create a new compute field (`allowed_so_line_ids`), to determine all allowed so_lines,
following the domain that is returned by those methods. The compute method will call the domain method on instances, which allows us to get their `commercial_partner_id`.
- Replace the domain arg of `so_line` by `[('id', 'in', allowed_so_line_ids)]`.

task-3507195




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
