### PR TITLE
[IMP] point_of_sale: copy combo lines on duplicating a combo

### DIFF
--- a/addons/point_of_sale/models/pos_combo.py
+++ b/addons/point_of_sale/models/pos_combo.py
@@ -20,7 +20,7 @@ class PosCombo(models.Model):
     _description = "Product combo choices"
 
     name = fields.Char(string="Name", required=True)
-    combo_line_ids = fields.One2many("pos.combo.line", "combo_id", string="Products in Combo")
+    combo_line_ids = fields.One2many("pos.combo.line", "combo_id", string="Products in Combo", copy=True)
     num_of_products = fields.Integer("No of Products", compute="_compute_num_of_products")
 
     @api.depends("combo_line_ids")


### PR DESCRIPTION
before this commit, on duplicating a combo product, the combo lines are not copied to new records

after this commit, the combo lines will get copied during the duplicate


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
