### PR TITLE
[FIX] web: fix profiling to show stats again

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_qweb.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_qweb.js
@@ -23,9 +23,12 @@ export class ProfilingQwebView extends Component {
         this.ace = useRef("ace");
         this.selector = useRef("selector");
 
-        for (const line of this.profile.data) {
+        let data = JSON.parse(this.props.value);
+        for (const line of data[0].results.data) {
             line.xpath = line.xpath.replace(/([^\]])\//g, "$1[1]/").replace(/([^\]])$/g, "$1[1]");
         }
+        this.props.value = JSON.stringify(data);
+
         this.state = useState({
             viewID: this.profile.data.length ? this.profile.data[0].view_id : 0,
             view: null,


### PR DESCRIPTION
Since the refactoring to owl, the stats in the left zone were not shown anymore and the hover was missing.

This was because the method that fixes the xpath to match line by line the qweb, was done on a getter and not on the data itself.

Now we replace in the prop value, from this way, in every place we use the getter, we have fixed the data with the xpath.

/t/div -> /t[1]/div[1]

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
