### PR TITLE
[FIX] web_editor: fix dropdown not visible after opening

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1090,11 +1090,25 @@ const SelectUserValueWidget = BaseSelectionUserValueWidget.extend({
 
         if (!this.menuTogglerEl.classList.contains('active')) {
             this.open();
+            const menuElBottomPosition = this.menuEl.getBoundingClientRect().bottom;
+            const snippetsPanelEl = this.menuEl.closest("#oe_snippets");
+            if (!snippetsPanelEl) {
+                return;
+            }
+            // If after opening, the dropdown list overflows the customization
+            // panel at the bottom, scroll the customization panel so that the
+            // dropdown is completely visible.
+            if (menuElBottomPosition > snippetsPanelEl.offsetHeight) {
+                const customizePanelEl = this.menuEl.closest(".o_we_customize_panel");
+                customizePanelEl.scrollTop += menuElBottomPosition - snippetsPanelEl.offsetHeight;
+            }
         } else {
             this.close();
         }
         const activeButton = this._userValueWidgets.find(widget => widget.isActive());
         if (activeButton) {
+            // Useful when the dropdown has a vertical scrollbar => scroll to
+            // the active button.
             this.menuEl.scrollTop = activeButton.el.offsetTop - (this.menuEl.offsetHeight / 2);
         }
     },


### PR DESCRIPTION
Whenever an option is at the bottom of the right panel and displays a dropdown to select an option, it's kind of opening off screen, you then actually need to scroll down to see the dropdown.

After this commit, it will automatically scroll down to ensure the dropdown menu is fully visible, so the user won't have to scroll manually.

task-3500768