### PR TITLE
[FIX] mail: fix activity view pager

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -578,13 +578,13 @@ class MailActivity(models.Model):
     @api.model
     def get_activity_data(self, res_model, domain, limit=None, offset=0):
         activity_domain = [('res_model', '=', res_model)]
-        if domain:
-            res = self.env[res_model].search(domain)
+        if domain or limit or offset:
+            res = self.env[res_model].search(domain or [], limit=limit, offset=offset)
             activity_domain.append(('res_id', 'in', res.ids))
         grouped_activities = self.env['mail.activity']._read_group(
             activity_domain,
             ['res_id', 'activity_type_id'],
-            ['id:array_agg', 'date_deadline:min', '__count'], limit=limit, offset=offset)
+            ['id:array_agg', 'date_deadline:min', '__count'])
         # filter out unreadable records
         if not domain:
             res_ids = tuple(res_id for res_id, *_ in grouped_activities)

--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -47,8 +47,7 @@ export class ActivityController extends Component {
                 limit: limit,
                 total: count,
                 onUpdate: async (params) => {
-                    await this.model.root.load(params);
-                    this.model.fetchActivityData(params);
+                    await Promise.all([this.model.root.load(params), this.model.fetchActivityData(params)]);
                 },
                 updateTotal: hasLimitedCount ? () => this.model.root.fetchCount() : undefined,
             };

--- a/addons/mail/static/src/views/web/activity/activity_model.js
+++ b/addons/mail/static/src/views/web/activity/activity_model.js
@@ -11,14 +11,11 @@ export class ActivityModel extends RelationalModel {
         if (params && "groupBy" in params) {
             params.groupBy = [];
         }
-        const prom = this.fetchActivityData(params).then((data) => {
-            this.activityData = data;
-        });
-        await Promise.all([prom, super.load(params)]);
+        await Promise.all([this.fetchActivityData(params), super.load(params)]);
     }
 
-    fetchActivityData(params) {
-        return this.orm.call("mail.activity", "get_activity_data", [], {
+    async fetchActivityData(params) {
+        this.activityData = await this.orm.call("mail.activity", "get_activity_data", [], {
             res_model: this.config.resModel,
             domain: params.domain || this.env.searchModel._domain,
             limit: params.limit || this.initialLimit,

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_activity.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_activity.js
@@ -24,7 +24,9 @@ patch(MockServer.prototype, {
         if (args.model === "mail.activity" && args.method === "get_activity_data") {
             const res_model = args.args[0] || args.kwargs.res_model;
             const domain = args.args[1] || args.kwargs.domain;
-            return this._mockMailActivityGetActivityData(res_model, domain);
+            const limit = args[2] || args.kwargs.limit || 0;
+            const offset = args[3] || args.kwargs.offset || 0;
+            return this._mockMailActivityGetActivityData(res_model, domain, limit, offset);
         }
         return super._performRPC(route, args);
     },
@@ -112,11 +114,14 @@ patch(MockServer.prototype, {
      * @private
      * @param {string} res_model
      * @param {string} domain
+     * @param {number} limit
+     * @param {number} offset
      * @returns {Object}
      */
-    _mockMailActivityGetActivityData(res_model, domain) {
+    _mockMailActivityGetActivityData(res_model, domain, limit = 0, offset = 0) {
         const self = this;
-        const records = this.getRecords(res_model, domain);
+        const allRecords = this.getRecords(res_model, domain);
+        const records = limit ? allRecords.slice(offset, offset + limit) : allRecords;
 
         const activityTypes = this.getRecords("mail.activity.type", []);
         const activityIds = records.map((x) => x.activity_ids).flat();


### PR DESCRIPTION
This solves the following problem:
- Add 150 records with 2 activities each (ex. A call and a to do)
- Go to the activity view (ex.: event through the systray) and clear filter
- Only 50 of the 150 records are displayed (instead of 100)
- Going to the next page, only 2 are displayed (instead of ~50) (will depends
on the data already present)

Technical notes:
Not all activities were displayed because the search limit was applied on the
activity search instead of searching all activity related to the records.

The method fetchActivityData was doing half of the job because it was not
assigning the activity data fetch on the server to the instance variable
activityData, which was causing strange behavior when clicking on next page. To
simplify and correct the code, that logic has been moved to that method instead
of relying on the caller to do that assignation.

Task-3508744