### PR TITLE
[IMP] l10n_{}: redirect to own documentation

### DIFF
--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Brazilian - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/brazil.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['br'],
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_hk/__manifest__.py
+++ b/addons/l10n_hk/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Hong Kong - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/hong_kong.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['hk'],
     'version': '1.0',

--- a/addons/l10n_ph/__manifest__.py
+++ b/addons/l10n_ph/__manifest__.py
@@ -9,7 +9,7 @@
     'category': 'Accounting/Localizations/Account Charts',
     'version': '1.0',
     'author': 'Odoo PS',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/philippines.html',
     'depends': [
         'account',
         'base_vat',

--- a/addons/l10n_ro/__manifest__.py
+++ b/addons/l10n_ro/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Romania - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/romania.html',
     'author': 'Fekete Mihai (NextERP Romania SRL), Odoo S.A.',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ro'],

--- a/addons/l10n_sa/__manifest__.py
+++ b/addons/l10n_sa/__manifest__.py
@@ -9,7 +9,7 @@
     'description': """
 Odoo Arabic localization for most Saudi Arabia.
 """,
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/saudi_arabia.html',
     'depends': [
         'l10n_gcc_invoice',
         'account',

--- a/addons/l10n_sg/__manifest__.py
+++ b/addons/l10n_sg/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'Singapore - Accounting',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/singapore.html',
     'icon': '/account/static/description/l10n.png',
     'countries': ['sg'],
     'author': 'Tech Receptives',

--- a/addons/l10n_th/__manifest__.py
+++ b/addons/l10n_th/__manifest__.py
@@ -12,7 +12,7 @@ Chart of Accounts for Thailand.
 Thai accounting chart and localization.
     """,
     'author': 'Almacom (http://almacom.co.th/)',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/thailand.html',
     'depends': [
         'account_qr_code_emv',
     ],

--- a/addons/l10n_vn/__manifest__.py
+++ b/addons/l10n_vn/__manifest__.py
@@ -5,7 +5,7 @@
     'countries': ['vn'],
     'version': '2.0.1',
     'author': 'General Solutions',
-    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations/vietnam.html',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
 This is the module to manage the accounting chart, bank information for Vietnam in Odoo.


### PR DESCRIPTION
before this commit, the website link given to
l10n module was generic link of fiscal
localization.

after this commit, on clicking website/learn more
user will be redirected to documentation of specific country localization.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
