### PR TITLE
[FIX] stock: Display the right destination partner on inter-warehouse transfer

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -326,6 +326,7 @@ class Picking(models.Model):
         default=lambda self: self.env['stock.picking.type'].browse(self._context.get('default_picking_type_id')).default_location_dest_id,
         check_company=True, readonly=True, required=True,
         states={'draft': [('readonly', False)]})
+    location_dest_partner_id = fields.Many2one('res.partner', compute='_compute_location_dest_partner_id')
     move_lines = fields.One2many('stock.move', 'picking_id', string="Stock Moves", copy=True)
     move_ids_without_package = fields.One2many('stock.move', 'picking_id', string="Stock moves not in package", compute='_compute_move_without_package', inverse='_set_move_without_package')
     has_scrap_move = fields.Boolean(
@@ -628,6 +629,10 @@ class Picking(models.Model):
             return
         for picking in self:
             picking.show_allocation = picking._get_show_allocation(picking.picking_type_id)
+
+    def _compute_location_dest_partner_id(self):
+        for picking in self:
+            picking.location_dest_partner_id = picking.location_dest_id.company_id.partner_id or picking.partner_id
 
     def _get_show_allocation(self, picking_type_id):
         """ Helper method for computing "show_allocation" value.

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -235,6 +235,7 @@
                 <field name="has_packages" invisible="1"/>
                 <field name="picking_type_entire_packs" invisible="1"/>
                 <field name="use_create_lots" invisible="1"/>
+                <field name="partner_id" invisible="1"/>
 
                 <header>
                     <button name="action_confirm" attrs="{'invisible': [('show_mark_as_todo', '=', False)]}" string="Mark as Todo" type="object" class="oe_highlight" groups="base.group_user" data-hotkey="x"/>
@@ -298,14 +299,14 @@
                     <group>
                         <group>
                             <div class="o_td_label">
-                                <label for="partner_id" string="Delivery Address" style="font-weight:bold;"
+                                <label for="location_dest_partner_id" string="Delivery Address" style="font-weight:bold;"
                                        attrs="{'invisible': [('picking_type_code', '!=', 'outgoing')]}"/>
-                                <label for="partner_id" string="Receive From" style="font-weight:bold;"
+                                <label for="location_dest_partner_id" string="Receive From" style="font-weight:bold;"
                                        attrs="{'invisible': [('picking_type_code', '!=', 'incoming')]}"/>
-                                <label for="partner_id" string="Contact" style="font-weight:bold;"
+                                <label for="location_dest_partner_id" string="Contact" style="font-weight:bold;"
                                        attrs="{'invisible': [('picking_type_code', 'in', ['incoming', 'outgoing'])]}"/>
                             </div>
-                            <field name="partner_id" nolabel="1"/>
+                            <field name="location_dest_partner_id" nolabel="1"/>
                             <field name="picking_type_id" attrs="{'invisible': [('hide_picking_type', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
                             <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('picking_type_code', '=', 'incoming')]}"/>
                             <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" attrs="{'invisible': [('picking_type_code', '=', 'outgoing')]}"/>


### PR DESCRIPTION
### Steps
- Unarchive the 'Replenish on Order (MTO)' route.
- Create a second warehouse and enable 'Buy to Resupply' and 'Resupply from'.
- Create a product with 'Replenish on Order (MTO)' and '<Second warehouse> : Supply Product from <First warehouse>' routes enabled.
- Create a quotation on the product and in 'other info' change the warehouse to the second one.
- Confirm the quotation, 3 transfers will be created.

### Issue
When opening the inter-warehouse transfers of the sale order, the Delivery address is set to the partner of the sale order.

### Reason 
On the stock.picking.form view it's the partner of the transfer which is always used however it's an inter-warehouse transfer or not.

### Solution
Create a computed field(so it can be deployed on stable) to compute the partner of the destination location. when it's a inter warehouse transfer it will point to the partner of that ``stock.location`` or the partner of the transfer.

opw-3484436