### PR TITLE
[ADD] project_todo: Add default 'reminder' action for 'todo' category…

### DIFF
--- a/addons/project_todo/data/mail_activity_type_data.xml
+++ b/addons/project_todo/data/mail_activity_type_data.xml
@@ -8,5 +8,8 @@
             <field name="delay_count">0</field>
             <field name="sequence">20</field>
         </record>
+        <record id="mail.mail_activity_data_todo" model="mail.activity.type">
+            <field name="category">reminder</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
… type

Before this PR, when we set the activity type to 'todo' in our project, the default action was set to 'none.' This configuration made the 'todo' category type less intuitive and less useful.

In this PR, we have improved the default behavior. Now, when you select the 'todo' category type, it will automatically have the 'reminder' action assigned by default. This change enhances user experience and ensures that 'todo' items have a meaningful default action.

task-3500700

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
