### PR TITLE
[IMP] l10n_lu: use sections in the tax report

### DIFF
--- a/addons/l10n_lu/__manifest__.py
+++ b/addons/l10n_lu/__manifest__.py
@@ -28,7 +28,10 @@ Notes:
     ],
     'data': [
         'data/l10n_lu_chart_data.xml',
-        'data/account_tax_report_line.xml',
+        'data/tax_report/section_1.xml',
+        'data/tax_report/section_2.xml',
+        'data/tax_report/sections_34.xml',
+        'data/tax_report/tax_report.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_lu/data/tax_report/section_1.xml
+++ b/addons/l10n_lu/data/tax_report/section_1.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="l10n_lu_tax_report_section_1" model="account.report">
+        <field name="name">Section I</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.lu"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_report_section_1_balance" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="l10n_lu_tax_report_assessment_turnover" model="account.report.line">
+                <field name="name">I. ASSESSMENT OF TAXABLE TURNOVER</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_line_1a_overall_turnover" model="account.report.line">
+                        <field name="name">012 - Overall turnover</field>
+                        <field name="code">LUTAX_012</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="aggregation_formula">LUTAX_454.balance + LUTAX_455.balance + LUTAX_456.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_line_1a_total_sale" model="account.report.line">
+                                <field name="name">454 - Total Sales / Receipts</field>
+                                <field name="code">LUTAX_454</field>
+                                <field name="aggregation_formula">LUTAX_471.balance + LUTAX_472.balance</field>
+                                <field name="children_ids">
+                                    <record id="account_tax_report_line_1a_telecom_service" model="account.report.line">
+                                        <field name="name">471 - Telecommunications services, radio and television broadcasting services...</field>
+                                        <field name="code">LUTAX_471</field>
+                                        <field name="expression_ids">
+                                            <record id="account_tax_report_line_1a_telecom_service_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">tax_tags</field>
+                                                <field name="formula">471</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="account_tax_report_line_1a_other_sales" model="account.report.line">
+                                        <field name="name">472 - Other sales / receipts</field>
+                                        <field name="code">LUTAX_472</field>
+                                        <field name="expression_ids">
+                                            <record id="account_tax_report_line_1a_other_sales_balance" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">aggregation</field>
+                                                <field name="formula">LUTAX_021.balance + LUTAX_022.balance - LUTAX_456.balance - LUTAX_455.balance - LUTAX_471.balance</field>
+                                                <field name="subformula">cross_report</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1a_app_goods_non_bus" model="account.report.line">
+                                <field name="name">455 - Application of goods for non-business use and for business purposes</field>
+                                <field name="code">LUTAX_455</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1a_app_goods_non_bus_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">455</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1a_non_bus_gs" model="account.report.line">
+                                <field name="name">456 - Non-business use of goods and supply of services free of charge</field>
+                                <field name="code">LUTAX_456</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1a_non_bus_gs_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">456</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_1b_exemptions_deductible_amounts" model="account.report.line">
+                        <field name="name">021 - Exemptions and deductible amounts</field>
+                        <field name="code">LUTAX_021</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="aggregation_formula">LUTAX_014.balance + LUTAX_457.balance + LUTAX_015.balance + LUTAX_016.balance + LUTAX_017.balance + LUTAX_018.balance + LUTAX_423.balance + LUTAX_424.balance + LUTAX_226.balance + LUTAX_019.balance + LUTAX_419.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat" model="account.report.line">
+                                <field name="name">457 - Intra-Community supply of goods to persons identified for VAT purposes in another Member State (MS)</field>
+                                <field name="code">LUTAX_457</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">457</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_2_export" model="account.report.line">
+                                <field name="name">014 - Exports</field>
+                                <field name="code">LUTAX_014</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_2_export_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">014</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_3_other_exemptions_art_43" model="account.report.line">
+                                <field name="name">015 - Other exemptions</field>
+                                <field name="code">LUTAX_015</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_3_other_exemptions_art_43_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">015</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater" model="account.report.line">
+                                <field name="name">016 - Other exemptions</field>
+                                <field name="code">LUTAX_016</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">016</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_5_manufactured_tobacco_vat_collected" model="account.report.line">
+                                <field name="name">017 - Manufactured tobacco whose VAT was collected at the source or at the exit of the tax...</field>
+                                <field name="code">LUTAX_017</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_5_manufactured_tobacco_vat_collected_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">017</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_a_subsequent_to_intra_community" model="account.report.line">
+                                <field name="name">018 - Supply, subsequent to intra-Community acquisitions of goods, in the context of triangular transactions, when the customer identified,...</field>
+                                <field name="code">LUTAX_018</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_6_a_subsequent_to_intra_community_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">018</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_b1_non_exempt_customer_vat" model="account.report.line">
+                                <field name="name">423 - not exempt in the MS where the customer is liable for payment of VAT</field>
+                                <field name="code">LUTAX_423</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_6_b1_non_exempt_customer_vat_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">423</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_b2_exempt_ms_customer" model="account.report.line">
+                                <field name="name">424 - exempt in the MS where the customer is identified</field>
+                                <field name="code">LUTAX_424</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_6_b2_exempt_ms_customer_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">424</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement" model="account.report.line">
+                                <field name="name">226 - Supplies carried out within the scope of the special arrangement of art. 56sexies</field>
+                                <field name="code">LUTAX_226</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">226</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_6_d_supplies_other_referred" model="account.report.line">
+                                <field name="name">019 - Supplies other than referred to in 018 and 423 or 424</field>
+                                <field name="code">LUTAX_019</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_6_d_supplies_other_referred_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">019</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_1b_7_inland_supplies_for_customer" model="account.report.line">
+                                <field name="name">419 - Inland supplies for which the customer is liable for the payment of VAT</field>
+                                <field name="code">LUTAX_419</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_1b_7_inland_supplies_for_customer_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">419</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_1c_taxable_turnover" model="account.report.line">
+                        <field name="name">022 - Taxable turnover</field>
+                        <field name="code">LUTAX_022</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_line_1c_taxable_turnover_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">LUTAX_037.balance</field>
+                                <field name="subformula">cross_report</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_lu/data/tax_report/section_2.xml
+++ b/addons/l10n_lu/data/tax_report/section_2.xml
@@ -1,211 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo auto_sequence="1">
-    <record id="tax_report" model="account.report">
-        <field name="name">Tax Report</field>
-        <field name="root_report_id" ref="account.generic_tax_report"/>
+    <record id="l10n_lu_tax_report_section_2" model="account.report">
+        <field name="name">Section II</field>
+        <field name="sequence">2</field>
         <field name="country_id" ref="base.lu"/>
-        <field name="filter_fiscal_position" eval="True"/>
         <field name="availability_condition">country</field>
         <field name="column_ids">
-            <record id="tax_report_balance" model="account.report.column">
+            <record id="tax_report_section_2_balance" model="account.report.column">
                 <field name="name">Balance</field>
                 <field name="expression_label">balance</field>
             </record>
         </field>
         <field name="line_ids">
-            <record id="account_tax_report_line_1_assessment_taxable_turnover" model="account.report.line">
-                <field name="name">I. ASSESSMENT OF TAXABLE TURNOVER</field>
-                <field name="hierarchy_level">0</field>
-                <field name="children_ids">
-                    <record id="account_tax_report_line_1a_overall_turnover" model="account.report.line">
-                        <field name="name">012 - Overall turnover</field>
-                        <field name="code">LUTAX_012</field>
-                        <field name="aggregation_formula">LUTAX_454.balance + LUTAX_455.balance + LUTAX_456.balance</field>
-                        <field name="children_ids">
-                            <record id="account_tax_report_line_1a_total_sale" model="account.report.line">
-                                <field name="name">454 - Total Sales / Receipts</field>
-                                <field name="code">LUTAX_454</field>
-                                <field name="aggregation_formula">LUTAX_471.balance + LUTAX_472.balance</field>
-                                <field name="children_ids">
-                                    <record id="account_tax_report_line_1a_telecom_service" model="account.report.line">
-                                        <field name="name">471 - Telecommunications services, radio and television broadcasting services...</field>
-                                        <field name="code">LUTAX_471</field>
-                                        <field name="expression_ids">
-                                            <record id="account_tax_report_line_1a_telecom_service_tag" model="account.report.expression">
-                                                <field name="label">balance</field>
-                                                <field name="engine">tax_tags</field>
-                                                <field name="formula">471</field>
-                                            </record>
-                                        </field>
-                                    </record>
-                                    <record id="account_tax_report_line_1a_other_sales" model="account.report.line">
-                                        <field name="name">472 - Other sales / receipts</field>
-                                        <field name="code">LUTAX_472</field>
-                                        <field name="aggregation_formula">LUTAX_021.balance + LUTAX_037.balance - LUTAX_456.balance - LUTAX_455.balance - LUTAX_471.balance</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1a_app_goods_non_bus" model="account.report.line">
-                                <field name="name">455 - Application of goods for non-business use and for business purposes</field>
-                                <field name="code">LUTAX_455</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1a_app_goods_non_bus_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">455</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1a_non_bus_gs" model="account.report.line">
-                                <field name="name">456 - Non-business use of goods and supply of services free of charge</field>
-                                <field name="code">LUTAX_456</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1a_non_bus_gs_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">456</field>
-                                    </record>
-                                </field>
-                            </record>
-                        </field>
-                    </record>
-                    <record id="account_tax_report_line_1b_exemptions_deductible_amounts" model="account.report.line">
-                        <field name="name">021 - Exemptions and deductible amounts</field>
-                        <field name="code">LUTAX_021</field>
-                        <field name="aggregation_formula">LUTAX_014.balance + LUTAX_457.balance + LUTAX_015.balance + LUTAX_016.balance + LUTAX_017.balance + LUTAX_018.balance + LUTAX_423.balance + LUTAX_424.balance + LUTAX_226.balance + LUTAX_019.balance + LUTAX_419.balance</field>
-                        <field name="children_ids">
-                            <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat" model="account.report.line">
-                                <field name="name">457 - Intra-Community supply of goods to persons identified for VAT purposes in another Member State (MS)</field>
-                                <field name="code">LUTAX_457</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_1_intra_community_goods_pi_vat_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">457</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_2_export" model="account.report.line">
-                                <field name="name">014 - Exports</field>
-                                <field name="code">LUTAX_014</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_2_export_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">014</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_3_other_exemptions_art_43" model="account.report.line">
-                                <field name="name">015 - Other exemptions</field>
-                                <field name="code">LUTAX_015</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_3_other_exemptions_art_43_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">015</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater" model="account.report.line">
-                                <field name="name">016 - Other exemptions</field>
-                                <field name="code">LUTAX_016</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">016</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_5_manufactured_tobacco_vat_collected" model="account.report.line">
-                                <field name="name">017 - Manufactured tobacco whose VAT was collected at the source or at the exit of the tax...</field>
-                                <field name="code">LUTAX_017</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_5_manufactured_tobacco_vat_collected_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">017</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_6_a_subsequent_to_intra_community" model="account.report.line">
-                                <field name="name">018 - Supply, subsequent to intra-Community acquisitions of goods, in the context of triangular transactions, when the customer identified,...</field>
-                                <field name="code">LUTAX_018</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_6_a_subsequent_to_intra_community_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">018</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_6_b1_non_exempt_customer_vat" model="account.report.line">
-                                <field name="name">423 - not exempt in the MS where the customer is liable for payment of VAT</field>
-                                <field name="code">LUTAX_423</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_6_b1_non_exempt_customer_vat_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">423</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_6_b2_exempt_ms_customer" model="account.report.line">
-                                <field name="name">424 - exempt in the MS where the customer is identified</field>
-                                <field name="code">LUTAX_424</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_6_b2_exempt_ms_customer_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">424</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement" model="account.report.line">
-                                <field name="name">226 - Supplies carried out within the scope of the special arrangement of art. 56sexies</field>
-                                <field name="code">LUTAX_226</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_6_c_supplies_scope_special_arrangement_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">226</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_6_d_supplies_other_referred" model="account.report.line">
-                                <field name="name">019 - Supplies other than referred to in 018 and 423 or 424</field>
-                                <field name="code">LUTAX_019</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_6_d_supplies_other_referred_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">019</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_1b_7_inland_supplies_for_customer" model="account.report.line">
-                                <field name="name">419 - Inland supplies for which the customer is liable for the payment of VAT</field>
-                                <field name="code">LUTAX_419</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_1b_7_inland_supplies_for_customer_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">419</field>
-                                    </record>
-                                </field>
-                            </record>
-                        </field>
-                    </record>
-                    <record id="account_tax_report_line_1c_taxable_turnover" model="account.report.line">
-                        <field name="name">022 - Taxable turnover</field>
-                        <field name="code">LUTAX_022</field>
-                        <field name="aggregation_formula">LUTAX_037.balance</field>
-                    </record>
-                </field>
-            </record>
-            <record id="account_tax_report_line_2_assesment_of_tax_due" model="account.report.line">
-                <field name="name">II. ASSESSMENT OF TAX DUE (output tax)</field>
+            <record id="l10n_lu_tax_report_assessment_tax_due" model="account.report.line">
+                <field name="name">II. ASSESSMENT OF TAX DUE</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <record id="account_tax_report_line_2a_breakdown_taxable_turnover_base" model="account.report.line">
@@ -216,6 +24,7 @@
                             <record id="account_tax_report_line_2a_base_17" model="account.report.line">
                                 <field name="name">701 - base 17%</field>
                                 <field name="code">LUTAX_701</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -227,6 +36,7 @@
                             <record id="account_tax_report_line_2a_base_16" model="account.report.line">
                                 <field name="name">901 - base 16%</field>
                                 <field name="code">LUTAX_901</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -238,6 +48,7 @@
                             <record id="account_tax_report_line_2a_base_14" model="account.report.line">
                                 <field name="name">703 - base 14%</field>
                                 <field name="code">LUTAX_703</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -249,6 +60,7 @@
                             <record id="account_tax_report_line_2a_base_13" model="account.report.line">
                                 <field name="name">903 - base 13%</field>
                                 <field name="code">LUTAX_903</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -260,6 +72,7 @@
                             <record id="account_tax_report_line_2a_base_8" model="account.report.line">
                                 <field name="name">705 - base 8%</field>
                                 <field name="code">LUTAX_705</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -271,6 +84,7 @@
                             <record id="account_tax_report_line_2a_base_7" model="account.report.line">
                                 <field name="name">905 - base 7%</field>
                                 <field name="code">LUTAX_905</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -282,6 +96,7 @@
                             <record id="account_tax_report_line_2a_base_3" model="account.report.line">
                                 <field name="name">031 - base 3%</field>
                                 <field name="code">LUTAX_031</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_base_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -311,6 +126,7 @@
                             <record id="account_tax_report_line_2a_tax_17" model="account.report.line">
                                 <field name="name">702 - tax 17%</field>
                                 <field name="code">LUTAX_702</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -322,6 +138,7 @@
                             <record id="account_tax_report_line_2a_tax_16" model="account.report.line">
                                 <field name="name">902 - tax 16%</field>
                                 <field name="code">LUTAX_902</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -333,6 +150,7 @@
                             <record id="account_tax_report_line_2a_tax_14" model="account.report.line">
                                 <field name="name">704 - tax 14%</field>
                                 <field name="code">LUTAX_704</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -344,6 +162,7 @@
                             <record id="account_tax_report_line_2a_tax_13" model="account.report.line">
                                 <field name="name">904 - tax 13%</field>
                                 <field name="code">LUTAX_904</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -355,6 +174,7 @@
                             <record id="account_tax_report_line_2a_tax_8" model="account.report.line">
                                 <field name="name">706 - tax 8%</field>
                                 <field name="code">LUTAX_706</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -366,6 +186,7 @@
                             <record id="account_tax_report_line_2a_tax_7" model="account.report.line">
                                 <field name="name">906 - tax 7%</field>
                                 <field name="code">LUTAX_906</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -377,6 +198,7 @@
                             <record id="account_tax_report_line_2a_tax_3" model="account.report.line">
                                 <field name="name">040 - tax 3%</field>
                                 <field name="code">LUTAX_040</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2a_tax_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -395,6 +217,7 @@
                             <record id="account_tax_report_line_2b_base_17" model="account.report.line">
                                 <field name="name">711 - base 17%</field>
                                 <field name="code">LUTAX_711</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -406,6 +229,7 @@
                             <record id="account_tax_report_line_2b_base_16" model="account.report.line">
                                 <field name="name">911 - base 16%</field>
                                 <field name="code">LUTAX_911</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -417,6 +241,7 @@
                             <record id="account_tax_report_line_2b_base_14" model="account.report.line">
                                 <field name="name">713 - base 14%</field>
                                 <field name="code">LUTAX_713</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -428,6 +253,7 @@
                             <record id="account_tax_report_line_2b_base_13" model="account.report.line">
                                 <field name="name">913 - base 13%</field>
                                 <field name="code">LUTAX_913</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -439,6 +265,7 @@
                             <record id="account_tax_report_line_2b_base_8" model="account.report.line">
                                 <field name="name">715 - base 8%</field>
                                 <field name="code">LUTAX_715</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -450,6 +277,7 @@
                             <record id="account_tax_report_line_2b_base_7" model="account.report.line">
                                 <field name="name">915 - base 7%</field>
                                 <field name="code">LUTAX_915</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -461,6 +289,7 @@
                             <record id="account_tax_report_line_2b_base_3" model="account.report.line">
                                 <field name="name">049 - base 3%</field>
                                 <field name="code">LUTAX_049</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -472,6 +301,7 @@
                             <record id="account_tax_report_line_2b_base_exempt" model="account.report.line">
                                 <field name="name">194 - base exempt</field>
                                 <field name="code">LUTAX_194</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_base_exempt_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -483,6 +313,7 @@
                             <record id="account_tax_report_line_2b_manufactured_tobacco" model="account.report.line">
                                 <field name="name">719 - of manufactured tobacco (VAT is collected at the exit of the tax warehouse with excise duties)</field>
                                 <field name="code">LUTAX_719</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_manufactured_tobacco_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -501,6 +332,7 @@
                             <record id="account_tax_report_line_2b_tax_17" model="account.report.line">
                                 <field name="name">712 - tax 17%</field>
                                 <field name="code">LUTAX_712</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -512,6 +344,7 @@
                             <record id="account_tax_report_line_2b_tax_16" model="account.report.line">
                                 <field name="name">912 - tax 16%</field>
                                 <field name="code">LUTAX_912</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -523,6 +356,7 @@
                             <record id="account_tax_report_line_2b_tax_14" model="account.report.line">
                                 <field name="name">714 - tax 14%</field>
                                 <field name="code">LUTAX_714</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -534,6 +368,7 @@
                             <record id="account_tax_report_line_2b_tax_13" model="account.report.line">
                                 <field name="name">914 - tax 13%</field>
                                 <field name="code">LUTAX_914</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -545,6 +380,7 @@
                             <record id="account_tax_report_line_2b_tax_8" model="account.report.line">
                                 <field name="name">716 - tax 8%</field>
                                 <field name="code">LUTAX_716</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -556,6 +392,7 @@
                             <record id="account_tax_report_line_2b_tax_7" model="account.report.line">
                                 <field name="name">916 - tax 7%</field>
                                 <field name="code">LUTAX_916</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -567,6 +404,7 @@
                             <record id="account_tax_report_line_2b_tax_3" model="account.report.line">
                                 <field name="name">054 - tax 3%</field>
                                 <field name="code">LUTAX_054</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2b_tax_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -596,6 +434,7 @@
                             <record id="account_tax_report_line_2d_1_base_17" model="account.report.line">
                                 <field name="name">721 - for business purposes: base 17%</field>
                                 <field name="code">LUTAX_721</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -607,6 +446,7 @@
                             <record id="account_tax_report_line_2d_1_base_16" model="account.report.line">
                                 <field name="name">921 - for business purposes: base 16%</field>
                                 <field name="code">LUTAX_921</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -618,6 +458,7 @@
                             <record id="account_tax_report_line_2d_1_base_14" model="account.report.line">
                                 <field name="name">723 - for business purposes: base 14%</field>
                                 <field name="code">LUTAX_723</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -629,6 +470,7 @@
                             <record id="account_tax_report_line_2d_1_base_13" model="account.report.line">
                                 <field name="name">923 - for business purposes: base 13%</field>
                                 <field name="code">LUTAX_923</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -640,6 +482,7 @@
                             <record id="account_tax_report_line_2d_1_base_8" model="account.report.line">
                                 <field name="name">725 - for business purposes: base 8%</field>
                                 <field name="code">LUTAX_725</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -651,6 +494,7 @@
                             <record id="account_tax_report_line_2d_1_base_7" model="account.report.line">
                                 <field name="name">925 - for business purposes: base 7%</field>
                                 <field name="code">LUTAX_925</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -662,6 +506,7 @@
                             <record id="account_tax_report_line_2d_1_base_3" model="account.report.line">
                                 <field name="name">059 - for business purposes: base 3%</field>
                                 <field name="code">LUTAX_059</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -673,6 +518,7 @@
                             <record id="account_tax_report_line_2d_1_base_exempt" model="account.report.line">
                                 <field name="name">195 - for business purposes: base exempt</field>
                                 <field name="code">LUTAX_195</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_base_exempt_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -684,6 +530,7 @@
                             <record id="account_tax_report_line_2d_1_manufactured_tobacco" model="account.report.line">
                                 <field name="name">729 - of manufactured tobacco (VAT is collected at the exit of the tax warehouse with excise duties)</field>
                                 <field name="code">LUTAX_729</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_manufactured_tobacco_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -695,6 +542,7 @@
                             <record id="account_tax_report_line_2d_2_base_17" model="account.report.line">
                                 <field name="name">731 - for non-business purposes: base 17%</field>
                                 <field name="code">LUTAX_731</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -706,6 +554,7 @@
                             <record id="account_tax_report_line_2d_2_base_16" model="account.report.line">
                                 <field name="name">931 - for non-business purposes: base 16%</field>
                                 <field name="code">LUTAX_931</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -717,6 +566,7 @@
                             <record id="account_tax_report_line_2d_2_base_14" model="account.report.line">
                                 <field name="name">733 - for non-business purposes: base 14%</field>
                                 <field name="code">LUTAX_733</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -728,6 +578,7 @@
                             <record id="account_tax_report_line_2d_2_base_13" model="account.report.line">
                                 <field name="name">933 - for non-business purposes: base 13%</field>
                                 <field name="code">LUTAX_933</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -739,6 +590,7 @@
                             <record id="account_tax_report_line_2d_2_base_8" model="account.report.line">
                                 <field name="name">735 - for non-business purposes: base 8%</field>
                                 <field name="code">LUTAX_735</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -750,6 +602,7 @@
                             <record id="account_tax_report_line_2d_2_base_7" model="account.report.line">
                                 <field name="name">935 - for non-business purposes: base 7%</field>
                                 <field name="code">LUTAX_935</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -761,6 +614,7 @@
                             <record id="account_tax_report_line_2d_2_base_3" model="account.report.line">
                                 <field name="name">063 - for non-business purposes: base 3%</field>
                                 <field name="code">LUTAX_063</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -772,6 +626,7 @@
                             <record id="account_tax_report_line_2d_2_base_exempt" model="account.report.line">
                                 <field name="name">196 - for non-business purposes: base exempt</field>
                                 <field name="code">LUTAX_196</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_base_exempt_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -790,6 +645,7 @@
                             <record id="account_tax_report_line_2d_1_tax_17" model="account.report.line">
                                 <field name="name">722 - for business purposes: tax 17%</field>
                                 <field name="code">LUTAX_722</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -801,6 +657,7 @@
                             <record id="account_tax_report_line_2d_1_tax_16" model="account.report.line">
                                 <field name="name">922 - for business purposes: tax 16%</field>
                                 <field name="code">LUTAX_922</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -812,6 +669,7 @@
                             <record id="account_tax_report_line_2d_1_tax_14" model="account.report.line">
                                 <field name="name">724 - for business purposes: tax 14%</field>
                                 <field name="code">LUTAX_724</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -823,6 +681,7 @@
                             <record id="account_tax_report_line_2d_1_tax_13" model="account.report.line">
                                 <field name="name">924 - for business purposes: tax 13%</field>
                                 <field name="code">LUTAX_924</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -834,6 +693,7 @@
                             <record id="account_tax_report_line_2d_1_tax_8" model="account.report.line">
                                 <field name="name">726 - for business purposes: tax 8%</field>
                                 <field name="code">LUTAX_726</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -845,6 +705,7 @@
                             <record id="account_tax_report_line_2d_1_tax_7" model="account.report.line">
                                 <field name="name">926 - for business purposes: tax 7%</field>
                                 <field name="code">LUTAX_926</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -856,6 +717,7 @@
                             <record id="account_tax_report_line_2d_1_tax_3" model="account.report.line">
                                 <field name="name">068 - for business purposes: tax 3%</field>
                                 <field name="code">LUTAX_068</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_1_tax_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -867,6 +729,7 @@
                             <record id="account_tax_report_line_2d_2_tax_17" model="account.report.line">
                                 <field name="name">732 - for non-business purposes: tax 17%</field>
                                 <field name="code">LUTAX_732</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_17_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -878,6 +741,7 @@
                             <record id="account_tax_report_line_2d_2_tax_16" model="account.report.line">
                                 <field name="name">932 - for non-business purposes: tax 16%</field>
                                 <field name="code">LUTAX_932</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_16_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -889,6 +753,7 @@
                             <record id="account_tax_report_line_2d_2_tax_14" model="account.report.line">
                                 <field name="name">734 - for non-business purposes: tax 14%</field>
                                 <field name="code">LUTAX_734</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_14_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -900,6 +765,7 @@
                             <record id="account_tax_report_line_2d_2_tax_13" model="account.report.line">
                                 <field name="name">934 - for non-business purposes: tax 13%</field>
                                 <field name="code">LUTAX_934</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_13_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -911,6 +777,7 @@
                             <record id="account_tax_report_line_2d_2_tax_8" model="account.report.line">
                                 <field name="name">736 - for non-business purposes: tax 8%</field>
                                 <field name="code">LUTAX_736</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_8_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -922,6 +789,7 @@
                             <record id="account_tax_report_line_2d_2_tax_7" model="account.report.line">
                                 <field name="name">936 - for non-business purposes: tax 7%</field>
                                 <field name="code">LUTAX_936</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_7_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -933,6 +801,7 @@
                             <record id="account_tax_report_line_2d_2_tax_3" model="account.report.line">
                                 <field name="name">073 - for non-business purposes: tax 3%</field>
                                 <field name="code">LUTAX_073</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2d_2_tax_3_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -956,6 +825,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_17" model="account.report.line">
                                         <field name="name">741 - not exempt within the territory: base 17%</field>
                                         <field name="code">LUTAX_741</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_17_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -967,6 +837,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_16" model="account.report.line">
                                         <field name="name">941 - not exempt within the territory: base 16%</field>
                                         <field name="code">LUTAX_941</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_16_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -978,6 +849,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_14" model="account.report.line">
                                         <field name="name">743 - not exempt within the territory: base 14%</field>
                                         <field name="code">LUTAX_743</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_14_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -989,6 +861,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_13" model="account.report.line">
                                         <field name="name">943 - not exempt within the territory: base 13%</field>
                                         <field name="code">LUTAX_943</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_13_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1000,6 +873,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_8" model="account.report.line">
                                         <field name="name">745 - not exempt within the territory: base 8%</field>
                                         <field name="code">LUTAX_745</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_8_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1011,6 +885,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_7" model="account.report.line">
                                         <field name="name">945 - not exempt within the territory: base 7%</field>
                                         <field name="code">LUTAX_945</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_7_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1022,6 +897,7 @@
                                     <record id="account_tax_report_line_2e_1_a_base_3" model="account.report.line">
                                         <field name="name">431 - not exempt within the territory: base 3%</field>
                                         <field name="code">LUTAX_431</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_base_3_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1035,6 +911,7 @@
                             <record id="account_tax_report_line_2e_1_b_exempt" model="account.report.line">
                                 <field name="name">435 - exempt within the territory: exempt</field>
                                 <field name="code">LUTAX_435</field>
+                                <field name="hide_if_zero" eval="1"/>
                                 <field name="expression_ids">
                                     <record id="account_tax_report_line_2e_1_b_exempt_tag" model="account.report.expression">
                                         <field name="label">balance</field>
@@ -1051,6 +928,7 @@
                                     <record id="account_tax_report_line_2e_2_base_17" model="account.report.line">
                                         <field name="name">751 - not established or residing within the Community: base 17%</field>
                                         <field name="code">LUTAX_751</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_17_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1062,6 +940,7 @@
                                     <record id="account_tax_report_line_2e_2_base_16" model="account.report.line">
                                         <field name="name">951 - not established or residing within the Community: base 16%</field>
                                         <field name="code">LUTAX_951</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_16_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1073,6 +952,7 @@
                                     <record id="account_tax_report_line_2e_2_base_14" model="account.report.line">
                                         <field name="name">753 - not established or residing within the Community: base 14%</field>
                                         <field name="code">LUTAX_753</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_14_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1084,6 +964,7 @@
                                     <record id="account_tax_report_line_2e_2_base_13" model="account.report.line">
                                         <field name="name">953 - not established or residing within the Community: base 13%</field>
                                         <field name="code">LUTAX_953</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_13_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1095,6 +976,7 @@
                                     <record id="account_tax_report_line_2e_2_base_8" model="account.report.line">
                                         <field name="name">755 - not established or residing within the Community: base 8%</field>
                                         <field name="code">LUTAX_755</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_8_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1106,6 +988,7 @@
                                     <record id="account_tax_report_line_2e_2_base_7" model="account.report.line">
                                         <field name="name">955 - not established or residing within the Community: base 7%</field>
                                         <field name="code">LUTAX_955</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_7_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1117,6 +1000,7 @@
                                     <record id="account_tax_report_line_2e_2_base_3" model="account.report.line">
                                         <field name="name">441 - not established or residing within the Community: base 3%</field>
                                         <field name="code">LUTAX_441</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_base_3_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1128,6 +1012,7 @@
                                     <record id="account_tax_report_line_2e_2_exempt" model="account.report.line">
                                         <field name="name">445 - not established or residing within the Community: exempt</field>
                                         <field name="code">LUTAX_445</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_exempt_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1146,6 +1031,7 @@
                                     <record id="account_tax_report_line_2e_3_base_17" model="account.report.line">
                                         <field name="name">761 - suppliers established within the territory: base 17%</field>
                                         <field name="code">LUTAX_761</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_3_base_17_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1157,6 +1043,7 @@
                                     <record id="account_tax_report_line_2e_3_base_16" model="account.report.line">
                                         <field name="name">961 - suppliers established within the territory: base 16%</field>
                                         <field name="code">LUTAX_961</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_3_base_16_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1182,6 +1069,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_17" model="account.report.line">
                                         <field name="name">742 - not exempt within the territory: tax 17%</field>
                                         <field name="code">LUTAX_742</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_17_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1193,6 +1081,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_16" model="account.report.line">
                                         <field name="name">942 - not exempt within the territory: tax 16%</field>
                                         <field name="code">LUTAX_942</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_16_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1204,6 +1093,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_14" model="account.report.line">
                                         <field name="name">744 - not exempt within the territory: tax 14%</field>
                                         <field name="code">LUTAX_744</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_14_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1215,6 +1105,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_13" model="account.report.line">
                                         <field name="name">944 - not exempt within the territory: tax 13%</field>
                                         <field name="code">LUTAX_944</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_13_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1226,6 +1117,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_8" model="account.report.line">
                                         <field name="name">746 - not exempt within the territory: tax 8%</field>
                                         <field name="code">LUTAX_746</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_8_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1237,6 +1129,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_7" model="account.report.line">
                                         <field name="name">946 - not exempt within the territory: tax 7%</field>
                                         <field name="code">LUTAX_946</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_7_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1248,6 +1141,7 @@
                                     <record id="account_tax_report_line_2e_1_a_tax_3" model="account.report.line">
                                         <field name="name">432 - not exempt within the territory: tax 3%</field>
                                         <field name="code">LUTAX_432</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_1_a_tax_3_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1266,6 +1160,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_17" model="account.report.line">
                                         <field name="name">752 - not established or residing within the Community: tax 17%</field>
                                         <field name="code">LUTAX_752</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_17_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1277,6 +1172,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_16" model="account.report.line">
                                         <field name="name">952 - not established or residing within the Community: tax 16%</field>
                                         <field name="code">LUTAX_952</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_16_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1288,6 +1184,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_14" model="account.report.line">
                                         <field name="name">754 - not established or residing within the Community: tax 14%</field>
                                         <field name="code">LUTAX_754</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_14_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1299,6 +1196,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_13" model="account.report.line">
                                         <field name="name">954 - not established or residing within the Community: tax 13%</field>
                                         <field name="code">LUTAX_954</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_13_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1310,6 +1208,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_8" model="account.report.line">
                                         <field name="name">756 - not established or residing within the Community: tax 8%</field>
                                         <field name="code">LUTAX_756</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_8_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1321,6 +1220,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_7" model="account.report.line">
                                         <field name="name">956 - not established or residing within the Community: tax 7%</field>
                                         <field name="code">LUTAX_956</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_7_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1332,6 +1232,7 @@
                                     <record id="account_tax_report_line_2e_2_tax_3" model="account.report.line">
                                         <field name="name">442 - not established or residing within the Community: tax 3%</field>
                                         <field name="code">LUTAX_442</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_2_tax_3_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1350,6 +1251,7 @@
                                     <record id="account_tax_report_line_2e_3_tax_17" model="account.report.line">
                                         <field name="name">762 - suppliers established within the territory: tax 17%</field>
                                         <field name="code">LUTAX_762</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_3_tax_17_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1361,6 +1263,7 @@
                                     <record id="account_tax_report_line_2e_3_tax_16" model="account.report.line">
                                         <field name="name">962 - suppliers established within the territory: tax 16%</field>
                                         <field name="code">LUTAX_962</field>
+                                        <field name="hide_if_zero" eval="1"/>
                                         <field name="expression_ids">
                                             <record id="account_tax_report_line_2e_3_tax_16_tag" model="account.report.expression">
                                                 <field name="label">balance</field>
@@ -1445,163 +1348,14 @@
                     <record id="account_tax_report_line_2h_total_tax_due" model="account.report.line">
                         <field name="name">076 - Total tax due</field>
                         <field name="code">LUTAX_076</field>
-                        <field name="aggregation_formula">LUTAX_103.balance</field>
-                    </record>
-                </field>
-            </record>
-            <record id="account_tax_report_line_3_assessment_deducible_tax" model="account.report.line">
-                <field name="name">III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)</field>
-                <field name="hierarchy_level">0</field>
-                <field name="children_ids">
-                    <record id="account_tax_report_line_3a_total_input_tax" model="account.report.line">
-                        <field name="name">093 - Total input tax</field>
-                        <field name="code">LUTAX_093</field>
-                        <field name="aggregation_formula">LUTAX_090.balance + LUTAX_092.balance + LUTAX_228.balance + LUTAX_458.balance + LUTAX_459.balance + LUTAX_460.balance + LUTAX_461.balance</field>
-                        <field name="children_ids">
-                            <record id="account_tax_report_line_3a_1_invoiced_by_other_taxable_person" model="account.report.line">
-                                <field name="name">458 - Invoiced by other taxable persons for goods or services supplied</field>
-                                <field name="code">LUTAX_458</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_1_invoiced_by_other_taxable_person_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">458</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3a_2_due_respect_intra_comm_goods" model="account.report.line">
-                                <field name="name">459 - Due in respect of intra-Community acquisitions of goods</field>
-                                <field name="code">LUTAX_459</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_2_due_respect_intra_comm_goods_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">459</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3a_3_due_paid_respect_importation_goods" model="account.report.line">
-                                <field name="name">460 - Due or paid in respect of importation of goods</field>
-                                <field name="code">LUTAX_460</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_3_due_paid_respect_importation_goods_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">460</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3a_4_due_respect_application_goods" model="account.report.line">
-                                <field name="name">090 - Due in respect of the application of goods for business purposes</field>
-                                <field name="code">LUTAX_090</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_4_due_respect_application_goods_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">090</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3a_5_due_under_reverse_charge" model="account.report.line">
-                                <field name="name">461 - Due under the reverse charge (see points II.E and F)</field>
-                                <field name="code">LUTAX_461</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_5_due_under_reverse_charge_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">461</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3a_6_paid_joint_several_guarantee" model="account.report.line">
-                                <field name="name">092 - Paid as joint and several guarantee</field>
-                                <field name="code">LUTAX_092</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_6_paid_joint_several_guarantee_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">092</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3a_7_adjusted_tax_special_arrangement" model="account.report.line">
-                                <field name="name">228 - Adjusted tax - special arrangement for tax suspension</field>
-                                <field name="code">LUTAX_228</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3a_7_adjusted_tax_special_arrangement_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">228</field>
-                                    </record>
-                                </field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_line_2h_total_tax_due_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">LUTAX_046.balance + LUTAX_056.balance + LUTAX_407.balance + LUTAX_410.balance + LUTAX_768.balance + LUTAX_227.balance</field>
+                                <field name="subformula">cross_report</field>
                             </record>
                         </field>
-                    </record>
-                    <record id="account_tax_report_line_3b_total_input_tax_nd" model="account.report.line">
-                        <field name="name">097 - Total input tax non-deductible</field>
-                        <field name="code">LUTAX_097</field>
-                        <field name="aggregation_formula">LUTAX_094.balance + LUTAX_095.balance + LUTAX_096.balance</field>
-                        <field name="children_ids">
-                            <record id="account_tax_report_line_3b1_rel_trans" model="account.report.line">
-                                <field name="name">094 - relating to transactions which are exempt pursuant to articles 44 and 56quater</field>
-                                <field name="code">LUTAX_094</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3b1_rel_trans_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">094</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3b2_ded_prop" model="account.report.line">
-                                <field name="name">095 - where the deductible proportion determined in accordance to article 50 is applied</field>
-                                <field name="code">LUTAX_095</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3b2_ded_prop_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">095</field>
-                                    </record>
-                                </field>
-                            </record>
-                            <record id="account_tax_report_line_3b2_input_tax_margin" model="account.report.line">
-                                <field name="name">096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and 56ter-2(7) (when applying the margin scheme)</field>
-                                <field name="code">LUTAX_096</field>
-                                <field name="expression_ids">
-                                    <record id="account_tax_report_line_3b2_input_tax_margin_tag" model="account.report.expression">
-                                        <field name="label">balance</field>
-                                        <field name="engine">tax_tags</field>
-                                        <field name="formula">096</field>
-                                    </record>
-                                </field>
-                            </record>
-                        </field>
-                    </record>
-                    <record id="account_tax_report_line_3c_total_input_tax_deductible" model="account.report.line">
-                        <field name="name">102 - Total input tax deductible</field>
-                        <field name="code">LUTAX_102</field>
-                        <field name="aggregation_formula">LUTAX_093.balance - LUTAX_097.balance</field>
-                    </record>
-                </field>
-            </record>
-            <record id="account_tax_report_line_4_tax_tobe_paid_or_reclaimed" model="account.report.line">
-                <field name="name">IV. TAX TO BE PAID OR TO BE RECLAIMED</field>
-                <field name="hierarchy_level">0</field>
-                <field name="children_ids">
-                    <record id="account_tax_report_line_4a_total_tax_due" model="account.report.line">
-                        <field name="name">103 - Total tax due</field>
-                        <field name="code">LUTAX_103</field>
-                        <field name="aggregation_formula">LUTAX_046.balance + LUTAX_056.balance + LUTAX_407.balance + LUTAX_410.balance + LUTAX_768.balance + LUTAX_227.balance</field>
-                    </record>
-                    <record id="account_tax_report_line_4a_total_input_tax_deductible" model="account.report.line">
-                        <field name="name">104 - Total input tax deductible</field>
-                        <field name="code">LUTAX_104</field>
-                        <field name="aggregation_formula">LUTAX_102.balance</field>
-                    </record>
-                    <record id="account_tax_report_line_4c_exceeding_amount" model="account.report.line">
-                        <field name="name">105 - Exceeding amount</field>
-                        <field name="code">LUTAX_105</field>
-                        <field name="aggregation_formula">LUTAX_103.balance - LUTAX_102.balance</field>
                     </record>
                 </field>
             </record>

--- a/addons/l10n_lu/data/tax_report/sections_34.xml
+++ b/addons/l10n_lu/data/tax_report/sections_34.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="l10n_lu_tax_report_sections_3_4" model="account.report">
+        <field name="name">Sections III, IV</field>
+        <field name="sequence">3</field>
+        <field name="country_id" ref="base.lu"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_report_sections_3_4_balance" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="account_tax_report_line_3_assessment_deducible_tax" model="account.report.line">
+                <field name="name">III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_line_3a_total_input_tax" model="account.report.line">
+                        <field name="name">093 - Total input tax</field>
+                        <field name="code">LUTAX_093</field>
+                        <field name="aggregation_formula">LUTAX_090.balance + LUTAX_092.balance + LUTAX_228.balance + LUTAX_458.balance + LUTAX_459.balance + LUTAX_460.balance + LUTAX_461.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_line_3a_1_invoiced_by_other_taxable_person" model="account.report.line">
+                                <field name="name">458 - Invoiced by other taxable persons for goods or services supplied</field>
+                                <field name="code">LUTAX_458</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_1_invoiced_by_other_taxable_person_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">458</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3a_2_due_respect_intra_comm_goods" model="account.report.line">
+                                <field name="name">459 - Due in respect of intra-Community acquisitions of goods</field>
+                                <field name="code">LUTAX_459</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_2_due_respect_intra_comm_goods_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">459</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3a_3_due_paid_respect_importation_goods" model="account.report.line">
+                                <field name="name">460 - Due or paid in respect of importation of goods</field>
+                                <field name="code">LUTAX_460</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_3_due_paid_respect_importation_goods_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">460</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3a_4_due_respect_application_goods" model="account.report.line">
+                                <field name="name">090 - Due in respect of the application of goods for business purposes</field>
+                                <field name="code">LUTAX_090</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_4_due_respect_application_goods_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">090</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3a_5_due_under_reverse_charge" model="account.report.line">
+                                <field name="name">461 - Due under the reverse charge (see points II.E and F)</field>
+                                <field name="code">LUTAX_461</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_5_due_under_reverse_charge_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">461</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3a_6_paid_joint_several_guarantee" model="account.report.line">
+                                <field name="name">092 - Paid as joint and several guarantee</field>
+                                <field name="code">LUTAX_092</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_6_paid_joint_several_guarantee_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">092</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3a_7_adjusted_tax_special_arrangement" model="account.report.line">
+                                <field name="name">228 - Adjusted tax - special arrangement for tax suspension</field>
+                                <field name="code">LUTAX_228</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3a_7_adjusted_tax_special_arrangement_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">228</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_3b_total_input_tax_nd" model="account.report.line">
+                        <field name="name">097 - Total input tax non-deductible</field>
+                        <field name="code">LUTAX_097</field>
+                        <field name="aggregation_formula">LUTAX_094.balance + LUTAX_095.balance + LUTAX_096.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_line_3b1_rel_trans" model="account.report.line">
+                                <field name="name">094 - relating to transactions which are exempt pursuant to articles 44 and 56quater</field>
+                                <field name="code">LUTAX_094</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3b1_rel_trans_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">094</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3b2_ded_prop" model="account.report.line">
+                                <field name="name">095 - where the deductible proportion determined in accordance to article 50 is applied</field>
+                                <field name="code">LUTAX_095</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3b2_ded_prop_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">095</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_line_3b2_input_tax_margin" model="account.report.line">
+                                <field name="name">096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and 56ter-2(7) (when applying the margin scheme)</field>
+                                <field name="code">LUTAX_096</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_line_3b2_input_tax_margin_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">096</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_3c_total_input_tax_deductible" model="account.report.line">
+                        <field name="name">102 - Total input tax deductible</field>
+                        <field name="code">LUTAX_102</field>
+                        <field name="aggregation_formula">LUTAX_093.balance - LUTAX_097.balance</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_line_4_tax_tobe_paid_or_reclaimed" model="account.report.line">
+                <field name="name">IV. TAX TO BE PAID OR TO BE RECLAIMED</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_line_4a_total_tax_due" model="account.report.line">
+                        <field name="name">103 - Total tax due</field>
+                        <field name="code">LUTAX_103</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_line_4a_total_tax_due_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">LUTAX_076.balance</field>
+                                <field name="subformula">cross_report</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_line_4a_total_input_tax_deductible" model="account.report.line">
+                        <field name="name">104 - Total input tax deductible</field>
+                        <field name="code">LUTAX_104</field>
+                        <field name="aggregation_formula">LUTAX_102.balance</field>
+                    </record>
+                    <record id="account_tax_report_line_4c_exceeding_amount" model="account.report.line">
+                        <field name="name">105 - Exceeding amount</field>
+                        <field name="code">LUTAX_105</field>
+                        <field name="aggregation_formula">LUTAX_103.balance - LUTAX_102.balance</field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_lu/data/tax_report/tax_report.xml
+++ b/addons/l10n_lu/data/tax_report/tax_report.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_report" model="account.report">
+        <field name="name">Tax Report</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.lu"/>
+        <field name="availability_condition">country</field>
+        <field name="filter_fiscal_position" eval="True"/>
+        <field name="filter_multi_company">tax_units</field>
+        <field name="filter_hierarchy">never</field>
+        <field name="use_sections" eval="True"/>
+        <field name="section_report_ids" eval="[Command.set([ref('l10n_lu.l10n_lu_tax_report_section_1'),
+                                                            ref('l10n_lu.l10n_lu_tax_report_section_2'),
+                                                            ref('l10n_lu.l10n_lu_tax_report_sections_3_4')])]"/>
+    </record>
+</odoo>


### PR DESCRIPTION
### [IMP] l10n_lu: use sections in the tax report

LU tax report comprises several sections and now we can restructure the report,
so that the sections are split into different tabs, using the new sections
functionality.
This also allows for reusing one of the sections of the simplified tax report
in the full annual VAT declaration, thus avoiding a lot of duplication in the
xml files.

task-3074547

### [IMP] account: add external formula shortcut

account.report.line can have shortcuts for adding basic expressions
for various engines. This commit adds such a shortcut for external engine
so that reports with lots of external expressions (manual fields) can
be added easier and can be shorter.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
