### PR TITLE
[IMP] delivery, sale(_management): hooks on catalog and quotation templates

### DIFF
--- a/addons/delivery/__init__.py
+++ b/addons/delivery/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models
 from . import wizard

--- a/addons/delivery/controllers/catalog.py
+++ b/addons/delivery/controllers/catalog.py
@@ -1,10 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.http import request, Controller
+from odoo.http import request, route
+from odoo.addons.sale.controllers.catalog import CatalogController
 
 
-class CatalogController(Controller):
+class CatalogControllerDelivery(CatalogController):
 
+    @route()
     def sale_product_catalog_update_sale_order_line_info(self, order_id, product_id, quantity):
         """ Override of `sale` to recompute the delivery prices.
 
@@ -15,7 +17,7 @@ class CatalogController(Controller):
                  the quantity selected.
         :rtype: float
         """
-        price_unit = super.sale_product_catalog_update_sale_order_line_info(
+        price_unit = super().sale_product_catalog_update_sale_order_line_info(
             order_id, product_id, quantity
         )
         order = request.env['sale.order'].browse(order_id)

--- a/addons/delivery/controllers/catalog.py
+++ b/addons/delivery/controllers/catalog.py
@@ -7,7 +7,9 @@ from odoo.addons.sale.controllers.catalog import CatalogController
 class CatalogControllerDelivery(CatalogController):
 
     @route()
-    def sale_product_catalog_update_sale_order_line_info(self, order_id, product_id, quantity):
+    def sale_product_catalog_update_sale_order_line_info(
+        self, order_id, product_id, quantity, **kwargs
+    ):
         """ Override of `sale` to recompute the delivery prices.
 
         :param int order_id: The sale order, as a `sale.order` id.
@@ -18,7 +20,7 @@ class CatalogControllerDelivery(CatalogController):
         :rtype: float
         """
         price_unit = super().sale_product_catalog_update_sale_order_line_info(
-            order_id, product_id, quantity
+            order_id, product_id, quantity, **kwargs
         )
         order = request.env['sale.order'].browse(order_id)
         if order:

--- a/addons/sale/controllers/catalog.py
+++ b/addons/sale/controllers/catalog.py
@@ -7,7 +7,7 @@ from odoo.tools import groupby
 class CatalogController(Controller):
 
     @route('/sales/catalog/sale_order_lines_info', auth='user', type='json')
-    def sale_product_catalog_get_sale_order_lines_info(self, order_id, product_ids):
+    def sale_product_catalog_get_sale_order_lines_info(self, order_id, product_ids, **kwargs):
         """ Returns products information to be shown in the catalog.
 
         :param int order_id: The sale order, as a `sale.order` id.
@@ -50,12 +50,15 @@ class CatalogController(Controller):
                 products=request.env['product.product'].browse(product_ids),
                 currency=order.currency_id,
                 date=order.date_order,
+                **kwargs,
             ).items()
         })
         return sale_order_line_info
 
     @route('/sales/catalog/update_sale_order_line_info', auth='user', type='json')
-    def sale_product_catalog_update_sale_order_line_info(self, order_id, product_id, quantity):
+    def sale_product_catalog_update_sale_order_line_info(
+        self, order_id, product_id, quantity, **kwargs
+    ):
         """ Update sale order line information on a given sale order for a given product.
 
         :param int order_id: The sale order, as a `sale.order` id.
@@ -77,6 +80,7 @@ class CatalogController(Controller):
                     quantity=1.0,
                     currency=sol.order_id.currency_id,
                     date=sol.order_id.date_order,
+                    **kwargs,
                 )
                 sol.unlink()
                 return price_unit

--- a/addons/sale_management/models/sale_order_line.py
+++ b/addons/sale_management/models/sale_order_line.py
@@ -33,8 +33,12 @@ class SaleOrderLine(models.Model):
     def _compute_price_unit(self):
         # Avoid recomputing the price with pricelist rules, use the initial price
         # used in the optional product line.
-        optional_product_lines = self.filtered('sale_order_option_ids')
-        super(SaleOrderLine, self - optional_product_lines)._compute_price_unit()
+        lines_without_price_recomputation = self._lines_without_price_recomputation()
+        super(SaleOrderLine, self - lines_without_price_recomputation)._compute_price_unit()
+
+    def _lines_without_price_recomputation(self):
+        """ Hook to allow filtering the lines to avoid the recomputation of the price. """
+        return self.filtered('sale_order_option_ids')
 
     #=== TOOLING ===#
 

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -148,3 +148,5 @@ class SaleOrderOption(models.Model):
         self.write({'line_id': order_line.id})
         if sale_order:
             sale_order.add_option_to_order_with_taxcloud()
+
+        return order_line

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -36,7 +36,7 @@ class SaleOrderTemplateLine(models.Model):
     product_id = fields.Many2one(
         comodel_name='product.product',
         check_company=True,
-        domain="[('sale_ok', '=', True)]")
+        domain=lambda self: self._product_id_domain())
 
     name = fields.Text(
         string="Description",
@@ -91,6 +91,11 @@ class SaleOrderTemplateLine(models.Model):
         return super().write(values)
 
     #=== BUSINESS METHODS ===#
+
+    @api.model
+    def _product_id_domain(self):
+        """ Returns the domain of the products that can be added to the template. """
+        return [('sale_ok', '=', True)]
 
     def _prepare_order_line_values(self):
         """ Give the values to create the corresponding order line.

--- a/addons/sale_management/models/sale_order_template_option.py
+++ b/addons/sale_management/models/sale_order_template_option.py
@@ -21,7 +21,7 @@ class SaleOrderTemplateOption(models.Model):
     product_id = fields.Many2one(
         comodel_name='product.product',
         required=True, check_company=True,
-        domain="[('sale_ok', '=', True)]")
+        domain=lambda self: self._product_id_domain())
 
     name = fields.Text(
         string="Description",
@@ -58,6 +58,11 @@ class SaleOrderTemplateOption(models.Model):
             option.uom_id = option.product_id.uom_id
 
     #=== BUSINESS METHODS ===#
+
+    @api.model
+    def _product_id_domain(self):
+        """Returns the domain of the products that can be added as a template option."""
+        return [('sale_ok', '=', True)]
 
     def _prepare_option_line_values(self):
         """ Give the values to create the corresponding option line.


### PR DESCRIPTION
In order to add rental products to the catalog and the quotation templates, there is a need for hooks in sale and sale_management.

See also:
- https://github.com/odoo/enterprise/pull/47557