### PR TITLE
[FIX] product,*: review visibility condition for some pages displayed in product form view

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -50,7 +50,7 @@
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//page[@name='purchase']" position="attributes">
-                    <attribute name="invisible">0</attribute>
+                    <attribute name="invisible" remove="1" separator=" or "></attribute>
                 </xpath>
                 <xpath expr="//field[@name='company_id']" position="after">
                     <field name="fiscal_country_codes" invisible="1"/>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -87,7 +87,7 @@
                 </page>
             </xpath>
             <xpath expr="//page[@name='purchase']" position="attributes">
-                <attribute name="invisible">detailed_type == "combo"</attribute>
+                <attribute name="invisible" separator=" or " add="detailed_type == 'combo'"></attribute>
             </xpath>
             <xpath expr="//page[@name='inventory']" position="attributes">
                 <attribute name="invisible">type in ['combo', 'service']</attribute>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -90,10 +90,10 @@
                 <attribute name="invisible">detailed_type == "combo"</attribute>
             </xpath>
             <xpath expr="//page[@name='inventory']" position="attributes">
-                <attribute name="invisible">detailed_type == "combo"</attribute>
+                <attribute name="invisible">type in ['combo', 'service']</attribute>
             </xpath>
             <xpath expr="//page[@name='invoicing']" position="attributes">
-                <attribute name="invisible">detailed_type == "combo"</attribute>
+                <attribute name="invisible">type in ['combo', 'service']</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -65,7 +65,7 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales']" position="attributes">
-                <attribute name="invisible">0</attribute>
+                <attribute name="invisible" remove="1" separator=" or "></attribute>
             </xpath>
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="inside">
                 <group name="pos" string="Point of Sale" invisible="not sale_ok">

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -101,7 +101,7 @@
                                 <field colspan="2" name="description" nolabel="1" placeholder="This note is only for internal purposes."/>
                             </group>
                         </page>
-                        <page string="Sales" name="sales" invisible="1">
+                        <page string="Sales" name="sales" invisible="1 or not sale_ok">
                             <group name="sale">
                                 <group string="Upsell &amp; Cross-Sell" name="upsell" invisible="1"/>
                             </group>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -111,7 +111,7 @@
                                 </group>
                             </group>
                         </page>
-                        <page string="Purchase" name="purchase" invisible="1">
+                        <page string="Purchase" name="purchase" invisible="1 or not purchase_ok">
                             <group name="purchase">
                                 <group string="Vendor Bills" name="bill"/>
                             </group>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -38,7 +38,7 @@
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//page[@name='purchase']" position="attributes">
-                    <attribute name="invisible">0</attribute>
+                    <attribute name="invisible" remove="1" separator=" or "></attribute>
                     <attribute name="groups">purchase.group_purchase_user</attribute>
                 </xpath>
                 <group name="purchase" position="before">

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <page name="sales" position="attributes">
-                <attribute name="invisible">0</attribute>
+                <attribute name="invisible" remove="1" separator=" or "></attribute>
             </page>
             <field name="product_variant_count" position="after">
                 <field name="service_type" widget="radio" invisible="True"/>


### PR DESCRIPTION
Before this commit, the product view is extended to change the `invisible`
attribute of page with name attribute equals to `inventory`. The problem
is in the initial form view that page has a invisible condition and
the extended view defined in `point_of_sale` module completely overrides
that condition without rewriting the initial condition.

This commit reintroduces the initial condition to also hide that page
when the product is a service type.

task-3506730