### PR TITLE
[IMP] spreadsheet_edition: field matching for extend filters

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -21,7 +21,7 @@ export default class OdooChartCorePlugin extends CorePlugin {
         this.charts = {};
 
         globalFiltersFieldMatchers["chart"] = {
-            geIds: () => this.getters.getOdooChartIds(),
+            getIds: () => this.getters.getOdooChartIds(),
             getDisplayName: (chartId) => this.getters.getOdooChartDisplayName(chartId),
             getFieldMatching: (chartId, filterId) =>
                 this.getOdooChartFieldMatching(chartId, filterId),
@@ -184,8 +184,12 @@ export default class OdooChartCorePlugin extends CorePlugin {
      * @param {string} chartId
      * @param {Object} fieldMatching
      */
-    _addOdooChart(chartId, fieldMatching = {}) {
+    _addOdooChart(chartId, fieldMatching = undefined) {
         const charts = { ...this.charts };
+        if (!fieldMatching) {
+            const model = this.getters.getChartDefinition(chartId).metaData.resModel;
+            fieldMatching = this.getters.getFieldMatchingForModel(model);
+        }
         charts[chartId] = {
             fieldMatching,
         };

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
@@ -128,6 +128,37 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
         return this.getGlobalFilter(id).defaultValue;
     }
 
+    /**
+     * Returns the field matching for a given model by copying the matchings of another DataSource that
+     * share the same model, including only the chain and type.
+     */
+    getFieldMatchingForModel(newModel) {
+        const globalFilters = this.getGlobalFilters();
+        if (globalFilters.length === 0) {
+            return {};
+        }
+
+        for (const matcher of Object.values(globalFiltersFieldMatchers)) {
+            for (const dataSourceId of matcher.getIds()) {
+                const model = matcher.getModel(dataSourceId);
+                if (model === newModel) {
+                    const fieldMatching = {};
+                    for (const filter of globalFilters) {
+                        const matchedField = matcher.getFieldMatching(dataSourceId, filter.id);
+                        if (matchedField) {
+                            fieldMatching[filter.id] = {
+                                chain: matchedField.chain,
+                                type: matchedField.type,
+                            };
+                        }
+                    }
+                    return fieldMatching;
+                }
+            }
+        }
+        return {};
+    }
+
     // ---------------------------------------------------------------------
     // Handlers
     // ---------------------------------------------------------------------
@@ -231,4 +262,5 @@ GlobalFiltersCorePlugin.getters = [
     "getGlobalFilters",
     "getGlobalFilterDefaultValue",
     "getGlobalFilterLabel",
+    "getFieldMatchingForModel",
 ];

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -39,7 +39,7 @@ export default class ListCorePlugin extends CorePlugin {
         this.lists = {};
 
         globalFiltersFieldMatchers["list"] = {
-            geIds: () => this.getters.getListIds(),
+            getIds: () => this.getters.getListIds(),
             getDisplayName: (listId) => this.getters.getListName(listId),
             getTag: (listId) => sprintf(_t("List #%s"), listId),
             getFieldMatching: (listId, filterId) => this.getListFieldMatching(listId, filterId),
@@ -241,8 +241,12 @@ export default class ListCorePlugin extends CorePlugin {
         }
     }
 
-    _addList(id, definition, fieldMatching = {}) {
+    _addList(id, definition, fieldMatching = undefined) {
         const lists = { ...this.lists };
+        if (!fieldMatching) {
+            const model = definition.metaData.resModel;
+            fieldMatching = this.getters.getFieldMatchingForModel(model);
+        }
         lists[id] = {
             id,
             definition,

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
@@ -42,7 +42,7 @@ export default class PivotCorePlugin extends CorePlugin {
         /** @type {Object.<string, Pivot>} */
         this.pivots = {};
         globalFiltersFieldMatchers["pivot"] = {
-            geIds: () => this.getters.getPivotIds(),
+            getIds: () => this.getters.getPivotIds(),
             getDisplayName: (pivotId) => this.getters.getPivotName(pivotId),
             getTag: (pivotId) => sprintf(_t("Pivot #%s"), pivotId),
             getFieldMatching: (pivotId, filterId) => this.getPivotFieldMatching(pivotId, filterId),
@@ -255,8 +255,12 @@ export default class PivotCorePlugin extends CorePlugin {
      * @param {PivotDefinition} definition
      * @param {string} dataSourceId
      */
-    _addPivot(id, definition, fieldMatching = {}) {
+    _addPivot(id, definition, fieldMatching = undefined) {
         const pivots = { ...this.pivots };
+        if (!fieldMatching) {
+            const model = definition.metaData.resModel;
+            fieldMatching = this.getters.getFieldMatchingForModel(model);
+        }
         pivots[id] = {
             id,
             definition,

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_chart_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_chart_test.js
@@ -88,14 +88,14 @@ QUnit.module("spreadsheet > Global filters chart", {}, () => {
             id: chartId,
         });
         assert.deepEqual(
-            globalFiltersFieldMatchers["chart"].geIds(),
+            globalFiltersFieldMatchers["chart"].getIds(),
             [],
             "it should have removed the chart and its fieldMatching and datasource altogether"
         );
         model.dispatch("REQUEST_UNDO");
         assert.deepEqual(model.getters.getChartFieldMatch(chartId)[filter.id], matching);
         model.dispatch("REQUEST_REDO");
-        assert.deepEqual(globalFiltersFieldMatchers["chart"].geIds(), []);
+        assert.deepEqual(globalFiltersFieldMatchers["chart"].getIds(), []);
     });
 
     QUnit.test("field matching is removed when filter is deleted", async function (assert) {


### PR DESCRIPTION
- When a new pivot is added, and if the user has already defined field matching in a previous pivot, the new pivot will inherit the field matching from the previous pivot as default values.

- If multiple pivots are added from different models, will check the model of the new pivot against previous pivots. If the model matches, the field matching from the matching previous pivot will be used. If no matching model is found, the field matching will be left empty.

- Same will also done in case of list and odoo chart.

taskId: [3373163](https://www.odoo.com/web#id=3373163&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
