### PR TITLE
[FIX] survey: compute matrix answers display_name too

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -314,7 +314,7 @@
         <field name="name">survey.question.answer.view.form</field>
         <field name="model">survey.question.answer</field>
         <field name="arch" type="xml">
-            <form string="Question Answer Form">
+            <form string="Question Answer Form" create="False">
                 <sheet>
                     <field name="question_type" invisible="1"/>
                     <group>


### PR DESCRIPTION
We here fix the `SurveyQuestionAnswer._compute_display_name` method introduced in 55fa52be.

`survey.question.answers` used as matrix rows and columns require different treatment as they are not used in triggers but are both shown on the `survey.user.input.line` views, where the display shouldn't change (nor cause a crash).

It also doesn't make much sense to create answers outside the context of a question, so we remove the button that already wasn't shown on the tree view.

As users may not fully upgrade their views though, we added a fallback question title in `compute_display_name`too.

Task-3495142
