### PR TITLE
[REF] point_of_sale: handle dblClick

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.js
@@ -2,9 +2,6 @@
 
 import { Component } from "@odoo/owl";
 
-/**
- * How to extend this component:
- */
 export class Orderline extends Component {
     static template = "point_of_sale.Orderline";
     static props = {

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -117,32 +117,14 @@ export class TicketScreen extends Component {
         }
     }
     onClickOrder(clickedOrder) {
-        if (!clickedOrder || clickedOrder.locked) {
-            this._state.ui.selectedOrder = clickedOrder;
-            if (!this.getSelectedOrderlineId()) {
-                // Automatically select the first orderline of the selected order.
-                const firstLine = this._state.ui.selectedOrder.get_orderlines()[0];
-                if (firstLine) {
-                    this._state.ui.selectedOrderlineIds[clickedOrder.backendId] = firstLine.id;
-                }
+        this._state.ui.selectedOrder = clickedOrder;
+        this.numberBuffer.reset();
+        if ((!clickedOrder || clickedOrder.locked) && !this.getSelectedOrderlineId()) {
+            // Automatically select the first orderline of the selected order.
+            const firstLine = this._state.ui.selectedOrder.get_orderlines()[0];
+            if (firstLine) {
+                this._state.ui.selectedOrderlineIds[clickedOrder.backendId] = firstLine.id;
             }
-            this.numberBuffer.reset();
-        } else {
-            if (
-                !this._state.ui.selectedOrder ||
-                clickedOrder.uid !== this._state.ui.selectedOrder.uid
-            ) {
-                this.dbclk_time = new Date().getTime();
-            } else if (!this.dbclk_time) {
-                this.dbclk_time = new Date().getTime();
-            } else if (this.dbclk_time + 500 > new Date().getTime()) {
-                this._setOrder(clickedOrder);
-                this.dbclk_time = 0;
-            } else {
-                this.dbclk_time = new Date().getTime();
-            }
-            this._state.ui.selectedOrder = clickedOrder;
-            this.numberBuffer.reset();
         }
     }
     onCreateNewOrder() {
@@ -191,9 +173,6 @@ export class TicketScreen extends Component {
         if (this.pos.isOpenOrderShareable()) {
             this.pos._removeOrdersFromServer();
         }
-        // When deleting an order, the double click time should be reset, so that it's not taken into account
-        // when clicking on another order.
-        this.dbclk_time = 0;
     }
     async onNextPage() {
         if (this._state.syncedOrders.currentPage < this._getLastPage()) {
@@ -650,8 +629,7 @@ export class TicketScreen extends Component {
                 modelField: "pos_reference",
             },
             DATE: {
-                repr: (order) =>
-                    deserializeDate(order.date_order).toFormat("yyyy-MM-dd HH:mm a"),
+                repr: (order) => deserializeDate(order.date_order).toFormat("yyyy-MM-dd HH:mm a"),
                 displayName: _t("Date"),
                 modelField: "date_order",
             },

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -59,7 +59,8 @@
                                 <div class="col very-narrow p-2" name="delete"></div>
                             </div>
                             <t t-if="!ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.cid">
-                                <div class="order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }" t-on-click="() => this.onClickOrder(order)">
+                                <div class="order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
+                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.locked ? ()=>{} : this._setOrder(order)" >
                                     <div class="col wide p-2 ">
                                         <div><t t-esc="getDate(order)"></t></div>
                                     </div>
@@ -88,7 +89,8 @@
                                 </div>
                             </t>
                             <t t-if="ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.cid">
-                                <div class="mobileOrderList order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }" t-on-click="() => this.onClickOrder(order)">
+                                <div class="mobileOrderList order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
+                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.locked ? ()=>{} : this._setOrder(order)" >
                                     <div class="col p-2 d-flex justify-content-between align-items-center">
                                         <div><t t-esc="order.name"></t></div>
                                         <div><t t-esc="getTotal(order)"></t></div>

--- a/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
@@ -41,6 +41,14 @@ class Do {
             },
         ];
     }
+    doubleClickOrder(orderName) {
+        return [
+            {
+                trigger: `.ticket-screen .order-row > .col:nth-child(2):contains("${orderName}")`,
+                run: "dblclick",
+            },
+        ];
+    }
     loadSelectedOrder() {
         return [
             {

--- a/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
@@ -47,8 +47,7 @@ registry
             Chrome.do.clickTicketButton();
             TicketScreen.do.deleteOrder("-0003");
             Chrome.do.confirmPopup();
-            TicketScreen.do.selectOrder("-0002");
-            TicketScreen.do.loadSelectedOrder();
+            TicketScreen.do.doubleClickOrder("-0002");
             ProductScreen.check.isShown();
             ProductScreen.check.totalAmountIs("2.0");
             Chrome.do.backToFloor();


### PR DESCRIPTION
In the ticket screen the user has the option to double click on an
    order in order to continue editing it. This functionality is implemented
    using custom code for handling the double click. This is cumbersome and
    error prone.
In this PR we replace the custom double click logic with the default
    `t-on-dblclick` from `owl`.
Task: 3512282

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
