### PR TITLE
[IMP] mail, web: call the installation prompt from the notification area

### DIFF
--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -24,6 +24,7 @@ export class MessagingMenu extends Component {
         this.chatWindowService = useState(useService("mail.chat_window"));
         this.threadService = useState(useService("mail.thread"));
         this.action = useService("action");
+        this.installPrompt = useState(useService("installPrompt"));
         this.ui = useState(useService("ui"));
         this.state = useState({
             addingChat: false,
@@ -71,6 +72,10 @@ export class MessagingMenu extends Component {
         return tab === "chat" ? ["chat", "group"] : [tab];
     }
 
+    get canPromptToInstall() {
+        return this.installPrompt.canPromptToInstall;
+    }
+
     get hasPreviews() {
         return (
             this.threads.length > 0 ||
@@ -78,6 +83,19 @@ export class MessagingMenu extends Component {
                 this.store.discuss.activeTab === "all") ||
             (this.notification.permission === "prompt" && this.store.discuss.activeTab === "all")
         );
+    }
+
+    get installationRequest() {
+        return {
+            body: _t("Come here often? Install Odoo on your device!"),
+            displayName: _t("%s has a suggestion", this.store.odoobot.name),
+            onClick: () => {
+                this.installPrompt.show();
+            },
+            iconSrc: this.threadService.avatarUrl(this.store.odoobot),
+            partner: this.store.odoobot,
+            isShown: this.canPromptToInstall,
+        };
     }
 
     get notificationRequest() {
@@ -301,6 +319,9 @@ export class MessagingMenu extends Component {
                 (acc, ng) => acc + parseInt(ng.notifications.length),
                 0
             );
+        if (this.canPromptToInstall) {
+            value++;
+        }
         if (this.notification.permission === "prompt") {
             value++;
         }

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -28,6 +28,24 @@
             <div class="d-flex justify-content-center py-4 px-2 text-muted" t-if="!hasPreviews">
                 No conversation yet...
             </div>
+            <t t-if="installationRequest.isShown">
+                <NotificationItem
+                    body="installationRequest.body"
+                    displayName="installationRequest.displayName"
+                    iconSrc="installationRequest.iconSrc"
+                    onClick="installationRequest.onClick"
+                >
+                    <t t-set-slot="icon">
+                        <ImStatus persona="installationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
+                    </t>
+                    <t t-set-slot="requestContent">
+                        <a t-if="ui.isSmall" class="btn fa fa-cloud-download" />
+                        <a t-else="" class="btn btn-primary">
+                            Install
+                        </a>
+                    </t>
+                </NotificationItem>
+            </t>
             <t t-if="notificationRequest.isShown">
                 <NotificationItem
                     body="notificationRequest.body"

--- a/addons/mail/static/src/core/web/notification_item.xml
+++ b/addons/mail/static/src/core/web/notification_item.xml
@@ -28,6 +28,9 @@
                     </div>
                 </div>
             </div>
+            <t t-if="props.slots and props.slots.requestContent">
+                <t t-slot="requestContent" />
+            </t>
         </button>
     </ActionSwiper>
 </t>

--- a/addons/web/static/src/core/browser/browser.js
+++ b/addons/web/static/src/core/browser/browser.js
@@ -27,6 +27,7 @@ export const browser = {
     AudioBufferSourceNode: window.AudioBufferSourceNode,
     AudioContext: window.AudioContext,
     AudioWorkletNode: window.AudioWorkletNode,
+    BeforeInstallPromptEvent: window.BeforeInstallPromptEvent?.bind(window),
     GainNode: window.GainNode,
     MediaStreamAudioSourceNode: window.MediaStreamAudioSourceNode,
     removeEventListener: window.removeEventListener.bind(window),

--- a/addons/web/static/src/core/install_prompt/install_prompt.js
+++ b/addons/web/static/src/core/install_prompt/install_prompt.js
@@ -1,0 +1,25 @@
+/** @odoo-module **/
+
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { isIOS } from "@web/core/browser/feature_detection";
+
+export class InstallPrompt extends Component {
+    static props = {
+        close: true,
+        onClose: { type: Function },
+    };
+    static components = {
+        Dialog,
+    };
+    static template = "web.InstallPrompt";
+
+    get isMobileSafari() {
+        return isIOS();
+    }
+
+    onClose() {
+        this.props.close();
+        this.props.onClose();
+    }
+}

--- a/addons/web/static/src/core/install_prompt/install_prompt.scss
+++ b/addons/web/static/src/core/install_prompt/install_prompt.scss
@@ -1,0 +1,30 @@
+.o_install_prompt {
+    /* We don't use a rounded-x class for this dialog to match the look of a native OS dialog */
+    border-radius: 20px;
+    height: unset !important;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+    background: rgba($white, .7);
+    inset: 0 auto auto 0 !important;
+    width: fit-content !important;
+
+    &.o_touch_bounce {
+        animation: none;
+    }
+
+    @media screen and (max-width: 768px) {
+        inset: auto auto 0 0 !important;
+        width: 90% !important;
+        margin: 5% !important;
+        transform: translateX(-50%);
+
+        .modal-header {
+            background: none !important;
+            border: none !important;
+
+            button {
+                color: $black !important;
+            }
+        }
+    }
+}

--- a/addons/web/static/src/core/install_prompt/install_prompt.xml
+++ b/addons/web/static/src/core/install_prompt/install_prompt.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.InstallPrompt" owl="1">
+        <Dialog contentClass="'o_install_prompt position-fixed px-2 py-3 m-2'" size="'md'" footer="false">
+            <t t-set-slot="header">
+                <div class="d-flex w-100">
+                    <h4>How to get the application</h4>
+                    <div t-on-click="onClose" type="button" class="btn-close" aria-label="Close"/>
+                </div>
+            </t>
+            <p>Install Odoo on your device to access it easily. Here are the steps to follow:</p>
+            <t t-if="isMobileSafari">
+                <ul class="list-group list-group-numbered">
+                    <li>
+                        Tap on the share icon
+                    </li>
+                    <li>
+                        Select "Add to home screen"
+                    </li>
+                </ul>
+            </t>
+            <t t-else="">
+                <ul class="list-group list-group-numbered">
+                    <li>
+                        Open "File" menu from your browser
+                    </li>
+                    <li>
+                        Select "Add to dock"
+                    </li>
+                </ul>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/web/static/src/core/install_prompt/install_prompt_service.js
+++ b/addons/web/static/src/core/install_prompt/install_prompt_service.js
@@ -1,0 +1,83 @@
+/** @odoo-module **/
+
+import { reactive } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
+import {
+    isDisplayStandalone,
+    isIOS,
+    isMacOS,
+    isBrowserSafari,
+} from "@web/core/browser/feature_detection";
+import { registry } from "@web/core/registry";
+import { InstallPrompt } from "./install_prompt";
+
+const serviceRegistry = registry.category("services");
+
+const installPromptService = {
+    dependencies: ["dialog"],
+    start(env, { dialog }) {
+        let nativePrompt;
+
+        const state = reactive({
+            canPromptToInstall: false,
+            decline,
+            show,
+        });
+
+        // The PWA can only be installed if the app is not already launched (display-mode standalone)
+        // For Apple devices, PWA are supported on any mobile version of Safari, or in desktop since version 17
+        const canBeInstalled =
+            !isDisplayStandalone() &&
+            (browser.BeforeInstallPromptEvent !== undefined ||
+                (isBrowserSafari() &&
+                    (isIOS() ||
+                        (isMacOS() &&
+                            browser.navigator.userAgent.match(/Version\/(\d+)/)[1] >= 17))));
+
+        const installationState = browser.localStorage.getItem("pwa.installationState");
+
+        // It is possible that the browser still has the installationState stored in the localstorage once
+        // the app has been uninstalled. This is why we don't use installationState directly in canBeInstalled
+        state.canPromptToInstall = canBeInstalled && !installationState;
+
+        const isDeclined = installationState === "dismissed";
+
+        if (canBeInstalled && !isDeclined) {
+            browser.addEventListener("beforeinstallprompt", (ev) => {
+                if (installationState === "accepted") {
+                    // If this event is triggered with the installationState stored, it means that the app has been
+                    // removed since its installation. The prompt can be displayed, and the installation state is reset.
+                    state.canPromptToInstall = true;
+                    browser.localStorage.removeItem("pwa.installationState");
+                }
+                ev.preventDefault();
+                nativePrompt = ev;
+            });
+        }
+
+        async function show() {
+            if (!state.canPromptToInstall) {
+                return;
+            }
+            if (nativePrompt) {
+                const res = await nativePrompt.prompt();
+                browser.localStorage.setItem("pwa.installationState", res.outcome);
+                state.canPromptToInstall = false;
+            } else if (isBrowserSafari()) {
+                // since those platforms don't support a native installation prompt yet, we
+                // show a custom dialog to explain how to pin the app to the application menu
+                dialog.add(InstallPrompt, {
+                    onClose: () => this.decline(),
+                });
+            }
+        }
+
+        function decline() {
+            browser.localStorage.setItem("pwa.installationState", "dismissed");
+            state.canPromptToInstall = false;
+        }
+
+        return state;
+    },
+};
+serviceRegistry.add("installPrompt", installPromptService);

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -136,6 +136,9 @@ function patchBrowserWithCleanup() {
             });
             return interval;
         },
+        // patch BeforeInstallPromptEvent to prevent the installPrompt service to return an uncontrolled
+        // canPromptToInstall value depending the browser settings (we ensure the value is always falsy)
+        BeforeInstallPromptEvent: undefined,
         navigator: {
             mediaDevices: browser.navigator.mediaDevices,
             permissions: browser.navigator.permissions,


### PR DESCRIPTION
The NotificationItem component has been modified to support a new slot allowing to display some content at the right of the notification item. It is used in this commit to display an additional 'Install button', inviting the user to click on the notification. Note that the entire notification is still clickable, it is only a visual indicator.

Once the notification is clicked, the installation process is triggered:

- In case the system supports the native installation prompt, we now display it, and the user is free to install the PWA from there.

- On Apple devices, a custom popup^is displayed to the user, explaining the steps to install the website as an application, since iOS and macOS don't support a native prompt, and won't be using one anytime soon, since it's a design decision from their side.

task-3275275