### PR TITLE
[IMP] spreadsheet: allow to reorder global filters

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/index.js
+++ b/addons/spreadsheet/static/src/global_filters/index.js
@@ -21,6 +21,7 @@ const {
 coreTypes.add("ADD_GLOBAL_FILTER");
 coreTypes.add("EDIT_GLOBAL_FILTER");
 coreTypes.add("REMOVE_GLOBAL_FILTER");
+coreTypes.add("MOVE_GLOBAL_FILTER");
 
 invalidateEvaluationCommands.add("ADD_GLOBAL_FILTER");
 invalidateEvaluationCommands.add("EDIT_GLOBAL_FILTER");

--- a/addons/spreadsheet/static/src/global_filters/index.js
+++ b/addons/spreadsheet/static/src/global_filters/index.js
@@ -51,7 +51,7 @@ inverseCommandRegistry
         return [
             {
                 type: "REMOVE_GLOBAL_FILTER",
-                id: cmd.id,
+                id: cmd.filter.id,
             },
         ];
     })
@@ -59,7 +59,6 @@ inverseCommandRegistry
         return [
             {
                 type: "ADD_GLOBAL_FILTER",
-                id: cmd.id,
                 filter: {},
             },
         ];

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
@@ -32,8 +32,8 @@ import { escapeRegExp } from "@web/core/utils/strings";
 export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
     constructor(config) {
         super(config);
-        /** @type {Object.<string, GlobalFilter>} */
-        this.globalFilters = {};
+        /** @type {Array.<GlobalFilter>} */
+        this.globalFilters = [];
     }
 
     /**
@@ -60,6 +60,17 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
                     return CommandResult.DuplicatedFilterLabel;
                 }
                 return checkFiltersTypeValueCombination(cmd.filter.type, cmd.filter.defaultValue);
+            case "MOVE_GLOBAL_FILTER": {
+                const index = this.globalFilters.findIndex((filter) => filter.id === cmd.id);
+                if (index === -1) {
+                    return CommandResult.FilterNotFound;
+                }
+                const targetIndex = index + cmd.delta;
+                if (targetIndex < 0 || targetIndex >= this.globalFilters.length) {
+                    return CommandResult.InvalidFilterMove;
+                }
+                break;
+            }
         }
         return CommandResult.Success;
     }
@@ -72,13 +83,18 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
     handle(cmd) {
         switch (cmd.type) {
             case "ADD_GLOBAL_FILTER":
-                this.history.update("globalFilters", cmd.filter.id, cmd.filter);
+                this.history.update("globalFilters", [...this.globalFilters, cmd.filter]);
                 break;
             case "EDIT_GLOBAL_FILTER":
                 this._editGlobalFilter(cmd.filter);
                 break;
-            case "REMOVE_GLOBAL_FILTER":
-                this.history.update("globalFilters", cmd.id, undefined);
+            case "REMOVE_GLOBAL_FILTER": {
+                const filters = this.globalFilters.filter((filter) => filter.id !== cmd.id);
+                this.history.update("globalFilters", filters);
+                break;
+            }
+            case "MOVE_GLOBAL_FILTER":
+                this._onMoveFilter(cmd.id, cmd.delta);
                 break;
         }
     }
@@ -94,7 +110,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      * @returns {GlobalFilter|undefined} Global filter
      */
     getGlobalFilter(id) {
-        return this.globalFilters[id];
+        return this.globalFilters.find((filter) => filter.id === id);
     }
 
     /**
@@ -105,7 +121,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      * @returns {GlobalFilter|undefined}
      */
     getGlobalFilterLabel(label) {
-        return this.getGlobalFilters().find((filter) => _t(filter.label) === _t(label));
+        return this.globalFilters.find((filter) => _t(filter.label) === _t(label));
     }
 
     /**
@@ -114,7 +130,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      * @returns {Array<GlobalFilter>} Array of Global filters
      */
     getGlobalFilters() {
-        return Object.values(this.globalFilters);
+        return [...this.globalFilters];
     }
 
     /**
@@ -172,9 +188,11 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
     _editGlobalFilter(newFilter) {
         const id = newFilter.id;
         const currentLabel = this.getGlobalFilter(id).label;
-        const globalFilters = { ...this.globalFilters };
-        globalFilters[id] = newFilter;
-        this.history.update("globalFilters", globalFilters);
+        const index = this.globalFilters.findIndex((filter) => filter.id === id);
+        if (index === -1) {
+            return;
+        }
+        this.history.update("globalFilters", index, newFilter);
         const newLabel = this.getGlobalFilter(id).label;
         if (currentLabel !== newLabel) {
             this._updateFilterLabelInFormulas(currentLabel, newLabel);
@@ -192,7 +210,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      */
     import(data) {
         for (const globalFilter of data.globalFilters || []) {
-            this.globalFilters[globalFilter.id] = globalFilter;
+            this.globalFilters.push(globalFilter);
         }
     }
     /**
@@ -201,7 +219,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      * @param {Object} data
      */
     export(data) {
-        data.globalFilters = this.getGlobalFilters().map((filter) => ({
+        data.globalFilters = this.globalFilters.map((filter) => ({
             ...filter,
         }));
     }
@@ -250,10 +268,22 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      */
     _isDuplicatedLabel(filterId, label) {
         return (
-            this.getGlobalFilters().findIndex(
+            this.globalFilters.findIndex(
                 (filter) => (!filterId || filter.id !== filterId) && filter.label === label
             ) > -1
         );
+    }
+
+    _onMoveFilter(filterId, delta) {
+        const filters = [...this.globalFilters];
+        const currentIndex = filters.findIndex((s) => s.id === filterId);
+        const filter = filters[currentIndex];
+        const targetIndex = currentIndex + delta;
+
+        filters.splice(currentIndex, 1);
+        filters.splice(targetIndex, 0, filter);
+
+        this.history.update("globalFilters", filters);
     }
 }
 

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
@@ -44,9 +44,9 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
     allowDispatch(cmd) {
         switch (cmd.type) {
             case "EDIT_GLOBAL_FILTER":
-                if (!this.getGlobalFilter(cmd.id)) {
+                if (!this.getGlobalFilter(cmd.filter.id)) {
                     return CommandResult.FilterNotFound;
-                } else if (this._isDuplicatedLabel(cmd.id, cmd.filter.label)) {
+                } else if (this._isDuplicatedLabel(cmd.filter.id, cmd.filter.label)) {
                     return CommandResult.DuplicatedFilterLabel;
                 }
                 return checkFiltersTypeValueCombination(cmd.filter.type, cmd.filter.defaultValue);
@@ -56,7 +56,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
                 }
                 break;
             case "ADD_GLOBAL_FILTER":
-                if (this._isDuplicatedLabel(cmd.id, cmd.filter.label)) {
+                if (this._isDuplicatedLabel(cmd.filter.id, cmd.filter.label)) {
                     return CommandResult.DuplicatedFilterLabel;
                 }
                 return checkFiltersTypeValueCombination(cmd.filter.type, cmd.filter.defaultValue);
@@ -75,7 +75,7 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
                 this.history.update("globalFilters", cmd.filter.id, cmd.filter);
                 break;
             case "EDIT_GLOBAL_FILTER":
-                this._editGlobalFilter(cmd.id, cmd.filter);
+                this._editGlobalFilter(cmd.filter);
                 break;
             case "REMOVE_GLOBAL_FILTER":
                 this.history.update("globalFilters", cmd.id, undefined);
@@ -169,10 +169,10 @@ export class GlobalFiltersCorePlugin extends spreadsheet.CorePlugin {
      * @param {string} id Id of the filter to update
      * @param {GlobalFilter} newFilter
      */
-    _editGlobalFilter(id, newFilter) {
+    _editGlobalFilter(newFilter) {
+        const id = newFilter.id;
         const currentLabel = this.getGlobalFilter(id).label;
         const globalFilters = { ...this.globalFilters };
-        newFilter.id = id;
         globalFilters[id] = newFilter;
         this.history.update("globalFilters", globalFilters);
         const newLabel = this.getGlobalFilter(id).label;

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -4,7 +4,7 @@
  * @typedef {import("@spreadsheet/data_sources/metadata_repository").Field} Field
  * @typedef {import("./global_filters_core_plugin").GlobalFilter} GlobalFilter
  * @typedef {import("./global_filters_core_plugin").FieldMatching} FieldMatching
- 
+
  */
 
 import { _t } from "@web/core/l10n/translation";
@@ -86,12 +86,14 @@ export default class GlobalFiltersUIPlugin extends spreadsheet.UIPlugin {
             case "ADD_GLOBAL_FILTER":
                 this.recordsDisplayName[cmd.filter.id] = cmd.filter.defaultValueDisplayNames;
                 break;
-            case "EDIT_GLOBAL_FILTER":
-                if (this.values[cmd.id] && this.values[cmd.id].rangeType !== cmd.filter.rangeType) {
-                    delete this.values[cmd.id];
+            case "EDIT_GLOBAL_FILTER": {
+                const id = cmd.filter.id;
+                if (this.values[id] && this.values[id].rangeType !== cmd.filter.rangeType) {
+                    delete this.values[id];
                 }
-                this.recordsDisplayName[cmd.filter.id] = cmd.filter.defaultValueDisplayNames;
+                this.recordsDisplayName[id] = cmd.filter.defaultValueDisplayNames;
                 break;
+            }
             case "SET_GLOBAL_FILTER_VALUE":
                 this.recordsDisplayName[cmd.id] = cmd.displayNames;
                 if (!cmd.value) {

--- a/addons/spreadsheet/static/src/o_spreadsheet/cancelled_reason.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/cancelled_reason.js
@@ -3,6 +3,7 @@
 export default {
     Success: "Success", // should be imported from o-spreadsheet instead of redefined here
     FilterNotFound: "FilterNotFound",
+    InvalidFilterMove: "InvalidFilterMove",
     DuplicatedFilterLabel: "DuplicatedFilterLabel",
     PivotCacheNotLoaded: "PivotCacheNotLoaded",
     InvalidValueTypeCombination: "InvalidValueTypeCombination",

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_chart_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_chart_test.js
@@ -14,11 +14,7 @@ async function addChartGlobalFilter(model) {
         rangeType: "fixedPeriod",
         defaultValue: { yearOffset: -1 },
     };
-    await addGlobalFilter(
-        model,
-        { filter },
-        { chart: { [chartId]: { chain: "date", type: "date" } } }
-    );
+    await addGlobalFilter(model, filter, { chart: { [chartId]: { chain: "date", type: "date" } } });
 }
 
 QUnit.module("spreadsheet > Global filters chart", {}, () => {
@@ -56,11 +52,9 @@ QUnit.module("spreadsheet > Global filters chart", {}, () => {
             label: "Last Year",
             rangeType: "fixedPeriod",
         };
-        await addGlobalFilter(
-            model,
-            { filter },
-            { chart: { [chartId]: { chain: "date", type: "date" } } }
-        );
+        await addGlobalFilter(model, filter, {
+            chart: { [chartId]: { chain: "date", type: "date" } },
+        });
         model.updateMode("dashboard");
         let computedDomain = model.getters.getChartDataSource(chartId).getComputedDomain();
         assert.deepEqual(computedDomain, []);

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -493,14 +493,12 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
         await addGlobalFilter(
             model,
             {
-                filter: {
-                    id: "42",
-                    type: "relation",
-                    label: "test",
-                    defaultValue: [41],
-                    modelName: undefined,
-                    rangeType: undefined,
-                },
+                id: "42",
+                type: "relation",
+                label: "test",
+                defaultValue: [41],
+                modelName: undefined,
+                rangeType: undefined,
             },
             {
                 list: { 1: { chain: "product_id", type: "many2one" } },

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -778,14 +778,12 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
         await addGlobalFilter(
             model,
             {
-                filter: {
-                    id: "42",
-                    type: "relation",
-                    label: "test",
-                    defaultValue: [41],
-                    modelName: undefined,
-                    rangeType: undefined,
-                },
+                id: "42",
+                type: "relation",
+                label: "test",
+                defaultValue: [41],
+                modelName: undefined,
+                rangeType: undefined,
             },
             {
                 pivot: { 1: { chain: "product_id", type: "many2one" } },

--- a/addons/spreadsheet/static/tests/utils/commands.js
+++ b/addons/spreadsheet/static/tests/utils/commands.js
@@ -56,6 +56,10 @@ export async function setGlobalFilterValue(model, payload) {
     return result;
 }
 
+export function moveGlobalFilter(model, id, delta) {
+    return model.dispatch("MOVE_GLOBAL_FILTER", { id, delta });
+}
+
 /**
  * Set the selection
  */

--- a/addons/spreadsheet/static/tests/utils/commands.js
+++ b/addons/spreadsheet/static/tests/utils/commands.js
@@ -23,7 +23,7 @@ export function selectCell(model, xc) {
  * @param {{filter: GlobalFilter}} filter
  */
 export async function addGlobalFilter(model, filter, fieldMatchings = {}) {
-    const result = model.dispatch("ADD_GLOBAL_FILTER", { ...filter, ...fieldMatchings });
+    const result = model.dispatch("ADD_GLOBAL_FILTER", { filter, ...fieldMatchings });
     await waitForDataSourcesLoaded(model);
     return result;
 }
@@ -41,7 +41,7 @@ export async function removeGlobalFilter(model, id) {
  * Edit a global filter and ensure the data sources are completely reloaded
  */
 export async function editGlobalFilter(model, filter) {
-    const result = model.dispatch("EDIT_GLOBAL_FILTER", filter);
+    const result = model.dispatch("EDIT_GLOBAL_FILTER", { filter });
     await waitForDataSourcesLoaded(model);
     return result;
 }

--- a/addons/spreadsheet/static/tests/utils/global_filter.js
+++ b/addons/spreadsheet/static/tests/utils/global_filter.js
@@ -1,8 +1,33 @@
 /** @odoo-module */
+
+/**
+ * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").GlobalFilter} GlobalFilter
+ *
+ */
+
+/** @type GlobalFilter */
 export const THIS_YEAR_GLOBAL_FILTER = {
     id: "43",
     type: "date",
     label: "This Year",
     rangeType: "fixedPeriod",
     defaultValue: { yearOffset: 0 },
+};
+
+/** @type GlobalFilter */
+export const LAST_YEAR_GLOBAL_FILTER = {
+    id: "42",
+    type: "date",
+    label: "Last Year",
+    rangeType: "fixedPeriod",
+    defaultValue: { yearOffset: -1 },
+};
+
+/** @type GlobalFilter */
+export const NEXT_YEAR_GLOBAL_FILTER = {
+    id: "44",
+    type: "date",
+    label: "Next Year",
+    rangeType: "year",
+    defaultValue: { yearOffset: 1 },
 };

--- a/addons/spreadsheet/static/tests/utils/global_filter.js
+++ b/addons/spreadsheet/static/tests/utils/global_filter.js
@@ -1,10 +1,8 @@
 /** @odoo-module */
 export const THIS_YEAR_GLOBAL_FILTER = {
-    filter: {
-        id: "43",
-        type: "date",
-        label: "This Year",
-        rangeType: "fixedPeriod",
-        defaultValue: { yearOffset: 0 },
-    },
+    id: "43",
+    type: "date",
+    label: "This Year",
+    rangeType: "fixedPeriod",
+    defaultValue: { yearOffset: 0 },
 };

--- a/addons/spreadsheet/static/tests/utils/model.js
+++ b/addons/spreadsheet/static/tests/utils/model.js
@@ -66,8 +66,7 @@ export async function waitForDataSourcesLoaded(model) {
     }
     // Read a first time in order to trigger the RPC
     readAllCellsValue();
-    //@ts-ignore
-    await model.config.custom.dataSources.waitForAllLoaded();
+    await model.config.custom.dataSources?.waitForAllLoaded();
     await nextTick();
     // Read a second time to trigger the compute format (which could trigger a RPC for currency, in list)
     readAllCellsValue();


### PR DESCRIPTION
## [IMP] spreadsheet: allow to reorder global filters

This commit allows to reorder global filters via drag and drop. The
fact that global filters have a concept of order means taht the
structure of the global filters in the core plugin need to change from
an Object<string, GlobalFilter> to an Array<GlobalFilter>.

## [REF] spreadsheet_edition: de-duplicate filter id in cmds

The commands `ADD_GLOBAL_FILTER` and `EDIT_GLOBAL_FILTER` had the filter id
once in cmd.id, and once in cmd.filter.id. This made it possible to send
a command with 2 different ids, which can have arbitrary behaviour depending
on the implementation details of the command.

Changed it so we only use cmd.filter.id, and removed the cmd.id field. Also
simplified the commands helpers for the tests.

Task: [3502684](https://www.odoo.com/web#id=3502684&menu_id=4720&cids=1&action=333&active_id=2328&model=project.task&view_type=form)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
