### PR TITLE
[IMP] web_editor, web_unsplash: improve the UX of the media dialog

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/document_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/document_selector.xml
@@ -9,7 +9,7 @@
 </t>
 
 <t t-name="web_editor.DocumentsListTemplate">
-    <div class="o_we_existing_attachments o_we_documents">
+    <div class="o_we_existing_attachments o_we_documents" t-ref="existing-attachments">
         <div t-if="!hasContent" class="o_nocontent_help">
             <p class="o_empty_folder_image">No documents found.</p>
             <p class="o_empty_folder_subtitle">You can upload documents with the button located in the top left of the screen.</p>

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
 <t t-name="web_editor.FileSelectorControlPanel">
-    <div class="d-flex flex-wrap gap-2 mt-4 mb-2 align-items-end">
+    <div class="o_we_file_selector_control_panel sticky-top d-flex flex-wrap gap-2 mb-1 p-3 align-items-end">
         <SearchMedia searchPlaceholder="props.searchPlaceholder" needle="props.needle" search="props.search"/>
         <div class="d-flex gap-3 justify-content-start align-items-center">
             <div t-if="props.showOptimizedOption" class="flex-shrink-0 form-check form-switch align-items-center" t-on-change="props.changeShowOptimized">
@@ -37,7 +37,7 @@
 </t>
 
 <t t-name="web_editor.FileSelector">
-    <div>
+    <div class="o_we_file_selector_container">
         <FileSelectorControlPanel uploadText="uploadText"
             accept="fileMimetypes"
             urlPlaceholder="urlPlaceholder"
@@ -57,9 +57,10 @@
             validateUrl="validateUrl"
             multiSelect="props.multiSelect"/>
         <t t-call="{{ constructor.attachmentsListTemplate }}"/>
-        <div name="load_more_attachments" class="mt-4 text-center mx-auto o_we_load_more" t-ref="load-more-button">
-            <button t-if="canLoadMore" class="btn btn-primary o_load_more" type="button" t-on-click="handleLoadMore">Load more...</button>
-            <div t-if="hasContent and !canLoadMore" class="mt-4 o_load_done_msg">
+        <div name="load_more_attachments" class="position-fixed pt-3 text-center mx-auto o_we_load_more" t-ref="load-more-button">
+            <div t-if="canScroll" class="d-flex align-items-center mx-auto btn btn-primary rounded-circle oi oi-chevron-down o_scroll_attachments" t-on-click="handleScrollAttachments"/>
+            <button t-if="canLoadMore and !canScroll" class="btn btn-primary o_load_more" type="button" t-on-click="handleLoadMore">Load more...</button>
+            <div t-if="hasContent and !canLoadMore and !canScroll" class="mt-2 o_load_done_msg">
                 <span><i t-esc="allLoadedText"/></span>
             </div>
         </div>

--- a/addons/web_editor/static/src/components/media_dialog/icon_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/icon_selector.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 <t t-name="web_editor.IconSelector">
     <div>
-        <div class="d-flex gap-2 align-items-center py-4">
+        <div class="o_we_file_selector_control_panel sticky-top d-flex gap-2 align-items-center mb-1 py-4 px-3">
             <SearchMedia searchPlaceholder="searchPlaceholder"
                 search.bind="this.search"
                 needle="state.needle"/>

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -98,6 +98,10 @@ export class ImageSelector extends FileSelector {
         return this.props.selectedMedia[this.props.id].filter(media => media.mediaType === 'libraryMedia').map(({ id }) => id);
     }
 
+    get allAttachments() {
+        return [...super.allAttachments, ...this.state.libraryMedia];
+    }
+
     get attachmentsDomain() {
         const domain = super.attachmentsDomain;
         domain.push(['mimetype', 'in', IMAGE_MIMETYPES]);
@@ -307,7 +311,7 @@ export class ImageSelector extends FileSelector {
     }
 
     async onImageLoaded(imgEl, attachment) {
-        this.debouncedScroll();
+        this.debouncedScrollUpdate();
         if (attachment.mediaType === 'libraryMedia' && !imgEl.src.startsWith('blob')) {
             // This call applies the theme's color palette to the
             // loaded illustration. Upon replacement of the image,

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.xml
@@ -26,7 +26,7 @@
 </t>
 
 <t t-name="web_editor.ImagesListTemplate">
-    <div class="o_we_existing_attachments o_we_images d-flex flex-wrap my-0">
+    <div class="o_we_existing_attachments o_we_images d-flex flex-wrap my-0" t-ref="existing-attachments">
         <t t-if="!hasContent and !isFetching">
             <div t-if="state.needle" class="o_nocontent_help">
                 <p class="o_empty_folder_image">No images found.</p>

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.js
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { _t } from "@web/core/l10n/translation";
-import { useService } from '@web/core/utils/hooks';
+import { useService, useChildRef } from '@web/core/utils/hooks';
 import { Dialog } from '@web/core/dialog/dialog';
 import { Notebook } from '@web/core/notebook/notebook';
 import { ImageSelector } from './image_selector';
@@ -9,7 +9,7 @@ import { DocumentSelector } from './document_selector';
 import { IconSelector } from './icon_selector';
 import { VideoSelector } from './video_selector';
 
-import { Component, useState } from "@odoo/owl";
+import { Component, useState, useRef, useEffect } from "@odoo/owl";
 
 export const TABS = {
     IMAGES: {
@@ -37,8 +37,9 @@ export const TABS = {
 export class MediaDialog extends Component {
     setup() {
         this.size = 'xl';
-        this.contentClass = 'o_select_media_dialog';
+        this.contentClass = 'o_select_media_dialog h-100';
         this.title = _t("Select a media");
+        this.modalRef = useChildRef();
 
         this.rpc = useService('rpc');
         this.orm = useService('orm');
@@ -46,6 +47,8 @@ export class MediaDialog extends Component {
 
         this.tabs = [];
         this.selectedMedia = useState({});
+
+        this.addButtonRef = useRef('add-button');
 
         this.initialIconClasses = [];
 
@@ -55,6 +58,15 @@ export class MediaDialog extends Component {
         this.state = useState({
             activeTab: this.initialActiveTab,
         });
+
+        useEffect(
+            (nbSelectedAttachments) => {
+                // Disable/enable the add button depending on whether some media
+                // are selected or not.
+                this.addButtonRef.el.toggleAttribute("disabled", !nbSelectedAttachments);
+            },
+            () => [this.selectedMedia[this.state.activeTab].length]
+        );
     }
 
     get initialActiveTab() {
@@ -87,6 +99,7 @@ export class MediaDialog extends Component {
                 save: this.save.bind(this),
                 onAttachmentChange: this.props.onAttachmentChange,
                 errorMessages: (errorMessage) => this.errorMessages[tab.id] = errorMessage,
+                modalRef: this.modalRef,
             },
         });
     }

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.scss
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.scss
@@ -1,5 +1,16 @@
 .modal:not(.o_legacy_dialog) .o_select_media_dialog {
     $min-row-height: 128;
+    $bottom-bar-height: 52px;
+
+    .o_we_file_selector_container {
+        // Letting some space for the bottom bar.
+        padding-bottom: $bottom-bar-height;
+    }
+
+    .o_we_file_selector_control_panel {
+        top: -$modal-inner-padding;
+        background-color: $modal-content-bg;
+    }
 
     .o_we_existing_attachments {
         min-height: $min-row-height + px;
@@ -31,7 +42,21 @@
     }
 
     .o_we_load_more {
+        top: calc(var(--footer-top) - #{$bottom-bar-height} - #{$modal-inner-padding});
+        width: calc(var(--footer-width) - 2 * #{$modal-inner-padding});
+        height: $bottom-bar-height;
         scroll-margin: $modal-inner-padding;
+
+        &.o_can_scroll {
+            z-index: 2;
+            pointer-events: none;
+
+            > .o_scroll_attachments {
+                width: 36px;
+                height: 36px;
+                pointer-events: all;
+            }
+        }
     }
 
     .font-icons-icons > span {

--- a/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
+++ b/addons/web_editor/static/src/components/media_dialog/media_dialog.xml
@@ -3,10 +3,11 @@
 <t t-name="web_editor.MediaDialog">
     <Dialog contentClass="contentClass"
         size="size"
-        title="title">
+        title="title"
+        modalRef="modalRef">
         <Notebook pages="tabs" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">
-            <button class="btn btn-primary" t-on-click="() => this.save()">Add</button>
+            <button class="btn btn-primary" t-on-click="() => this.save()" t-ref="add-button">Add</button>
             <button class="btn btn-secondary" t-on-click="() => this.props.close()">Discard</button>
         </t>
     </Dialog>

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
@@ -8,7 +8,7 @@ import { ImageSelector } from '@web_editor/components/media_dialog/image_selecto
 import { useService } from '@web/core/utils/hooks';
 import { uploadService, AUTOCLOSE_DELAY } from '@web_editor/components/upload_progress_toast/upload_service';
 
-import { useState, Component } from "@odoo/owl";
+import { useState, Component, useRef } from "@odoo/owl";
 
 class UnsplashCredentials extends Component {
     setup() {
@@ -43,6 +43,8 @@ patch(ImageSelector.prototype, {
         super.setup();
         this.unsplash = useService('unsplash');
         this.keepLastUnsplash = new KeepLast();
+
+        this.unsplashErrorRef = useRef("unsplash-error");
 
         this.state.unsplashRecords = [];
         this.state.isFetchingUnsplash = false;
@@ -125,6 +127,10 @@ patch(ImageSelector.prototype, {
         return alternate(this.state.unsplashRecords, this.state.libraryMedia);
     },
 
+    get allAttachments() {
+        return [...super.allAttachments, ...this.state.unsplashRecords];
+    },
+
     // It seems that setters are mandatory when patching a component that
     // extends another component.
     set canLoadMore(_) {},
@@ -205,6 +211,35 @@ patch(ImageSelector.prototype, {
         this.state.unsplashError = null;
         await this.rpc('/web_unsplash/save_unsplash', { key, appId });
         await this.searchUnsplash();
+    },
+
+    /**
+     * Updates the scroll button but takes the unsplash error into account.
+     */
+    updateScroll() {
+        if (!this.state.unsplashError) {
+            super.updateScroll();
+            return;
+        }
+        const unsplashErrorEl = this.unsplashErrorRef.el.querySelector(".alert");
+        const canScroll = this.isElementHidden(unsplashErrorEl);
+        this.state.canScrollAttachments = canScroll;
+        this.loadMoreButtonRef.el.classList.toggle("o_can_scroll", canScroll);
+    },
+
+    /**
+     * Computes the amount to scroll: first for the attachments, then for the
+     * unsplash error when all the attachments are already above the bottom bar.
+     */
+    computeScroll() {
+        let scrollAmount = super.computeScroll();
+        if (this.state.unsplashError && scrollAmount === 15) {
+            const unsplashErrorEl = this.unsplashErrorRef.el.querySelector(".alert");
+            const unsplashErrorBottom = unsplashErrorEl.getBoundingClientRect().bottom;
+            const loadMoreTop = this.loadMoreButtonRef.el.getBoundingClientRect().top;
+            scrollAmount += Math.ceil(unsplashErrorBottom - loadMoreTop);
+        }
+        return scrollAmount;
     },
 });
 ImageSelector.components = {

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.xml
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.xml
@@ -62,8 +62,8 @@
 </t>
 
 <t t-inherit="web_editor.FileSelector" t-inherit-mode="extension">
-    <xpath expr="//div[@name='load_more_attachments']" position="after">
-        <div t-if="state.unsplashError" class="d-flex mt-2 unsplash_error">
+    <xpath expr="//div[@name='load_more_attachments']" position="before">
+        <div t-if="state.unsplashError" class="d-flex mt-2 unsplash_error" t-ref="unsplash-error">
             <UnsplashError
                 title="errorTitle"
                 subtitle="errorSubtitle"


### PR DESCRIPTION
When using the media dialog, the dialog always seems glitchy as its size
is always changing with the loading files. This behavior is not really
convenient as it can make the user click on unwanted images. Another
"issue" of the current media dialog is that when loading more images,
the dialog auto-scrolls to the "Load More" button, which can make the
user miss new images and he therefore needs to revert the scroll. A last
issue encountered by the users is that some of them think that the "Add"
button in the footer is used to upload files from their device, while it
only adds the selected media to the page.

This commit improves the UX of the media dialog:
- The dialog height is now fixed and has the same size as when it is
fully filled by images.
- The top bar with the search input now stays at the top when scrolling.
- There is now a small footer under the attachments (for the Images and
Documents tabs only) and containing the following:
    - When there is content to scroll, a small circle with an arrow that
scrolls one row when clicking on it.
    - When there is nothing to scroll, the "Load More" button which will
load more images. When new images are loaded, if we can scroll, the
small arrow is displayed again.
    - When there is nothing to scroll and to load anymore, the "All
images/documents have been loaded" text.

Note that the main goal of this footer is simply to indicate to the user
when there is still content to scroll and when he can load more files.

In order to solve the "Add" button issue, this commit also enables and
disables this button, depending on whether some media are selected:
- if a media is already selected, we can click on the button;
- if not, the button is greyed out and we cannot click on it.

task-3441587