### PR TITLE
[FIX] pos_loyalty: check for `tax_id` when adding reward line

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1154,10 +1154,15 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
             return _t("The reward could not be applied.");
         }
         for (const rewardLine of rewardLines) {
-            this.orderlines.add(this._createLineFromVals(rewardLine));
+            this._addRewardLine(this._createLineFromVals(rewardLine));
         }
         return true;
     }
+
+    _addRewardLine(line){
+        this.orderlines.add(line);
+    }
+
     _createLineFromVals(vals) {
         vals['lst_price'] = vals['price'];
         const line = Orderline.create({}, {pos: this.pos, order: this, product: vals['product']});


### PR DESCRIPTION
Steps to reproduce:

1. Install l10n_de_pos_cert and configure Fiskaly
2. Install pos_loyalty
3. Configure a PoS, generate gift cards, don't add tax ID to the
associated product
4. Open a PoS session, add the gift card code
5. Validate the order, an error appears, and the order will not sync

This happens because in `pos_loyalty`, reward line is added directly and not through the `add_orderline` method, which is overriden in `l10n_de_pos_cert` to make sure correct VAT rates are used.

This PR moves the functionality to a new method, which is overriden in https://github.com/odoo/enterprise/pull/49107 to validate the VAT rate.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
