### PR TITLE
[FIX] crm: incorrect field name as expression source

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -743,7 +743,7 @@ class Lead(models.Model):
             index_name = f'crm_lead_{field_name}_partial_tgm'
             if tools.index_exists(self._cr, index_name):
                 continue
-            regex_expression = "regexp_replace((phone::text), %s::text, ''::text, 'g'::text)"
+            regex_expression = f"regexp_replace(({field_name}::text), %s::text, ''::text, 'g'::text)"
             self._cr.execute(
                 f'CREATE INDEX "{index_name}" ON "{self._table}" ({regex_expression}) WHERE {field_name} IS NOT NULL',
                 (phone_pattern,)


### PR DESCRIPTION
PR #105873 added computed indexes on the `mobile` and `phone` fields for the benefit of `phone_mobile_search`, however it created both indexes to work on the `phone` field as source, rather than whichever field they were named after and partial for. As a result, the index has no effect when searching on `mobile`.

Thankfully (?) the "mobile" field is mostly unused (4000 to 120000 "phone" set)