### PR TITLE
[FIX] mrp: force readonly=False on compute

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -16,8 +16,6 @@ class StockPickingType(models.Model):
         compute='_get_mo_count')
     count_mo_late = fields.Integer(string="Number of Manufacturing Orders Late",
         compute='_get_mo_count')
-    use_create_lots = fields.Boolean(compute='_compute_use_create_lots', store=True)
-    use_existing_lots = fields.Boolean(compute='_compute_use_existing_lots', store=True)
     use_create_components_lots = fields.Boolean(
         string="Create New Lots/Serial Numbers for Components",
         help="Allow to create new lot/serial numbers for the components",

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -57,9 +57,11 @@ class PickingType(models.Model):
     active = fields.Boolean('Active', default=True)
     use_create_lots = fields.Boolean(
         'Create New Lots/Serial Numbers', default=True,
+        compute='_compute_use_create_lots', store=True, readonly=False,
         help="If this is checked only, it will suppose you want to create new Lots/Serial Numbers, so you can provide them in a text field. ")
     use_existing_lots = fields.Boolean(
         'Use Existing Lots/Serial Numbers', default=True,
+        compute='_compute_use_existing_lots', store=True, readonly=False,
         help="If this is checked, you will be able to choose the Lots/Serial Numbers. You can also decide to not put lots in this operation type.  This means it will create stock with no lot or not put a restriction on the lot taken. ")
     print_label = fields.Boolean(
         'Print Label',
@@ -173,6 +175,18 @@ class PickingType(models.Model):
                 picking_type.display_name = f"{picking_type.warehouse_id.name}: {picking_type.name}"
             else:
                 picking_type.display_name = picking_type.name
+
+    @api.depends('code')
+    def _compute_use_create_lots(self):
+        for picking_type in self:
+            if picking_type.code == 'incoming':
+                picking_type.use_create_lots = True
+
+    @api.depends('code')
+    def _compute_use_existing_lots(self):
+        for picking_type in self:
+            if picking_type.code == 'outgoing':
+                picking_type.use_existing_lots = True
 
     @api.model
     def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -954,7 +954,6 @@ class Warehouse(models.Model):
             'in_type_id': {
                 'name': _('Receipts'),
                 'code': 'incoming',
-                'use_create_lots': True,
                 'use_existing_lots': False,
                 'default_location_src_id': False,
                 'sequence': max_sequence + 1,
@@ -966,7 +965,6 @@ class Warehouse(models.Model):
                 'name': _('Delivery Orders'),
                 'code': 'outgoing',
                 'use_create_lots': False,
-                'use_existing_lots': True,
                 'default_location_dest_id': False,
                 'sequence': max_sequence + 5,
                 'sequence_code': 'OUT',


### PR DESCRIPTION
Commit 167c51b1f9019c25f412be8420f60fe649b3c3c5 makes `use_create_lots` and 'use_exisitng_lots` computed fields in MRP module but did not mark them as `readonly=False`. Thus, they were readonly by default for any picking types.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
