### PR TITLE
[FIX] point of sale: check if config_currencies null

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -62,7 +62,7 @@ class ReportSaleDetails(models.AbstractModel):
         else:
             config_currencies = self.env['pos.session'].search([('id', 'in', session_ids)]).mapped('config_id.currency_id')
         # If all the pos.config have the same currency, we can use it, else we use the company currency
-        if all(i == config_currencies.ids[0] for i in config_currencies.ids):
+        if config_currencies and all(i == config_currencies.ids[0] for i in config_currencies.ids):
             user_currency = config_currencies[0]
         else:
             user_currency = self.env.company.currency_id

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -20,3 +20,4 @@ from . import test_pos_stock_account
 from . import test_js
 from . import test_report_pos_order
 from . import test_res_config_settings
+from . import test_report_sale_details

--- a/addons/point_of_sale/tests/test_report_sale_details.py
+++ b/addons/point_of_sale/tests/test_report_sale_details.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import odoo
+
+from odoo.addons.point_of_sale.tests.common import TestPoSCommon
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestReportSaleDetails(TestPoSCommon):
+
+    def setUp(self):
+        super(TestReportSaleDetails, self).setUp()
+        self.config = self.basic_config
+
+    def test_get_sale_details(self):
+        # Check if the get report details function works without any errors
+        try:
+            report = self.env['report.point_of_sale.report_saledetails']
+            report._get_report_values(None, None)
+        except Exception:
+            self.fail('Get Report Details function failed to execute properly.')


### PR DESCRIPTION
A traceback is generated if config currencies are none. This is because we are trying to access the 0 index which does not exist in a None object.

### Steps to reproduce:
1. Go to studio.
2. Click on reports.
3. Search for sale details.
4. Click on the sale details report.

### Current Behavior:
As we click on the sales details report, a traceback pops up.

### Expected Behavior:
There should be no traceback and the report editor should open smoothly if nothing is wrong.

OPW-3501650

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
