### PR TITLE
[FIX] account: compute label according to payment ref

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -457,16 +457,14 @@ class AccountMoveLine(models.Model):
 
     @api.depends('product_id')
     def _compute_name(self):
-        for line in self:
+        for line in self.filtered(lambda l: l.move_id.inalterable_hash is False):
             if line.display_type == 'payment_term':
-                if not line.name:
-                    term_lines = line.move_id.line_ids.filtered(lambda l: l.display_type == 'payment_term') | line
-                    name = line.move_id.payment_reference or ''
-                    if len(term_lines) > 1:
-                        index = term_lines._ids.index(line.id) + 1
-                        name = _('%s installment #%s', name, index).lstrip()
-                    line.name = name
-                continue
+                term_lines = line.move_id.line_ids.filtered(lambda l: l.display_type == 'payment_term') | line
+                name = line.move_id.payment_reference or ''
+                if len(term_lines) > 1:
+                    index = term_lines._ids.index(line.id) + 1
+                    name = _('%s installment #%s', name, index).lstrip()
+                line.name = name
             if not line.product_id or line.display_type in ('line_section', 'line_note'):
                 continue
             if line.partner_id.lang:

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3760,3 +3760,46 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             other_income_account,
             "Removing a product from an invoice line should no change the account."
         )
+
+    def test_compute_name_payment_reference(self):
+        """
+        Test that the label of the payment_term line is consistent with the payment reference
+        Also tests that it won't affect the hash inalterability report
+        """
+        self.company_data['default_journal_sale'].restrict_mode_hash_table = True
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='out_invoice'))
+        move_form.partner_id = self.partner_b
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_a
+        invoice = move_form.save()
+        payment_term_lines = invoice.line_ids.filtered(lambda line: line.display_type == 'payment_term')
+
+        self.assertRecordValues(payment_term_lines, [
+            {'name': ''},
+            {'name': ''},
+        ])
+
+        move_form.payment_reference = "Super Reference"
+        move_form.save()
+
+        self.assertRecordValues(payment_term_lines, [
+            {'name': 'Super Reference installment #1'},
+            {'name': 'Super Reference installment #2'},
+        ])
+
+        move_form.payment_reference = "Great Reference"
+        invoice = move_form.save()
+
+        self.assertRecordValues(payment_term_lines, [
+            {'name': 'Great Reference installment #1'},
+            {'name': 'Great Reference installment #2'},
+        ])
+
+        invoice.action_post()
+        move_form.payment_reference = "Bad Reference"
+        move_form.save()
+
+        # The integrity check should work
+        integrity_check = invoice.company_id._check_hash_integrity()['results'][0]
+        self.assertEqual(integrity_check['msg_cover'], 'All entries are hashed.')

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -749,6 +749,7 @@
                         <field name="invoice_pdf_report_id" invisible="1"/>
                         <field name="has_reconciled_entries" invisible="1"/>
                         <field name="restrict_mode_hash_table" invisible="1"/>
+                        <field name="inalterable_hash" invisible="1"/>
                         <field name="country_code" invisible="1"/>
                         <field name="display_inactive_currency_warning" invisible="1"/>
                         <field name="statement_line_id" invisible="1"/>
@@ -824,7 +825,10 @@
                                             'readonly': [('state', '!=', 'draft')],
                                        }"/>
                                 <field name="payment_reference"
-                                       attrs="{'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]}"/>
+                                       attrs="{
+                                            'invisible': [('move_type', 'not in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))],
+                                            'readonly': [('inalterable_hash', '!=', False)],
+                                       }"/>
                                 <field name="partner_bank_id"
                                        context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
                                        domain="[('partner_id', '=', bank_partner_id)]"


### PR DESCRIPTION
Steps to reproduce:
- create a bill
- add a product line
- add a payment reference
- save it
- change the payment ref
- confirm
- register a payment

Issue:
The memo is not the updated payment reference

Cause:
The memo is computed by taking in priority the `line.name`
https://github.com/odoo/odoo/blob/a39050e15195eb095b3480899cedb5cb458fa6cc/addons/account/wizard/account_payment_register.py#L139-L145

And whenever we change the payment reference, the line.name is not recomputed if it has already been set

opw-3476835