### PR TITLE
[IMP] http_routing, website_slides: redirect the user on /slides on AccessError

### DIFF
--- a/addons/website_sale_wishlist/controllers/main.py
+++ b/addons/website_sale_wishlist/controllers/main.py
@@ -48,12 +48,13 @@ class WebsiteSaleWishlist(WebsiteSale):
 
         return request.render("website_sale_wishlist.product_wishlist", dict(wishes=values))
 
-    @route(['/shop/wishlist/remove/<model("product.wishlist"):wish>'], type='json', auth="public", website=True)
-    def rm_from_wishlist(self, wish, **kw):
+    @route('/shop/wishlist/remove/<int:wish_id>', type='json', auth='public', website=True)
+    def rm_from_wishlist(self, wish_id, **kw):
+        wish = request.env['product.wishlist'].browse(wish_id)
         if request.website.is_public_user():
             wish_ids = request.session.get('wishlist_ids') or []
-            if wish.id in wish_ids:
-                request.session['wishlist_ids'].remove(wish.id)
+            if wish_id in wish_ids:
+                request.session['wishlist_ids'].remove(wish_id)
                 request.session.touch()
                 wish.sudo().unlink()
         else:

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -696,6 +696,9 @@ def route(route=None, **routing):
     :param bool csrf: Whether CSRF protection should be enabled for the
         route. Enabled by default for ``'http'``-type requests, disabled
         by default for ``'json'``-type requests.
+    :param Callable[[Exception], Response] handle_params_access_error:
+        Implement a custom behavior if an error occurred when retrieving the record
+        from the URL parameters (access error or missing error).
     """
     def decorator(endpoint):
         fname = f"<function {endpoint.__module__}.{endpoint.__name__}>"


### PR DESCRIPTION
Purpose
=======
When a user tries to reach a course, an AccessError can occur when we
unslug the URL. Instead of the traditional error page, we want to
redirect the users to /slides, and the error will be displayed there.

Task-3477630