### PR TITLE
[IMP] base_automation: implement mail and webhook triggers

### DIFF
--- a/addons/base_automation/__init__.py
+++ b/addons/base_automation/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from . import controllers

--- a/addons/base_automation/controllers/__init__.py
+++ b/addons/base_automation/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/base_automation/controllers/main.py
+++ b/addons/base_automation/controllers/main.py
@@ -1,0 +1,23 @@
+from odoo.http import request, route, Controller
+
+from json import JSONDecodeError
+
+class BaseAutomationController(Controller):
+
+    @route(['/web/hook/<string:rule_uuid>'], type='http', auth='none', methods=['GET', 'POST'], csrf=False, save_session=False)
+    def call_webhook_http(self, rule_uuid, **kwargs):
+        """ Execute an automation webhook """
+        rule = request.env['base.automation'].sudo().search([('webhook_uuid', '=', rule_uuid)])
+        if not rule:
+            return request.make_json_response({'status': 'error'}, status=404)
+
+        try:
+            data = request.get_json_data()
+        except JSONDecodeError:
+            data = kwargs or {}
+
+        try:
+            rule._execute_webhook(data)
+        except Exception: # noqa: BLE001
+            return request.make_json_response({'status': 'error'}, status=500)
+        return request.make_json_response({'status': 'ok'}, status=200)

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.js
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.js
@@ -31,6 +31,10 @@ const OPT_GROUPS = [
         triggers: ["on_unlink", "on_change"],
     },
     {
+        group: { sequence: 50, key: "external", name: _lt("External") },
+        triggers: ["on_webhook"],
+    },
+    {
         group: { sequence: 20, key: "mail", name: _t("Email Events") },
         triggers: ["on_message_sent", "on_message_received"],
     },

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.js
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.js
@@ -12,7 +12,6 @@ const OPT_GROUPS = [
     {
         group: { sequence: 10, key: "values", name: _lt("Values Updated") },
         triggers: [
-            "on_create_or_write",
             "on_stage_set",
             "on_user_set",
             "on_tag_set",
@@ -28,7 +27,7 @@ const OPT_GROUPS = [
     },
     {
         group: { sequence: 40, key: "custom", name: _lt("Custom") },
-        triggers: ["on_unlink", "on_change"],
+        triggers: ["on_create_or_write", "on_unlink", "on_change"],
     },
     {
         group: { sequence: 50, key: "external", name: _lt("External") },
@@ -64,6 +63,7 @@ function computeDerivedOptions(options, fields, currentSelection, { excludeGroup
                 continue;
             }
         }
+
         const option = { group, value, label };
         derivedOptions.push(option);
     }

--- a/addons/base_automation/static/src/utils.js
+++ b/addons/base_automation/static/src/utils.js
@@ -21,4 +21,5 @@ export const TRIGGER_FILTERS = {
         f.ttype === "selection" && ["priority", "x_studio_priority"].includes(f.name),
     on_archive: (f) => f.ttype === "boolean" && ["active", "x_active"].includes(f.name),
     on_unarchive: (f) => f.ttype === "boolean" && ["active", "x_active"].includes(f.name),
+    on_webhook: (f) => true,
 };

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -8,8 +8,12 @@
             <field name="arch" type="xml">
                 <form string="Automation Rule">
                     <sheet>
+                        <div class="oe_button_box" name="button_box">
+                            <button name="action_view_webhook_logs" type="object" string="Logs" class="oe_stat_button" icon="fa-list" invisible="trigger != 'on_webhook'">
+                            </button>
+                        </div>
                         <field name="active" invisible="1" />
-                        <field name="model_name" invisible="1" />
+                        <field name="model_name" invisible="1" force_save="True" />
                         <widget name="web_ribbon" title="Archived" bg_color="bg-danger" invisible="active"/>
                         <div class="oe_title">
                             <h1><field name="name" placeholder="e.g. Support flow"/></h1>
@@ -60,6 +64,20 @@
                                     </div>
                                     <div class="text-muted" invisible="trigger != 'on_change'"><i class="fa fa-lightbulb-o"/> Automation rules that run on live updates will be executed every time the trigger fields change, <em>whether you save or not</em>.</div>
                                 </div>
+                                <label for="url" string="URL" invisible="trigger != 'on_webhook'"/>
+                                <div invisible="trigger != 'on_webhook'">
+                                    <field name="url" widget="CopyClipboardURL"  placeholder="URL will be created once the rule is saved."/>
+                                    <div class="alert alert-warning" role="status">
+                                        <strong><i class="fa fa-lock"/> Keep it secret, keep it safe.</strong>
+                                        <p>Your webhook URL contains a secret. Don't share it online or carelessly.</p>
+                                        <button class="btn btn-seconadry" type="object" name="action_rotate_webhook_uuid" string="Rotate Secret" icon="fa-refresh" help="Change the URL's secret if you think the URL is no longer secure. You will have to update any automated system that calls this webhook to the new URL."/>
+                                    </div>
+                                </div>
+                                <field name="log_webhook_calls" widget="boolean_toggle" invisible="trigger != 'on_webhook'"/>
+                                <field name="trg_date_id" class="oe_inline" string="Date Field"
+                                    options="{'no_open': True, 'no_create': True}"
+                                    invisible="trigger != 'on_time'"
+                                    required="trigger in ['on_time', 'on_time_created', 'on_time_updated']"/>
                                 <label for="trg_date_range" class="oe_inline" string="Delay"
                                     invisible="trigger not in ['on_time', 'on_time_created', 'on_time_updated']"/>
                                 <div class="o_row oe_inline" invisible="trigger not in ['on_time', 'on_time_created', 'on_time_updated']" >
@@ -75,11 +93,27 @@
                                 </div>
                                 <field name="filter_pre_domain" class="oe_inline" widget="domain" groups="base.group_no_one"
                                        options="{'model': 'model_name', 'in_dialog': True}"
+                                       invisible="trigger == 'on_webhook'"
                                 />
                                 <field name="filter_domain" class="oe_inline" widget="domain"
                                     options="{'model': 'model_name', 'in_dialog': True}"
                                     invisible="trigger not in ['on_create_or_write', 'on_change', 'on_unlink']"
                                 />
+                            </group>
+                            <group>
+                                <label for="record_getter" string="Target Record" invisible="trigger != 'on_webhook'" />
+                                <div invisible="trigger != 'on_webhook'">
+                                    <field name="record_getter" string="Target Record"/>
+                                    <div>
+                                        <span colspan="2" class="text-muted"> Available variables: </span>
+                                        <ul colspan="2" class="text-muted">
+                                            <li><code>env</code>: environment on which the action is triggered</li>
+                                            <li><code>model</code>: model of the record on which the action is triggered; is a void recordset</li>
+                                            <li><code>time</code>, <code>datetime</code>, <code>dateutil</code>, <code>timezone</code>: useful Python libraries</li>
+                                            <li><code>payload</code>: the payload of the call (GET parameters, JSON body), as a dict.</li>
+                                        </ul>
+                                    </div>
+                                </div>
                             </group>
                         </group>
                         <notebook invisible="not model_id">

--- a/addons/base_automation/views/base_automation_views.xml
+++ b/addons/base_automation/views/base_automation_views.xml
@@ -131,9 +131,14 @@
                                         <templates>
                                             <t t-name="kanban-box">
                                                 <div class="oe_kanban_global_click row g-0 align-items-center">
-                                                    <div class="d-flex align-items-center">
-                                                        <field name="sequence" widget="handle" class="px-3" />
+                                                    <div class="d-flex align-items-center gap-2">
+                                                        <field name="sequence" widget="handle" class="px-1" />
                                                         <field name="state" invisible="1" />
+                                                        <field name="evaluation_type" invisible="1" />
+                                                        <field name="value" invisible="1" />
+                                                        <field name="selection_value" invisible="1" />
+                                                        <field name="value_field_to_show" invisible="1"/>
+
                                                         <!-- Icon section -->
                                                         <i
                                                             data-name="server_action_icon"
@@ -151,8 +156,19 @@
                                                                 'sms': 'fa-comments-o',
                                                             }[record.state.raw_value]"
                                                         />
-                                                        <field name="name" class="ps-2 text-truncate w-0 flex-grow-1" />
-                                                        <button type="delete" name="delete" class="btn fa fa-trash fa-xl px-3" title="Delete Action" />
+                                                        <field name="name" class="text-truncate" />
+                                                        <t invisible="state != 'object_write'">
+                                                            <code invisible="evaluation_type != 'equation'" t-esc="record.value.raw_value"/>
+                                                            <span invisible="evaluation_type == 'equation'" >
+                                                                <field name="selection_value" invisible="value_field_to_show != 'selection_value'" class="d-inline"/>
+                                                                <span invisible="value_field_to_show == 'selection_value'">
+                                                                    <span invisible="value == False or evaluation_type == False">"</span>
+                                                                    <field name="value" class="d-inline"/>
+                                                                    <span invisible="value == False or evaluation_type == False">"</span>
+                                                                </span>
+                                                            </span>
+                                                        </t>
+                                                        <button type="delete" name="delete" class="btn fa fa-trash fa-xl px-3 ms-auto" title="Delete Action" />
                                                     </div>
                                                 </div>
                                             </t>

--- a/addons/test_base_automation/models/test_base_automation.py
+++ b/addons/test_base_automation/models/test_base_automation.py
@@ -109,3 +109,8 @@ class Stage(models.Model):
 class Tag(models.Model):
     _name = _description = 'test_base_automation.tag'
     name = fields.Char()
+
+class LeadThread(models.Model):
+    _inherit = ["base.automation.lead.test", "mail.thread"]
+    _name = "base.automation.lead.thread.test"
+    _description = "Threaded Lead Test"

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -142,10 +142,10 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
                         on_user_set: "User is set",
                         on_tag_set: "Tag is added",
                         on_priority_set: "Priority is set to",
-                        on_create_or_write: "On save",
                         on_time: "Based on date field",
                         on_time_created: "After creation",
                         on_time_updated: "After last update",
+                        on_create_or_write: "On save",
                         on_unlink: "On deletion",
                         on_change: "On live update",
                         on_webhook: "On webhook",
@@ -299,7 +299,7 @@ registry.category("web_tour.tours").add("test_kanban_automation_view_time_trigge
                 );
                 assertEqual(
                     document.querySelector(".o_kanban_record .o_tag").innerText,
-                    "Date (res.partner)"
+                    "Date (Contact)"
                 );
             },
         },
@@ -454,7 +454,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
                 );
                 assertEqual(
                     triggerGroups.map((el) => el.innerText).join(" // "),
-                    "User is setOn save // Based on date fieldAfter creationAfter last update // On deletionOn live update // On webhook"
+                    "User is set // Based on date fieldAfter creationAfter last update // On saveOn deletionOn live update // On webhook"
                 );
             },
         },
@@ -488,7 +488,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
                 );
                 assertEqual(
                     triggerGroups.map((el) => el.innerText).join(" // "),
-                    "Stage is set toUser is setTag is addedPriority is set toOn save // Based on date fieldAfter creationAfter last update // On deletionOn live update // On webhook"
+                    "Stage is set toUser is setTag is addedPriority is set to // Based on date fieldAfter creationAfter last update // On saveOn deletionOn live update // On webhook"
                 );
             },
         },

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -148,6 +148,7 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
                         on_time_updated: "After last update",
                         on_unlink: "On deletion",
                         on_change: "On live update",
+                        on_webhook: "On webhook",
                     })
                 );
             },
@@ -449,11 +450,11 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
                 const triggerGroups = Array.from(this.$anchor[0].querySelectorAll("optgroup"));
                 assertEqual(
                     triggerGroups.map((el) => el.getAttribute("label")).join(" // "),
-                    "Values Updated // Timing Conditions // Custom"
+                    "Values Updated // Timing Conditions // Custom // External"
                 );
                 assertEqual(
                     triggerGroups.map((el) => el.innerText).join(" // "),
-                    "User is setOn save // Based on date fieldAfter creationAfter last update // On deletionOn live update"
+                    "User is setOn save // Based on date fieldAfter creationAfter last update // On deletionOn live update // On webhook"
                 );
             },
         },
@@ -483,11 +484,11 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
                 const triggerGroups = Array.from(this.$anchor[0].querySelectorAll("optgroup"));
                 assertEqual(
                     triggerGroups.map((el) => el.getAttribute("label")).join(" // "),
-                    "Values Updated // Timing Conditions // Custom"
+                    "Values Updated // Timing Conditions // Custom // External"
                 );
                 assertEqual(
                     triggerGroups.map((el) => el.innerText).join(" // "),
-                    "Stage is set toUser is setTag is addedPriority is set toOn save // Based on date fieldAfter creationAfter last update // On deletionOn live update"
+                    "Stage is set toUser is setTag is addedPriority is set toOn save // Based on date fieldAfter creationAfter last update // On deletionOn live update // On webhook"
                 );
             },
         },
@@ -565,7 +566,7 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
         {
             trigger: ".o_field_widget[name='trigger'] select",
             run() {
-                assertEqual(Array.from(this.$anchor[0].querySelectorAll("optgroup")).map(el => el.label).join(", "), "Values Updated, Timing Conditions, Custom")
+                assertEqual(Array.from(this.$anchor[0].querySelectorAll("optgroup")).map(el => el.label).join(", "), "Values Updated, Timing Conditions, Custom, External")
             }
         },
         {
@@ -591,7 +592,7 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
         {
             trigger: ".o_field_widget[name='trigger']",
             run() {
-                assertEqual(Array.from(this.$anchor[0].querySelectorAll("select optgroup")).map(el => el.label).join(", "), "Values Updated, Email Events, Timing Conditions, Custom")
+                assertEqual(Array.from(this.$anchor[0].querySelectorAll("select optgroup")).map(el => el.label).join(", "), "Values Updated, Email Events, Timing Conditions, Custom, External")
             }
         },
         {

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -550,3 +550,56 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
         },
     ],
 });
+
+registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
+    test: true,
+    steps: () => [
+        {
+            trigger: ".o_field_widget[name='model_id'] input",
+            run: "text base.automation.lead.test",
+        },
+        {
+            trigger:
+                ".o_field_widget[name='model_id'] .dropdown-menu li a:contains(Automated Rule Test)",
+        },
+        {
+            trigger: ".o_field_widget[name='trigger'] select",
+            run() {
+                assertEqual(Array.from(this.$anchor[0].querySelectorAll("optgroup")).map(el => el.label).join(", "), "Values Updated, Timing Conditions, Custom")
+            }
+        },
+        {
+            trigger: ".o_field_widget[name='model_id'] input",
+            run: "text base.automation.lead.thread.test",
+        },
+        {
+            trigger:
+                ".o_field_widget[name='model_id'] .dropdown-menu li a:contains(Threaded Lead Test)",
+            run(helpers) {
+                waitOrmCalls = observeOrmCalls();
+                helpers.click(this.$anchor);
+                return nextTick();
+            },
+        },
+        {
+            trigger: "body",
+            async run() {
+                await waitOrmCalls();
+                await nextTick();
+            },
+        },
+        {
+            trigger: ".o_field_widget[name='trigger']",
+            run() {
+                assertEqual(Array.from(this.$anchor[0].querySelectorAll("select optgroup")).map(el => el.label).join(", "), "Values Updated, Email Events, Timing Conditions, Custom")
+            }
+        },
+        {
+            trigger: "button.o_form_button_cancel",
+        },
+        {
+            trigger: "body:not(:has(button.o_form_button_cancel)",
+            run() {}
+        }
+    ],
+});

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -4,9 +4,10 @@
 from unittest.mock import patch
 import sys
 
+from odoo.tools import mute_logger
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.tests import common, tagged
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, ValidationError
 from odoo import Command
 
 
@@ -959,3 +960,51 @@ class TestCompute(common.TransactionCase):
             task.unlink()
         finally:
             sys.setrecursionlimit(limit)
+
+    def test_mail_triggers(self):
+        lead_model = self.env["ir.model"]._get("base.automation.lead.test")
+        with self.assertRaises(ValidationError):
+            create_automation(self, trigger="on_message_sent", model_id=lead_model.id)
+
+        lead_thread_model = self.env["ir.model"]._get("base.automation.lead.thread.test")
+        automation = create_automation(self, trigger="on_message_sent", model_id=lead_thread_model.id, _actions={
+            "state": "object_write",
+            "update_field_id": self.env["ir.model.fields"]._get("base.automation.lead.thread.test", "active").id,
+            "value": False
+        })
+
+        ext_partner = self.env["res.partner"].create({"name": "ext", "email": "email@server.com"})
+        internal_partner = self.env["res.users"].browse(2).partner_id
+
+        obj = self.env["base.automation.lead.thread.test"].create({"name": "test"})
+        obj.message_subscribe([ext_partner.id, internal_partner.id])
+
+        obj.message_post(author_id=internal_partner.id, message_type="comment", subtype_xmlid="mail.mt_comment")
+        self.assertFalse(obj.active)
+
+        obj.active = True
+        obj.message_post(author_id=internal_partner.id, subtype_xmlid="mail.mt_comment")
+        self.assertTrue(obj.active)
+
+        obj.message_post(author_id=ext_partner.id, message_type="comment")
+        self.assertTrue(obj.active)
+
+        obj.message_post(author_id=internal_partner.id, message_type="comment")
+        self.assertTrue(obj.active)
+        obj.message_post(author_id=internal_partner.id, subtype_xmlid="mail.mt_comment", message_type="comment")
+        self.assertFalse(obj.active)
+
+        automation.trigger = "on_message_received"
+        obj.active = True
+        obj.message_post(author_id=internal_partner.id, subtype_xmlid="mail.mt_comment", message_type="comment")
+        self.assertTrue(obj.active)
+
+        obj.message_post(author_id=ext_partner.id, message_type="comment")
+        self.assertTrue(obj.active)
+
+        obj.message_post(author_id=ext_partner.id, subtype_xmlid="mail.mt_comment", message_type="comment")
+        self.assertFalse(obj.active)
+
+        obj.active = True
+        obj.message_post(author_id=ext_partner.id, subtype_xmlid="mail.mt_comment")
+        self.assertTrue(obj.active)

--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -79,7 +79,6 @@ class BaseAutomationTestUi(HttpCase):
         self.assertEqual(base_auto.trg_field_ref_model_name, "test_base_automation.tag")
         self.assertEqual(base_auto.trg_field_ref, tag.id)
 
-
     def test_kanban_automation_view_stage_trigger(self):
         self._neutralize_preexisting_automations()
 

--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -284,3 +284,12 @@ class BaseAutomationTestUi(HttpCase):
             "test_form_view_custom_reference_field",
             login="admin",
         )
+
+    def test_form_view_mail_triggers(self):
+        self.start_tour(
+            (
+                f"/web?debug=0#{_urlencode_kwargs(action=self.env.ref('base_automation.base_automation_act').id, view_type='form')}"
+            ),
+            "test_form_view_mail_triggers",
+            login="admin",
+        )

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -508,7 +508,7 @@ class IrActionsServer(models.Model):
     groups_id = fields.Many2many('res.groups', 'ir_act_server_group_rel',
                                  'act_id', 'gid', string='Allowed Groups', help='Groups that can execute the server action. Leave empty to allow everybody.')
 
-    update_field_id = fields.Many2one('ir.model.fields', string='Field to update', default=_default_update_field_id, ondelete='cascade')
+    update_field_id = fields.Many2one('ir.model.fields', string='Field to Update', default=_default_update_field_id, ondelete='cascade')
     update_related_model_id = fields.Many2one('ir.model', compute='_compute_update_related_model_id')
 
     value = fields.Text(help="For Python expressions, this field may hold a Python expression "
@@ -518,12 +518,12 @@ class IrActionsServer(models.Model):
                              "For Static values, the value will be used directly without evaluation, e.g."
                              "`42` or `My custom name` or the selected record.")
     evaluation_type = fields.Selection([
-        ('value', 'Static value'),
+        ('value', 'Custom Value'),
         ('equation', 'Python expression')
     ], 'Value Type', default='value', change_default=True)
     resource_ref = fields.Reference(
         string='Record', selection='_selection_target_model', inverse='_set_resource_ref')
-    selection_value = fields.Many2one('ir.model.fields.selection', string="Selection value", ondelete='cascade',
+    selection_value = fields.Many2one('ir.model.fields.selection', string="Custom Value", ondelete='cascade',
                                       domain='[("field_id", "=", update_field_id)]', inverse='_set_selection_value')
 
     value_field_to_show = fields.Selection([

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1059,8 +1059,10 @@ class IrModelFields(models.Model):
 
     @api.depends('field_description', 'model')
     def _compute_display_name(self):
+        IrModel = self.env["ir.model"]
         for field in self:
-            field.display_name = f'{field.field_description} ({field.model})'
+            model_string = IrModel._get(field.model).name
+            field.display_name = f'{field.field_description} ({model_string})'
 
     def _reflect_field_params(self, field, model_id):
         """ Return the values to write to the database for the given field. """

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -333,26 +333,26 @@
                             <group name="action_content">
                                 <field name="model_name" invisible="1"/>
                                 <field name="available_model_ids" invisible="1"/>
-                                <field name="model_id" options="{'no_create': True}" groups="base.group_no_one"
+                                <field name="model_id" options="{'no_create': True, 'no_open': True}" groups="base.group_no_one"
                                        domain="[('id', 'in', available_model_ids)]"/>
-                                <field name="model_id" options="{'no_create': True}" groups="!base.group_no_one" invisible="context.get('default_model_id')"
+                                <field name="model_id" options="{'no_create': True, 'no_open': True}" groups="!base.group_no_one" invisible="context.get('default_model_id')"
                                        domain="[('id', 'in', available_model_ids)]"/>
                                 <field name="groups_id" widget="many2many_tags" groups="base.group_no_one" />
                                 <field name="state" string="Action Type"/>
                                 <field name="update_field_id" invisible="state != 'object_write'"
-                                    options="{'no_create': True}"
+                                    options="{'no_create': True, 'no_open': True}"
                                     domain="['|', ('model_id', '=', crud_model_id), ('model_id', '=', model_id)]"/>
-                                <field name="evaluation_type" invisible="state != 'object_write'"/>
+                                <field name="evaluation_type" invisible="state != 'object_write'" widget="radio" options="{'horizontal': True}"/>
                                 <field name="value_field_to_show" invisible="1"/>
                                 <field name="update_related_model_id" invisible="1"/>
-                                <field name="value" invisible="state != 'object_write' or value_field_to_show != 'value' or evaluation_type != 'value'"/>
-                                <field name="value" widget="code" options="{'mode': 'python'}" invisible="state != 'object_write' or evaluation_type != 'equation'"/>
-                                <field name="resource_ref" string="Value" options="{'model_field': 'update_related_model_id', 'no_create': True}" invisible="state != 'object_write' or value_field_to_show != 'resource_ref' or evaluation_type == 'equation'"/>
-                                <field name="selection_value" options="{'no_create': True}" invisible="state != 'object_write' or value_field_to_show != 'selection_value' or evaluation_type == 'equation'"/>
+                                <field name="value" invisible="state != 'object_write' or value_field_to_show != 'value' or evaluation_type != 'value'" string="Custom Value"/>
+                                <field name="value" widget="code" options="{'mode': 'python'}" invisible="state != 'object_write' or evaluation_type != 'equation'" string="Expression"/>
+                                <field name="resource_ref" string="Custom Value" options="{'model_field': 'update_related_model_id', 'no_create': True, 'no_open': True}" invisible="state != 'object_write' or value_field_to_show != 'resource_ref' or evaluation_type == 'equation'"/>
+                                <field name="selection_value" options="{'no_create': True, 'no_open': True}" invisible="state != 'object_write' or value_field_to_show != 'selection_value' or evaluation_type == 'equation'"/>
 
                                 <field name="type" invisible="1"/>
                                 <field name="crud_model_id"
-                                    options="{'no_create': True}"
+                                    options="{'no_create': True, 'no_open': True}"
                                     invisible="state != 'object_create'"
                                     required="state == 'object_create'"/>
                                 <field name="crud_model_name" invisible="1"/>
@@ -360,7 +360,7 @@
                                 <field name="link_field_id"
                                     domain="[('model_id', '=', model_id), ('relation', '=', crud_model_name),
                                     ('ttype', 'in', ['many2one', 'one2many', 'many2many'])]"
-                                    options="{'no_create': True}"
+                                    options="{'no_create': True, 'no_open': True}"
                                     invisible="state != 'object_create'"
                                     context="{'default_model_id': model_id, 'default_relation': crud_model_name}"/>
                             </group>


### PR DESCRIPTION
This commit slightly improves the experience of Base Automation that has been revamped in commit 0a744accc2aaa965d5353e854317895d822ad954.

This commit also implements two major features:
- If a base automation applies to a model that inherits from `mail.thread`, it can react to mails being sent to or received from a partner outside of the company. This can be useful to create an activity or some other warning on a record when a customer writes to it.

- A base automation can react to a webhook distant service via the generic route `/web/hook/<some hash>` This can be useful to change some task's tags when Github sends a relavant payload, or when a payment service sends some data.

Co-authored-by: Damien Bouvy <dbo@odoo.com>

task-id-3450200

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
