### PR TITLE
[FIX] lunch: fix traceback when we add to cart product

### DIFF
--- a/addons/lunch/models/lunch_order.py
+++ b/addons/lunch/models/lunch_order.py
@@ -86,16 +86,19 @@ class LunchOrder(models.Model):
         """
             If called in api.multi then it will pop topping_ids_1,2,3 from values
         """
+        topping_1_values = values.get('topping_ids_1', False)
+        topping_2_values = values.get('topping_ids_2', False)
+        topping_3_values = values.get('topping_ids_3', False)
         if self.ids:
             # TODO This is not taking into account all the toppings for each individual order, this is usually not a problem
             # since in the interface you usually don't update more than one order at a time but this is a bug nonetheless
-            topping_1 = values.pop('topping_ids_1')[0][2] if 'topping_ids_1' in values else self[:1].topping_ids_1.ids
-            topping_2 = values.pop('topping_ids_2')[0][2] if 'topping_ids_2' in values else self[:1].topping_ids_2.ids
-            topping_3 = values.pop('topping_ids_3')[0][2] if 'topping_ids_3' in values else self[:1].topping_ids_3.ids
+            topping_1 = values.pop('topping_ids_1')[0][2] if topping_1_values else self[:1].topping_ids_1.ids
+            topping_2 = values.pop('topping_ids_2')[0][2] if topping_2_values else self[:1].topping_ids_2.ids
+            topping_3 = values.pop('topping_ids_3')[0][2] if topping_3_values else self[:1].topping_ids_3.ids
         else:
-            topping_1 = values['topping_ids_1'][0][2] if 'topping_ids_1' in values else []
-            topping_2 = values['topping_ids_2'][0][2] if 'topping_ids_2' in values else []
-            topping_3 = values['topping_ids_3'][0][2] if 'topping_ids_3' in values else []
+            topping_1 = values['topping_ids_1'][0][2] if topping_1_values else []
+            topping_2 = values['topping_ids_2'][0][2] if topping_2_values else []
+            topping_3 = values['topping_ids_3'][0][2] if topping_3_values else []
 
         return topping_1 + topping_2 + topping_3
 


### PR DESCRIPTION
Description of the issue:
This commit addresses a traceback error that occurred when adding a product to
the cart with an empty cart. The issue was related to accessing values for
'topping_ids_1', 'topping_ids_2', and 'topping_ids_3' without proper validation

Fix:
In this fix i have added checks to ensure that the values are present before
accessing them this prevents an 'index out of range' error and resolves the
traceback problem, additionally, the code now considers the values in
'topping_1_values', 'topping_2_values', and 'topping_3_values' to determine
 whether to access the values or fall back to default values from the order.

Desired behavior after PR is merged:
traceback will fixed and work properly

task-3511953