### PR TITLE
[IMP] l10n_br: support LATAM document types

### DIFF
--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -11,36 +11,43 @@ Base module for the Brazilian localization
 
 This module consists of:
 
- - Generic Brazilian chart of accounts
- - Brazilian taxes such as:
+- Generic Brazilian chart of accounts
+- Brazilian taxes such as:
 
-        - IPI
-        - ICMS
-        - PIS
-        - COFINS
-        - ISS
-        - IR
-        - IRPJ
-        - CSLL
+  - IPI
+  - ICMS
+  - PIS
+  - COFINS
+  - ISS
+  - IR
+  - CSLL
+
+- Document Types as NFC-e, NFS-e, etc.
+- Identification Documents as CNPJ and CPF
 
 The field tax_discount has also been added in the account.tax.template and
 account.tax objects to allow the proper computation of some Brazilian VATs
 such as ICMS. The chart of account creation wizard has been extended to
 propagate those new data properly.
 
-It's important to note however that this module lack many implementations to
-use Odoo properly in Brazil. Those implementations (such as the electronic
-fiscal Invoicing which is already operational) are brought by more than 15
-additional modules of the Brazilian Launchpad localization project
-https://launchpad.net/openerp.pt-br-localiz and their dependencies in the
-extra addons branch. Those modules aim at not breaking with the remarkable
-Odoo modularity, this is why they are numerous but small. One of the
-reasons for maintaining those modules apart is that Brazilian Localization
-leaders need commit rights agility to complete the localization as companies
-fund the remaining legal requirements (such as soon fiscal ledgers,
-accounting SPED, fiscal SPED and PAF ECF that are still missing as September
-2011). Those modules are also strictly licensed under AGPL V3 and today don't
-come with any additional paid permission for online use of 'private modules'.
+In addition to this module, the Brazilian Localizations is also
+extended and complemented with several additional modules.
+
+Brazil - Accounting Reports (l10n_br_reports)
+---------------------------------------------
+Adds a simple tax report that helps check the tax amount per tax group
+in a given period of time. Also adds the P&L and BS adapted for the
+Brazilian market.
+
+Avatax Brazil (l10n_br_avatax)
+------------------------------
+Add Brazilian tax calculation via Avatax and all necessary fields needed to
+configure Odoo in order to properly use Avatax and send the needed fiscal
+information to retrieve the correct taxes.
+
+Avatax for SOs in Brazil (l10n_br_avatax_sale)
+----------------------------------------------
+Same as the l10n_br_avatax module with the extension to the sales order module.
 """,
     'author': 'Akretion, Odoo Brasil',
     'depends': [

--- a/addons/l10n_br/__manifest__.py
+++ b/addons/l10n_br/__manifest__.py
@@ -47,14 +47,17 @@ come with any additional paid permission for online use of 'private modules'.
         'account',
         'base_vat',
         'l10n_latam_base',
+        'l10n_latam_invoice_document',
     ],
     'data': [
         'data/account_tax_report_data.xml',
         'data/l10n_latam.identification.type.csv',
+        'data/l10n_latam.document.type.csv',
         'views/account_view.xml',
         'views/account_fiscal_position_views.xml',
         'views/res_company_views.xml',
         'views/res_partner_views.xml',
+        'views/account_journal_views.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_br/data/l10n_latam.document.type.csv
+++ b/addons/l10n_br/data/l10n_latam.document.type.csv
@@ -1,0 +1,32 @@
+id,sequence,code,country_id/id,name,internal_type,doc_code_prefix,active
+dt_55,10,55,base.br,Electronic Invoice (NF-e),all,NFe,True
+dt_57,20,57,base.br,Electronic Bill of Lading (CT-e),invoice,CTe,False
+dt_58,30,58,base.br,Electronic Manifesto of Tax Documents (MDF-e),invoice,MDFe,False
+dt_59,40,59,base.br,Electronic Tax Coupon (CF-e-SAT),invoice,CFeS,False
+dt_60,50,60,base.br,Electronic Tax Coupon (CF-e-ECF),invoice,CFeE,False
+dt_65,60,65,base.br,Electronic Invoice to the Final Consumer (NFC-e),all,NFCe,True
+dt_SE,70,SE,base.br,Electronic Service Invoice - NFS-e,all,NFSe,True
+dt_01,80,01,base.br,Invoice 1 / 1A,all,NF,False
+dt_1B,90,1B,base.br,Single invoice,all,NFA,False
+dt_02,100,02,base.br,In-Consumer Sales Invoice,all,NFC,False
+dt_2D,110,2D,base.br,Tax Coupon,invoice,CF,False
+dt_2E,120,2E,base.br,Tax Coupon-Ticket,invoice,TIQP,False
+dt_04,130,04,base.br,Invoice from Producer,invoice,NFP,False
+dt_06,140,06,base.br,Nota Fiscal / Electricity Bill,invoice,NFCE,False
+dt_07,150,07,base.br,Invoice for Transport Service,invoice,NFST,False
+dt_08,160,08,base.br,Ground Bill of Lading,invoice,CTRC,False
+dt_8B,170,8B,base.br,Loose Ground Bill of Lading,invoice,CTCA,False
+dt_09,180,09,base.br,Maritime Bill of Lading,invoice,CTAC,False
+dt_10,190,10,base.br,Aircraft Knowledge,invoice,CA,False
+dt_11,200,11,base.br,Railway Bill of Lading,invoice,CTFC,False
+dt_13,210,13,base.br,Road Ticket,invoice,BPR,False
+dt_14,220,14,base.br,Waterway Ticket,invoice,BPA,False
+dt_15,230,15,base.br,e-Baggage Ticket,invoice,BPNB,False
+dt_16,240,16,base.br,Railway Ticket,invoice,BPF,False
+dt_18,250,18,base.br,Daily Movement Summary,invoice,RMD,False
+dt_21,260,21,base.br,Invoice for de-Communication Service,invoice,NFSC,False
+dt_22,270,22,base.br,Invoice for Telecommunication Service,invoice,NFST,False
+dt_26,280,26,base.br,Bill of Lading Multimodal Transport,invoice,CTMC,False
+dt_27,290,27,base.br,Invoice for Rail Transport De-Cargo,invoice,NFTFC,False
+dt_28,300,28,base.br,Invoice / Gas Supply Channel Account,invoice,NFCFGC,False
+dt_29,310,29,base.br,Invoice / Water Supply Account,invoice,NFCFAC,False

--- a/addons/l10n_br/i18n/l10n_br.pot
+++ b/addons/l10n_br/i18n/l10n_br.pot
@@ -377,3 +377,182 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_br.field_account_tax_template__base_reduction
 msgid "A decimal percentage in % between 0-1."
 msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields,field_description:l10n_br.field_account_bank_statement_line__l10n_br_invoice_serial
+#: model:ir.model.fields,field_description:l10n_br.field_account_journal__l10n_br_invoice_serial
+#: model:ir.model.fields,field_description:l10n_br.field_account_move__l10n_br_invoice_serial
+#: model:ir.model.fields,field_description:l10n_br.field_account_payment__l10n_br_invoice_serial
+msgid "Series"
+msgstr ""
+
+#. module: l10n_br
+#: model:ir.model.fields,help:l10n_br.field_account_bank_statement_line__l10n_br_invoice_serial
+#: model:ir.model.fields,help:l10n_br.field_account_journal__l10n_br_invoice_serial
+#: model:ir.model.fields,help:l10n_br.field_account_move__l10n_br_invoice_serial
+#: model:ir.model.fields,help:l10n_br.field_account_payment__l10n_br_invoice_serial
+msgid ""
+"Brazil: Series number associated with this Journal. If more than one Series "
+"needs to be used, duplicate this Journal and assign the new Series to the "
+"duplicated Journal"
+msgstr ""
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.view_account_invoice_filter
+msgid "Adjustment Invoices"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_10
+msgid "Aircraft Knowledge"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_26
+msgid "Bill of Lading Multimodal Transport"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_18
+msgid "Daily Movement Summary"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_57
+msgid "Electronic Bill of Lading (CT-e)"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_55
+msgid "Electronic Invoice (NF-e)"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_65
+msgid "Electronic Invoice to the Final Consumer (NFC-e)"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_58
+msgid "Electronic Manifesto of Tax Documents (MDF-e)"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_SE
+msgid "Electronic Service Invoice - NFS-e"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_60
+msgid "Electronic Tax Coupon (CF-e-ECF)"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_59
+msgid "Electronic Tax Coupon (CF-e-SAT)"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_08
+msgid "Ground Bill of Lading"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_02
+msgid "In-Consumer Sales Invoice"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_28
+msgid "Invoice / Gas Supply Channel Account"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_29
+msgid "Invoice / Water Supply Account"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_01
+msgid "Invoice 1 / 1A"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_27
+msgid "Invoice for Rail Transport De-Cargo"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_22
+msgid "Invoice for Telecommunication Service"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_07
+msgid "Invoice for Transport Service"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_21
+msgid "Invoice for de-Communication Service"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_04
+msgid "Invoice from Producer"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_8B
+msgid "Loose Ground Bill of Lading"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_09
+msgid "Maritime Bill of Lading"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_06
+msgid "Nota Fiscal / Electricity Bill"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_11
+msgid "Railway Bill of Lading"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_16
+msgid "Railway Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_13
+msgid "Road Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_1B
+msgid "Single invoice"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_2D
+msgid "Tax Coupon"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_2E
+msgid "Tax Coupon-Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_14
+msgid "Waterway Ticket"
+msgstr ""
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_15
+msgid "e-Baggage Ticket"
+msgstr ""

--- a/addons/l10n_br/i18n/pt.po
+++ b/addons/l10n_br/i18n/pt.po
@@ -364,3 +364,184 @@ msgstr "Tributada integralmente"
 #: model:ir.model.fields,help:l10n_br.field_account_tax_template__base_reduction
 msgid "A decimal percentage in % between 0-1."
 msgstr "Um percentual decimal em % entre 0-1."
+
+#. module: l10n_br
+#: model:ir.model.fields,field_description:l10n_br.field_account_bank_statement_line__l10n_br_invoice_serial
+#: model:ir.model.fields,field_description:l10n_br.field_account_journal__l10n_br_invoice_serial
+#: model:ir.model.fields,field_description:l10n_br.field_account_move__l10n_br_invoice_serial
+#: model:ir.model.fields,field_description:l10n_br.field_account_payment__l10n_br_invoice_serial
+msgid "Series"
+msgstr "Série"
+
+#. module: l10n_br
+#: model:ir.model.fields,help:l10n_br.field_account_bank_statement_line__l10n_br_invoice_serial
+#: model:ir.model.fields,help:l10n_br.field_account_journal__l10n_br_invoice_serial
+#: model:ir.model.fields,help:l10n_br.field_account_move__l10n_br_invoice_serial
+#: model:ir.model.fields,help:l10n_br.field_account_payment__l10n_br_invoice_serial
+msgid ""
+"Brazil: Series number associated with this Journal. If more than one Series "
+"needs to be used, duplicate this Journal and assign the new Series to the "
+"duplicated Journal"
+msgstr ""
+"Brazil: Número da série associado a este Diário. Se for necessário usar mais de"
+"uma série, duplique este Diário e atribua a nova série ao Diário duplicado."
+
+#. module: l10n_br
+#: model_terms:ir.ui.view,arch_db:l10n_br.view_account_invoice_filter
+msgid "Adjustment Invoices"
+msgstr "Notas de Ajuste"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_10
+msgid "Aircraft Knowledge"
+msgstr "Conhecimento Aéreo"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_26
+msgid "Bill of Lading Multimodal Transport"
+msgstr "Conhecimento de Transporte Multimodal de Cargas"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_18
+msgid "Daily Movement Summary"
+msgstr "Resumo de Movimento Diário"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_57
+msgid "Electronic Bill of Lading (CT-e)"
+msgstr "Conhecimento de Transporte Eletrônico – CT-e"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_55
+msgid "Electronic Invoice (NF-e)"
+msgstr "Nota Fiscal Eletrônica (NF-e)"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_65
+msgid "Electronic Invoice to the Final Consumer (NFC-e)"
+msgstr "Nota Fiscal Eletrônica ao Consumidor Final – NFC-e"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_58
+msgid "Electronic Manifesto of Tax Documents (MDF-e)"
+msgstr "Manifesto Eletrônico de Documentos Fiscais (MDF-e)"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_SE
+msgid "Electronic Service Invoice - NFS-e"
+msgstr "Manifesto Eletrônico de Documentos Fiscais (MDF-e)"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_60
+msgid "Electronic Tax Coupon (CF-e-ECF)"
+msgstr "Cupom Fiscal Eletrônico CF-e-ECF"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_59
+msgid "Electronic Tax Coupon (CF-e-SAT)"
+msgstr "Cupom Fiscal Eletrônico (CF-e-SAT)"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_08
+msgid "Ground Bill of Lading"
+msgstr "Conhecimento de Transporte Rodoviário de Cargas"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_02
+msgid "In-Consumer Sales Invoice"
+msgstr "Nota Fiscal de Venda a Consumidor"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_28
+msgid "Invoice / Gas Supply Channel Account"
+msgstr "Nota Fiscal/Conta de Fornecimento de Gás Canalizado"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_29
+msgid "Invoice / Water Supply Account"
+msgstr "Nota Fiscal/Conta de Fornecimento de Água Canalizada"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_01
+msgid "Invoice 1 / 1A"
+msgstr "Nota Fiscal"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_27
+msgid "Invoice for Rail Transport De-Cargo"
+msgstr "Nota Fiscal de Serviço de Comunicação"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_22
+msgid "Invoice for Telecommunication Service"
+msgstr "Nota Fiscal de Transporte Ferroviário de Cargas"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_07
+msgid "Invoice for Transport Service"
+msgstr "Nota Fiscal de Serviço de Telecomunicação"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_21
+msgid "Invoice for de-Communication Service"
+msgstr "Nota Fiscal de Serviço de Transporte"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_04
+msgid "Invoice from Producer"
+msgstr "Nota Fiscal de Produtor"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_8B
+msgid "Loose Ground Bill of Lading"
+msgstr "Conhecimento de Transporte de Cargas Avulso"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_09
+msgid "Maritime Bill of Lading"
+msgstr "Conhecimento de Transporte Aquaviário de Cargas"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_06
+msgid "Nota Fiscal / Electricity Bill"
+msgstr "Nota Fiscal/Conta de Energia Elétrica"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_11
+msgid "Railway Bill of Lading"
+msgstr "Conhecimento de Transporte Ferroviário de Cargas"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_16
+msgid "Railway Ticket"
+msgstr "Bilhete de Passagem Ferroviário"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_13
+msgid "Road Ticket"
+msgstr "Bilhete de Passagem Rodoviário"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_1B
+msgid "Single invoice"
+msgstr "Nota Fiscal Avulsa"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_2D
+msgid "Tax Coupon"
+msgstr "Cupom Fiscal emitido por ECF"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_2E
+msgid "Tax Coupon-Ticket"
+msgstr "Bilhete de Passagem emitido por ECF"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_14
+msgid "Waterway Ticket"
+msgstr "Bilhete de Passagem Aquaviário"
+
+#. module: l10n_br
+#: model:l10n_latam.document.type,name:l10n_br.dt_15
+msgid "e-Baggage Ticket"
+msgstr "Bilhete de Passagem e Nota de Bagagem"

--- a/addons/l10n_br/models/__init__.py
+++ b/addons/l10n_br/models/__init__.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_br
 from . import account
+from . import account_journal
+from . import account_move
 from . import account_fiscal_position
 from . import res_partner
 from . import res_company

--- a/addons/l10n_br/models/account_journal.py
+++ b/addons/l10n_br/models/account_journal.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models, api
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    l10n_br_invoice_serial = fields.Char(
+        'Series', copy=False,
+        help='Brazil: Series number associated with this Journal. If more than one Series needs to be used, duplicate this Journal and assign the new Series to the duplicated Journal.'
+    )
+
+    @api.depends('l10n_br_invoice_serial')
+    def _compute_display_name(self):
+        res = super()._compute_display_name()
+        for journal in self.filtered('l10n_br_invoice_serial'):
+            journal.display_name = f'{journal.l10n_br_invoice_serial}-{journal.display_name}'
+
+        return res

--- a/addons/l10n_br/models/account_move.py
+++ b/addons/l10n_br/models/account_move.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _compute_l10n_latam_document_type(self):
+        """ Override for debit notes. This sets the same document type as the one on the origin. Cannot
+         override the defaults in the account.move.debit wizard because l10n_latam_invoice_document explicitly
+         calls _compute_l10n_latam_document_type() after the debit note is created. """
+        br_debit_notes = self.filtered(lambda m: m.state == "draft" and m.country_code == "BR" and m.debit_origin_id.l10n_latam_document_type_id)
+        for move in br_debit_notes:
+            move.l10n_latam_document_type_id = move.debit_origin_id.l10n_latam_document_type_id
+
+        return super(AccountMove, self - br_debit_notes)._compute_l10n_latam_document_type()
+
+    def _get_last_sequence_domain(self, relaxed=False):
+        """ Override to give sequence names in the same journal their own, independent numbering. """
+        where_string, param = super()._get_last_sequence_domain(relaxed)
+        if self.country_code == "BR" and self.l10n_latam_use_documents:
+            where_string += " AND l10n_latam_document_type_id = %(l10n_latam_document_type_id)s "
+            param["l10n_latam_document_type_id"] = self.l10n_latam_document_type_id.id or 0
+        return where_string, param

--- a/addons/l10n_br/models/res_company.py
+++ b/addons/l10n_br/models/res_company.py
@@ -12,3 +12,7 @@ class ResCompany(models.Model):
     l10n_br_ie_code = fields.Char(string="IE", help="State Tax Identification Number. Should contain 9-14 digits.") # each state has its own format. Not all of the validation rules can be easily found.
     l10n_br_im_code = fields.Char(string="IM", help="Municipal Tax Identification Number") # each municipality has its own format. There is no information about validation anywhere.
     l10n_br_nire_code = fields.Char(string="NIRE", help="State Commercial Identification Number. Should contain 11 digits.")
+
+    def _localization_use_documents(self):
+        self.ensure_one()
+        return self.account_fiscal_country_id.code == "BR" or super()._localization_use_documents()

--- a/addons/l10n_br/models/template_br.py
+++ b/addons/l10n_br/models/template_br.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models
+from odoo import models, api
 from odoo.addons.account.models.chart_template import template
 
 
@@ -35,3 +35,22 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_purchase_tax_id': 'tax_template_in_icms_interno17',
             },
         }
+
+    @template('br', 'account.journal')
+    def _get_br_account_journal(self):
+        return {
+            'sale': {'l10n_br_invoice_serial': '1'},
+        }
+
+    @api.model
+    def _get_demo_data_move(self, company=False):
+        move_data = super()._get_demo_data_move(company)
+        if company.account_fiscal_country_id.code == 'BR':
+            number = 0
+            for move in move_data.values():
+                # vendor bills must be manually numbered (l10n_br uses the standard AccountMove._is_manual_document_number())
+                if move['move_type'] == 'in_invoice':
+                    move['l10n_latam_document_number'] = f'{number:08d}'
+                    number += 1
+
+        return move_data

--- a/addons/l10n_br/views/account_journal_views.xml
+++ b/addons/l10n_br/views/account_journal_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_account_journal_form" model="ir.ui.view">
+            <field name="model">account.journal</field>
+            <field name="name">account.journal.form</field>
+            <field name="inherit_id" ref="l10n_latam_invoice_document.view_account_journal_form"/>
+            <field name="arch" type="xml">
+                 <field name="type" position="after">
+                    <field name="l10n_br_invoice_serial" invisible="not l10n_latam_use_documents or country_code != 'BR'"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_br/wizard/__init__.py
+++ b/addons/l10n_br/wizard/__init__.py
@@ -1,3 +1,2 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import models
-from . import wizard
+from . import account_move_reversal

--- a/addons/l10n_br/wizard/account_move_reversal.py
+++ b/addons/l10n_br/wizard/account_move_reversal.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reversal"
+
+    def _compute_document_type(self):
+        """ If a l10n_latam_document_type_id was set, change it in the case of Brazil to be
+        the same as the move that is being reversed.
+        """
+        res = super()._compute_document_type()
+        for reversal in self.filtered("l10n_latam_document_type_id"):
+            # LATAM invoices are guaranteed to be just one by _compute_documents_info().
+            move = reversal.move_ids[0]
+            if move.country_code == "BR":
+                reversal.l10n_latam_document_type_id = move.l10n_latam_document_type_id
+
+        return res

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -23,7 +23,7 @@ class L10nLatamDocumentType(models.Model):
     code = fields.Char(help='Code used by different localizations')
     report_name = fields.Char('Name on Reports', help='Name that will be printed in reports, for example "CREDIT NOTE"', translate=True)
     internal_type = fields.Selection(
-        [('invoice', 'Invoices'), ('debit_note', 'Debit Notes'), ('credit_note', 'Credit Notes')],
+        [('invoice', 'Invoices'), ('debit_note', 'Debit Notes'), ('credit_note', 'Credit Notes'), ('all', 'All Documents')],
         help='Analog to odoo account.move.move_type but with more options allowing to identify the kind of document we are'
         ' working with. (not only related to account.move, could be for documents of other models like stock.picking)')
 


### PR DESCRIPTION
This implements common Brazilian document types and adds a government-assigned Series field used to identify each journal.

Sequence names in the same journal must have their own, independent numbering. Because of this _get_last_sequence_domain() was extended.

A non-stored related l10n_br_invoice_serial field was added to account.move to allow a user in the Bookkeeper access group (group_account_user) without access to journals to see the number.

task-3507518