### PR TITLE
[FIX] web: always return a Node from compileButtonBox

### DIFF
--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -124,7 +124,7 @@ export class FormCompiler extends ViewCompiler {
      * @returns {Element}
      */
     compileButtonBox(el, params) {
-        if (!el.childNodes.length) {
+        if (!el.children.length) {
             return this.compileGenericNode(el, params);
         }
 
@@ -166,7 +166,7 @@ export class FormCompiler extends ViewCompiler {
             append(buttonBox, mainSlot);
         }
 
-        return hasContent ? buttonBox : '';
+        return hasContent ? buttonBox : this.compileGenericNode(el, params);
     }
 
     compileButton(el, params) {


### PR DESCRIPTION
Avoid errors trying to append or prepend strings instead of nodes caused by empty strings returned from the `compileButtonBox` method.

Steps to reproduce:

Install both the hr and studio modules (nothing else), then try to open the editor for the employees form view. An error is thrown while the editor form compiler tries to call `insertAdjacentElement` on an empty string.

opw-3504192