### PR TITLE
[FIX] hr.expense: cange default uom to match the default product

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -25,7 +25,7 @@ class HrExpense(models.Model):
 
     @api.model
     def _default_product_uom_id(self):
-        return self.env['uom.uom'].search([], limit=1, order='id')
+        return self.env['product.product'].search([('can_be_expensed', '=', True)],limit = 1).uom_id
 
     @api.model
     def _default_account_id(self):


### PR DESCRIPTION
upon creating an expense a default product will be selected. Along with it in the expense there will be selected a unit of measure (uom) for the expense
the product already have a uom and if its uom dont match the expense's uom there will be a constraint preventing the creation of the expense. This makes at leats the default product always match the default expense uom

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
