### PR TITLE
[FIX] core: '=like'/'like' doesn't use unaccent anymore

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -601,7 +601,7 @@ class AccountJournal(models.Model):
         journal_code_base = prefix_map.get(journal_type)
         existing_codes = set(self.env['account.journal'].with_context(active_test=False).search([
             *self.env['account.journal']._check_company_domain(company),
-            ('code', 'like', journal_code_base + '%'),
+            ('code', '=like', journal_code_base + '%'),
         ]).mapped('code') + (cache or []))
 
         for num in range(1, 100):

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -137,7 +137,7 @@ class AccountReport(models.Model):
             # as their sections
             if report.root_report_id:
                 report[field_name] = report.root_report_id[field_name]
-            elif len(report.section_main_report_ids) == 1 and not self.env['ir.actions.client'].search_count([('context', 'ilike', f"%'report_id': {report.id}"), ('tag', '=', 'account_report')]):
+            elif len(report.section_main_report_ids) == 1 and not self.env['ir.actions.client'].search_count([('context', 'ilike', f"'report_id': {report.id}"), ('tag', '=', 'account_report')]):
                 report[field_name] = report.section_main_report_ids[field_name]
             else:
                 report[field_name] = default_value

--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -18,7 +18,7 @@ def test_all_l10n(env):
 
     # Install the requiriments
     l10n_mods = env['ir.module.module'].search([
-        ('name', 'like', 'l10n%'),
+        ('name', '=like', 'l10n%'),
         ('state', '=', 'uninstalled'),
     ])
     l10n_mods.button_immediate_install()

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -286,7 +286,7 @@ class TestChartTemplate(TransactionCase):
             self.env['account.chart.template'].try_loading('test', company=company_2, install_demo=False)
 
         taxes_1_companies = self.env['account.tax'].search([
-            ('name', 'like', '%Tax 1'),
+            ('name', '=like', '%Tax 1'),
             ('company_id', 'in', [self.company_1.id, company_2.id]),
         ])
         # we should have 4 records: 2 companies * (1 original tax + 1 recreated tax)

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -71,7 +71,7 @@ class TaxReportTest(AccountTestInvoicingCommon):
     def _get_tax_tags(self, country, tag_name=None, active_test=True):
         domain = [('country_id', '=', country.id), ('applicability', '=', 'taxes')]
         if tag_name:
-            domain.append(('name', 'like', '_' + tag_name))
+            domain.append(('name', '=like', '_' + tag_name))
         return self.env['account.account.tag'].with_context(active_test=active_test).search(domain)
 
     def test_create_shared_tags(self):

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -100,7 +100,7 @@ class AccountMove(models.Model):
         """
         it_tax_report_vj_lines = self.env['account.report.line'].search([
             ('report_id.country_id.code', '=', 'IT'),
-            ('code', 'like', 'VJ%'),
+            ('code', '=like', 'VJ%'),
         ])
         vj_lines_tags = it_tax_report_vj_lines.expression_ids._get_matching_tags()
         for move in self:

--- a/addons/mrp_subcontracting/models/stock_warehouse.py
+++ b/addons/mrp_subcontracting/models/stock_warehouse.py
@@ -156,7 +156,7 @@ class StockWarehouse(models.Model):
 
     def _get_sequence_values(self, name=False, code=False):
         values = super(StockWarehouse, self)._get_sequence_values(name=name, code=code)
-        count = self.env['ir.sequence'].search_count([('prefix', 'like', self.code + '/SBC%/%')])
+        count = self.env['ir.sequence'].search_count([('prefix', '=like', self.code + '/SBC%/%')])
         values.update({
             'subcontracting_type_id': {
                 'name': self.name + ' ' + _('Sequence subcontracting'),

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -372,7 +372,7 @@ class PaymentTransaction(models.Model):
             # query wouldn't help either as the selector is arbitrary and doing that would be an
             # open-door to SQL injections.
             same_prefix_references = self.sudo().search(
-                [('reference', 'like', f'{prefix}{separator}%')]
+                [('reference', '=like', f'{prefix}{separator}%')]
             ).with_context(prefetch_fields=False).mapped('reference')
 
             # A final regex search is necessary to figure out the next sequence number. The previous

--- a/addons/stock/__init__.py
+++ b/addons/stock/__init__.py
@@ -11,7 +11,7 @@ from . import populate
 # TODO: Apply proper fix & remove in master
 def pre_init_hook(env):
     env['ir.model.data'].search([
-        ('model', 'like', '%stock%'),
+        ('model', 'like', 'stock'),
         ('module', '=', 'stock')
     ]).unlink()
 

--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -103,7 +103,7 @@ class StockPicking(models.Model):
     def _compute_return_label(self):
         for picking in self:
             if picking.carrier_id:
-                picking.return_label_ids = self.env['ir.attachment'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', picking.id), ('name', 'like', '%s%%' % picking.carrier_id.get_return_label_prefix())])
+                picking.return_label_ids = self.env['ir.attachment'].search([('res_model', '=', 'stock.picking'), ('res_id', '=', picking.id), ('name', '=like', '%s%%' % picking.carrier_id.get_return_label_prefix())])
             else:
                 picking.return_label_ids = False
 

--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -55,7 +55,7 @@ class Assets(models.AbstractModel):
             IrAttachment.search([
                 '|', ('id', '=', delete_attachment_id),
                 ('original_id', '=', delete_attachment_id),
-                ('name', 'like', '%google-font%')
+                ('name', 'like', 'google-font'),
             ]).unlink()
 
         google_local_fonts = values.get('google-local-fonts')

--- a/odoo/addons/base/tests/test_base.py
+++ b/odoo/addons/base/tests/test_base.py
@@ -127,15 +127,15 @@ class TestGroups(TransactionCase):
     def test_res_groups_fullname_search(self):
         all_groups = self.env['res.groups'].search([])
 
-        groups = all_groups.search([('full_name', 'like', '%Sale%')])
+        groups = all_groups.search([('full_name', 'like', 'Sale')])
         self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Sale' in g.full_name],
                               "did not match search for 'Sale'")
 
-        groups = all_groups.search([('full_name', 'like', '%Technical%')])
+        groups = all_groups.search([('full_name', 'like', 'Technical')])
         self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Technical' in g.full_name],
                               "did not match search for 'Technical'")
 
-        groups = all_groups.search([('full_name', 'like', '%Sales /%')])
+        groups = all_groups.search([('full_name', 'like', 'Sales /')])
         self.assertItemsEqual(groups.ids, [g.id for g in all_groups if 'Sales /' in g.full_name],
                               "did not match search for 'Sales /'")
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -728,8 +728,16 @@ class TestExpression(SavepointCaseWithUserDemo):
         helen = Model.create({'name': 'Hélène'})
         self.assertEqual(helen, Model.search([('name', 'ilike', 'Helene')]))
         self.assertEqual(helen, Model.search([('name', 'ilike', 'hélène')]))
+        self.assertEqual(helen, Model.search([('name', '=ilike', 'Hel%')]))
+        self.assertEqual(helen, Model.search([('name', '=ilike', 'hél%')]))
         self.assertNotIn(helen, Model.search([('name', 'not ilike', 'Helene')]))
         self.assertNotIn(helen, Model.search([('name', 'not ilike', 'hélène')]))
+
+        # =like and like should be case and accent sensitive
+        self.assertEqual(helen, Model.search([('name', '=like', 'Hél%')]))
+        self.assertNotIn(helen, Model.search([('name', '=like', 'Hel%')]))
+        self.assertEqual(helen, Model.search([('name', 'like', 'élè')]))
+        self.assertNotIn(helen, Model.search([('name', 'like', 'ele')]))
 
         hermione, nicostratus = Model.create([
             {'name': 'Hermione', 'parent_id': helen.id},

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1036,7 +1036,7 @@ class expression(object):
                     push_result(expr, [right])
 
                 else:
-                    if 'like' in operator:
+                    if operator in ('like', 'ilike', 'not like', 'not ilike'):
                         right = f'%{pycompat.to_text(right)}%'
                         unaccent = self._unaccent(field)
                     else:
@@ -1372,7 +1372,7 @@ class expression(object):
                             expr += f"{_left} {_sql_operator} {_unaccent('%s')} AND "
                             params.append(_right)
 
-                    unaccent = self._unaccent(field) if sql_operator.endswith('like') else lambda x: x
+                    unaccent = self._unaccent(field) if sql_operator.endswith('ilike') else lambda x: x
                     lang = model.env.lang or 'en_US'
                     if lang == 'en_US':
                         left = unaccent(f""""{alias}"."{field.name}"->>'en_US'""")
@@ -1518,7 +1518,7 @@ class expression(object):
             sql_operator = {'=like': 'like', '=ilike': 'ilike'}.get(operator, operator)
             cast = '::text' if sql_operator.endswith('like') else ''
 
-            unaccent = self._unaccent(field) if sql_operator.endswith('like') else lambda x: x
+            unaccent = self._unaccent(field) if sql_operator.endswith('ilike') else lambda x: x
             column = '%s.%s' % (table_alias, _quote(left))
             query = f'({unaccent(column + cast)} {sql_operator} {unaccent("%s")})'
 


### PR DESCRIPTION
### [FIX] core: '=like'/'like' doesn't use unaccent anymore

The `=like`/`like` domain operators are accent-insensitive, but still
case-sensitive. This is not really coherent, since `unaccent` is a best
effort to find records from the client, and it is the same idea behind
being case-insensitive. Also, `=like`/`like` cannot be used from the web
client, and we use them in domain to search from the Python side.

Moreover, adding `unaccent` to `=like` can be very inefficient when
searching for a prefix ('prefix%'). In fact, PostgreSQL can use btree
index to find prefix matches, but because we create by default btree
index without unaccent (when we put
`index=True/'btree'/'btree_not_null'` on the field), PostgreSQL cannot
use this index.

### [FIX] *: Fix bad usage of 'like'/'ilike' operator

The 'like'/'ilike' operators automatically add the wildcard character
(`%`) at the beginning and at the end of the value. This commit fixes
the incorrect usage.

https://github.com/odoo/enterprise/pull/47886

task-3508361