### PR TITLE
[IMP] web: prevent jquery from throwing error at start

### DIFF
--- a/addons/web/static/lib/jquery/jquery.js
+++ b/addons/web/static/lib/jquery/jquery.js
@@ -1427,8 +1427,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 			// Support: Firefox <=3.6 - 5 only
 			// Old Firefox doesn't throw on a badly-escaped identifier.
-			el.querySelectorAll( "\\\f" );
-			rbuggyQSA.push( "[\\r\\n\\f]" );
+			// el.querySelectorAll( "\\\f" );
+			// rbuggyQSA.push( "[\\r\\n\\f]" );
 		} );
 
 		assert( function( el ) {
@@ -1462,8 +1462,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 			// Support: Opera 10 - 11 only
 			// Opera 10-11 does not throw on post-comma invalid pseudos
-			el.querySelectorAll( "*,:x" );
-			rbuggyQSA.push( ",.*:" );
+			// el.querySelectorAll( "*,:x" );
+			// rbuggyQSA.push( ",.*:" );
 		} );
 	}
 
@@ -1481,8 +1481,8 @@ setDocument = Sizzle.setDocument = function( node ) {
 
 			// This should fail with an exception
 			// Gecko does not error, returns false instead
-			matches.call( el, "[s!='']:x" );
-			rbuggyMatches.push( "!=", pseudos );
+			// matches.call( el, "[s!='']:x" );
+			// rbuggyMatches.push( "!=", pseudos );
 		} );
 	}
 


### PR DESCRIPTION
To test which browser is currently running, jquery performs some checks when it starts, by doing invalid queryselectors. Depending on which selectors crashes, it can determinate if it is running in an old browser and need to activate some part of the code to support them.

This would not be a big deal, except that it makes the life of some developers much more difficult: we can no longer easily reload a page with a "Pause on exception" setting to debug odoo. Doing so works, but the workflow is polluted by 3 errors initially.

It is so common that I propose to simply remove the checks. This should be acceptable, since Odoo does not work on old browser versions anyway

We are talking about firefox 5, opera 11 or "Gecko", for a commit that is at least 11 years old

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
