### PR TITLE
[FIX] project: handle type error in project.tags object

### DIFF
--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -82,8 +82,9 @@ class ProjectTags(models.Model):
             project_tasks_tags_domain = [('id', 'in', [row[0] for row in self.env.cr.fetchall()])]
             # we apply the domain and limit to the ids we've already found
             ids += self.env['project.tags'].search(expression.AND([domain, project_tasks_tags_domain]), limit=limit, order=order).ids
-        if len(ids) < limit:
-            ids += self.env['project.tags'].search(expression.AND([domain, [('id', 'not in', ids)]]), limit=limit - len(ids), order=order).ids
+        if not limit or len(ids) < limit:
+            limit = limit and limit - len(ids)
+            ids += self.env['project.tags'].search(expression.AND([domain, [('id', 'not in', ids)]]), limit=limit, order=order).ids
         return ids
 
     @api.model


### PR DESCRIPTION
When users search for projects by tag name, in that case, a traceback error occurs.

Steps to produce:
- Install the "project" module.
- Go to the "Project" icon, and Kanban View will open.
- Search projects by tag name, e.g., "Internal" 

After that, a traceback will be generated.
Error:  TypeError: '<' not supported between instances of 'int' and 'NoneType'

Sentry Traceback:
```TypeError: '<' not supported between instances of 'int' and 'NoneType'
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 457, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 430, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 59, in web_search_read
    values_records = self.search_read(domain, fields, offset=offset, limit=limit, order=order)
  File "addons/project/models/project_tags.py", line 43, in search_read
    tag_ids = self._name_search('')
  File "addons/project/models/project_tags.py", line 85, in _name_search
    if len(ids) < limit:
```

When users search for projects by tag name, in that case, limit is none type and len(ids), i.e., project tag ids and its type int, so a type error occurs.

Code reference:
https://github.com/odoo/odoo/blob/8240ad0d32c8f80d7fc3f91cc7fee16cd3ab7eca/addons/project/models/project_tags.py#L85

sentry:4489689778