### PR TITLE
[FIX] point_of_sale: reprint-receipt

### DIFF
--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -24,16 +24,6 @@
             </div>
         </xpath>
 
-        <xpath expr="//span[@t-esc='env.utils.formatCurrency(receiptData.receipt.subtotal)']/.." position="attributes">
-            <attribute name="t-if">!receiptData.receipt.is_gcc_country</attribute>
-        </xpath>
-        <xpath expr="//span[@t-esc='env.utils.formatCurrency(receiptData.receipt.subtotal)']/.." position="after">
-            <div t-if="receiptData.receipt.is_gcc_country" t-translation="off">
-                Subtotal / الإجمالي الفرعي
-                <span t-esc="env.utils.formatCurrency(receiptData.receipt.subtotal)" class="pos-receipt-right-align"/>
-            </div>
-        </xpath>
-
         <xpath expr="//span[@t-esc='env.utils.formatCurrency(receiptData.receipt.total_with_tax)']/.." position="attributes">
             <attribute name="t-if">!receiptData.receipt.is_gcc_country</attribute>
         </xpath>

--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt_screen.js
@@ -1,11 +1,11 @@
 /** @odoo-module */
 
-import { ReceiptScreen } from "@point_of_sale/app/screens/receipt_screen/receipt_screen";
+import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(ReceiptScreen.prototype, {
-    get receiptData() {
-        const receiptData = super.receiptData;
+patch(Order.prototype, {
+    getOrderReceiptEnv() {
+        const receiptData = super.getOrderReceiptEnv();
         const receipt = receiptData.receipt;
         const country = receiptData.order.pos.company.country;
         receipt.is_gcc_country = country

--- a/addons/l10n_sa_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_sa_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-inherit="point_of_sale.OrderReceipt" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('pos-receipt-logo')]" position="after">
-            <t t-if="receiptData.receipt.is_gcc_country and !receipt.is_settlement">
+            <t t-if="receiptData.receipt.is_gcc_country and !receiptData.receipt.is_settlement">
                 <img t-if="receiptData.receipt.qr_code" id="qrcode" t-att-src="receiptData.receipt.qr_code" class="pos-receipt-logo"/>
                 <br/>
             </t>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -256,9 +256,9 @@ export class PaymentScreen extends Component {
         }
 
         this.currentOrder.date_order = luxon.DateTime.now();
-        for (let line of this.paymentLines) {
+        for (const line of this.paymentLines) {
             if (!line.amount === 0) {
-                 this.currentOrder.remove_paymentline(line);
+                this.currentOrder.remove_paymentline(line);
             }
         }
         this.currentOrder.finalized = true;
@@ -350,9 +350,7 @@ export class PaymentScreen extends Component {
 
             if (this.hardwareProxy.printer && invoiced_finalized) {
                 const orderReceipt = renderToElement("point_of_sale.OrderReceipt", {
-                    receiptData: {
-                        ...this.pos.get_order().getOrderReceiptEnv(),
-                    },
+                    receiptData: this.pos.get_order().getOrderReceiptEnv(),
                     pos: this.pos,
                     env: this.env,
                 });

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -45,19 +45,6 @@
             <div class="orderlines">
                 <t t-call="point_of_sale.OrderLinesReceipt"/>
             </div>
-            <!-- Subtotal -->
-
-            <t t-if="!isTaxIncluded">
-                <div class="pos-receipt-right-align">--------</div>
-                <br/>
-                <div>Subtotal<span t-esc="env.utils.formatCurrency(receiptData.receipt.subtotal)" class="pos-receipt-right-align"/></div>
-                <t t-foreach="receiptData.receipt.tax_details" t-as="tax" t-key="tax.name">
-                    <div class="responsive-price">
-                        <t t-esc="tax.name" />
-                        <span t-esc='env.utils.formatCurrency(tax.amount, false)' class="pos-receipt-right-align"/>
-                    </div>
-                </t>
-            </t>
 
             <!-- Total -->
             <div class="pos-receipt-right-align">--------</div>
@@ -102,7 +89,7 @@
                     <span t-esc="env.utils.formatCurrency(receiptData.receipt.total_discount)" class="pos-receipt-right-align"/>
                 </div>
             </t>
-            <div t-if="receiptData.isTaxIncluded" class="pos-receipt-taxes">
+            <div t-if="receiptData.receipt.tax_details.length > 0" class="pos-receipt-taxes">
                 <span />
                 <span>VAT%</span>
                 <span>VAT</span>
@@ -110,7 +97,7 @@
                 <span>Total</span>
                 <t t-foreach="receiptData.receipt.tax_details" t-as="tax" t-key="tax.tax.id">
                     <span />
-                    <span><t t-esc="tax.tax.amount"/> %</span> 
+                    <span><t t-esc="tax.tax.amount"/> %</span>
                     <span t-esc="env.utils.formatCurrency(tax.amount, false)" />
                     <span t-esc="env.utils.formatCurrency(tax.base, false)" />
                     <span t-esc="env.utils.formatCurrency(tax.amount + tax.base, false)" />

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/reprint_receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/reprint_receipt_screen.js
@@ -21,7 +21,7 @@ export class ReprintReceiptScreen extends AbstractReceiptScreen {
     }
 
     get receiptData() {
-        return this.pos.get_order().getOrderReceiptEnv();
+        return this.props.order.getOrderReceiptEnv();
     }
 }
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/reprint_receipt_button/reprint_receipt_button.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/reprint_receipt_button/reprint_receipt_button.js
@@ -22,7 +22,7 @@ export class ReprintReceiptButton extends Component {
         if (this.hardwareProxy.printer) {
             const orderReceipt = renderToElement("point_of_sale.OrderReceipt", {
                 receiptData: {
-                    ...this.pos.get_order().getOrderReceiptEnv(),
+                    ...this.props.order.getOrderReceiptEnv(),
                 },
                 pos: this.pos,
                 env: this.env,

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -77,7 +77,6 @@ export class TicketScreen extends Component {
     //#region EVENT HANDLERS
     async onFilterSelected(selectedFilter) {
         this._state.ui.filter = selectedFilter;
-        this._state.ui.selectedOrder = null;
         if (this._state.ui.filter == "ACTIVE_ORDERS" || this._state.ui.filter === null) {
             this._state.ui.selectedOrder = this.pos.get_order();
         }
@@ -646,8 +645,7 @@ export class TicketScreen extends Component {
                 modelField: "pos_reference",
             },
             DATE: {
-                repr: (order) =>
-                    deserializeDate(order.date_order).toFormat("yyyy-MM-dd HH:mm a"),
+                repr: (order) => deserializeDate(order.date_order).toFormat("yyyy-MM-dd HH:mm a"),
                 displayName: _t("Date"),
                 modelField: "date_order",
             },

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -2683,12 +2683,10 @@ export class Order extends PosModel {
     getOrderReceiptEnv() {
         // Formerly get_receipt_render_env defined in ScreenWidget.
         const receipt = this.export_for_printing();
-        const isTaxIncluded = Math.abs(receipt.subtotal - receipt.total_with_tax) <= 0.000001;
         const getOrderlineTaxes = (line) =>
             Object.keys(line.tax_details).map((taxId) => this.pos.taxes_by_id[taxId]);
         return {
             getOrderlineTaxes: getOrderlineTaxes,
-            isTaxIncluded: isTaxIncluded,
             order: this,
             receipt: receipt,
             orderlines: this.get_orderlines(),

--- a/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/TicketScreen.tour.js
@@ -84,6 +84,11 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
         Chrome.do.clickTicketButton();
         TicketScreen.do.selectFilter("Paid");
         TicketScreen.check.nthRowContains(2, "-0005");
+        TicketScreen.do.selectOrder("-0005");
+        TicketScreen.do.clickControlButton("Print Receipt");
+        TicketScreen.check.receiptTotalIs("8.00");
+        ReceiptScreen.do.clickBack();
+        TicketScreen.do.clickBackToMainTicketScreen();
         // Pay the order that was in PaymentScreen.
         TicketScreen.do.selectFilter("Payment");
         TicketScreen.do.selectOrder("-0004");

--- a/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
@@ -305,6 +305,14 @@ class Check {
             },
         ];
     }
+    receiptTotalIs(amount) {
+        return [
+            {
+                trigger: `.receipt-screen .pos-receipt-amount:contains("${amount}")`,
+                run: () => {},
+            },
+        ];
+    }
 }
 
 class Execute {}

--- a/addons/pos_mercury/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/pos_mercury/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -1,11 +1,11 @@
 /** @odoo-module */
 
-import { ReceiptScreen } from "@point_of_sale/app/screens/receipt_screen/receipt_screen";
+import { Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
-patch(ReceiptScreen.prototype, {
-    get receiptData() {
-        const receiptData = super.receiptData;
+patch(Order.prototype, {
+    getOrderReceiptEnv() {
+        const receiptData = super.getOrderReceiptEnv();
 
         receiptData.hasPosMercurySignature = receiptData.paymentlines.some((line) => {
             if (line.mercury_data) {


### PR DESCRIPTION
Prior to this commit, the reprint receipt screen was not displaying the orderlines. This fix the issue and add steps in the TicketScreen tour to test it.

This commit also removes the sub-total section of the receipt because there is already a breakdown of tax details at the bottom.
