### PR TITLE
[IMP] l10n_us,account: display setting

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -115,7 +115,6 @@ class ResConfigSettings(models.TransientModel):
     module_account_intrastat = fields.Boolean(string='Intrastat')
     module_product_margin = fields.Boolean(string="Allow Product Margin")
     module_l10n_eu_oss = fields.Boolean(string="EU Intra-community Distance Selling")
-    module_account_taxcloud = fields.Boolean(string="Account TaxCloud")
     module_account_avatax = fields.Boolean(string="Account Avatax")
     module_account_invoice_extract = fields.Boolean(string="Document Digitization")
     module_snailmail_account = fields.Boolean(string="Snailmail")

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -58,10 +58,6 @@
                             <setting id="rounding_method" company_dependent="1" string="Rounding Method" help="How total tax amount is computed in orders and invoices" title="A rounding per line is advised if your prices are tax-included. That way, the sum of line subtotals equals the total with taxes.">
                                 <field name="tax_calculation_rounding_method" class="o_light_label mt16" widget="radio"/>
                             </setting>
-                            <setting id="taxcloud_settings" string="TaxCloud" help="Compute tax rates based on U.S. ZIP codes"
-                                documentation="/applications/finance/accounting/taxation/taxes/taxcloud.html">
-                                <field name="module_account_taxcloud" widget="upgrade_boolean"/>
-                            </setting>
                             <setting id="avatax_settings" string="AvaTax" help="Automatically compute tax rates"
                                 documentation="/applications/finance/accounting/taxation/taxes/avatax.html">
                                 <field name="module_account_avatax" widget="upgrade_boolean"/>

--- a/addons/l10n_us/__manifest__.py
+++ b/addons/l10n_us/__manifest__.py
@@ -15,7 +15,8 @@ United States - Chart of accounts.
     'depends': ['account'],
     'data': [
         'data/res_company_data.xml',
-        'views/res_partner_bank_views.xml'
+        'views/res_partner_bank_views.xml',
+        'views/res_config_views.xml',
     ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_us/models/__init__.py
+++ b/addons/l10n_us/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import res_partner_bank
+from . import res_config_settings

--- a/addons/l10n_us/models/res_config_settings.py
+++ b/addons/l10n_us/models/res_config_settings.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    module_l10n_us_taxcloud = fields.Boolean(string="L10n US TaxCloud")

--- a/addons/l10n_us/views/res_config_views.xml
+++ b/addons/l10n_us/views/res_config_views.xml
@@ -1,0 +1,16 @@
+<?xml version = "1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.l10n_us</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <setting id="rounding_method" position="after">
+                <setting id="taxcloud_settings" string="TaxCloud" help="Compute tax rates based on U.S. ZIP codes"
+                    documentation="/applications/finance/accounting/taxation/taxes/taxcloud.html">
+                    <field name="module_l10n_us_taxcloud" widget="upgrade_boolean"/>
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this PR the setting of tax cloud was displayed for everyone which wasn't something that some clients wanted. Now, the setting only appears when you install l10n_us or account_taxcloud directly. The settings is by default falsy because we have removed the auto install in the manifest of account_taxcloud.

upgrade:https://github.com/odoo/upgrade/pull/5315
enterprise: https://github.com/odoo/enterprise/pull/47663

task: 3475032




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
