### PR TITLE
[IMP] web_editor, website: add a favorite field to attachments

### DIFF
--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -13,7 +13,9 @@ Odoo Web Editor widget.
     'data': [
         'security/ir.model.access.csv',
         'data/editor_assets.xml',
+        'data/editor_attachment_tags.xml',
         'views/editor.xml',
+        'views/ir_attachment_views.xml',
         'views/snippets.xml',
     ],
     'assets': {

--- a/addons/web_editor/data/editor_attachment_tags.xml
+++ b/addons/web_editor/data/editor_attachment_tags.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="web_editor.favorite_attachment_tag" model="ir.attachment.tag">
+            <field name="name">Favorite</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/web_editor/security/ir.model.access.csv
+++ b/addons/web_editor/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_web_editor_converter_test,access_web_editor_converter_test,model_web_editor_converter_test,base.group_system,1,1,1,1
 access_web_editor_converter_test_sub,access_web_editor_converter_test_sub,model_web_editor_converter_test_sub,base.group_system,1,1,1,1
+access_ir_attachment_tag,access_ir_attachment_tag,model_ir_attachment_tag,base.group_user,1,0,0,0

--- a/addons/web_editor/static/src/scss/web_editor.backend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.backend.scss
@@ -84,3 +84,7 @@
         transform: none !important;
     }
 }
+
+h1 .o_field_widget .o_favorite i.fa {
+    font-size: inherit;
+}

--- a/addons/web_editor/views/ir_attachment_views.xml
+++ b/addons/web_editor/views/ir_attachment_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_attachment_form_inherit_web_editor" model="ir.ui.view">
+        <field name="name">ir.attachment.form.inherit.web_editor</field>
+        <field name="model">ir.attachment</field>
+        <field name="inherit_id" ref="base.view_attachment_form"/>
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field class="me-2" name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+            </field>
+        </field>
+    </record>
+    <record id="view_attachment_tree_inherit_web_editor" model="ir.ui.view">
+        <field name="name">ir.attachment.tree.inherit.web_editor</field>
+        <field name="model">ir.attachment</field>
+        <field name="inherit_id" ref="base.view_attachment_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="is_favorite" widget="boolean_favorite" nolabel="1"/>
+            </field>
+        </field>
+    </record>
+    <record id="view_attachment_search_inherit_web_editor" model="ir.ui.view">
+        <field name="name">ir.attachment.search.inherit.web_editor</field>
+        <field name="model">ir.attachment</field>
+        <field name="inherit_id" ref="base.view_attachment_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='my_documents_filter']" position="after">
+                <filter name="is_favorite" string="Favorite" domain="[('is_favorite', '=', True)]"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/website/views/ir_attachment_views.xml
+++ b/addons/website/views/ir_attachment_views.xml
@@ -11,13 +11,26 @@
         </field>
     </record>
     <record id="view_attachment_tree_inherit_website" model="ir.ui.view">
-       <field name="name">ir.attachment.tree.inherit.website</field>
-       <field name="model">ir.attachment</field>
-       <field name="inherit_id" ref="base.view_attachment_tree"/>
-       <field name="arch" type="xml">
-           <field name="name" position="after">
-               <field name="website_id" groups="website.group_multi_website"/>
-           </field>
-       </field>
-   </record>
+        <field name="name">ir.attachment.tree.inherit.website</field>
+        <field name="model">ir.attachment</field>
+        <field name="inherit_id" ref="base.view_attachment_tree"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="website_id" groups="website.group_multi_website"/>
+            </field>
+        </field>
+    </record>
+    <!-- This should be in a web_editor_mail bridge module but that would be overkill -->
+    <record id="view_attachment_kanban_inherit_website" model="ir.ui.view">
+        <field name="name">ir.attachment.kanban.inherit.website</field>
+        <field name="model">ir.attachment</field>
+        <field name="inherit_id" ref="mail.view_document_file_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('o_kanban_image')]" position="before">
+                <div class="float-start me-1">
+                    <field name="is_favorite" widget="boolean_favorite" nolabel="1" force_save="1" />
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This commit adds an `is_favorite` computed field to attachments.
In a future media dialog improvement, this will be used to make it
possible for users to mark attachments as favorite so that they can be
found more easily.
This is achieved through the introduction of an `tag_ids` field on
`ir.attachment` and a predefined record for `ir.attachment.tag`.

task-3514226
