### PR TITLE
[FIX] analytic: Add analytic field using studio

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -682,7 +682,7 @@ AnalyticDistribution.props = {
 
 export const analyticDistribution = {
     component: AnalyticDistribution,
-    supportedTypes: ["char", "text"],
+    supportedTypes: ["char", "text", "json"],
     fieldDependencies: [{ name:"analytic_precision", type: "integer" }],
     extractProps: ({ attrs, options }) => ({
         business_domain: options.business_domain,


### PR DESCRIPTION
When adding the analytic field using studio, the user is unable to choose the analytic_distribution widget. 
This is because the supportedTypes were text & char, while the actual field type is json.

Note (limitation in studio):
This should be backported to 16.0. However, this fix alone is not adequate as there seems to be problem with studio. 
With this fix, this studio UI widget field displays the analytic_distribution widget as being used, but it is not written in the generated xml template. 
Without this fix, the widget is not available for selection.

Task submitted by PO: TSB
