### PR TITLE
[ADD] pos_order_customer_screen

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -113,6 +113,10 @@ class PosOrder(models.Model):
 
         return new_session
 
+    def _get_tracking_ref(self):
+        self.ensure_one()
+        return str(self.session_id.id)[-1] + str(self.sequence_number)[-2:]
+
     @api.model
     def _process_order(self, order, draft, existing_order):
         """Create or update an pos.order from a given dictionary.

--- a/addons/point_of_sale/static/src/app/generic_components/odoo_logo/odoo_logo.js
+++ b/addons/point_of_sale/static/src/app/generic_components/odoo_logo/odoo_logo.js
@@ -1,0 +1,17 @@
+/** @odoo-module */
+
+import { Component } from "@odoo/owl";
+
+export class OdooLogo extends Component {
+    static template = "point_of_sale.OdooLogo";
+    static props = {
+        class: { type: String, optional: true },
+        style: { type: String, optional: true },
+        monochrome: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        class: "",
+        style: "",
+        monochrome: false,
+    };
+}

--- a/addons/point_of_sale/static/src/app/generic_components/odoo_logo/odoo_logo.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/odoo_logo/odoo_logo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.OdooLogo">
+        <div t-attf-class="{{ props.class }}" t-attf-style="{{ props.style }}">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 919 495">
+                <path d="M695,346a75,75,0,1,1,75-75A75,75,0,0,1,695,346Zm0-31a44,44,0,1,0-44-44A44,44,0,0,0,695,315ZM538,346a75,75,0,1,1,75-75A75,75,0,0,1,538,346Zm0-31a44,44,0,1,0-44-44A44,44,0,0,0,538,315Zm-82-45c0,41.9-33.6,76-75,76s-75-34-75-75.9S336.5,196,381,196c16.4,0,31.6,3.5,44,12.6V165.1c0-8.3,7.3-15.1,15.5-15.1s15.5,6.8,15.5,15.1Zm-75,45a44,44,0,1,0-44-44A44,44,0,0,0,381,315Z"
+                    t-attf-style="fill:{{ props.monochrome ? '#FFF' : '#8f8f8f' }}"/>
+                <path d="M224,346a75,75,0,1,1,75-75A75,75,0,0,1,224,346Zm0-31a44,44,0,1,0-44-44A44,44,0,0,0,224,315Z"
+                    t-attf-style="fill:{{ props.monochrome ? '#FFF' : '#714b67' }}"/>
+            </svg>
+        </div>
+    </t>
+</templates>


### PR DESCRIPTION
We introduce a new module that enables restaurants to show
their customers a display with all the current orders, filtered by
their preparation state.

In order to know the preparation state of the orders, we rely on the
information provided by the pos_preparation_display module.

In this commit we create a new function on the `pos.order` model
that returns a tracking number for a certain order.
This tracking number will be used by the `pos_order_status_customer_screen`.

Task: 3514516

We also create a generic OdooLogo component that
renders the odoo logo in svg format.
This component has the prop `monochrome` that dictates which
type of odoo logo will be rendered.

task: 3520164
https://github.com/odoo/enterprise/pull/47668




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
