### PR TITLE
[REF] base: introduce hierarchical structure of menus

### DIFF
--- a/odoo/addons/base/views/base_menus.xml
+++ b/odoo/addons/base/views/base_menus.xml
@@ -6,25 +6,29 @@
           id="menu_administration"
           web_icon="base,static/description/settings.png"
           sequence="550"
-          groups="base.group_erp_manager"/>
-          <menuitem id="menu_management" name="Apps" sequence="500" web_icon="base,static/description/modules.png" groups="base.group_system"/>
-          <menuitem id="menu_administration_shortcut" parent="menu_administration" name="Custom Shortcuts" sequence="50"/>
+          groups="base.group_erp_manager">
+          <menuitem id="menu_administration_shortcut" name="Custom Shortcuts" sequence="50"/>
           <!-- FYI The group no_one on 'User & Companies' and 'Translations' is a FP/APR request -->
-          <menuitem id="menu_users" name="Users &amp; Companies" parent="menu_administration" sequence="1"/>
-          <menuitem id="menu_translation" name="Translations" parent="menu_administration" sequence="2" groups="base.group_no_one"/>
-              <menuitem id="menu_translation_app" name="Application Terms" parent="menu_translation" sequence="4" groups="base.group_no_one"/>
-              <menuitem id="menu_translation_export" name="Import / Export" parent="menu_translation" sequence="3" groups="base.group_no_one"/>
-          <menuitem id="menu_config" name="General Settings" parent="menu_administration" sequence='3'/>
+          <menuitem id="menu_users" name="Users &amp; Companies" sequence="1"/>
+          <menuitem id="menu_translation" name="Translations" sequence="2" groups="base.group_no_one">
+              <menuitem id="menu_translation_app" name="Application Terms" sequence="4" groups="base.group_no_one"/>
+              <menuitem id="menu_translation_export" name="Import / Export" sequence="3" groups="base.group_no_one"/>
+          </menuitem>
 
-          <menuitem id="menu_custom" name="Technical" parent="menu_administration" sequence="110" groups="base.group_no_one"/>
-              <menuitem id="next_id_2" name="User Interface" parent="menu_custom"/>
-              <menuitem id="menu_email" name="Email" parent="menu_custom" sequence="1"/>
-              <menuitem id="next_id_9" name="Database Structure" parent="base.menu_custom"/>
-              <menuitem id="menu_automation" name="Automation" parent="base.menu_custom"/>
-              <menuitem id="menu_security" name="Security" parent="menu_custom" sequence="25"/>
-              <menuitem id="menu_ir_property" name="Parameters" parent="menu_custom" sequence="24"/>
+          <menuitem id="menu_config" name="General Settings" sequence='3'/>
 
-          <menuitem id="base.menu_tests" name="Tests" sequence="1000" web_icon="test_exceptions,static/description/icon.png"/>
+          <menuitem id="menu_custom" name="Technical" sequence="110" groups="base.group_no_one">
+              <menuitem id="next_id_2" name="User Interface"/>
+              <menuitem id="menu_email" name="Email" sequence="1"/>
+              <menuitem id="next_id_9" name="Database Structure"/>
+              <menuitem id="menu_automation" name="Automation"/>
+              <menuitem id="menu_security" name="Security" sequence="25"/>
+              <menuitem id="menu_ir_property" name="Parameters" sequence="24"/>
+          </menuitem>
+      </menuitem>
+
+      <menuitem id="menu_management" name="Apps" sequence="500" web_icon="base,static/description/modules.png" groups="base.group_system"/>
+      <menuitem id="base.menu_tests" name="Tests" sequence="1000" web_icon="test_exceptions,static/description/icon.png"/>
 
       <record model="ir.ui.menu" id="base.menu_administration">
           <field name="groups_id" eval="[Command.set([ref('group_system'), ref('group_erp_manager')])]"/>


### PR DESCRIPTION
Introduces a hierarchical structure of some menus. Reasons:

1. Allows testing the child-parent relation of specifically those menus that do not have `parent` or `parent_id` attribute in the source xml using standard menus. It's likely a rare use case, but that's precisely what we currently need in https://github.com/odoo/upgrade/pull/5163.
2. Provides a unique example usage of menus written in this manner in `base`, as opposed to using the `parent` attribute.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
