### PR TITLE
[IMP] web: better looking cids in url

### DIFF
--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
@@ -119,7 +119,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 2);
         assert.containsN(scMenuEl, "[data-company-id] .fa-square-o", 1);
         await prom;
-        assert.verifySteps(["cids=1%2C2"]);
+        assert.verifySteps(["cids=1-2"]);
     });
 
     QUnit.test("can toggle multiple companies at once", async (assert) => {
@@ -157,7 +157,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
 
         assert.verifySteps([]);
         await prom; // await toggle promise
-        assert.verifySteps(["cids=2%2C3"]);
+        assert.verifySteps(["cids=2-3"]);
     });
 
     QUnit.test("single company selected: toggling it off will keep it", async (assert) => {
@@ -231,7 +231,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=3%2C1" });
+        Object.assign(browser.location, { hash: "cids=3-1" });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
         const scMenuEl = target.querySelector(".o_burger_menu_companies");
 
@@ -261,7 +261,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=2%2C3" });
+        Object.assign(browser.location, { hash: "cids=2-3" });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
         const scMenuEl = target.querySelector(".o_burger_menu_companies");
 

--- a/addons/web/static/tests/webclient/switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/switch_company_menu_tests.js
@@ -101,13 +101,15 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         assert.containsN(target, "[data-company-id] .fa-check-square", 1);
         assert.containsN(target, "[data-company-id] .fa-square-o", 4);
         assert.deepEqual(
-            [...target.querySelectorAll("[data-company-id] .toggle_company")].map(
-                (el) => el.getAttribute('aria-checked')
+            [...target.querySelectorAll("[data-company-id] .toggle_company")].map((el) =>
+                el.getAttribute("aria-checked")
             ),
             ["true", "false", "false", "false", "false"]
         );
         assert.deepEqual(
-            [...target.querySelectorAll("[data-company-id] .log_into")].map((el) => el.getAttribute('aria-pressed')),
+            [...target.querySelectorAll("[data-company-id] .log_into")].map((el) =>
+                el.getAttribute("aria-pressed")
+            ),
             ["true", "false", "false", "false", "false"]
         );
 
@@ -123,17 +125,19 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         assert.containsN(target, "[data-company-id] .fa-check-square", 2);
         assert.containsN(target, "[data-company-id] .fa-square-o", 3);
         assert.deepEqual(
-            [...target.querySelectorAll("[data-company-id] .toggle_company")].map(
-                (el) => el.getAttribute('aria-checked')
+            [...target.querySelectorAll("[data-company-id] .toggle_company")].map((el) =>
+                el.getAttribute("aria-checked")
             ),
             ["true", "true", "false", "false", "false"]
         );
         assert.deepEqual(
-            [...target.querySelectorAll("[data-company-id] .log_into")].map((el) => el.getAttribute('aria-pressed')),
+            [...target.querySelectorAll("[data-company-id] .log_into")].map((el) =>
+                el.getAttribute("aria-pressed")
+            ),
             ["true", "false", "false", "false", "false"]
         );
         await prom;
-        assert.verifySteps(["cids=3%2C2"]);
+        assert.verifySteps(["cids=3-2"]);
     });
 
     QUnit.test("can toggle multiple companies at once", async (assert) => {
@@ -176,7 +180,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
 
         assert.verifySteps([]);
         await prom; // await toggle promise
-        assert.verifySteps(["cids=2%2C1%2C4%2C5"]);
+        assert.verifySteps(["cids=2-1-4-5"]);
     });
 
     QUnit.test("single company selected: toggling it off will keep it", async (assert) => {
@@ -260,7 +264,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=3%2C1" });
+        Object.assign(browser.location, { hash: "cids=3-1" });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
@@ -295,7 +299,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=2%2C1" });
+        Object.assign(browser.location, { hash: "cids=2-1" });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
@@ -321,7 +325,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          */
         await click(target.querySelectorAll(".log_into")[2]);
         assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
-        assert.verifySteps(["cids=1%2C4%2C5"]);
+        assert.verifySteps(["cids=1-4-5"]);
     });
 
     QUnit.test("companies can be logged in even if some toggled within delay", async (assert) => {


### PR DESCRIPTION
Before this commit, cids in the url (in the hash part) were separated by a comma, which was encoded by encodeURIComponent as it is not considered as a safe character, resulting into "%2C" appearing in the url in between company ids. This was kind of ugly and made the url a bit hard to read.

This commit uses "-" as separator for cids, which is a safe characters [1] to use in the url and which is thus left untouched by encodeURIComponent.

AL request.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
