### PR TITLE
[FIX] stock: fix _check_backorder

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1214,7 +1214,7 @@ class Picking(models.Model):
                     continue
                 quantity_todo.setdefault(move.product_id.id, 0)
                 quantity_done.setdefault(move.product_id.id, 0)
-                quantity_todo[move.product_id.id] += sum(move.move_line_ids.mapped('reserved_qty'))
+                quantity_todo[move.product_id.id] += move.product_uom._compute_quantity(move.product_uom_qty, move.product_id.uom_id, rounding_method='HALF-UP')
                 quantity_done[move.product_id.id] += move.product_uom._compute_quantity(move.quantity_done, move.product_id.uom_id, rounding_method='HALF-UP')
             if any(
                 float_compare(quantity_done[x], quantity_todo.get(x, 0), precision_digits=prec,) == -1


### PR DESCRIPTION
Steps to reproduce the bug:
- Set up delivery operation with "Create Backorder" set to Ask
- Create SO with storable product
- Validate delivery with incomplete quantity

Problem:
The wizard for backorder creation is not displayed, and the backorder is automatically created. This issue occurs because, in the backorder check, we compare the quantity reserved instead of the product_uom_qty with the quantity done.

opw-3498241
