### PR TITLE
[FIX] account: enable full display of exchange diff partials

### DIFF
--- a/addons/account/static/src/xml/account_payment.xml
+++ b/addons/account/static/src/xml/account_payment.xml
@@ -37,21 +37,24 @@
                         <td>
                            <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line.index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-toggle="tooltip"></a>
                         </td>
-                        <td>
+                        <td t-if="!line.is_exchange">
                             <i class="o_field_widget text-right o_payment_label">Paid on <t t-esc="line.date"></t></i>
                         </td>
-                    </t>
-                        <td style="text-align:right;">
-                            <span class="oe_form_field oe_form_field_float oe_form_field_monetary" style="margin-left: -10px;">
-                                <t t-if="line.position === 'before'">
-                                    <t t-esc="line.currency"/>
-                                </t>
-                                <t t-esc="line.amount"></t>
-                                <t t-if="line.position === 'after'">
-                                    <t t-esc="line.currency"/>
-                                </t>
-                            </span>
+                        <td t-if="line.is_exchange" colspan="2" >
+                            <i class="o_field_widget text-start text-muted text-start">
+                                <span class="oe_form_field oe_form_field_float oe_form_field_monetary fw-bold">
+                                    <t t-out="line.amount_company_currency"/>
+                                </span>
+                                <span> Exchange Difference</span>
+                            </i>
                         </td>
+                    </t>
+                    <td t-if="!line.is_exchange" style="text-align:right;">
+                        <span class="oe_form_field oe_form_field_float oe_form_field_monetary" style="margin-left: -10px;">
+                            <t t-if="line.amount_foreign_currency" t-out="line.amount_foreign_currency"/>
+                            <t t-else="" t-out="line.amount_company_currency"/>
+                        </span>
+                    </td>
                     </tr>
                 </t>
             </table>

--- a/addons/account/static/tests/account_payment_field_tests.js
+++ b/addons/account/static/tests/account_payment_field_tests.js
@@ -16,8 +16,8 @@ QUnit.module('account', {
                 },
                 records: [{
                     id: 1,
-                    payments_widget: '{"content": [{"digits": [69, 2], "currency": "$", "amount": 555.0, "name": "Customer Payment: INV/2017/0004", "date": "2017-04-25", "position": "before", "ref": "BNK1/2017/0003 (INV/2017/0004)", "payment_id": 22, "move_id": 10, "partial_id": 38, "journal_name": "Bank"}], "outstanding": false, "title": "Less Payment"}',
-                    outstanding_credits_debits_widget: '{"content": [{"digits": [69, 2], "currency": "$", "amount": 100.0, "journal_name": "INV/2017/0004", "position": "before", "id": 20}], "move_id": 4, "outstanding": true, "title": "Outstanding credits"}',
+                    payments_widget: '{"content": [{"digits": [69, 2], "currency": "$", "amount": 555.0, "amount_company_currency": "$ 555.00", "name": "Customer Payment: INV/2017/0004", "date": "2017-04-25", "position": "before", "ref": "BNK1/2017/0003 (INV/2017/0004)", "payment_id": 22, "move_id": 10, "partial_id": 38, "journal_name": "Bank"}], "outstanding": false, "title": "Less Payment"}',
+                    outstanding_credits_debits_widget: '{"content": [{"digits": [69, 2], "currency": "$", "amount": 100.0, "amount_company_currency": "$ 100.00", "journal_name": "INV/2017/0004", "position": "before", "id": 20}], "move_id": 4, "outstanding": true, "title": "Outstanding credits"}',
                 }]
             },
         };


### PR DESCRIPTION
Steps to reproduce:
- create a bill for yesterday in a foreign currency
- register payment with today's date the with same foreign currency
- make sure the exchange rate of yesterday is higher than the one of Today

Issue:
The payment widget display two entries:
- the payment
- the exchange diff with an amount_currency of 0

opw-3357649