### PR TITLE
[FIX] web: graph_renderer should use fields formatters

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { getBorderWhite, DEFAULT_BG, getColor, hexToRGBA } from "@web/core/colors/colors";
-import { formatFloat } from "@web/core/utils/numbers";
+import { formatFloat } from "@web/views/fields/formatters";
 import { SEP } from "./graph_model";
 import { sortBy } from "@web/core/utils/arrays";
 import { loadJS } from "@web/core/assets";


### PR DESCRIPTION
This commit fixes a crash that could happen in graph view when the value of a datapoint is false and passed to the formatFloat method. In this case, it should use the field version of the formatFloat method to handle the case where the value is false properly.

