### PR TITLE
[REF] web,*: make draggable hook builder independant from Owl

### DIFF
--- a/addons/im_livechat/static/src/embed/core_ui/livechat_button.js
+++ b/addons/im_livechat/static/src/embed/core_ui/livechat_button.js
@@ -1,7 +1,7 @@
 /* @odoo-module */
 
 import { Component, useRef, useState } from "@odoo/owl";
-import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder";
+import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { debounce } from "@web/core/utils/timing";

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -5,7 +5,7 @@ import { useActiveElement } from "../ui/ui_service";
 import { useForwardRefToParent } from "@web/core/utils/hooks";
 import { Component, useChildSubEnv, useExternalListener, useState } from "@odoo/owl";
 import { throttleForAnimation } from "@web/core/utils/timing";
-import { makeDraggableHook } from "../utils/draggable_hook_builder";
+import { makeDraggableHook } from "../utils/draggable_hook_builder_owl";
 
 const useDialogDraggable = makeDraggableHook({
     name: "useDialogDraggable",

--- a/addons/web/static/src/core/utils/draggable.js
+++ b/addons/web/static/src/core/utils/draggable.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder";
+import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { pick } from "@web/core/utils/objects";
 
 /** @typedef {import("@web/core/utils/draggable_hook_builder").DraggableHandlerParams} DraggableHandlerParams */
@@ -43,7 +43,7 @@ import { pick } from "@web/core/utils/objects";
 /** @type {(params: DraggableParams) => DraggableState} */
 export const useDraggable = makeDraggableHook({
     name: "useDraggable",
-    onWillStartDrag: ({ctx}) => pick(ctx.current, "element"),
+    onWillStartDrag: ({ ctx }) => pick(ctx.current, "element"),
     onDragStart: ({ ctx }) => pick(ctx.current, "element"),
     onDrag: ({ ctx }) => pick(ctx.current, "element"),
     onDragEnd: ({ ctx }) => pick(ctx.current, "element"),

--- a/addons/web/static/src/core/utils/draggable_hook_builder_owl.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder_owl.js
@@ -1,0 +1,26 @@
+/** @odoo-module */
+
+import { onWillUnmount, reactive, useEffect, useExternalListener } from "@odoo/owl";
+import { useThrottleForAnimation } from "./timing";
+import { makeDraggableHook as nativeMakeDraggableHook } from "./draggable_hook_builder";
+
+/**
+ * Set of default `makeDraggableHook` setup hooks that makes use of Owl lifecycle
+ * and reactivity hooks to properly set up, update and tear down the elements and
+ * listeners added by the draggable hook builder.
+ *
+ * @see {nativeMakeDraggableHook}
+ * @type {typeof nativeMakeDraggableHook}
+ */
+export function makeDraggableHook(params) {
+    return nativeMakeDraggableHook({
+        ...params,
+        setupHooks: {
+            addListener: useExternalListener,
+            setup: useEffect,
+            teardown: onWillUnmount,
+            throttle: useThrottleForAnimation,
+            wrapState: reactive,
+        },
+    });
+}

--- a/addons/web/static/src/core/utils/nested_sortable.js
+++ b/addons/web/static/src/core/utils/nested_sortable.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { localization } from "@web/core/l10n/localization";
-import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder";
+import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 
 /** @typedef {import("@web/core/utils/draggable_hook_builder").DraggableHandlerParams} DraggableHandlerParams */
 /** @typedef {DraggableHandlerParams & { group: HTMLElement | null }} NestedSortableHandlerParams */

--- a/addons/web/static/src/core/utils/sortable.js
+++ b/addons/web/static/src/core/utils/sortable.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder";
+import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
 import { pick } from "@web/core/utils/objects";
 
 /** @typedef {import("@web/core/utils/draggable_hook_builder").DraggableHandlerParams} DraggableHandlerParams */


### PR DESCRIPTION
This commit removes Owl hooks from the draggable hook builder file and introduces a new parameter attribute (`setupHooks`) to specify which functions must be used to set up, update and tear down the draggable hook.

This has been done to allow the draggable hook builder function to be used in environments where Owl is not available.

Enterprise: https://github.com/odoo/enterprise/pull/47693

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
