### PR TITLE
[IMP] web: list many2oneAvatar should not be a link

### DIFF
--- a/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/web/fields/m2x_avatar_user_tests.js
@@ -265,11 +265,11 @@ QUnit.test(
                 views: [[false, "list"]],
             });
             await contains(
-                ":nth-child(1 of .o_data_row) .o_field_many2one_avatar_user .o_form_uri span",
+                ":nth-child(1 of .o_data_row) .o_field_many2one_avatar_user span > span",
                 { text: "Luigi" }
             );
             await contains(
-                ":nth-child(2 of .o_data_row) .o_field_many2one_avatar_user .o_form_uri span",
+                ":nth-child(2 of .o_data_row) .o_field_many2one_avatar_user span > span",
                 { text: "Mario" }
             );
             // Select all
@@ -284,11 +284,11 @@ QUnit.test(
             // Cancel
             await click(".o_dialog .modal-footer button:nth-child(2)");
             await contains(
-                ":nth-child(1 of .o_data_row) .o_field_many2one_avatar_user .o_form_uri span",
+                ":nth-child(1 of .o_data_row) .o_field_many2one_avatar_user span > span",
                 { text: "Luigi" }
             );
             await contains(
-                ":nth-child(2 of .o_data_row) .o_field_many2one_avatar_user .o_form_uri span",
+                ":nth-child(2 of .o_data_row) .o_field_many2one_avatar_user span > span",
                 { text: "Mario" }
             );
 
@@ -300,11 +300,11 @@ QUnit.test(
             await click(".o_dialog .modal-footer button:nth-child(1)");
             await contains(".o_dialog", { count: 0 });
             await contains(
-                ":nth-child(1 of .o_data_row) .o_field_many2one_avatar_user .o_form_uri span",
+                ":nth-child(1 of .o_data_row) .o_field_many2one_avatar_user span > span",
                 { text: "Luigi" }
             );
             await contains(
-                ":nth-child(2 of .o_data_row) .o_field_many2one_avatar_user .o_form_uri span",
+                ":nth-child(2 of .o_data_row) .o_field_many2one_avatar_user span > span",
                 { text: "Luigi" }
             );
 

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
@@ -32,7 +32,13 @@ export class Many2OneAvatarField extends Component {
 export const many2OneAvatarField = {
     ...many2OneField,
     component: Many2OneAvatarField,
+    extractProps(fieldInfo) {
+        const props = many2OneField.extractProps(...arguments);
+        props.canOpen = fieldInfo.viewType === "form";
+        return props;
+    },
 };
+
 export class Many2OneFieldPopover extends Many2OneField {
     static props = {
         ...Many2OneField.props,
@@ -96,7 +102,7 @@ export const kanbanMany2OneAvatarField = {
     component: KanbanMany2OneAvatarField,
     additionalClasses: ["o_field_many2one_avatar_kanban"],
     extractProps(fieldInfo, dynamicInfo) {
-        const props = many2OneField.extractProps(...arguments);
+        const props = many2OneAvatarField.extractProps(...arguments);
         props.isEditable = !dynamicInfo.readonly;
         return props;
     },

--- a/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
@@ -309,17 +309,34 @@ QUnit.module("Fields", (hooks) => {
         assert.verifySteps(["openRecord"]);
     });
 
-    QUnit.test("readonly many2one_avatar should contain a link", async function (assert) {
-        await makeView({
-            type: "form",
-            serverData,
-            resModel: "partner",
-            resId: 1,
-            arch: `<form><field name="user_id" widget="many2one_avatar" readonly="1"/></form>`,
-        });
+    QUnit.test(
+        "readonly many2one_avatar in form view should contain a link",
+        async function (assert) {
+            await makeView({
+                type: "form",
+                serverData,
+                resModel: "partner",
+                resId: 1,
+                arch: `<form><field name="user_id" widget="many2one_avatar" readonly="1"/></form>`,
+            });
 
-        assert.containsOnce(target, "[name='user_id'] a");
-    });
+            assert.containsOnce(target, "[name='user_id'] a");
+        }
+    );
+
+    QUnit.test(
+        "readonly many2one_avatar in list view should not contain a link",
+        async function (assert) {
+            await makeView({
+                type: "list",
+                serverData,
+                resModel: "partner",
+                arch: `<tree><field name="user_id" widget="many2one_avatar"/></tree>`,
+            });
+
+            assert.containsNone(target, "[name='user_id'] a");
+        }
+    );
 
     QUnit.test("cancelling create dialog should clear value in the field", async function (assert) {
         serverData.views = {


### PR DESCRIPTION
This commit changes the canOpen prop of the many2oneAvatar field to be set to true only when in form view. The field will therefore stop being a link in readonly when outside of form view.