### PR TITLE
[FIX] website_slides_survey: revised certificate title on change

### DIFF
--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -50,7 +50,7 @@ class Slide(models.Model):
     @api.depends('survey_id')
     def _compute_name(self):
         for slide in self:
-            if not slide.name and slide.survey_id:
+            if slide.survey_id:
                 slide.name = slide.survey_id.title
 
     def _compute_mark_complete_actions(self):

--- a/addons/website_slides_survey/static/src/js/slides_upload.js
+++ b/addons/website_slides_survey/static/src/js/slides_upload.js
@@ -25,9 +25,11 @@ SlidesUpload.SlideUploadDialog.include({
         if (ev.added) {
             this.$('.o_error_no_certification').addClass('d-none');
             this.$('#certification_id').parent().find('.select2-container').removeClass('is-invalid');
-            if (ev.added.text && !$inputElement.val().trim()) {
+            if (ev.added.text) {
                 $inputElement.val(ev.added.text);
             }
+        }else {
+            $inputElement.val("");
         }
     },
 


### PR DESCRIPTION
Steps to reproduce
===================
1. Open E-learning.
2. Create new course.
3. Add a certification.
4. Select any certification survey.
5. Re-select the other certification survey.
6. Title has not been revised.

Technical
========
This issue is coming from this commit https://github.com/odoo/odoo/commit/ee0f4b130004d09224e2b96acf7536c13d891377
Here in the "_compute_name" method, once the title is set then it is not getting
revised.So now in this PR if the survey_id changes then the title will be
revised.

This same issue is also occurring in frontend, their in
" _onChangeCertification" function if the title is set then it is not getting
revised so changes are made over there also.

After this PR
==================
Now the title of the certificate will revised on changing the certification
survey from frontend as well as backend.

Task-3510815
