### PR TITLE
[FIX] onboarding, web: restore validating steps

### DIFF
--- a/addons/onboarding/static/src/views/form/onboarding_step_form_controller.js
+++ b/addons/onboarding/static/src/views/form/onboarding_step_form_controller.js
@@ -17,16 +17,23 @@ export default class OnboardingStepFormController extends FormController {
      * If necessary, mark the step as done and reload the main view.
      * @override
      */
-    async onRecordSaved(record) {
-        const { reloadOnFirstValidation, reloadAlways } = this.stepConfig;
-        const validationResponse = await this.orm.call(
-            'onboarding.onboarding.step',
-            'action_validate_step',
-            [this.stepName],
-        );
-        if (reloadAlways || (reloadOnFirstValidation && validationResponse === "JUST_DONE")) {
-            this.action.restore(this.action.currentController.jsId);
+    async saveButtonClicked({ closable, ...otherParams }) {
+        const saved = await super.saveButtonClicked(otherParams);
+        if (saved) {
+            const { reloadOnFirstValidation, reloadAlways } = this.stepConfig;
+            const validationResponse = await this.orm.call(
+                'onboarding.onboarding.step',
+                'action_validate_step',
+                [this.stepName],
+            );
+            if (reloadAlways || (reloadOnFirstValidation && validationResponse === "JUST_DONE")) {
+                this.action.restore(this.action.currentController.jsId);
+            }
+            else if (closable) {
+                this.action.doAction({ type: "ir.actions.act_window_close" });
+            }
         }
+        return saved;
     }
     /**
      * Returns the name of the onboarding step to validate after the dialog

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -285,7 +285,8 @@ export class FormController extends Component {
     /**
      * onRecordSaved is a callBack that will be executed after the save
      * if it was done. It will therefore not be executed if the record
-     * is invalid or if a server error is thrown.
+     * is invalid, if a server error is thrown, or if there are no
+     * changes to save.
      * @param {Record} record
      */
     async onRecordSaved(record) {}


### PR DESCRIPTION
Reproduce:
1. Open "Sales" app.
2. Open the fist step about company data
3. Hit "Save"
4. The step should have been marked as complete

onboarding: Since the relational model refactoring, saving a record that is not changed will not result in calling the onRecordSaved callback, while saved will be `true` in `saveButtonClicked`.

web: Be more explicit about this fact in the onRecordSaved doc.

Task-3516270
