### PR TITLE
[IMP] stock_delivery: don't require partner_id if not integration_level == 'rate_and_ship'

### DIFF
--- a/addons/stock_delivery/views/delivery_view.xml
+++ b/addons/stock_delivery/views/delivery_view.xml
@@ -50,7 +50,7 @@
                     <button name="print_return_label" string="Print Return Label" type="object" invisible="not is_return_picking or state == 'done' or picking_type_code != 'incoming'" data-hotkey="shift+o"/>
                 </xpath>
                 <xpath expr="//field[@name='partner_id']" position="attributes">
-                    <attribute name="required">delivery_type and delivery_type not in ['fixed', 'base_on_rule']</attribute>
+                    <attribute name="required">carrier_id and carrier_id.integration_level == 'rate_and_ship'</attribute>
                 </xpath>
               </data>
             </field>


### PR DESCRIPTION
The requirement of partner_id was put long ago because send_to_shipper() method requires it. But if you look into the python code, you see in _send_confirmation_email() method that the requirement to enter into send_to_shipper() is `integration_level == 'rate_and_ship'` instead of `delivery_type not in ['fixed', 'base_on_rule']`. It means that, with this change, if we have a `delivery_type not in ['fixed', 'base_on_rule']`, we should be able to validate the picking without partner if we have `integration_level == 'rate'`.

See python code requirement:
![Selection_1826](https://github.com/odoo/odoo/assets/25005517/5ee20a4d-5215-45b5-ae62-507b27511658)

**Description of the issue/feature this PR addresses:**
We adapt view requirement to the python requirement.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr