### PR TITLE
[IMP] account,*: refactor '_get_query_currency_table'

### DIFF
--- a/addons/account/models/res_currency.py
+++ b/addons/account/models/res_currency.py
@@ -43,30 +43,28 @@ class ResCurrency(models.Model):
         return bool(self.env['account.move.line'].search_count(['|', ('currency_id', '=', self.id), ('company_currency_id', '=', self.id)]))
 
     @api.model
-    def _get_query_currency_table(self, options):
+    def _get_query_currency_table(self, company_ids, conversion_date):
         ''' Construct the currency table as a mapping company -> rate to convert the amount to the user's company
         currency in a multi-company/multi-currency environment.
         The currency_table is a small postgresql table construct with VALUES.
-        :param options: The report options.
+        :param company_ids: list of company ids
+        :param conversion_date: date, used to determine the currency rate between the individual companies and the user's company
         :return:        The query representing the currency table.
         '''
 
+        companies = self.env['res.company'].browse(company_ids)
         user_company = self.env.company
-        user_currency = user_company.currency_id
-        if options.get('multi_company', False):
-            companies = self.env.companies
-            conversion_date = options['date']['date_to']
-            currency_rates = companies.mapped('currency_id')._get_rates(user_company, conversion_date)
+        if companies == user_company:
+            currency_rates = {user_company.currency_id.id: 1.0}
         else:
-            companies = user_company
-            currency_rates = {user_currency.id: 1.0}
+            currency_rates = companies.mapped('currency_id')._get_rates(user_company, conversion_date)
 
         conversion_rates = []
         for company in companies:
             conversion_rates.extend((
                 company.id,
                 currency_rates[user_company.currency_id.id] / currency_rates[company.currency_id.id],
-                user_currency.decimal_places,
+                user_company.currency_id.decimal_places,
             ))
         query = '(VALUES %s) AS currency_table(company_id, rate, precision)' % ','.join('(%s, %s, %s)' for i in companies)
         return self.env.cr.mogrify(query, conversion_rates).decode(self.env.cr.connection.encoding)

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -120,7 +120,7 @@ class AccountInvoiceReport(models.Model):
                 LEFT JOIN res_partner commercial_partner ON commercial_partner.id = move.commercial_partner_id
                 JOIN {currency_table} ON currency_table.company_id = line.company_id
         '''.format(
-            currency_table=self.env['res.currency']._get_query_currency_table({'multi_company': True, 'date': {'date_to': fields.Date.today()}}),
+            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
         )
 
     @api.model

--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -106,11 +106,7 @@ class SaleReport(models.Model):
             LEFT JOIN pos_config config ON config.id = session.config_id
             JOIN {currency_table} ON currency_table.company_id = pos.company_id
             """.format(
-            currency_table=self.env['res.currency']._get_query_currency_table(
-                {
-                    'multi_company': True,
-                    'date': {'date_to': fields.Date.today()}
-                }),
+            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
             )
 
     def _where_pos(self):

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -106,7 +106,7 @@ class PurchaseReport(models.Model):
                 left join uom_uom product_uom on (product_uom.id=t.uom_id)
                 left join {currency_table} ON currency_table.company_id = po.company_id
         """.format(
-            currency_table=self.env['res.currency']._get_query_currency_table({'multi_company': True, 'date': {'date_to': fields.Date.today()}}),
+            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
         )
         return from_str
 

--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -177,11 +177,7 @@ class SaleReport(models.Model):
             LEFT JOIN uom_uom u2 ON u2.id=t.uom_id
             JOIN {currency_table} ON currency_table.company_id = s.company_id
             """.format(
-            currency_table=self.env['res.currency']._get_query_currency_table(
-                {
-                    'multi_company': True,
-                    'date': {'date_to': fields.Date.today()}
-                }),
+            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
             )
 
     def _where_sale(self):


### PR DESCRIPTION
*: pos_sale,purchase,sale

The '_get_query_currency_table' function of the res.currency
model (added in 'account' module) was refactored in this commit.
After this commit the functions parameters are effectively "decoupled"
from the 'account_reports' module.

Previously the the function took an 'options' parameter.
The 'options' was a dictionary that was formatted to be compatible with
the report options from the 'account_reports' module (enterprise).
Due to a change to these report options (see enterprise PR)
the function had to be changed in some ways.

It was chosen to "decouple" it from the report options for the following reasons:
1. The 'account' module does not (really) depend on 'account_reports'
   or knows about it at all.
2. There was still a (soft) dependency on the 'account_reports' options though:
   Changes to the report options had to be reflected here too.
3. Every function that calls this function previously had to create some pseudo
   'account_reports' report options. This made it inconvenient to use the
   function outside of a report.

task-3484368

Community PR: https://github.com/odoo/odoo/pull/136173
Enterprise PR: https://github.com/odoo/enterprise/pull/47735

