### PR TITLE
[IMP] project_purchase: change project updates with PO

### DIFF
--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -494,13 +494,13 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         self.assertEqual('purchase_order', items['data'][0]['id'])
         self.assertEqual(project._get_profitability_sequence_per_invoice_type()['purchase_order'], items['data'][0]['sequence'])
         self.assertEqual(0.0, items['data'][0]['to_bill'])
-        self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 3.6, items['data'][0]['billed'], 2), 0)
+        self.assertEqual(float_compare(-self.product_order.standard_price * analytic_contribution * 3.6, items['data'][0]['billed'], 2), 1)
         self.assertEqual('other_purchase_costs', items['data'][1]['id'])
         self.assertEqual(project._get_profitability_sequence_per_invoice_type()['other_purchase_costs'], items['data'][1]['sequence'])
         self.assertEqual(0.0, items['data'][1]['to_bill'])
         self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6, items['data'][1]['billed'], 2), 0)
         self.assertEqual(0.0, items['total']['to_bill'])
-        self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6 - self.product_order.standard_price * analytic_contribution * 3.6, items['total']['billed'], 2), 0)
+        self.assertEqual(float_compare(-self.product_a.standard_price * analytic_contribution * 3.6 - self.product_order.standard_price * analytic_contribution * 3.6, items['total']['billed'], 2), 1)
 
     def _create_invoice_for_po(self, purchase_order):
         purchase_order.action_create_invoice()


### PR DESCRIPTION
[[FIX] project_purchase: fix project updates with PO](https://github.com/odoo/odoo/pull/136233/commits/8299587a56725b7e7e54a6518bf6f74f7a409d47) 

Steps:
- Install purchase, project,sale_timesheet, and sales.
- Create a new PO linked with analytical distribution to any one project.
- Add product in PO and set price as '100'.
- Check-in project updates, it will show '100' in the to-bill section.

Issue:
- When we make the Vendor Bill of that PO and at the time of making we change
the price or product to '200', the project update still shows '100'.

Cause:
- We are showing the PO's amount in the project updates 'Billed' section and not
the invoiced amount.

Fix:
- We will show the updated invoice amount in the 'Billed' section and the amount
of PO in the 'To bill' section.

Technical:
- The price_unit is calculated not using the price but `price_subtotal` divided
by `quantity` , the reason is if we calculate it using price then if afterwards
discount is applied on it, then it isn't calculated.
- amount_invoiced is calculated using `pol_read['invoice_lines'].price_subtotal
/ pol_read['invoice_lines'].quantity` to handle the case of discount as well.

task-3418661