### PR TITLE
[IMP] stock, barcode: search pickings from lot/serial number

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -153,6 +153,9 @@ class BarcodeNomenclature(models.Model):
                     data_type = data['rule'].type
                     value = data['value']
                     if data_type in barcode_types:
+                        if data_type == 'lot':
+                            args[i] = (field_name, operator, value)
+                            break
                         match = re.match('0*([0-9]+)$', str(value))
                         if match:
                             unpadded_barcode = match.groups()[0]

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -467,6 +467,8 @@ class Picking(models.Model):
                                'changing the done quantities.')
     # Used to search on pickings
     product_id = fields.Many2one('product.product', 'Product', related='move_ids.product_id', readonly=True)
+    lot_id = fields.Many2one('stock.lot', 'Lot/Serial Number', related='move_line_ids.lot_id', readonly=True)
+
     show_operations = fields.Boolean(compute='_compute_show_operations')
     show_reserved = fields.Boolean(related='picking_type_id.show_reserved')
     show_lots_text = fields.Boolean(compute='_compute_show_lots_text')

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -377,6 +377,7 @@
                         string="Package"
                         filter_domain="['|', ('move_line_ids.package_id.name', 'ilike', self), ('move_line_ids.result_package_id.name', 'ilike', self)]"
                         groups="stock.group_tracking_lot"/>
+                    <field name="lot_id" groups="stock.group_production_lot"/>
                     <filter name="to_do_transfers" string="To Do" domain="['&amp;',('user_id', 'in', [uid, False]),('state','not in',['done','cancel'])]"/>
                     <filter name="my_transfers" string="My Transfers" domain="[('user_id', '=', uid)]"/>
                     <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>

--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -275,6 +275,19 @@ export const fakeCompanyService = {
     },
 };
 
+export function makeFakeBarcodeService() {
+    return {
+        start() {
+            return {
+                bus: {
+                    async addEventListener() {},
+                    async removeEventListener() {},
+                }
+            };
+        },
+    };
+}
+
 export function makeFakeHTTPService(getResponse, postResponse) {
     getResponse =
         getResponse ||

--- a/addons/web/static/tests/webclient/helpers.js
+++ b/addons/web/static/tests/webclient/helpers.js
@@ -20,6 +20,7 @@ import {
     makeFakeLocalizationService,
     makeFakeRouterService,
     makeFakeHTTPService,
+    makeFakeBarcodeService,
     makeFakeUserService,
 } from "../helpers/mock_services";
 import { getFixture, mount, nextTick } from "../helpers/utils";
@@ -58,6 +59,7 @@ export function setupWebClientRegistries() {
     }
     const services = {
         action: () => actionService,
+        barcode: () => makeFakeBarcodeService(),
         command: () => commandService,
         dialog: () => dialogService,
         effect: () => effectService,


### PR DESCRIPTION
Give the ability to filter pickings base on lot/serial number set on stock move lines.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
