### PR TITLE
[IMP] web: keep supporting old cids syntax in url

### DIFF
--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -38,8 +38,15 @@ export const companyService = {
     dependencies: ["user", "router", "cookie", "action"],
     start(env, { user, router, cookie, action }) {
         let cids;
-        if ("cids" in router.current.hash) {
-            cids = parseCompanyIds(router.current.hash.cids, CIDS_HASH_SEPARATOR);
+        const hash = router.current.hash;
+        if ("cids" in hash) {
+            // backward compatibility s.t. old urls (still using "," as separator) keep working
+            // deprecated as of 17.0
+            let separator = CIDS_HASH_SEPARATOR;
+            if (typeof hash.cids === "string" && !hash.cids.includes(CIDS_HASH_SEPARATOR)) {
+                separator = ",";
+            }
+            cids = parseCompanyIds(hash.cids, separator);
         } else if ("cids" in cookie.current) {
             cids = parseCompanyIds(cookie.current.cids);
         }

--- a/addons/web/static/tests/webclient/company_service_tests.js
+++ b/addons/web/static/tests/webclient/company_service_tests.js
@@ -1,9 +1,12 @@
 /** @odoo-module **/
 
+import { browser } from "@web/core/browser/browser";
 import { ormService } from "@web/core/orm_service";
 import { registry } from "@web/core/registry";
+import { session } from "@web/session";
 import { companyService } from "@web/webclient/company_service";
 import { makeTestEnv } from "../helpers/mock_env";
+import { patchWithCleanup } from "../helpers/utils";
 
 const serviceRegistry = registry.category("services");
 
@@ -48,16 +51,43 @@ QUnit.test(
         const env = await makeTestEnv();
         assert.verifySteps([]);
         env.bus.trigger("RPC:RESPONSE", {
-            data: { params: { model: "res.company", method: "write"}},
+            data: { params: { model: "res.company", method: "write" } },
             settings: {},
             result: {},
         });
         assert.verifySteps(["reload_context"]);
         env.bus.trigger("RPC:RESPONSE", {
-            data: { params: { model: "res.company", method: "write" }},
+            data: { params: { model: "res.company", method: "write" } },
             settings: {},
             error: {},
         });
         assert.verifySteps([]);
     }
 );
+
+QUnit.test("extract allowed company ids from url hash", async (assert) => {
+    patchWithCleanup(session.user_companies, {
+        allowed_companies: {
+            1: { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
+            2: { id: 2, name: "Company 2", sequence: 2, parent_id: false, child_ids: [] },
+            3: { id: 3, name: "Company 3", sequence: 3, parent_id: false, child_ids: [] },
+        },
+    });
+
+    serviceRegistry.add("company", companyService);
+
+    Object.assign(browser.location, { hash: "cids=3-1" });
+    let env = await makeTestEnv();
+    assert.deepEqual(
+        Object.values(env.services.company.availableCompanies).map((c) => c.id),
+        [1, 2, 3]
+    );
+    assert.deepEqual(env.services.company.allowedCompanyIds, [3, 1]);
+    assert.strictEqual(env.services.company.currentCompany.id, 3);
+
+    // backward compatibility
+    Object.assign(browser.location, { hash: "cids=3%2C1" });
+    env = await makeTestEnv();
+    assert.deepEqual(env.services.company.allowedCompanyIds, [3, 1]);
+    assert.strictEqual(env.services.company.currentCompany.id, 3);
+});


### PR DESCRIPTION
Commit [1] changed the separator of cids in the url to make it better looking, by using a character that doesn't need to be encoded (namely, "-" instead of ","). However, by doing so, urls still using the former separator couldn't be correctly parsed anymore. This commit adds a small backward compatibility layer, s.t. links in emails for instance keep working as before.

[1] abae4d4a5ce2a420581a0ce1b52349457019c66d

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
