### PR TITLE
[IMP] account: demo data for auto-reconcile

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -38,6 +38,15 @@ class AccountChartTemplate(models.AbstractModel):
             + self.ref('demo_invoice_followup')
             + self.ref('demo_invoice_5')
             + self.ref('demo_invoice_equipment_purchase')
+            + self.ref('demo_move_auto_reconcile_1')
+            + self.ref('demo_move_auto_reconcile_2')
+            + self.ref('demo_move_auto_reconcile_3')
+            + self.ref('demo_move_auto_reconcile_4')
+            + self.ref('demo_move_auto_reconcile_5')
+            + self.ref('demo_move_auto_reconcile_6')
+            + self.ref('demo_move_auto_reconcile_7')
+            + self.ref('demo_move_auto_reconcile_8')
+            + self.ref('demo_move_auto_reconcile_9')
         ).with_context(check_move_validity=False)
 
         # the invoice_extract acts like a placeholder for the OCR to be ran and doesn't contain
@@ -58,7 +67,29 @@ class AccountChartTemplate(models.AbstractModel):
 
     @api.model
     def _get_demo_data_move(self, company=False):
+        one_month_ago = fields.Date.today() + relativedelta(months=-1)
         fifteen_months_ago = fields.Date.today() + relativedelta(months=-15)
+        cid = company.id or self.env.company.id
+        misc_journal = self.env['account.journal'].search(
+            domain=[
+                *self.env['account.journal']._check_company_domain(cid),
+                ('type', '=', 'general'),
+            ],
+            limit=1,
+        )
+        bank_journal = self.env['account.journal'].search(
+            domain=[
+                *self.env['account.journal']._check_company_domain(cid),
+                ('type', '=', 'bank'),
+            ],
+            limit=1,
+        )
+        default_receivable = self.env.ref('base.res_partner_3').with_company(company).property_account_receivable_id
+        income_account = self.env['account.account'].search([
+            ('company_id', '=', cid),
+            ('account_type', '=', 'income'),
+            ('id', '!=', (company or self.env.company).account_journal_early_pay_discount_gain_account_id.id)
+        ], limit=1)
         return {
             'demo_invoice_1': {
                 'move_type': 'out_invoice',
@@ -76,8 +107,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_2',
                 'invoice_user_id': False,
-                'invoice_date': time.strftime('%Y-%m-08'),
-                'delivery_date': time.strftime('%Y-%m-08'),
+                'invoice_date': (fields.Date.today() + timedelta(days=-2)).strftime('%Y-%m-%d'),
+                'delivery_date': (fields.Date.today() + timedelta(days=-2)).strftime('%Y-%m-%d'),
                 'invoice_line_ids': [
                     Command.create({'product_id': 'product.consu_delivery_03', 'quantity': 5}),
                     Command.create({'product_id': 'product.consu_delivery_01', 'quantity': 20}),
@@ -87,8 +118,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'move_type': 'out_invoice',
                 'partner_id': 'base.res_partner_2',
                 'invoice_user_id': False,
-                'invoice_date': time.strftime('%Y-%m-08'),
-                'delivery_date': time.strftime('%Y-%m-08'),
+                'invoice_date': (fields.Date.today() + timedelta(days=-3)).strftime('%Y-%m-%d'),
+                'delivery_date': (fields.Date.today() + timedelta(days=-3)).strftime('%Y-%m-%d'),
                 'invoice_line_ids': [
                     Command.create({'product_id': 'product.consu_delivery_01', 'quantity': 5}),
                     Command.create({'product_id': 'product.consu_delivery_03', 'quantity': 5}),
@@ -130,6 +161,95 @@ class AccountChartTemplate(models.AbstractModel):
                 'invoice_line_ids': [
                     Command.create({'name': 'Redeem Reference Number: PO02529', 'quantity': 1, 'price_unit': 541.10,
                                     'tax_ids': self.env.company.account_purchase_tax_id.ids}),
+                ],
+            },
+            'demo_move_auto_reconcile_1': {
+                'move_type': 'out_refund',
+                'partner_id': 'base.res_partner_12',
+                'invoice_date': one_month_ago.strftime("%Y-%m-02"),
+                'delivery_date': one_month_ago.strftime("%Y-%m-02"),
+                'invoice_line_ids': [
+                    Command.create({'product_id': 'product.consu_delivery_03', 'quantity': 5}),
+                ],
+            },
+            'demo_move_auto_reconcile_2': {
+                'move_type': 'out_refund',
+                'partner_id': 'base.res_partner_12',
+                'invoice_date': one_month_ago.strftime("%Y-%m-03"),
+                'delivery_date': one_month_ago.strftime("%Y-%m-03"),
+                'invoice_line_ids': [
+                    Command.create({'product_id': 'product.consu_delivery_02', 'quantity': 5}),
+                ],
+            },
+            'demo_move_auto_reconcile_3': {
+                'move_type': 'in_refund',
+                'partner_id': 'base.res_partner_12',
+                'invoice_date': time.strftime('%Y-%m-01'),
+                'delivery_date': time.strftime('%Y-%m-01'),
+                'invoice_line_ids': [
+                    Command.create({'product_id': 'product.product_delivery_01', 'price_unit': 10.0, 'quantity': 1}),
+                    Command.create({'product_id': 'product.product_order_01', 'price_unit': 4.0, 'quantity': 5}),
+                ],
+            },
+            'demo_move_auto_reconcile_4': {
+                'move_type': 'in_refund',
+                'partner_id': 'base.res_partner_12',
+                'invoice_date': fifteen_months_ago.strftime("%Y-%m-19"),
+                'delivery_date': fifteen_months_ago.strftime("%Y-%m-19"),
+                'invoice_line_ids': [
+                    Command.create({'name': 'Redeem Reference Number: PO02529', 'quantity': 1, 'price_unit': 541.10,
+                                    'tax_ids': self.env.company.account_purchase_tax_id.ids}),
+                ],
+            },
+            'demo_move_auto_reconcile_5': {
+                'move_type': 'out_refund',
+                'partner_id': 'base.res_partner_2',
+                'invoice_date': (fields.Date.today() + timedelta(days=-10)).strftime('%Y-%m-%d'),
+                'delivery_date': (fields.Date.today() + timedelta(days=-10)).strftime('%Y-%m-%d'),
+                'invoice_line_ids': [
+                    Command.create({'product_id': 'product.consu_delivery_02', 'quantity': 5}),
+                    Command.create({'product_id': 'product.consu_delivery_03', 'quantity': 5}),
+                ],
+            },
+            'demo_move_auto_reconcile_6': {
+                'move_type': 'out_refund',
+                'partner_id': 'base.res_partner_2',
+                'invoice_user_id': False,
+                'invoice_date': (fields.Date.today() + timedelta(days=-1)).strftime('%Y-%m-%d'),
+                'delivery_date': (fields.Date.today() + timedelta(days=-1)).strftime('%Y-%m-%d'),
+                'invoice_line_ids': [
+                    Command.create({'product_id': 'product.consu_delivery_03', 'quantity': 5}),
+                    Command.create({'product_id': 'product.consu_delivery_01', 'quantity': 20}),
+                ],
+            },
+            'demo_move_auto_reconcile_7': {
+                'move_type': 'out_refund',
+                'partner_id': 'base.res_partner_2',
+                'invoice_date': (fields.Date.today() + timedelta(days=-2)).strftime('%Y-%m-%d'),
+                'delivery_date': (fields.Date.today() + timedelta(days=-2)).strftime('%Y-%m-%d'),
+                'invoice_line_ids': [
+                    Command.create({'product_id': 'product.consu_delivery_01', 'quantity': 5}),
+                    Command.create({'product_id': 'product.consu_delivery_03', 'quantity': 5}),
+                ],
+            },
+            'demo_move_auto_reconcile_8': {
+                'move_type': 'entry',
+                'partner_id': 'base.res_partner_2',
+                'date': (fields.Date.today() + timedelta(days=-20)).strftime('%Y-%m-%d'),
+                'journal_id': misc_journal.id,
+                'line_ids': [
+                    Command.create({'debit': 0.0, 'credit': 2500.0, 'account_id': default_receivable.id}),
+                    Command.create({'debit': 2500.0, 'credit': 0.0, 'account_id': bank_journal.default_account_id.id}),
+                ],
+            },
+            'demo_move_auto_reconcile_9': {
+                'move_type': 'entry',
+                'partner_id': 'base.res_partner_2',
+                'date': (fields.Date.today() + timedelta(days=-20)).strftime('%Y-%m-%d'),
+                'journal_id': misc_journal.id,
+                'line_ids': [
+                    Command.create({'debit': 2500.0, 'credit': 0.0, 'account_id': default_receivable.id}),
+                    Command.create({'debit': 0.0, 'credit': 2500.0, 'account_id': income_account.id}),
                 ],
             },
         }

--- a/addons/l10n_br/demo/account_demo.py
+++ b/addons/l10n_br/demo/account_demo.py
@@ -12,8 +12,8 @@ class AccountChartTemplate(models.AbstractModel):
         if company.account_fiscal_country_id.code == 'BR':
             number = 0
             for move in move_data.values():
-                # vendor bills must be manually numbered (l10n_br uses the standard AccountMove._is_manual_document_number())
-                if move['move_type'] == 'in_invoice':
+                # vendor bills and refund must be manually numbered (l10n_br uses the standard AccountMove._is_manual_document_number())
+                if move['move_type'] in ('in_invoice', 'in_refund'):
                     move['l10n_latam_document_number'] = f'{number:08d}'
                     number += 1
 

--- a/addons/l10n_cl/demo/account_demo.py
+++ b/addons/l10n_cl/demo/account_demo.py
@@ -29,13 +29,19 @@ class AccountChartTemplate(models.AbstractModel):
         ref = self.env.ref
         move_data = super()._get_demo_data_move(company)
         if company.account_fiscal_country_id.code == "CL":
-            foreign = ref('l10n_cl.dc_fe_dte').id
+            foreign_invoice = ref('l10n_cl.dc_fe_dte').id
+            foreign_credit_note = ref('l10n_cl.dc_ncex_dte').id
             self.env['account.journal'].search([
                 *self.env['account.journal']._check_company_domain(company),
                 ('type', '=', 'purchase'),
             ]).l10n_latam_use_documents = False
-            move_data['demo_invoice_1']['l10n_latam_document_type_id'] = foreign
-            move_data['demo_invoice_2']['l10n_latam_document_type_id'] = foreign
-            move_data['demo_invoice_3']['l10n_latam_document_type_id'] = foreign
-            move_data['demo_invoice_followup']['l10n_latam_document_type_id'] = foreign
+            move_data['demo_invoice_1']['l10n_latam_document_type_id'] = foreign_invoice
+            move_data['demo_invoice_2']['l10n_latam_document_type_id'] = foreign_invoice
+            move_data['demo_invoice_3']['l10n_latam_document_type_id'] = foreign_invoice
+            move_data['demo_invoice_followup']['l10n_latam_document_type_id'] = foreign_invoice
+            move_data['demo_move_auto_reconcile_1']['l10n_latam_document_type_id'] = foreign_credit_note
+            move_data['demo_move_auto_reconcile_2']['l10n_latam_document_type_id'] = foreign_credit_note
+            move_data['demo_move_auto_reconcile_5']['l10n_latam_document_type_id'] = foreign_credit_note
+            move_data['demo_move_auto_reconcile_6']['l10n_latam_document_type_id'] = foreign_credit_note
+            move_data['demo_move_auto_reconcile_7']['l10n_latam_document_type_id'] = foreign_credit_note
         return move_data

--- a/addons/l10n_ec/demo/account_demo.py
+++ b/addons/l10n_ec/demo/account_demo.py
@@ -16,4 +16,11 @@ class AccountChartTemplate(models.AbstractModel):
             move_data['demo_invoice_followup']['l10n_latam_document_type_id'] = 'l10n_ec.ec_dt_01'
             move_data['demo_invoice_5']['l10n_latam_document_number'] = '001-001-00001'
             move_data['demo_invoice_equipment_purchase']['l10n_latam_document_number'] = '001-001-00002'
+            move_data['demo_move_auto_reconcile_1']['l10n_latam_document_type_id'] = 'l10n_ec.ec_dt_04'
+            move_data['demo_move_auto_reconcile_2']['l10n_latam_document_type_id'] = 'l10n_ec.ec_dt_04'
+            move_data['demo_move_auto_reconcile_3']['l10n_latam_document_number'] = '001-001-00003'
+            move_data['demo_move_auto_reconcile_4']['l10n_latam_document_number'] = '001-001-00004'
+            move_data['demo_move_auto_reconcile_5']['l10n_latam_document_type_id'] = 'l10n_ec.ec_dt_04'
+            move_data['demo_move_auto_reconcile_6']['l10n_latam_document_type_id'] = 'l10n_ec.ec_dt_04'
+            move_data['demo_move_auto_reconcile_7']['l10n_latam_document_type_id'] = 'l10n_ec.ec_dt_04'
         return move_data

--- a/addons/l10n_pe/demo/account_demo.py
+++ b/addons/l10n_pe/demo/account_demo.py
@@ -145,4 +145,6 @@ class AccountChartTemplate(models.AbstractModel):
                     Command.create({'product_id': ref('product.consu_delivery_03').id, 'quantity': 1.0, 'price_unit': 500.0}),
                 ],
             }
+            move_data['demo_move_auto_reconcile_3']['l10n_latam_document_number'] = 'FFF-100007'
+            move_data['demo_move_auto_reconcile_4']['l10n_latam_document_number'] = 'FFF-100008'
         return move_data


### PR DESCRIPTION
Adds demo data for auto-reconcile.
We now have data that can auto reconcile:
- in both modes (zero total balance or opposite
balance one-by-one)
- on payable and receivable accounts
- by filtering on Azure Interior and/or Deco Addict

task-id:3517768