### PR TITLE
[FIX] point_of_sale: missing product cross order

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -804,6 +804,7 @@ export class PosStore extends Reactive {
                 message = messageFp;
             }
         }
+        await this._getMissingProducts(ordersJson);
         const allOrders = [...this.get_order_list()];
         this._replaceOrders(allOrders, ordersJson);
         this.sortOrders();
@@ -841,6 +842,17 @@ export class PosStore extends Reactive {
             "get_pos_ui_product_pricelists_by_ids",
             [[odoo.pos_session_id], pricelistsToGet]
         );
+    }
+    async _getMissingProducts(ordersJson) {
+        const productIds = [];
+        for (const order of ordersJson) {
+            for (const orderline of order.lines) {
+                if (!this.db.get_product_by_id(orderline[2].product_id)) {
+                    productIds.push(orderline[2].product_id);
+                }
+            }
+        }
+        await this._addProducts(productIds, false);
     }
     _addPosPricelists(pricelistsJson) {
         if (!this.config.use_pricelist) {


### PR DESCRIPTION
Prior to this commit if an order was sent to another pos with the cross order, if the product was missing in the target pos, the product will be missing in the order. This commit loads the products that are missing for the cross orders.



Task-3504316