### PR TITLE
[IMP] base: import/exports of 'state' fields on res.partner records

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -174,6 +174,8 @@ class CountryState(models.Model):
         if self.env.context.get('country_id'):
             domain = expression.AND([domain, [('country_id', '=', self.env.context.get('country_id'))]])
 
+        name = re.sub(r'\([^)]*\)$', '', name).strip()
+
         if operator == 'ilike' and not (name or '').strip():
             domain1 = []
             domain2 = []


### PR DESCRIPTION
PURPOSE
Allow import/exports of 'state' fields on res.partner records.

SPECIFICATION:
When the user exports a `state(state_id)` field, the formatting does not match 
the formatting for the import. 

Export Format: California (US)
Import Format: California

Task-2745728