### PR TITLE
[FIX] account: allow only positive number for prefix and suffix in sequence

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12098,6 +12098,13 @@ msgid "The payment's currency."
 msgstr ""
 
 #. module: account
+#: code:addons/account/models/ir_sequence.py:0
+#, python-format
+msgid ""
+"The prefix and suffix for this sequence should only be positive numbers."
+msgstr ""
+
+#. module: account
 #: code:addons/account/models/account_move.py:0
 #, python-format
 msgid ""

--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -27,6 +27,7 @@ from . import account_incoterms
 from . import digest
 from . import res_users
 from . import ir_actions_report
+from . import ir_sequence
 from . import res_currency
 from . import res_bank
 from . import mail_thread

--- a/addons/account/models/ir_sequence.py
+++ b/addons/account/models/ir_sequence.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
+
+
+class IrSequence(models.Model):
+    _inherit = 'ir.sequence'
+
+    @api.constrains('prefix', 'suffix')
+    def _validate_sequence_number(self):
+        journal_ids = self.env['account.journal'].search([('restrict_mode_hash_table', '=', True), ('secure_sequence_id', 'in', self.ids)])
+        prefix = journal_ids.mapped('secure_sequence_id.prefix')
+        suffix = journal_ids.mapped('secure_sequence_id.suffix')
+
+        if any(seq and not seq.isdigit() for seq in (prefix + suffix)):
+            raise ValidationError(_("The prefix and suffix for this sequence should only be positive numbers."))

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -26,6 +26,7 @@ from . import test_sequence_mixin
 from . import test_settings
 from . import test_tax
 from . import test_invoice_taxes
+from . import test_ir_sequence
 from . import test_templates_consistency
 from . import test_account_all_l10n
 from . import test_reconciliation_matching_rules

--- a/addons/account/tests/test_ir_sequence.py
+++ b/addons/account/tests/test_ir_sequence.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+
+
+class TestIrSequenceConstraints(TransactionCase):
+
+    def setUp(self):
+        super(TestIrSequenceConstraints, self).setUp()
+        self.journal = self.env['account.journal']
+
+    def test_validate_sequence_of_journals(self):
+
+        # Create a journal with restrict_mode_hash_table=True
+        journal = self.journal.create({
+            'name' : 'Test Sequence Journal',
+            'code' : 'tsj',
+            'type' : 'sale',
+            'restrict_mode_hash_table' : True
+        })
+
+        sequence = journal.secure_sequence_id
+
+        # Update a sequence with a numeric prefix and suffix
+        sequence.write({'prefix' : '123', 'suffix' : '456'})
+
+        # Update a sequence with non-numeric prefix and numeric suffix
+        with self.assertRaises(ValidationError):
+            sequence.write({'prefix': 'test', 'suffix': '111'})
+
+        # Update a sequence with numeric prefix and non-numeric suffix
+        with self.assertRaises(ValidationError):
+            sequence.write({'prefix' : '111', 'suffix' : 'Abc'})
+
+        # Update a sequence with non-numeric prefix
+        with self.assertRaises(ValidationError):
+            sequence.write({'prefix' : 'test'})
+
+        # Update a sequence with non-numeric suffix
+        with self.assertRaises(ValidationError):
+            sequence.write({'suffix' : 'Test'})
+
+        sequence.write({'prefix' : '001'})
+
+        # Make sure the sequence is updated sucessfully
+        self.assertEqual(sequence.prefix, '001')
+        self.assertEqual(sequence.suffix, '456')


### PR DESCRIPTION
This traceback arises when the user gives `alphabets` or `special characters` 
in `prefix` or `suffix` for `Lock Posted Entries with Hash` enabled journal sequences.

To reproduce this issue:

1) Install `Invoicing` and make sure developer mode is On
2) Open `settings/groups/Show Accounting Features - Readonly`
3) Add the current user to that group.
4) Open `Invoicing/Configuration/Journals/Customer Invoices` record
5) Enable `Lock Posted Entries with Hash` in `Advance Settings ` 
6) Open `Sequences` from `Settings/Technical`
7) Open the `Securisation of secure_sequence_id - Customer Invoices` sequence record
8) Give any alphabet to prefix or suffix like `INV-2023-` and save. 
9) create a new invoice with the `Customer Invoices` journal.

Note:- No need to follow step 2 and 3 if you install `Accounting` module

Error:
```
ValueError: invalid literal for int() with base 10: 'INV-2023-002'
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/account_move.py", line 70, in action_post
    res = super().action_post()
  File "addons/account/models/account_move.py", line 4014, in action_post
    other_moves._post(soft=False)
  File "home/odoo/src/enterprise/saas-16.4/account_asset/models/account_move.py", line 113, in _post
    posted = super()._post(soft)
  File "addons/l10n_sa/models/account_move.py", line 50, in _post
    res = super()._post(soft)
  File "home/odoo/src/enterprise/saas-16.4/account_reports/models/account_move.py", line 51, in _post
    return super()._post(soft)
  File "home/odoo/src/enterprise/saas-16.4/account_invoice_extract/models/account_invoice.py", line 248, in _post
    posted = super()._post(soft)
  File "addons/account_edi/models/account_move.py", line 240, in _post
    posted = super()._post(soft=soft)
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/account_move.py", line 62, in _post
    posted = super()._post(soft)
  File "addons/account/models/account_move.py", line 3800, in _post
    to_post.write({
  File "home/odoo/src/enterprise/saas-16.4/documents_account/models/account_move.py", line 29, in write
    res = super().write(vals)
  File "addons/account/models/account_move.py", line 2501, in write
    'inalterable_hash': move._get_new_hash(new_number),
  File "addons/account/models/account_move.py", line 2966, in _get_new_hash
    ('secure_sequence_number', '=', int(secure_seq_number) - 1)])

```

[1] On the `_get_new_hash` method in `account.move`, `secure_seq_number` is
    is converted to an integer using the `int()` function.

[2] Here `secure_seq_number` is getting value from
    `journal_id.secure_sequence_id.next_by_id()`.

[3] In that `next_by_id()`, prefix and suffix are used to get sequence number.

When the user enabled `restrict_mode_hash_table` a new sequence is created.

In that sequence, when the user gives any alphabet or special character to a prefix or suffix. 
It leads to the above traceback, as the `int()` function is used to convert that sequence number
while creating invoice.

See:-

[1]
https://github.com/odoo/odoo/blob/883c03a06c092c0f8a90ac590b1fe8e40e4f54cb/addons/account/models/account_move.py#L2935-L2943

[2]
https://github.com/odoo/odoo/blob/883c03a06c092c0f8a90ac590b1fe8e40e4f54cb/addons/account/models/account_move.py#L2122-L2125

[3]
https://github.com/odoo/odoo/blob/883c03a06c092c0f8a90ac590b1fe8e40e4f54cb/odoo/addons/base/models/ir_sequence.py#L237-L238

After applying this commit will resolve the issue by validating prefix and suffix.

sentry-4477040897