### PR TITLE
[REF] mail, *: tests: simplify text option of contains

### DIFF
--- a/addons/bus/static/tests/assets_watchdog_tests.js
+++ b/addons/bus/static/tests/assets_watchdog_tests.js
@@ -38,7 +38,7 @@ QUnit.module("Bus Assets WatchDog", (hooks) => {
         pyEnv["bus.bus"]._sendone("broadcast", "bundle_changed", {
             server_version: "NEW_MAJOR_VERSION",
         });
-        await contains(".o_notification_content", { text: "The page appears to be out of date." });
+        await contains(".o_notification", { text: "The page appears to be out of date." });
         await click(".o_notification_buttons .btn-primary", { text: "Refresh" });
         assert.verifySteps(["reloadPage"]);
     });

--- a/addons/calendar/static/tests/activity_menu_tests.js
+++ b/addons/calendar/static/tests/activity_menu_tests.js
@@ -34,7 +34,7 @@ QUnit.test("activity menu widget:today meetings", async function (assert) {
             assert.step("action");
         },
     });
-    await contains(".o-mail-ActivityGroup span", { text: "Today's Meetings" });
+    await contains(".o-mail-ActivityGroup", { text: "Today's Meetings" });
     await contains(".o-mail-ActivityGroup .o-calendar-meeting", { count: 2 });
     await contains(".o-calendar-meeting span.fw-bold", { text: "meeting1" });
     await contains(".o-calendar-meeting span:not(.fw-bold)", { text: "meeting2" });

--- a/addons/calendar/static/tests/calendar_notification_tests.js
+++ b/addons/calendar/static/tests/calendar_notification_tests.js
@@ -47,7 +47,7 @@ QUnit.module("Calendar Notification", (hooks) => {
                     notify_at: "1978-04-14 12:45:00",
                 },
             ]);
-            await contains(".o_notification_content", { text: "Very old meeting message" });
+            await contains(".o_notification", { text: "Very old meeting message" });
             await click(".o_notification_buttons button", { text: "OK" });
             await contains(".o_notification", { count: 0 });
             assert.verifySteps(["notifyAck"]);
@@ -89,7 +89,7 @@ QUnit.module("Calendar Notification", (hooks) => {
                     notify_at: "1978-04-14 12:45:00",
                 },
             ]);
-            await contains(".o_notification_content", { text: "Very old meeting message" });
+            await contains(".o_notification", { text: "Very old meeting message" });
             await click(".o_notification_buttons button", { text: "Details" });
             await contains(".o_notification", { count: 0 });
             assert.verifySteps(["ir.actions.act_window"]);
@@ -120,8 +120,8 @@ QUnit.module("Calendar Notification", (hooks) => {
                     notify_at: "1978-04-14 12:45:00",
                 },
             ]);
-            await contains(".o_notification_content", { text: "Very old meeting message" });
-            await click(".o_notification_buttons button", { text: "Snooze" });
+            await contains(".o_notification", { text: "Very old meeting message" });
+            await click(".o_notification button", { text: "Snooze" });
             await contains(".o_notification", { count: 0 });
             assert.verifySteps([], "should only close the notification withtout calling a rpc");
         }

--- a/addons/hr/static/tests/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/m2x_avatar_employee_tests.js
@@ -62,16 +62,16 @@ QUnit.test("many2one_avatar_employee widget in list view", async function (asser
     // TODO: avatar card employee
     // click on first employee
     // dom.click(document.querySelector(".o_data_cell .o_m2o_avatar > img"));
-    // await contains(".o-mail-ChatWindow-name");
+    // await contains(".o-mail-ChatWindow");
     // assert.verifySteps([`read hr.employee.public ${employeeId_1}`]);
-    // assert.strictEqual(document.querySelector(".o-mail-ChatWindow-name").textContent, "Mario");
+    // assert.strictEqual(document.querySelector(".o-mail-ChatWindow").textContent, "Mario");
 
     // // click on second employee
     // dom.click(document.querySelectorAll(".o_data_cell .o_m2o_avatar > img")[1]);
-    // await contains(".o-mail-ChatWindow-name", { count: 2 });
+    // await contains(".o-mail-ChatWindow", { count: 2 });
     // assert.verifySteps([`read hr.employee.public ${employeeId_2}`]);
     // assert.strictEqual(
-    //     document.querySelectorAll(".o-mail-ChatWindow-name")[1].textContent,
+    //     document.querySelectorAll(".o-mail-ChatWindow")[1].textContent,
     //     "Luigi"
     // );
 
@@ -79,7 +79,7 @@ QUnit.test("many2one_avatar_employee widget in list view", async function (asser
     // dom.click(document.querySelectorAll(".o_data_cell .o_m2o_avatar > img")[2]);
     // assert.containsN(
     //     document.body,
-    //     ".o-mail-ChatWindow-name",
+    //     ".o-mail-ChatWindow",
     //     2,
     //     "should still have only 2 chat windows because third is the same partner as first"
     // );
@@ -217,9 +217,7 @@ QUnit.test("many2many_avatar_employee widget in form view", async function (asse
         document.querySelectorAll(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar")[1]
     );
     // TODO: avatar card employee
-    assert.verifySteps([
-        `web_read m2x.avatar.employee ${avatarId_1}`,
-    ]);
+    assert.verifySteps([`web_read m2x.avatar.employee ${avatarId_1}`]);
 });
 
 QUnit.test("many2many_avatar_employee widget in list view", async function (assert) {
@@ -264,16 +262,16 @@ QUnit.test("many2many_avatar_employee widget in list view", async function (asse
     // TODO: avatar card employee
     // // click on first employee badge
     // dom.click(document.querySelector(".o_data_cell .o_m2m_avatar"));
-    // await contains(".o-mail-ChatWindow-name");
+    // await contains(".o-mail-ChatWindow");
     // assert.verifySteps([`read hr.employee.public ${employeeId_1}`]);
-    // assert.strictEqual(document.querySelector(".o-mail-ChatWindow-name").textContent, "Mario");
+    // assert.strictEqual(document.querySelector(".o-mail-ChatWindow").textContent, "Mario");
 
     // // click on second employee
     // dom.click(document.querySelectorAll(".o_data_cell .o_m2m_avatar")[1]);
-    // await contains(".o-mail-ChatWindow-name", { count: 2 });
+    // await contains(".o-mail-ChatWindow", { count: 2 });
     // assert.verifySteps([`read hr.employee.public ${employeeId_2}`]);
     // assert.strictEqual(
-    //     document.querySelectorAll(".o-mail-ChatWindow-name")[1].textContent,
+    //     document.querySelectorAll(".o-mail-ChatWindow")[1].textContent,
     //     "Yoshi"
     // );
 });
@@ -342,8 +340,8 @@ QUnit.test("many2many_avatar_employee widget in kanban view", async function (as
         `/web/image/hr.employee.public/${employeeId_1}/avatar_128`
     );
 
-    await dom.click(document.querySelectorAll('.o_kanban_record img.o_m2m_avatar')[1]);
-    await dom.click(document.querySelectorAll('.o_kanban_record img.o_m2m_avatar')[0]);
+    await dom.click(document.querySelectorAll(".o_kanban_record img.o_m2m_avatar")[1]);
+    await dom.click(document.querySelectorAll(".o_kanban_record img.o_m2m_avatar")[0]);
     // TODO: avatar card employee
 });
 
@@ -393,9 +391,7 @@ QUnit.test(
         await dom.click(
             document.querySelectorAll(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar")[1]
         );
-        assert.verifySteps([
-            `web_read m2x.avatar.employee ${employeeId_1}`,
-        ]);
+        assert.verifySteps([`web_read m2x.avatar.employee ${employeeId_1}`]);
         // TODO: avtar card employee
     }
 );

--- a/addons/im_livechat/static/tests/channel_invite_tests.js
+++ b/addons/im_livechat/static/tests/channel_invite_tests.js
@@ -105,11 +105,11 @@ QUnit.test("Partners invited most frequently by the current user come first", as
 
     const { openDiscuss } = await start();
     await openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel span", { text: "Visitor #1" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #1" });
     await click("button[title='Add Users']");
     await click(".o-discuss-ChannelInvitation-selectable:contains(John) input");
     await click("button:contains(Invite):enabled");
-    await click(".o-mail-DiscussSidebarChannel span", { text: "Visitor #2" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #2" });
     await click("button[title='Add Users']");
     await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
     await contains(":nth-child(1 of .o-discuss-ChannelInvitation-selectable)", { text: "John" });

--- a/addons/im_livechat/static/tests/discuss_patch_tests.js
+++ b/addons/im_livechat/static/tests/discuss_patch_tests.js
@@ -107,17 +107,11 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss();
         await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
-        await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel) span", {
-            text: "Visitor 12",
-        });
-        await click(":nth-child(2 of .o-mail-DiscussSidebarChannel) span", { text: "Visitor 11" });
+        await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 12" });
+        await click(":nth-child(2 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 11" });
         await insertText(".o-mail-Composer-input", "Blabla");
         await click(".o-mail-Composer-send:enabled");
-        await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel) span", {
-            text: "Visitor 11",
-        });
-        await contains(":nth-child(2 of .o-mail-DiscussSidebarChannel) span", {
-            text: "Visitor 12",
-        });
+        await contains(":nth-child(1 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 11" });
+        await contains(":nth-child(2 of .o-mail-DiscussSidebarChannel)", { text: "Visitor 12" });
     }
 );

--- a/addons/im_livechat/static/tests/embed/livechat_button_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button_tests.js
@@ -28,9 +28,7 @@ QUnit.test("open/close persisted channel", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-Message-content", { text: "How can I help?" });
     await click("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow-content p", {
-        text: "Did we correctly answer your question?",
-    });
+    await contains(".o-mail-ChatWindow", { text: "Did we correctly answer your question?" });
     await click("[title='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
     await contains(".o-livechat-LivechatButton", { count: 1 });

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -24,7 +24,7 @@ QUnit.test("Session is reset after failing to persist the channel", async (asser
     await click(".o-livechat-LivechatButton");
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
-    await contains(".o_notification_content", {
+    await contains(".o_notification", {
         text: "No available collaborator, please try again later.",
     });
     await contains(".o-livechat-LivechatButton");
@@ -38,13 +38,13 @@ QUnit.test("Thread state is saved on the session", async (assert) => {
     await loadDefaultConfig();
     const env = await start();
     await click(".o-livechat-LivechatButton");
-    await contains(".o-mail-ChatWindow-content");
+    await contains(".o-mail-Thread");
     assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
     await click(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-content", { count: 0 });
+    await contains(".o-mail-Thread", { count: 0 });
     assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "folded");
     await click(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-content");
+    await contains(".o-mail-Thread");
     assert.strictEqual(env.services["im_livechat.livechat"].sessionCookie.state, "open");
 });
 

--- a/addons/im_livechat/static/tests/embed/unread_messages_tests.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages_tests.js
@@ -6,7 +6,7 @@ import { loadDefaultConfig, setCookie, start } from "@im_livechat/../tests/embed
 
 import { Command } from "@mail/../tests/helpers/command";
 
-import { contains } from "@web/../tests/utils";
+import { contains, focus } from "@web/../tests/utils";
 
 QUnit.module("thread service");
 
@@ -63,9 +63,7 @@ QUnit.test("focus on unread livechat marks it as read", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", {
-        text: "Are you there?",
-    });
-    $(".o-mail-Composer-input").trigger("focus");
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "Are you there?" });
+    await focus(".o-mail-Composer-input");
     await contains(".o-mail-Thread-newMessage", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch_tests.js
@@ -25,10 +25,10 @@ QUnit.test('livechats should be in "chat" filter', async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu button:contains(All).fw-bolder");
-    await contains(".o-mail-NotificationItem-name", { text: "Visitor 11" });
+    await contains(".o-mail-NotificationItem", { text: "Visitor 11" });
     await click(".o-mail-MessagingMenu button", { text: "Chats" });
     await contains(".o-mail-MessagingMenu button:contains(Chat).fw-bolder");
-    await contains(".o-mail-NotificationItem-name", { text: "Visitor 11" });
+    await contains(".o-mail-NotificationItem", { text: "Visitor 11" });
 });
 
 QUnit.test('livechats should be in "livechat" tab in mobile', async () => {

--- a/addons/im_livechat/static/tests/messaging_service_patch_tests.js
+++ b/addons/im_livechat/static/tests/messaging_service_patch_tests.js
@@ -37,5 +37,5 @@ QUnit.test("Notify message received out of focus", async () => {
             uuid: channel.uuid,
         })
     );
-    await contains(".o_notification.border-info .o_notification_content", { text: "Hello" });
+    await contains(".o_notification.border-info", { text: "Hello" });
 });

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch_tests.js
@@ -34,5 +34,5 @@ QUnit.test("Livechat button is present when there is at least one livechat threa
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-MessagingMenu");
-    await contains(".o-mail-MessagingMenu-navbar span", { text: "Livechat" });
+    await contains(".o-mail-MessagingMenu-navbar", { text: "Livechat" });
 });

--- a/addons/im_livechat/static/tests/sidebar_patch_tests.js
+++ b/addons/im_livechat/static/tests/sidebar_patch_tests.js
@@ -25,7 +25,7 @@ QUnit.test("Unknown visitor", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebar .o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Visitor 11" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Visitor 11" });
 });
 
 QUnit.test("Known user with country", async () => {
@@ -333,9 +333,7 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss();
-        await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", {
-            text: "1",
-        });
+        await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", { text: "1" });
     }
 );
 
@@ -448,9 +446,7 @@ QUnit.test("Clicking on unpin button unpins the channel", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o_notification_content", {
-        text: "You unpinned your conversation with Visitor 11",
-    });
+    await contains(".o_notification", { text: "You unpinned your conversation with Visitor 11" });
 });
 
 QUnit.test("Message unread counter", async () => {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -27,7 +27,7 @@
                 </Dropdown>
                 <AutoresizeInput
                     t-if="state.editingName"
-                    className="'o-mail-ChatWindow-name text-truncate fw-bold flex-shrink-1 me-1 py-0'"
+                    className="'text-truncate fw-bold flex-shrink-1 me-1 py-0'"
                     enabled="true"
                     autofocus="true"
                     onValidate.bind="renameThread"
@@ -54,7 +54,7 @@
                 <t t-set="itemClass" t-value="'me-1'"/>
             </t>
         </div>
-        <div t-if="!props.chatWindow.folded or ui.isSmall" class="o-mail-ChatWindow-content bg-view d-flex flex-column h-100 overflow-auto position-relative" t-ref="content">
+        <div t-if="!props.chatWindow.folded or ui.isSmall" class="bg-view d-flex flex-column h-100 overflow-auto position-relative" t-ref="content">
             <t t-if="thread" name="thread content">
                 <div t-if="threadActions.activeAction?.componentCondition" class="h-100" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}">
                     <t t-component="threadActions.activeAction.component" t-props="{ ...threadActions.activeAction.componentProps, thread }"/>
@@ -82,6 +82,6 @@
         <img class="rounded" t-att-src="thread.imgUrl" alt="Thread Image"/>
     </div>
     <ThreadIcon t-if="thread and thread.type === 'chat' and thread.correspondent" thread="thread"/>
-    <div t-if="!state.editingName" class="o-mail-ChatWindow-name text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
+    <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/link_preview.scss
+++ b/addons/mail/static/src/core/common/link_preview.scss
@@ -26,7 +26,7 @@
     max-width: $o-mail-LinkPreview-width;
 }
 
-.o-mail-ChatWindow-content .o-mail-LinkPreviewImage img {
+.o-mail-ChatWindow .o-mail-LinkPreviewImage img {
     max-width: 100%;
 }
 

--- a/addons/mail/static/src/core/web/notification_item.xml
+++ b/addons/mail/static/src/core/web/notification_item.xml
@@ -15,7 +15,6 @@
                     <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2" t-att-class="{ 'opacity-75 fw-bold': props.counter > 0, 'opacity-50 text-muted': props.counter === 0 }">
                         <RelativeTime datetime="props.datetime"/>
                     </small>
-
                 </div>
                 <div class="d-flex">
                     <div class="o-mail-NotificationItem-text text-truncate">

--- a/addons/mail/static/tests/activity/activity_tests.js
+++ b/addons/mail/static/tests/activity/activity_tests.js
@@ -39,7 +39,7 @@ QUnit.test("activity upload document is available", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info span", { text: "Upload Document" });
+    await contains(".o-mail-Activity .btn", { text: "Upload Document" });
     await contains(".btn .fa-upload");
     await contains(".o-mail-Activity .o_input_file");
 });
@@ -57,7 +57,7 @@ QUnit.test("activity can upload a document", async () => {
     });
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.partner", fakeId);
-    await contains(".o-mail-Activity-info span", { text: "Upload Document" });
+    await contains(".o-mail-Activity .btn", { text: "Upload Document" });
     await inputFiles(".o-mail-Activity .o_input_file", [
         await createFile({
             content: "hello, world",
@@ -65,7 +65,7 @@ QUnit.test("activity can upload a document", async () => {
             name: "text.txt",
         }),
     ]);
-    await contains(".o-mail-Activity-info span", { count: 0, text: "Upload Document" });
+    await contains(".o-mail-Activity .btn", { count: 0, text: "Upload Document" });
     await contains("button[aria-label='Attach files']", { text: "1" });
 });
 
@@ -81,14 +81,13 @@ QUnit.test("activity simplest layout", async () => {
     await contains(".o-mail-Activity");
     await contains(".o-mail-Activity-sidebar");
     await contains(".o-mail-Activity-user");
-    await contains(".o-mail-Activity-info");
     await contains(".o-mail-Activity-note", { count: 0 });
     await contains(".o-mail-Activity-details", { count: 0 });
     await contains(".o-mail-Activity-mailTemplates", { count: 0 });
     await contains(".btn", { count: 0, text: "Edit" });
-    await contains(".o-mail-Activity span", { count: 0, text: "Cancel" });
+    await contains(".o-mail-Activity .btn", { count: 0, text: "Cancel" });
     await contains(".btn", { count: 0, text: "Mark Done" });
-    await contains(".o-mail-Activity-info span", { count: 0, text: "Upload Document" });
+    await contains(".o-mail-Activity .btn", { count: 0, text: "Upload Document" });
 });
 
 QUnit.test("activity with note layout", async () => {
@@ -230,7 +229,7 @@ QUnit.test("activity with a summary layout", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info span", { text: "“test summary”" });
+    await contains(".o-mail-Activity", { text: "“test summary”" });
 });
 
 QUnit.test("activity without summary layout", async () => {
@@ -243,7 +242,7 @@ QUnit.test("activity without summary layout", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(".o-mail-Activity-info span", { text: "Email" });
+    await contains(".o-mail-Activity", { text: "Email" });
 });
 
 QUnit.test("activity details toggle", async () => {
@@ -265,12 +264,12 @@ QUnit.test("activity details toggle", async () => {
     openFormView("res.partner", partnerId);
     await contains(".o-mail-Activity");
     await contains(".o-mail-Activity-details", { count: 0 });
-    await contains(".o-mail-Activity-info i[aria-label='Info']");
+    await contains(".o-mail-Activity i[aria-label='Info']");
 
-    await click(".o-mail-Activity-info i[aria-label='Info']");
+    await click(".o-mail-Activity i[aria-label='Info']");
     await contains(".o-mail-Activity-details");
 
-    await click(".o-mail-Activity-info i[aria-label='Info']");
+    await click(".o-mail-Activity i[aria-label='Info']");
     await contains(".o-mail-Activity-details", { count: 0 });
 });
 
@@ -446,7 +445,7 @@ QUnit.test("activity click on cancel", async (assert) => {
         },
     });
     openFormView("res.partner", partnerId);
-    await click(".o-mail-Activity span", { text: "Cancel" });
+    await click(".o-mail-Activity .btn", { text: "Cancel" });
     await contains(".o-mail-Activity", { count: 0 });
     assert.verifySteps(["unlink"]);
 });
@@ -519,7 +518,7 @@ QUnit.test("Activity are sorted by deadline", async () => {
     });
     const { openFormView } = await start();
     openFormView("res.partner", partnerId);
-    await contains(":nth-child(1 of .o-mail-Activity) span", { text: "5 days overdue:" });
-    await contains(":nth-child(2 of .o-mail-Activity) span", { text: "Today:" });
-    await contains(":nth-child(3 of .o-mail-Activity) span", { text: "Due in 4 days:" });
+    await contains(":nth-child(1 of .o-mail-Activity)", { text: "5 days overdue:" });
+    await contains(":nth-child(2 of .o-mail-Activity)", { text: "Today:" });
+    await contains(":nth-child(3 of .o-mail-Activity)", { text: "Due in 4 days:" });
 });

--- a/addons/mail/static/tests/chat_window/chat_window_manager_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_manager_tests.js
@@ -168,31 +168,23 @@ QUnit.test(
         );
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "channel-A" });
+        await click(".o-mail-NotificationItem", { text: "channel-A" });
         await contains(".o-mail-ChatWindow");
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "channel-B" });
+        await click(".o-mail-NotificationItem", { text: "channel-B" });
         await contains(".o-mail-ChatWindow", { count: 2 });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "channel-C" });
+        await click(".o-mail-NotificationItem", { text: "channel-C" });
         await contains(".o-mail-ChatWindowHiddenToggler", { text: "1" });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "channel-D" });
+        await click(".o-mail-NotificationItem", { text: "channel-D" });
         await contains(".o-mail-ChatWindowHiddenToggler", { text: "2" });
-        await contains(":nth-child(1 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "channel-A",
-        });
-        await contains(":nth-child(2 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "channel-D",
-        });
+        await contains(":nth-child(1 of .o-mail-ChatWindow)", { text: "channel-A" });
+        await contains(":nth-child(2 of .o-mail-ChatWindow)", { text: "channel-D" });
         await click(".o-mail-ChatWindow-command[title='Close Chat Window']", {
-            parent: [".o-mail-ChatWindow-header", { text: "channel-D" }],
+            parent: [".o-mail-ChatWindow", { text: "channel-D" }],
         });
-        await contains(":nth-child(1 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "channel-A",
-        });
-        await contains(":nth-child(2 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "channel-C",
-        });
+        await contains(":nth-child(1 of .o-mail-ChatWindow)", { text: "channel-A" });
+        await contains(":nth-child(2 of .o-mail-ChatWindow)", { text: "channel-C" });
     }
 );

--- a/addons/mail/static/tests/chat_window/chat_window_tests.js
+++ b/addons/mail/static/tests/chat_window/chat_window_tests.js
@@ -94,26 +94,16 @@ QUnit.test("Message post in chat window of chatter should log a note", async () 
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-Message-content", {
-        text: "A needaction message to have it in messaging menu",
-    });
     await contains(".o-mail-Message", {
-        containsMulti: [
-            [
-                ".o-mail-Message-content",
-                { text: "A needaction message to have it in messaging menu" },
-            ],
-            [".o-mail-Message-bubble.border"], // bordered bubble = "Send message" mode
-        ],
+        text: "A needaction message to have it in messaging menu",
+        contains: [".o-mail-Message-bubble.border"], // bordered bubble = "Send message" mode
     });
     await contains(".o-mail-Composer [placeholder='Log an internal note…']");
     await insertText(".o-mail-ChatWindow .o-mail-Composer-input", "Test");
     triggerHotkey("control+Enter");
     await contains(".o-mail-Message", {
-        containsMulti: [
-            [".o-mail-Message-content", { text: "Test" }],
-            [".o-mail-Message-bubble:not(.border)"], // non-bordered bubble = "Log note" mode
-        ],
+        text: "Test",
+        contains: [".o-mail-Message-bubble:not(.border)"], // non-bordered bubble = "Log note" mode
     });
 });
 
@@ -144,15 +134,14 @@ QUnit.test("chat window: basic rendering", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-header");
+    await contains(".o-mail-ChatWindow-header", { text: "General" });
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-threadAvatar");
-    await contains(".o-mail-ChatWindow-name", { text: "General" });
     await contains(".o-mail-ChatWindow-command", { count: 4 });
     await contains("[title='Start a Call']");
     await contains("[title='Open Actions Menu']");
     await contains("[title='Fold']");
     await contains("[title='Close Chat Window']");
-    await contains(".o-mail-ChatWindow-content .o-mail-Thread .o-mail-Thread-empty", {
+    await contains(".o-mail-ChatWindow .o-mail-Thread", {
         text: "There are no messages in this conversation.",
     });
     await click("[title='Open Actions Menu']");
@@ -173,11 +162,11 @@ QUnit.test("Fold state of chat window is sync among browser tabs", async () => {
     await click(".o_menu_systray i[aria-label='Messages']", { target: tab1.target });
     await click(".o-mail-NotificationItem", { target: tab1.target });
     await click(".o-mail-ChatWindow-header", { target: tab1.target }); // Fold
-    await contains(".o-mail-ChatWindow-content", { count: 0, target: tab1.target });
-    await contains(".o-mail-ChatWindow-content", { count: 0, target: tab2.target });
+    await contains(".o-mail-Thread", { count: 0, target: tab1.target });
+    await contains(".o-mail-Thread", { count: 0, target: tab2.target });
     await click(".o-mail-ChatWindow-header", { target: tab2.target }); // Unfold
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", { target: tab1.target });
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", { target: tab2.target });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { target: tab1.target });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { target: tab2.target });
     await click("[title='Close Chat Window']", { target: tab1.target });
     await contains(".o-mail-ChatWindow", { count: 0, target: tab1.target });
     await contains(".o-mail-ChatWindow", { count: 0, target: tab2.target });
@@ -367,22 +356,18 @@ QUnit.test("open 2 different chat windows: enough screen width [REQUIRE FOCUS]",
     );
     await start();
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Channel_1" });
+    await click(".o-mail-NotificationItem", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "Channel_1" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "Channel_1",
+        contains: [".o-mail-Composer-input:focus"],
     });
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Channel_2" });
+    await click(".o-mail-NotificationItem", { text: "Channel_2" });
     await contains(".o-mail-ChatWindow", { count: 2 });
-    await contains(".o-mail-ChatWindow-name", { text: "Channel_1" });
+    await contains(".o-mail-ChatWindow", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "Channel_2" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "Channel_2",
+        contains: [".o-mail-Composer-input:focus"],
     });
 });
 
@@ -406,23 +391,21 @@ QUnit.test("open 3 different chat windows: not enough screen width", async (asse
     await start();
     // open, from systray menu, chat windows of channels with Id 1, 2, then 3
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Channel_1" });
+    await click(".o-mail-NotificationItem", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindowHiddenToggler", { count: 0 });
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Channel_2" });
+    await click(".o-mail-NotificationItem", { text: "Channel_2" });
     await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindowHiddenToggler", { count: 0 });
     await click("button i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Channel_3" });
+    await click(".o-mail-NotificationItem", { text: "Channel_3" });
     await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindowHiddenToggler");
-    await contains(".o-mail-ChatWindow-name", { text: "Channel_1" });
+    await contains(".o-mail-ChatWindow", { text: "Channel_1" });
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "Channel_3" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "Channel_3",
+        contains: [".o-mail-Composer-input:focus"],
     });
 });
 
@@ -446,37 +429,29 @@ QUnit.test("closing hidden chat window", async (assert) => {
     );
     await start();
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_1" });
+    await click(".o-mail-NotificationItem", { text: "Ch_1" });
     await contains(".o-mail-ChatWindow");
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
+    await click(".o-mail-NotificationItem", { text: "Ch_2" });
     await contains(".o-mail-ChatWindow", { count: 2 });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_3" });
+    await click(".o-mail-NotificationItem", { text: "Ch_3" });
     await contains(".o-mail-ChatWindowHiddenToggler", { text: "1" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_4" });
+    await click(".o-mail-NotificationItem", { text: "Ch_4" });
     await contains(".o-mail-ChatWindowHiddenToggler", { text: "2" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_1",
-    });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_2" });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_3" });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_4",
-    });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_1" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow", { text: "Ch_2" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow", { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_4" });
     await click(".o-mail-ChatWindow-command[title='Close Chat Window']", {
         parent: [".o-mail-ChatWindow-header", { text: "Ch_2" }],
     });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_1",
-    });
-    await contains(".o-mail-ChatWindow-name", { count: 0, text: "Ch_2" });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_3" });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_4",
-    });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_1" });
+    await contains(".o-mail-ChatWindow", { count: 0, text: "Ch_2" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow", { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_4" });
 });
 
 QUnit.test("Opening hidden chat window from messaging menu", async (assert) => {
@@ -494,29 +469,21 @@ QUnit.test("Opening hidden chat window from messaging menu", async (assert) => {
     );
     await start();
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_1" });
+    await click(".o-mail-NotificationItem", { text: "Ch_1" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
+    await click(".o-mail-NotificationItem", { text: "Ch_2" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_3" });
+    await click(".o-mail-NotificationItem", { text: "Ch_3" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_1",
-    });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_2" });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_3",
-    });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_1" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow", { text: "Ch_2" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_3" });
     await click("i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "Ch_2" });
+    await click(".o-mail-NotificationItem", { text: "Ch_2" });
     await click(".o-mail-ChatWindowHiddenToggler");
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_1",
-    });
-    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow-name", {
-        text: "Ch_2",
-    });
-    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow-name", { text: "Ch_3" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_1" });
+    await contains(":not(.o-mail-ChatWindowHiddenMenu) .o-mail-ChatWindow", { text: "Ch_2" });
+    await contains(".o-mail-ChatWindowHiddenMenu .o-mail-ChatWindow", { text: "Ch_3" });
 });
 
 QUnit.test(
@@ -562,18 +529,13 @@ QUnit.test(
         await start();
         await contains(".o-mail-ChatWindow .o-mail-Composer-input", { count: 2 });
         await focus(".o-mail-Composer-input", {
-            parent: [
-                ".o-mail-ChatWindow",
-                { contains: [".o-mail-ChatWindow-name", { text: "MyTeam" }] },
-            ],
+            parent: [".o-mail-ChatWindow", { text: "MyTeam" }],
         });
         triggerHotkey("Escape");
         await contains(".o-mail-ChatWindow");
         await contains(".o-mail-ChatWindow", {
-            containsMulti: [
-                [".o-mail-ChatWindow-name", { text: "General" }],
-                [".o-mail-Composer-input:focus"],
-            ],
+            text: "General",
+            contains: [".o-mail-Composer-input:focus"],
         });
     }
 );
@@ -588,36 +550,28 @@ QUnit.test("chat window: switch on TAB [REQUIRE FOCUS]", async (assert) => {
     );
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "channel1" });
+    await click(".o-mail-NotificationItem", { text: "channel1" });
     await contains(".o-mail-ChatWindow", { count: 1 });
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "channel1" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "channel1",
+        contains: [".o-mail-Composer-input:focus"],
     });
     triggerHotkey("Tab");
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "channel1" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "channel1",
+        contains: [".o-mail-Composer-input:focus"],
     });
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "channel2" });
+    await click(".o-mail-NotificationItem", { text: "channel2" });
     await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "channel2" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "channel2",
+        contains: [".o-mail-Composer-input:focus"],
     });
     triggerHotkey("Tab");
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "channel1" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "channel1",
+        contains: [".o-mail-Composer-input:focus"],
     });
 });
 
@@ -677,31 +631,22 @@ QUnit.test("chat window: TAB cycle with 3 open chat windows [REQUIRE FOCUS]", as
     // FIXME: assumes ordering: MyProject, MyTeam, General
     await contains(".o-mail-ChatWindow .o-mail-Composer-input", { count: 3 });
     await focus(".o-mail-Composer-input", {
-        parent: [
-            ".o-mail-ChatWindow",
-            { contains: [".o-mail-ChatWindow-name", { text: "MyProject" }] },
-        ],
+        parent: [".o-mail-ChatWindow", { text: "MyProject" }],
     });
     triggerHotkey("Tab");
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "MyTeam" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "MyTeam",
+        contains: [".o-mail-Composer-input:focus"],
     });
     triggerHotkey("Tab");
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "General" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "General",
+        contains: [".o-mail-Composer-input:focus"],
     });
     triggerHotkey("Tab");
     await contains(".o-mail-ChatWindow", {
-        containsMulti: [
-            [".o-mail-ChatWindow-name", { text: "MyProject" }],
-            [".o-mail-Composer-input:focus"],
-        ],
+        text: "MyProject",
+        contains: [".o-mail-Composer-input:focus"],
     });
 });
 
@@ -920,11 +865,11 @@ QUnit.test(
         openDiscuss();
         // open, from systray menu, chat windows of channels with id 1, 2, 3
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "Channel-1" });
+        await click(".o-mail-NotificationItem", { text: "Channel-1" });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "Channel-2" });
+        await click(".o-mail-NotificationItem", { text: "Channel-2" });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "Channel-3" });
+        await click(".o-mail-NotificationItem", { text: "Channel-3" });
         // simulate resize to go into mobile
         patchUiSize({ size: SIZES.SM });
         window.dispatchEvent(new UIEvent("resize"));
@@ -1153,7 +1098,7 @@ QUnit.test("Chat window in mobile are not foldable", async () => {
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow-header.cursor-pointer", { count: 0 });
     await click(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-content"); // content => non-folded
+    await contains(".o-mail-Thread"); // content => non-folded
 });
 
 QUnit.test("Server-synced chat windows should not open at page load on mobile", async () => {
@@ -1196,8 +1141,8 @@ QUnit.test("Open chat window of new inviter", async () => {
         username: "Newbie",
         partnerId,
     });
-    await contains(".o-mail-ChatWindow-name", { text: "Newbie" });
-    await contains(".o_notification_content", {
+    await contains(".o-mail-ChatWindow", { text: "Newbie" });
+    await contains(".o_notification", {
         text: "Newbie connected. This is their first connection. Wish them luck.",
     });
 });

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -289,7 +289,7 @@ QUnit.test("Show send button in mobile", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click("button", { text: "Channel" });
-    await click(".o-mail-NotificationItem-name", { text: "minecraft-wii-u" });
+    await click(".o-mail-NotificationItem", { text: "minecraft-wii-u" });
     await contains(".o-mail-Composer button[aria-label='Send']");
     await contains(".o-mail-Composer button[aria-label='Send'] i.fa-paper-plane-o");
 });
@@ -422,10 +422,10 @@ QUnit.test("leave command on channel", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-Composer-input", { value: "/leave " });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "general" });
 
-    await contains(".o-mail-Discuss h4.text-muted", { text: "No conversation selected." });
-    await contains(".o_notification_content", { text: "You unsubscribed from general." });
+    await contains(".o-mail-Discuss", { text: "No conversation selected." });
+    await contains(".o_notification", { text: "You unsubscribed from general." });
 });
 
 QUnit.test("Can handle leave notification from unknown member", async () => {
@@ -467,12 +467,10 @@ QUnit.test("leave command on chat", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-Composer-input", { value: "/leave " });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "Chuck Norris" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Chuck Norris" });
 
     await contains(".o-mail-Discuss h4.text-muted", { text: "No conversation selected." });
-    await contains(".o_notification_content", {
-        text: "You unpinned your conversation with Chuck Norris",
-    });
+    await contains(".o_notification", { text: "You unpinned your conversation with Chuck Norris" });
 });
 
 QUnit.test("Can post suggestions", async () => {
@@ -783,7 +781,7 @@ QUnit.test("Show recipient list when there is more than 5 followers.", async () 
     await contains("li", { text: "test4@odoo.com" });
     await contains("li", { text: "test5@odoo.com" });
     await contains("li", { text: "test6@odoo.com" });
-    await contains(".o-mail-Chatter div", { text: "To: test1, test2, test3, test4, test5, …" });
+    await contains(".o-mail-Chatter", { text: "To: test1, test2, test3, test4, test5, …" });
 });
 
 QUnit.test(
@@ -813,8 +811,8 @@ QUnit.test(
                 contentType: "text/plain",
             }),
         ]);
-        await contains(".o-mail-AttachmentCard div", { text: "text1.txt" });
-        await contains(".o-mail-AttachmentCard div", { text: "text2.txt" });
+        await contains(".o-mail-AttachmentCard", { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard", { text: "text2.txt" });
         await contains(".o-mail-AttachmentCard-aside div[title='Uploading']", { count: 2 });
     }
 );
@@ -849,17 +847,14 @@ QUnit.test(
                 contentType: "text/plain",
             }),
         ]);
-        await contains(".o-mail-AttachmentCard.o-isUploading div", { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard.o-isUploading", { text: "text1.txt" });
         await click(".o-mail-AttachmentCard-unlink", {
-            parent: [
-                ".o-mail-AttachmentCard.o-isUploading",
-                { contains: ["div", { text: "text2.txt" }] },
-            ],
+            parent: [".o-mail-AttachmentCard.o-isUploading", { text: "text2.txt" }],
         });
-        await contains(".o-mail-AttachmentCard div", { count: 0, text: "text2.txt" });
+        await contains(".o-mail-AttachmentCard", { count: 0, text: "text2.txt" });
         // Simulates the completion of the upload of the first attachment
         uploadPromise.resolve();
-        await contains(".o-mail-AttachmentCard:not(.o-isUploading) div", { text: "text1.txt" });
+        await contains(".o-mail-AttachmentCard:not(.o-isUploading)", { text: "text1.txt" });
     }
 );
 

--- a/addons/mail/static/tests/core/out_of_focus_tests.js
+++ b/addons/mail/static/tests/core/out_of_focus_tests.js
@@ -26,7 +26,5 @@ QUnit.test("Spaces in notifications are not encoded", async () => {
             res_id: channelId,
         },
     });
-    await contains(".o_notification.border-info .o_notification_content", {
-        text: "Hello world!",
-    });
+    await contains(".o_notification.border-info", { text: "Hello world!" });
 });

--- a/addons/mail/static/tests/crosstab/crosstab_tests.js
+++ b/addons/mail/static/tests/crosstab/crosstab_tests.js
@@ -65,7 +65,7 @@ QUnit.test("Thread rename", async () => {
     });
     triggerHotkey("Enter");
     await contains(".o-mail-Discuss-threadName[title='Sales']", { target: tab2.target });
-    await contains(".o-mail-DiscussSidebarChannel span", { target: tab2.target, text: "Sales" });
+    await contains(".o-mail-DiscussSidebarChannel", { target: tab2.target, text: "Sales" });
 });
 
 QUnit.test("Thread description update", async () => {
@@ -148,7 +148,7 @@ QUnit.test("Adding attachments", async () => {
         attachment_ids: [attachmentId],
         message_id: messageId,
     });
-    await contains(".o-mail-AttachmentCard div", { target: tab2.target, text: "test.txt" });
+    await contains(".o-mail-AttachmentCard", { target: tab2.target, text: "test.txt" });
 });
 
 QUnit.test("Remove attachment from message", async () => {
@@ -169,15 +169,11 @@ QUnit.test("Remove attachment from message", async () => {
     const tab2 = await start({ asTab: true });
     tab1.openDiscuss(channelId);
     tab2.openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard div", { target: tab1.target, text: "test.txt" });
+    await contains(".o-mail-AttachmentCard", { target: tab1.target, text: "test.txt" });
 
     await click(".o-mail-AttachmentCard-unlink", { target: tab2.target });
     await click(".modal-footer .btn", { text: "Ok", target: tab2.target });
-    await contains(".o-mail-AttachmentCard div", {
-        count: 0,
-        target: tab1.target,
-        text: "test.txt",
-    });
+    await contains(".o-mail-AttachmentCard", { count: 0, target: tab1.target, text: "test.txt" });
 });
 
 QUnit.test("Message delete notification", async () => {
@@ -199,32 +195,12 @@ QUnit.test("Message delete notification", async () => {
     openDiscuss();
     await click("[title='Expand']");
     await click("[title='Mark as Todo']");
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { text: "1" }],
-        ],
-    });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { text: "1" }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
+    await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/delete", {
         message_ids: [messageId],
     });
     await contains(".o-mail-Message", { count: 0 });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { count: 0 }],
-        ],
-    });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });
+    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
 });

--- a/addons/mail/static/tests/discuss/call/call_settings_menu_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu_tests.js
@@ -109,7 +109,7 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await click("button[title='Show Call Settings']");
-        await click("button div", { text: "Inbox" });
+        await click("button", { text: "Inbox" });
         await contains("button[title='Hide Call Settings']", { count: 0 });
         await contains(".o-discuss-CallSettings", { count: 0 });
     }

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -69,7 +69,7 @@ QUnit.test("show call UI in chat window when in call", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "General" });
+    await click(".o-mail-NotificationItem", { text: "General" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-discuss-Call", { count: 0 });
     await click(".o-mail-ChatWindow-command[title='Start a Call']");
@@ -186,7 +186,7 @@ QUnit.test("Create a direct message channel when clicking on start a meeting", a
     const { openDiscuss } = await start();
     openDiscuss();
     await click("button", { text: "Start a meeting" });
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Mitchell Admin" });
     await contains(".o-discuss-Call");
     await contains(".o-discuss-ChannelInvitation");
 });

--- a/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
@@ -14,7 +14,7 @@ QUnit.test("Empty attachment panel", async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
-    await contains(".o-mail-Discuss-inspector p", {
+    await contains(".o-mail-Discuss-inspector", {
         text: "This channel doesn't have any attachments.",
     });
 });
@@ -39,13 +39,13 @@ QUnit.test("Attachment panel sort by date", async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
-    await contains(".o-mail-AttachmentList div", {
+    await contains(".o-mail-AttachmentList", {
         text: "file2.pdf",
-        after: [".o-mail-DateSection span", { text: "September, 2023" }],
-        before: [".o-mail-DateSection span", { text: "August, 2023" }],
+        after: [".o-mail-DateSection", { text: "September, 2023" }],
+        before: [".o-mail-DateSection", { text: "August, 2023" }],
     });
-    await contains(".o-mail-AttachmentList div", {
+    await contains(".o-mail-AttachmentList", {
         text: "file1.pdf",
-        after: [".o-mail-DateSection span", { text: "August, 2023" }],
+        after: [".o-mail-DateSection", { text: "August, 2023" }],
     });
 });

--- a/addons/mail/static/tests/discuss/core/suggestion_tests.js
+++ b/addons/mail/static/tests/discuss/core/suggestion_tests.js
@@ -112,11 +112,11 @@ QUnit.test("Sort partner suggestions by recent chats", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel span", { text: "User 2" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "User 2" });
     await insertText(".o-mail-Composer-input", "This is a test");
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message-content", { text: "This is a test" });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await insertText(".o-mail-Composer-input[placeholder='Message #General…']", "@");
     await insertText(".o-mail-Composer-input", "User");
     await contains(".o-mail-Composer-suggestion strong", { count: 3 });

--- a/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/chat_window_new_message_tests.js
@@ -21,7 +21,7 @@ QUnit.test("basic rendering", async () => {
     await click("button", { text: "New Message" });
     await contains(".o-mail-ChatWindow");
     await contains(".o-mail-ChatWindow-header");
-    await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-name", { text: "New message" });
+    await contains(".o-mail-ChatWindow-header", { text: "New message" });
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command", { count: 2 });
     await contains(".o-mail-ChatWindow-header .o-mail-ChatWindow-command[title='Fold']");
     await contains(
@@ -50,15 +50,10 @@ QUnit.test("fold", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click("button", { text: "New Message" });
-    await contains(".o-mail-ChatWindow-content");
     await contains(".o-discuss-ChannelSelector");
-
     await click(".o-mail-ChatWindow-command[title='Fold']");
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content", { count: 0 });
     await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector", { count: 0 });
-
     await click(".o-mail-ChatWindow-command[title='Open']");
-    await contains(".o-mail-ChatWindow .o-mail-ChatWindow-content");
     await contains(".o-discuss-ChannelSelector");
 });
 
@@ -95,24 +90,18 @@ QUnit.test(
         await click(".o_menu_systray i[aria-label='Messages']");
         await click("button", { text: "New Message" });
         await contains(".o-mail-ChatWindow", { count: 2 });
-        await contains(":nth-child(2 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "New message",
-        });
+        await contains(":nth-child(2 of .o-mail-ChatWindow)", { text: "New message" });
         await contains(".o-mail-ChatWindow .o-discuss-ChannelSelector");
         // open channel-2
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "channel-2" });
+        await click(".o-mail-NotificationItem", { text: "channel-2" });
         await contains(".o-mail-ChatWindow", { count: 3 });
-        await contains(":nth-child(2 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "New message",
-        });
+        await contains(":nth-child(2 of .o-mail-ChatWindow)", { text: "New message" });
         // search for a user in "new message" autocomplete
         await insertText(".o-discuss-ChannelSelector input", "131");
         await click(".o-discuss-ChannelSelector-suggestion a", { text: "Partner 131" });
-        await contains(".o-mail-ChatWindow-name", { count: 0, text: "New message" });
-        await contains(":nth-child(2 of .o-mail-ChatWindow) .o-mail-ChatWindow-name", {
-            text: "Partner 131",
-        });
+        await contains(".o-mail-ChatWindow", { count: 0, text: "New message" });
+        await contains(":nth-child(2 of .o-mail-ChatWindow)", { text: "Partner 131" });
     }
 );
 
@@ -143,7 +132,7 @@ QUnit.test(
         await click("button", { text: "New Message" });
         await insertText(".o-discuss-ChannelSelector input", "131");
         await click(".o-discuss-ChannelSelector-suggestion a");
-        await contains(".o-mail-ChatWindow-name", { count: 0, text: "New message" });
+        await contains(".o-mail-ChatWindow", { count: 0, text: "New message" });
         await contains(".o-mail-ChatWindow");
     }
 );

--- a/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/command_palette_tests.js
@@ -48,7 +48,7 @@ QUnit.test("open the chatWindow of a channel from the command palette", async ()
 
     await click(".o_command.focused");
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-name", { text: "general" });
+    await contains(".o-mail-ChatWindow", { text: "general" });
 });
 
 QUnit.test("Channel mentions in the command palette of Discuss app with @", async () => {
@@ -90,7 +90,7 @@ QUnit.test("Channel mentions in the command palette of Discuss app with @", asyn
         ],
     });
     await click(".o_command.focused");
-    await contains(".o-mail-ChatWindow-name", { text: "Mitchell Admin and Mario" });
+    await contains(".o-mail-ChatWindow", { text: "Mitchell Admin and Mario" });
 });
 
 QUnit.test("Max 3 most recent channels in command palette of Discuss app with #", async () => {

--- a/addons/mail/static/tests/discuss/core/web/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss_tests.js
@@ -138,7 +138,7 @@ QUnit.test("should create DM chat when adding self and another user", async () =
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Mario" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Mario" });
 });
 
 QUnit.test("chat search should display no result when no matches found", async () => {

--- a/addons/mail/static/tests/discuss/core/web/messaging_menu_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/messaging_menu_tests.js
@@ -23,7 +23,7 @@ QUnit.test('"Start a conversation" item selection opens chat', async () => {
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
     triggerHotkey("Enter");
-    await contains(".o-mail-ChatWindow-name[title='Gandalf']");
+    await contains(".o-mail-ChatWindow", { text: "Gandalf" });
 });
 
 QUnit.test('"New channel" item selection opens channel (existing)', async () => {
@@ -37,7 +37,7 @@ QUnit.test('"New channel" item selection opens channel (existing)', async () => 
     await insertText("input[placeholder='Add or join a channel']", "Gryff");
     await click(":nth-child(1 of .o-discuss-ChannelSelector-suggestion)");
     await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
-    await contains(".o-mail-ChatWindow-name[title='Gryffindors']");
+    await contains(".o-mail-ChatWindow", { text: "Gryffindors" });
 });
 
 QUnit.test('"New channel" item selection opens channel (new)', async () => {
@@ -49,7 +49,7 @@ QUnit.test('"New channel" item selection opens channel (new)', async () => {
     await insertText("input[placeholder='Add or join a channel']", "slytherins");
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-discuss-ChannelSelector-suggestion", { count: 0 });
-    await contains(".o-mail-ChatWindow-name[title='slytherins']");
+    await contains(".o-mail-ChatWindow", { text: "slytherins" });
 });
 
 QUnit.test("new message [REQUIRE FOCUS]", async () => {

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages_tests.js
@@ -26,9 +26,7 @@ QUnit.test("Pin message", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".dropdown-item", { text: "Pin" });
     await click(".modal-footer button", { text: "Yeah, pin it!" });
-    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message-content", {
-        text: "Hello world!",
-    });
+    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", { text: "Hello world!" });
 });
 
 QUnit.test("Unpin message", async () => {

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -51,7 +51,7 @@ QUnit.test("can change the thread name of #general [REQUIRE FOCUS]", async (asse
     await contains("input.o-mail-Discuss-threadName", { value: "general" });
     await insertText("input.o-mail-Discuss-threadName:enabled", "special", { replace: true });
     triggerHotkey("Enter");
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "special" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "special" });
     await contains("input.o-mail-Discuss-threadName", { value: "special" });
     assert.verifySteps(["/web/dataset/call_kw/discuss.channel/channel_rename"]);
 });
@@ -283,7 +283,7 @@ QUnit.test("show date separator above mesages of similar date", async () => {
     openDiscuss(channelId);
     await contains(".o-mail-Message", {
         count: 29,
-        after: [".o-mail-DateSection span", { text: "April 20, 2019" }],
+        after: [".o-mail-DateSection", { text: "April 20, 2019" }],
     });
 });
 
@@ -299,7 +299,7 @@ QUnit.test("sidebar: chat custom name", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Marc" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Marc" });
 });
 
 QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FOCUS]", async () => {
@@ -326,7 +326,7 @@ QUnit.test("reply to message from inbox (message linked to document) [REQUIRE FO
     await click("[title='Reply']");
     await contains(".o-mail-Message.o-selected");
     await contains(".o-mail-Composer");
-    await contains(".o-mail-Composer-coreHeader span", { text: "on: Refactoring" });
+    await contains(".o-mail-Composer-coreHeader", { text: "on: Refactoring" });
     await insertText(".o-mail-Composer-input:focus", "Hello");
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Composer", { count: 0 });
@@ -349,12 +349,12 @@ QUnit.test("Can reply to starred message", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer-coreHeader b", { text: "RandomName" });
+    await contains(".o-mail-Composer-coreHeader", { text: "RandomName" });
     await insertText(".o-mail-Composer-input", "abc");
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Composer-send", { count: 0 });
     await contains(".o_notification", { text: 'Message posted on "RandomName"' });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "RandomName" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "RandomName" });
     await contains(".o-mail-Message-content", { text: "abc" });
 });
 
@@ -376,24 +376,19 @@ QUnit.test("Can reply to history message", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
     await click("[title='Reply']");
-    await contains(".o-mail-Composer-coreHeader b", { text: "RandomName" });
+    await contains(".o-mail-Composer-coreHeader", { text: "RandomName" });
     await insertText(".o-mail-Composer-input", "abc");
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Composer-send", { count: 0 });
     await contains(".o_notification", { text: 'Message posted on "RandomName"' });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "RandomName" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "RandomName" });
     await contains(".o-mail-Message-content", { text: "abc" });
 });
 
 QUnit.test("receive new needaction messages", async () => {
     const { openDiscuss, pyEnv } = await start();
     openDiscuss();
-    await contains("button.o-active", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button.o-active", { text: "Inbox", contains: [".badge", { count: 0 }] });
     await contains(".o-mail-Thread .o-mail-Message", { count: 0 });
 
     // simulate receiving a new needaction message
@@ -404,12 +399,7 @@ QUnit.test("receive new needaction messages", async () => {
         model: "res.partner",
         res_id: 20,
     });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { text: "1" }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     await contains(".o-mail-Message");
     await contains(".o-mail-Message-content", { text: "not empty 1" });
 
@@ -421,12 +411,7 @@ QUnit.test("receive new needaction messages", async () => {
         model: "res.partner",
         res_id: 20,
     });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { text: "2" }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { text: "2" }] });
     await contains(".o-mail-Message", { count: 2 });
     await contains(".o-mail-Message-content", { text: "not empty 1" });
     await contains(".o-mail-Message-content", { text: "not empty 2" });
@@ -443,9 +428,9 @@ QUnit.test("basic rendering", async () => {
 QUnit.test("basic rendering: sidebar", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebar button div", { text: "Inbox" });
-    await contains(".o-mail-DiscussSidebar button div", { text: "Starred" });
-    await contains(".o-mail-DiscussSidebar button div", { text: "History" });
+    await contains(".o-mail-DiscussSidebar button", { text: "Inbox" });
+    await contains(".o-mail-DiscussSidebar button", { text: "Starred" });
+    await contains(".o-mail-DiscussSidebar button", { text: "History" });
     await contains(".o-mail-DiscussSidebarCategory", { count: 2 });
     await contains(".o-mail-DiscussSidebarCategory-channel", { text: "Channels" });
     await contains(".o-mail-DiscussSidebarCategory-chat", { text: "Direct messages" });
@@ -454,23 +439,23 @@ QUnit.test("basic rendering: sidebar", async () => {
 QUnit.test("sidebar: Inbox should have icon", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button", { containsMulti: [[".fa-inbox"], ["div", { text: "Inbox" }]] });
+    await contains("button", { text: "Inbox", contains: [".fa-inbox"] });
 });
 
 QUnit.test("sidebar: default active inbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button.o-active div", { text: "Inbox" });
+    await contains("button.o-active", { text: "Inbox" });
 });
 
 QUnit.test("sidebar: change active", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button.o-active div", { text: "Inbox" });
-    await contains("button:not(.o-active) div", { text: "Starred" });
-    await click("button div", { text: "Starred" });
-    await contains("button:not(.o-active) div", { text: "Inbox" });
-    await contains("button.o-active div", { text: "Starred" });
+    await contains("button.o-active", { text: "Inbox" });
+    await contains("button:not(.o-active)", { text: "Starred" });
+    await click("button", { text: "Starred" });
+    await contains("button:not(.o-active)", { text: "Inbox" });
+    await contains("button.o-active", { text: "Starred" });
 });
 
 QUnit.test("sidebar: basic channel rendering", async () => {
@@ -478,7 +463,7 @@ QUnit.test("sidebar: basic channel rendering", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands.d-none");
     await contains(
@@ -584,7 +569,7 @@ QUnit.test("initially load messages from inbox", async (assert) => {
 QUnit.test("default active id on mailbox", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
-    await contains("button.o-active div", { text: "Starred" });
+    await contains("button.o-active", { text: "Starred" });
 });
 
 QUnit.test("basic top bar rendering", async () => {
@@ -595,11 +580,11 @@ QUnit.test("basic top bar rendering", async () => {
     await contains("button:disabled", { text: "Mark all read" });
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
 
-    await click("button div", { text: "Starred" });
+    await click("button", { text: "Starred" });
     await contains("button:disabled", { text: "Unstar all" });
     await contains(".o-mail-Discuss-threadName", { value: "Starred" });
 
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Discuss-header button[title='Add Users']");
     await contains(".o-mail-Discuss-threadName", { value: "General" });
 });
@@ -749,17 +734,17 @@ QUnit.test('messages marked as read move to "History" mailbox', async () => {
     await contains("button.o-active", { text: "History" });
     await contains(".o-mail-Thread h4", { text: "No history messages" });
 
-    await click("button div", { text: "Inbox" });
-    await contains("button.o-active div", { text: "Inbox" });
+    await click("button", { text: "Inbox" });
+    await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-Thread h4", { count: 0, text: "Congratulations, your inbox is empty" });
 
     await contains(".o-mail-Thread .o-mail-Message", { count: 2 });
 
     await click("button", { text: "Mark all read" });
-    await contains("button.o-active div", { text: "Inbox" });
+    await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-Thread h4", { text: "Congratulations, your inbox is empty" });
 
-    await click("button div", { text: "History" });
+    await click("button", { text: "History" });
     await contains("button.o-active", { text: "History" });
     await contains(".o-mail-Thread h4", { count: 0, text: "No history messages" });
 
@@ -798,18 +783,15 @@ QUnit.test(
         openDiscuss("mail.box_history");
         await contains("button.o-active", { text: "History" });
         await contains(".o-mail-Thread h4", { text: "No history messages" });
-        await click("button div", { text: "Inbox" });
-        await contains("button.o-active div", { text: "Inbox" });
+        await click("button", { text: "Inbox" });
+        await contains("button.o-active", { text: "Inbox" });
         await contains(".o-mail-Message", { count: 2 });
         await click("[title='Mark as Read']", {
-            parent: [
-                ".o-mail-Message",
-                { contains: [".o-mail-Message-content", { text: "not empty 1" }] },
-            ],
+            parent: [".o-mail-Message", { text: "not empty 1" }],
         });
         await contains(".o-mail-Message");
         await contains(".o-mail-Message-content", { text: "not empty 2" });
-        await click("button div", { text: "History" });
+        await click("button", { text: "History" });
         await contains("button.o-active", { text: "History" });
         await contains(".o-mail-Message");
         await contains(".o-mail-Message-content", { text: "not empty 1" });
@@ -834,7 +816,7 @@ QUnit.test('all messages in "Inbox" in "History" after marked all as read', asyn
     await contains(".o-mail-Message", { count: 30 });
     await click("button", { text: "Mark all read" });
     await contains(".o-mail-Message", { count: 0 });
-    await click("button div", { text: "History" });
+    await click("button", { text: "History" });
     await contains(".o-mail-Message", { count: 30 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
@@ -857,9 +839,7 @@ QUnit.test("post a simple message", async (assert) => {
         },
     });
     openDiscuss(channelId);
-    await contains(".o-mail-Thread .o-mail-Thread-empty", {
-        text: "There are no messages in this conversation.",
-    });
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
     await contains(".o-mail-Message", { count: 0 });
     await insertText(".o-mail-Composer-input", "Test");
     await click(".o-mail-Composer-send:enabled");
@@ -878,19 +858,9 @@ QUnit.test("starred: unstar all", async () => {
     const { openDiscuss } = await start();
     openDiscuss("mail.box_starred");
     await contains(".o-mail-Message", { count: 2 });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { text: "2" }],
-        ],
-    });
+    await contains("button", { text: "Starred", contains: [".badge", { text: "2" }] });
     await click("button:enabled", { text: "Unstar all" });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
     await contains(".o-mail-Message", { count: 0 });
     await contains("button:disabled", { text: "Unstar all" });
 });
@@ -910,16 +880,16 @@ QUnit.test("auto-focus composer on opening thread [REQUIRE FOCUS]", async () => 
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button.o-active div", { text: "Inbox" });
-    await contains(".o-mail-DiscussSidebarChannel:not(.o-active) span", { text: "General" });
-    await contains(".o-mail-DiscussSidebarChannel:not(.o-active) span", { text: "Demo User" });
+    await contains("button.o-active", { text: "Inbox" });
+    await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel:not(.o-active)", { text: "Demo User" });
     await contains(".o-mail-Composer", { count: 0 });
 
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
-    await contains(".o-mail-DiscussSidebarChannel.o-active span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });
     await contains(".o-mail-Composer-input:focus");
-    await click(".o-mail-DiscussSidebarChannel span", { text: "Demo User" });
-    await contains(".o-mail-DiscussSidebarChannel.o-active span", { text: "Demo User" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Demo User" });
+    await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "Demo User" });
     await contains(".o-mail-Composer-input:focus");
 });
 
@@ -1090,7 +1060,7 @@ QUnit.test("should auto-pin chat when receiving a new DM", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-chat");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Demo" });
 
     // simulate receiving the first message on channel 11
     pyEnv.withUser(userId, () =>
@@ -1100,7 +1070,7 @@ QUnit.test("should auto-pin chat when receiving a new DM", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Demo" });
 });
 
 QUnit.test("'Add Users' button should be displayed in the topbar of channels", async () => {
@@ -1231,15 +1201,15 @@ QUnit.test(
         ]);
         const { openDiscuss } = await start();
         openDiscuss();
-        await click(".o-mail-DiscussSidebarChannel span", { text: "Michel Online" });
+        await click(".o-mail-DiscussSidebarChannel", { text: "Michel Online" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Online']");
-        await click(".o-mail-DiscussSidebarChannel span", { text: "Jacqueline Offline" });
+        await click(".o-mail-DiscussSidebarChannel", { text: "Jacqueline Offline" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Offline']");
-        await click(".o-mail-DiscussSidebarChannel span", { text: "Nabuchodonosor Idle" });
+        await click(".o-mail-DiscussSidebarChannel", { text: "Nabuchodonosor Idle" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Idle']");
-        await click(".o-mail-DiscussSidebarChannel span", { text: "Robert Fired" });
+        await click(".o-mail-DiscussSidebarChannel", { text: "Robert Fired" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='No IM status available']");
-        await click(".o-mail-DiscussSidebarChannel span", { text: "OdooBot" });
+        await click(".o-mail-DiscussSidebarChannel", { text: "OdooBot" });
         await contains(".o-mail-Discuss-header .o-mail-ImStatus [title='Bot']");
     }
 );
@@ -1305,17 +1275,15 @@ QUnit.test("Channel is added to discuss after invitation", async () => {
     const { env, openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-channel");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "General" });
 
     pyEnv.withUser(userId, () =>
         env.services.orm.call("discuss.channel", "add_members", [[channelId]], {
             partner_ids: [pyEnv.adminPartnerId],
         })
     );
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
-    await contains(".o_notification.border-info .o_notification_content", {
-        text: "You have been invited to #General",
-    });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
+    await contains(".o_notification.border-info", { text: "You have been invited to #General" });
 });
 
 QUnit.test("select another mailbox", async () => {
@@ -1503,9 +1471,7 @@ QUnit.test("failure on loading messages should display error", async () => {
         },
     });
     openDiscuss(channelId);
-    await contains(".o-mail-Thread-error", {
-        text: "An error occurred while fetching messages.",
-    });
+    await contains(".o-mail-Thread", { text: "An error occurred while fetching messages." });
 });
 
 QUnit.test("failure on loading messages should prompt retry button", async () => {
@@ -1557,9 +1523,7 @@ QUnit.test(
         await contains(".o-mail-Message", { count: 30 });
         messageFetchShouldFail = true;
         await click("button", { text: "Load More" });
-        await contains(".o-mail-Thread-error", {
-            text: "An error occurred while fetching messages.",
-        });
+        await contains(".o-mail-Thread", { text: "An error occurred while fetching messages." });
         await contains("button", { text: "Click here to retry" });
         await contains("button", { count: 0, text: "Load More" });
     }
@@ -1657,13 +1621,13 @@ QUnit.test("composer state: attachments save and restore", async () => {
     // Switch back to #general
     await click("button", { text: "General" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard");
-    await contains(".o-mail-AttachmentCard div", { text: "text.txt" });
+    await contains(".o-mail-AttachmentCard", { text: "text.txt" });
     // Switch back to #special
     await click("button", { text: "Special" });
     await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 3 });
-    await contains(".o-mail-AttachmentCard div", { text: "text2.txt" });
-    await contains(".o-mail-AttachmentCard div", { text: "text3.txt" });
-    await contains(".o-mail-AttachmentCard div", { text: "text4.txt" });
+    await contains(".o-mail-AttachmentCard", { text: "text2.txt" });
+    await contains(".o-mail-AttachmentCard", { text: "text3.txt" });
+    await contains(".o-mail-AttachmentCard", { text: "text4.txt" });
 });
 
 QUnit.test(
@@ -1757,7 +1721,7 @@ QUnit.test("Message shows up even if channel data is incomplete", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await click(".o-mail-DiscussSidebarChannel span", { text: "Albert" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Albert" });
     await contains(".o-mail-Message-content", { text: "hello world" });
 });
 
@@ -1766,7 +1730,7 @@ QUnit.test("Correct breadcrumb when open discuss from chat window then see setti
     pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await click(".o_main_navbar i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name", { text: "General" });
+    await click(".o-mail-NotificationItem", { text: "General" });
     await click("[title='Open Actions Menu']");
     await click("[title='Open in Discuss']");
     await click("[title='Channel settings']", {
@@ -1801,7 +1765,7 @@ QUnit.test(
         await contains(".o-mail-Discuss", { count: 0 });
         await contains(".o_form_view .o-mail-Chatter");
         await contains(".o_form_view .o_last_breadcrumb_item", { text: "TestPartner" });
-        await contains(".o-mail-Chatter .o-mail-Message-content", {
+        await contains(".o-mail-Chatter .o-mail-Message", {
             text: "A needaction message to have it in messaging menu",
         });
     }

--- a/addons/mail/static/tests/discuss_app/im_status_tests.js
+++ b/addons/mail/static/tests/discuss_app/im_status_tests.js
@@ -112,9 +112,7 @@ QUnit.test("show im status in messaging menu preview of chat", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", {
-        containsMulti: [
-            [".o-mail-NotificationItem-name", { text: "Demo" }],
-            ["i[aria-label='User is online']"],
-        ],
+        text: "Demo",
+        contains: ["i[aria-label='User is online']"],
     });
 });

--- a/addons/mail/static/tests/discuss_app/inbox_tests.js
+++ b/addons/mail/static/tests/discuss_app/inbox_tests.js
@@ -179,10 +179,7 @@ QUnit.test("show subject of message in Inbox", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", {
-        text: "Subject: Salutations, voyageurnot empty",
-    });
+    await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
 });
 
 QUnit.test("show subject of message in history", async () => {
@@ -202,10 +199,7 @@ QUnit.test("show subject of message in history", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss("mail.box_history");
-    await contains(".o-mail-Message");
-    await contains(".o-mail-Message-content", {
-        text: "Subject: Salutations, voyageurnot empty",
-    });
+    await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
 });
 
 QUnit.test("subject should not be shown when subject is the same as the thread name", async () => {
@@ -226,8 +220,8 @@ QUnit.test("subject should not be shown when subject is the same as the thread n
     });
     const { openDiscuss } = await start();
     openDiscuss("mail.box_inbox");
-    await contains(".o-mail-Message-content");
-    await contains(".o-mail-Message-content", {
+    await contains(".o-mail-Message");
+    await contains(".o-mail-Message", {
         count: 0,
         text: "Subject: Salutations, voyageurnot empty",
     });
@@ -253,8 +247,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
-        await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", {
+        await contains(".o-mail-Message");
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
@@ -281,8 +275,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
-        await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", {
+        await contains(".o-mail-Message");
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
@@ -309,8 +303,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
-        await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", {
+        await contains(".o-mail-Message");
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
@@ -337,8 +331,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
-        await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", {
+        await contains(".o-mail-Message");
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
@@ -365,8 +359,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
-        await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", {
+        await contains(".o-mail-Message");
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
@@ -393,8 +387,8 @@ QUnit.test(
         });
         const { openDiscuss } = await start();
         openDiscuss("mail.box_inbox");
-        await contains(".o-mail-Message-content");
-        await contains(".o-mail-Message-content", {
+        await contains(".o-mail-Message");
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Salutations, voyageurnot empty",
         });
@@ -432,12 +426,7 @@ QUnit.test("inbox: mark all messages as read", async (assert) => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { text: "2" }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { text: "2" }] });
     await contains(".o-mail-DiscussSidebarChannel", {
         containsMulti: [
             ["span", { text: "General" }],
@@ -446,12 +435,7 @@ QUnit.test("inbox: mark all messages as read", async (assert) => {
     });
     await contains(".o-mail-Discuss-content .o-mail-Message", { count: 2 });
     await click(".o-mail-Discuss-header button:enabled", { text: "Mark all read" });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });
     await contains(".o-mail-DiscussSidebarChannel", {
         containsMulti: [
             ["span", { text: "General" }],
@@ -547,14 +531,10 @@ QUnit.test("inbox messages are never squashed", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", {
-        text: "body1",
-    });
-    await contains(".o-mail-Message:not(.o-squashed) .o-mail-Message-content", {
-        text: "body2",
-    });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "test" });
-    await contains(".o-mail-Message.o-squashed .o-mail-Message-content", { text: "body2" });
+    await contains(".o-mail-Message:not(.o-squashed)", { text: "body1" });
+    await contains(".o-mail-Message:not(.o-squashed)", { text: "body2" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "test" });
+    await contains(".o-mail-Message.o-squashed", { text: "body2" });
 });
 
 QUnit.test("reply: stop replying button click", async () => {
@@ -656,22 +636,12 @@ QUnit.test("emptying inbox doesn't display rainbow man in another thread", async
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { text: "1" }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/mark_as_read", {
         message_ids: [messageId],
         needaction_inbox_counter: 0,
     });
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });
     // weak test, no guarantee that we waited long enough for the potential rainbow man to show
     await contains(".o_reward_rainbow", { count: 0 });
 });

--- a/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
+++ b/addons/mail/static/tests/discuss_app/jump_to_present_tests.js
@@ -37,11 +37,9 @@ QUnit.test("Basic jump to present when scrolling to outdated messages", async (a
     );
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", 0);
-    await contains(".o-mail-Thread-jumpPresent", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains(".o-mail-Thread", { text: "You're viewing older messagesJump to Present" });
     await click(".o-mail-Thread-jumpPresent");
-    await contains(".o-mail-Thread-jumpPresent", {
+    await contains(".o-mail-Thread", {
         count: 0,
         text: "You're viewing older messagesJump to Present",
     });
@@ -88,12 +86,8 @@ QUnit.test("Jump to old reply should prompt jump to presence", async () => {
     await contains(".o-mail-Message", { count: 30 });
     await click(".o-mail-MessageInReply .cursor-pointer");
     await contains(".o-mail-Message", { count: 46 });
-    await contains(":nth-child(1 of .o-mail-Message) .o-mail-Message-content", {
-        text: "Hello world!",
-    });
-    await contains(".o-mail-Thread-jumpPresent", {
-        text: "You're viewing older messagesJump to Present",
-    });
+    await contains(":nth-child(1 of .o-mail-Message)", { text: "Hello world!" });
+    await contains(".o-mail-Thread", { text: "You're viewing older messagesJump to Present" });
     await click(".o-mail-Thread-jumpPresent");
     await contains(".o-mail-Thread-jumpPresent", { count: 0 });
     await contains(".o-mail-Message", { count: 30 });

--- a/addons/mail/static/tests/discuss_app/sidebar_tests.js
+++ b/addons/mail/static/tests/discuss_app/sidebar_tests.js
@@ -102,7 +102,7 @@ QUnit.test("channel - command: should have view command when category is folded"
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
+    await click(".o-mail-DiscussSidebarCategory-channel .btn", { text: "Channels" });
     await contains("i[title='View or join channels']");
 });
 
@@ -133,9 +133,9 @@ QUnit.test("channel - states: close manually by clicking the title", async () =>
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "general" });
-    await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "general" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "general" });
+    await click(".o-mail-DiscussSidebarCategory-channel .btn", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "general" });
 });
 
 QUnit.test("channel - states: open manually by clicking the title", async () => {
@@ -147,11 +147,11 @@ QUnit.test("channel - states: open manually by clicking the title", async () => 
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "general" });
+    await contains(".o-mail-DiscussSidebarCategory-channel", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "general" });
 
-    await click(".o-mail-DiscussSidebarCategory-channel span", { text: "Channels" });
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "general" });
+    await click(".o-mail-DiscussSidebarCategory-channel .btn", { text: "Channels" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "general" });
 });
 
 QUnit.test("sidebar: inbox with counter", async () => {
@@ -162,12 +162,7 @@ QUnit.test("sidebar: inbox with counter", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Inbox" }],
-            [".badge", { text: "1" }],
-        ],
-    });
+    await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
 });
 
 QUnit.test("default thread rendering", async () => {
@@ -175,32 +170,30 @@ QUnit.test("default thread rendering", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains("button div", { text: "Inbox" });
-    await contains("button div", { text: "Starred" });
-    await contains("button div", { text: "History" });
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
-    await contains("button.o-active div", { text: "Inbox" });
+    await contains("button", { text: "Inbox" });
+    await contains("button", { text: "Starred" });
+    await contains("button", { text: "History" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
+    await contains("button.o-active", { text: "Inbox" });
     await contains(".o-mail-Thread", {
         text: "Congratulations, your inbox is empty  New messages appear here.",
     });
 
-    await click("button div", { text: "Starred" });
-    await contains("button.o-active div", { text: "Starred" });
+    await click("button", { text: "Starred" });
+    await contains("button.o-active", { text: "Starred" });
     await contains(".o-mail-Thread", {
         text: "No starred messages  You can mark any message as 'starred', and it shows up in this mailbox.",
     });
 
-    await click("button div", { text: "History" });
-    await contains("button.o-active div", { text: "History" });
+    await click("button", { text: "History" });
+    await contains("button.o-active", { text: "History" });
     await contains(".o-mail-Thread", {
         text: "No history messages  Messages marked as read will appear in the history.",
     });
 
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-DiscussSidebarChannel.o-active", { text: "General" });
-    await contains(".o-mail-Thread .o-mail-Thread-empty", {
-        text: "There are no messages in this conversation.",
-    });
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
 });
 
 QUnit.test("sidebar quick search at 20 or more pinned channels", async () => {
@@ -210,28 +203,28 @@ QUnit.test("sidebar quick search at 20 or more pinned channels", async () => {
     }
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 20 });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 20 });
     await contains(".o-mail-DiscussSidebar input[placeholder='Quick search...']");
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "1");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 11 });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 11 });
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "12", {
         replace: true,
     });
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "channel12" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "channel12" });
 
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "123", {
         replace: true,
     });
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0 });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 
     // search should work in case-insensitive
     await insertText(".o-mail-DiscussSidebar input[placeholder='Quick search...']", "C", {
         replace: true,
     });
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 20 });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 20 });
 });
 
 QUnit.test("sidebar: basic chat rendering", async () => {
@@ -247,7 +240,7 @@ QUnit.test("sidebar: basic chat rendering", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     await contains(".o-mail-DiscussSidebarChannel img[data-alt='Thread Image']");
     await contains(
         ".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-commands div[title='Unpin Conversation']"
@@ -260,7 +253,7 @@ QUnit.test("sidebar: show pinned channel", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
 });
 
 QUnit.test("sidebar: open pinned channel", async () => {
@@ -268,7 +261,7 @@ QUnit.test("sidebar: open pinned channel", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Composer-input[placeholder='Message #General…']");
     await contains(".o-mail-Discuss-threadName", { value: "General" });
 });
@@ -294,13 +287,13 @@ QUnit.test("sidebar: open channel and leave it", async (assert) => {
         },
     });
     openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "General" });
     assert.verifySteps([]);
     await click(".btn[title='Leave this channel']", {
         parent: [".o-mail-DiscussSidebarChannel.o-active", { text: "General" }],
     });
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "General" });
     await contains(".o-mail-Discuss-threadName", { value: "Inbox" });
     assert.verifySteps(["action_unfollow"]);
 });
@@ -310,16 +303,16 @@ QUnit.test("sidebar: unpin channel from bus", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
 
-    await click(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "General" });
     await contains(".o-mail-Composer-input[placeholder='Message #General…']");
     await contains(".o-mail-Discuss-threadName", { value: "General" });
 
     // Simulate receiving a leave channel notification
     // (e.g. from user interaction from another device or browser tab)
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "discuss.channel/unpin", { id: channelId });
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "General" });
 
     await contains(".o-mail-Discuss-threadName", { count: 0, value: "General" });
 });
@@ -346,7 +339,7 @@ QUnit.test("chat - channel should count unread message [REQUIRE FOCUS]", async (
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-discuss-badge", { text: "1" });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     await contains(".o-discuss-badge", { count: 0 });
 });
 
@@ -668,7 +661,7 @@ QUnit.test("chat - states: close manually by clicking the title", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
-    await click(".o-mail-DiscussSidebarCategory div", { text: "Direct messages" });
+    await click(".o-mail-DiscussSidebarCategory .btn", { text: "Direct messages" });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });
 
@@ -770,7 +763,7 @@ QUnit.test("channel - states: close should update the value on the server", asyn
         [[currentUserId]]
     );
     assert.ok(initalSettings.is_discuss_sidebar_category_channel_open);
-    await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
+    await click(".o-mail-DiscussSidebarCategory .btn", { text: "Channels" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -796,7 +789,7 @@ QUnit.test("channel - states: open should update the value on the server", async
     );
     assert.notOk(initalSettings.is_discuss_sidebar_category_channel_open);
 
-    await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
+    await click(".o-mail-DiscussSidebarCategory .btn", { text: "Channels" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -850,14 +843,14 @@ QUnit.test(
         pyEnv["discuss.channel"].create({ name: "channel1" });
         const { openDiscuss } = await start();
         openDiscuss();
-        await click(".o-mail-DiscussSidebarChannel span", { text: "channel1" });
+        await click(".o-mail-DiscussSidebarChannel", { text: "channel1" });
         await contains("button.o-active", { text: "channel1" });
 
-        await click(".o-mail-DiscussSidebarCategory span", { text: "Channels" });
+        await click(".o-mail-DiscussSidebarCategory .btn", { text: "Channels" });
         await contains(".o-mail-DiscussSidebarCategory-channel .oi-chevron-right");
         await contains("button", { text: "channel1" });
 
-        await click("button div", { text: "Inbox" });
+        await click("button", { text: "Inbox" });
         await contains("button", { count: 0, text: "channel1" });
     }
 );
@@ -873,7 +866,7 @@ QUnit.test("chat - states: open manually by clicking the title", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss();
-    await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
+    await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
     await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
 });
 
@@ -894,7 +887,7 @@ QUnit.test("chat - states: close should call update server data", async (assert)
     );
     assert.ok(initalSettings.is_discuss_sidebar_category_chat_open);
 
-    await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
+    await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -920,7 +913,7 @@ QUnit.test("chat - states: open should call update server data", async (assert) 
     );
     assert.notOk(initalSettings.is_discuss_sidebar_category_chat_open);
 
-    await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
+    await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
     const newSettings = await env.services.orm.call(
         "res.users.settings",
         "_find_or_create_for_user",
@@ -980,11 +973,11 @@ QUnit.test(
         await click(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
         await contains("button.o-active", { text: "Mitchell Admin" });
 
-        await click(".o-mail-DiscussSidebarCategory-chat span", { text: "Direct messages" });
+        await click(".o-mail-DiscussSidebarCategory-chat .btn", { text: "Direct messages" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
         await contains(".o-mail-DiscussSidebar button", { text: "Mitchell Admin" });
 
-        await click("button div", { text: "Inbox" });
+        await click("button", { text: "Inbox" });
         await contains(".o-mail-DiscussSidebarCategory-chat .oi-chevron-right");
         await contains(".o-mail-DiscussSidebar button", { count: 0, text: "Mitchell Admin" });
     }
@@ -1067,9 +1060,9 @@ QUnit.test("Can unpin chat channel", async () => {
     pyEnv["discuss.channel"].create({ channel_type: "chat" });
     const { openDiscuss } = await start();
     openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "Mitchell Admin" });
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "Mitchell Admin" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Mitchell Admin" });
 });
 
 QUnit.test("Unpinning chat should display notification", async () => {
@@ -1078,7 +1071,7 @@ QUnit.test("Unpinning chat should display notification", async () => {
     const { openDiscuss } = await start();
     openDiscuss();
     await click(".o-mail-DiscussSidebarChannel [title='Unpin Conversation']");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0 });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
     await contains(".o_notification.border-info", {
         text: "You unpinned your conversation with Mitchell Admin",
     });
@@ -1089,9 +1082,9 @@ QUnit.test("Can leave channel", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-DiscussSidebarChannel span", { text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { text: "General" });
     await click("[title='Leave this channel']");
-    await contains(".o-mail-DiscussSidebarChannel span", { count: 0, text: "General" });
+    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "General" });
 });
 
 QUnit.test("Do no channel_info after unpin", async (assert) => {
@@ -1157,7 +1150,7 @@ QUnit.test("Unpinning channel closes its chat window", async () => {
     await openFormView("discuss.channel");
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-ChatWindow-name", { text: "Sales" });
+    await contains(".o-mail-ChatWindow", { text: "Sales" });
     openDiscuss();
     await click("[title='Leave this channel']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Sales" }],

--- a/addons/mail/static/tests/emoji/emoji_tests.js
+++ b/addons/mail/static/tests/emoji/emoji_tests.js
@@ -97,8 +97,8 @@ QUnit.test("recent category (basic)", async () => {
     await contains(".o-EmojiPicker-navbar [title='Frequently used']");
     await contains(".o-Emoji", {
         text: "😀",
-        after: ["span", { text: "Frequently used" }],
-        before: ["span", { text: "Smileys & Emotion" }],
+        after: ["span", { textContent: "Frequently used" }],
+        before: ["span", { textContent: "Smileys & Emotion" }],
     });
 });
 
@@ -116,13 +116,13 @@ QUnit.test("emoji usage amount orders frequent emojis", async () => {
     await click("button[aria-label='Emojis']");
     await contains(".o-Emoji", {
         text: "👽",
-        after: ["span", { text: "Frequently used" }],
+        after: ["span", { textContent: "Frequently used" }],
         before: [
             ".o-Emoji",
             {
                 text: "😀",
-                after: ["span", { text: "Frequently used" }],
-                before: ["span", { text: "Smileys & Emotion" }],
+                after: ["span", { textContent: "Frequently used" }],
+                before: ["span", { textContent: "Smileys & Emotion" }],
             },
         ],
     });
@@ -138,8 +138,8 @@ QUnit.test("posting :wink: in message should impact recent", async () => {
     await click("button[aria-label='Emojis']");
     await contains(".o-Emoji", {
         text: "😉",
-        after: ["span", { text: "Frequently used" }],
-        before: ["span", { text: "Smileys & Emotion" }],
+        after: ["span", { textContent: "Frequently used" }],
+        before: ["span", { textContent: "Smileys & Emotion" }],
     });
 });
 
@@ -154,8 +154,8 @@ QUnit.test("posting :snowman: in message should impact recent", async () => {
     await click("button[aria-label='Emojis']");
     await contains(".o-Emoji", {
         text: "☃️",
-        after: ["span", { text: "Frequently used" }],
-        before: ["span", { text: "Smileys & Emotion" }],
+        after: ["span", { textContent: "Frequently used" }],
+        before: ["span", { textContent: "Smileys & Emotion" }],
     });
 });
 

--- a/addons/mail/static/tests/message/message_reply_tests.js
+++ b/addons/mail/static/tests/message/message_reply_tests.js
@@ -28,10 +28,7 @@ QUnit.test("click on message in reply to highlight the parent message", async ()
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-MessageInReply-message", {
-        parent: [
-            ".o-mail-Message",
-            { contains: [".o-mail-Message-content", { text: "Reply to Hey" }] },
-        ],
+        parent: [".o-mail-Message", { text: "Reply to Hey" }],
     });
     await contains(".o-mail-Message.o-highlighted .o-mail-Message-content", { text: "Hey lol" });
 });
@@ -65,10 +62,7 @@ QUnit.test("click on message in reply to scroll to the parent message", async ()
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await click(".o-mail-MessageInReply-message", {
-        parent: [
-            ".o-mail-Message",
-            { contains: [".o-mail-Message-content", { text: "Response to first message" }] },
-        ],
+        parent: [".o-mail-Message", { text: "Response to first message" }],
     });
     await contains(":nth-child(1 of .o-mail-Message)", { visible: true });
 });

--- a/addons/mail/static/tests/message/message_seen_indicator_tests.js
+++ b/addons/mail/static/tests/message/message_seen_indicator_tests.js
@@ -344,10 +344,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         await openDiscuss(channelId);
         await contains(".o-mail-Message", {
-            containsMulti: [
-                [".o-mail-Message-content", { text: "Message before last seen" }],
-                [".o-mail-MessageSeenIndicator", { contains: ["i", { count: 0 }] }],
-            ],
+            text: "Message before last seen",
+            contains: [".o-mail-MessageSeenIndicator", { contains: ["i", { count: 0 }] }],
         });
     }
 );

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -304,7 +304,7 @@ QUnit.test("mentions are kept when editing message", async () => {
         replace: true,
     });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-body", {
+    await contains(".o-mail-Message", {
         text: "Hi @Mitchell Admin",
         contains: ["a.o_mail_redirect", { text: "@Mitchell Admin" }],
     });
@@ -340,7 +340,7 @@ QUnit.test("can add new mentions when editing message", async () => {
     await click(".o-mail-Composer-suggestion strong", { text: "TestPartner" });
     await contains(".o-mail-Composer-input", { value: "Hello @TestPartner " });
     await click(".o-mail-Message a", { text: "save" });
-    await contains(".o-mail-Message-body", {
+    await contains(".o-mail-Message", {
         text: "Hello @TestPartner",
         contains: ["a.o_mail_redirect", { text: "@TestPartner" }],
     });
@@ -360,17 +360,10 @@ QUnit.test("Other messages are grayed out when replying to another one", async (
     openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 2 });
     await click("[title='Reply']", {
-        parent: [
-            ".o-mail-Message",
-            { contains: [".o-mail-Message-content", { text: "Hello world" }] },
-        ],
+        parent: [".o-mail-Message", { text: "Hello world" }],
     });
-    await contains(".o-mail-Message.opacity-50 .o-mail-Message-content", {
-        text: "Goodbye world",
-    });
-    await contains(".o-mail-Message:not(.opacity_50) .o-mail-Message-content", {
-        text: "Hello world",
-    });
+    await contains(".o-mail-Message.opacity-50", { text: "Goodbye world" });
+    await contains(".o-mail-Message:not(.opacity_50)", { text: "Hello world" });
 });
 
 QUnit.test("Parent message body is displayed on replies", async () => {
@@ -566,7 +559,10 @@ QUnit.test("Reaction summary", async () => {
         pyEnv["res.partner"].create({ name, user_ids: [Command.link(userId)] });
         await pyEnv.withUser(userId, async () => {
             await click("[title='Add a Reaction']");
-            await click(".o-Emoji", { after: ["span", { text: "Smileys & Emotion" }], text: "😅" });
+            await click(".o-Emoji", {
+                after: ["span", { textContent: "Smileys & Emotion" }],
+                text: "😅",
+            });
             await contains(`.o-mail-MessageReaction[title="${expectedSummaries[idx]}"]`);
         });
     }
@@ -740,29 +736,14 @@ QUnit.test("toggle_star message", async (assert) => {
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo']");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star-o");
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
     await click("[title='Mark as Todo']");
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { text: "1" }],
-        ],
-    });
+    await contains("button", { text: "Starred", contains: [".badge", { text: "1" }] });
     assert.verifySteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star");
     await click("[title='Mark as Todo']");
-    await contains("button", {
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { count: 0 }],
-        ],
-    });
+    await contains("button", { text: "Starred", contains: [".badge", { count: 0 }] });
     assert.verifySteps(["rpc:toggle_message_starred"]);
     await contains(".o-mail-Message");
     await contains(".o-mail-Message [title='Mark as Todo'] i.fa-star-o");
@@ -1124,10 +1105,8 @@ QUnit.test("Toggle star should update starred counter on all tabs", async () => 
     await click(".o-mail-Message [title='Mark as Todo']", { target: tab1.target });
     await contains("button", {
         target: tab2.target,
-        containsMulti: [
-            ["div", { text: "Starred" }],
-            [".badge", { text: "1" }],
-        ],
+        text: "Starred",
+        contains: [".badge", { text: "1" }],
     });
 });
 
@@ -1214,10 +1193,16 @@ QUnit.test("Can remove files of message individually", async () => {
     ]);
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    await contains("[title='Remove']", { target: $(".o-mail-AttachmentCard:eq(0)")[0] });
-    await contains("[title='Remove']", { target: $(".o-mail-AttachmentCard:eq(1)")[0] });
-    await contains("[title='Remove']", { count: 0, target: $(".o-mail-AttachmentCard:eq(2)")[0] });
-    await contains("[title='Remove']", { target: $(".o-mail-AttachmentCard:eq(3)")[0] });
+    await contains(
+        ":nth-child(1 of .o-mail-Message) :nth-child(1 of .o-mail-AttachmentCard) [title='Remove']"
+    );
+    await contains(
+        ":nth-child(1 of .o-mail-Message) :nth-child(2 of .o-mail-AttachmentCard) [title='Remove']"
+    );
+    await contains(":nth-child(2 of .o-mail-Message) .o-mail-AttachmentCard [title='Remove']", {
+        count: 0,
+    });
+    await contains(":nth-child(3 of .o-mail-Message) .o-mail-AttachmentCard [title='Remove']");
 });
 
 QUnit.test(
@@ -1269,9 +1254,7 @@ QUnit.test("avatar card from author should be opened after clicking on their nam
     });
     const { openFormView } = await start();
     await openFormView("res.partner", partnerId);
-    await contains(".o-mail-Message span", { text: "Demo" });
-
-    await click(".o-mail-Message span", { text: "Demo" });
+    await click(".o-mail-Message-author", { text: "Demo" });
     await contains(".o_avatar_card");
     await contains(".o_card_user_infos > span", { text: "Demo" });
     await contains(".o_card_user_infos > a", { text: "demo@example.com" });
@@ -1345,8 +1328,8 @@ QUnit.test("Chat with partner should be opened after clicking on their mention",
     await contains(".o-mail-Composer-input", { value: "@Test Partner " });
     await click(".o-mail-Composer-send:enabled");
     await click(".o_mail_redirect");
-    await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-name", { text: "Test Partner" });
+    await contains(".o-mail-ChatWindow .o-mail-Thread");
+    await contains(".o-mail-ChatWindow", { text: "Test Partner" });
 });
 
 QUnit.test("Channel should be opened after clicking on its mention", async () => {
@@ -1360,8 +1343,8 @@ QUnit.test("Channel should be opened after clicking on its mention", async () =>
     await click(".o-mail-Composer-suggestion strong", { text: "#my-channel" });
     await click(".o-mail-Composer-send:enabled");
     await click(".o_channel_redirect");
-    await contains(".o-mail-ChatWindow-content");
-    await contains(".o-mail-ChatWindow-name", { text: "my-channel" });
+    await contains(".o-mail-ChatWindow .o-mail-Thread");
+    await contains(".o-mail-ChatWindow", { text: "my-channel" });
 });
 
 QUnit.test(
@@ -1427,7 +1410,6 @@ QUnit.test("message with subtype should be displayed (and not considered as empt
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message");
     await contains(".o-mail-Message-content", { text: "Task created" });
 });
 
@@ -1477,7 +1459,7 @@ QUnit.test("message considered empty", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Thread-empty");
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
     await contains(".o-mail-Message", { count: 0 });
 });
 
@@ -1606,7 +1588,7 @@ QUnit.test("Message should display attachments in order", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(":nth-child(1 of .o-mail-AttachmentCard) div", { text: "A.txt" });
-    await contains(":nth-child(2 of .o-mail-AttachmentCard) div", { text: "B.txt" });
-    await contains(":nth-child(3 of .o-mail-AttachmentCard) div", { text: "C.txt" });
+    await contains(":nth-child(1 of .o-mail-AttachmentCard)", { text: "A.txt" });
+    await contains(":nth-child(2 of .o-mail-AttachmentCard)", { text: "B.txt" });
+    await contains(":nth-child(3 of .o-mail-AttachmentCard)", { text: "C.txt" });
 });

--- a/addons/mail/static/tests/messaging/messaging_tests.js
+++ b/addons/mail/static/tests/messaging/messaging_tests.js
@@ -29,7 +29,7 @@ QUnit.test("Receiving a new message out of discuss app should open a chat window
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-ChatWindow-name", { text: "Dumbledore" });
+    await contains(".o-mail-ChatWindow", { text: "Dumbledore" });
 });
 
 QUnit.test(
@@ -57,7 +57,7 @@ QUnit.test(
         );
         // leaving discuss.
         await openFormView("res.partner", partnerId);
-        await contains(".o-mail-ChatWindow-name", { text: "Dumbledore" });
+        await contains(".o-mail-ChatWindow", { text: "Dumbledore" });
     }
 );
 
@@ -80,6 +80,6 @@ QUnit.test(
         // leaving discuss.
         await openFormView("res.partner", partnerId);
         // weak test, no guarantee that we waited long enough for the potential chat window to open
-        await contains(".o-mail-ChatWindow-name", { count: 0, text: "Dumbledore" });
+        await contains(".o-mail-ChatWindow", { count: 0, text: "Dumbledore" });
     }
 );

--- a/addons/mail/static/tests/messaging_menu/messaging_menu_tests.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu_tests.js
@@ -69,7 +69,7 @@ QUnit.test("rendering with OdooBot has a request (default)", async (assert) => {
             .data("src")
             .includes("/web/image?field=avatar_128&id=2&model=res.partner")
     );
-    await contains(".o-mail-NotificationItem-name", { text: "OdooBot has a request" });
+    await contains(".o-mail-NotificationItem", { text: "OdooBot has a request" });
 });
 
 QUnit.test("rendering without OdooBot has a request (denied)", async () => {
@@ -93,7 +93,7 @@ QUnit.test("respond to notification prompt (denied)", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o_notification.border-warning .o_notification_body", {
+    await contains(".o_notification.border-warning", {
         text: "Odoo will not send notifications on this device.",
     });
     await contains(".o-mail-MessagingMenu-counter", { count: 0 });
@@ -106,7 +106,7 @@ QUnit.test("respond to notification prompt (granted)", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o_notification.border-success .o_notification_body", {
+    await contains(".o_notification.border-success", {
         text: "Odoo will send notifications on this device!",
     });
 });
@@ -180,10 +180,8 @@ QUnit.test("grouped notifications by document", async () => {
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-ChatWindow", { count: 0 });
     await click(".o-mail-NotificationItem", {
-        containsMulti: [
-            [".o-mail-NotificationItem-name", { text: "Partner" }],
-            [".badge", { text: "2" }],
-        ],
+        text: "Partner",
+        contains: [".badge", { text: "2" }],
     });
     await contains(".o-mail-ChatWindow");
 });
@@ -241,10 +239,8 @@ QUnit.test("grouped notifications by document model", async (assert) => {
     });
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", {
-        containsMulti: [
-            [".o-mail-NotificationItem-name", { text: "Partner" }],
-            [".badge", { text: "2" }],
-        ],
+        text: "Partner",
+        contains: [".badge", { text: "2" }],
     });
     assert.verifySteps(["do_action"]);
 });
@@ -292,12 +288,8 @@ QUnit.test(
         await start();
         await click(".o_menu_systray i[aria-label='Messages']");
         await contains(".o-mail-NotificationItem", { count: 2 });
-        await contains(":nth-child(1 of .o-mail-NotificationItem) .o-mail-NotificationItem-name", {
-            text: "Company",
-        });
-        await contains(":nth-child(2 of .o-mail-NotificationItem) .o-mail-NotificationItem-name", {
-            text: "Partner",
-        });
+        await contains(":nth-child(1 of .o-mail-NotificationItem)", { text: "Company" });
+        await contains(":nth-child(2 of .o-mail-NotificationItem)", { text: "Partner" });
     }
 );
 
@@ -380,13 +372,10 @@ QUnit.test("mark failure as read", async () => {
         ],
     });
     await click("[title='Mark As Read']", {
-        parent: [
-            ".o-mail-NotificationItem",
-            { contains: [".o-mail-NotificationItem-name", { text: "Channel" }] },
-        ],
+        parent: [".o-mail-NotificationItem", { text: "Channel" }],
     });
-    await contains(".o-mail-NotificationItem-name", { count: 0, text: "Channel" });
-    await contains("o-mail-NotificationItem-text", {
+    await contains(".o-mail-NotificationItem", { count: 0, text: "Channel" });
+    await contains("o-mail-NotificationItem", {
         count: 0,
         text: "An error occurred when sending an email",
     });
@@ -437,9 +426,7 @@ QUnit.test("different discuss.channel are not grouped", async () => {
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { count: 4 });
-    await click(":nth-child(1 of .o-mail-NotificationItem)", {
-        contains: [".o-mail-NotificationItem-name", { text: "Channel" }],
-    });
+    await click(":nth-child(1 of .o-mail-NotificationItem)", { text: "Channel" });
     await contains(".o-mail-ChatWindow");
 });
 
@@ -624,17 +611,17 @@ QUnit.test("filtered previews", async () => {
     await start();
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await contains(".o-mail-NotificationItem", { count: 2 });
-    await contains(".o-mail-NotificationItem-name", { text: "Mitchell Admin" });
-    await contains(".o-mail-NotificationItem-name", { text: "channel1" });
+    await contains(".o-mail-NotificationItem", { text: "Mitchell Admin" });
+    await contains(".o-mail-NotificationItem", { text: "channel1" });
     await click(".o-mail-MessagingMenu button", { text: "Chats" });
-    await contains(".o-mail-NotificationItem-name", { text: "Mitchell Admin" });
+    await contains(".o-mail-NotificationItem", { text: "Mitchell Admin" });
     await click(".o-mail-MessagingMenu button", { text: "Channels" });
-    await contains(".o-mail-NotificationItem-name", { text: "channel1" });
+    await contains(".o-mail-NotificationItem", { text: "channel1" });
     await click(".o-mail-MessagingMenu button", { text: "All" });
     await contains(".o-mail-NotificationItem", { count: 2 });
-    await contains(".o-mail-NotificationItem-name", { text: "Mitchell Admin" });
+    await contains(".o-mail-NotificationItem", { text: "Mitchell Admin" });
     await click(".o-mail-MessagingMenu button", { text: "Channels" });
-    await contains(".o-mail-NotificationItem-name", { text: "channel1" });
+    await contains(".o-mail-NotificationItem", { text: "channel1" });
 });
 
 QUnit.test("no code injection in message body preview", async () => {
@@ -700,8 +687,8 @@ QUnit.test("Messaging menu notification body of chat should show author name onc
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", { text: "Demo User" });
-    await contains(".o-mail-NotificationItem-text", { text: "Hey!" });
+    await contains(".o-mail-NotificationItem", { text: "Demo User" });
+    await contains(".o-mail-NotificationItem-text", { textContent: "Hey!" });
 });
 
 QUnit.test(
@@ -735,12 +722,12 @@ QUnit.test("click on preview should mark as read and open the thread", async () 
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
+    await contains(".o-mail-NotificationItem", { text: "Frodo Baggins" });
     await contains(".o-mail-ChatWindow", { count: 0 });
-    await click(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
+    await click(".o-mail-NotificationItem", { text: "Frodo Baggins" });
     await contains(".o-mail-ChatWindow");
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", { count: 0, text: "Frodo Baggins" });
+    await contains(".o-mail-NotificationItem", { count: 0, text: "Frodo Baggins" });
 });
 
 QUnit.test(
@@ -771,7 +758,7 @@ QUnit.test(
             },
         });
         await click(".o_menu_systray i[aria-label='Messages']");
-        await click(".o-mail-NotificationItem-name", { text: "Frodo Baggins" });
+        await click(".o-mail-NotificationItem", { text: "Frodo Baggins" });
         await click(".o-mail-ChatWindow-command i.fa-expand");
         await contains(".o-mail-ChatWindow", { count: 0 });
         assert.verifySteps(["do_action"], "should have done an action to open the form view");
@@ -863,9 +850,8 @@ QUnit.test("chat should show unread counter on receiving new messages", async ()
         ],
     });
     await start();
-    click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem");
-    await contains(".o-mail-NotificationItem-name", { text: "Partner1" });
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem", { text: "Partner1" });
     await contains(".o-mail-NotificationItem .badge", { count: 0, text: "1" });
 
     // simulate receiving a new message

--- a/addons/mail/static/tests/messaging_menu/notification_tests.js
+++ b/addons/mail/static/tests/messaging_menu/notification_tests.js
@@ -64,18 +64,11 @@ QUnit.test("mark as read", async () => {
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], {
-        contains: [".o-mail-NotificationItem-name", { text: "Channel" }],
-    });
+    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"], { text: "Channel" });
     await click(".o-mail-NotificationItem-markAsRead", {
-        parent: [
-            ".o-mail-NotificationItem",
-            {
-                contains: [".o-mail-NotificationItem-name", { text: "Channel" }],
-            },
-        ],
+        parent: [".o-mail-NotificationItem", { text: "Channel" }],
     });
-    await contains(".o-mail-NotificationItem-name", { count: 0, text: "Channel" });
+    await contains(".o-mail-NotificationItem", { count: 0, text: "Channel" });
 });
 
 QUnit.test("open non-channel failure", async (assert) => {
@@ -267,13 +260,9 @@ QUnit.test("marked as read thread notifications are ordered by last message date
     ]);
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", { count: 2 });
-    await contains(":nth-child(1 of .o-mail-NotificationItem) .o-mail-NotificationItem-name", {
-        text: "Channel 2020",
-    });
-    await contains(":nth-child(2 of .o-mail-NotificationItem) .o-mail-NotificationItem-name", {
-        text: "Channel 2019",
-    });
+    await contains(".o-mail-NotificationItem", { count: 2 });
+    await contains(":nth-child(1 of .o-mail-NotificationItem)", { text: "Channel 2020" });
+    await contains(":nth-child(2 of .o-mail-NotificationItem)", { text: "Channel 2019" });
 });
 
 QUnit.test("thread notifications are re-ordered on receiving a new message", async () => {
@@ -311,12 +300,8 @@ QUnit.test("thread notifications are re-ordered on receiving a new message", asy
             res_id: channelId_1,
         },
     });
-    await contains(":nth-child(1 of .o-mail-NotificationItem) .o-mail-NotificationItem-name", {
-        text: "Channel 2019",
-    });
-    await contains(":nth-child(2 of .o-mail-NotificationItem) .o-mail-NotificationItem-name", {
-        text: "Channel 2020",
-    });
+    await contains(":nth-child(1 of .o-mail-NotificationItem)", { text: "Channel 2019" });
+    await contains(":nth-child(2 of .o-mail-NotificationItem)", { text: "Channel 2020" });
     await contains(".o-mail-NotificationItem", { count: 2 });
 });
 

--- a/addons/mail/static/tests/thread/attachment_list_tests.js
+++ b/addons/mail/static/tests/thread/attachment_list_tests.js
@@ -57,7 +57,7 @@ QUnit.test("layout with card details and filename and extension", async () => {
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-AttachmentCard div", { text: "test.txt" });
+    await contains(".o-mail-AttachmentCard", { text: "test.txt" });
     await contains(".o-mail-AttachmentCard small", { text: "txt" });
 });
 
@@ -313,8 +313,8 @@ QUnit.test(
         const { openDiscuss } = await start();
         openDiscuss(channelId);
         await contains(".o-mail-AttachmentImage[title='test.png'] img.o-viewable");
-        await contains(".o-mail-AttachmentCard:not(.o-viewable) div", { text: "test.odt" });
-        await click(".o-mail-AttachmentCard", { contains: ["div", { text: "test.odt" }] });
+        await contains(".o-mail-AttachmentCard:not(.o-viewable)", { text: "test.odt" });
+        await click(".o-mail-AttachmentCard", { text: "test.odt" });
         // weak test, no guarantee that we waited long enough for the potential file viewer to show
         await contains(".o-FileViewer", { count: 0 });
         await click(".o-mail-AttachmentImage[title='test.png']");

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -77,9 +77,7 @@ QUnit.test("show message subject when subject is not the same as the thread name
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message .o-mail-Message-content", {
-        text: "Subject: Salutations, voyageurnot empty",
-    });
+    await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
 });
 
 QUnit.test("do not show message subject when subject is the same as the thread name", async () => {
@@ -97,10 +95,8 @@ QUnit.test("do not show message subject when subject is the same as the thread n
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Message .o-mail-Message-content", {
-        text: "not empty",
-    });
-    await contains(".o-mail-Message .o-mail-Message-content", {
+    await contains(".o-mail-Message", { text: "not empty" });
+    await contains(".o-mail-Message", {
         count: 0,
         text: "Subject: Salutations, voyageurnot empty",
     });
@@ -152,7 +148,7 @@ QUnit.test("do not display day separator if all messages of the day are empty", 
     });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Thread-empty");
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
     await contains(".o-mail-DateSection", { count: 0 });
 });
 
@@ -178,15 +174,15 @@ QUnit.test("scroll position is kept when navigating from one channel to another"
     const scrollValue1 = $(".o-mail-Thread")[0].scrollHeight / 2;
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", scrollValue1);
-    await click(".o-mail-DiscussSidebarChannel span", { text: "channel-2" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "channel-2" });
     await contains(".o-mail-Message", { count: 30 });
     const scrollValue2 = $(".o-mail-Thread")[0].scrollHeight / 3;
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await scroll(".o-mail-Thread", scrollValue2);
-    await click(".o-mail-DiscussSidebarChannel span", { text: "channel-1" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "channel-1" });
     await contains(".o-mail-Message", { count: 20 });
     await contains(".o-mail-Thread", { scroll: scrollValue1 });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "channel-2" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "channel-2" });
     await contains(".o-mail-Message", { count: 30 });
     await contains(".o-mail-Thread", { scroll: scrollValue2 });
 });
@@ -407,9 +403,7 @@ QUnit.test("show empty placeholder when thread contains no message", async () =>
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Thread .o-mail-Thread-empty", {
-        text: "There are no messages in this conversation.",
-    });
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
     await contains(".o-mail-Message", { count: 0 });
 });
 
@@ -419,9 +413,7 @@ QUnit.test("show empty placeholder when thread contains only empty messages", as
     pyEnv["mail.message"].create({ model: "discuss.channel", res_id: channelId });
     const { openDiscuss } = await start();
     openDiscuss(channelId);
-    await contains(".o-mail-Thread .o-mail-Thread-empty", {
-        text: "There are no messages in this conversation.",
-    });
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
     await contains(".o-mail-Message", { count: 0 });
 });
 
@@ -523,9 +515,7 @@ QUnit.test("new messages separator on receiving new message [REQUIRE FOCUS]", as
     );
     await contains(".o-mail-Message", { count: 2 });
     await contains(".o-mail-Thread-newMessage hr + span", { text: "New messages" });
-    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message .o-mail-Message-content", {
-        text: "hu",
-    });
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", { text: "hu" });
     await focus(".o-mail-Composer-input");
     await nextTick();
     await contains(".o-mail-Thread-newMessage hr + span", { count: 0, text: "New messages" });
@@ -817,7 +807,7 @@ QUnit.test("chat window header should not have unread counter for non-channel th
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await click(".o-mail-NotificationItem-name");
+    await click(".o-mail-NotificationItem");
     await contains(".o-mail-ChatWindow-counter", { count: 0, text: "1" });
 });
 
@@ -915,7 +905,7 @@ QUnit.test(
         openDiscuss(channelId);
         await contains(".o-mail-Composer-input");
         await triggerEvents(".o-mail-Composer-input", ["blur", "focusout"]);
-        await click("button div", { text: "Inbox" });
+        await click("button", { text: "Inbox" });
         await contains("h4", { text: "Congratulations, your inbox is empty" });
         const messageId = pyEnv["mail.message"].create({
             author_id: partnerId,
@@ -936,20 +926,10 @@ QUnit.test(
             [messageId],
         ]);
         pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "mail.message/inbox", formattedMessage);
-        await contains("button", {
-            containsMulti: [
-                ["div", { text: "Inbox" }],
-                [".badge", { text: "1" }],
-            ],
-        });
-        await click("button span", { text: "General" });
+        await contains("button", { text: "Inbox", contains: [".badge", { text: "1" }] });
+        await click("button", { text: "General" });
         await contains(".o-discuss-badge", { count: 0 });
-        await contains("button", {
-            containsMulti: [
-                ["div", { text: "Inbox" }],
-                [".badge", { count: 0 }],
-            ],
-        });
+        await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });
         assert.verifySteps(["mark-all-messages-as-read"]);
     }
 );
@@ -967,7 +947,7 @@ QUnit.test(
             },
         });
         openDiscuss(channelId);
-        await click("button div", { text: "Inbox" });
+        await click("button", { text: "Inbox" });
         await env.services.rpc("/mail/message/post", {
             post_data: {
                 body: "Hello world!",
@@ -1008,7 +988,7 @@ QUnit.test("can be marked as read while loading", async function () {
     });
     openDiscuss(undefined);
     await contains(".o-discuss-badge", { text: "1" });
-    await click(".o-mail-DiscussSidebarChannel span", { text: "Demo" });
+    await click(".o-mail-DiscussSidebarChannel", { text: "Demo" });
     loadDeferred.resolve();
     await contains(".o-discuss-badge", { count: 0 });
 });
@@ -1046,8 +1026,6 @@ QUnit.test("Transient messages are added at the end of the thread", async () => 
     await insertText(".o-mail-Composer-input", "/help");
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message", { count: 2 });
-    await contains(":nth-child(1 of .o-mail-Message) .o-mail-Message-author", {
-        text: "Mitchell Admin",
-    });
-    await contains(":nth-child(2 of .o-mail-Message) .o-mail-Message-author", { text: "OdooBot" });
+    await contains(":nth-child(1 of .o-mail-Message)", { text: "Mitchell Admin" });
+    await contains(":nth-child(2 of .o-mail-Message)", { text: "OdooBot" });
 });

--- a/addons/mail/static/tests/tours/dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/dynamic_placeholder_tour.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { registry } from "@web/core/registry";
+import { contains } from "@web/../tests/utils";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("dynamic_placeholder_tour", {
@@ -23,34 +24,17 @@ registry.category("web_tour.tours").add("dynamic_placeholder_tour", {
         {
             content: 'Insert # inside "Subject" input',
             trigger: 'div[name="subject"] input[type="text"]',
-            run(actions) {
+            async run(actions) {
                 actions.text(`no_model_id #`, this.$anchor);
                 this.$anchor[0].dispatchEvent(
                     new KeyboardEvent("keydown", { bubbles: true, key: "#" })
                 );
-            },
-        },
-        {
-            content: "Check subject kept the # char And an error notification appear",
-            trigger: 'div[name="subject"] input[type="text"]',
-            run() {
-                const subjectValue = this.$anchor[0].value;
-                if (subjectValue !== "no_model_id #") {
-                    console.error(
-                        `Email template should have "#" in subject input (actual: ${subjectValue})`
-                    );
-                }
-
-                const notification = document.querySelector(
-                    "div.o_notification_manager .o_notification .o_notification_content"
-                );
-                if (
-                    !notification ||
-                    notification.textContent !==
-                        "You need to select a model before opening the dynamic placeholder selector."
-                ) {
-                    console.error(`Email template did not show correct notification.`);
-                }
+                await contains("div[name='subject'] input[type='text']", {
+                    value: "no_model_id #",
+                });
+                await contains(".o_notification", {
+                    text: "You need to select a model before opening the dynamic placeholder selector.",
+                });
             },
         },
         {

--- a/addons/mail/static/tests/web/attachment_box_tests.js
+++ b/addons/mail/static/tests/web/attachment_box_tests.js
@@ -117,15 +117,15 @@ QUnit.test("view attachments", async () => {
     });
     await click('.o-mail-AttachmentCard[aria-label="Blah.txt"] .o-mail-AttachmentCard-image');
     await contains(".o-FileViewer");
-    await contains(".o-FileViewer-header span", { text: "Blah.txt" });
+    await contains(".o-FileViewer-header", { text: "Blah.txt" });
     await contains(".o-FileViewer div[aria-label='Next']");
 
     await click(".o-FileViewer div[aria-label='Next']");
-    await contains(".o-FileViewer-header span", { text: "Blu.txt" });
+    await contains(".o-FileViewer-header", { text: "Blu.txt" });
     await contains(".o-FileViewer div[aria-label='Next']");
 
     await click(".o-FileViewer div[aria-label='Next']");
-    await contains(".o-FileViewer-header span", { text: "Blah.txt" });
+    await contains(".o-FileViewer-header", { text: "Blah.txt" });
 });
 
 QUnit.test("scroll to attachment box when toggling on", async () => {
@@ -208,9 +208,9 @@ QUnit.test("attachment box should order attachments from newest to oldest", asyn
     });
     await contains(".o-mail-Chatter [aria-label='Attach files']", { text: "3" });
     await click(".o-mail-Chatter [aria-label='Attach files']"); // open attachment box
-    await contains(":nth-child(1 of .o-mail-AttachmentCard) div", { text: "C.txt" });
-    await contains(":nth-child(2 of .o-mail-AttachmentCard) div", { text: "B.txt" });
-    await contains(":nth-child(3 of .o-mail-AttachmentCard) div", { text: "A.txt" });
+    await contains(":nth-child(1 of .o-mail-AttachmentCard)", { text: "C.txt" });
+    await contains(":nth-child(2 of .o-mail-AttachmentCard)", { text: "B.txt" });
+    await contains(":nth-child(3 of .o-mail-AttachmentCard)", { text: "A.txt" });
 });
 
 QUnit.test("attachment box auto-closed on switch to record wih no attachments", async () => {

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -241,9 +241,7 @@ QUnit.test("should display subject when subject isn't infered from the record", 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message-content", {
-        text: "Subject: Salutations, voyageurnot empty",
-    });
+    await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
 });
 
 QUnit.test("should not display user notification messages in chatter", async () => {
@@ -260,7 +258,7 @@ QUnit.test("should not display user notification messages in chatter", async () 
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Thread-empty");
+    await contains(".o-mail-Thread", { text: "There are no messages in this conversation." });
     await contains(".o-mail-Message", { count: 0 });
 });
 
@@ -446,10 +444,8 @@ QUnit.test("should not display subject when subject is the same as the thread na
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains(".o-mail-Message .o-mail-Message-content", {
-        text: "not empty",
-    });
-    await contains(".o-mail-Message .o-mail-Message-content", {
+    await contains(".o-mail-Message", { text: "not empty" });
+    await contains(".o-mail-Message", {
         count: 0,
         text: "Subject: Salutations, voyageurnot empty",
     });
@@ -581,9 +577,7 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message .o-mail-Message-content", {
-            text: "Subject: Another Subjectnot empty",
-        });
+        await contains(".o-mail-Message", { text: "Subject: Another Subjectnot empty" });
     }
 );
 
@@ -600,10 +594,8 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message .o-mail-Message-content", {
-            text: "not empty",
-        });
-        await contains(".o-mail-Message .o-mail-Message-content", {
+        await contains(".o-mail-Message", { text: "not empty" });
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Custom Default Subjectnot empty",
         });
@@ -623,10 +615,8 @@ QUnit.test(
         });
         const { openFormView } = await start();
         openFormView("res.fake", fakeId);
-        await contains(".o-mail-Message .o-mail-Message-content", {
-            text: "not empty",
-        });
-        await contains(".o-mail-Message .o-mail-Message-content", {
+        await contains(".o-mail-Message", { text: "not empty" });
+        await contains(".o-mail-Message", {
             count: 0,
             text: "Subject: Custom Default Subjectnot empty",
         });

--- a/addons/mail/static/tests/web/follow_button_tests.js
+++ b/addons/mail/static/tests/web/follow_button_tests.js
@@ -47,10 +47,10 @@ QUnit.test('click on "follow" button', async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
-    await contains("button span", { text: "Follow" });
+    await contains("button", { text: "Follow" });
 
-    await click("button span", { text: "Follow" });
-    await contains("button span", { text: "Following" });
+    await click("button", { text: "Follow" });
+    await contains("button", { text: "Following" });
 });
 
 QUnit.test('Click on "follow" button should save draft record', async () => {
@@ -67,9 +67,9 @@ QUnit.test('Click on "follow" button should save draft record', async () => {
     };
     const { openFormView } = await start({ serverData: { views } });
     openFormView("res.partner");
-    await contains("button span", { text: "Follow" });
+    await contains("button", { text: "Follow" });
     await contains("div.o_field_char");
-    await click("button span", { text: "Follow" });
+    await click("button", { text: "Follow" });
     await contains("div.o_field_invalid");
 });
 
@@ -89,5 +89,5 @@ QUnit.test('click on "unfollow" button', async () => {
         views: [[false, "form"]],
     });
     await click(".fa-check + span", { text: "Following" });
-    await contains("button span", { text: "Follow" });
+    await contains("button", { text: "Follow" });
 });

--- a/addons/mail/static/tests/web/follower_list_menu_tests.js
+++ b/addons/mail/static/tests/web/follower_list_menu_tests.js
@@ -232,7 +232,7 @@ QUnit.test("Load 100 followers at once", async () => {
     await click("button[title='Show Followers']");
     await contains(".o-mail-Follower", { text: "Mitchell Admin" });
     await contains(".o-mail-Follower", { count: 100 });
-    await contains(".o-mail-Followers-dropdown span", { text: "Load more" });
+    await contains(".o-mail-Followers-dropdown", { text: "Load more" });
     await scroll(".o-mail-Followers-dropdown", "bottom");
     await contains(".o-mail-Follower", { count: 200 });
     await new Promise(setTimeout); // give enough time for the useVisible hook to register load more as hidden
@@ -264,13 +264,13 @@ QUnit.test("Load 100 recipients at once", async () => {
     await openFormView("res.partner", partnerIds[0]);
     await contains("button[title='Show Followers']", { text: "210" });
     await click("button", { text: "Send message" });
-    await contains(".o-mail-Chatter div", {
+    await contains(".o-mail-Chatter", {
         text: "To: partner1, partner2, partner3, partner4, partner5, …",
     });
     await contains("button[title='Show all recipients']");
     await click("button[title='Show all recipients']");
     await contains(".o-mail-RecipientList li", { count: 100 });
-    await contains(".o-mail-RecipientList span", { text: "Load more" });
+    await contains(".o-mail-RecipientList", { text: "Load more" });
     await scroll(".o-mail-RecipientList", "bottom");
     await contains(".o-mail-RecipientList li", { count: 200 });
     await new Promise(setTimeout); // give enough time for the useVisible hook to register load more as hidden

--- a/addons/project_todo/static/tests/activity_menu_tests.js
+++ b/addons/project_todo/static/tests/activity_menu_tests.js
@@ -25,7 +25,7 @@ QUnit.test("create todo from activity menu without date", async function () {
     // Need to reopen systray as it automatically closes when a todo is created
     await click(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu-counter", { text: "1" });
-    await contains(".o-mail-ActivityGroup span", { text: "project.task" });
+    await contains(".o-mail-ActivityGroup", { text: "project.task" });
     await contains(".btn", { text: "1 Today" });
     await contains(".btn", { text: "Add a To-do" });
     await contains(".o-mail-ActivityMenu-show", { count: 0 });
@@ -72,6 +72,6 @@ QUnit.test("create to-do from activity menu with date", async function () {
     // Need to reopen systray as it automatically closes when a todo is created
     await click(".o_menu_systray i[aria-label='Activities']");
     await contains(".o-mail-ActivityMenu-counter", { text: "1" });
-    await contains(".o-mail-ActivityGroup span", { text: "project.task" });
+    await contains(".o-mail-ActivityGroup", { text: "project.task" });
     await contains(".btn", { text: "1 Future" });
 });

--- a/addons/sms/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/sms/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -139,10 +139,8 @@ QUnit.test("grouped notifications by document model", async (assert) => {
 
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", {
-        containsMulti: [
-            [".o-mail-NotificationItem-name", { text: "Partner" }],
-            [".badge", { text: "2" }],
-        ],
+        text: "Partner",
+        contains: [".badge", { text: "2" }],
     });
     assert.verifySteps(["do_action"]);
 });

--- a/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
+++ b/addons/snailmail/static/tests/messaging_menu/messaging_menu_patch_tests.js
@@ -149,7 +149,7 @@ QUnit.test("grouped notifications by document model", async (assert) => {
         },
     });
     await click(".o_menu_systray i[aria-label='Messages']");
-    await contains(".o-mail-NotificationItem-name", { text: "Partner" });
+    await contains(".o-mail-NotificationItem", { text: "Partner" });
     await contains(".o-mail-NotificationItem-counter", { text: "2" });
     await click(".o-mail-NotificationItem");
     assert.verifySteps(["do_action"]);

--- a/addons/test_mail/static/tests/properties_field_tests.js
+++ b/addons/test_mail/static/tests/properties_field_tests.js
@@ -66,7 +66,7 @@ async function testPropertyFieldAvatarOpenChat(assert, propertyType) {
         propertyType === "many2one" ? ".o_field_property_many2one_value img" : ".o_m2m_avatar"
     );
     assert.verifySteps(["read res.users"]);
-    await contains(".o-mail-ChatWindow-name", { text: "Partner Test" });
+    await contains(".o-mail-ChatWindow", { text: "Partner Test" });
 }
 
 QUnit.test("Properties fields: many2one avatar open chat on click", async function (assert) {

--- a/addons/test_mail/static/tests/systray_activity_menu_tests.js
+++ b/addons/test_mail/static/tests/systray_activity_menu_tests.js
@@ -111,7 +111,7 @@ QUnit.test("activity menu widget: activity menu with 2 models", async (assert) =
         search_default_activities_today: 1,
     };
     await click(".o_menu_systray i[aria-label='Activities']");
-    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup span", { text: "mail.test.activity" });
+    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup", { text: "mail.test.activity" });
     await contains(".o-mail-ActivityMenu", { count: 0 });
 });
 

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -170,34 +170,40 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !addons/bus/
 !addons/bus/**/*
 
-# Whitelist mail
-!addons/mail/
-!addons/mail/**/*
-!addons/sms/
-!addons/sms/**/*
-!addons/snailmail/
-!addons/snailmail/**/*
-!addons/test_discuss_full/
-!addons/test_discuss_full/**/*
-!addons/test_discuss_full_enterprise/
-!addons/test_discuss_full_enterprise/**/*
-!addons/test_mail/
-!addons/test_mail/**/*
-
-# Whitelist im_livechat
-!addons/im_livechat/
+# Whitelist mail & dependents (with a lot of JS overrides)
+!addons/calendar
+!addons/calendar/**/*
+!addons/hr
+!addons/hr/**/*
+!addons/hr_holidays
+!addons/hr_holidays/**/*
+!addons/im_livechat
 !addons/im_livechat/**/*
-
-# Whitelist im_livechat
-!addons/website_livechat/
+!addons/mail
+!addons/mail/**/*
+!addons/sms
+!addons/sms/**/*
+!addons/snailmail
+!addons/snailmail/**/*
+!addons/test_discuss_full
+!addons/test_discuss_full/**/*
+!addons/test_mail
+!addons/test_mail/**/*
+!addons/website_livechat
 !addons/website_livechat/**/*
-
-# Whitelist whatsapp
+!approvals
+!approvals/**/*
+!documents
+!documents/**/*
+!mail_enterprise
+!mail_enterprise/**/*
+!test_discuss_full_enterprise
+!test_discuss_full_enterprise/**/*
 !whatsapp
 !whatsapp/**/*
 
 # Whitelist point_of_sale
-!addons/point_of_sale/
+!addons/point_of_sale
 !addons/point_of_sale/**/*
 
 # Whitelist community pos modules

--- a/addons/website_livechat/static/tests/messaging_service_patch_tests.js
+++ b/addons/website_livechat/static/tests/messaging_service_patch_tests.js
@@ -31,6 +31,6 @@ QUnit.test("Should open chat window on send chat request to website visitor", as
         method: "action_send_chat_request",
         model: "website.visitor",
     });
-    await contains(".o-mail-ChatWindow-name", { text: `Visitor #${visitorId}` });
+    await contains(".o-mail-ChatWindow", { text: `Visitor #${visitorId}` });
     await contains(".o-mail-ChatWindow .o-mail-Composer-input:focus");
 });


### PR DESCRIPTION
\* = bus, calendar, im_livechat, hr, project_todo, sms, snailmail, test_mail, web, website_livechat

The current implementation often led to tests relying on DOM structure to properly target the correct element with the text.

It is now easier to simply check if a parent contains some text.

https://github.com/odoo/enterprise/pull/47770