### PR TITLE
[FIX] hr_holidays: fix the confirm button visibility

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -70,7 +70,7 @@
                 <field name="can_approve" invisible="1"/>
                 <field name="holiday_type" invisible="1" readonly="state not in ['confirm', 'draft']"/>
                 <header>
-                    <button string="Confirm" name="action_confirm" invisible="state != 'draft' and 'allocation_type' != 'accrual' and not employee_id" type="object" class="oe_highlight"/>
+                    <button string="Confirm" name="action_confirm" invisible="state != 'draft' or 'allocation_type' != 'accrual' and not employee_id" type="object" class="oe_highlight"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirm,validate"/>
                 </header>
                 <sheet>


### PR DESCRIPTION
Current behaviour before PR:
In the time off module,go to approvals form view the confirm button is visible for all the stages instead of being visible  only for 'To Submit' stage

fix:
modifying the current condition according to the flow

task-3517898
