### PR TITLE
[FIX] base: use non-breaking spaces for thousand separators

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -236,7 +236,7 @@ class IrHttp(models.AbstractModel):
                 "time_format": langs.time_format,
                 "grouping": langs.grouping,
                 "decimal_point": langs.decimal_point,
-                "thousands_sep": langs.thousands_sep,
+                "thousands_sep": langs.thousands_sep.replace(' ', '\xa0'),
                 "week_start": langs.week_start,
             }
             lang_params['week_start'] = int(lang_params['week_start'])


### PR DESCRIPTION
Avoid line breaks in monetary amounts on small screens or in crowded views.

opw-3482329