### PR TITLE
[IMP] point_of_sale: custom combo choices order

### DIFF
--- a/addons/point_of_sale/models/pos_combo.py
+++ b/addons/point_of_sale/models/pos_combo.py
@@ -18,10 +18,11 @@ class PosCombo(models.Model):
     """
     _name = "pos.combo"
     _description = "Product combo choices"
-
+    _order = "sequence, id"
     name = fields.Char(string="Name", required=True)
     combo_line_ids = fields.One2many("pos.combo.line", "combo_id", string="Products in Combo")
     num_of_products = fields.Integer("No of Products", compute="_compute_num_of_products")
+    sequence = fields.Integer(copy=False)
 
     @api.depends("combo_line_ids")
     def _compute_num_of_products(self):

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -75,6 +75,7 @@
                 <page name="combos" string="Combo Choices" groups="point_of_sale.group_pos_user" invisible="not detailed_type == 'combo'">
                     <field name="combo_ids" widget="one2many" >
                         <tree string="combos">
+                            <field name="sequence" widget="handle"/>
                             <field name="name" />
                             <field name="num_of_products"/>
                         </tree>


### PR DESCRIPTION
Prior to this commit the combo choices were displayed in their ID order. This commit add a sequence field that allows the user to choose the order of the combo choices.

