### PR TITLE
[FIX] l10n_latam_check: Prevent Multiple Uses of Same Third-Party Check

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -166,7 +166,7 @@ class AccountPayment(models.Model):
                         rec.l10n_latam_check_id.l10n_latam_check_current_journal_id != rec.destination_journal_id):
                     # check outbound payment and transfer or inbound transfer
                     msgs.append(_(
-                        'Check "%s" is not anymore in journal "%s", it seems it has been moved by another payment.',
+                        'Check "%s" is not anymore in journal "%s", is already used on another payment.',
                         rec.l10n_latam_check_id.display_name, rec.journal_id.name
                         if rec.payment_type == 'outbound' else rec.destination_journal_id.name))
                 elif rec.payment_type == 'inbound' and not rec.is_internal_transfer and \
@@ -263,15 +263,17 @@ class AccountPayment(models.Model):
         return super().action_unmark_sent()
 
     def action_post(self):
-        msgs = self._get_blocking_l10n_latam_warning_msg()
-        if msgs:
-            raise ValidationError('* %s' % '\n* '.join(msgs))
+        check_payments = self.filtered('l10n_latam_check_id')
+        for check_payment in check_payments:
+            msgs = check_payment._get_blocking_l10n_latam_warning_msg()
+            if msgs:
+                raise ValidationError('* %s' % '\n* '.join(msgs))
+            super(AccountPayment, check_payment).action_post()
 
-        res = super().action_post()
+        super(AccountPayment, self - check_payments).action_post()
 
         # mark own checks that are not printed as sent
         self.filtered(lambda x: x.payment_method_line_id.code == 'check_printing' and x.l10n_latam_manual_checks).write({'is_move_sent': True})
-        return res
 
     @api.model
     def _get_trigger_fields_to_synchronize(self):

--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -345,17 +345,3 @@ class AccountPayment(models.Model):
                     default_l10n_latam_check_id=rec.l10n_latam_check_id,
                 ))._create_paired_internal_transfer_payment()
         super(AccountPayment, self - third_party_checks)._create_paired_internal_transfer_payment()
-
-    @api.constrains('l10n_latam_check_id')
-    def _check_l10n_latam_check_id(self):
-        if self.filtered(lambda x: x.payment_method_line_id.code == 'out_third_party_checks'):
-            payments = self.env['account.payment'].search_count([
-                ('l10n_latam_check_id', 'in', self.l10n_latam_check_id.ids),
-                ('payment_type', '=', 'outbound'),
-                ('journal_id', 'in', self.journal_id.ids),
-                ('id', 'not in', self.ids)],
-                limit=1)
-            if payments:
-                raise ValidationError(_(
-                    "The check(s) '%s' is already used on another payment. Please select another check or "
-                    "deselect the check on this payment.", self.l10n_latam_check_id.mapped('display_name')))

--- a/addons/l10n_latam_check/tests/test_third_party_checks.py
+++ b/addons/l10n_latam_check/tests/test_third_party_checks.py
@@ -65,7 +65,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         delivery.action_post()
         self.assertFalse(check.l10n_latam_check_current_journal_id, 'Current journal was not computed properly on delivery')
         # check dont delivery twice
-        with self.assertRaisesRegex(ValidationError, "is already used on another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         # Check Return / Rejection
@@ -97,7 +97,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         customer_return.action_post()
         self.assertFalse(check.l10n_latam_check_current_journal_id, 'Current journal was not computed properly on customer return')
         # check dont claim twice
-        with self.assertRaisesRegex(ValidationError, "is already used on another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         operations = self.env['account.payment'].search([('l10n_latam_check_id', '=', check.id), ('state', '=', 'posted')], order="date desc, id desc")
@@ -147,7 +147,7 @@ class TestThirdChecks(L10nLatamCheckTest):
         customer_return.action_post()
         self.assertFalse(check.l10n_latam_check_current_journal_id, 'Current journal was not computed properly on customer return')
         # check dont return twice
-        with self.assertRaisesRegex(ValidationError, "is already used on another payment"), self.cr.savepoint():
+        with self.assertRaisesRegex(ValidationError, "it seems it has been moved by another payment"), self.cr.savepoint():
             self.env['account.payment'].create(vals).action_post()
 
         operations = self.env['account.payment'].search([('l10n_latam_check_id', '=', check.id), ('state', '=', 'posted')], order="date desc, id desc")


### PR DESCRIPTION
Revert this fix that actually breaaks something else https://github.com/odoo/odoo/pull/135815
With that fix the user can't send back a rejected check to the owner (and other use cases won't work neither)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
