### PR TITLE
[FIX] web_editor: ensure the hook element is in the map

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/MoveNodePlugin.js
+++ b/addons/web_editor/static/src/js/wysiwyg/MoveNodePlugin.js
@@ -93,7 +93,10 @@ export class MoveNodePlugin {
                 this._resetHooksNextMousemove = true;
             } else {
                 this._visibleMovableElements.delete(element);
-                this._elementHookMap.get(element).style.display = `none`;
+                const hookElement = this._elementHookMap.get(element);
+                if (hookElement) {
+                    hookElement.style.display = `none`;
+                }
             }
         }
     }


### PR DESCRIPTION
There is a traceback that could happen in a race condition when reloading the page.
The reason is because `_intersectionObserverCallback` is async and could be called after an element has been removed in `_updateHooks`.

This commit ensures the existence of the element to avoid a traceback.

task-3519508



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
