### PR TITLE
[IMP] *: use private _read_group for efficiency/consistency.

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -427,19 +427,19 @@ class ResPartner(models.Model):
     api.depends('credit')
     def _compute_days_sales_outstanding(self):
         commercial_partners = {
-            commercial_partner['commercial_partner_id'][0]: (commercial_partner['invoice_date'], commercial_partner['amount_total_signed'])
-            for commercial_partner in self.env['account.move'].read_group(
+            commercial_partner: (invoice_date_min, amount_total_signed_sum)
+            for commercial_partner, invoice_date_min, amount_total_signed_sum in self.env['account.move']._read_group(
                 domain=[
                     ('state', 'not in', ['draft', 'cancel']),
                     ('move_type', 'in', self.env["account.move"].get_sale_types(include_receipts=True)),
                     ('company_id', '=', self.env.company.id)
                 ],
-                fields=['invoice_date:min', 'amount_total_signed:sum'],
                 groupby=['commercial_partner_id'],
+                aggregates=['invoice_date:min', 'amount_total_signed:sum'],
             )
         }
         for partner in self:
-            oldest_invoice_date, total_invoiced_tax_included = commercial_partners.get(partner.id, (fields.Date.context_today(self), 0))
+            oldest_invoice_date, total_invoiced_tax_included = commercial_partners.get(partner, (fields.Date.context_today(self), 0))
             days_since_oldest_invoice = (fields.Date.context_today(self) - oldest_invoice_date).days
             partner.days_sales_outstanding = ((partner.credit / total_invoiced_tax_included) * days_since_oldest_invoice) if total_invoiced_tax_included else 0
 

--- a/addons/repair/models/stock_picking.py
+++ b/addons/repair/models/stock_picking.py
@@ -62,14 +62,13 @@ class PickingType(models.Model):
         }
 
         for field, domain in domains.items():
-            picking_types = self.env['repair.order'].read_group(
+            counts = dict(self.env['repair.order']._read_group(
                 [('picking_type_id', 'in', repair_picking_types.ids), ('state', 'in', ('confirmed', 'under_repair'))] + domain,
-                fields=['picking_type_id'],
-                groupby=['picking_type_id']
-            )
-            counts = {pt['picking_type_id'][0]:pt['picking_type_id_count'] for pt in picking_types}
+                groupby=['picking_type_id'],
+                aggregates=['__count'],
+            ))
             for record in repair_picking_types:
-                record[field] = counts.get(record.id)
+                record[field] = counts.get(record)
 
     @api.depends('return_type_of_ids', 'code')
     def _compute_is_repairable(self):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -312,12 +312,10 @@ class PickingType(models.Model):
     def _check_sequence_code(self):
         domain = expression.OR([[('company_id', '=', record.company_id.id), ('name', '=', record.sequence_id.name)]
                                 for record in self])
-        record_counts = self.env['ir.sequence'].read_group(
-            domain, ['company_id', 'name'], ['company_id', 'name'], lazy=False)
-        duplicate_records = list(filter(
-            lambda r: r['__count'] > 1, record_counts))
+        duplicate_records = self.env['ir.sequence']._read_group(
+            domain, ['company_id', 'name'], having=[('__count', '>', 1)])
         if duplicate_records:
-            duplicate_names = list(map(lambda r: r['name'], duplicate_records))
+            duplicate_names = [name for __, name in duplicate_records]
             raise UserError(_("Sequences %s already exist.",
                             ', '.join(duplicate_names)))
 

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -960,12 +960,12 @@ class StockQuant(models.Model):
     def _get_quants_by_products_locations(self, product_ids, location_ids):
         quants_by_product = defaultdict(lambda: self.env['stock.quant'])
         if product_ids and location_ids:
-            needed_quants = self.env['stock.quant'].read_group([('product_id', 'in', product_ids.ids),
+            needed_quants = self.env['stock.quant']._read_group([('product_id', 'in', product_ids.ids),
                                                                 ('location_id', 'child_of', location_ids.ids)],
-                                                            ['ids:array_agg(id)', 'product_id'],
-                                                            ['product_id'])
-            for quant in needed_quants:
-                quants_by_product[quant['product_id'][0]] = self.env['stock.quant'].browse(quant['ids'])
+                                                            ['product_id'],
+                                                            ['id:recordset'])
+            for product, quants in needed_quants:
+                quants_by_product[product.id] = quants
         return quants_by_product
 
     @api.model


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/110737, it is better to use
`_read_group` instead of `read_group` in the backend. In fact, the
public method is less efficient (it computes display_name of relational
groupby, extra order, ...) and more verbose.

This commit replaces these new uses of `read_group` with `_read_group`.

https://github.com/odoo/enterprise/pull/47826