### PR TITLE
[FIX] mrp: call correct action in action_view_mos

### DIFF
--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -73,10 +73,9 @@ class ProductTemplate(models.Model):
             template.mrp_product_qty = float_round(sum(template.mapped('product_variant_ids').mapped('mrp_product_qty')), precision_rounding=template.uom_id.rounding)
 
     def action_view_mos(self):
-        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_production_report")
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_production_action")
         action['domain'] = [('state', '=', 'done'), ('product_tmpl_id', 'in', self.ids)]
         action['context'] = {
-            'graph_measure': 'product_uom_qty',
             'search_default_filter_plan_date': 1,
         }
         return action


### PR DESCRIPTION
In 6698406b92a598f24fa0a778a28b6ef727adc008, we removed action mrp.mrp_production_report. action_view_mos still using this action, we change it to use mrp.mrp_production_action instead.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
