### PR TITLE
[FIX] account: fix traceback on payment info button

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -37,7 +37,7 @@
                     </t>
                     <t t-if="!info.outstanding">
                         <td>
-                           <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line_index)"></a>
+                           <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line)"></a>
                         </td>
                         <td t-if="!line.is_exchange">
                             <i class="o_field_widget text-start o_payment_label">Paid on <t t-out="line.date"></t></i>

--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -53,10 +53,10 @@ export class AccountPaymentField extends Component {
         };
     }
 
-    onInfoClick(ev, idx) {
+    onInfoClick(ev, line) {
         this.popover.open(ev.currentTarget, {
             title: _t("Journal Entry Info"),
-            ...this.lines[idx],
+            ...line,
             _onRemoveMoveReconcile: this.removeMoveReconcile.bind(this),
             _onOpenMove: this.openMove.bind(this),
         });


### PR DESCRIPTION
Steps to reproduce:
1. Accounting > Invoices > click any unpaid invoice
2. Register Payment (doesn't matter if it's full or not)
3. Click the info (i) button next to the "Paid on" below invoice lines -> Traceback
Before the traceback the unreconciliation button available was not refreshing the view, which still appeared with "Paid on". We fix both problems at the same time.

task-id:3516681
