### PR TITLE
[FIX] point_of_sale: close session when no cash pm

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -136,7 +136,7 @@ export class ClosePosPopup extends AbstractAwaitablePopup {
             return NaN;
         }
         const expectedAmount =
-            paymentId === this.props.default_cash_details.id
+            paymentId === this.props.default_cash_details?.id
                 ? this.props.default_cash_details.amount
                 : this.props.other_payment_methods.find((pm) => pm.id === paymentId).amount;
 


### PR DESCRIPTION
Since a869ee87f28c517c67d782b132b65aaf86309d1e, the cashier can no longer close a session from the frontend UI if the POS config has not a cash payment method.

Steps to reproduce:
 - Remove any cash payment method from the POS config you want to use
 - Open a POS session for the previous POS config
 - Make an order
 - Try to close the session

A (silent) error is raised, the user cannot close the session. This error is particularly noticeable when we don't use demo data (--without-demo=True).

The fix consists in correctly checking if there is a cash payment method or not.

task-id: 3519547
