### PR TITLE
[FIX] account: Report Customization

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4666,7 +4666,7 @@ class AccountMove(models.Model):
         """ This method need to be inherit by the localizations if they want to print a custom invoice report instead of
         the default one. For example please review the l10n_ar module """
         self.ensure_one()
-        return self._context.get('force_report_invoice_template') or 'account.report_invoice_document'
+        return 'account.report_invoice_document'
 
     def _is_downpayment(self):
         ''' Return true if the invoice is a downpayment.

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -816,22 +816,6 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         # The PDF is generated even in case of error.
         self.assertTrue(invoice.invoice_pdf_report_id)
 
-    def test_get_invoice_pdf_report_to_render(self):
-        invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
-        _get_name_invoice_report = invoice._get_name_invoice_report
-        wizard = self.create_send_and_print(invoice)
-
-        def get_invoice_pdf_report_to_render(record, *args, **kwargs):
-            return 'account.report_invoice_document', {}
-
-        def get_name_invoice_report(record, *args, **kwargs):
-            self.assertEqual(record._context.get('force_report_invoice_template'), 'account.report_invoice_document')
-            return _get_name_invoice_report(*args, **kwargs)
-
-        with patch.object(type(wizard), '_get_invoice_pdf_report_to_render', get_invoice_pdf_report_to_render), \
-            patch.object(type(invoice), '_get_name_invoice_report', get_name_invoice_report):
-            wizard.action_send_and_print(allow_fallback_pdf=True)
-
     def test_with_unlink_invoices(self):
         invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
         wizard = self.create_send_and_print(invoice)

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -302,10 +302,6 @@ class AccountMoveSend(models.Model):
         """
         self.ensure_one()
 
-    def _get_invoice_pdf_report_to_render(self, invoice, invoice_data):
-        self.ensure_one()
-        return None, {}
-
     def _prepare_invoice_pdf_report(self, invoice, invoice_data):
         """ Prepare the pdf report for the invoice passed as parameter.
 
@@ -317,30 +313,7 @@ class AccountMoveSend(models.Model):
         if invoice.invoice_pdf_report_id:
             return
 
-        # Render the invoice PDF but allow to set a custom report_name and custom values.
-        # That way, all invoice reports are separated from the main one but don't need an
-        # extra report every time.
-        IrActionsReport = type(self.env['ir.actions.report'])
-        _render_template = IrActionsReport._render_template
-        inv_report, inv_report_values = self._get_invoice_pdf_report_to_render(invoice, invoice_data)
-
-        def render_template(records, template, values=None):
-            return _render_template(
-                records,
-                template,
-                values={
-                    **(values or {}),
-                    **inv_report_values,
-                },
-            )
-
-        with patch.object(IrActionsReport, '_render_template', side_effect=render_template, autospec=True):
-            content, _report_format = self.env['ir.actions.report']\
-                .with_context(force_report_invoice_template=inv_report)\
-                ._render(
-                    'account.account_invoices',
-                    invoice.ids,
-                )
+        content, _report_format = self.env['ir.actions.report']._render('account.account_invoices', invoice.ids)
 
         invoice_data['pdf_attachment_values'] = {
             'raw': content,


### PR DESCRIPTION
Ease the way invoice report is selected for rendering. We now only rely on `_get_name_invoice_report()` to decide the report, and it is automatically selected in the report template `report_invoice` that is extended by localizations.

Task-id:3492033
