### PR TITLE
Avoid searching on undefined object

### DIFF
--- a/addons/web_editor/static/src/js/backend/field_html.js
+++ b/addons/web_editor/static/src/js/backend/field_html.js
@@ -470,6 +470,9 @@ var FieldHtml = basic_fields.DebouncedField.extend(TranslatableFieldMixin, {
     _onChange: function (ev) {
         this._doDebouncedAction.apply(this, arguments);
 
+        if (!this.$content) {
+            return;
+        }
         var $lis = this.$content.find('.note-editable ul.o_checklist > li:not(:has(> ul.o_checklist))');
         if (!$lis.length) {
             return;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
I ended up here with this.$content undefined. I have not investigated how it happens, but since it's possible, I guess this safety check is nice to have.
Of course this is not needed, if it can be guaranteed, that this.$content is never undefined.

In the cases I have seen, everything works fine, if the error is ignored, so I guess it's safe to just return when $content is undefined.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
