### PR TITLE
[FIX] pos_restaurant: onboarding data loading

### DIFF
--- a/addons/pos_restaurant/data/pos_restaurant_onboarding.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_onboarding.xml
@@ -8,11 +8,11 @@
     <record id="product_category_pos_food" model="product.category">
         <field name="parent_id" ref="point_of_sale.product_category_pos"/>
         <field name="name">Food</field>
-        <field name="image_128" type="base64" file="pos_restaurant/static/img/food_category.png" />
     </record>
 
     <record id="food" model="pos.category">
-            <field name="name">Food</field>
+        <field name="name">Food</field>
+        <field name="image_128" type="base64" file="pos_restaurant/static/img/food_category.png" />
     </record>
 
     <!-- Food -->


### PR DESCRIPTION
The onboarding demo data cannot be loaded since f96ea753f35355e8344a30623f2b21aa284972f2.

Steps to reproduce:
 - Start a database without demo data (--without-demo=True)
 - Open a POS session for the default shop
 - Click to load demo (onboarding) data

An error is raised.
The error is due to a mistake in the XML, the food category logo is not assigned to the right record.

task-id: 3519677
