### PR TITLE
[IMP] mail: notification settings for channel

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from werkzeug.exceptions import NotFound
 
-from odoo import http
+from odoo import fields, http
 from odoo.http import request
 from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 
@@ -53,6 +55,41 @@ class ChannelController(http.Controller):
         if not channel:
             raise NotFound()
         return channel.pinned_message_ids.sorted(key="pinned_at", reverse=True).message_format()
+
+    @http.route("/discuss/channel/mute", methods=["POST"], type="json", auth="user")
+    def discuss_channel_mute(self, channel_id, minutes):
+        """Mute notifications for the given number of minutes.
+        :param minutes: (integer) number of minutes to mute notifications, -1 means mute until the user unmutes
+        """
+        member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
+        if not member:
+            raise request.not_found()
+        if minutes == -1:
+            member.mute_until_dt = datetime.max
+        elif minutes:
+            member.mute_until_dt = fields.Datetime.now() + relativedelta(minutes=minutes)
+            request.env.ref("mail.ir_cron_discuss_channel_member_unmute")._trigger(member.mute_until_dt)
+        else:
+            member.mute_until_dt = False
+        channel_data = {
+            "id": member.channel_id.id,
+            "model": "discuss.channel",
+            "mute_until_dt": member.mute_until_dt,
+        }
+        request.env["bus.bus"]._sendone(member.partner_id, "mail.record/insert", {"Thread": channel_data})
+
+    @http.route("/discuss/channel/update_custom_notifications", methods=["POST"], type="json", auth="user")
+    def discuss_channel_update_custom_notifications(self, channel_id, custom_notifications):
+        member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
+        if not member:
+            raise request.not_found()
+        member.custom_notifications = custom_notifications
+        channel_data = {
+            "custom_notifications": member.custom_notifications,
+            "id": member.channel_id.id,
+            "model": "discuss.channel",
+        }
+        request.env["bus.bus"]._sendone(member.partner_id, "mail.record/insert", {"Thread": channel_data})
 
     @http.route("/discuss/channel/set_last_seen_message", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -77,5 +77,16 @@
             <field name="numbercall">-1</field>
             <field name="doall" eval="True"/>
         </record>
+
+        <record id="ir_cron_discuss_channel_member_unmute" model="ir.cron">
+            <field name="name">Discuss: channel member unmute</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+            <field name="model_id" ref="model_discuss_channel_member"/>
+            <field name="code">model._unmute()</field>
+            <field name="state">code</field>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -799,6 +799,8 @@ class Channel(models.Model):
                     info['state'] = member.fold_state or 'open'
                     info['message_unread_counter'] = member.message_unread_counter
                     info['is_minimized'] = member.is_minimized
+                    info['custom_notifications'] = member.custom_notifications
+                    info['mute_until_dt'] = member.mute_until_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT) if member.mute_until_dt else False
                     info['seen_message_id'] = member.seen_message_id.id
                     info['custom_channel_name'] = member.custom_channel_name
                     info['is_pinned'] = member.is_pinned

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -30,6 +30,10 @@
     min-width: 0;
 }
 
+.o-smaller {
+    font-size: smaller;
+}
+
 .o-text-white {
     color: #FFF;
 }

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -111,9 +111,15 @@ function transformAction(component, id, action) {
             return action.disabledCondition?.(component);
         },
         /** Icon for the button this action. */
-        icon: action.icon,
+        get icon() {
+            return typeof action.icon === "function" ? action.icon(component) : action.icon;
+        },
         /** Large icon for the button this action. */
-        iconLarge: action.iconLarge ?? action.icon,
+        get iconLarge() {
+            return typeof action.iconLarge === "function"
+                ? action.iconLarge(component)
+                : action.iconLarge ?? action.icon;
+        },
         /** Unique id of this action. */
         id,
         /** States whether this action is currently active. */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -92,6 +92,8 @@ export class Thread extends Record {
                 "status",
                 "group_based_subscription",
                 "last_interest_dt",
+                "custom_notifications",
+                "mute_until_dt",
                 "is_editable",
                 "defaultDisplayMode",
             ]);
@@ -250,6 +252,10 @@ export class Thread extends Record {
     last_interest_dt;
     /** @type {Boolean} */
     is_editable;
+    /** @type {false|'mentions'|'no_notif'} */
+    custom_notifications = false;
+    /** @type {String} */
+    mute_until_dt;
 
     get accessRestrictedToGroupText() {
         if (!this.authorizedGroupFullName) {
@@ -493,6 +499,13 @@ export class Thread extends Record {
             return undefined;
         }
         return deserializeDateTime(this.last_interest_dt);
+    }
+
+    get muteUntilDateTime() {
+        if (!this.mute_until_dt) {
+            return undefined;
+        }
+        return deserializeDateTime(this.mute_until_dt);
     }
 
     /** @param {import("models").Persona} persona */

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -40,6 +40,7 @@ export class ThreadService {
         this.user = services.user;
         this.messageService = services["mail.message"];
         this.personaService = services["mail.persona"];
+        this.outOfFocusService = services["mail.out_of_focus"];
     }
 
     /**
@@ -919,6 +920,42 @@ export class ThreadService {
     }
 
     /**
+     * Handle the notification of a new message based on the notification setting of the user.
+     * Thread on mute:
+     * 1. No longer see the unread status: the bold text disappears and the channel name fades out.
+     * 2. Without sound + need action counter.
+
+     * Thread Notification Type:
+     * All messages:All messages sound + need action counter
+     * Mentions:Only mention sounds + need action counter
+     * Nothing: No sound + need action counter
+
+     * @param {Thread} thread
+     * @param {Message} message
+     */
+    notifyMessageToUser(thread, message) {
+        if (
+            thread.type === "channel" &&
+            message.recipients?.includes(this.store.user) &&
+            message.notIn(thread.needactionMessages)
+        ) {
+            thread.needactionMessages.add(message);
+            thread.message_needaction_counter++;
+        }
+        if (
+            thread.chatPartner?.eq(this.store.odoobot) ||
+            thread.muteUntilDateTime ||
+            thread.custom_notifications === "no_notif" ||
+            (thread.custom_notifications === "mentions" &&
+                !message.recipients?.includes(this.store.user))
+        ) {
+            return;
+        }
+        this.store.ChatWindow.insert({ thread });
+        this.outOfFocusService.notify(message, thread);
+    }
+
+    /**
      * Following a load more or load around, listing of messages contains persistent messages.
      * Transient messages are missing, so this function puts known transient messages at the
      * right place in message list of thread.
@@ -977,6 +1014,7 @@ export const threadService = {
         "router",
         "mail.message",
         "mail.persona",
+        "mail.out_of_focus",
         "ui",
         "user",
     ],

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -80,6 +80,7 @@
                     displayName="thread.displayName"
                     iconSrc="thread.imgUrl"
                     hasMarkAsReadButton="thread.isUnread"
+                    muted="thread.muteUntilDateTime"
                     onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread)"
                     onSwipeRight="hasTouch() and thread.isUnread ? { action: () => this.markAsRead(thread), icon: 'fa-check-circle', bgColor: 'bg-success' } : undefined"
                     onSwipeLeft="hasTouch() and threadService.canUnpin(thread) ? { action: () => this.threadService.unpin(thread), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"

--- a/addons/mail/static/src/core/web/notification_item.js
+++ b/addons/mail/static/src/core/web/notification_item.js
@@ -17,6 +17,7 @@ export class NotificationItem extends Component {
         "displayName?",
         "hasMarkAsReadButton?",
         "iconSrc?",
+        "muted?",
         "onClick",
         "onSwipeLeft?",
         "onSwipeRight?",

--- a/addons/mail/static/src/core/web/notification_item.xml
+++ b/addons/mail/static/src/core/web/notification_item.xml
@@ -3,16 +3,16 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item list-group-item-action d-flex cursor-pointer align-items-center p-1" t-att-class="{ 'o-muted': !props.hasMarkAsReadButton }" t-on-click="onClick" t-ref="root">
+        <button class="o-mail-NotificationItem list-group-item list-group-item-action d-flex cursor-pointer align-items-center p-1" t-att-class="{ 'o-muted': !props.hasMarkAsReadButton, 'opacity-50': props.muted }" t-on-click="onClick" t-ref="root">
             <div class="position-relative o-bg-inherit m-1 flex-shrink-0" style="width:40px;height:40px;">
                 <img class="o_avatar w-100 h-100 rounded" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start m-2 overflow-auto">
                 <div class="d-flex text-nowrap">
-                    <span class="o-mail-NotificationItem-name text-truncate" t-att-class="props.hasMarkAsReadButton ? 'fw-bolder' : 'fw-bold'" t-esc="props.displayName"/>
+                    <span class="o-mail-NotificationItem-name text-truncate" t-att-class="props.hasMarkAsReadButton and !props.muted ? 'fw-bolder' : 'fw-bold'" t-esc="props.displayName"/>
                     <span class="flex-grow-1"/>
-                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2" t-att-class="{ 'opacity-75 fw-bold': props.counter > 0, 'opacity-50 text-muted': props.counter === 0 }">
+                    <small t-if="props.datetime" class="o-mail-NotificationItem-date ms-2" t-att-class="{ 'opacity-75 fw-bold': props.counter > 0 and !props.muted, 'opacity-50 text-muted': props.counter === 0 || props.muted }">
                         <RelativeTime datetime="props.datetime"/>
                     </small>
                 </div>
@@ -23,7 +23,7 @@
                     </div>
                     <div class="flex-grow-1"/>
                     <div class="d-flex align-items-center">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badge d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
+                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
                         <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-50 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
                     </div>
                 </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -19,7 +19,6 @@ export class DiscussCoreCommon {
         this.rpc = services.rpc;
         this.messageService = services["mail.message"];
         this.messagingService = services["mail.messaging"];
-        this.outOfFocusService = services["mail.out_of_focus"];
         this.store = services["mail.store"];
         this.threadService = services["mail.thread"];
     }
@@ -245,20 +244,14 @@ export class DiscussCoreCommon {
                 }
             }
         }
-        if (!channel.chatPartner?.eq(this.store.odoobot)) {
-            if (
-                !this.presence.isOdooFocused() &&
-                channel.isChatChannel &&
-                !message.isSelfAuthored
-            ) {
-                this.outOfFocusService.notify(message, channel);
-            }
-
-            if (channel.type !== "channel" && !this.store.guest) {
-                // disabled on non-channel threads and
-                // on "channel" channels for performance reasons
-                this.threadService.markAsFetched(channel);
-            }
+        if (
+            !channel.chatPartner?.eq(this.store.odoobot) &&
+            channel.type !== "channel" &&
+            this.store.user
+        ) {
+            // disabled on non-channel threads and
+            // on "channel" channels for performance reasons
+            this.threadService.markAsFetched(channel);
         }
         if (
             !channel.loadNewer &&

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -1,0 +1,42 @@
+/* @odoo-module */
+
+import { useState, Component } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+export class NotificationSettings extends Component {
+    static components = { Dropdown, DropdownItem };
+    static props = ["hasSizeConstraints?", "thread", "close", "className?"];
+    static template = "discuss.NotificationSettings";
+
+    setup() {
+        this.threadService = useState(useService("mail.thread"));
+    }
+
+    get muteUntilText() {
+        if (
+            this.props.thread.muteUntilDateTime &&
+            this.props.thread.muteUntilDateTime.year <= new Date().getFullYear() + 2
+        ) {
+            return _t("Until ") + this.props.thread.muteUntilDateTime.toFormat("MM/dd, HH:mm");
+        }
+        // Forever is a special case, so we don't want to display the date.
+        return undefined;
+    }
+
+    selectUnmute() {
+        this.threadService.muteThread(this.props.thread);
+        this.props.close();
+    }
+
+    setMute(minutes) {
+        this.threadService.muteThread(this.props.thread, { minutes });
+        this.props.close();
+    }
+
+    setSetting(setting) {
+        this.threadService.updateCustomNotifications(this.props.thread, setting.id);
+    }
+}

--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -1,0 +1,3 @@
+.o-discuss-NotificationSettings {
+    width: 150px;
+}

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="discuss.NotificationSettings">
+        <div class="o-discuss-NotificationSettings">
+            <t t-if="props.thread.muteUntilDateTime">
+                <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" t-on-click="selectUnmute">
+                    <div class="d-flex flex-column flex-grow-1 text-start px-2 py-1 rounded">
+                        <span class="fs-6 fw-bold">Unmute Channel</span>
+                        <span class="fw-normal o-smaller" t-if="muteUntilText" t-out="muteUntilText"/>
+                    </div>
+                </button>
+            </t>
+            <t t-else="">
+                <Dropdown position="'right-start'" onStateChanged="state => {}" togglerClass="`d-flex btn w-100 align-items-center text-truncate p-0`" menuClass="'d-flex flex-column py-0 my-0'" class="'d-flex text-truncate'">
+                    <t t-set-slot="toggler">
+                        <button class="btn w-100 d-flex p-1 opacity-75 opacity-100-hover" title="Mute Channel">
+                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
+                                <span class="">Mute Channel</span>
+                                <div class="flex-grow-1"/>
+                                <i class="fa fa-arrow-right"/>
+                            </div>
+                        </button>
+                    </t>
+                    <t t-set-slot="default">
+                        <t t-foreach="props.thread.MUTES" t-as="item" t-key="item.id">
+                            <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0 opacity-75 opacity-100-hover'" title="item.name" onSelected="()=>this.setMute(item.value)"><span class="mx-2" t-out="item.name"/></DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+            </t>
+            <hr class="solid mx-2 my-1"/>
+            <t t-foreach="props.thread.SETTINGS" t-as="setting" t-key="setting.id">
+                <button class="btn w-100 d-flex px-1 py-0 opacity-75 opacity-100-hover" t-on-click="() => this.setSetting(setting)">
+                    <div class="d-flex flex-grow-1 align-items-center p-2 rounded">
+                        <span class="fs-6 fw-normal" t-esc="setting.name"/>
+                        <div class="flex-grow-1"/>
+                        <input class="form-check-input" type="radio" t-att-checked="props.thread.custom_notifications === setting.id"/>
+                    </div>
+                </button>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -4,6 +4,7 @@ import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { AttachmentPanel } from "@mail/discuss/core/common/attachment_panel";
 import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
 import { ChannelMemberList } from "@mail/discuss/core/common/channel_member_list";
+import { NotificationSettings } from "@mail/discuss/core/common/notification_settings";
 
 import { useComponent } from "@odoo/owl";
 
@@ -11,6 +12,45 @@ import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 
 threadActionsRegistry
+    .add("notification-settings", {
+        condition(component) {
+            return component.thread?.model === "discuss.channel" && !component.props.chatWindow;
+        },
+        setup(action) {
+            const component = useComponent();
+            if (!component.props.chatWindow) {
+                action.popover = usePopover(NotificationSettings, {
+                    onClose: () => action.close(),
+                    position: "bottom-end",
+                    fixedPosition: true,
+                    popoverClass: action.panelOuterClass,
+                });
+            }
+        },
+        open(component, action) {
+            action.popover?.open(component.root.el.querySelector(`[name="${action.id}"]`), {
+                hasSizeConstraints: true,
+                thread: component.thread,
+            });
+        },
+        close(component, action) {
+            action.popover?.close();
+        },
+        component: NotificationSettings,
+        icon(component) {
+            return component.thread.muteUntilDateTime
+                ? "fa fa-fw text-danger fa-bell-slash"
+                : "fa fa-fw fa-bell";
+        },
+        iconLarge(component) {
+            return component.thread.muteUntilDateTime
+                ? "fa fa-fw fa-lg text-danger fa-bell-slash"
+                : "fa fa-fw fa-lg fa-bell";
+        },
+        name: _t("Notification Settings"),
+        sequence: 5,
+        toggle: true,
+    })
     .add("attachments", {
         condition: (component) =>
             component.thread?.hasAttachmentPanel &&

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -5,8 +5,59 @@ import { assignDefined } from "@mail/utils/common/misc";
 
 import { patch } from "@web/core/utils/patch";
 import { url } from "@web/core/utils/urls";
+import { _t } from "@web/core/l10n/translation";
 
 patch(Thread.prototype, {
+    get SETTINGS() {
+        return [
+            {
+                id: false,
+                name: _t("All Messages"),
+            },
+            {
+                id: "mentions",
+                name: _t("Mentions Only"),
+            },
+            {
+                id: "no_notif",
+                name: _t("Nothing"),
+            },
+        ];
+    },
+    get MUTES() {
+        return [
+            {
+                id: "15_mins",
+                value: 15,
+                name: _t("For 15 minutes"),
+            },
+            {
+                id: "1_hour",
+                value: 60,
+                name: _t("For 1 hour"),
+            },
+            {
+                id: "3_hours",
+                value: 180,
+                name: _t("For 3 hours"),
+            },
+            {
+                id: "8_hours",
+                value: 480,
+                name: _t("For 8 hours"),
+            },
+            {
+                id: "24_hours",
+                value: 1440,
+                name: _t("For 24 hours"),
+            },
+            {
+                id: "forever",
+                value: -1,
+                name: _t("Until I turn it back on"),
+            },
+        ];
+    },
     get imgUrl() {
         if (this.type === "channel" || this.type === "group") {
             return url(

--- a/addons/mail/static/src/discuss/core/common/thread_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_service_patch.js
@@ -47,4 +47,17 @@ patch(ThreadService.prototype, {
             thread.isLoadingAttachments = false;
         }
     },
+
+    async muteThread(thread, { minutes = false } = {}) {
+        await this.rpc("/discuss/channel/mute", { channel_id: thread.id, minutes });
+    },
+
+    async updateCustomNotifications(thread, custom_notifications) {
+        // Update the UI instantly to provide a better UX (no need to wait for the RPC to finish).
+        thread.custom_notifications = custom_notifications;
+        await this.rpc("/discuss/channel/update_custom_notifications", {
+            channel_id: thread.id,
+            custom_notifications,
+        });
+    },
 });

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -55,7 +55,7 @@ export class DiscussCoreWeb {
                     this.store.odoobotOnboarding = false;
                     return;
                 }
-                this.store.ChatWindow.insert({ thread: channel });
+                this.threadService.notifyMessageToUser(channel, message);
             }
         );
         this.busService.subscribe("res.users.settings", (payload) => {

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -45,7 +45,8 @@
             t-att-class="{
                 'o-bg-inherit': thread.notEq(store.discuss.thread),
                 'o-active': thread.eq(store.discuss.thread),
-                'o-unread': thread.message_unread_counter > 0,
+                'o-unread': thread.message_unread_counter > 0 and !thread.muteUntilDateTime,
+                'opacity-50': thread.muteUntilDateTime,
             }"
             t-on-click="(ev) => this.openThread(ev, thread)"
         >
@@ -53,7 +54,7 @@
                 <img class="w-100 h-100 rounded" t-att-src="thread.imgUrl" alt="Thread Image"/>
                 <ThreadIcon t-if="thread.type === 'chat' or (thread.type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute bottom-0 end-0 p-1 me-n1 mb-n1 d-flex align-items-center justify-content-center rounded-circle o-bg-inherit'"/>
             </div>
-            <span class="ms-3 me-2 text-truncate" t-att-class="{ 'o-item-unread fw-bolder': thread.message_unread_counter > 0 }">
+            <span class="ms-3 me-2 text-truncate" t-att-class="{ 'o-item-unread fw-bolder': thread.message_unread_counter > 0 and !thread.muteUntilDateTime }">
                 <t t-esc="thread.displayName"/>
             </span>
             <div class="flex-grow-1"/>
@@ -65,7 +66,7 @@
             </div>
             <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
             <div t-if="counter > 0">
-                <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-3 fw-bold" t-esc="counter"/>
+                <span t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge ms-1 me-3 fw-bold {{thread.muteUntilDateTime ? 'o-muted' : ''}}" t-esc="counter"/>
             </div>
         </button>
     </t>

--- a/addons/mail/static/tests/discuss_app/discuss_tests.js
+++ b/addons/mail/static/tests/discuss_app/discuss_tests.js
@@ -1836,3 +1836,62 @@ QUnit.test("Escape key should focus the composer if it's not focused", async () 
     triggerHotkey("escape");
     await contains(".o-mail-Composer-input:focus");
 });
+
+QUnit.test("Notification settings: basic rendering", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Mario Party",
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await click("[title='Notification Settings']");
+    await contains("button", { text: "All Messages" });
+    await contains("button", { text: "Mentions Only" });
+    await contains("button", { text: "Nothing" });
+    await click("[title='Mute Channel']");
+    await contains("[title='For 15 minutes']");
+    await contains("[title='For 1 hour']");
+    await contains("[title='For 3 hours']");
+    await contains("[title='For 8 hours']");
+    await contains("[title='For 24 hours']");
+    await contains("[title='Until I turn it back on']");
+});
+
+QUnit.test("Notification settings: mute channel will change the style of sidebar", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Mario Party",
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await contains(".o-mail-DiscussSidebar-item", { text: "Mario Party" });
+    await contains(".o-mail-DiscussSidebar-item[class*='opacity-50']", {
+        text: "Mario Party",
+        count: 0,
+    });
+    await click("[title='Notification Settings']");
+    await click("[title='Mute Channel']");
+    await click("[title='For 15 minutes']");
+    await contains(".o-mail-DiscussSidebar-item", { text: "Mario Party" });
+    await contains(".o-mail-DiscussSidebar-item[class*='opacity-50']", { text: "Mario Party" });
+});
+
+QUnit.test("Notification settings: mute/unmute channel works correctly", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Mario Party",
+        channel_type: "channel",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await click("[title='Notification Settings']");
+    await click("[title='Mute Channel']");
+    await click("[title='For 15 minutes']");
+    await click("[title='Notification Settings']");
+    await contains("span", { text: "Unmute Channel" });
+    await click("button", { text: "Unmute Channel" });
+    await click("[title='Notification Settings']");
+    await contains("span", { text: "Unmute Channel" });
+});

--- a/addons/mail/views/discuss_channel_member_views.xml
+++ b/addons/mail/views/discuss_channel_member_views.xml
@@ -33,6 +33,8 @@
                         <field name="message_unread_counter"/>
                         <field name="fold_state"/>
                         <field name="is_minimized"/>
+                        <field name="custom_notifications"/>
+                        <field name="mute_until_dt"/>
                         <field name="is_pinned"/>
                         <field name="last_interest_dt"/>
                         <field name="last_seen_dt"/>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -175,6 +175,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'general',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_message_id': False,
                     'state': 'open',
                     'uuid': self.channel_general.uuid,
@@ -224,6 +226,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 1,
                     'name': 'public channel 1',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_message_id': next(res['message_id'] for res in self.channel_channel_public_1._channel_last_message_ids()),
                     'state': 'open',
                     'uuid': self.channel_channel_public_1.uuid,
@@ -273,6 +277,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'public channel 2',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_message_id': next(res['message_id'] for res in self.channel_channel_public_2._channel_last_message_ids()),
                     'state': 'open',
                     'uuid': self.channel_channel_public_2.uuid,
@@ -322,6 +328,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'group restricted channel 1',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_message_id': next(res['message_id'] for res in self.channel_channel_group_1._channel_last_message_ids()),
                     'state': 'open',
                     'uuid': self.channel_channel_group_1.uuid,
@@ -371,6 +379,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'group restricted channel 2',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_message_id': next(res['message_id'] for res in self.channel_channel_group_2._channel_last_message_ids()),
                     'state': 'open',
                     'uuid': self.channel_channel_group_2.uuid,
@@ -443,6 +453,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': '',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_message_id': False,
                     'seen_partners_info': [
                         {
@@ -529,6 +541,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'Ernest Employee, test14',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_partners_info': [
                         {
                             'fetched_message_id': False,
@@ -615,6 +629,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'Ernest Employee, test15',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_partners_info': [
                         {
                             'fetched_message_id': False,
@@ -701,6 +717,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'Ernest Employee, test2',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_partners_info': [
                         {
                             'fetched_message_id': False,
@@ -787,6 +805,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'message_needaction_counter': 0,
                     'name': 'Ernest Employee, test3',
                     'rtcSessions': [('ADD', [])],
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'seen_partners_info': [
                         {
                             'fetched_message_id': False,
@@ -870,6 +890,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'last_interest_dt': self.channel_livechat_1.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'message_needaction_counter': 0,
                     'name': 'test1 Ernest Employee',
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'operator_pid': (self.users[0].partner_id.id, 'Ernest Employee'),
                     'rtcSessions': [('ADD', [])],
                     'seen_partners_info': [
@@ -948,6 +970,8 @@ class TestDiscussFullPerformance(HttpCase):
                     'last_interest_dt': self.channel_livechat_2.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id).last_interest_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT),
                     'message_needaction_counter': 0,
                     'name': 'anon 2 Ernest Employee',
+                    "custom_notifications": False,
+                    'mute_until_dt': False,
                     'operator_pid': (self.users[0].partner_id.id, 'Ernest Employee'),
                     'rtcSessions': [('ADD', [])],
                     'seen_partners_info': [


### PR DESCRIPTION
New fa-bell icon to manage notifications according to that channel only Options: 
Mute (+choose time period):
​No longer see the unread status: the bold text disappears and the channel name fades out. As if you are not a channel member anymore.
Receive messages but without sound + only need action counter (grayed). Add a crossed-out bell icon next to the channel or user name to indicate that the channel is muted
 
All messages: all messages sound + need action counter @Mentions: only mention sounds + need action counter Nothing (Discord-like): No sound + need action counter

By default: all messages

task-3328665


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
