### PR TITLE
[FIX] project: Empty task display name on creation

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -290,6 +290,10 @@ class Task(models.Model):
         for task in self:
             task.analytic_account_id = task.project_id.analytic_account_id
 
+    def _compute_display_name(self):
+        for task in self:
+            task.display_name = ''
+
     @api.depends('stage_id', 'depend_on_ids.state', 'project_id.allow_task_dependencies')
     def _compute_state(self):
         for task in self:


### PR DESCRIPTION
### Steps
- install 'hr_timesheet' module.
- Go to project, select one.
- Add a task.

### Issue
The task's display name is set to ``Project.task,<record_id>``.

### Cause
In ``_compute_display_name()`` the ``super._compute_display_name()`` is called, which refers directly to the ``BaseModel._compute_display_name()``. We can solve it just by deleting that call.

opw-3513609