### PR TITLE
[FIX] web_editor: link / unlink buttons not appearing/disappearing

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2366,7 +2366,7 @@ export class OdooEditor extends EventTarget {
                 this._activateContenteditable();
             }
             const returnValue = editorCommands[method](this, ...args);
-            if (link) {
+            if (link && link.isConnected) {
                 this.setContenteditableLink(link);
             }
             return returnValue;
@@ -3100,6 +3100,8 @@ export class OdooEditor extends EventTarget {
         const linkNode = getInSelection(this.document, 'a');
         const linkButton = this.toolbar.querySelector('#create-link');
         linkButton && linkButton.classList.toggle('active', !!linkNode);
+        const unlinkButton = this.toolbar.querySelector('#unlink');
+        unlinkButton && unlinkButton.classList.toggle('d-none', !linkNode);
         const undoButton = this.toolbar.querySelector('#undo');
         undoButton && undoButton.classList.toggle('disabled', !this.historyCanUndo());
         const redoButton = this.toolbar.querySelector('#redo');


### PR DESCRIPTION
**Current behaviour before commit:**

-When creating a link, the 'unlink' button is not getting
 appeared in the toolbar.

-When removing link through 'unlink' button, the 'unlink'
 button is not getting disappeared in toolbar.

**Desired behaviour after commit:**

-Now, When creating a link, the 'unlink' button gets
 appeared in the toolbar.

-When removing link through 'unlink' button, the 'unlink'
 button gets disappeared in toolbar.


task-3514639




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
