### PR TITLE
[REF] web: ReferenceField reactive

### DIFF
--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -54,15 +54,15 @@ export class ReferenceField extends Component {
         this.state = useState({
             formattedCharValue: undefined, // Value extracted from reference char field
             modelName: undefined, // Name get of the value of the model field
+            currentRelation: undefined,
         });
-        this.currentValue = undefined;
-        this.currentRelation = this.getRelation();
         if (this._isCharField(this.props)) {
             /** Fetch the display name of the record referenced by the field */
+            let currentValue = undefined;
             useRecordObserver(async (record) => {
-                if (this.currentValue !== record.data[this.props.name]) {
+                if (currentValue !== record.data[this.props.name]) {
                     this.state.formattedCharValue = await this._fetchReferenceCharData(this.props);
-                    this.currentValue = record.data[this.props.name];
+                    currentValue = record.data[this.props.name];
                 }
             });
         } else if (this.props.modelField) {
@@ -76,8 +76,6 @@ export class ReferenceField extends Component {
                     this.currentModelId = record.data[this.props.modelField]?.[0];
                 }
             });
-        } else {
-            this.currentValue = this.props.record.data[this.props.name];
         }
     }
 
@@ -118,7 +116,7 @@ export class ReferenceField extends Component {
         if (value && value.resModel) {
             return value.resModel;
         } else {
-            return this.currentRelation;
+            return this.state.currentRelation;
         }
     }
 
@@ -141,18 +139,16 @@ export class ReferenceField extends Component {
     }
 
     updateModel(value) {
-        this.currentRelation = value;
+        this.state.currentRelation = value;
         this.props.record.update({ [this.props.name]: false });
     }
 
     updateM2O(data) {
         const value = data[this.props.name];
-        if (!this.currentRelation) {
-            this.currentRelation = this.getRelation();
-        }
+        const resModel = this.state.currentRelation || this.getRelation();
         this.props.record.update({
             [this.props.name]: value && {
-                resModel: this.currentRelation,
+                resModel,
                 resId: value[0],
                 displayName: value[1],
             },


### PR DESCRIPTION
This commit simplifies the implementation of ReferenceField and makes
it fully reactive.

Currently, the ReferenceField is not automatically rendered when the
relation is updated from the component. The problem does not currently
occur because when a field is updated, a delete is performed on the
invalidField Set, which causes all the Fields to be rendered. This
behaviour is a bug in owl. Performing a delete on a Set that does not
delete any values should not trigger reactivity. When this is fixed, some
tests will no longer pass.

This commit simplifies the implementation of ReferenceField and makes it fully reactive.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
