### PR TITLE
[FIX] web: x2m causes an onchange on the parent which fails

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1044,7 +1044,7 @@ export class Record extends DataPoint {
             }
         }
         if (Object.keys(changes).length > 0) {
-            const initialChanges = pick(this._changes, ...Object.keys(changes));
+            const initialChanges = pick(this.data, ...Object.keys(changes));
             this._applyChanges(changes);
             try {
                 await this._onUpdate({ withoutParentUpdate });


### PR DESCRIPTION
When the onchange triggered by an x2m fails on the parent record, we want to reuse a valid value (the one before the onchange).

How to reproduce:
- Go to a form view with an x2m (onchange=true) that contains at least one record
- Edit the record in the x2m
- onchange on parent record fails

Before this commit:
    The value is unchanged.

After this commit:
    The value of the edited field is replaced by its old value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
