### PR TITLE
[FIX] account: handle unsigned with signed tax tags

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -941,7 +941,7 @@ class AccountChartTemplate(models.AbstractModel):
             ('applicability', '=', 'taxes'),
             ('country_id', '=', self._get_chart_template_mapping()[template_code]['country_id']),
         ])}
-        return lambda *args: [tags[re.sub(r'\s+', ' ', x.strip())] for x in args]
+        return lambda *args: [tags[re.sub(r'\s+', ' ', x.strip())] if not re.match(r"^(\w+\.\w+,)*\w+\.\w+$", x) else x for x in args]
 
     def _deref_account_tags(self, template_code, tax_data):
         mapper = self._get_tag_mapper(template_code)
@@ -950,7 +950,7 @@ class AccountChartTemplate(models.AbstractModel):
                 if tax.get(fname):
                     for _command, _id, repartition in tax[fname]:
                         tags = repartition.get('tag_ids')
-                        if isinstance(tags, str) and not re.match(r"^(\w+\.\w+,)*\w+\.\w+$", tags):
+                        if isinstance(tags, str):
                             repartition['tag_ids'] = [Command.set(mapper(*tags.split(TAX_TAG_DELIMITER)))]
 
     def _parse_csv(self, template_code, model, module=None):


### PR DESCRIPTION
When a tax is created using an unsigned tax tags AND a signed tax tag, the mapper in the chart template model was crashing, skipping the needed mapping for the signed tax (the unsigned tax doesn't need to be mapped as it comes from a template).

task-3520182