### PR TITLE
[IMP] hr_expense: Filter Payment Methods by Company + UI/UX Improvements

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1375,6 +1375,13 @@ class HrExpenseSheet(models.Model):
 
     def action_open_expense_view(self):
         self.ensure_one()
+        if self.expense_number == 1:
+            return {
+                'type': 'ir.actions.act_window',
+                'view_mode': 'form',
+                'res_model': 'hr.expense',
+                'res_id': self.expense_line_ids.id,
+            }
         return {
             'name': _('Expenses'),
             'type': 'ir.actions.act_window',

--- a/addons/hr_expense/models/res_company.py
+++ b/addons/hr_expense/models/res_company.py
@@ -10,7 +10,7 @@ class ResCompany(models.Model):
         "product.product",
         string="Default Expense Category",
         check_company=True,
-        domain="[('can_be_expensed', '=', True), '|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        domain="[('can_be_expensed', '=', True)]",
     )
     expense_journal_id = fields.Many2one(
         "account.journal",

--- a/addons/hr_expense/models/res_config_settings.py
+++ b/addons/hr_expense/models/res_config_settings.py
@@ -15,10 +15,11 @@ class ResConfigSettings(models.TransientModel):
                                              config_parameter='hr_expense.use_mailgateway')
     module_hr_payroll_expense = fields.Boolean(string='Reimburse Expenses in Payslip')
     module_hr_expense_extract = fields.Boolean(string='Send bills to OCR to generate expenses')
-    expense_product_id = fields.Many2one('product.product', related='company_id.expense_product_id', readonly=False)
+    expense_product_id = fields.Many2one('product.product', related='company_id.expense_product_id', readonly=False, check_company=True)
     expense_journal_id = fields.Many2one('account.journal', related='company_id.expense_journal_id', readonly=False, check_company=True)
     company_expense_allowed_payment_method_line_ids = fields.Many2many(
         comodel_name='account.payment.method.line',
+        check_company=True,
         related='company_id.company_expense_allowed_payment_method_line_ids',
         readonly=False,
     )

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -40,7 +40,7 @@
                             <setting company_dependent="1" help="Default accounting journal for expenses paid by employees." string="Employee Expense Journal">
                                 <field name="expense_journal_id"/>
                             </setting>
-                            <setting company_dependent="1" string="Company payment methods available" help="Payment method allowed for expenses paid by company.">
+                            <setting company_dependent="1" string="Payment methods" help="Payment method allowed for expenses paid by company.">
                                 <field name="company_expense_allowed_payment_method_line_ids" widget="many2many_tags" placeholder="All payment methods allowed" options="{'no_create': True}" context="{'show_payment_journal_id': 1}"/>
                             </setting>
                         </block>


### PR DESCRIPTION
- Applies a domain filter to limit payment methods to those of the running company in multi-company settings.
- Some wording adjustments for better clarity.
- UI tweak: Directly open the expense detail view when only one expense is linked to an expense report, bypassing list view for better usability

Task-3500674

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
