### PR TITLE
[REF] mail: set data immediately on discuss model relational field 

### DIFF
--- a/addons/im_livechat/static/src/chat_window/chat_window_patch.js
+++ b/addons/im_livechat/static/src/chat_window/chat_window_patch.js
@@ -8,8 +8,11 @@ patch(ChatWindow.prototype, {
     async close(options) {
         const thread = this.thread;
         await super.close(options);
-        if (thread?.type === "livechat" && thread.isLoaded && thread.messages.length === 0) {
-            this.threadService.unpin(thread);
+        if (thread?.type === "livechat") {
+            await thread?.isLoadedDeferred;
+            if (thread.messages.length === 0) {
+                this.threadService.unpin(thread);
+            }
         }
     },
 });

--- a/addons/im_livechat/static/src/core/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/@types/models.d.ts
@@ -2,4 +2,7 @@ declare module "models" {
     export interface DiscussApp {
         livechat: DiscussAppCategory,
     }
+    export interface Thread {
+        operator: Persona,
+    }
 }

--- a/addons/im_livechat/static/src/core/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/discuss_app_model_patch.js
@@ -9,7 +9,7 @@ import { patch } from "@web/core/utils/patch";
 patch(DiscussApp, {
     new(data) {
         const res = super.new(data);
-        res.livechat = this.store.DiscussAppCategory.insert({
+        res.livechat = {
             extraClass: "o-mail-DiscussSidebarCategory-livechat",
             id: "livechat",
             name: _t("Livechat"),
@@ -17,7 +17,7 @@ patch(DiscussApp, {
             canView: false,
             canAdd: false,
             serverStateKey: "is_discuss_sidebar_category_livechat_open",
-        });
+        };
         return res;
     },
 });

--- a/addons/im_livechat/static/src/embed/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/chatbot/chatbot_service.js
@@ -131,9 +131,7 @@ export class ChatBotService {
             channel_uuid: this.livechatService.thread.uuid,
             chatbot_script_id: this.chatbot.scriptId,
         });
-        this.livechatService.thread?.messages.push(
-            this.store.Message.insert({ ...message, body: markup(message.body) })
-        );
+        this.livechatService.thread?.messages.push({ ...message, body: markup(message.body) });
         this.currentStep = null;
         this.start();
     }
@@ -147,11 +145,10 @@ export class ChatBotService {
             chatbot_script_id: this.chatbot.scriptId,
         });
         for (const rawMessage of rawMessages) {
-            const message = this.store.Message.insert({
+            this.livechatService.thread?.messages.add({
                 ...rawMessage,
                 body: markup(rawMessage.body),
             });
-            this.livechatService.thread?.messages.add(message);
         }
         this.hasPostedWelcomeSteps = true;
     }
@@ -180,11 +177,10 @@ export class ChatBotService {
                 return;
             }
             if (stepMessage) {
-                const message = this.store.Message.insert({
+                this.livechatService.thread?.messages.add({
                     ...stepMessage,
                     body: markup(stepMessage.body),
                 });
-                this.livechatService.thread?.messages.add(message);
             }
             this.currentStep = step;
             if (
@@ -281,10 +277,8 @@ export class ChatBotService {
             channel_uuid: this.livechatService.thread.uuid,
         });
         this.currentStep.isEmailValid = success;
-        if (msg && !this.livechatService.thread.messages.some((m) => m.id === msg.id)) {
-            this.livechatService.thread.messages.push(
-                this.store.Message.insert({ ...msg, body: markup(msg.body) })
-            );
+        if (msg) {
+            this.livechatService.thread.messages.add({ ...msg, body: markup(msg.body) });
         }
     }
 

--- a/addons/im_livechat/static/src/embed/core/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/core/@types/models.d.ts
@@ -1,0 +1,6 @@
+declare module "models" {
+    export interface Thread {
+        chatbotTypingMessage: Message,
+        livechatWelcomeMessage: Message,
+    }
+}

--- a/addons/im_livechat/static/src/embed/core/messaging_service_patch.js
+++ b/addons/im_livechat/static/src/embed/core/messaging_service_patch.js
@@ -11,10 +11,10 @@ patch(Messaging.prototype, {
             return super.initialize();
         }
         if (session.livechatData?.options.current_partner_id) {
-            this.store.user = this.store.Persona.insert({
+            this.store.user = {
                 type: "partner",
                 id: session.livechatData.options.current_partner_id,
-            });
+            };
         }
         this.store.isMessagingReady = true;
         this.isReady.resolve({

--- a/addons/im_livechat/static/src/embed/core/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/core/thread_model_patch.js
@@ -1,5 +1,6 @@
 /* @odoo-module */
 
+import { Record } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 import { onChange } from "@mail/utils/common/misc";
 
@@ -25,20 +26,20 @@ patch(Thread, {
                 }
             });
             if (chatbotService.isChatbotThread(thread)) {
-                thread.chatbotTypingMessage = this.store.Message.insert({
+                thread.chatbotTypingMessage = {
                     id: messageService.getNextTemporaryId(),
                     res_id: thread.id,
                     model: thread.model,
                     author: thread.operator,
-                });
+                };
             } else {
-                thread.livechatWelcomeMessage = this.store.Message.insert({
+                thread.livechatWelcomeMessage = {
                     id: messageService.getNextTemporaryId(),
                     body: livechatService.options.default_message,
                     res_id: thread.id,
                     model: thread.model,
                     author: thread.operator,
-                });
+                };
             }
         }
         return thread;
@@ -48,14 +49,19 @@ patch(Thread, {
 patch(Thread.prototype, {
     chatbotScriptId: null,
 
+    setup() {
+        super.setup();
+        this.chatbotTypingMessage = Record.one("Message");
+        this.livechatWelcomeMessage = Record.one("Message");
+    },
     update(data) {
         super.update(...arguments);
         if (data.operator_pid) {
-            this.operator = this._store.Persona.insert({
+            this.operator = {
                 type: "partner",
                 id: data.operator_pid[0],
                 name: data.operator_pid[1],
-            });
+            };
         }
     },
 

--- a/addons/im_livechat/static/src/embed/core/thread_service_patch.js
+++ b/addons/im_livechat/static/src/embed/core/thread_service_patch.js
@@ -64,7 +64,7 @@ patch(ThreadService.prototype, {
     },
 
     avatarUrl(author, thread) {
-        if (thread.type !== "livechat") {
+        if (thread?.type !== "livechat") {
             return super.avatarUrl(...arguments);
         }
         const isFromOperator =

--- a/addons/im_livechat/static/tests/embed/livechat_session_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session_tests.js
@@ -5,7 +5,7 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
 import { LivechatButton } from "@im_livechat/embed/core_ui/livechat_button";
 
-import { mockTimeout, triggerHotkey } from "@web/../tests/helpers/utils";
+import { mockTimeout, nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
 import { click, contains, insertText } from "@web/../tests/utils";
 
 QUnit.module("livechat session");
@@ -57,6 +57,7 @@ QUnit.test("Seen message is saved on the session", async (assert) => {
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
     await contains(".o-mail-Message", { count: 2 });
+    await nextTick(); // wait for message seen
     assert.strictEqual(
         env.services["im_livechat.livechat"].sessionCookie.seen_message_id,
         env.services["im_livechat.livechat"].thread.newestMessage.id

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -11,10 +11,6 @@ export class Attachment extends Record {
     /** @type {Object.<number, import("models").Attachment>} */
     static records = {};
     /** @returns {import("models").Attachment} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").Attachment} */
     static get(data) {
         return super.get(data);
     }
@@ -26,7 +22,8 @@ export class Attachment extends Record {
         if (!("id" in data)) {
             throw new Error("Cannot insert attachment: id is missing in data");
         }
-        const attachment = this.get(data) ?? this.new(data);
+        /** @type {import("models").Attachment} */
+        const attachment = this.preinsert(data);
         Object.assign(attachment, { id: data.id });
         attachment.update(data);
         return attachment;
@@ -55,10 +52,10 @@ export class Attachment extends Record {
             const threadData = Array.isArray(data.originThread)
                 ? data.originThread[0][1]
                 : data.originThread;
-            this.originThread = this._store.Thread.insert({
+            this.originThread = {
                 model: threadData.model,
                 id: threadData.id,
-            });
+            };
             const thread = this.originThread;
             thread.attachments.add(this);
             thread.attachments.sort((a1, a2) => (a1.id < a2.id ? 1 : -1));

--- a/addons/mail/static/src/core/common/autoresize_input.js
+++ b/addons/mail/static/src/core/common/autoresize_input.js
@@ -14,7 +14,7 @@ export class AutoresizeInput extends Component {
         enabled: { optional: true },
         onValidate: { type: Function, optional: true },
         placeholder: { type: String, optional: true },
-        value: { type: String },
+        value: { type: String, optional: true },
     };
     static defaultProps = {
         autofocus: false,

--- a/addons/mail/static/src/core/common/canned_response_model.js
+++ b/addons/mail/static/src/core/common/canned_response_model.js
@@ -7,10 +7,6 @@ export class CannedResponse extends Record {
     /** @type {Object.<number, import("models").CannedResponse>} */
     static records = {};
     /** @returns {import("models").CannedResponse} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").CannedResponse} */
     static get(data) {
         return super.get(data);
     }
@@ -19,7 +15,8 @@ export class CannedResponse extends Record {
      * @returns {import("models").CannedResponse}
      */
     static insert(data) {
-        const cannedResponse = this.get(data) ?? this.new(data);
+        /** @type {import("models").CannedResponse} */
+        const cannedResponse = this.preinsert(data);
         Object.assign(cannedResponse, {
             id: data.id,
             name: data.source,

--- a/addons/mail/static/src/core/common/channel_member_model.js
+++ b/addons/mail/static/src/core/common/channel_member_model.js
@@ -14,10 +14,6 @@ export class ChannelMember extends Record {
     /** @type {Object.<number, import("models").ChannelMember>} */
     static records = {};
     /** @returns {import("models").ChannelMember} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").ChannelMember} */
     static get(data) {
         return super.get(data);
     }
@@ -27,7 +23,8 @@ export class ChannelMember extends Record {
      */
     static insert(data) {
         const memberData = Array.isArray(data) ? data[1] : data;
-        const member = this.get(memberData) ?? this.new(memberData);
+        /** @type {import("models").ChannelMember} */
+        const member = this.preinsert(memberData);
         member.update(data);
         return member;
     }
@@ -36,19 +33,19 @@ export class ChannelMember extends Record {
         const [command, memberData] = Array.isArray(data) ? data : ["ADD", data];
         this.id = memberData.id;
         if ("persona" in memberData) {
-            this.persona = this._store.Persona.insert({
+            this.persona = {
                 ...(memberData.persona.partner ?? memberData.persona.guest),
                 type: memberData.persona.guest ? "guest" : "partner",
                 country: memberData.persona.partner?.country,
                 channelId: memberData.persona.guest ? memberData.channel.id : null,
-            });
+            };
         }
         let thread = memberData.thread ?? this.thread;
         if (!thread && memberData.channel?.id) {
-            thread = this._store.Thread.insert({
+            thread = {
                 id: memberData.channel.id,
                 model: "discuss.channel",
-            });
+            };
         }
         if (thread && !this.thread) {
             this.thread = thread;

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -12,10 +12,6 @@ export class ChatWindow extends Record {
     /** @type {Object<number, import("models").ChatWindow} */
     static records = {};
     /** @returns {import("models").ChatWindow} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").ChatWindow} */
     static get(data) {
         return super.get(data);
     }
@@ -26,7 +22,8 @@ export class ChatWindow extends Record {
     static insert(data = {}) {
         const chatWindow = this.store.discuss.chatWindows.find((c) => c.thread?.eq(data.thread));
         if (!chatWindow) {
-            const chatWindow = this.new(data);
+            /** @type {import("models").ChatWindow} */
+            const chatWindow = this.preinsert(data);
             Object.assign(chatWindow, { thread: data.thread });
             assignDefined(chatWindow, data);
             let index;
@@ -54,7 +51,7 @@ export class ChatWindow extends Record {
                 data.replaceNewMessageChatWindow ? 1 : 0,
                 chatWindow
             );
-            return this.store.discuss.chatWindows[index]; // return reactive version
+            return chatWindow; // return reactive version
         }
         if (chatWindow.hidden) {
             this.env.services["mail.chat_window"].makeVisible(chatWindow);

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -9,10 +9,6 @@ import { OR, Record } from "@mail/core/common/record";
 export class Composer extends Record {
     static id = OR("thread", "message");
     /** @returns {import("models").Composer} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").Composer} */
     static get(data) {
         return super.get(data);
     }
@@ -27,7 +23,8 @@ export class Composer extends Record {
         }
         let composer = (thread ?? message)?.composer;
         if (!composer) {
-            composer = this.new(data);
+            /** @type {import("models").Composer} */
+            composer = this.preinsert(data);
             const { message, thread } = data;
             if (thread) {
                 composer.thread = thread;

--- a/addons/mail/static/src/core/common/discuss_app_category_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_category_model.js
@@ -6,16 +6,13 @@ import { Record } from "./record";
 export class DiscussAppCategory extends Record {
     static id = "id";
     /** @returns {import("models").DiscussAppCategory} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").DiscussAppCategory} */
     static get(data) {
         return super.get(data);
     }
     /** @returns {import("models").DiscussAppCategory} */
     static insert(data) {
-        const category = this.get(data) ?? this.new(data);
+        /** @type {import("models").DiscussAppCategory} */
+        const category = this.preinsert(data);
         assignDefined(category, data);
         return category;
     }

--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -4,11 +4,11 @@ import { _t } from "@web/core/l10n/translation";
 import { Record } from "./record";
 
 export class DiscussApp extends Record {
-    /** @returns {import("models").DiscussApp} */
     static new(data) {
+        /** @type {import("models").DiscussApp} */
         const res = super.new(data);
         Object.assign(res, {
-            channels: this.store.DiscussAppCategory.insert({
+            channels: {
                 extraClass: "o-mail-DiscussSidebarCategory-channel",
                 id: "channels",
                 name: _t("Channels"),
@@ -18,8 +18,8 @@ export class DiscussApp extends Record {
                 serverStateKey: "is_discuss_sidebar_category_channel_open",
                 addTitle: _t("Add or join a channel"),
                 addHotkey: "c",
-            }),
-            chats: this.store.DiscussAppCategory.insert({
+            },
+            chats: {
                 extraClass: "o-mail-DiscussSidebarCategory-chat",
                 id: "chats",
                 name: _t("Direct messages"),
@@ -29,7 +29,7 @@ export class DiscussApp extends Record {
                 serverStateKey: "is_discuss_sidebar_category_chat_open",
                 addTitle: _t("Start a conversation"),
                 addHotkey: "d",
-            }),
+            },
         });
         return res;
     }
@@ -38,9 +38,8 @@ export class DiscussApp extends Record {
         return super.get(data);
     }
     /** @returns {import("models").DiscussApp} */
-    static insert() {
-        const app = this.get() ?? this.new();
-        return app;
+    static insert(data) {
+        return super.insert(data);
     }
 
     /** @type {'mailbox'|'all'|'channel'|'chat'|'livechat'} */

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -15,10 +15,6 @@ export class Follower extends Record {
     /** @type {Object.<number, import("models").Follower>} */
     static records = {};
     /** @returns {import("models").Follower} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").Follower} */
     static get(data) {
         return super.get(data);
     }
@@ -27,12 +23,13 @@ export class Follower extends Record {
      * @returns {import("models").Follower}
      */
     static insert(data) {
-        const follower = this.get(data) ?? this.new(data);
+        /** @type {import("models").Follower} */
+        const follower = this.preinsert(data);
         Object.assign(follower, {
             followedThread: data.followedThread,
             id: data.id,
             isActive: data.is_active,
-            partner: this.store.Persona.insert({ ...data.partner, type: "partner" }),
+            partner: { ...data.partner, type: "partner" },
         });
         return follower;
     }

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -5,10 +5,6 @@ import { Record } from "@mail/core/common/record";
 export class LinkPreview extends Record {
     static id = "id";
     /** @returns {import("models").LinkPreview} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").LinkPreview} */
     static get(data) {
         return super.get(data);
     }
@@ -20,13 +16,10 @@ export class LinkPreview extends Record {
         const message = this.store.Message.get(data.message_id);
         data.message = message;
         delete data.message_id;
-        let linkPreview = message?.linkPreviews.find((lp) => lp.id === data.id);
-        if (linkPreview) {
-            return Object.assign(linkPreview, data);
-        }
-        linkPreview = this.new(data);
+        /** @type {import("models").LinkPreview} */
+        const linkPreview = this.preinsert(data);
         Object.assign(linkPreview, data);
-        message?.linkPreviews.push(linkPreview);
+        message?.linkPreviews.add(linkPreview);
         return linkPreview;
     }
 

--- a/addons/mail/static/src/core/common/message_reactions_model.js
+++ b/addons/mail/static/src/core/common/message_reactions_model.js
@@ -5,10 +5,6 @@ import { AND, Record } from "@mail/core/common/record";
 export class MessageReactions extends Record {
     static id = AND("message", "content");
     /** @returns {import("models").MessageReactions} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").MessageReactions} */
     static get(data) {
         return super.get(data);
     }
@@ -21,7 +17,8 @@ export class MessageReactions extends Record {
             ({ content }) => content === data.content
         );
         if (!reaction) {
-            reaction = this.new(data);
+            /** @type {import("models").MessageReactions} */
+            reaction = this.preinsert(data);
         }
         const personasToUnlink = new Set();
         const alreadyKnownPersonaIds = new Set(reaction.personas.map((p) => p.localId));
@@ -48,7 +45,7 @@ export class MessageReactions extends Record {
         Object.assign(reaction, {
             count: data.count,
             content: data.content,
-            message: this.store.Message.insert(data.message),
+            message: data.message,
             personas: reaction.personas.filter((p) => !personasToUnlink.has(p)),
         });
         return reaction;

--- a/addons/mail/static/src/core/common/messaging_service.js
+++ b/addons/mail/static/src/core/common/messaging_service.js
@@ -30,26 +30,26 @@ export class Messaging {
         this.store.Persona.insert({ id: user.partnerId, type: "partner", isAdmin: user.isAdmin });
         this.registeredImStatusPartners = reactive([], () => this.updateImStatusRegistration());
         this.store.registeredImStatusPartners = this.registeredImStatusPartners;
-        this.store.discuss.inbox = this.store.Thread.insert({
+        this.store.discuss.inbox = {
             id: "inbox",
             model: "mail.box",
             name: _t("Inbox"),
             type: "mailbox",
-        });
-        this.store.discuss.starred = this.store.Thread.insert({
+        };
+        this.store.discuss.starred = {
             id: "starred",
             model: "mail.box",
             name: _t("Starred"),
             type: "mailbox",
             counter: 0,
-        });
-        this.store.discuss.history = this.store.Thread.insert({
+        };
+        this.store.discuss.history = {
             id: "history",
             model: "mail.box",
             name: _t("History"),
             type: "mailbox",
             counter: 0,
-        });
+        };
         this.updateImStatusRegistration();
     }
 
@@ -64,22 +64,16 @@ export class Messaging {
 
     initMessagingCallback(data) {
         if (data.current_partner) {
-            this.store.user = this.store.Persona.insert({
-                ...data.current_partner,
-                type: "partner",
-            });
+            this.store.user = { ...data.current_partner, type: "partner" };
         }
         if (data.currentGuest) {
-            this.store.guest = this.store.Persona.insert({
+            this.store.guest = {
                 ...data.currentGuest,
                 type: "guest",
                 channelId: data.channels[0]?.id,
-            });
+            };
         }
-        this.store.odoobot = this.store.Persona.insert({
-            ...data.odoobot,
-            type: "partner",
-        });
+        this.store.odoobot = { ...data.odoobot, type: "partner" };
         const settings = data.current_user_settings;
         this.userSettingsService.updateFromCommands(settings);
         this.userSettingsService.id = settings.id;

--- a/addons/mail/static/src/core/common/notification_group_model.js
+++ b/addons/mail/static/src/core/common/notification_group_model.js
@@ -10,10 +10,6 @@ export class NotificationGroup extends Record {
     /** @type {Object.<number, import("models").NotificationGroup>} */
     static records = {};
     /** @returns {import("models").NotificationGroup} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").NotificationGroup} */
     static get(data) {
         return super.get(data);
     }
@@ -31,7 +27,8 @@ export class NotificationGroup extends Record {
         });
         if (!group) {
             const id = nextId++;
-            group = this.new({ id });
+            /** @type {import("models").NotificationGroup} */
+            group = this.preinsert({ id });
             Object.assign(group, { id });
             this.store.discuss.notificationGroups.add(group);
         }

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -9,10 +9,6 @@ export class Notification extends Record {
     /** @type {Object.<number, import("models").Notification>} */
     static records = {};
     /** @returns {import("models").Notification} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").Notification} */
     static get(data) {
         return super.get(data);
     }
@@ -21,7 +17,8 @@ export class Notification extends Record {
      * @returns {import("models").Notification}
      */
     static insert(data) {
-        const notification = this.get(data) ?? this.new(data);
+        /** @type {import("models").Notification} */
+        const notification = this.preinsert(data);
         Object.assign(notification, { id: data.id });
         notification.update(data);
         return notification;
@@ -34,11 +31,11 @@ export class Notification extends Record {
             notification_type: data.notification_type,
             failure_type: data.failure_type,
             persona: data.res_partner_id
-                ? this._store.Persona.insert({
+                ? {
                       id: data.res_partner_id[0],
                       displayName: data.res_partner_id[1],
                       type: "partner",
-                  })
+                  }
                 : undefined,
         });
         if (!this.message.author?.eq(this._store.self)) {

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -18,10 +18,6 @@ export class Persona extends Record {
     /** @type {Object.<number, import("models").Persona>} */
     static records = {};
     /** @returns {import("models").Persona} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").Persona} */
     static get(data) {
         return super.get(data);
     }
@@ -30,10 +26,7 @@ export class Persona extends Record {
      * @returns {import("models").Persona}
      */
     static insert(data) {
-        const persona = this.get(data) ?? this.new(data);
-        persona.update(data);
-        // return reactive version
-        return persona;
+        return super.insert(data);
     }
 
     update(data) {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -8,7 +8,12 @@ import { registry } from "@web/core/registry";
 import { debounce } from "@web/core/utils/timing";
 import { modelRegistry, Record, RecordInverses, RecordList } from "./record";
 
-export class Store {
+export class Store extends Record {
+    /** @returns {import("models").Store} */
+    static insert() {
+        return this.get() ?? this.new();
+    }
+
     /** @type {typeof import("@mail/core/web/activity_model").Activity} */
     Activity;
     /** @type {typeof import("@mail/core/common/attachment_model").Attachment} */
@@ -44,6 +49,56 @@ export class Store {
     /** @type {typeof import("@mail/core/common/thread_model").Thread} */
     Thread;
 
+    lastChannelSubscription = "";
+    /**
+     * This is the current logged partner
+     *
+     * @type {import("models").Persona}
+     */
+    user = null;
+    /**
+     * This is the current logged guest
+     *
+     * @type {import("models").Persona}
+     */
+    guest = null;
+    /**
+     * The last id of bus notification at the time for fetch init_messaging.
+     * When receiving a notification:
+     * - if id greater than this value: the notification is newer than init_messaging state.
+     * - if same id or lower: the notification is older than init_messaging state.
+     * This is useful to determine whether we should increment or decrement a counter based
+     * on init_messaging state.
+     */
+    initBusId = 0;
+    /**
+     * Indicates whether the current user is using the application through the
+     * public page.
+     */
+    inPublicPage = false;
+    companyName = "";
+    /** @type {import("models").Persona} */
+    odoobot = null;
+    odoobotOnboarding;
+    users = {};
+    internalUserGroupId = null;
+    registeredImStatusPartners = null;
+    hasLinkPreviewFeature = true;
+    // messaging menu
+    menu = { counter: 0 };
+    discuss = Record.one("DiscussApp");
+    activityCounter = 0;
+    isMessagingReady = false;
+
+    get self() {
+        return this.guest ?? this.user;
+    }
+
+    setup() {
+        super.setup();
+        this.updateBusSubscription = debounce(this.updateBusSubscription, 0); // Wait for thread fully inserted.
+    }
+
     /**
      * @param {string} localId
      * @returns {Record}
@@ -54,22 +109,6 @@ export class Store {
         }
         const modelName = Record.modelFromLocalId(localId);
         return this[modelName].records[localId];
-    }
-
-    /**
-     * @param {import("@web/env").OdooEnv} env
-     */
-    constructor(env) {
-        this.setup(env);
-        this.lastChannelSubscription = "";
-        this.updateBusSubscription = debounce(this.updateBusSubscription, 0); // Wait for thread fully inserted.
-    }
-
-    /**
-     * @param {import("@web/env").OdooEnv} env
-     */
-    setup(env) {
-        this.env = env;
     }
 
     updateBusSubscription() {
@@ -87,64 +126,8 @@ export class Store {
         }
         this.lastChannelSubscription = channels;
     }
-
-    get self() {
-        return this.guest ?? this.user;
-    }
-
-    // base data
-
-    /**
-     * This is the current logged partner
-     *
-     * @type {import("models").Persona}
-     */
-    user = null;
-    /**
-     * This is the current logged guest
-     *
-     * @type {import("models").Persona}
-     */
-    guest = null;
-
-    /**
-     * The last id of bus notification at the time for fetch init_messaging.
-     * When receiving a notification:
-     * - if id greater than this value: the notification is newer than init_messaging state.
-     * - if same id or lower: the notification is older than init_messaging state.
-     * This is useful to determine whether we should increment or decrement a counter based
-     * on init_messaging state.
-     */
-    initBusId = 0;
-
-    /**
-     * Indicates whether the current user is using the application through the
-     * public page.
-     */
-    inPublicPage = false;
-
-    companyName = "";
-
-    /** @type {import("models").Persona} */
-    odoobot = null;
-    odoobotOnboarding;
-    users = {};
-    internalUserGroupId = null;
-    registeredImStatusPartners = null;
-
-    hasLinkPreviewFeature = true;
-
-    // messaging menu
-    menu = {
-        counter: 0,
-    };
-
-    discuss = Record.one("DiscussApp");
-
-    activityCounter = 0;
-
-    isMessagingReady = false;
 }
+Store.register();
 
 export const storeService = {
     dependencies: ["bus_service", "ui"],
@@ -153,11 +136,19 @@ export const storeService = {
      * @param {Partial<import("services").Services>} services
      */
     start(env, services) {
-        const res = reactive(new Store(env, services));
+        const res = {
+            // fake store for now, until it becomes a model
+            /** @type {Store} */
+            store: {
+                env,
+                get: (...args) => Store.prototype.get.call(this, ...args),
+            },
+        };
+        const Models = {};
         for (const [name, _Model] of modelRegistry.getEntries()) {
             /** @type {typeof Record} */
             const Model = _Model;
-            if (res[name]) {
+            if (res.store[name]) {
                 throw new Error(
                     `There must be no duplicated Model Names (duplicate found: ${name})`
                 );
@@ -165,7 +156,7 @@ export const storeService = {
             // classes cannot be made reactive because they are functions and they are not supported.
             // work-around: make an object whose prototype is the class, so that static props become
             // instance props.
-            const entry = Object.assign(Object.create(Model), { env, store: res });
+            const entry = Object.assign(Object.create(Model), { env, store: res.store });
             // Produce another class with changed prototype, so that there are automatic get/set on relational fields
             let detecting = true;
             const Class = {
@@ -187,7 +178,7 @@ export const storeService = {
                             }
                             if (this[name] === Record.many()) {
                                 newVal = new RecordList();
-                                newVal.__store__ = res;
+                                newVal.__store__ = res.store;
                                 newVal.name = name;
                                 newVal.owner = this;
                             }
@@ -203,7 +194,7 @@ export const storeService = {
                                     if (l1 instanceof RecordList) {
                                         return l1;
                                     }
-                                    return res.get(l1);
+                                    return res.store.get(l1);
                                 }
                                 return Reflect.get(target, name, receiver);
                             },
@@ -211,7 +202,7 @@ export const storeService = {
                                 if (name !== "__rels__" && target.__rels__.has(name)) {
                                     const r1 = target;
                                     const l1 = r1.__rels__.get(name);
-                                    const r2 = res.get(l1);
+                                    const r2 = res.store.get(l1);
                                     if (r2) {
                                         r2.__invs__.delete(r1.localId, name);
                                     }
@@ -242,7 +233,7 @@ export const storeService = {
                                     } else {
                                         const r1 = receiver;
                                         const l1 = r1.__rels__.get(name);
-                                        const r2 = res.get(l1);
+                                        const r2 = res.store.get(l1);
                                         /** @type {Record} */
                                         const r3 = val;
                                         if (r2 && r2.notEq(r3)) {
@@ -269,7 +260,8 @@ export const storeService = {
             }[Model.name];
             entry.Class = Class;
             entry.records = JSON.parse(JSON.stringify(Model.records));
-            res[name] = entry;
+            Models[name] = entry;
+            res.store[name] = entry;
             // Detect relational fields with a dummy record and setup getter/setters on them
             const obj = new Model();
             detecting = false;
@@ -280,17 +272,25 @@ export const storeService = {
                 Class.__rels__.add(name);
             }
         }
-        res.discuss = res.DiscussApp.insert();
-        res.discuss.activeTab = env.services.ui.isSmall ? "mailbox" : "all";
-        onChange(res.Thread, "records", () => res.updateBusSubscription());
+        // Make true store (as a model)
+        res.store = reactive(res.store.Store.insert());
+        res.store.env = env;
+        for (const Model of Object.values(Models)) {
+            Model.store = res.store;
+            res.store[Model.name] = Model;
+        }
+        const store = res.store;
+        store.discuss = store.DiscussApp.insert();
+        store.discuss.activeTab = env.services.ui.isSmall ? "mailbox" : "all";
+        onChange(store.Thread, "records", () => store.updateBusSubscription());
         services.ui.bus.addEventListener("resize", () => {
             if (!services.ui.isSmall) {
-                res.discuss.activeTab = "all";
+                store.discuss.activeTab = "all";
             } else {
-                res.discuss.activeTab = res.discuss.thread?.type ?? "all";
+                store.discuss.activeTab = store.discuss.thread?.type ?? "all";
             }
         });
-        return res;
+        return store;
     },
 };
 

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -81,7 +81,7 @@ export class ThreadService {
      * @param {import("models").Thread} thread
      */
     async markAsRead(thread) {
-        if (!thread.isLoaded && thread.status === "loading") {
+        if (!thread.isLoaded) {
             await thread.isLoadedDeferred;
             await new Promise(setTimeout);
         }

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -38,10 +38,6 @@ export class Activity extends Record {
     /** @type {Object.<number, import("models").Activity>} */
     static records = {};
     /** @returns {import("models").Activity} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").Activity} */
     static get(data) {
         return super.get(data);
     }
@@ -52,7 +48,8 @@ export class Activity extends Record {
      * @returns {import("models").Activity}
      */
     static insert(data, { broadcast = true } = {}) {
-        const activity = this.get(data) ?? this.new(data);
+        /** @type {import("models").Activity} */
+        const activity = this.preinsert(data);
         Object.assign(activity, { id: data.id });
         if (data.request_partner_id) {
             data.request_partner_id = data.request_partner_id[0];

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Chatter">
-    <div class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.hasMessageListScrollAdjust, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
+    <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.hasMessageListScrollAdjust, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
             <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 px-3 overflow-x-auto">
                 <button t-if="props.hasMessageList" class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{

--- a/addons/mail/static/src/core/web/messaging_menu.js
+++ b/addons/mail/static/src/core/web/messaging_menu.js
@@ -287,7 +287,7 @@ export class MessagingMenu extends Component {
             );
         }
         if (this.store.discuss.activeTab !== "mailbox") {
-            delete this.store.discuss.thread;
+            this.store.discuss.thread = undefined;
         }
     }
 

--- a/addons/mail/static/src/core/web/thread_service_patch.js
+++ b/addons/mail/static/src/core/web/thread_service_patch.js
@@ -70,19 +70,14 @@ patch(ThreadService.prototype, {
             });
         }
         if ("mainAttachment" in result) {
-            thread.mainAttachment = result.mainAttachment.id
-                ? this.store.Attachment.insert(result.mainAttachment)
-                : undefined;
+            thread.mainAttachment = result.mainAttachment.id ? result.mainAttachment : undefined;
         }
         if (!thread.mainAttachment && thread.attachmentsInWebClientView.length > 0) {
             this.setMainAttachmentFromIndex(thread, 0);
         }
         if ("followers" in result) {
             if (result.selfFollower) {
-                thread.selfFollower = this.store.Follower.insert({
-                    followedThread: thread,
-                    ...result.selfFollower,
-                });
+                thread.selfFollower = { followedThread: thread, ...result.selfFollower };
             }
             thread.followersCount = result.followersCount;
             for (const followerData of result.followers) {
@@ -96,11 +91,7 @@ patch(ThreadService.prototype, {
             }
             thread.recipientsCount = result.recipientsCount;
             for (const recipientData of result.recipients) {
-                const recipient = this.store.Follower.insert({
-                    followedThread: thread,
-                    ...recipientData,
-                });
-                thread.recipients.add(recipient);
+                thread.recipients.add({ followedThread: thread, ...recipientData });
             }
         }
         if ("suggestedRecipients" in result) {
@@ -123,18 +114,15 @@ patch(ThreadService.prototype, {
             type: "chatter",
         });
         if (resId === false) {
-            const tmpId = this.messageService.getNextTemporaryId();
-            const tmpData = {
-                id: tmpId,
+            thread.messages.push({
+                id: this.messageService.getNextTemporaryId(),
                 author: { id: this.store.self.id },
                 body: _t("Creating a new record..."),
                 message_type: "notification",
                 trackingValues: [],
                 res_id: thread.id,
                 model: thread.model,
-            };
-            const message = this.store.Message.insert(tmpData);
-            thread.messages.push(message);
+            });
         }
         return thread;
     },
@@ -156,12 +144,7 @@ patch(ThreadService.prototype, {
                 email,
                 lang,
                 reason,
-                persona: partner_id
-                    ? this.store.Persona.insert({
-                          type: "partner",
-                          id: partner_id,
-                      })
-                    : false,
+                persona: partner_id ? { type: "partner", id: partner_id } : false,
                 checked: true,
             });
         }
@@ -198,11 +181,7 @@ patch(ThreadService.prototype, {
             { filter_recipients: true }
         );
         for (const data of recipients) {
-            const recipient = this.store.Follower.insert({
-                followedThread: thread,
-                ...data,
-            });
-            thread.recipients.add(recipient);
+            thread.recipients.add({ followedThread: thread, ...data });
         }
     },
     open(thread, replaceNewMessageChatWindow) {

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -273,7 +273,7 @@ export class Rtc {
      * @param {import("models").Thread} [channel]
      */
     endCall(channel = this.state.channel) {
-        channel.rtcInvitingSessionId = undefined;
+        channel.rtcInvitingSession = undefined;
         if (channel.eq(this.state.channel)) {
             this.clear();
             this.soundEffectsService.play("channel-leave");
@@ -762,7 +762,7 @@ export class Rtc {
             3000,
             true
         );
-        this.state.channel.rtcInvitingSessionId = undefined;
+        this.state.channel.rtcInvitingSession = undefined;
         this.call();
         this.soundEffectsService.play("channel-join");
         await this.resetAudioTrack({ force: true });
@@ -830,8 +830,7 @@ export class Rtc {
         if (this.state.channel && rtcSessions) {
             const activeSessionsData = rtcSessions[0][1];
             for (const sessionData of activeSessionsData) {
-                const session = this.store.RtcSession.insert(sessionData);
-                this.state.channel.rtcSessions.add(session);
+                this.state.channel.rtcSessions.add(sessionData);
             }
             const outdatedSessionsData = rtcSessions[1][1];
             for (const sessionData of outdatedSessionsData) {
@@ -892,19 +891,19 @@ export class Rtc {
                 // ignore error during remove, the value will be overwritten at next usage anyway
             }
         }
-        delete session.audioStream;
-        delete session.connectionState;
-        delete session.localCandidateType;
-        delete session.remoteCandidateType;
-        delete session.dataChannelState;
-        delete session.packetsReceived;
-        delete session.packetsSent;
-        delete session.dtlsState;
-        delete session.iceState;
-        delete session.raisingHand;
-        delete session.logStep;
-        delete session.audioError;
-        delete session.videoError;
+        session.audioStream = undefined;
+        session.connectionState = undefined;
+        session.localCandidateType = undefined;
+        session.remoteCandidateType = undefined;
+        session.dataChannelState = undefined;
+        session.packetsReceived = undefined;
+        session.packetsSent = undefined;
+        session.dtlsState = undefined;
+        session.iceState = undefined;
+        session.raisingHand = undefined;
+        session.logStep = undefined;
+        session.audioError = undefined;
+        session.videoError = undefined;
         session.isTalking = false;
         this.removeVideoFromSession(session);
         session.dataChannel?.close();
@@ -927,7 +926,7 @@ export class Rtc {
                 }
             }
             peerConnection.close();
-            delete session.peerConnection;
+            session.peerConnection = undefined;
         }
         browser.clearTimeout(this.state.recoverTimeouts.get(session.id));
         this.state.recoverTimeouts.delete(session.id);
@@ -1537,8 +1536,7 @@ export class Rtc {
                 break;
             case "ADD":
                 for (const sessionData of sessionsData) {
-                    const session = this.store.RtcSession.insert(sessionData);
-                    channel.rtcSessions.add(session);
+                    channel.rtcSessions.add(sessionData);
                 }
                 break;
         }

--- a/addons/mail/static/src/discuss/call/common/rtc_session_model.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_session_model.js
@@ -7,10 +7,6 @@ export class RtcSession extends Record {
     /** @type {Object.<number, import("models").RtcSession>} */
     static records = {};
     /** @returns {import("models").RtcSession} */
-    static new(data) {
-        return super.new(data);
-    }
-    /** @returns {import("models").RtcSession} */
     static get(data) {
         return super.get(data);
     }
@@ -19,7 +15,8 @@ export class RtcSession extends Record {
      * @returns {number, import("models").RtcSession}
      */
     static insert(data) {
-        const session = this.get(data) ?? this.new(data);
+        /** @type {import("models").RtcSession} */
+        const session = this.preinsert(data);
         const { channelMember, ...remainingData } = data;
         for (const key in remainingData) {
             session[key] = remainingData[key];

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -8,8 +8,7 @@ patch(Thread.prototype, {
     update(data) {
         super.update(data);
         if ("rtc_inviting_session" in data) {
-            const session = this._store.RtcSession.insert(data.rtc_inviting_session);
-            this.rtcSessions.add(session);
+            this.rtcSessions.add(data.rtc_inviting_session);
             this._store.discuss.ringingThreads.add(this);
         }
         let rtcContinue = true;
@@ -21,8 +20,7 @@ patch(Thread.prototype, {
                 }
                 rtcContinue = false;
             } else {
-                const session = this._store.RtcSession.insert(data.rtcInvitingSession);
-                this.rtcSessions.add(session);
+                this.rtcSessions.add(data.rtcInvitingSession);
                 this._store.discuss.ringingThreads.add(this);
             }
         }
@@ -37,8 +35,7 @@ patch(Thread.prototype, {
                         break;
                     case "ADD":
                         for (const rtcSessionData of sessionsData) {
-                            const session = this._store.RtcSession.insert(rtcSessionData);
-                            this.rtcSessions.add(session);
+                            this.rtcSessions.add(rtcSessionData);
                         }
                         break;
                 }

--- a/addons/mail/static/src/discuss/message_pin/common/message_pin_service.js
+++ b/addons/mail/static/src/discuss/message_pin/common/message_pin_service.js
@@ -40,7 +40,7 @@ patch(MessageModel.prototype, {
                 this.originThread.pinnedMessages.add(this);
                 this.pinnedAt = pinnedAt;
             } else {
-                delete this.pinnedAt;
+                this.pinnedAt = undefined;
                 this.originThread.pinnedMessages.delete(this);
             }
         }

--- a/addons/mail/static/src/utils/common/arrays.js
+++ b/addons/mail/static/src/utils/common/arrays.js
@@ -1,7 +1,5 @@
 /* @odoo-module */
 
-import { toRaw } from "@odoo/owl";
-
 export function removeFromArray(array, elem) {
     const index = array.indexOf(elem);
     if (index >= 0) {
@@ -13,31 +11,5 @@ export function removeFromArrayWithPredicate(array, predicate) {
     const index = array.findIndex(predicate);
     if (index >= 0) {
         array.splice(index, 1);
-    }
-}
-
-/**
- * Replaces the content of array1 with the content of array2. Order of elements
- * is not guaranteed: new elements are inserted last.
- *
- * Smart process to avoid triggering reactives when there is no change between
- * the 2 arrays.
- */
-export function replaceArrayWithCompare(array1, array2) {
-    array1 = toRaw(array1);
-    array2 = toRaw(array2);
-    const elementsToRemove = new Set();
-    for (const el1 of array1) {
-        if (!array2.includes(el1)) {
-            elementsToRemove.add(el1);
-        }
-    }
-    for (const el of elementsToRemove) {
-        removeFromArray(array1, el);
-    }
-    for (const el2 of array2) {
-        if (!array1.includes(el2)) {
-            array1.push(el2);
-        }
     }
 }

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -331,6 +331,7 @@ export function useSelection({ refName, model, preserveOnClickAwayPredicate = ()
  */
 export function useScrollPosition(refName, model, clearOn) {
     const ref = useRef(refName);
+    let observeScroll = false;
     const self = {
         ref,
         model,
@@ -368,11 +369,21 @@ export function useScrollPosition(refName, model, clearOn) {
     }
 
     onMounted(() => {
-        ref.el.addEventListener("scroll", onScrolled);
+        if (ref.el) {
+            observeScroll = true;
+        }
+        ref.el?.addEventListener("scroll", onScrolled);
+    });
+
+    onPatched(() => {
+        if (!observeScroll && ref.el) {
+            observeScroll = true;
+            ref.el.addEventListener("scroll", onScrolled);
+        }
     });
 
     onWillUnmount(() => {
-        ref.el.removeEventListener("scroll", onScrolled);
+        ref.el?.removeEventListener("scroll", onScrolled);
     });
     return self;
 }

--- a/addons/mail/static/tests/discuss_app/inbox_tests.js
+++ b/addons/mail/static/tests/discuss_app/inbox_tests.js
@@ -612,7 +612,8 @@ QUnit.test("emptying inbox displays rainbow man in inbox", async () => {
     ]);
     const { openDiscuss } = await start();
     openDiscuss();
-    await click("button", { text: "Mark all read" });
+    await contains(".o-mail-Message");
+    await click("button:enabled", { text: "Mark all read" });
     await contains(".o_reward_rainbow");
 });
 

--- a/addons/mail/static/tests/message/message_reply_tests.js
+++ b/addons/mail/static/tests/message/message_reply_tests.js
@@ -4,6 +4,7 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
+import { getOrigin } from "@web/core/utils/urls";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { click, contains } from "@web/../tests/utils";
 
@@ -87,10 +88,9 @@ QUnit.test("reply shows correct author avatar", async (assert) => {
     });
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
-    const replyAvatar = document.querySelector(".o-mail-MessageInReply-avatar");
-    assert.ok(
-        replyAvatar.dataset["src"].includes(
-            `/discuss/channel/${channelId}/partner/${pyEnv.currentPartnerId}/avatar_128`
-        )
+    await contains(
+        `.o-mail-MessageInReply-avatar[data-src='${`${getOrigin()}/discuss/channel/${channelId}/partner/${
+            pyEnv.currentPartnerId
+        }/avatar_128`}']`
     );
 });

--- a/addons/mail/static/tests/web/form_renderer_tests.js
+++ b/addons/mail/static/tests/web/form_renderer_tests.js
@@ -16,7 +16,10 @@ QUnit.test("Form view not scrolled when switching record", async () => {
             description: [...Array(60).keys()].join("\n"),
             display_name: "Partner 1",
         },
-        { display_name: "Partner 2" },
+        {
+            description: [...Array(60).keys()].join("\n"),
+            display_name: "Partner 2",
+        },
     ]);
     const messages = [...Array(60).keys()].map((id) => {
         return {

--- a/addons/test_mail/static/tests/chatter_tests.js
+++ b/addons/test_mail/static/tests/chatter_tests.js
@@ -4,6 +4,8 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
+import { contains } from "@web/../tests/utils";
+
 QUnit.module("chatter");
 
 QUnit.test("Send message button activation (access rights dependent)", async function (assert) {
@@ -54,19 +56,10 @@ QUnit.test("Send message button activation (access rights dependent)", async fun
             res_model: model,
             views: [[false, "form"]],
         });
-        const details = `hasReadAccess: ${hasReadAccess}, hasWriteAccess: ${hasWriteAccess}, model: ${model}, resId: ${resId}`;
         if (enabled) {
-            assert.containsNone(
-                document.body,
-                ".o-mail-Chatter-topbar button:contains(Send message):disabled",
-                `${msg}: send message button must not be disabled (${details}`
-            );
+            await contains(".o-mail-Chatter-topbar button:enabled", { text: "Send message" });
         } else {
-            assert.containsOnce(
-                document.body,
-                ".o-mail-Chatter-topbar button:contains(Send message):disabled",
-                `${msg}: send message button must be disabled (${details})`
-            );
+            await contains(".o-mail-Chatter-topbar button:disabled", { text: "Send message" });
         }
     }
     await assertSendButton(

--- a/addons/website_livechat/static/src/core/@ypes/models.d.ts
+++ b/addons/website_livechat/static/src/core/@ypes/models.d.ts
@@ -1,0 +1,5 @@
+declare module "models" {
+    export interface Thread {
+        visitor: Persona,
+    }
+}

--- a/addons/website_livechat/static/src/core/thread_model_patch.js
+++ b/addons/website_livechat/static/src/core/thread_model_patch.js
@@ -1,17 +1,19 @@
 /** @odoo-module */
 
+import { Record } from "@mail/core/common/record";
 import { Thread } from "@mail/core/common/thread_model";
 import { assignDefined } from "@mail/utils/common/misc";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
+    setup() {
+        super.setup();
+        this.visitor = Record.one("Persona");
+    },
     update(data) {
         super.update(data);
         if (data?.visitor) {
-            this.visitor = this._store.Persona.insert({
-                ...data.visitor,
-                type: "visitor",
-            });
+            this.visitor = { ...data.visitor, type: "visitor" };
         }
         assignDefined(this, data, ["requested_by_operator"]);
     },

--- a/addons/website_slides/static/tests/activity_patch_tests.js
+++ b/addons/website_slides/static/tests/activity_patch_tests.js
@@ -4,7 +4,7 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { click } from "@web/../tests/utils";
+import { click, contains } from "@web/../tests/utils";
 
 QUnit.module("activity (patch)");
 
@@ -36,9 +36,7 @@ QUnit.test("grant course access", async (assert) => {
         res_model: "slide.channel",
         views: [[false, "form"]],
     });
-    assert.containsOnce($, ".o-mail-Activity");
-    assert.containsOnce($, "button:contains(Grant Access)");
-
+    await contains(".o-mail-Activity");
     await click("button", { text: "Grant Access" });
     assert.verifySteps(["access_grant"]);
 });
@@ -71,9 +69,7 @@ QUnit.test("refuse course access", async (assert) => {
         res_model: "slide.channel",
         views: [[false, "form"]],
     });
-    assert.containsOnce($, ".o-mail-Activity");
-    assert.containsOnce($, "button:contains(Refuse Access)");
-
+    await contains(".o-mail-Activity");
     await click("button", { text: "Refuse Access" });
     assert.verifySteps(["access_refuse"]);
 });


### PR DESCRIPTION
With this commit, instead of `Record.insert()` before setting
relation with records, we can immediately pass record data.
For example:
```js
message.author = { id: 3, type: "partner", name: "Admin" };
thread.messages.add({ id: 10, body: "some-text-content" })
```

This is supported on all relational fields that define a target
model.

To make this work while drastically avoiding cyclic dependencies
in code, whenever data have to be inserted in relation, they are
pre-inserted with essential data, and then they are fully inserted
after being registered in the relation.

https://github.com/odoo/enterprise/pull/47854