### PR TITLE
[FIX] base: handle deletion of multiple records

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -300,10 +300,9 @@ class IrModel(models.Model):
 
     def unlink(self):
         # prevent screwing up fields that depend on these models' fields
-        if self.state == 'manual':
-            self.field_id.filtered(lambda f: f.state == 'manual')._prepare_update()
-        else:
-            self.field_id._prepare_update()
+        manual_models = self.filtered(lambda m: m.state == 'manual')
+        manual_models.field_id.filtered(lambda f: f.state == 'manual')._prepare_update()
+        (self - manual_models).field_id._prepare_update()
 
         # delete fields whose comodel is being removed
         self.env['ir.model.fields'].search([('relation', 'in', self.mapped('model'))]).unlink()


### PR DESCRIPTION
This error occurs when we try to delete the multiple records of `ir.model` model

Steps to produce :
- Go to settings > Technical > Database structure > Models.
- Select the multiple records and try to delete the records.
- Error will be generated.

see traceback:
```
ValueError: too many values to unpack (expected 1)
  File "odoo/models.py", line 5457, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: ir.model(621, 622, 623, 624, 426, 425, 416, 427, 638)
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/mail/models/ir_model.py", line 70, in unlink
    return super(IrModel, self).unlink()
  File "odoo/addons/base/models/ir_model.py", line 317, in unlink
    if self.state == 'manual':
  File "odoo/fields.py", line 1153, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5460, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```
In this PR https://github.com/odoo/odoo/pull/133562 'if self.state == manual' condition has been added but when we get multiple records in self a singleton error occurs. To solve this issue the mapped has been used to only take records having state manual at a time.

sentry-4502537032

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
