### PR TITLE
[FIX] web: prevent unintended closure of dialog attached to a dropdown

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -47,10 +47,10 @@ import {
 //
 export function useSelectCreate({ resModel, activeActions, onSelected, onCreateEdit, onUnselect }) {
     const env = useEnv();
-    const addDialog = useOwnedDialogs();
+    const dialogService = useService("dialog");
 
     function selectCreate({ domain, context, filters, title }) {
-        addDialog(SelectCreateDialog, {
+        dialogService.add(SelectCreateDialog, {
             title: title || env._t("Select records"),
             noCreate: !activeActions.create,
             multiSelect: "link" in activeActions ? activeActions.link : false, // LPE Fixme


### PR DESCRIPTION
### Summary
Activating a new dropdown within a dialog, initiated from another dropdown, leads to the unintended closure of the original dropdown and its dialog.

### Steps to reproduce
- Install `account_accountant`
- Navigate to Report > Partner Ledger
- Click 'Partners' button to open a dropdown (referred to as `DD`)
- In that dropdown, click the 'Partners' text field, then 'Search More'
- A dialog opens. In that dialog, toggle the search panel

You should see that the dialog closes.

### Cause
When a new dropdown is activated, the existing implementation closes all other open dropdowns. In this case, toggling the search panel within the 'Search More' dialog opens a new dropdown. This action triggers the closure of `DD`, which also unmounts 'Search More'. Unmounting 'Search More' also leads to the unmounting of the dialog, as they are tied together through `useOwnedDialogs()`.

opw-3464528