### PR TITLE
[FIX] project : traceback with multi-company

### DIFF
--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -76,12 +76,4 @@ class TestProjectStagesMulticompany(TestMultiCompanyProject):
         project.company_id = self.company_b.id
 
         # Check that project was moved to stage_company_b
-        self.assertEqual(self.project_company_a.stage_id, self.stage_company_b, "Project Company A should now be in Stage Company B")
-
-        # Here we remove the company from the stage; then changing the project's company to company A should
-        # move it to the first stage in sequence that is linked to no company, and not in stage company A
-        self.stage_company_a.company_id = False
-
-        project.company_id = self.company_a.id
-
-        self.assertNotEqual(self.project_company_a.stage_id, self.stage_company_a, "Project Company A should not be in Stage Company A")
+        self.assertFalse(self.project_company_a.stage_id.company_id, "Project Company A should now be in a stage without company")


### PR DESCRIPTION
How to reproduce:
    - Link 2 distinct projects to at least 2 different companies
    - Modify and save any setting in project settings (this action
    should trigger the write function of the project)
    --> Traceback: expected singleton

Why?
    - If projects associated with differing companies are updated
    collectively, the condition self.company_id.id anticipates a
    singular value, but it’s possible for there to be multiple.

Solution:
    - When we want to write a company_id on some projects, take back the
    ones already with the right companyc(as we don't have to change their
    stage) and then write the first stage found on the other records (
    by putting self.company_id.ids in order to avoid the singleton
    exception).

taskid:3520107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
