### PR TITLE
[IMP] account: make account tags unique

### DIFF
--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -14,6 +14,8 @@ class AccountAccountTag(models.Model):
     tax_negate = fields.Boolean(string="Negate Tax Balance", help="Check this box to negate the absolute value of the balance of the lines associated with this tag in tax report computation.")
     country_id = fields.Many2one(string="Country", comodel_name='res.country', help="Country for which this tag is available, when applied on taxes.")
 
+    _sql_constraints = [('name_uniq', "unique(name, applicability, country_id)", "A tag with the same name and applicability already exists in this country.")]
+
     @api.depends('applicability', 'country_id')
     @api.depends_context('company')
     def _compute_display_name(self):

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -40,7 +40,7 @@ def test_get_data(self, template_code):
             },
         },
         'account.account.tag': {
-            'account_tax_tag_1': {
+            'account.account_tax_tag_1': {
                 'name': 'tax_tag_name_1',
                 'applicability': 'taxes',
                 'country_id': 'base.be',
@@ -249,7 +249,7 @@ class TestChartTemplate(TransactionCase):
         """ When a tax is close enough from an existing tax we want to update that tax with the new values. """
         def local_get_data(self, template_code):
             data = test_get_data(self, template_code)
-            data['account.account.tag']['account_tax_tag_1']['name'] += ' [DUP]'
+            data['account.account.tag']['account.account_tax_tag_1']['name'] += ' [DUP]'
             return data
 
         tax_existing = self.env['account.tax'].search([('company_id', '=', self.company_1.id), ('name', '=', 'Tax 1')])

--- a/addons/l10n_cl/data/account_tax_tags_data.xml
+++ b/addons/l10n_cl/data/account_tax_tags_data.xml
@@ -109,7 +109,7 @@
 
         <record id="tag_cl_purchase_mnt_iva_actf_no_recup" model="account.account.tag">
             <!-- TotMntIVAActivoFijo -->
-            <field name="name">Purchases - Amount of Active Fixed VAT (Common Use)</field>
+            <field name="name">Purchases - Amount of Active Fixed VAT (Non Deductible)</field>
             <field name="applicability">taxes</field>
             <field name="country_id" ref="base.cl"/>
         </record>


### PR DESCRIPTION
mplemented a uniqueness constraint for account tags to allow some localizations to use tags over account codes.

Task-3497548



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
