### PR TITLE
[FIX] web: autocomplete inEdition

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -12,6 +12,7 @@ export class AutoComplete extends Component {
         this.nextSourceId = 0;
         this.nextOptionId = 0;
         this.sources = [];
+        this.inEdition = false;
 
         this.state = useState({
             navigationRev: 0,
@@ -45,7 +46,6 @@ export class AutoComplete extends Component {
             }
         }, this.constructor.timeout);
 
-
         useExternalListener(window, "scroll", this.onWindowScroll, true);
 
         this.hotkey = useService("hotkey");
@@ -54,8 +54,10 @@ export class AutoComplete extends Component {
         owl.onWillUpdateProps((nextProps) => {
             if (this.props.value !== nextProps.value || this.forceValFromProp) {
                 this.forceValFromProp = false;
-                this.state.value = nextProps.value;
-                this.inputRef.el.value = nextProps.value;
+                if (!this.inEdition) {
+                    this.state.value = nextProps.value;
+                    this.inputRef.el.value = nextProps.value;
+                }
                 this.close();
             }
         });
@@ -156,6 +158,7 @@ export class AutoComplete extends Component {
     }
     selectOption(indices, params = {}) {
         const option = this.sources[indices[0]].options[indices[1]];
+        this.inEdition = false;
         if (option.unselectable) {
             this.inputRef.el.value = "";
             this.close();
@@ -234,6 +237,7 @@ export class AutoComplete extends Component {
             this.props.onBlur({
                 inputValue: value,
             });
+            this.inEdition = false;
             this.close();
         }
     }
@@ -250,6 +254,7 @@ export class AutoComplete extends Component {
         });
     }
     async onInput() {
+        this.inEdition = true;
         this.pendingPromise = this.pendingPromise || new Deferred();
         this.loadingPromise = this.pendingPromise;
         this.debouncedProcessInput();

--- a/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field_tests.js
@@ -10,6 +10,7 @@ import {
     selectDropdownItem,
     triggerEvent,
     clickDiscard,
+    clickOpenedDropdownItem,
 } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { browser } from "@web/core/browser/browser";
@@ -343,8 +344,7 @@ QUnit.module("Fields", (hooks) => {
         const input = target.querySelector(".o_field_widget[name=user_id] input");
         input.value = "yy";
         await triggerEvent(input, null, "input");
-        await click(target, ".o_field_widget[name=user_id] input");
-        await selectDropdownItem(target, "user_id", "Create and edit...");
+        await clickOpenedDropdownItem(target, "user_id", "Create and edit...");
 
         await clickDiscard(target.querySelector(".modal"));
         assert.strictEqual(target.querySelector(".o_field_widget[name=user_id] input").value, "");

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -692,8 +692,7 @@ QUnit.module("Fields", (hooks) => {
             const input = target.querySelector(".o_field_widget[name=trululu] input");
             input.value = "yy";
             await triggerEvent(input, null, "input");
-            await click(target, ".o_field_widget[name=trululu] input");
-            await selectDropdownItem(target, "trululu", "Create and edit...");
+            await clickOpenedDropdownItem(target, "trululu", "Create and edit...");
 
             await clickSave(target.querySelector(".modal"));
             assert.verifySteps([`web_save: [[],{"name":"yy"}]`]);
@@ -742,8 +741,7 @@ QUnit.module("Fields", (hooks) => {
             await click(target.querySelectorAll(".o_data_cell")[0]);
             const input = target.querySelector(".o_field_widget[name=user_id] input");
             await editInput(input, null, "yy");
-            await click(target, ".o_field_widget[name=user_id] input");
-            await selectDropdownItem(target, "user_id", 'Create "yy"');
+            await clickOpenedDropdownItem(target, "user_id", 'Create "yy"');
 
             assert.verifySteps(["name_create"]);
         }
@@ -831,6 +829,46 @@ QUnit.module("Fields", (hooks) => {
                 "read",
                 "onchange",
             ]);
+        }
+    );
+
+    QUnit.test(
+        "edit many2one before onchange is finished should not reset the value",
+        async function (assert) {
+            serverData.models.partner.onchanges.display_name = function (obj) {
+                obj.user_id = 19;
+            };
+
+            const def = makeDeferred();
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                    <form>
+                        <field name="display_name"/>
+                        <field name="user_id"/>
+                    </form>`,
+                async mockRPC(route, { method }) {
+                    if (method === "onchange") {
+                        assert.step("onchange");
+                        await def;
+                    }
+                },
+            });
+
+            await editInput(target, "[name='display_name'] input", "new name");
+            const input = target.querySelector("[name='user_id'] input");
+            input.value = "Plop";
+            await triggerEvent(input, null, "input");
+            assert.strictEqual(target.querySelector("[name='user_id'] input").value, "Plop");
+
+            def.resolve();
+            await nextTick();
+            assert.strictEqual(target.querySelector("[name='user_id'] input").value, "Plop");
+
+            assert.verifySteps(["onchange"]);
         }
     );
 


### PR DESCRIPTION
When a user is editing an Autocomplete, we don't want to delete its value if the props value changes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
