### PR TITLE
[FIX] im_livechat: fix missing css class on embed livechat

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -95,6 +95,7 @@ Help your customers with this chat, and analyse their feedback.
         ],
         'im_livechat.assets_core': [
             'web/static/lib/odoo_ui_icons/style.css',
+            'web/static/src/scss/ui.scss',
             'mail/static/src/core/common/**/*',
             'mail/static/src/discuss/core/common/*',
             'mail/static/src/discuss/call/common/**',


### PR DESCRIPTION
This commit adds the `ui.scss` file in order to provide image related css classes to the embed livechat (`o_object_fit_cover`) was missing.

Steps to reproduce:
- Go to the website
- Open a livechat
- Paste a link in order to display a link preview
- The image is stretched since the `o_object_fit_cover` class is not available in the shadow DOM.
