### PR TITLE
[FIX] web_editor: inactive history steps after LinkDialog

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -64,7 +64,6 @@ export class LinkDialog extends Link {
             };
         }
         data.linkDialog = this;
-        this.props.close();
         this.props.onSave(data);
     }
 


### PR DESCRIPTION
Before this commit, after opening a LinkDialog, the history steps were left inactivated.

This happened because the `close` prop passed to the dialog service's `add` method was overwritten by the `close` function defined by this method. As a result, the call to `historyUnpauseSteps` was never done.

This commit fixes such issue by using the `dialogService.add`'s `onClose` option instead.

This commit also handles the conditional history steps revert, that must be done only when the dialog is closed without saving.

task-3522850
