### PR TITLE
[REF] test_discuss_full: replace method by static property

### DIFF
--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -12,6 +12,8 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 @tagged('post_install', '-at_install')
 class TestDiscussFullPerformance(HttpCase):
+    _query_count = 59
+
     def setUp(self):
         super().setUp()
         self.group_user = self.env.ref('base.group_user')
@@ -109,7 +111,7 @@ class TestDiscussFullPerformance(HttpCase):
         self.maxDiff = None
         self.env.flush_all()
         self.env.invalidate_all()
-        with self.assertQueryCount(emp=self._get_query_count()):
+        with self.assertQueryCount(emp=self._query_count):
             init_messaging = self.users[0].with_user(self.users[0])._init_messaging()
 
         self.assertEqual(init_messaging, self._get_init_messaging_result())
@@ -1038,10 +1040,3 @@ class TestDiscussFullPerformance(HttpCase):
                 'volume_settings_ids': [('insert', [])],
             },
         }
-
-    def _get_query_count(self):
-        """
-            Returns the expected query count.
-            The point of having a separate getter is to allow it to be overriden.
-        """
-        return 59


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As it currently is, the query counter in this specific test class is inflexible and modifying the base implementation of the _get_query_count() method breaks tests in dependant modules.

Current behavior before PR:
Adding a query and updating the count in community does not change the expected count value of enterprise, resulting in a broken test.

Desired behavior after PR is merged:
Queries added to the base implementation are taken into account by dependant modules and it is trivial to increment the counter without braking anything.

Enterprise PR: https://github.com/odoo/enterprise/pull/47931