### PR TITLE
Grid gap + individual column padding options

### DIFF
--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -295,6 +295,18 @@ export function _convertColumnToGrid(rowEl, columnEl, columnWidth, columnHeight)
     return {columnColCount: columnColCount, columnRowCount: columnRowCount};
 }
 /**
+ * Removes the grid properties from the grid column when it becomes a normal
+ * column.
+ *
+ * @param {Element} columnEl
+ */
+export function _convertToNormalColumn(columnEl) {
+    const gridSizeClasses = columnEl.className.match(/(g-col-lg|g-height)-[0-9]+/g);
+    columnEl.classList.remove("o_grid_item", "o_grid_item_image", "o_grid_item_image_contain", ...gridSizeClasses);
+    columnEl.style.removeProperty("z-index");
+    columnEl.style.removeProperty("grid-area");
+}
+/**
  * Checks whether the column only contains an image or not. An image is
  * considered alone if the column only contains empty textnodes and line breaks
  * in addition to the image.

--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -29,7 +29,8 @@ export function _getGridProperties(rowEl) {
  * @param {Element} rowEl the parent grid element of the element
  */
 export function _setElementToMaxZindex(element, rowEl) {
-    const childrenEls = [...rowEl.children].filter(el => el !== element);
+    const childrenEls = [...rowEl.children].filter(el => el !== element
+        && !el.classList.contains("o_we_grid_preview"));
     element.style.zIndex = Math.max(...childrenEls.map(el => el.style.zIndex)) + 1;
 }
 /**

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1354,10 +1354,7 @@ var SnippetEditor = Widget.extend({
         } else if (this.$target[0].classList.contains('o_grid_item') && this.dropped) {
             // Case when dropping a grid item in a non-grid dropzone.
             this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-            const gridSizeClasses = this.$target[0].className.match(/(g-col-lg|g-height)-[0-9]+/g);
-            this.$target[0].classList.remove('o_grid_item', 'o_grid_item_image', 'o_grid_item_image_contain', ...gridSizeClasses);
-            this.$target[0].style.removeProperty('z-index');
-            this.$target[0].style.removeProperty('grid-area');
+            gridUtils._convertToNormalColumn(this.$target[0]);
             this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
         }
 
@@ -1401,10 +1398,7 @@ var SnippetEditor = Widget.extend({
                         // Case when a grid column is dropped near a non-grid
                         // dropzone.
                         this.options.wysiwyg.odooEditor.observerActive('dragAndDropMoveSnippet');
-                        const gridSizeClasses = this.$target[0].className.match(/(g-col-lg|g-height)-[0-9]+/g);
-                        this.$target[0].classList.remove('o_grid_item', 'o_grid_item_image', 'o_grid_item_image_contain', ...gridSizeClasses);
-                        this.$target[0].style.removeProperty('z-index');
-                        this.$target[0].style.removeProperty('grid-area');
+                        gridUtils._convertToNormalColumn(this.$target[0]);
                         this.options.wysiwyg.odooEditor.observerUnactive('dragAndDropMoveSnippet');
                     }
                 }

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -3256,6 +3256,15 @@ const SnippetOptionWidget = Widget.extend({
      */
     cleanForSave: async function () {},
     /**
+     * Called when the associated snippet UI needs to be cleaned (e.g. from
+     * visual effects like previews).
+     * TODO this function will replace `cleanForSave` in the future.
+     *
+     * @abstract
+     * @return {Promise|undefined}
+     */
+    cleanUI: async function () {},
+    /**
      * Adds the given widget to the known list of user value widgets
      *
      * @param {UserValueWidget} widget

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5388,12 +5388,8 @@ registry.layout_column = SnippetOptionWidget.extend({
         for (const columnEl of columnEls) {
             // Reloading the images.
             gridUtils._reloadLazyImages(columnEl);
-
             // Removing the grid properties.
-            const gridSizeClasses = columnEl.className.match(/(g-col-lg|g-height)-[0-9]+/g);
-            columnEl.classList.remove('o_grid_item', 'o_grid_item_image', 'o_grid_item_image_contain', ...gridSizeClasses);
-            columnEl.style.removeProperty('grid-area');
-            columnEl.style.removeProperty('z-index');
+            gridUtils._convertToNormalColumn(columnEl);
         }
         // Removing the grid properties.
         delete rowEl.dataset.rowCount;

--- a/addons/web_editor/static/src/scss/web_editor.frontend.scss
+++ b/addons/web_editor/static/src/scss/web_editor.frontend.scss
@@ -34,6 +34,11 @@
 
 // GRID LAYOUT
 .o_grid_mode {
+    @include media-breakpoint-down(lg) {
+        // No gaps in mobile view.
+        row-gap: 0px !important;
+        column-gap: 0px !important;
+    }
     @include media-breakpoint-up(lg) {
         display: grid !important;
         grid-auto-rows: 50px;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2603,10 +2603,6 @@ we-select.o_grid we-toggler {
     width: fit-content !important;
 }
 
-we-button-group.o_grid we-selection-items {
-    width: fit-content !important;
-}
-
 // Background grid.
 .o_we_background_grid {
     padding: 0 !important;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2614,6 +2614,22 @@ we-select.o_grid we-toggler {
         stroke-opacity: .2;
         stroke-width: 1px;
     }
+
+    &.o_we_grid_preview {
+        pointer-events: none;
+
+        .o_we_cell {
+            animation: gridPreview 2s 0.5s;
+        }
+    }
+}
+
+// Grid preview.
+@keyframes gridPreview {
+    to {
+        fill-opacity: 0;
+        stroke-opacity: 0;
+    }
 }
 
 .o_we_drag_helper {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2638,7 +2638,7 @@ we-button-group.o_grid we-selection-items {
     }
 }
 
-.o_we_padding_highlight > .o_grid_item {
+.o_we_padding_highlight.o_grid_item {
     position: relative;
 
     &::after {

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2613,6 +2613,7 @@ we-select.o_grid we-toggler {
         stroke: $o-we-bg-darkest;
         stroke-opacity: .2;
         stroke-width: 1px;
+        filter: drop-shadow(-1px -1px 0px rgba(255, 255, 255, 0.3));
     }
 
     &.o_we_grid_preview {

--- a/addons/website/views/snippets/s_banner.xml
+++ b/addons/website/views/snippets/s_banner.xml
@@ -4,8 +4,8 @@
 <template id="s_banner" name="Banner">
     <section class="s_banner pt96 pb96">
         <div class="container">
-            <div class="row s_nb_column_fixed o_grid_mode">
-                <div class="justify-content-center o_grid_item g-height-4 g-col-lg-5 col-lg-5" data-name="Box" style="z-index: 1; grid-area: 2 / 1 / 10 / 6;">
+            <div class="row s_nb_column_fixed o_grid_mode" data-row-count="11">
+                <div class="justify-content-center o_grid_item g-height-8 g-col-lg-5 col-lg-5" data-name="Box" style="z-index: 1; grid-area: 2 / 1 / 10 / 6;">
                     <h1><font style="font-size: 62px;">Sell Online. <strong>Easily.</strong></font></h1>
                     <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
                     <div class="s_hr text-start pb32 pt4" data-snippet="s_hr" data-name="Separator">

--- a/addons/website/views/snippets/s_text_cover.xml
+++ b/addons/website/views/snippets/s_text_cover.xml
@@ -10,7 +10,7 @@
                     <p class="lead">Write one or two paragraphs describing your product, services or a specific feature. To be successful your content needs to be useful to your readers.</p>
                     <a t-att-href="cta_btn_href" class="btn btn-primary"><t t-esc="cta_btn_text">Contact us</t></a>
                 </div>
-                <div class="o_not_editable pt160 pb160 oe_img_bg col-lg-7 d-none d-md-block" style="background-image: url('/web/image/website.s_text_cover_default_image'); background-position: 100% 0;"/>
+                <div class="o_not_editable o_colored_level o_cc o_cc1 pt160 pb160 oe_img_bg col-lg-7 d-none d-md-block" style="background-image: url('/web/image/website.s_text_cover_default_image'); background-position: 100% 0;"/>
             </div>
         </div>
     </section>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -341,6 +341,28 @@
         data-allow-delete="true" data-fakem2m="true"/>
 </template>
 
+<!-- Column count option -->
+<template id="column_count_option">
+    <we-select t-att-string="not with_grid and 'Columns'" t-att-class="with_grid and 'o_grid'" data-no-preview="true" data-name="column_count_opt" t-att-data-dependencies="with_grid and 'normal_mode'">
+        <we-button data-select-count="0" data-name="zero_cols_opt">None</we-button>
+        <we-button data-select-count="1">1</we-button>
+        <we-button data-select-count="2">2</we-button>
+        <we-button data-select-count="3">3</we-button>
+        <we-button data-select-count="4">4</we-button>
+        <we-button data-select-count="5">5</we-button>
+        <we-button data-select-count="6">6</we-button>
+    </we-select>
+</template>
+
+<!-- Grid layout options -->
+<template id="grid_layout_options">
+    <we-button-group t-att-class="indent and 'o_we_sublevel_1'" string="Add Elements" data-no-preview="true" data-dependencies="grid_mode">
+        <we-button class="o_we_bg_brand_primary o_grid" data-add-element="image" title="Image" data-name="image">Image</we-button>
+        <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
+        <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
+    </we-button-group>
+</template>
+
 <template id="snippet_options" inherit_id="web_editor.snippet_options" primary="True">
     <!-- =================================================================== -->
     <!-- Modify generic snippet options                                      -->
@@ -519,26 +541,14 @@
     <div data-js="layout_column"
         data-selector="section.s_features_grid, section.s_process_steps"
         data-target="> *:has(> .row), > .s_allow_columns">
-        <we-select string="Columns" data-no-preview="true" data-name="column_count_opt">
-            <we-button data-select-count="0" data-name="zero_cols_opt">None</we-button>
-            <we-button data-select-count="1">1</we-button>
-            <we-button data-select-count="2">2</we-button>
-            <we-button data-select-count="3">3</we-button>
-            <we-button data-select-count="4">4</we-button>
-            <we-button data-select-count="5">5</we-button>
-            <we-button data-select-count="6">6</we-button>
-        </we-select>
+        <t t-call="website.column_count_option"/>
     </div>
 
     <!-- Grid only -->
     <div data-js="layout_column"
         data-selector="section.s_masonry_block"
         data-target="> *:has(> .row)">
-        <we-button-group class="o_grid" string="Add Elements" data-no-preview="true" data-dependencies="grid_mode">
-            <we-button class="o_we_bg_brand_primary o_grid" data-add-element="image" title="Image" data-name="image">Image</we-button>
-            <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
-            <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
-        </we-button-group>
+        <t t-call="website.grid_layout_options"/>
     </div>
 
     <!-- Grid and columns -->
@@ -551,21 +561,13 @@
                 <we-button data-select-layout="grid" data-name="grid_mode">Grid</we-button>
                 <we-button data-select-layout="normal" data-name="normal_mode">Cols</we-button>
             </we-button-group>
-            <we-select class="o_grid" data-no-preview="true" data-name="column_count_opt" data-dependencies="normal_mode">
-                <we-button data-select-count="0" data-name="zero_cols_opt">None</we-button>
-                <we-button data-select-count="1">1</we-button>
-                <we-button data-select-count="2">2</we-button>
-                <we-button data-select-count="3">3</we-button>
-                <we-button data-select-count="4">4</we-button>
-                <we-button data-select-count="5">5</we-button>
-                <we-button data-select-count="6">6</we-button>
-            </we-select>
+            <t t-call="website.column_count_option">
+                <t t-set="with_grid" t-value="True"/>
+            </t>
         </we-row>
-        <we-button-group class="o_grid o_we_sublevel_1" string="Add Elements" data-no-preview="true" data-dependencies="grid_mode">
-            <we-button class="o_we_bg_brand_primary o_grid" data-add-element="image" title="Image" data-name="image">Image</we-button>
-            <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
-            <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
-        </we-button-group>
+        <t t-call="website.grid_layout_options">
+            <t t-set="indent" t-value="True"/>
+        </t>
     </div>
 
     <!--  Vertical Alignment -->

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -361,6 +361,10 @@
         <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
         <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
     </we-button-group>
+    <we-row t-att-class="indent and 'o_we_sublevel_1'" string="Spacing (Y, X)">
+        <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="row-gap" data-unit="px" data-prevent-important="true" data-apply-to=".row"/>
+        <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="column-gap" data-unit="px" data-max="60" data-prevent-important="true" data-apply-to=".row"/>
+    </we-row>
 </template>
 
 <template id="snippet_options" inherit_id="web_editor.snippet_options" primary="True">

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -539,10 +539,6 @@
             <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
             <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
         </we-button-group>
-        <we-row string="Padding (Y, X)">
-            <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="--grid-item-padding-y" data-unit="px" data-apply-to=".row"/>
-            <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="--grid-item-padding-x" data-unit="px" data-apply-to=".row"/>
-        </we-row>
     </div>
 
     <!-- Grid and columns -->
@@ -570,10 +566,6 @@
             <we-button class="o_we_bg_brand_primary o_grid" data-add-element="text" title="Text" data-name="text">Text</we-button>
             <we-button class="o_we_bg_brand_primary o_grid" data-add-element="button" title="Button" data-name="button">Button</we-button>
         </we-button-group>
-        <we-row class="o_we_sublevel_1" string="Padding (Y, X)">
-            <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="--grid-item-padding-y" data-unit="px" data-apply-to=".row"/>
-            <we-input data-dependencies="grid_mode" data-select-style="" data-css-property="--grid-item-padding-x" data-unit="px" data-apply-to=".row"/>
-        </we-row>
     </div>
 
     <!--  Vertical Alignment -->
@@ -646,6 +638,15 @@
         <t t-set="with_videos" t-value="True"/>
         <t t-set="with_shapes" t-value="True"/>
     </t>
+
+    <!-- Grid mode columns -->
+    <div data-js="GridColumns"
+         data-selector=".row > div">
+        <we-row string="Padding (Y, X)">
+            <we-input data-select-style="" data-css-property="--grid-item-padding-y" data-unit="px" data-name="grid_padding_y_opt"/>
+            <we-input data-select-style="" data-css-property="--grid-item-padding-x" data-unit="px" data-name="grid_padding_x_opt"/>
+        </we-row>
+    </div>
 
     <!-- Border | Columns -->
     <div data-js="Box"


### PR DESCRIPTION
[IMP] web_editor: clean the snippet UI before cloning it

When cloning a snippet, if it had some previews displayed, the previews
may be cloned with it. This is not a good behavior because the clone
is a new snippet so it should not have all the preview classes that were
added when editing. Moreover, these previews could also cause bugs.

To solve this, an idea could be to call the `cleanForSave` function of
all its options before cloning the snippet. But the problem is that in
some options, the `cleanForSave` function does more than simply clean
the UI (as it was originally supposed to) and so it cannot be used for
that purpose only.

As a solution, this commit adds a new function called `cleanUI` whose
exclusive purpose will be to clean the snippet UI. In the future, it
will replace the `cleanForSave` function.

task-3369695

---
[IMP] web_editor: add support for data-min/max to InputUserValueWidget

Before this commit, when using a `we-input`, there was no way to easily
specify the min and max values that could be entered in the input, which
could be useful when too low/high values could break some behaviors, for
example.

This commit adds the support for the `data-min` and `data-max` data-
attributes in `InputUserValueWidget`. More precisely, when these
attributes are added on a `we-input`, if the user writes a value smaller
than the `data-min` or bigger than the `data-max`, the value snaps to
these bounds. When using the arrows, the value cannot be decreased/
increased beyond them either.

task-3369695

---
[REF] web_editor: refactor some grid code

In the grid mode code, the code managing the transformation of a grid
item into a normal column (when it is dropped or when we toggle the
normal mode) is repeated at several places.

This commits fixes that by creating a function doing this conversion
instead.

task-3369695

---
[IMP] web_editor, website: add individual Padding option for grid items

Before this commit, the "Padding" grid mode option, added in commit [1],
was impacting all the grid items at the same time, which was not
convenient since all these elements would have the same padding and
could not be styled individually.

This commit improves this option in order to modify the padding of the
grid items individually. The highlight effect, added in commit [2], when
changing the padding is still added.

[1]: https://github.com/odoo/odoo/commit/cc406afcea7bf5846233a9f97a4a8ac5f618f3ec
[2]: https://github.com/odoo/odoo/commit/f3f2c4c73ce08d3898b8c88e1ef045f7bbd1f624

task-3369695

---
[REF] web_editor, website: remove duplicated grid/column options

When adding the grid options in commits [1] and [6], some of them have
been duplicated in order to cover the different use cases: grid-only,
columns-only and grid + columns. However, they should have been declared
only once and then called when needed.

This commit extracts the common options into views, to avoid duplicating
them.

[1]: https://github.com/odoo/odoo/commit/cc406afcea7bf5846233a9f97a4a8ac5f618f3ec
[6]: https://github.com/odoo/odoo/commit/85b352af319edec84407f2046cf795b4e5503460

task-3369695

---
[IMP] web_editor, website: add a Spacing option to modify the grid gaps

The `display: grid` property allows to modify the spacing (or gaps)
between the rows and columns of the grid with the `row-gap` and `column-
gap` CSS properties. When the grid mode was added with [1], these
properties were deliberately ignored and the gaps were forced to 0px.

This commit adds the "Spacing (Y, X)" option that allows to modify these
grid gaps. A grid preview is also added when using this option, in order
to visualize what is being changed in the grid.

[1]: https://github.com/odoo/odoo/commit/cc406afcea7bf5846233a9f97a4a8ac5f618f3ec

task-3369695

---
[FIX] web_editor: make background grid more visible on dark backgrounds

When redesigning the grid layout and handles, commit [3] removed the
filter that allowed the grid to be clearly visible on dark backgrounds
(added in commit [4]). Without this, the background grid when dragging/
resizing and the highlight effect when changing the gaps are difficult
to see.

This commit adds this filter back, but with a lowered opacity in order
to not obstruct the view too much.

[3]: https://github.com/odoo/odoo/commit/70f723a9f78c406746f5409f6a89cbe93ad21580
[4]: https://github.com/odoo/odoo/commit/1aa81243b7c80069c576381e2f3b04281455794f

task-3369695

---
[FIX] website: make the "Text Cover" snippet look good in grid mode

Before this commit, toggling the "Text Cover" snippet to grid mode did
not produce a good-looking result: the column containing the background
image loses all its padding and therefore appears smaller and shifted
compared to the normal mode.

This commit adds a background color to the image column. Indeed, with a
background color, and more precisely thanks to the `o_cc` class, the
padding is taken into account when computing the grid items size, making
them look similar to how they were in normal mode.

task-3369695

---
[FIX] website: fix the new design of the Banner snippet

In commit [5], the Banner snippet has been redesigned in order to be
in grid mode by default, to highlight some cool features of the editor.
However, some grid classes and attributes are missing or not well set:
- the first column has a `g-height-4` class despite having 8 rows: this
causes the vertical resize to not work correctly.
- the row does not have the `data-row-count` attribute, which is needed
to display the background grid correctly.

This commit fixes this by replacing the class by `g-height-8` and adding
the `data-row-count` attribute, which is set to 11 rows.

[5]: https://github.com/odoo/odoo/commit/3cbdf754ff8fac8a77887c4307b658cb86b0be1d

task-3369695