### PR TITLE
[FIX] stock_account: SVL revaluation negative amount

### DIFF
--- a/addons/stock_account/i18n/stock_account.pot
+++ b/addons/stock_account/i18n/stock_account.pot
@@ -888,5 +888,5 @@ msgstr ""
 
 #. module: stock_account
 #: code:addons/stock_account/wizard/stock_valuation_layer_revaluation.py:0
-msgid "'The value of a stock valuation layer cannot be negative. Landed cost could be use to correct a specific transfer."
+msgid "Total value of stock valuation cannot be decreased to a negative value."
 msgstr ""

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -61,7 +61,7 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         self.assertEqual(new_layer.value, 20)
 
         # Check the remaing value of current layers
-        self.assertEqual(old_layers[0].remaining_value, 50)
+        self.assertEqual(old_layers[0].remaining_value, 53.33)
         self.assertEqual(sum(slv.remaining_value for slv in old_layers), 80)
 
         # Check account move
@@ -218,14 +218,14 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         revaluation_wizard.account_id = self.stock_valuation_account
         revaluation_wizard.save().action_validate_revaluation()
 
-        self.assertEqual(self.product1.standard_price, 3)
+        self.assertEqual(self.product1.standard_price, 2.67)
 
         # Check the creation of stock.valuation.layer
         new_layer = self.env['stock.valuation.layer'].search([('product_id', '=', self.product1.id)], order="create_date desc, id desc", limit=1)
         self.assertEqual(new_layer.value, 20)
 
         # Check the remaing value of current layers
-        self.assertEqual(old_layers[0].remaining_value, 50)
+        self.assertEqual(old_layers[0].remaining_value, 53.33)
         self.assertEqual(sum(slv.remaining_value for slv in old_layers), 80)
 
         # Check account move


### PR DESCRIPTION
since commit[1] it is not possible to revaluate a layer to a negative value.
Instead of throwing a User error we could set layers that have low values to zero and take the remaining value split equally from the others

opw-3508824

[1]:https://github.com/odoo/odoo/commit/8898739331090a96b3a9a54074a9b7de2233e550

