### PR TITLE
[IMP] l10n_hu: vat validation

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -47,7 +47,7 @@ _ref_vat = {
     'fr': 'FR23334175221',
     'gb': 'GB123456782 or XI123456782',
     'gr': 'GR12345670',
-    'hu': 'HU12345676',
+    'hu': 'HU12345676 or 12345678-1-11',
     'hr': 'HR01234567896',  # Croatia, contributed by Milan Tribuson
     'ie': 'IE1234567FA',
     'in': "12AAAAA1234AAZA",
@@ -295,6 +295,19 @@ class ResPartner(models.Model):
         if len(number) == 10 and self.__check_vat_al_re.match(number):
             return True
         return False
+
+    __check_vat_hu_re = re.compile(r'^\d{8}-\d-\d{2}$')
+    def check_vat_hu(self, vat):
+        """
+            Check Hungary VAT number
+        """
+        match = self.__check_vat_hu_re.match(vat)
+        if match:
+            return True
+        elif len(vat) == 10 and vat[:2] == 'HU':
+            return True
+        else:
+            return False
 
     __check_vat_ch_re = re.compile(r'E([0-9]{9}|-[0-9]{3}\.[0-9]{3}\.[0-9]{3})(MWST|TVA|IVA)$')
 


### PR DESCRIPTION
In Hungary, the tax id can be valid in two distinct ways. Either by putting a vat number looking like 'HU12345678' or putting the national numbers looking like this '12345678-1-11'. To do so we added a regex to check if it matches the national number, if not we check if it's ok for the vat number. Otherwise a validation error will be thrown.

task: 3522940




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
