### PR TITLE
[FIX] hr_skills_survey: UX changes

### DIFF
--- a/addons/hr_skills_survey/views/hr_templates.xml
+++ b/addons/hr_skills_survey/views/hr_templates.xml
@@ -12,6 +12,14 @@
                     readonly="0"
                     invisible="display_type != 'certification'"/>
             </xpath>
+            <field name="employee_id" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </field>
+            <field name="survey_id" position="attributes">
+                <attribute name="context">
+                    {'default_certification': True}
+                </attribute>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Prior to this commit the required employee field was hidden on hr.resume.line form view. Which lead to validation error.

Moreover, on the same form view, on create the survey_id field was not certification by default. The survey_id field has the domain [('certification', '=', True)] on this view and this caused inconsistency. The survey that we created from this form, was not listed as one of the options.

After this commit the employee_id field is shown on hr.resume.line form view and the survey_id, created from this view, will be certification by default.

task-3522917
