### PR TITLE
[FIX] mrp: handle parse-error if reinstall mrp module

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -9,7 +9,7 @@ class StockPickingType(models.Model):
 
     code = fields.Selection(selection_add=[
         ('mrp_operation', 'Manufacturing')
-    ], ondelete={'mrp_operation': 'cascade'})
+    ], ondelete={'mrp_operation': lambda recs: recs.write({'code': 'incoming', 'active': False})})
     count_mo_todo = fields.Integer(string="Number of Manufacturing Orders to Process",
         compute='_get_mo_count')
     count_mo_waiting = fields.Integer(string="Number of Manufacturing Orders Waiting",


### PR DESCRIPTION
When users try to reinstall the "mrp", a traceback will be generated.

Tracebak:
```UserError: Séquences lefourgonbleu Séquence transfert avant fabrication existent déjà.
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 451, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "odoo/models.py", line 4700, in _load_records
    data['record']._load_records_write(data['values'])
  File "odoo/models.py", line 4631, in _load_records_write
    self.write(values)
  File "addons/mrp/models/stock_warehouse.py", line 289, in write
    return super(StockWarehouse, self).write(vals)
  File "addons/stock/models/stock_warehouse.py", line 194, in write
    picking_type_vals = warehouse._create_or_update_sequences_and_picking_types()
  File "addons/stock/models/stock_warehouse.py", line 348, in _create_or_update_sequences_and_picking_types
    warehouse_data[picking_type] = PickingType.create(values).id
  File "<decorator-gen-212>", line 2, in create
  File "odoo/api.py", line 409, in _model_create_multi
    return create(self, [arg])
  File "addons/stock/models/stock_picking.py", line 122, in create
    return super().create(vals_list)
  File "<decorator-gen-10>", line 2, in create
  File "odoo/api.py", line 410, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4268, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4542, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "odoo/models.py", line 1454, in _validate_fields
    check(self)
  File "addons/stock/models/stock_picking.py", line 286, in _check_sequence_code
    raise UserError(_("Sequences %s already exist.",
ParseError: while parsing /home/odoo/src/odoo/saas-16.4/addons/mrp/data/mrp_data.xml:17, somewhere inside
<record id="stock.warehouse0" model="stock.warehouse">
            <field name="manufacture_to_resupply" eval="True"/>
        </record>
  File "odoo/modules/registry.py", line 105, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```



When users try to reinstall the "mrp", a traceback will be generated. This is because duplicate sequence records exist
and raise the ParseError.

This commit solves the above issue by clean-up sequences mrp module uninstallation time.

Apart from this commit, we are also updating the code of the picking type and archiving it after the uninstallation
of the module using the 'ondelete' function.

code reference:
https://github.com/odoo/odoo/blob/cb104f1bb8fe700f66d9424ee28ac6a385f2c1b8/addons/stock/models/stock_picking.py#L280
https://github.com/odoo/odoo/blob/cb104f1bb8fe700f66d9424ee28ac6a385f2c1b8/addons/mrp/data/mrp_data.xml#L17

sentry-4489149490