### PR TITLE
[IMP] website: make website page URL required

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1298,7 +1298,6 @@ class Website(models.Model):
         if domain is None:
             domain = []
         domain += self.get_current_website().website_domain()
-        domain = AND([domain, [('url', '!=', False)]])
         pages = self.env['website.page'].sudo().search(domain, order=order, limit=limit)
         pages = pages._get_most_specific_pages()
         return pages

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -97,7 +97,7 @@ class Page(models.Model):
         ids = []
         previous_page = None
         # Iterate a single time on the whole list sorted on specific-website first.
-        for page in self.sorted(key=lambda p: (p.url or '', not p.website_id)):
+        for page in self.sorted(key=lambda p: (p.url, not p.website_id)):
             if not previous_page or page.url != previous_page.url:
                 ids.append(page.id)
             previous_page = page

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -22,7 +22,7 @@ class Page(models.Model):
     _description = 'Page'
     _order = 'website_id'
 
-    url = fields.Char('Page URL')
+    url = fields.Char('Page URL', required=True)
     view_id = fields.Many2one('ir.ui.view', string='View', required=True, ondelete="cascade")
     website_indexed = fields.Boolean('Is Indexed', default=True)
     date_publish = fields.Datetime('Publishing Date')


### PR DESCRIPTION
Commit [1] was made to avoid that the search snippet fails when there
are pages without URLS.

In master this can be reverted and the URL field can be made mandatory.

[1]: https://github.com/odoo/odoo/commit/f75ec6131eff9165b06d42d27a49dd756387f4a0

task-3443119
