### PR TITLE
[FIX] web_editor, website: copy the font CSS variables

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -5,7 +5,7 @@ const {ColorpickerWidget} = require('web.Colorpicker');
 
 let editableWindow = window;
 const _setEditableWindow = (ew) => editableWindow = ew;
-
+const EDITOR_FONT_CSS_VARIABLES = ["headings-font", "navbar-font", "buttons-font", "font"];
 const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = ['primary', 'secondary', 'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'success', 'info', 'warning', 'danger'];
 
 /**
@@ -466,6 +466,7 @@ return {
     CSS_UNITS_CONVERSION: CSS_UNITS_CONVERSION,
     DEFAULT_PALETTE: DEFAULT_PALETTE,
     EDITOR_COLOR_CSS_VARIABLES: EDITOR_COLOR_CSS_VARIABLES,
+    EDITOR_FONT_CSS_VARIABLES: EDITOR_FONT_CSS_VARIABLES,
     computePxByRem: _computePxByRem,
     convertValueToUnit: _convertValueToUnit,
     convertNumericToUnit: _convertNumericToUnit,

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1337,10 +1337,17 @@ const Wysiwyg = Widget.extend({
      * @param {HTMLElement} element
      */
     setCSSVariables(element) {
-        const stylesToCopy = weUtils.EDITOR_COLOR_CSS_VARIABLES;
+        const stylesToCopy = [
+            ...weUtils.EDITOR_COLOR_CSS_VARIABLES, 
+            ...weUtils.EDITOR_FONT_CSS_VARIABLES,
+        ];
 
         for (const style of stylesToCopy) {
-            element.style.setProperty(`--we-cp-${style}`, weUtils.getCSSVariableValue(style));
+            let value = weUtils.getCSSVariableValue(style);
+            if (value === "'SYSTEM_FONTS'") {
+                value = "var(--o-system-fonts)";
+            }
+            element.style.setProperty(`--we-cp-${style}`, value);
         }
 
         element.classList.toggle('o_we_has_btn_outline_primary',

--- a/addons/website/static/src/components/editor/editor.scss
+++ b/addons/website/static/src/components/editor/editor.scss
@@ -105,18 +105,25 @@
                 &.o_cc#{$index} {
                     background-color: var(--we-cp-o-cc#{$index}-bg);
                     color: var(--we-cp-o-cc#{$index}-text);
+                    font-family: var(--we-cp-font);
                     h1 {
                         color: var(--we-cp-o-cc#{$index}-headings);
+                        font-family: var(--we-cp-headings-font);
+                    }
+                    p {
+                        font-family: var(--we-cp-font) !important;
                     }
                     .btn-primary {
                         background-color: var(--we-cp-o-cc#{$index}-btn-primary);
                         color: var(--we-cp-o-cc#{$index}-btn-primary-text);
                         border-color: var(--we-cp-o-cc#{$index}-btn-primary-border);
+                        font-family: var(--we-cp-buttons-font);
                     }
                     .btn-secondary {
                         background-color: var(--we-cp-o-cc#{$index}-btn-secondary);
                         color: var(--we-cp-o-cc#{$index}-btn-secondary-text);
                         border-color: var(--we-cp-o-cc#{$index}-btn-secondary-border);
+                        font-family: var(--we-cp-buttons-font);
                     }
                 }
             }


### PR DESCRIPTION
The copy of font styles are now defined in web_editor/common/utils: 
[EDITOR_FONT_CSS_VARIABLES] are copied on the snippet menu, and used for 
the preview elements.
For the color presets collapse menu, the texts "Title/Text" are replaced 
by "Heading/Paragraphs" in their respected font. 
This fix is applied to meet the purpose of the task-3377096

task-3377096