### PR TITLE
[FIX] base_import: prevent crash when uploading large files in import

### DIFF
--- a/addons/base_import/controllers/main.py
+++ b/addons/base_import/controllers/main.py
@@ -13,9 +13,16 @@ class ImportController(http.Controller):
     @http.route('/base_import/set_file', methods=['POST'])
     def set_file(self, file, import_id, jsonp='callback'):
         import_id = int(import_id)
+        file_data = file.read()
+
+        if (len(file_data) > request.env['ir.http'].session_info()['max_file_upload_size']):
+            return 'window.top.%s(%s)' % (misc.html_escape(jsonp), json.dumps({
+                'import_size_exceeded': True,
+                'result': False,
+            }))
 
         written = request.env['base_import.import'].browse(import_id).write({
-            'file': file.read(),
+            'file': file_data,
             'file_name': file.filename,
             'file_type': file.content_type,
         })

--- a/addons/base_import/static/src/js/import_action.js
+++ b/addons/base_import/static/src/js/import_action.js
@@ -361,7 +361,14 @@ var DataImport = AbstractAction.extend({
         this.$form.find('.oe_import_box').toggle(import_toggle);
         jsonp(this.$form, {
             url: '/base_import/set_file'
-        }, this.proxy('settings_changed'));
+        }, (res) => {
+            if (res.result) {
+                this.proxy('settings_changed');
+            }
+            if (res.import_size_exceeded) {
+                this.do_notify(false, _t('The file is too large to be imported.'))
+            }
+        });
     },
     onpreviewing: function () {
         var self = this;


### PR DESCRIPTION
This commit prevents the import action to crash during the import of a large file. Before this fix, when importing a file that causes a MemoryError, there was a crash happening on the web client, since the server would crash and send a 500 error page.

Instead of this, the 'set_file' call returns an 'import_size_exceeded' key as a result to the import if the maximum file size is exceeded,, and the call ends there. Without return there, the write would try to read the file, which would raise the MemoryError.

task-2841341