### PR TITLE
[FIX] base_import: prevent crash when uploading large files in import

### DIFF
--- a/addons/base_import/controllers/main.py
+++ b/addons/base_import/controllers/main.py
@@ -14,9 +14,15 @@ class ImportController(http.Controller):
     # pylint: disable=redefined-builtin
     def set_file(self, id):
         file = request.httprequest.files.getlist('ufile')[0]
+        file_data = file.read()
+        if(len(file_data) > request.env['ir.http'].session_info()['max_file_upload_size']):
+            return json.dumps({
+                'import_size_exceeded': True,
+                'result': False,
+            })
 
         written = request.env['base_import.import'].browse(int(id)).write({
-            'file': file.read(),
+            'file': file_data,
             'file_name': file.filename,
             'file_type': file.content_type,
         })

--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -121,7 +121,13 @@ export class ImportAction extends Component {
     // File
     //--------------------------------------------------------------------------
 
-    async handleFilesUpload(files) {
+    async handleFilesUpload(data, files) {
+        if (data.import_size_exceeded) {
+            return this.notification.add(
+                this.env._t("This file is too large to be imported."),
+                { type: "danger" }
+            );
+        }
         if (!files || files.length <= 0) {
             return;
         }

--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -11,7 +11,7 @@
                     </t>
                     <FileInput
                         acceptedFileExtensions="'.csv, .xls, .xlsx, .xlsm, .ods'"
-                        onUpload.bind="(data, files) => this.handleFilesUpload(files)"
+                        onUpload.bind="(data, files) => this.handleFilesUpload(data, files)"
                         resId="model.id"
                         resModel="this.resModel"
                         route="'/base_import/set_file'"


### PR DESCRIPTION
This commit prevents the import action to crash during the import of a large file. Before this fix, when importing a file that causes a MemoryError, there was a crash happening on the web client, since the server would crash and send a 500 error page.

Instead of this, the 'set_file' call returns an 'import_size_exceeded' key as a result to the import if the maximum file size is exceeded,, and the call ends there. Without return there, the write would try to read the file, which would raise the MemoryError.

task-2841341