### PR TITLE
[IMP] project: disable  /image for portal user

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -178,7 +178,7 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <field name="description" type="html" options="{'collaborative': true, 'allowCommandImage': false, 'allowCommandVideo': false, 'allowCommandFile': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks">
                             <field name="child_ids" context="{'default_parent_id': id, 'default_partner_id': partner_id, 'form_view_ref' : 'project.project_sharing_project_task_view_form'}">


### PR DESCRIPTION
Steps:
- Install project.
- Create a project and it's task.
- Share this project to portal user with editable rights.
- Open that project from portal user.
- In task description, using `/image`, add one image.

Issue:
- There comes an Access error: Sorry, you are not allowed to access this document.

Solution:
- We are passing `'allowCommandImage': false, 'allowCommandVideo': false, 'allowCommandFile': false}` so that portal user can't have the /image and related options.

task-3463461