### PR TITLE
[FIX] web_editor: toolbar horizontal scroll and wrong radius

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -524,6 +524,10 @@
                 display: none; // remove ballon
             }
 
+            .fa {
+                font-size: $o-we-sidebar-font-size;
+            }
+
             .btn {
                 @extend %we-generic-button;
                 display: flex;

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -170,8 +170,16 @@
 
             <div t-if="props.showLink" id="link" class="btn-group">
                 <div id="media-insert" title="Insert media" class="fa fa-file-image-o fa-fw btn editor-ignore"></div>
+                <!--
+                Unlink button is visually last but thanks through the order-1
+                class. Indeed the create-link button needs to be last in the DOM
+                for the border-radius to be right when unlink is not shown, e.g.
+                in website.
+                TODO this should be done another way (split web_editor/website
+                to review).
+                -->
+                <div id="unlink" data-call="unlink" title="Remove link" class="fa fa-unlink fa-fw btn order-1"></div>
                 <div id="create-link" title="Insert or edit link" class="fa fa-link fa-fw btn editor-ignore"></div>
-                <div id="unlink" data-call="unlink" title="Remove link" class="fa fa-unlink fa-fw btn"></div>
                 <a id="media-description" href="#" title="Edit media description" class="btn editor-ignore">Description</a>
             </div>
 


### PR DESCRIPTION
The font-awesome icons taking the `.btn` font-size was making them 14px while the other icons in the web_editor are 12px (eg. the svg ones)

It creates an overflow on the #toolbar creating on some screensize an horizontal overflow. This commit applies a font size of 12px on the .fa inside the `#toolbar`.

Additionally the createlink was not receiving the border radius rule due to the `#unlink` element being present in the DOM but invisible on screen after the create-link el. Swapping their order in the xml and using the class `order-1` solve the issue without impacting the backend editor.

task-3634260
Part of task-3503975