### PR TITLE
[IMP] account: enable index scan on AML

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -455,6 +455,10 @@ class AccountBankStatementLine(models.Model):
         return bank_account.filtered(lambda x: x.company_id in (False, self.company_id))
 
     def _get_default_amls_matching_domain(self):
+        all_reconcilable_account_ids = self.env['account.account'].search([
+            ("company_id", "child_of", self.company_id.root_id.id),
+            ('reconcile', '=', True),
+        ]).ids
         return [
             # Base domain.
             ('display_type', 'not in', ('line_section', 'line_note')),
@@ -462,7 +466,8 @@ class AccountBankStatementLine(models.Model):
             ('company_id', 'child_of', self.company_id.root_id.id),
             # Reconciliation domain.
             ('reconciled', '=', False),
-            ('account_id.reconcile', '=', True),
+            # Domain to use the account_move_line__unreconciled_index
+            ('account_id', 'in', all_reconcilable_account_ids),
             # Special domain for payments.
             '|',
             ('account_id.account_type', 'not in', ('asset_receivable', 'liability_payable')),

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1286,7 +1286,7 @@ class AccountMoveLine(models.Model):
         def to_tuple(t):
             return tuple(map(to_tuple, t)) if isinstance(t, (list, tuple)) else t
         # Make an explicit order because we will need to reverse it
-        order = (order or self._order) + ', id'
+        order = order + ', id' if order else self._order
         # Add the domain and order by in order to compute the cumulated balance in _compute_cumulated_balance
         contextualized = self.with_context(
             domain_cumulated_balance=to_tuple(domain or []),
@@ -1301,6 +1301,8 @@ class AccountMoveLine(models.Model):
         """
         create_index(self._cr, 'account_move_line_partner_id_ref_idx', 'account_move_line', ["partner_id", "ref"])
         create_index(self._cr, 'account_move_line_date_name_id_idx', 'account_move_line', ["date desc", "move_name desc", "id"])
+        create_index(self._cr, 'account_move_line__unreconciled_index', 'account_move_line', ['account_id', 'partner_id'],
+                     where="(reconciled IS NULL OR reconciled = false OR reconciled IS NOT true) AND parent_state = 'posted'")
         super().init()
 
     def default_get(self, fields_list):


### PR DESCRIPTION
The corresponding enterprise PR enables sorting account move lines on the bank recon by matching amount. Unfortunately there is a significant performance impact when enabling this ORDER BY (~300 ms -> ~2600 ms tested on a large db)

In order to optimise the above, we slightly modify the domains used so that the existing index `account_move_line__unreconciled_index` is used. This is not yet tested on a large DB (due to the index change), however observations on a populated database indicate an improvement: 
without index: 80ms
with index: 30ms

