### PR TITLE
[FIX] mrp: correctly print replenishments

### DIFF
--- a/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.js
+++ b/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.js
@@ -71,6 +71,15 @@ export class MoOverviewComponentsBlock extends Component {
     hasComponentsBlock(replenishment) {
         return this.hasComponents(replenishment) && !this.state.fold[replenishment?.summary.index];
     }
+
+    getNextIndex(component) {
+        if (!this.hasReplenishments(component)) return `${component.index}0`;
+        // Get the highest index of the replenishments of the component
+        const levelIndexes = component.replenishments.map(rep => rep.summary.index.substring(component.summary.index.length))
+                                                     .filter(index => !isNaN(index))
+                                                     .map(index => parseInt(index));
+        return levelIndexes.length > 0 ? `${component.summary.index}${Math.max(...levelIndexes) + 1}` : `${component.summary.index}0`;
+    }
 }
 
 MoOverviewComponentsBlock.components = {

--- a/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.xml
+++ b/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.xml
@@ -15,6 +15,7 @@
                     data="replenishment.summary"
                     hasFoldButton="hasComponents(replenishment)"
                     isFolded="state.fold[replenishment.summary.index]"
+                    nextIndex="getNextIndex(component)"
                     showOptions="props.showOptions"
                     toggleFolded.bind="onToggleFolded"/>
                 <t t-if="hasComponentsBlock(replenishment)">

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
@@ -52,6 +52,7 @@ export class MoOverviewLine extends Component {
             onClose: (closeInfo) => {
                 if (closeInfo?.done) {
                     // Trigger the reload only if a replenishment was done.
+                    this.env.overviewBus.trigger("update-folded", { indexes: [this.props.nextIndex], isFolded: false });
                     this.env.overviewBus.trigger("reload");
                 }
             },
@@ -176,5 +177,6 @@ MoOverviewLine.props = {
     },
     hasFoldButton: { type: Boolean, optional: true },
     isFolded: { type: Boolean, optional: true },
+    nextIndex: { type: String, optional: true },
     toggleFolded: { type: Function, optional: true },
 };


### PR DESCRIPTION
Steps to reproduce:
- Create a two-layers Bill of Material (BoM and child BoM).
- Create a Manufacturing Order with the top-level BoM and open the Overview.
- Click Unfold, then hit the 'Replenish' button on the component.
- Select 'Manufacture' as preferred route and confirm.
- Print the report.

Issue:
While the new line containing the Manufacturing Order is unfolded on screen, it won't be on the PDF, hiding its components. When validating the replenishment, we refresh the Overview data, but we don't update the inner set containing the unfolded lines to open for the PDF (so that the PDF displays the same thing as the html version does).

Now predicts which index will be generated and unfold it when a replenishment is made.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
