### PR TITLE
[REF] point_of_sale: remove identifyError

### DIFF
--- a/addons/point_of_sale/static/src/app/errors/error_handlers.js
+++ b/addons/point_of_sale/static/src/app/errors/error_handlers.js
@@ -8,12 +8,7 @@ import { ErrorTracebackPopup } from "@point_of_sale/app/errors/popups/error_trac
 import { OfflineErrorPopup } from "@point_of_sale/app/errors/popups/offline_error_popup";
 import { _t } from "@web/core/l10n/translation";
 
-export function identifyError(error) {
-    return error && error.legacy ? error.message : error;
-}
-
 function rpcErrorHandler(env, error, originalError) {
-    error = identifyError(originalError);
     if (error instanceof RPCError) {
         const { message, data } = error;
         if (odooExceptionTitleMap.has(error.exceptionName)) {
@@ -31,7 +26,6 @@ function rpcErrorHandler(env, error, originalError) {
 registry.category("error_handlers").add("rpcErrorHandler", rpcErrorHandler);
 
 function offlineErrorHandler(env, error, originalError) {
-    error = identifyError(originalError);
     if (error instanceof ConnectionLostError) {
         env.services.popup.add(OfflineErrorPopup);
         return true;
@@ -40,7 +34,6 @@ function offlineErrorHandler(env, error, originalError) {
 registry.category("error_handlers").add("offlineErrorHandler", offlineErrorHandler);
 
 function defaultErrorHandler(env, error, originalError) {
-    originalError = identifyError(originalError);
     if (error instanceof Error) {
         env.services.popup.add(ErrorTracebackPopup, {
             title: `${originalError.name}: ${originalError.message}`,

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -8,7 +8,6 @@ import { useService } from "@web/core/utils/hooks";
 import { useState } from "@odoo/owl";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
 import { ConnectionLostError } from "@web/core/network/rpc_service";
-import { identifyError } from "@point_of_sale/app/errors/error_handlers";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { parseFloat } from "@web/views/fields/parsers";
@@ -207,7 +206,7 @@ export class ClosePosPopup extends AbstractAwaitablePopup {
             }
             window.location = "/web#action=point_of_sale.action_client_pos_menu";
         } catch (error) {
-            if (identifyError(error) instanceof ConnectionLostError) {
+            if (error instanceof ConnectionLostError) {
                 // Cannot redirect to backend when offline, let error handlers show the offline popup
                 // FIXME POSREF: doing this means closing again when online will redo the beginning of the method
                 // although it's impossible to close again because this.closeSessionClicked isn't reset to false

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_list/product_list.js
@@ -3,7 +3,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { useService } from "@web/core/utils/hooks";
-import { identifyError } from "@point_of_sale/app/errors/error_handlers";
 import { ConnectionLostError, ConnectionAbortedError } from "@web/core/network/rpc_service";
 
 import { ProductCard } from "@point_of_sale/app/generic_components/product_card/product_card";
@@ -153,11 +152,7 @@ export class ProductsWidget extends Component {
             this.updateProductList();
             return ProductIds;
         } catch (error) {
-            const identifiedError = identifyError(error);
-            if (
-                identifiedError instanceof ConnectionLostError ||
-                identifiedError instanceof ConnectionAbortedError
-            ) {
+            if (error instanceof ConnectionLostError || error instanceof ConnectionAbortedError) {
                 return this.popup.add(OfflineErrorPopup, {
                     title: _t("Network Error"),
                     body: _t(


### PR DESCRIPTION
After the the POS refactoring, there are no more errors of type `legacy`, so the function `identifyError`, whose objective was to identify the `legacy` errrors, is now completely useless. We thus remove it.

Task: 3524670





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
