### PR TITLE
[FIX] microsoft_calendar: traceback after recurrences patch

### DIFF
--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -421,7 +421,7 @@ class MicrosoftSync(models.AbstractModel):
             if token:
                 self._ensure_attendees_have_email()
                 res = microsoft_service.patch(event_id, values, token=token, timeout=timeout)
-                self.write({
+                self.with_context(dont_notify=True).write({
                     'need_sync_m': not res,
                 })
 


### PR DESCRIPTION
Before this commit, a traceback was thrown after an edge case where recurrences were updated in Outlook side and then updated in Odoo.

After this commit, the traceback is not thrown anymore by fixing the mentioned flow.

Traceback:
``` 
  File "/home/odoo/src/odoo/addons/microsoft_calendar/models/microsoft_sync.py", line 44, in called_after
    func(self.with_env(env), *args, **kwargs)
  File "/home/odoo/src/odoo/addons/microsoft_calendar/models/microsoft_sync.py", line 424, in _microsoft_patch
    self.write({
  File "/home/odoo/src/odoo/addons/base_automation/models/base_automation.py", line 411, in write
    write.origin(self.with_env(actions.env), vals, **kw)
  File "/home/odoo/src/user/reportone_calendar/models/calendar_event.py", line 20, in write
    res = super(CalendarEvent, self.with_context(disable_cancel_warning=True)).write(vals)
  File "/home/odoo/src/odoo/addons/microsoft_calendar/models/calendar.py", line 147, in write
    self._forbid_recurrence_update()
  File "/home/odoo/src/odoo/addons/microsoft_calendar/models/calendar.py", line 130, in _forbid_recurrence_update
    raise UserError(error_msg)
odoo.exceptions.UserError: En raison d'une limite du Calendrier Outlook, les mises à jour des récurrences doivent être effectuées directement dans Calendrier Outlook.
```

Issue from: 115253