### PR TITLE
[FIX] account: auto-install account_avatax in Canada not Brazil

### DIFF
--- a/addons/account/__init__.py
+++ b/addons/account/__init__.py
@@ -37,7 +37,7 @@ def _auto_install_l10n(env):
 
 def _auto_install_avatax(env):
     """ Install the avatax module automatically if the company is in a country that uses avatax """
-    avatax_country_codes = ['US', 'BR']
+    avatax_country_codes = ['US', 'CA']
 
     country = env.company.country_id
     country_code = country.code


### PR DESCRIPTION
Small issue in 70329177713. `account_avatax` supports the US and Canada. `l10n_br_avatax` supports Brazil.

Introduced in https://github.com/odoo/odoo/pull/136490.