### PR TITLE
[IMP] core, requirements: bump minimal python version to 3.10

### DIFF
--- a/odoo/__init__.py
+++ b/odoo/__init__.py
@@ -16,7 +16,7 @@ __path__ = [
 ]
 
 import sys
-assert sys.version_info > (3, 8), "Outdated python version detected, Odoo requires Python >= 3.8 to run."
+assert sys.version_info > (3, 10), "Outdated python version detected, Odoo requires Python >= 3.10 to run."
 
 #----------------------------------------------------------
 # Running mode flags (gevent, prefork)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,58 +4,52 @@ Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==4.0.0
 cryptography==3.4.8
 decorator==4.4.2
-docutils==0.16
+docutils==0.17
 ebaysdk==2.1.5
-freezegun==0.3.15
+freezegun==1.1.0
 geoip2==2.9.0
-gevent==20.9.0 ; python_version <= '3.9'
 gevent==21.8.0 ; python_version == '3.10'  # (Jammy)
 gevent==22.10.2; python_version > '3.10'
-greenlet==0.4.17 ; python_version <= '3.9'
 greenlet==1.1.2 ; python_version == '3.10'  # (Jammy)
 greenlet==2.0.2 ; python_version > '3.10'
-idna==2.10
-Jinja2==2.11.3 ; python_version <= '3.10'  # min version = 2.10.1 (Focal - with security backports)
+idna==2.10  # requests 2.25.1 depends on idna<3 and >=2.5
+Jinja2==3.0.3 ; python_version <= '3.10'
 Jinja2==3.1.2 ; python_version > '3.10'
 libsass==0.20.1
-lxml==4.6.5 ; python_version <= '3.10'  # min version = 4.5.0 (Focal - with security backports)
+lxml==4.8.0 ; python_version <= '3.10'
 lxml==4.9.2 ; python_version > '3.10'
-MarkupSafe==1.1.1 ; python_version <= '3.10'
+MarkupSafe==2.0.1 ; python_version <= '3.10'
 MarkupSafe==2.1.2 ; python_version > '3.10'
-num2words==0.5.9
-ofxparse==0.19; python_version <= '3.9'
-ofxparse==0.21; python_version > '3.9'  # (Jammy)
+num2words==0.5.10
+ofxparse==0.21
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
 Pillow==9.0.1 ; python_version <= '3.10'  # min version = 7.0.0 (Focal with security backports)
 Pillow==9.4.0 ; python_version > '3.10'
-polib==1.1.0
-psutil==5.8.0 ; python_version <= '3.10' 
+polib==1.1.1
+psutil==5.9.0 ; python_version <= '3.10' 
 psutil==5.9.4 ; python_version > '3.10' 
-psycopg2==2.8.6 ; sys_platform != 'win32' and python_version <= '3.10'
-psycopg2==2.8.6 ; sys_platform == 'win32' and python_version < '3.10'
-psycopg2==2.9.5 ; python_version > '3.10' or ( sys_platform == 'win32' and python_version == '3.10')
+psycopg2==2.9.2 ; sys_platform != 'win32' and python_version <= '3.10'
+psycopg2==2.9.5 ; python_version > '3.10' or sys_platform == 'win32'
 pydot==1.4.2
-pyopenssl==20.0.1
+pyopenssl==21.0.0
 PyPDF2==1.26.0 ; python_version <= '3.10'
 PyPDF2==2.12.1 ; python_version > '3.10'
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.5
 python-dateutil==2.8.1
 python-ldap==3.4.0 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
-python-stdnum==1.16
+python-stdnum==1.17
 pytz  # no version pinning to avoid OS perturbations
-pyusb==1.0.2 ; python_version <= '3.10'
-pyusb==1.2.1 ; python_version > '3.10'
-qrcode==6.1
-reportlab==3.5.59 ; python_version <= '3.10'  # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
+pyusb==1.2.1
+qrcode==7.3.1
+reportlab==3.6.8 ; python_version <= '3.10'
 reportlab==3.6.12 ; python_version > '3.10'
 requests==2.25.1 # versions < 2.25 aren't compatible w/ urllib3 1.26. Bullseye = 2.25.1. min version = 2.22.0 (Focal)
 rjsmin==1.1.0
 urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1
-Werkzeug==0.16.1 ; python_version <= '3.9'
-Werkzeug==2.0.2 ; python_version > '3.9'  # (Jammy)
+Werkzeug==2.0.2
 xlrd==1.2.0
-XlsxWriter==1.1.2
+XlsxWriter==3.0.2
 xlwt==1.3.*
-zeep==4.0.0
+zeep==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'xlwt',
         'zeep',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     extras_require={
         'ldap': ['python-ldap'],
     },

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -1,6 +1,6 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM debian:bullseye
+FROM debian:bookworm
 MAINTAINER Odoo S.A. <info@odoo.com>
 
 RUN apt-get update && \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -1,6 +1,6 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM fedora:36
+FROM fedora:38
 MAINTAINER Odoo S.A. <info@odoo.com>
 
 # Dependencies and postgres

--- a/setup/package.py
+++ b/setup/package.py
@@ -327,11 +327,9 @@ class DockerDeb(Docker):
         logging.info('Start testing debian package')
         cmds = [
             'service postgresql start',
-            'su postgres -s /bin/bash -c "createdb mycompany"',
             '/usr/bin/apt-get update -y',
-            '/usr/bin/dpkg -i /data/src/odoo_%s.%s_all.deb ; /usr/bin/apt-get install -f -y' % (VERSION, TSTAMP),
-            'su odoo -s /bin/bash -c "odoo -d mycompany -i base --stop-after-init"',
-            'su odoo -s /bin/bash -c "odoo -d mycompany --pidfile=/data/src/odoo.pid"',
+            f'/usr/bin/apt-get install -y /data/src/odoo_{VERSION}.{TSTAMP}_all.deb',
+            'su odoo -s /bin/bash -c "odoo -d mycompany -i base --pidfile=/data/src/odoo.pid"',
         ]
         self.run(' && '.join(cmds), self.args.build_dir, 'odoo-deb-test-%s' % TSTAMP, user='root', detach=True, exposed_port=8069, timeout=300)
         self.test_odoo()


### PR DESCRIPTION
Now that the Debian 12 ("Bookworm") is out with Python 3.11 as the default, it's time to update our requirements.

Reminder of the constraints for our requirements:

We try choose the smallest version from the Ubuntu/Debian corresponding package (python3-...).

Also, if we find that one of the package was patched by the Debian/Ubuntu maintainer, we choose the version from which the patch is coming.

So, before this commit, the version were choose between Debian 11 and Ubuntu 22.04. With this commit, we can simplify the requirements because of a better matching between "Jammy" and "Bookworm".

About the choice of the python version:

* Ubuntu 22.04 ("Jammy") provides 3.10
* Debian 12 ("Bookworm") provides 3.11
* Some features that only exists in 3.9 will be needed in a near future
* 3.9 is a small release

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
