### PR TITLE
[IMP] pos_self_order, product, website_sale: add product info popup

### DIFF
--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -91,6 +91,9 @@
             <xpath expr="//page[@name='invoicing']" position="attributes">
                 <attribute name="invisible">detailed_type == "combo"</attribute>
             </xpath>
+            <group name="ecommerce_description" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </group>
         </field>
     </record>
 

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -59,6 +59,8 @@
             'web/static/lib/bootstrap/js/dist/scrollspy.js',
             "pos_self_order/static/src/app/**/*",
             "point_of_sale/static/src/app/store/models/product_custom_attribute.js",
+            'web_editor/static/src/js/editor/odoo-editor/src/base_style.scss',
+            'web_editor/static/src/scss/web_editor.common.scss',
         ],
         # Assets tests
         "pos_self_order.assets_tests": [

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -95,7 +95,7 @@ class ProductProduct(models.Model):
                 "attributes": self._get_attributes(pos_config),
                 "name": self._get_name(),
                 "id": self.id,
-                "description_sale": self.description_sale,
+                "description_ecommerce": self.description_ecommerce,
                 "pos_categ_ids": self.pos_categ_ids.mapped("name") or ["Other"],
                 "pos_combo_ids": self.combo_ids.mapped("id") or False,
                 "is_pos_groupable": self.uom_id.is_pos_groupable,

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -4,6 +4,7 @@ import { Component, useRef } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/self_order_service";
 import { useService, useForwardRefToParent } from "@web/core/utils/hooks";
 import { Line } from "@pos_self_order/app/models/line";
+import { ProductInfoPopup } from "@pos_self_order/app/components/product_info_popup/product_info_popup";
 
 export class ProductCard extends Component {
     static template = "pos_self_order.ProductCard";
@@ -15,6 +16,7 @@ export class ProductCard extends Component {
     setup() {
         this.selfOrder = useSelfOrder();
         this.router = useService("router");
+        this.dialog = useService("dialog");
 
         useForwardRefToParent("currentProductCard");
     }
@@ -108,5 +110,12 @@ export class ProductCard extends Component {
             }
             await this.selfOrder.getPricesFromServer();
         }
+    }
+
+    getProductInfo() {
+        this.dialog.add(ProductInfoPopup, {
+            product: this.props.product,
+            title: this.props.product.name,
+        });
     }
 }

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.scss
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.scss
@@ -2,6 +2,7 @@
     width: 100%;
     display:flex;
     flex-direction: column;
+    position: relative;
 
     .o_self_order_item_card_image {
         width: 100%;
@@ -27,4 +28,23 @@
             aspect-ratio: 1/1;
         }
     }
+}
+
+.product-information-tag {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 40px 40px 0;
+    border-color: transparent #9a9ea180 transparent transparent;
+    position: absolute;
+    top: 0;
+    right: 0;
+    color: white;
+    text-align: center;
+}
+
+.product-information-tag-logo {
+    position: absolute;
+    left: 25px;
+    top: 4px;
 }

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -5,6 +5,9 @@
             <button class="self_order_product_card btn btn-light m-0 overflow-hidden border fw-bolder"
                 t-on-click="selectProduct"
                 t-ref="selfProductCard">
+                <div t-if="props.product.description_ecommerce" class="product-information-tag" t-on-click.prevent.stop="getProductInfo">
+                    <i class="product-information-tag-logo fa fa-info fs-4" role="img" aria-label="Product Information" title="Product Information" />
+                </div>
                 <img
                     class="o_self_order_item_card_image rounded bg-view"
                     t-attf-src="/menu/get-image/{{ props.product.id }}/512?unique={{props.product.write_date}}"

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import { Component, useExternalListener } from "@odoo/owl";
+
+export class ProductInfoPopup extends Component {
+    static template = "pos_self_order.ProductInfoPopup";
+    static props = ["product"];
+
+    setup() {
+        useExternalListener(window, "click", this.props.close);
+    }
+}

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.scss
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.scss
@@ -1,0 +1,6 @@
+.self_order_product_info_popup {
+    .modal-dialog {
+        height: auto !important;
+        top: 20%;
+    }
+}

--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_self_order.ProductInfoPopup" owl="1">
+        <div class="self_order_product_info_popup o_dialog" t-att-id="id">
+            <div role="dialog" class="modal d-block" tabindex="-1">
+                <div class="modal-dialog" role="document" t-on-click.stop="">
+                    <div class="modal-content rounded">
+                        <div class="modal-header">
+                            <h1 class="modal-title fw-bolder" t-esc="props.product.name"/>
+                            <button type="button" class="btn-close" t-on-click.stop="() => this.props.close()"></button>
+                        </div>
+                        <span class="modal-body o_self_order_main_desc fs-3 fw-bolder p-4 ps-5 overflow-auto" t-out="props.product.description_ecommerce" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/pos_self_order/static/src/app/models/product.js
+++ b/addons/pos_self_order/static/src/app/models/product.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 import { Reactive } from "@web/core/utils/reactive";
+import { markup } from "@odoo/owl";
 
 export class Product extends Reactive {
     constructor(
@@ -9,7 +10,7 @@ export class Product extends Reactive {
             attributes,
             name,
             id,
-            description_sale,
+            description_ecommerce,
             pos_categ_ids,
             pos_combo_ids,
             is_pos_groupable,
@@ -28,7 +29,9 @@ export class Product extends Reactive {
         this.has_image = product.has_image;
         this.attributes = product.attributes;
         this.name = product.name;
-        this.description_sale = product.description_sale;
+        this.description_ecommerce = product.description_ecommerce
+            ? markup(product.description_ecommerce)
+            : false;
         this.pos_categ_ids = product.pos_categ_ids;
         this.pos_combo_ids = product.pos_combo_ids;
         this.is_pos_groupable = product.is_pos_groupable;

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -25,9 +25,9 @@
                                 onerror="this.remove()" />
                             <div class="d-flex flex-column justify-content-center w-75 p-3 ps-0">
                                 <span class="fs-1 fw-bolder" t-esc="state.selectedProduct.name"/>
-                                <div t-if="state.selectedProduct.description_sale"
+                                <div t-if="state.selectedProduct.description_ecommerce"
                                 class="o_self_order_main_desc text-muted overflow-y-auto"
-                                t-esc="state.selectedProduct.description_sale"
+                                t-esc="state.selectedProduct.description_ecommerce"
                                 />
                             </div>
                         </div>

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -58,7 +58,7 @@
                     <t t-set="availableProducts" t-value="!state.searchInput ? products : getFilteredProducts(products)" />
                     <h2 t-if="availableProducts.length > 0" class="pt-3 pb-1 px-4 m-0 fs-3" t-esc="category.name" />
                     <t t-foreach="availableProducts" t-as="product" t-key="product.id">
-                        <ProductCard product="product" currentProductCard="product.id === selfOrder.lastEditedProductId and currentProductCard" />
+                        <ProductCard product="product" currentProductCard="product.id === selfOrder.lastEditedProductId and currentProductCard"/>
                     </t>
                 </section>
                 <p t-if="getFilteredProducts(selfOrder.products).length === 0" class="mx-auto mt-3 text-center">No products found</p>

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -12,9 +12,9 @@
                     onerror="this.remove()" />
                 <div class="d-flex flex-column flex-grow-1 w-75 justify-content-start p-4 rounded shadow-sm bg-view overflow-auto">
                     <h1 class="fw-bolder" t-esc="product.name"/>
-                    <span t-if="product.description_sale"
+                    <span t-if="product.description_ecommerce"
                         class="o_self_order_main_desc flex-grow-1 pb-3 mb-3 bg-view text-muted "
-                        t-esc="product.description_sale"
+                        t-esc="product.description_ecommerce"
                     />
                     <span class="fs-3 fw-bolder" t-esc="selfOrder.formatMonetary(product.prices)"/>
                 </div>

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from odoo import api, fields, models, tools, _, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 PRICE_CONTEXT_KEYS = ['pricelist', 'quantity', 'uom', 'date']
@@ -48,6 +49,13 @@ class ProductTemplate(models.Model):
         'Sales Description', translate=True,
         help="A description of the Product that you want to communicate to your customers. "
              "This description will be copied to every Sales Order, Delivery Order and Customer Invoice/Credit Note")
+    description_ecommerce = fields.Html(
+        string="eCommerce Description",
+        translate=html_translate,
+        sanitize_overridable=True,
+        sanitize_attributes=False,
+        sanitize_form=False,
+    )
     detailed_type = fields.Selection([
         ('consu', 'Consumable'),
         ('service', 'Service')], string='Product Type', default='consu', required=True,

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -104,6 +104,12 @@
                         <page string="Sales" name="sales" invisible="1">
                             <group name="sale">
                                 <group string="Upsell &amp; Cross-Sell" name="upsell" invisible="1"/>
+                                <group string="eCommerce Description" name="ecommerce_description" invisible="1">
+                                    <field name="description_ecommerce"
+                                           placeholder="This note is added to the product page on your eCommerce/Point of Sale shop"
+                                           nolabel="1"
+                                           colspan="2"/>
+                                </group>
                             </group>
                             <group>
                                 <group string="Sales Description" name="description">

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -48,13 +48,6 @@ class ProductTemplate(models.Model):
         sanitize_attributes=False,
         sanitize_form=False,
     )
-    description_ecommerce = fields.Html(
-        string="eCommerce Description",
-        translate=html_translate,
-        sanitize_overridable=True,
-        sanitize_attributes=False,
-        sanitize_form=False,
-    )
 
     alternative_product_ids = fields.Many2many(
         string="Alternative Products",

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -157,6 +157,9 @@
                        invisible="not sale_ok"
                        placeholder="Displayed in bottom of product pages"/>
             </group>
+            <group name="ecommerce_description" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </group>
             <xpath expr="//page[@name='sales']/group[@name='sale']" position="inside">
                 <group string="eCommerce Shop" name="shop" invisible="not sale_ok">
                     <field name="website_url" invisible="1"/>
@@ -167,12 +170,6 @@
                 </group>
                 <group name="product_template_images" string="Extra Product Media" invisible="not sale_ok">
                     <field name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
-                </group>
-                <group string="eCommerce Description">
-                    <field name="description_ecommerce"
-                           placeholder="This note is added to the product page on your eCommerce shop"
-                           nolabel="1"
-                           colspan="2"/>
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
This commit adds a popup to show product information when clicking on
an info button in the product card in the self. This popup shows the
ecommerce description, the price and the name of the product.

This ecommerce description has thus been moved from website_sale to the
product module so that the pos_self_order module can use it.

Info button:
![image](https://github.com/odoo/odoo/assets/118442417/1f192255-53ff-453f-86f4-953091757fe7)

Ecommerce description backend:
![image](https://github.com/odoo/odoo/assets/118442417/6b6f4a56-3bf6-45ae-ad72-fdbeed586e7e)

Info Popup:
![image](https://github.com/odoo/odoo/assets/118442417/4eae50b2-5520-4902-90fe-a0f0d4d49d9c)

task-id: 3524272

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
