### PR TITLE
[FIX] web: fix calendar quick_add not working on some db

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -67,7 +67,7 @@ export function addFieldDependencies(activeFields, fields, dependencies = {}) {
  * @returns {boolean}
  */
 export function archParseBoolean(str, trueIfEmpty = false) {
-    return str ? !/^false|0$/i.test(str) : trueIfEmpty;
+    return str ? !/^(false|0)$/i.test(str) : trueIfEmpty;
 }
 
 /**

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
@@ -95,6 +95,7 @@ QUnit.test("hasQuickCreate", (assert) => {
     check(assert, "quick_add", "false", "hasQuickCreate", false);
     check(assert, "quick_add", "False", "hasQuickCreate", false);
     check(assert, "quick_add", "0", "hasQuickCreate", false);
+    check(assert, "quick_add", "390", "hasQuickCreate", true);
 });
 
 QUnit.test("isDateHidden", (assert) => {


### PR DESCRIPTION
When parsing calendar arch, ensure that if the `quick_add` form id ends with a `0` if will not be considered as falsy value.

OPW-3496926

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
