### PR TITLE
[REM] *: remove owl="1" from the templates

### DIFF
--- a/addons/base_automation/static/src/base_automation_actions_one2many_field.xml
+++ b/addons/base_automation/static/src/base_automation_actions_one2many_field.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates>
-    <t t-name="base_automation.ActionsOne2ManyField" owl="1">
+    <t t-name="base_automation.ActionsOne2ManyField">
         <div class="d-flex align-items-center" t-ref="root">
             <t t-if="currentActions.length === 0">
                 <span class="text-muted">no action defined...</span>

--- a/addons/base_automation/static/src/base_automation_trigger_selection_field.xml
+++ b/addons/base_automation/static/src/base_automation_trigger_selection_field.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <templates>
-    <t t-name="base_automation.TriggerSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary" owl="1">
+    <t t-name="base_automation.TriggerSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary">
         <xpath expr="//t[@t-foreach='options']" position="replace">
             <t t-foreach="groupedOptions" t-as="group" t-key="group.key">
                 <optgroup t-att-label="group.name">

--- a/addons/calendar/static/src/views/widgets/calendar_week_days.xml
+++ b/addons/calendar/static/src/views/widgets/calendar_week_days.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="calendar.WeekDays" owl="1">
+    <t t-name="calendar.WeekDays">
         <div class="o_recurrent_weekdays mt-2 mb-2 d-flex">
         <t t-foreach="weekdays" t-as="day" t-key="day">
                 <div t-attf-class="o_calendar_week_days_rounded {{data[day] ? 'btn-primary' : 'btn-secondary'}}" t-on-click="() => this.onChange(day)">

--- a/addons/hr_holidays/static/src/xml/x2many_field.xml
+++ b/addons/hr_holidays/static/src/xml/x2many_field.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="hr_holidays.AccrualLevelsX2ManyField" t-inherit="web.X2ManyField" t-inherit-mode="primary" owl="1">
+    <t t-name="hr_holidays.AccrualLevelsX2ManyField" t-inherit="web.X2ManyField" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_x2m_control_panel')]/.." position="before">
             <xpath expr="//ListRenderer" position="move"/>
             <xpath expr="//KanbanRenderer" position="move"/>

--- a/addons/l10n_ar_pos/static/src/overrides/components/partner_editor/partner_editor.xml
+++ b/addons/l10n_ar_pos/static/src/overrides/components/partner_editor/partner_editor.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="PartnerDetailsEdit" t-inherit="point_of_sale.PartnerDetailsEdit" t-inherit-mode="extension" owl="1">
+    <t t-name="PartnerDetailsEdit" t-inherit="point_of_sale.PartnerDetailsEdit" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('partner-details-box')]" position="inside">
             <t t-if="pos.isArgentineanCompany()">
 

--- a/addons/payment/static/src/xml/payment_form_templates.xml
+++ b/addons/payment/static/src/xml/payment_form_templates.xml
@@ -2,7 +2,7 @@
 
 <templates xml:space="preserve">
 
-    <t t-name="payment.deleteTokenDialog" owl="1">
+    <t t-name="payment.deleteTokenDialog">
         <div>
             <p>Are you sure you want to delete this payment method?</p>
             <t t-if="linkedRecordsInfo.length > 0">

--- a/addons/point_of_sale/static/src/app/generic_components/input/input.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/input/input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="point_of_sale.input" owl="1">
+    <t t-name="point_of_sale.input">
         <div t-attf-class="{{props.class}} d-flex align-items-center">
             <button t-if="props.isSmall" 
                 class="p-3 rounded" 
@@ -25,7 +25,7 @@
             </div>
         </div>
     </t>
-    <t t-name="point_of_sale.inputIcon" owl="1">
+    <t t-name="point_of_sale.inputIcon">
         <i t-if="props.icon.type === 'fa'" t-attf-class="fa {{props.icon.value}} {{margin}}"/>
         <span t-if="props.icon.type === 'string'" t-attf-class="{{margin}}" t-esc="props.icon.value"/>
     </t>

--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="point_of_sale.ComboConfiguratorPopup" owl="1">
+    <t t-name="point_of_sale.ComboConfiguratorPopup">
         <div class="popup popup-text popup-med combo-configurator-popup">
             <header class="modal-header h2" t-esc="props.product.display_name"/>
             <main class="body">

--- a/addons/portal/static/src/js/components/input_confirmation_dialog/input_confirmation_dialog.xml
+++ b/addons/portal/static/src/js/components/input_confirmation_dialog/input_confirmation_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="portal.InputConfirmationDialog" t-inherit="web.ConfirmationDialog" owl="1">
+  <t t-name="portal.InputConfirmationDialog" t-inherit="web.ConfirmationDialog">
     <xpath expr="//p[hasclass('text-prewrap')]" position="attributes">
         <attribute name="class"></attribute>
     </xpath>

--- a/addons/portal/static/src/xml/portal_security.xml
+++ b/addons/portal/static/src/xml/portal_security.xml
@@ -1,5 +1,5 @@
 <templates xml:space="preserve">
-    <t t-name="portal.identitycheck" owl="1">
+    <t t-name="portal.identitycheck">
         <form string="Security Control">
             <h3><strong>Please enter your password to confirm you own this account</strong></h3>
             <br/>
@@ -10,7 +10,7 @@
             <a href="/web/reset_password/" class="btn btn-link" role="button">Forgot password?</a>
         </form>
     </t>
-    <t t-name="portal.keydescription" owl="1">
+    <t t-name="portal.keydescription">
         <form string="Key Description">
             <h3><strong>Name your key</strong></h3>
             <p>Enter a description of and purpose for the key.</p>
@@ -23,7 +23,7 @@
             </p>
         </form>
     </t>
-    <t t-name="portal.keyshow" owl="1">
+    <t t-name="portal.keyshow">
         <div>
             <h3><strong>Write down your key</strong></h3>
             <p>
@@ -39,7 +39,7 @@
         </div>
     </t>
     <!-- Popup's view !-->
-    <t t-name="portal.revoke_all_devices_popup_template" owl="1">
+    <t t-name="portal.revoke_all_devices_popup_template">
         <section>
             <div>
                 You are about to log out from all devices that currently have access to this user's account.

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.AttributeSelection" owl="1">
+    <t t-name="pos_self_order.AttributeSelection">
         <div class="self_order_attribute_selection">
             <div class="attribute_name py-1 mt-3 mb-4 fw-bold">
                 <t t-if="!state.showResume">

--- a/addons/pos_self_order/static/src/app/components/cancel_popup/cancel_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/cancel_popup/cancel_popup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.CancelPopup" owl="1">
+    <t t-name="pos_self_order.CancelPopup">
         <div class="self_order_cancel_popup o_dialog" t-att-id="id">
             <div role="dialog" class="modal d-block" tabindex="-1">
                   <div class="modal-dialog" role="document">

--- a/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/combo_selection/combo_selection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ComboSelection" owl="1">
+    <t t-name="pos_self_order.ComboSelection">
         <div class="self_order_attribute_selection h-100 p-4">
             <t t-if="!props.comboState.selectedProduct">
                 <div class="attribute_name py-1 mt-3 mb-4 fw-bold">

--- a/addons/pos_self_order/static/src/app/components/language_popup/language_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/language_popup/language_popup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.LanguagePopup" owl="1">
+    <t t-name="pos_self_order.LanguagePopup">
         <div class="self_order_language_popup o_dialog" t-att-id="id">
             <div role="dialog" class="modal d-block" tabindex="-1">
                   <div class="modal-dialog" role="document">

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ProductCard" owl="1">
+    <t t-name="pos_self_order.ProductCard">
         <div class="col-sm-6 col-md-4 col-lg-3 col-xxl-2 p-2">
             <button class="self_order_product_card btn btn-light m-0 overflow-hidden border fw-bolder"
                 t-on-click="selectProduct"

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.CartPage" owl="1">
+    <t t-name="pos_self_order.CartPage">
         <div class="order-cart-content d-flex flex-column justify-content-between bg-100">
             <div class="p-3 position-absolute top-0 m-3">
                 <button class="btn btn-secondary" t-on-click="() => this.router.back()">

--- a/addons/pos_self_order/static/src/app/pages/closed_page/closed_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/closed_page/closed_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ClosedPage" owl="1">
+    <t t-name="pos_self_order.ClosedPage">
         <div class="d-flex gap-3 h-100 w-100 align-items-center justify-content-center text-bg-800">
             <span class="fs-1">The kiosk is closed</span>
         </div>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ComboPage" owl="1">
+    <t t-name="pos_self_order.ComboPage">
         <div class="d-flex flex-column  w-100 fs-2 text-center border-bottom">
             <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-primary text-white"><t t-esc="props.product.name" /></div>
             <div t-if="!state.showResume" class="breadcrumb h-100 w-100 d-flex flex-nowrap p-0 bg-200 overflow-x-auto overflow-y-hidden">

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.EatingLocationPage" owl="1">
+    <t t-name="pos_self_order.EatingLocationPage">
         <div class="o_kiosk_eating_location d-flex flex-column align-items-center h-100 bg-100 overflow-hidden">
             <div class="d-flex align-items-center justify-content-center flex-column w-100 h-100 my-auto px-5 text-center">
                 <h1>Choose your eating location</h1>

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.LandingPage" owl="1">
+    <t t-name="pos_self_order.LandingPage">
         <div t-if="languages.length > 1" t-on-click="openLanguages" class="self_order_language_selector position-absolute top-0 end-0 m-4 rounded p-4 bg-white shadow-lg">
             <img class="rounded" t-attf-src="{{currentLanguage.flag_image_url}}" />
             <span t-esc="currentLanguage.display_name" class="ms-3"></span>

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.PaymentPage" owl="1">
+    <t t-name="pos_self_order.PaymentPage">
         <div t-if="state.selection" class="h-100 d-flex flex-wrap p-5 gap-5 align-items-center justify-content-center">
             <div
                 t-foreach="paymentMethods"

--- a/addons/pos_self_order/static/src/app/pages/payment_success_page/payment_success_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_success_page/payment_success_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.PaymentSuccessPage" owl="1">
+    <t t-name="pos_self_order.PaymentSuccessPage">
         <div t-if="this.state.onReload" class="self_order_success_loader position-absolute vh-100 w-100 d-flex justify-content-center align-items-center opacity-50 bg-dark">
             <div class="page-loader d-flex justify-content-center align-items-center">
                 <div class="spinner-border text-primary" role="status">

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ProductListPage" owl="1">
+    <t t-name="pos_self_order.ProductListPage">
         <div class="vh-100 overflow-hidden">
             <!-- Categories selector -->
             <nav id="listgroup-categories" class="navbar category-list fixed-top d-flex flex-column flex-wrap gap-3 align-content-start py-2 px-3 shadow-sm bg-view" t-ref="categoryList">

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ProductPage" owl="1">
+    <t t-name="pos_self_order.ProductPage">
         <div class="h-100">
             <div class="d-flex flex-row align-content-flex-start p-3 gap-3 h-25">
                 <img

--- a/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.StandNumberPage" owl="1">
+    <t t-name="pos_self_order.StandNumberPage">
         <div class="self_order_stand_number">
             <div class="d-flex flex-column justify-content-between h-100">
                 <div class="h-100 d-flex flex-column justify-content-center align-items-center">

--- a/addons/pos_self_order/static/src/app/self_order_index.xml
+++ b/addons/pos_self_order/static/src/app/self_order_index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.selfOrderIndex" owl="1">
+    <t t-name="pos_self_order.selfOrderIndex">
         <Router pos_config_id="selfOrder.pos_config_id">
             <t t-set-slot="default" route="`/pos-self/${selfOrder.pos_config_id}`">
                 <LandingPage />

--- a/addons/pos_self_order_sale/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order_sale/static/src/app/pages/cart_page/cart_page.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order_sale.CartPage" t-inherit="pos_self_order.CartPage" t-inherit-mode="extension" owl="1">
+    <t t-name="pos_self_order_sale.CartPage" t-inherit="pos_self_order.CartPage" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('absolute-content-price')]" position="before">
             <div t-if="optionalProducts.length" class="upsale-content d-flex flex-column justify-content-center gap-3 h-75 border-top bg-100 pt-5 p-4">
                 <h2 class="m-0 fw-bolder">Want to add something ?</h2>

--- a/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -111,7 +111,7 @@
             </li>
         </ul>
     </t>
-    <t t-name="saleProductConfigurator.ptav-multi" owl="1">
+    <t t-name="saleProductConfigurator.ptav-multi">
          <ul t-attf-class="list-inline list-unstyled">
             <li t-foreach="this.props.attribute_values" t-as="ptav" t-key="ptav.id"
                 class="list-inline-item mb-3">

--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.xml
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit-mode="extension" t-inherit="web.ListRenderer.RecordRow" owl="1">
+    <t t-inherit-mode="extension" t-inherit="web.ListRenderer.RecordRow">
         <xpath expr="//tr/t[1]" position="inside">
             <t t-if="column.type === 'opendetailsop'">
                 <td class="o_data_cell cursor-pointer o_list_button">

--- a/addons/web/static/src/search/properties_group_by_item/properties_group_by_item.xml
+++ b/addons/web/static/src/search/properties_group_by_item/properties_group_by_item.xml
@@ -1,5 +1,5 @@
 <templates xml:space="preserve">
-    <t t-name="web.PropertiesGroupByItem" owl="1">
+    <t t-name="web.PropertiesGroupByItem">
         <AccordionItem
             class="'o_add_custom_group_menu text-truncate'"
             description="props.item.description"

--- a/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.xml
+++ b/addons/web/static/src/views/fields/dynamic_widget/dynamic_model_field_selector_char.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-name="web.DynamicModelFieldSelectorChar" t-inherit="web.CharField" t-inherit-mode="primary" owl="1">
+    <t t-name="web.DynamicModelFieldSelectorChar" t-inherit="web.CharField" t-inherit-mode="primary">
         <xpath expr="//input" position="attributes">
             <attribute name="class" add="d-none" separator=" "/>
         </xpath>

--- a/addons/website/static/src/components/navbar/navbar.xml
+++ b/addons/website/static/src/components/navbar/navbar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-inherit="web.NavBar" t-inherit-mode="extension" owl="1">
+<t t-inherit="web.NavBar" t-inherit-mode="extension">
     <xpath expr="//div[hasclass('o_menu_systray')]" position="attributes">
         <attribute name="t-attf-class" add="{{shouldDisplayWebsiteSystray ? 'o_website_systray': ''}}" separator=" "/>
     </xpath>

--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="website_event_exhibitor.ExhibitorConnectClosedDialog" owl="1">
+  <t t-name="website_event_exhibitor.ExhibitorConnectClosedDialog">
     <Dialog size="'md'" header="false" footer="false" >
         <div class="o_wesponsor_js_connect_modal_main container">
             <div class="row mt-2">

--- a/addons/website_forum/static/src/components/flag_mark_as_offensive/flag_mark_as_offensive.xml
+++ b/addons/website_forum/static/src/components/flag_mark_as_offensive/flag_mark_as_offensive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="website_forum.FlagMarkAsOffensiveDialog" owl="1">
+  <t t-name="website_forum.FlagMarkAsOffensiveDialog">
     <Dialog size="'md'" title="props.title" footer="false" modalRef="modalRef" >
       <t t-out="props.body"/>
     </Dialog>

--- a/addons/website_slides/static/src/js/public/components/category_add_dialog/category_add_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/category_add_dialog/category_add_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="website_slides.CategoryAddDialog" t-inherit="web.ConfirmationDialog" owl="1">
+  <t t-name="website_slides.CategoryAddDialog" t-inherit="web.ConfirmationDialog">
     <xpath expr="//p[hasclass('text-prewrap')]" position="replace">
         <div>
             <form t-on-submit.prevent="_confirm" action="/slides/category/add" method="POST" id="slide_category_add_form">

--- a/addons/website_slides/static/src/js/public/components/slide_unsubscribe_dialog/slide_unsubscribe_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_unsubscribe_dialog/slide_unsubscribe_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 
-  <t t-name="website_slides.SlideUnsubscribeDialog" owl="1">
+  <t t-name="website_slides.SlideUnsubscribeDialog">
     <Dialog size="'md'" title="state.title">
       <div>
         <t t-if="state.mode === 'subscription'">
@@ -19,7 +19,7 @@
         </t>
       </div>
 
-      <t t-set-slot="footer" owl="1">
+      <t t-set-slot="footer">
         <t t-if="state.mode === 'subscription'">
             <button class="btn btn-primary" t-att-disabled="state.buttonDisabled" t-on-click="() => this.onClickSubscriptionSubmit()">Save</button>
             <button class="btn" t-att-disabled="state.buttonDisabled" t-on-click="() => this.props.close()">Discard</button>


### PR DESCRIPTION
As all the templates are now imported in the owl app, there is not need anymore to specify the owl="1" attribute in the templates.

Ref-https://github.com/odoo/odoo/pull/130467

task-3508331





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
