### PR TITLE
 [FIX] web: Record.update with onChange

### DIFF
--- a/addons/web/static/src/views/fields/boolean/boolean_field.js
+++ b/addons/web/static/src/views/fields/boolean/boolean_field.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
-import { registry } from "@web/core/registry";
-import { _t } from "@web/core/l10n/translation";
-import { standardFieldProps } from "../standard_field_props";
+import { Component, useState } from "@odoo/owl";
 import { CheckBox } from "@web/core/checkbox/checkbox";
-
-import { Component } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useRecordObserver } from "@web/model/relational_model/utils";
+import { standardFieldProps } from "../standard_field_props";
 
 export class BooleanField extends Component {
     static template = "web.BooleanField";
@@ -14,10 +14,18 @@ export class BooleanField extends Component {
         ...standardFieldProps,
     };
 
+    setup() {
+        this.state = useState({});
+        useRecordObserver((record) => {
+            this.state.value = record.data[this.props.name];
+        });
+    }
+
     /**
      * @param {boolean} newValue
      */
     onChange(newValue) {
+        this.state.value = newValue;
         this.props.record.update({ [this.props.name]: newValue });
     }
 }

--- a/addons/web/static/src/views/fields/boolean/boolean_field.xml
+++ b/addons/web/static/src/views/fields/boolean/boolean_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.BooleanField">
-        <CheckBox id="props.id" value="props.record.data[props.name] or false" className="'d-inline-block'" disabled="props.readonly" onChange.bind="onChange" />
+        <CheckBox id="props.id" value="state.value" className="'d-inline-block'" disabled="props.readonly" onChange.bind="onChange" />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
@@ -12,6 +12,7 @@ export class BooleanToggleField extends BooleanField {
     };
 
     async onChange(newValue) {
+        this.state.value = newValue;
         const changes = { [this.props.name]: newValue };
         await this.props.record.update(changes, { save: this.props.autosave });
     }

--- a/addons/web/static/tests/views/fields/boolean_field_tests.js
+++ b/addons/web/static/tests/views/fields/boolean_field_tests.js
@@ -273,4 +273,34 @@ QUnit.module("Fields", (hooks) => {
             "checkbox should still be disabled"
         );
     });
+
+    QUnit.test("onchange return value before toggle checkbox", async function (assert) {
+        serverData.models.partner.onchanges = {
+            bar(obj) {
+                obj.bar = true;
+            },
+        };
+
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `<form><field name="bar"/></form>`,
+        });
+
+        assert.containsOnce(
+            target,
+            ".o_field_boolean input:checked",
+            "checkbox should still be checked"
+        );
+
+        await click(target, ".o_field_boolean .o-checkbox");
+        await nextTick();
+        assert.containsOnce(
+            target,
+            ".o_field_boolean input:checked",
+            "checkbox should still be checked"
+        );
+    });
 });

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -8929,7 +8929,7 @@ QUnit.module("Fields", (hooks) => {
     );
 
     QUnit.test("display correct value after validation error", async function (assert) {
-        assert.expect(5);
+        assert.expect(4);
 
         serviceRegistry.add("error", errorService);
         function validationHandler(env, error, originalError) {
@@ -8985,8 +8985,10 @@ QUnit.module("Fields", (hooks) => {
         await editInput(target, ".o_field_widget[name=turtle_foo] input", "pinky");
         await click(target, ".o_form_view");
         assert.strictEqual(target.querySelector(".o_data_row .o_data_cell").textContent, "foo");
-        assert.hasClass(target.querySelector(".o_field_widget[name=turtles]"), "o_field_invalid");
-        assert.ok(target.querySelector(".o_form_button_save").disabled);
+
+        // we make sure here that when we save, the values are the current
+        // values displayed in the field.
+        await clickSave(target);
     });
 
     QUnit.test("propagate context to sub views without default_* keys", async function (assert) {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -6352,9 +6352,9 @@ QUnit.module("Views", (hooks) => {
             document.body.querySelector(".modal-body").textContent,
             "Some business message"
         );
-        assert.hasClass(
-            target.querySelector('.o_field_widget[name="int_field"]'),
-            "o_field_invalid"
+        assert.strictEqual(
+            target.querySelector('.o_field_widget[name="int_field"] input').value,
+            "9"
         );
 
         await click(target.querySelector(".modal .btn-close"));


### PR DESCRIPTION
The goal of this commit is to resolve:
=====================================
1. When you edit a Char or Boolean field with an onChange that returns
   the value before editing, you must display the value of the onChange.
2. In the model, html fields are always Markup fields. But when we evaluate
   a modifier containing an html field, we use the server value (a string or false).
3. When we edit a field and its onChange returns an server error, we want to
   revert its value to the valuea before edition.

Solution:
=========
1. Always render when applying a change, even if the value does not change,
   because onChange returns the initial value. To do this, we'll apply
   the changes to record.data, then apply the changes from onChange.
   The value will therefore change, which will cause all the components
   observing the value in record.data to render.
2. When we update an html field, its value will always be markup and
   we'll store it as a string in _textValue so that we can evaluate the
   modifiers without the markup. For changes coming from the onChange, we
   will store the value in _textValue and apply markup on it for record.data.
3. When an onChange returns an server error, we will apply the changes and then
   revert them directly. This will have the effect of triggering a rendering
   on all the components observing to the record.data corresponding to
   the changes and so displaying the values before editing.

How to reproduce:
=================
Case 1:
------
- Go to a form view containing a boolean field with an onChange
- Check the boolean field
- The onChange returns with the value false

Before this commit:
    The boolean field is always checked

After this commit:
    The boolean field is no longer checked

Case 2:
------
- Go to a form view containing an html field and an field "x" with
  invisible ="not html_field" and an onChange
- Edit the field "x"
- The onChange returns the value false for "html_field".

Before this commit:
    The field "x" is always displayed

After this commit
    The field "x" is no longer displayed

Case 3:
------
- Go to a form view containing a char field with an onChange
- Edit the field
- onChange returns a server error

Before this commit:
    The field is marked as invalid and contains the value after editing.

After this commit:
    The field contains the pre-edit value