### PR TITLE
[FIX] mail: load gif category properly

### DIFF
--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -126,6 +126,10 @@ export class GifPicker extends Component {
         );
     }
 
+    get style() {
+        return "";
+    }
+
     get searchTerm() {
         return this.props.state ? this.props.state.searchTerm : this.state.searchTerm;
     }
@@ -157,6 +161,7 @@ export class GifPicker extends Component {
     }
 
     openCategories() {
+        this.showFavorite = false;
         this.state.showCategories = true;
         this.searchTerm = "";
         this.clear();

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -93,6 +93,7 @@
                 t-on-click="() => this.onClickGif(gif_value)"
                 loading="lazy"
                 alt="GIF"
+                t-att-style="style"
             />
         </div>
     </t>


### PR DESCRIPTION
Before this PR the showFavorite status was not properly updated after clicking on "back".
This cause the categories to use the favorite route when scrolling instead of the category route.

Task-3504566
