### PR TITLE
[FIX] crm: fixing the domain to have last 12 month's data

### DIFF
--- a/addons/crm/report/crm_activity_report_views.xml
+++ b/addons/crm/report/crm_activity_report_views.xml
@@ -55,7 +55,7 @@
                     <separator/>
                     <filter string="Trailing 12 months" name="completion_date" domain="[
                         ('date', '>=', (datetime.datetime.combine(context_today() + relativedelta(days=-365), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')),
-                        ('date', '>=', (datetime.datetime.combine(context_today(), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
+                        ('date', '&lt;=', (datetime.datetime.combine(context_today(), datetime.time(0,0,0)).to_utc()).strftime('%Y-%m-%d %H:%M:%S'))]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>
                     <separator/>


### PR DESCRIPTION
- Before fix: only select activities done today or in the future so it does not reflect the expected behavior of the filter.

- After fix: have expected data with a suitable filter name

- OPW: [3504670](https://www.odoo.com/web?debug=1#id=3504670&cids=2&menu_id=4720&action=333&active_id=70&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
