### PR TITLE
[IMP] mail: fa-tasks icons as default in activity icons

### DIFF
--- a/addons/mail/static/src/core/web/activity_button.js
+++ b/addons/mail/static/src/core/web/activity_button.js
@@ -44,13 +44,15 @@ export class ActivityButton extends Component {
                 classes.push("text-danger");
                 classes.push(this.props.record.data.activity_exception_icon);
                 break;
-            default:
-                if (this.props.record.data.activity_type_icon) {
-                    classes.push(this.props.record.data.activity_type_icon);
+            default: {
+                const { activity_ids, activity_type_icon } = this.props.record.data;
+                if (activity_ids.records.length) {
+                    classes.push(activity_type_icon || "fa-tasks");
                     break;
                 }
                 classes.push("fa-clock-o btn-link text-dark");
                 break;
+            }
         }
         return classes.join(" ");
     }
@@ -76,7 +78,8 @@ export class ActivityButton extends Component {
             const selectedRecords = this.env?.model?.root?.selection ?? [];
             const selectedIds = selectedRecords.map((r) => r.resId);
             // If the current record is not selected, ignore the selection
-            const resIds = (selectedIds.includes(resId) && (selectedIds.length > 1)) ? selectedIds : undefined;
+            const resIds =
+                selectedIds.includes(resId) && selectedIds.length > 1 ? selectedIds : undefined;
             this.popover.open(this.buttonRef.el, {
                 activityIds: this.props.record.data.activity_ids.currentIds,
                 onActivityChanged: () => {

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -53,6 +53,9 @@ export class Activity extends Record {
         if (data.request_partner_id) {
             data.request_partner_id = data.request_partner_id[0];
         }
+        if (!data.icon) {
+            data.icon = "fa-tasks";
+        }
         assignDefined(activity, data);
         if (broadcast) {
             this.env.services["mail.activity"].broadcastChannel?.postMessage({

--- a/addons/mail/static/tests/web/activity/activity_widget_tests.js
+++ b/addons/mail/static/tests/web/activity/activity_widget_tests.js
@@ -103,7 +103,7 @@ QUnit.test("list activity widget with activities", async (assert) => {
     });
     await contains(":nth-child(2 of .o_data_row)", {
         contains: [
-            [".o-mail-ActivityButton i.text-success.fa-clock-o"],
+            [".o-mail-ActivityButton i.text-success.fa-tasks"],
             [".o-mail-ListActivity-summary", { text: "Type 2" }],
         ],
     });


### PR DESCRIPTION
Before this commit:
There were no default icon set when a new activity type is created.

After this commit:
When user will create a new activity type, 'fa-tasks' will be added as
its default icon.

task-3525592