### PR TITLE
[FIX] base: Set (default_)address_format more intelligently

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -198,6 +198,18 @@ class Company(models.Model):
     def cache_restart(self):
         self.clear_caches()
 
+    def _recurse_country_id(self):
+        self.ensure_one()
+
+        current_id = self
+        country_id = current_id.partner_id.country_id
+
+        while current_id and not country_id:
+            current_id = current_id.parent_id
+            country_id = current_id.partner_id.country_id
+
+        return country_id
+
     @api.model
     def create(self, vals):
         if not vals.get('favicon'):


### PR DESCRIPTION
Currently, if the current contact doesn't have a country_id set, the _get_address_format() method uses the default value from _get_default_address_format() which is just a simple format string.

The contact might have a parent_id with a country_id set, or there may be no country_id set on all contacts, since it's a single-country business and they assume all customers come from the same country as the company.

With this fix, _get_address_format() will try to recursively find the appropriate "default country" from either the direct ancestors of the contact, company set for the contact, or the current company, before using the default address_format string.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
