### PR TITLE
[IMP] web_editor: add document parameter to parseHTML

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -595,7 +595,7 @@ export class OdooEditor extends EventTarget {
                         let html = '\u200B<span contenteditable="false" class="o_stars o_three_stars">';
                         html += Array(3).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
                         html += '</span>';
-                        this.execCommand('insert', parseHTML(html));
+                        this.execCommand('insert', parseHTML(this.document, html));
                     },
                 },
                 {
@@ -608,7 +608,7 @@ export class OdooEditor extends EventTarget {
                         let html = '\u200B<span contenteditable="false" class="o_stars o_five_stars">';
                         html += Array(5).fill().map(() => '<i class="fa fa-star-o"></i>').join('');
                         html += '</span>';
-                        this.execCommand('insert', parseHTML(html));
+                        this.execCommand('insert', parseHTML(this.document, html));
                     },
                 },
                 ...(this.options.commands || []),
@@ -3206,7 +3206,7 @@ export class OdooEditor extends EventTarget {
      */
     _prepareClipboardData(clipboardData) {
         const container = document.createElement('fake-container');
-        container.append(parseHTML(clipboardData));
+        container.append(parseHTML(this.document, clipboardData));
 
         for (const tableElement of container.querySelectorAll('table')) {
             tableElement.classList.add('table', 'table-bordered', 'o_table');
@@ -3714,7 +3714,7 @@ export class OdooEditor extends EventTarget {
                 this._onTabulationInTable(ev);
             } else if (!ev.shiftKey && sel.isCollapsed && !closestLi) {
                 // Indent text (collapsed selection).
-                this.execCommand('insert', parseHTML(tabHtml));
+                this.execCommand('insert', parseHTML(this.document, tabHtml));
             } else {
                 // Indent/outdent selection.
                 // Split traversed nodes into list items and the rest.
@@ -3776,7 +3776,7 @@ export class OdooEditor extends EventTarget {
                         tab.remove();
                     };
                 } else {
-                    const tab = parseHTML(tabHtml);
+                    const tab = parseHTML(this.document, tabHtml);
                     for (const block of new Set([...nonListItems].map(node => closestBlock(node)).filter(node => node))) {
                         block.prepend(tab.cloneNode(true));
                     }
@@ -4675,7 +4675,7 @@ export class OdooEditor extends EventTarget {
             setSelection(...start, ...start, false);
         }
         if (odooEditorHtml && targetSupportsHtmlContent) {
-            const fragment = parseHTML(odooEditorHtml);
+            const fragment = parseHTML(this.document, odooEditorHtml);
             DOMPurify.sanitize(fragment, { IN_PLACE: true });
             if (fragment.hasChildNodes()) {
                 this._applyCommand('insert', fragment);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -657,7 +657,7 @@ export const editorCommands = {
             const newPosition = rightPos(newAnchorNode);
             setSelection(...newPosition, ...newPosition, false);
         }
-        const [table] = editorCommands.insert(editor, parseHTML(tableHtml));
+        const [table] = editorCommands.insert(editor, parseHTML(editor.document, tableHtml));
         setCursorStart(table.querySelector('td'));
     },
     addColumn: (editor, beforeOrAfter, referenceCell) => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -2536,7 +2536,7 @@ export function rgbToHex(rgb = '', node = null) {
     }
 }
 
-export function parseHTML(html) {
+export function parseHTML(document, html) {
     const fragment = document.createDocumentFragment();
     const parser = new DOMParser();
     const parsedDocument = parser.parseFromString(html, 'text/html');

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/collab.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/collab.test.js
@@ -574,7 +574,7 @@ describe('Collaboration', () => {
                 clientIds: ['c1', 'c2'],
                 contentBefore: '<p>[c1}{c1][c2}{c2]</p>',
                 afterCreate: clientInfos => {
-                    clientInfos.c1.editor.editable.prepend(...parseHTML(unformat(`
+                    clientInfos.c1.editor.editable.prepend(...parseHTML(clientInfos.c1.editor.document, unformat(`
                         <div data-oe-protected="true">
                             <p id="true"><br></p>
                             <div data-oe-protected="false">
@@ -621,7 +621,7 @@ describe('Collaboration', () => {
                 clientIds: ['c1', 'c2'],
                 contentBefore: '<p>[c1}{c1][c2}{c2]</p>',
                 afterCreate: clientInfos => {
-                    clientInfos.c1.editor.editable.prepend(...parseHTML(unformat(`
+                    clientInfos.c1.editor.editable.prepend(...parseHTML(clientInfos.c1.editor.document, unformat(`
                         <div data-oe-transient-content="true">
                             <p>secret</p>
                         </div>
@@ -666,13 +666,13 @@ describe('Collaboration', () => {
                 clientIds: ['c1', 'c2'],
                 contentBefore: '<p>[c1}{c1][c2}{c2]</p>',
                 afterCreate: async clientInfos => {
-                    clientInfos.c1.editor.editable.append(...parseHTML(unformat(`
+                    clientInfos.c1.editor.editable.append(...parseHTML(clientInfos.c1.editor.document, unformat(`
                         <div class="process">
                             <p>secret</p>
                         </div>
                     `)).children);
                     clientInfos.c1.editor.historyStep();
-                    clientInfos.c1.editor.editable.append(...parseHTML(unformat(`
+                    clientInfos.c1.editor.editable.append(...parseHTML(clientInfos.c1.editor.document, unformat(`
                         <p>post-process</p>
                     `)).children);
                     clientInfos.c1.editor.historyStep();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -15,7 +15,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>[]<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
@@ -27,7 +27,7 @@ describe('insert HTML', () => {
                 // This scenario is only possible with the allowInlineAtRoot option.
                 contentBefore: '<p><br></p>[]',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p><br></p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]',
@@ -38,7 +38,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[]b<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b<br></p>',
@@ -49,7 +49,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[]b<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]b<br></p>',
@@ -60,7 +60,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[]e<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<p>b</p><p>c</p><p>d</p>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<p>b</p><p>c</p><p>d</p>'));
                 },
                 contentAfter: '<p>ab</p><p>c</p><p>d[]e<br></p>',
             });
@@ -69,7 +69,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>[]<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<div><p>content</p></div>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<div><p>content</p></div>'));
                 },
                 contentAfter: '<div><p>content</p></div><p>[]<br></p>',
             });
@@ -78,7 +78,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<pre>abc[]<br>ghi</pre>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<pre>def</pre>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<pre>def</pre>'));
                 },
                 contentAfter: '<pre>abcdef[]<br>ghi</pre>',
             });
@@ -87,7 +87,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>content[]</p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<p>unwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after</p>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<p>unwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after</p>'));
                 },
                 contentAfter: '<p>contentunwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after[]</p>',
             });
@@ -97,7 +97,7 @@ describe('insert HTML', () => {
                 contentBefore: '<p>content</p>',
                 stepFunction: async editor => {
                     setCursorEnd(editor.editable, false);
-                    await editor.execCommand('insert', parseHTML('<p>def</p>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<p>def</p>'));
                 },
                 contentAfter: '<p>content</p><p>def[]</p>',
             });
@@ -107,7 +107,7 @@ describe('insert HTML', () => {
                 contentBefore: '<p>content</p>',
                 stepFunction: async editor => {
                     setCursorEnd(editor.editable, false);
-                    await editor.execCommand('insert', parseHTML('<div>abc</div><p>def</p>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<div>abc</div><p>def</p>'));
                 },
                 contentAfter: '<p>content</p><div>abc</div><p>def[]</p>',
             });
@@ -118,7 +118,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>[a]<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit: '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
                 contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]<br></p>',
@@ -128,7 +128,7 @@ describe('insert HTML', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[b]c<br></p>',
                 stepFunction: async editor => {
-                    await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
+                    await editor.execCommand('insert', parseHTML(editor.document, '<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
                     '<p>a<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]c<br></p>',

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2181,7 +2181,7 @@ export class Wysiwyg extends Component {
             fontawesome: iconClass,
             isDisabled: () => isSelectionInSelectors('.o_editor_banner') || !this.odooEditor.isSelectionInBlockRoot(),
             callback: () => {
-                const bannerElement = parseHTML(`
+                const bannerElement = parseHTML(this.odooEditor.document, `
                     <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" role="status" data-oe-protected="true">
                         <i class="fs-4 fa ${iconClass} mb-3" aria-label="${_t(title)}"></i>
                         <div class="o_editable o_editable_no_shadow w-100 ms-3" data-oe-protected="false">
@@ -2280,7 +2280,7 @@ export class Wysiwyg extends Component {
                         ['signature'],
                     );
                     if (user && user.signature) {
-                        this.odooEditor.execCommand('insert', parseHTML(user.signature));
+                        this.odooEditor.execCommand('insert', parseHTML(this.odooEditor.document, user.signature));
                     }
                 },
             },

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -418,7 +418,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
 
         // Replace the empty paragraph with a paragrah containing an unsaved
         // modified image
-        const imageContainerElement = parseHTML(imageContainerHTML).firstChild;
+        const imageContainerElement = parseHTML(editor.document, imageContainerHTML).firstChild;
         let paragraph = editor.editable.querySelector(".test_target");
         editor.editable.replaceChild(imageContainerElement, paragraph);
         editor.historyStep();


### PR DESCRIPTION
This commit changes the API of the public `parseHTML` util, in order to allow the use the editor's document to create a document fragment.

This aims to avoid mismatches in the prototype chain of HTML elements created by such util and the ones present in the editable, when the editor is mounted in an iframe. This is of particular relevance for the 'insert' command, in which the node to be inserted is tested for `instanceof` the editor's document global `Node` object.

task-3526134

Enterprise PR: https://github.com/odoo/enterprise/pull/48108