### PR TITLE
[FIX] website_sale: search in website_description

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -478,6 +478,8 @@ class ProductTemplate(models.Model):
             fetch_fields.append('description')
             search_fields.append('description_sale')
             fetch_fields.append('description_sale')
+            search_fields.append('website_description')
+            fetch_fields.append('website_description')
             mapping['description'] = {'name': 'description_sale', 'type': 'text', 'match': True}
         if with_price:
             mapping['detail'] = {'name': 'price', 'type': 'html', 'display_currency': options['display_currency']}


### PR DESCRIPTION
Currently, the search is only done on description (internal notes) and description_sale but not on website_description which might confuses users. 
This is not the intended behaviour as this PR: https://github.com/odoo/odoo/pull/79004 added `website_description` to the search domain (but not on the searched fields hence why it still doesn't work correctly). After this commit, a search on the website will also search in the `website_description` field as well. 
The `description` field is intentionally kept so it doesn't break any existing behaviour (according to the PR mentioned above).

Description of the issue/feature this PR addresses: Users can't search in website using the website_description field. A fix had been made 2 years ago

Current behavior before PR: Website search is only done on the 'description' and 'description_sale' fields.

Desired behavior after PR is merged: Website search is now done on 'description', 'description_sale' and 'website_description'.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
