### PR TITLE
[IMP] l10n_it_edi: Separate XML generation from sending

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -613,7 +613,8 @@ class AccountMoveSend(models.Model):
             moves_data[self.move_ids]['_form'] = self
         else:
             for move in self.move_ids:
-                moves_data[move]['_form'] = self.new(self._get_available_field_values_in_multi(move))
+                vals = self._get_available_field_values_in_multi(move)
+                moves_data[move]['_form'] = self.create(vals)
 
         if self.mode == 'invoice_multi' and not from_cron and not download:
             self.env.ref('account.ir_cron_account_move_send')._trigger()

--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -125,11 +125,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_move_send_inherit_l10n_it_edi
 msgid ""
 "<span invisible=\"not l10n_it_edi_warning_message\">\n"
-"                        <b>Tax Agency (Italy)</b>\n"
+"                        <b>Tax Agency</b>\n"
 "                    </span>"
 msgstr ""
 "<span invisible=\"not l10n_it_edi_warning_message\">\n"
-"                        <b>Agenzia delle Entrate (IT)</b>\n"
+"                        <b>Agenzia delle Entrate</b>\n"
 "                    </span>"
 
 #. module: l10n_it_edi
@@ -760,13 +760,9 @@ msgstr "Invio Integrazione Imposte"
 #. module: l10n_it_edi
 #: model:ir.model.fields,help:l10n_it_edi.field_account_move_send__l10n_it_edi_checkbox_send
 msgid ""
-"Send the invoice to the Italian Tax Agency.\n"
-"It is set as readonly if a report has already been created, to avoid inconsistencies.\n"
-"To re-enable it, delete the PDF attachment."
+"Send the invoice to the Italian Tax Agency."
 msgstr ""
-"Invia la Fatturazione Elettronica all'Agenzia delle Entrate\n"
-"Viene impostato in sola lettura se è stato già creato un resoconto, per evitare disallineamenti.\n"
-"Per riabilitarlo, cancellare l'allegato PDF."
+"Invia la Fatturazione Elettronica all'Agenzia delle Entrate"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -825,8 +821,8 @@ msgstr "Imposta"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move_send__l10n_it_edi_checkbox_send
-msgid "Tax Agency (Italy)"
-msgstr "Agenzia delle Entrate (IT)"
+msgid "Tax Agency"
+msgstr "Agenzia delle Entrate"
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_res_company__l10n_it_tax_system
@@ -1240,7 +1236,7 @@ msgstr ""
 msgid ""
 "You must accept the terms and conditions in the Settings to use the IT EDI."
 msgstr ""
-"Devi accettare i Termini e le Condiioni nelle Impostazioni di Contabilità "
+"Devi accettare i Termini e le Condizioni nelle Impostazioni di Contabilità "
 "per usare l'EDI (Italia)"
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -117,7 +117,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.account_move_send_inherit_l10n_it_edi
 msgid ""
 "<span invisible=\"not l10n_it_edi_warning_message\">\n"
-"                        <b>Tax Agency (Italy)</b>\n"
+"                        <b>Tax Agency</b>\n"
 "                    </span>"
 msgstr ""
 
@@ -774,7 +774,7 @@ msgstr ""
 
 #. module: l10n_it_edi
 #: model:ir.model.fields,field_description:l10n_it_edi.field_account_move_send__l10n_it_edi_checkbox_send
-msgid "Tax Agency (Italy)"
+msgid "Tax Agency"
 msgstr ""
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -189,9 +189,24 @@ class AccountMove(models.Model):
             raise UserError(_("This move is not waiting for updates from the SdI."))
         self._l10n_it_edi_update_send_state()
 
+    def button_draft(self):
+        # EXTENDS 'account'
+        for move in self:
+            move.l10n_it_edi_state = False
+        return super().button_draft()
+
     # -------------------------------------------------------------------------
     # Helpers
     # -------------------------------------------------------------------------
+
+    def _l10n_it_edi_ready_for_xml_export(self):
+        self.ensure_one()
+        return (
+            self.state == 'posted'
+            and self.company_id.account_fiscal_country_id.code == 'IT'
+            and self.journal_id.type == 'sale'
+            and self.l10n_it_edi_state in (False, 'rejected')
+        )
 
     def _l10n_it_edi_get_line_values(self, reverse_charge_refund=False, is_downpayment=False, convert_to_euros=True):
         """ Returns a list of dictionaries passed to the template for the invoice lines (DettaglioLinee)

--- a/addons/l10n_it_edi/tests/__init__.py
+++ b/addons/l10n_it_edi/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_edi_export
 from . import test_edi_import
 from . import test_edi_reverse_charge
 from . import test_edi_pa
+from . import test_account_move_send

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -1,0 +1,87 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged
+from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
+from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
+
+    def init_invoice(self, partners):
+        invoices = self.env['account.move']
+        for partner in partners:
+            invoices |= super().init_invoice(
+                "out_invoice",
+                partner=partner,
+                company=self.company,
+                amounts=[1000],
+                taxes=self.default_tax,
+                post=True)
+        return invoices
+
+    def get_attachments(self, res_id):
+        return self.env['ir.attachment'].with_company(self.company).search([
+            ('res_model', '=', 'account.move'),
+            ('res_id', '=', res_id),
+            ('res_field', 'in', ('invoice_pdf_report_file', 'l10n_it_edi_attachment_file')),
+        ])
+
+    def test_invoice_multi_without_l10n_it_edi_xml_export(self):
+        # Prepare
+        invoice1, invoice2 = self.init_invoice(self.italian_partner_a + self.italian_partner_a)
+        wizard = self.create_send_and_print(invoice1 + invoice2,
+            mode='invoice_multi',
+            enable_download=True,
+            checkbox_download=True,
+            enable_send_mail=True,
+            checkbox_send_mail=False,
+            l10n_it_edi_enable_xml_export=True,
+            l10n_it_edi_checkbox_xml_export=False,
+            l10n_it_edi_enable_send=True,
+            l10n_it_edi_checkbox_send=False,
+        )
+
+        # Process
+        results = wizard.action_send_and_print()
+
+        # Asserts
+        self.assertEqual(wizard.mode, 'done')
+        self.assertEqual(results['type'], 'ir.actions.act_url')
+        self.assertEqual(1, len(self.get_attachments(invoice1.id)))
+        self.assertTrue(invoice1.invoice_pdf_report_id)
+        self.assertFalse(invoice1.l10n_it_edi_attachment_id)
+        self.assertFalse(invoice1.is_being_sent)
+        self.assertEqual(1, len(self.get_attachments(invoice2.id)))
+        self.assertTrue(invoice2.invoice_pdf_report_id)
+        self.assertFalse(invoice2.l10n_it_edi_attachment_id)
+        self.assertFalse(invoice2.is_being_sent)
+
+    def test_invoice_multi_with_l10n_it_edi_xml_export(self):
+        # Prepare
+        invoice1, invoice2 = self.init_invoice(self.italian_partner_a + self.italian_partner_a)
+        wizard = self.create_send_and_print(invoice1 + invoice2,
+            mode='invoice_multi',
+            enable_download=True,
+            checkbox_download=True,
+            enable_send_mail=True,
+            checkbox_send_mail=False,
+            l10n_it_edi_enable_xml_export=True,
+            l10n_it_edi_checkbox_xml_export=True,
+            l10n_it_edi_enable_send=True,
+            l10n_it_edi_checkbox_send=False,
+        )
+
+        # Process
+        results = wizard.action_send_and_print()
+
+        # Asserts
+        self.assertEqual(wizard.mode, 'done')
+        self.assertEqual(results['type'], 'ir.actions.act_url')
+        self.assertEqual(2, len(self.get_attachments(invoice1.id)))
+        self.assertTrue(invoice1.invoice_pdf_report_id)
+        self.assertTrue(invoice1.l10n_it_edi_attachment_id)
+        self.assertFalse(invoice1.is_being_sent)
+        self.assertEqual(2, len(self.get_attachments(invoice2.id)))
+        self.assertTrue(invoice2.invoice_pdf_report_id)
+        self.assertTrue(invoice2.l10n_it_edi_attachment_id)
+        self.assertFalse(invoice2.is_being_sent)

--- a/addons/l10n_it_edi/wizard/account_move_send.py
+++ b/addons/l10n_it_edi/wizard/account_move_send.py
@@ -6,60 +6,75 @@ from odoo import _, api, fields, models
 class AccountMoveSend(models.Model):
     _inherit = 'account.move.send'
 
-    l10n_it_edi_enable_send = fields.Boolean(compute='_compute_send_mail_extra_fields')
-    l10n_it_edi_checkbox_send = fields.Boolean('Tax Agency (Italy)', compute='_compute_l10n_it_edi_checkbox_send',
-        store=True, readonly=False, help=(
-            "Send the invoice to the Italian Tax Agency.\n"
-            "It is set as readonly if a report has already been created, to avoid inconsistencies.\n"
-            "To re-enable it, delete the PDF attachment."))
-    l10n_it_edi_readonly = fields.Boolean(compute='_compute_send_mail_extra_fields')
-    l10n_it_edi_warning_message = fields.Html(compute='_compute_send_mail_extra_fields')
+    l10n_it_edi_warning_message = fields.Html(compute='_compute_l10n_it_edi_warning_message')
 
-    def _get_available_field_values_in_multi(self, move):
-        # EXTENDS 'account'
-        values = super()._get_available_field_values_in_multi(move)
-        values['l10n_it_edi_checkbox_send'] = self.l10n_it_edi_checkbox_send and self._get_default_l10n_it_edi_enable_send(move)
-        return values
+    l10n_it_edi_enable_xml_export = fields.Boolean(compute='_compute_l10n_it_edi_xml_export')
+    l10n_it_edi_readonly_xml_export = fields.Boolean(compute='_compute_l10n_it_edi_xml_export')
+    l10n_it_edi_checkbox_xml_export = fields.Boolean('E-invoice XML (Italy)',
+        compute='_compute_l10n_it_edi_checkbox_xml_export',
+        store=True,
+        readonly=False,
+        help="Create the e-invoice XML ready to be sent to the Italian Tax Agency.\n"
+             "It is set as readonly if a report has already been created, to avoid inconsistencies.\n"
+             "To re-enable it, delete the PDF attachment.")
+
+    l10n_it_edi_enable_send = fields.Boolean(compute='_compute_l10n_it_edi_enable_readonly_send')
+    l10n_it_edi_readonly_send = fields.Boolean(compute='_compute_l10n_it_edi_enable_readonly_send')
+    l10n_it_edi_checkbox_send = fields.Boolean('Tax Agency',
+        compute='_compute_l10n_it_edi_checkbox_send',
+        store=True,
+        readonly=False,
+        help="Send the e-invoice XML to the Italian Tax Agency.")
 
     # -------------------------------------------------------------------------
     # COMPUTE/CONSTRAINS METHODS
     # -------------------------------------------------------------------------
 
-    @api.depends('l10n_it_edi_enable_send')
-    def _compute_send_mail_extra_fields(self):
-        # EXTENDS account
-        super()._compute_send_mail_extra_fields()
+    @api.depends('move_ids')
+    def _compute_l10n_it_edi_xml_export(self):
         for wizard in self:
-            wizard.l10n_it_edi_enable_send = any(
-                wizard._get_default_l10n_it_edi_enable_send(m)
-                and not m.l10n_it_edi_attachment_id
-                for m in wizard.move_ids)
-
+            already_has_xml = any(wizard.move_ids.mapped("l10n_it_edi_attachment_id"))
+            already_has_pdf = any(wizard.move_ids.mapped("invoice_pdf_report_id"))
             if not wizard.company_id.l10n_it_edi_proxy_user_id:
                 wizard.l10n_it_edi_warning_message = _("You must accept the terms and conditions in the Settings to use the IT EDI.")
             else:
                 wizard.l10n_it_edi_warning_message = wizard.move_ids._l10n_it_edi_format_export_data_errors()
+            wizard.l10n_it_edi_enable_xml_export = any(m._l10n_it_edi_ready_for_xml_export() for m in wizard.move_ids)
+            wizard.l10n_it_edi_readonly_xml_export = bool(wizard.l10n_it_edi_warning_message) or already_has_pdf or already_has_xml
 
-            already_has_pdf = any(wizard.move_ids.mapped("invoice_pdf_report_id"))
-            already_has_xml = any(x._is_l10n_it_edi_import_file() for x in wizard.move_ids.mapped("attachment_ids"))
-            wizard.l10n_it_edi_readonly = wizard.l10n_it_edi_warning_message or already_has_pdf or already_has_xml
-
-    @api.depends('l10n_it_edi_readonly', 'l10n_it_edi_enable_send')
-    def _compute_l10n_it_edi_checkbox_send(self):
+    @api.depends('move_ids', 'l10n_it_edi_checkbox_xml_export', 'l10n_it_edi_warning_message')
+    def _compute_l10n_it_edi_enable_readonly_send(self):
         for wizard in self:
-            wizard.l10n_it_edi_checkbox_send = wizard.l10n_it_edi_enable_send and not wizard.l10n_it_edi_readonly
+            already_has_xml = any(wizard.move_ids.mapped("l10n_it_edi_attachment_id"))
+            xml_already_sent = all(m.l10n_it_edi_state not in (False, 'rejected') for m in wizard.move_ids)
+            wizard.l10n_it_edi_enable_send = already_has_xml or wizard.l10n_it_edi_checkbox_xml_export
+            wizard.l10n_it_edi_readonly_send = bool(wizard.l10n_it_edi_warning_message) or xml_already_sent
 
     @api.depends('move_ids')
-    def _get_default_l10n_it_edi_enable_send(self, move):
-        return (
-            move.company_id.account_fiscal_country_id.code == 'IT'
-            and move.journal_id.type == 'sale'
-            and move.l10n_it_edi_state in (False, 'rejected')
-        )
+    def _compute_l10n_it_edi_checkbox_xml_export(self):
+        for wizard in self:
+            wizard.l10n_it_edi_checkbox_xml_export = wizard.l10n_it_edi_enable_xml_export and not wizard.l10n_it_edi_readonly_xml_export
+
+    @api.depends('move_ids', 'l10n_it_edi_checkbox_xml_export')
+    def _compute_l10n_it_edi_checkbox_send(self):
+        for wizard in self:
+            wizard.l10n_it_edi_checkbox_send = not wizard.l10n_it_edi_readonly_send and wizard.l10n_it_edi_enable_send
+
+    def _get_available_field_values_in_multi(self, move):
+        # EXTENDS 'account'
+        values = super()._get_available_field_values_in_multi(move)
+        export = self.l10n_it_edi_checkbox_xml_export and move._l10n_it_edi_ready_for_xml_export()
+        values['l10n_it_edi_checkbox_xml_export'] = export
+        values['l10n_it_edi_checkbox_send'] = export or (bool(move.l10n_it_edi_attachment_id) and not move.l10n_it_edi_state)
+        return values
 
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
+
+    def _need_invoice_document(self, invoice):
+        # EXTENDS 'account'
+        return super()._need_invoice_document(invoice) and not invoice.l10n_it_edi_attachment_id
 
     @api.model
     def _get_invoice_extra_attachments(self, move):
@@ -69,7 +84,7 @@ class AccountMoveSend(models.Model):
     def _hook_invoice_document_before_pdf_report_render(self, invoice, invoice_data):
         # EXTENDS 'account'
         super()._hook_invoice_document_before_pdf_report_render(invoice, invoice_data)
-        if self.l10n_it_edi_checkbox_send and self._get_default_l10n_it_edi_enable_send(invoice):
+        if self.l10n_it_edi_checkbox_xml_export and invoice._l10n_it_edi_ready_for_xml_export():
             if errors := invoice._l10n_it_edi_export_data_check():
                 message = _("Errors occured while creating the e-invoice file.")
                 message += "\n- " + "\n- ".join(errors)
@@ -78,7 +93,7 @@ class AccountMoveSend(models.Model):
     def _hook_invoice_document_after_pdf_report_render(self, invoice, invoice_data):
         # EXTENDS 'account'
         super()._hook_invoice_document_after_pdf_report_render(invoice, invoice_data)
-        if self.l10n_it_edi_checkbox_send and self._get_default_l10n_it_edi_enable_send(invoice):
+        if self.l10n_it_edi_checkbox_xml_export and invoice._l10n_it_edi_ready_for_xml_export():
             invoice_data['l10n_it_edi_values'] = invoice._l10n_it_edi_get_attachment_values(
                 pdf_values=invoice_data['pdf_attachment_values'])
 
@@ -89,9 +104,12 @@ class AccountMoveSend(models.Model):
             attachments_vals = {}
             moves = self.env['account.move']
             for move in invoices_data:
-                if self._get_default_l10n_it_edi_enable_send(move):
+                if move._l10n_it_edi_ready_for_xml_export():
                     moves |= move
-                    attachments_vals[move] = invoices_data[move]['l10n_it_edi_values']
+                    if attachment := move.l10n_it_edi_attachment_id:
+                        attachments_vals[move] = {'name': attachment.name, 'raw': attachment.raw}
+                    else:
+                        attachments_vals[move] = invoices_data[move]['l10n_it_edi_values']
             moves._l10n_it_edi_send(attachments_vals)
 
     def _link_invoice_documents(self, invoice, invoice_data):

--- a/addons/l10n_it_edi/wizard/account_move_send_views.xml
+++ b/addons/l10n_it_edi/wizard/account_move_send_views.xml
@@ -6,7 +6,9 @@
             <field name="inherit_id" ref="account.account_move_send_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='warnings']" position="inside">
-                    <field name="l10n_it_edi_readonly" invisible="1"/>
+                    <field name="l10n_it_edi_readonly_xml_export" invisible="1"/>
+                    <field name="l10n_it_edi_enable_xml_export" invisible="1"/>
+                    <field name="l10n_it_edi_readonly_send" invisible="1"/>
                     <field name="l10n_it_edi_enable_send" invisible="1"/>
                     <span invisible="not l10n_it_edi_warning_message">
                         <b>Tax Agency (Italy)</b>
@@ -16,9 +18,15 @@
                     </div>
                 </xpath>
                 <xpath expr="//div[@name='option_send_mail']" position='after'>
-                    <div name="option_l10n_it_edi" invisible="not l10n_it_edi_enable_send">
-                        <field name="l10n_it_edi_checkbox_send" readonly="l10n_it_edi_readonly"/>
-                        <b><label for="l10n_it_edi_checkbox_send"/></b>
+                    <div name="option_l10n_it_edi">
+                        <div name="option_l10n_it_edi_xml_export" invisible="not l10n_it_edi_enable_xml_export">
+                            <field name="l10n_it_edi_checkbox_xml_export" readonly="l10n_it_edi_readonly_xml_export"/>
+                            <b><label for="l10n_it_edi_checkbox_xml_export"/></b>
+                        </div>
+                        <div name="option_l10n_it_edi_send" invisible="not l10n_it_edi_enable_send">
+                            <field name="l10n_it_edi_checkbox_send" readonly="l10n_it_edi_readonly_send"/>
+                            <b><label for="l10n_it_edi_checkbox_send"/></b>
+                        </div>
                     </div>
                 </xpath>
             </field>


### PR DESCRIPTION
The current Send and Print dialog doesn't let you generate the XML without sending it.
An additional checkbox will be added to allow that.

It can be useful in all those cases in which the XML is not yet 100% compliant or feature-covered to let the Odoo customer download the XML, modify it and send it manually through the Italian Tax Agency web portal.