### PR TITLE
[FIX] account: don't recompute narration on journal change

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3659,7 +3659,7 @@ class AccountMove(models.Model):
         """
         return []
 
-    @api.depends('move_type', 'partner_id', 'company_id')
+    @api.depends('move_type', 'partner_id')
     def _compute_narration(self):
         use_invoice_terms = self.env['ir.config_parameter'].sudo().get_param('account.use_invoice_terms')
         for move in self:

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3600,3 +3600,16 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertTrue(any(
             message.body == "<p>The move could not be posted for the following reason: You need to add a line before posting.</p>"
             for message in invalid_invoice_2.message_ids))
+
+    def test_narration_onchange_journal(self):
+        """ Check that the narration (terms & conditions) is not recomputed when changing the journal. """
+        # Enable invoicing terms
+        self.env['ir.config_parameter'].sudo().set_param('account.use_invoice_terms', True)
+        self.env.company.invoice_terms = "Don't look up"
+
+        invoice = self.init_invoice(move_type='out_invoice')
+        journal_copy = invoice.journal_id.copy()
+
+        invoice.narration = "I said don't look up!"
+        invoice.journal_id = journal_copy
+        self.assertEqual(invoice.narration, "<p>I said don't look up!</p>")


### PR DESCRIPTION
When changing the journal on an invoice, the terms
& conditions (narration) is recomputed. This is
because we recompute the company on the journal
change, therefore the compute of narration field
that depends on company_id is recomputed too.

Steps:

- In the settings, enable the terms & conditions
  and set a value
- Create a second customer journal
- Create an invoice, and change the value of
  Terms & Conditions
- Change the journal
-> Terms & Conditions are back to the default value

opw-3461662
