### PR TITLE
[FIX] pos_loyalty: accept generating Gift Cards starting with 043

### DIFF
--- a/addons/pos_loyalty/static/src/js/ProductScreen.js
+++ b/addons/pos_loyalty/static/src/js/ProductScreen.js
@@ -56,7 +56,7 @@ export const PosLoyaltyProductScreen = (ProductScreen) =>
                     return false;
                 }
                 const trimmedCode = code.trim();
-                if (trimmedCode && trimmedCode.startsWith('044')) {
+                if (trimmedCode && /^(044|043)/.test(trimmedCode)) {
                     // check if the code exist in the database
                     // if so, use its balance, otherwise, use the unit price of the gift card product
                     const fetchedGiftCard = await this.rpc({


### PR DESCRIPTION
Before this commit, when the "Scan existing cards" option was enabled in a PoS config, it was not possible to add a Gift Card starting with "043". Only cards starting with "044" were accepted. However, based on the barcode nomenclature, Gift Cards can start with"043".

opw-3499787

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
