### PR TITLE
[FIX] stock: flexible mto

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -421,6 +421,10 @@ class StockMove(models.Model):
             'bom_line_id': bom_line.id,
         }
 
+    def _should_trigger_assign(self):
+        self.ensure_one()
+        return bool(self.production_id) or super()._should_trigger_assign()
+
     def _generate_move_phantom(self, bom_line, product_qty, quantity_done):
         vals = []
         if bom_line.product_id.type in ['product', 'consu']:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -971,10 +971,6 @@ class Picking(models.Model):
         todo_moves._action_done(cancel_backorder=self.env.context.get('cancel_backorder'))
         self.write({'date_done': fields.Datetime.now(), 'priority': '0'})
 
-        # if incoming/internal moves make other confirmed/partially_available moves available, assign them
-        done_incoming_moves = self.filtered(lambda p: p.picking_type_id.code in ('incoming', 'internal')).move_ids.filtered(lambda m: m.state == 'done')
-        done_incoming_moves._trigger_assign()
-
         self._send_confirmation_email()
         return True
 

--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -255,17 +255,11 @@ class TestInventory(TransactionCase):
         inventory_quant.inventory_quantity = 10
         inventory_quant.action_apply_inventory()
 
-        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, self.pack_location), 2)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product1, self.pack_location), 0)
 
-        # Nothing should have changed for our pack move
-        self.assertEqual(move_pack_cust.state, 'partially_available')
-        self.assertEqual(move_pack_cust.quantity, 8)
-
-        # Running _action_assign will now find the new available quantity. Since the products
-        # are not differentiated (no lot/pack/owner), even if the new available quantity is not directly
-        # brought by the chain, the system will take them into account.
-        move_pack_cust._action_assign()
+        # Our pack move should have been entirely reserved.
         self.assertEqual(move_pack_cust.state, 'assigned')
+        self.assertEqual(move_pack_cust.quantity, 10)
 
         # move all the things
         move_pack_cust.move_line_ids.quantity = 10

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -3,6 +3,7 @@
 
 from datetime import timedelta
 
+from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.exceptions import UserError
 
@@ -170,6 +171,46 @@ class TestPickShip(TestStockCommon):
 
         backorder = self.env['stock.picking'].search([('backorder_id', '=', picking_client.id)])
         self.assertEqual(backorder.state, 'confirmed', 'Backorder should be waiting for reservation')
+
+    def test_mto_reorient_sub_loc(self):
+        """
+            check the mto chain is not broken in case of reorientation into sublocation
+        """
+        picking_pick, picking_client = self.create_pick_ship()
+        sub_pick_a, sub_pick_b = self.env['stock.location'].create([{
+            'name': 'Sub Pick A',
+            'usage': 'internal',
+            'location_id': self.pack_location,
+            }, {
+            'name': 'Sub Pick B',
+            'usage': 'internal',
+            'location_id': self.pack_location,
+        }])
+        location = self.env['stock.location'].browse(self.stock_location)
+
+        # make some stock
+        self.env['stock.quant']._update_available_quantity(self.productA, location, 10.0)
+        picking_pick.action_assign()
+        picking_pick.move_ids[0].move_line_ids[0].location_dest_id = sub_pick_a
+        picking_pick.button_validate()
+        self.MoveObj.create({
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 10,
+            'product_uom': self.productA.uom_id.id,
+            'location_id': self.pack_location,
+            'location_dest_id': self.pack_location,
+            'move_line_ids': [Command.create({
+                'location_id': sub_pick_a.id,
+                'location_dest_id': sub_pick_b.id,
+                'quantity': 10,
+                'product_id': self.productA.id,
+                })],
+            'state': 'confirmed',
+            'picked': True,
+        })._action_done()
+
+        self.assertEqual(picking_client.state, 'assigned', 'The state of the client should be assigned even after reorientation')
 
     def test_mto_to_mts(self):
         """

--- a/addons/website_sale_stock/tests/test_website_sale_stock_reorder_from_portal.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_reorder_from_portal.py
@@ -64,6 +64,7 @@ class TestWebsiteSaleStockReorderFromPortal(HttpCase):
             'inventory_quantity': 1.0,
             'location_id': 8,
         }).action_apply_inventory()
+        order.picking_ids.do_unreserve()
 
     def test_website_sale_stock_reorder_from_portal_stock(self):
         self.start_tour("/", 'website_sale_stock_reorder_from_portal', login='admin')


### PR DESCRIPTION
sell a product mto.
validate the receipt to shelf1
move manually the product from shelf1 to shelf2
The delivery should still be reserved

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
