### PR TITLE
[IMP] web,survey: better error management in tests

### DIFF
--- a/addons/survey/static/tests/components/question_page_one2many_field_tests.js
+++ b/addons/survey/static/tests/components/question_page_one2many_field_tests.js
@@ -2,7 +2,6 @@
 
 import { makeServerError } from "@web/../tests/helpers/mock_server";
 import { click, editInput, getFixture, nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
-import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { errorService } from "@web/core/errors/error_service";
 import { registry } from "@web/core/registry";
@@ -173,11 +172,6 @@ QUnit.module("QuestionPageOneToManyField", (hooks) => {
 
     QUnit.test("A validation error from saving parent form notifies and prevents dialog from closing", async (assert) => {
         registry.category("services").add("error", errorService);
-
-        // need to preventDefault to remove error from console (so python test pass)
-        const handler = (ev) => ev.preventDefault();
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
 
         await makeView({
             type: "form",

--- a/addons/web/static/lib/qunit/qunit-2.9.1.js
+++ b/addons/web/static/lib/qunit/qunit-2.9.1.js
@@ -3128,7 +3128,7 @@
   	},
 
 
-  	finish: function finish() {
+  	finish: async function finish() {
   		config.current = this;
 
   		// Release the test callback to ensure that anything referenced has been
@@ -3148,7 +3148,13 @@
   			this.pushFailure("Expected at least one assertion, but none were run - call " + "expect(0) to accept zero assertions.", this.stack);
   		}
 
-        emit("OdooAfterTestHook", this); // Odoo customization
+  		// Odoo customization
+  		// wait for the task queue to be fully consummed, s.t. if there has been rejected promises
+  		// during the test, the unhandledrejection handlers have been called before the cleanups
+  		// have been executed, for the errors to be properly preventDefaulted if necessary (see
+  		// qunit.js, Error management section).
+  		await new Promise((r) => setTimeout(r, 0));
+  		emit("OdooAfterTestHook", this);
 
   		var i,
   		    module = this.module,

--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -146,7 +146,7 @@ const defaultDialogs = new Map([
  * @param {UncaughError} error
  * @returns {boolean}
  */
-function defaultHandler(env, error) {
+export function defaultHandler(env, error) {
     const DialogComponent = defaultDialogs.get(error.constructor) || ErrorDialog;
     env.services.dialog.add(DialogComponent, {
         traceback: error.traceback,

--- a/addons/web/static/tests/views/fields/binary_field_tests.js
+++ b/addons/web/static/tests/views/fields/binary_field_tests.js
@@ -506,8 +506,10 @@ QUnit.module("Fields", (hooks) => {
 
     QUnit.test("Binary filename doesn't exceed 255 bytes", async function (assert) {
         const LARGE_BINARY_FILE = BINARY_FILE.repeat(5);
-        assert.ok((LARGE_BINARY_FILE.length / 4 * 3) > MAX_FILENAME_SIZE_BYTES,
-            "The initial binary file should be larger than max bytes that can represent the filename");
+        assert.ok(
+            (LARGE_BINARY_FILE.length / 4) * 3 > MAX_FILENAME_SIZE_BYTES,
+            "The initial binary file should be larger than max bytes that can represent the filename"
+        );
         serverData.models.partner.fields.document.default = LARGE_BINARY_FILE;
         await makeView({
             serverData,

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 
-import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { makeServerError } from "@web/../tests/helpers/mock_server";
 import {
@@ -2949,14 +2948,6 @@ QUnit.module("Fields", (hooks) => {
             assert.expect(5);
 
             registry.category("services").add("error", errorService);
-
-            // remove the override in qunit.js that swallows unhandledrejection errors
-            // s.t. we let the error service handle them
-            const originalOnUnhandledRejection = window.onunhandledrejection;
-            window.onunhandledrejection = () => {};
-            registerCleanup(() => {
-                window.onunhandledrejection = originalOnUnhandledRejection;
-            });
 
             serverData.views = {
                 "product,false,form": '<form><field name="name" /></form>',

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -8931,29 +8931,6 @@ QUnit.module("Fields", (hooks) => {
     QUnit.test("display correct value after validation error", async function (assert) {
         assert.expect(5);
 
-        /*
-         * By-pass QUnit's and test's error handling because the error service needs to be active
-         */
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
-
-        const originOnunhandledrejection = window.onunhandledrejection;
-        window.onunhandledrejection = () => {};
-        registerCleanup(() => {
-            window.onunhandledrejection = originOnunhandledrejection;
-        });
-        /*
-         * End By pass error handling
-         */
-
         serviceRegistry.add("error", errorService);
         function validationHandler(env, error, originalError) {
             if (originalError.data.name === "odoo.exceptions.ValidationError") {

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -20,7 +20,6 @@ import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { actionService } from "@web/webclient/actions/action_service";
 import { getPickerApplyButton, getPickerCell } from "../core/datetime/datetime_test_helpers";
 import { makeFakeLocalizationService, makeFakeUserService } from "../helpers/mock_services";
-import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import {
     addRow,
     click,
@@ -65,6 +64,7 @@ import {
 } from "../search/helpers";
 import { createWebClient, doAction, loadState } from "../webclient/helpers";
 import { makeView, makeViewInDialog, setupViewRegistries } from "./helpers";
+import { makeServerError } from "../helpers/mock_server";
 
 const fieldRegistry = registry.category("fields");
 const serviceRegistry = registry.category("services");
@@ -18361,10 +18361,6 @@ QUnit.module("Views", (hooks) => {
         "edit a record then select another record with a throw error when saving",
         async function (assert) {
             serviceRegistry.add("error", errorService);
-            // need to preventDefault to remove error from console (so python test pass)
-            const handler = (ev) => ev.preventDefault();
-            window.addEventListener("unhandledrejection", handler);
-            registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
 
             await makeView({
                 type: "list",
@@ -18376,7 +18372,7 @@ QUnit.module("Views", (hooks) => {
                     </tree>`,
                 mockRPC(route, args) {
                     if (args.method === "web_save") {
-                        throw new Error("Can't write");
+                        throw makeServerError({ message: "Can't write" });
                     }
                 },
             });

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -3,7 +3,6 @@
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import { WebClient } from "@web/webclient/webclient";
-import { registerCleanup } from "../../helpers/cleanup";
 import { makeTestEnv } from "../../helpers/mock_env";
 import {
     click,
@@ -741,17 +740,7 @@ QUnit.module("ActionManager", (hooks) => {
 
     QUnit.test("initial action crashes", async (assert) => {
         assert.expect(8);
-
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
+        assert.expectErrors();
 
         browser.location.hash = "#action=__test__client__action__&menu_id=1";
         const ClientAction = registry.category("actions").get("__test__client__action__");
@@ -769,6 +758,7 @@ QUnit.module("ActionManager", (hooks) => {
         const webClient = await createWebClient({ serverData });
         assert.verifySteps(["clientAction setup"]);
         await nextTick();
+        assert.expectErrors(["my error"]);
         assert.containsOnce(target, ".o_error_dialog");
         await click(target, ".modal-header .btn-close");
         assert.containsNone(target, ".o_error_dialog");

--- a/addons/web/static/tests/webclient/actions/target_tests.js
+++ b/addons/web/static/tests/webclient/actions/target_tests.js
@@ -4,7 +4,6 @@ import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { registry } from "@web/core/registry";
 import { click, getFixture, patchWithCleanup, makeDeferred, nextTick } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
-import { registerCleanup } from "../../helpers/cleanup";
 import { errorService } from "@web/core/errors/error_service";
 import { useService } from "@web/core/utils/hooks";
 import { ClientErrorDialog } from "@web/core/errors/error_dialogs";
@@ -266,18 +265,8 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.test("do not commit a dialog in error", async (assert) => {
-        assert.expect(6);
-
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
+        assert.expect(7);
+        assert.expectErrors();
 
         class ErrorClientAction extends Component {
             setup() {
@@ -333,6 +322,7 @@ QUnit.module("ActionManager", (hooks) => {
         assert.ok(
             target.querySelector(".modal-body .o_error_detail").textContent.includes("my error")
         );
+        assert.verifyErrors(["my error"]);
 
         await click(target, ".modal-footer .btn-primary");
         assert.containsNone(target, ".modal");

--- a/addons/web/static/tests/webclient/actions/window_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/window_action_tests.js
@@ -13,7 +13,6 @@ import { useSetupAction } from "@web/webclient/actions/action_hook";
 import { clearUncommittedChanges } from "@web/webclient/actions/action_service";
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { errorService } from "../../../src/core/errors/error_service";
-import { registerCleanup } from "../../helpers/cleanup";
 import {
     click,
     clickSave,
@@ -520,29 +519,6 @@ QUnit.module("ActionManager", (hooks) => {
 
     QUnit.test("A new form view can be reloaded after a failed one", async function (assert) {
         assert.expect(5);
-
-        /*
-         * By-pass QUnit's and test's error handling because the error service needs to be active
-         */
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
-
-        const originOnunhandledrejection = window.onunhandledrejection;
-        window.onunhandledrejection = () => {};
-        registerCleanup(() => {
-            window.onunhandledrejection = originOnunhandledrejection;
-        });
-        /*
-         * End By pass error handling
-         */
 
         const webClient = await createWebClient({ serverData });
         serviceRegistry.add("error", errorService);
@@ -2127,29 +2103,6 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.test("window action in target new fails (onchange)", async (assert) => {
-        /*
-         * By-pass QUnit's and test's error handling because the error service needs to be active
-         */
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
-
-        const originOnunhandledrejection = window.onunhandledrejection;
-        window.onunhandledrejection = () => {};
-        registerCleanup(() => {
-            window.onunhandledrejection = originOnunhandledrejection;
-        });
-        /*
-         * End By pass error handling
-         */
-
         const warningOpened = makeDeferred();
         class WarningDialogWait extends WarningDialog {
             setup() {
@@ -2362,26 +2315,6 @@ QUnit.module("ActionManager", (hooks) => {
 
     QUnit.test("click on breadcrumb of a deleted record", async function (assert) {
         serviceRegistry.add("error", errorService);
-        // In tests we catch unhandledrejection of promises rejected with something that isn't an
-        // error (see tests/qunit.js). In this scenario, with the legacy basic_model, the promise
-        // is rejected with undefined, so without the following lines, we can't reproduce the issue,
-        // which was that the error handlers were executed in a wrong order, and one of them crashed.
-        const windowUnhandledReject = window.onunhandledrejection;
-        window.onunhandledrejection = null;
-        registerCleanup(() => {
-            window.onunhandledrejection = windowUnhandledReject;
-        });
-
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
-
         serverData.views["partner,false,form"] = `
             <form>
                 <button type="action" name="3" string="Open Action 3" class="my_btn"/>
@@ -2440,29 +2373,6 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.test("Uncaught error in target new is catch only once", async (assert) => {
-        /*
-         * By-pass QUnit's and test's error handling because the error service needs to be active
-         */
-        const handler = (ev) => {
-            // need to preventDefault to remove error from console (so python test pass)
-            ev.preventDefault();
-        };
-        window.addEventListener("unhandledrejection", handler);
-        registerCleanup(() => window.removeEventListener("unhandledrejection", handler));
-
-        patchWithCleanup(QUnit, {
-            onUnhandledRejection: () => {},
-        });
-
-        const originOnunhandledrejection = window.onunhandledrejection;
-        window.onunhandledrejection = () => {};
-        registerCleanup(() => {
-            window.onunhandledrejection = originOnunhandledrejection;
-        });
-        /*
-         * End By pass error handling
-         */
-
         const warningOpened = makeDeferred();
         class WarningDialogWait extends WarningDialog {
             setup() {


### PR DESCRIPTION
The initial motivation of this commit was to ensure that the qunit
test suite doesn't stop when an error is thrown in a test, which
could happen if the error was thrown "sufficiently close to the
end of the test". Indeed, the "unhandledrejection" event being
async, it was sometimes triggered after the end of the test, when
the service registry was already reset, and the check of the
presence of the error service was wrong, so the error event wasn't
default prevented (e.g. await makeView(...) and the view crashes
at render time).

This led us to rework in more depth the way we deal with errors in
tests. Here are a few behaviors we want (probably not exhaustive):
 - an error in a test must never end the suite (executed in py)
 - an error in a test must always make the test fail, except if the
   error is expected in the scenario, which one must be able to
   state
 - a test must always wait for potential unhandledrejection events
   to be triggered before ending.
 - ideally, we don't want to have to deal with unhandledrejection
   in each test throwing an error (in order to prevent the suite to
   stop)

To achieve this, we come with the following solution. We introduce
a new assertion method, "expectToThrow" which allows to state that
during the test, we expect errors to be thrown. It takes a list of
error messages that will be compared at the end of the test with
the errors that have been thrown during the test. If they differ,
a qunit failure is pushed and the test fails. If an error occurs
in a test and "expectToThrow" hasn't been called, qunit is directly
informed of the error and a failing assertion is done, make the
test fail as well.

If the error service isn't available in the test environment, we
apply the logic above when an "error" or and "unhandledrejection"
event is thrown. If the error service is available, we wrap the
default handler (typically the one that handles everything that
hasn't been handled by specific handlers, like tracebacks) and if
we get to it, we apply the logic above. This means that one must
call "expectToThrow" if
 - the error service isn't deployed, or
 - the thrown error is handled by the default handler, because
   it is something like a traceback (errors like UserError,
   ValidationError are graciously handled by the RPCErrorHandler)
   and thus never reach the default handler.

In all cases, we prevent default the event such that the error
doesn't make the python test end.

Finally, to ensure that "undhandledrejection" events are handled
before the test ends, we wait, in the qunit lib, for a setTimeout
before ending the test, which ensures that all such events have
been dispatched.