### PR TITLE
[FIX] partner_autocomplete: fix `res_partner_manyone` widget

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -25,6 +25,7 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
                         const suggestions = await this.partner_autocomplete.autocomplete(request);
                         suggestions.forEach((suggestion) => {
                             suggestion.classList = "partner_autocomplete_dropdown_many2one";
+                            suggestion.isFromPartnerAutocomplete = true;
                         });
                         return suggestions;
                     }
@@ -39,7 +40,7 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
     }
 
     async onSelect(option, params) {
-        if (option.partner_gid) {  // Checks that it is a partner autocomplete option
+        if (option.isFromPartnerAutocomplete) {  // Checks that it is a partner autocomplete option
             const data = await this.partner_autocomplete.getCreateData(Object.getPrototypeOf(option));
             let context = {
                 'default_is_company': true


### PR DESCRIPTION
The `partner_gid` key isn't part of the response of the Autocomplete API of Clearbit anymore, so we can't rely on its presence to know if the suggestion comes from Clearbit or not.

Ticket #3321391
