### PR TITLE
[IMP] product: pricelist option in label printing

### DIFF
--- a/addons/product/report/product_label_report.py
+++ b/addons/product/report/product_label_report.py
@@ -43,6 +43,7 @@ def _prepare_data(env, data):
         'page_numbers': (total - 1) // (layout_wizard.rows * layout_wizard.columns) + 1,
         'price_included': data.get('price_included'),
         'extra_html': layout_wizard.extra_html,
+        'pricelist': layout_wizard.pricelist_id,
     }
 
 class ReportProductTemplateLabel(models.AbstractModel):

--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -21,12 +21,8 @@
                             <div class="o_label_extra_data">
                                 <t t-out="extra_html"/>
                             </div>
-                            <t t-if="product.is_product_variant">
-                                <strong class="o_label_price" t-field="product.lst_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                            </t>
-                            <t t-else="">
-                                <strong class="o_label_price" t-field="product.list_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                            </t>
+                            <strong class="o_label_price" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                                    t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                         </div>
                         <div class="o_label_clear"></div>
                     </div>
@@ -43,12 +39,8 @@
                         <strong t-field="product.display_name"/>
                     </div>
                     <div class="text-end" style="padding-top:0;padding-bottom:0">
-                        <t t-if="product.is_product_variant">
-                            <strong class="o_label_price_medium" t-field="product.lst_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                        </t>
-                        <t t-else="">
-                            <strong class="o_label_price_medium" t-field="product.list_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                        </t>
+                        <strong class="o_label_price_medium" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                                t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                     </div>
                     <div class= "text-center o_label_small_barcode">
                         <span class="text-nowrap" t-field="product.default_code"/>
@@ -74,12 +66,8 @@
                             <span class="text-nowrap" t-field="product.default_code"/>
                         </div>
                         <div class="o_label_price_medium text-end">
-                            <t t-if="product.is_product_variant">
-                                <strong t-field="product.lst_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                            </t>
-                            <t t-else="">
-                                <strong t-field="product.list_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                            </t>
+                            <strong t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                                t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                         </div>
                     </t>
                     <t t-else="">
@@ -117,12 +105,8 @@
                         <small class="text-nowrap" t-field="product.default_code"/>
                     </div>
                     <div class="text-end" style="padding: 0 4px;">
-                        <t t-if="product.is_product_variant">
-                            <strong class="o_label_price_small" t-field="product.lst_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                        </t>
-                        <t t-else="">
-                            <strong class="o_label_price_small" t-field="product.list_price" t-options="{'widget': 'monetary', 'label_price': True}"/>
-                        </t>
+                        <strong class="o_label_price_small" t-out="pricelist._get_product_price(product, 1, pricelist.currency_id or product.currency_id)"
+                                t-options="{'widget': 'monetary', 'display_currency': pricelist.currency_id or product.currency_id, 'label_price': True}"/>
                         <div class="o_label_extra_data">
                             <t t-out="extra_html"/>
                         </div>

--- a/addons/product/wizard/product_label_layout.py
+++ b/addons/product/wizard/product_label_layout.py
@@ -22,6 +22,7 @@ class ProductLabelLayout(models.TransientModel):
     extra_html = fields.Html('Extra Content', default='')
     rows = fields.Integer(compute='_compute_dimensions')
     columns = fields.Integer(compute='_compute_dimensions')
+    pricelist_id = fields.Many2one('product.pricelist', string="Pricelist")
 
     @api.depends('print_format')
     def _compute_dimensions(self):

--- a/addons/product/wizard/product_label_layout_views.xml
+++ b/addons/product/wizard/product_label_layout_views.xml
@@ -14,6 +14,7 @@
                         <field name="print_format" widget="radio"/>
                     </group>
                     <group>
+                        <field name="pricelist_id" groups="product.group_product_pricelist"/>
                         <field name="extra_html" widget="html" invisible="print_format not in ('dymo', '2x7xprice')"/>
                     </group>
                 </group>


### PR DESCRIPTION
before this commit, on printing product labels there is no option to select the price list, always the
printed price is the default product price

after this commit, in the label printing wizard
the price list field is introduced and user can
select the price list before printing the labels

![Screenshot from 2023-09-30 08-51-51](https://github.com/odoo/odoo/assets/27989791/74ddc266-bfd5-4434-8662-ec4ea7c8da54)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
