### PR TITLE
[IMP] hr: remove schedule on public employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -13,7 +13,7 @@ from markupsafe import Markup
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, AccessError
 from odoo.osv import expression
-from odoo.tools import format_date, Query
+from odoo.tools import format_date
 
 
 class HrEmployeePrivate(models.Model):

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -28,7 +28,6 @@ class HrEmployeePublic(models.Model):
     work_location_id = fields.Many2one(readonly=True)
     user_id = fields.Many2one(readonly=True)
     resource_id = fields.Many2one(readonly=True)
-    resource_calendar_id = fields.Many2one(readonly=True)
     tz = fields.Selection(readonly=True)
     color = fields.Integer(readonly=True)
 

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -90,9 +90,6 @@
                                         <group name="managers" string="Approvers" invisible="1">
                                             <!-- overridden in other modules -->
                                         </group>
-                                        <group string="Schedule" groups="base.group_no_one">
-                                            <field name="resource_calendar_id"/>
-                                        </group>
                                     </div>
                                 </div>
                             </page>


### PR DESCRIPTION
This commit removes the resource_calendar_id field on the public employee, as this is giving information that we don't necessarily want to be public. Additionnaly, it led to the possibility for every user to access calendar forms.

task-3519805