### PR TITLE
[FIX] tests: fix remaining patcher in python 3.10.12

### DIFF
--- a/addons/lunch/tests/common.py
+++ b/addons/lunch/tests/common.py
@@ -5,14 +5,12 @@ from freezegun import freeze_time
 from odoo.tests import common, new_test_user
 
 
-fakenow = datetime(2021, 1, 29, 12, 20, 0)
-
-@freeze_time(fakenow)
 class TestsCommon(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.fakenow = fakenow
+        cls.fakenow = datetime(2021, 1, 29, 12, 20, 0)
+        cls.startClassPatcher(freeze_time(cls.fakenow))
 
     def setUp(self):
         super(TestsCommon, self).setUp()

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -303,7 +303,7 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
     def setUpClass(cls):
         def check_remaining_patchers():
             for patcher in _patch._active_patches:
-                _logger.warning("A patcher was remaining active at the end of %s, disabling it...", cls.__name__)
+                _logger.warning("A patcher (targeting %s.%s) was remaining active at the end of %s, disabling it...", patcher.target, patcher.attribute, cls.__name__)
                 patcher.stop()
         cls.addClassCleanup(check_remaining_patchers)
         super().setUpClass()


### PR DESCRIPTION
While deploying runbot 200-204 an error started to occur on TestEquipement 

https://runbot.odoo.com/runbot/build/51753527
And also in the lunch single module 
https://runbot.odoo.com/runbot/build/51708103

> A patcher was remaining active at the end of TestEquipment, disabling it...

This is caused by a `freeze_time` on the previous executed class, `TestAlarm` (actually any class inheriting from  `odoo.addons.lunch.tests.common.TestsCommon`)

It looks like the issue appeared between 3.10.6 and 3.10.12 (maybe because of https://github.com/python/cpython/pull/99699): _class_cleanups is now on the TestCase. This is still unsure since we have a custom version of TestCase, could be a strange interaction.

Could be related to https://github.com/spulec/freezegun/issues/485

Switching the class decorator inside the setupClass fixes the issue

Freezetime code managing decorator on TestCase as a reference: 

```python
    def decorate_class(self, klass):
        if issubclass(klass, unittest.TestCase):
            # If it's a TestCase, we assume you want to freeze the time for the
            # tests, from setUpClass to tearDownClass

            # Use getattr as in Python 2.6 they are optional
            orig_setUpClass = getattr(klass, 'setUpClass', None)
            orig_tearDownClass = getattr(klass, 'tearDownClass', None)

            # noinspection PyDecorator
            @classmethod
            def setUpClass(cls):
                self.start()
                if orig_setUpClass is not None:
                    orig_setUpClass()

            # noinspection PyDecorator
            @classmethod
            def tearDownClass(cls):
                if orig_tearDownClass is not None:
                    orig_tearDownClass()
                self.stop()

            klass.setUpClass = setUpClass
            klass.tearDownClass = tearDownClass

            return klass

```


