### PR TITLE
[REM] web: redundant escapeHTML function

### DIFF
--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -11,7 +11,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { memoize } from "@web/core/utils/functions";
 import { url } from "@web/core/utils/urls";
-import { escapeHTML } from "@web/core/utils/strings";
+import { escape } from "@web/core/utils/strings";
 
 const FETCH_LIMIT = 30;
 
@@ -949,7 +949,7 @@ export class ThreadService {
     async search(searchTerm, thread, before = false) {
         const { messages, count } = await this.rpc(this.getFetchRoute(thread), {
             ...this.getFetchParams(thread),
-            search_term: escapeHTML(searchTerm),
+            search_term: escape(searchTerm),
             before,
         });
         return {

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -30,7 +30,7 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { _t } from "@web/core/l10n/translation";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
-import { escapeHTML } from "@web/core/utils/strings";
+import { escape } from "@web/core/utils/strings";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { FileUploader } from "@web/views/fields/file_handler";
 
@@ -253,7 +253,7 @@ export class Chatter extends Component {
             .slice(0, 5)
             .map(({ partner }) => {
                 const text = partner.email ? partner.emailWithoutDomain : partner.name;
-                return `<span class="text-muted" title="${escapeHTML(partner.email)}">${escapeHTML(
+                return `<span class="text-muted" title="${escape(partner.email)}">${escape(
                     text
                 )}</span>`;
             });

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -4,50 +4,8 @@ export const nbsp = "\u00a0";
 
 export const escapeMethod = Symbol("html");
 
-const htmlCaracters = {
-    "&": "&amp;",
-    "<": "&lt;",
-    ">": "&gt;",
-    "'": "&#x27;",
-    '"': "&quot;",
-    "`": "&#x60;",
-};
-
-/**
- * Replace ASCII character with HTML character
- * Do exactly the same as underscore function
- *
- * @param {string} [str] string to unescape
- * @returns {string} the unescaped string
- */
-export function unescapeHTML(str) {
-    for (const [key, value] of Object.entries(htmlCaracters)) {
-        str = String(str).replace(new RegExp(value, "g"), key);
-    }
-    return str;
-}
-
-/**
- * Replace HTML character with ASCII character
- * Do exactly the same as underscore function
- *
- * @param {string | number} [str] the string to escape
- * @returns {string} the escaped string
- */
-export function escapeHTML(str) {
-    if (typeof str === "object" && str[escapeMethod]) {
-        return str[escapeMethod]();
-    } else {
-        for (const [key, value] of Object.entries(htmlCaracters)) {
-            str = String(str).replace(new RegExp(key, "g"), value);
-        }
-        return str;
-    }
-}
-
 /**
  * Escapes a string for HTML.
- * Note that it doesn't work for escaping node attributes.
  *
  * @param {string | number} [str] the string to escape
  * @returns {string} an escaped string
@@ -62,9 +20,17 @@ export function escape(str) {
         if (typeof str === "number") {
             return String(str);
         }
-        const p = document.createElement("p");
-        p.textContent = str;
-        return p.innerHTML;
+        [
+            ["&", "&amp;"],
+            ["<", "&lt;"],
+            [">", "&gt;"],
+            ["'", "&#x27;"],
+            ['"', "&quot;"],
+            ["`", "&#x60;"],
+        ].forEach((pairs) => {
+            str = String(str).replaceAll(pairs[0], pairs[1]);
+        });
+        return str;
     }
 }
 

--- a/addons/web/static/tests/core/utils/strings_tests.js
+++ b/addons/web/static/tests/core/utils/strings_tests.js
@@ -1,13 +1,12 @@
 /** @odoo-module **/
 
 import {
-    escapeHTML,
+    escape,
     escapeRegExp,
     intersperse,
     isEmail,
     sprintf,
     unaccent,
-    unescapeHTML,
 } from "@web/core/utils/strings";
 import { _t, translatedTerms } from "@web/core/l10n/translation";
 import { patchWithCleanup } from "../../helpers/utils";
@@ -113,26 +112,19 @@ QUnit.module("utils", () => {
         assert.deepEqual(sprintf("Hello %(two)s %(one)s", vals), "Hello två en");
     });
 
-    QUnit.test("escapeHTML && unescapeHTML", (assert) => {
+    QUnit.test("escape", (assert) => {
+        assert.strictEqual(escape("<a>this is a link</a>"), "&lt;a&gt;this is a link&lt;/a&gt;");
         assert.strictEqual(
-            escapeHTML("<a>this is a link</a>"),
-            "&lt;a&gt;this is a link&lt;/a&gt;"
+            escape(`<a href="https://www.odoo.com">odoo<a>`),
+            `&lt;a href=&quot;https://www.odoo.com&quot;&gt;odoo&lt;a&gt;`
         );
         assert.strictEqual(
-            unescapeHTML("&lt;a&gt;this is a link&lt;/a&gt;"),
-            "<a>this is a link</a>"
+            escape(`<a href='https://www.odoo.com'>odoo<a>`),
+            `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;odoo&lt;a&gt;`
         );
         assert.strictEqual(
-            escapeHTML(`<a href="https://www.odoo.com">odoo<a>`),
-            "&lt;a href=&quot;https://www.odoo.com&quot;&gt;odoo&lt;a&gt;"
-        );
-        assert.strictEqual(
-            unescapeHTML(escapeHTML(`<a href="https://www.odoo.com">Odoo<a>`)),
-            `<a href="https://www.odoo.com">Odoo<a>`
-        );
-        assert.strictEqual(
-            unescapeHTML(escapeHTML`<a href="https://www.odoo.com">Odoo<a>`),
-            `<a href="https://www.odoo.com">Odoo<a>`
+            escape("<a href='https://www.odoo.com'>Odoo`s website<a>"),
+            `&lt;a href=&#x27;https://www.odoo.com&#x27;&gt;Odoo&#x60;s website&lt;a&gt;`
         );
     });
 


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/a6fea376bb2e75f2ca617811f41d83768c078f85, escapeHTML was introduced to replace the corresponding
underscore.js function. It is very similar to the widely used escape
function, except it additionally escapes single (') and double (")
quotes.

The additional escaping is not generally harmful, and is necessary to
safely inject values into attributes. As escapeHTML is almost unused,
remove it and update escape to include quotes.

taskId : 3522892
