### PR TITLE
[IMP] web: use the default placeholder image instead of nothing

### DIFF
--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -269,7 +269,17 @@ function removeUnwantedAttrsFromTemplates(attrs) {
     function replaceAttr(attrName, prefix, element) {
         const attrKey = `${prefix}${attrName}`;
         const attrValue = element.getAttribute(attrKey);
-        element.removeAttribute(attrKey);
+        if (element.nodeName === "img") {
+            if (!element.getAttribute("data-src")) {
+                if (attrKey === "src" || attrKey === "t-attf-src") {
+                    element.setAttribute(attrKey, "/web/image/web.image_placeholder");
+                } else if (attrKey === "t-att-src") {
+                    element.setAttribute(attrKey, "'/web/image/web.image_placeholder'");
+                }
+            }
+        } else {
+            element.removeAttribute(attrKey);
+        }
         element.setAttribute(`${prefix}data-${attrName}`, attrValue);
     }
     const attrPrefixes = ["", "t-att-", "t-attf-"];
@@ -394,10 +404,10 @@ export async function setupTests() {
         });
         for (const node of nodes) {
             const src = node.getAttribute("src");
-            if (src && src !== "about:blank") {
+            if (src && src !== "about:blank" && node.dataset.src) {
                 node.dataset.src = src;
                 if (node.nodeName === "IMG") {
-                    node.removeAttribute("src");
+                    node.setAttribute("src", "/web/image/web.image_placeholder");
                 } else {
                     node.setAttribute("src", "about:blank");
                 }

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -335,7 +335,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
                         data-scale-x="1"
                         data-scale-y="1"
                         data-aspect-ratio="0/0"
-                        ${src.startsWith("/web") ? 'data-src="' : 'src="'}${src}"
+                        ${src.startsWith("/web") && isModified ? 'data-src="' : 'src="'}${src}"
                     >
                     <br>
                 </p>
@@ -542,15 +542,12 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
 
         // Paste image.
         const img = await pasteImage(editor);
-        // Test environment replaces 'src' by 'data-src'.
-        assert.ok(/^data:image\/png;base64,/.test(img.dataset['src']));
+        assert.ok(/^data:image\/png;base64,/.test(img.getAttribute("src")));
         assert.ok(img.classList.contains('o_b64_image_to_save'));
 
         // Save changes.
-        // Restore 'src' attribute so that SavePendingImages can do its job.
-        img.src = img.dataset['src'];
         await htmlField.commitChanges();
-        assert.equal(img.dataset['src'], '/test_image_url.png?access_token=1234');
+        assert.equal(img.getAttribute("src"), '/test_image_url.png?access_token=1234');
         assert.ok(!img.classList.contains('o_b64_image_to_save'));
     });
 


### PR DESCRIPTION
Before this PR, src attributes where removed from the templates to avoid unnecessary request.
This PR redirect the src tag to the image placeholder instead, creating an actual image. It make it easier to debug since you can actually see whenever there is an image or not. It also allow to test scroll position that involve images.
