### PR TITLE
[IMP] account{_peppol}: allow install via settings

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -26,6 +26,12 @@ MONTH_SELECTION = [
     ('12', 'December'),
 ]
 
+PEPPOL_LIST = [
+    'AD', 'AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI',
+    'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MC', 'ME',
+    'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'SM', 'TR', 'VA',
+]
+
 class ResCompany(models.Model):
     _name = "res.company"
     _inherit = ["res.company", "mail.thread"]

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
+
+from odoo.addons.account.models.company import PEPPOL_LIST
 
 
 class ResConfigSettings(models.TransientModel):
@@ -117,6 +119,7 @@ class ResConfigSettings(models.TransientModel):
     module_account_avatax = fields.Boolean(string="Account Avatax")
     module_account_invoice_extract = fields.Boolean(string="Document Digitization")
     module_snailmail_account = fields.Boolean(string="Snailmail")
+    module_account_peppol = fields.Boolean(string='PEPPOL Invoicing')
     tax_exigibility = fields.Boolean(string='Cash Basis', related='company_id.tax_exigibility', readonly=False)
     tax_cash_basis_journal_id = fields.Many2one(
         'account.journal',
@@ -207,6 +210,19 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.account_discount_expense_allocation_id',
         domain="[('account_type', 'in', ('income', 'expense'))]",
     )
+
+    # PEPPOL
+    is_account_peppol_eligible = fields.Boolean(
+        string='PEPPOL eligible',
+        compute='_compute_is_account_peppol_eligible',
+    ) # technical field used for showing the Peppol settings conditionally
+
+    @api.depends('country_code')
+    def _compute_is_account_peppol_eligible(self):
+        # we want to show Peppol settings only to customers that are eligible for Peppol,
+        # except countries that are not in Europe
+        for config in self:
+            config.is_account_peppol_eligible = config.country_code in PEPPOL_LIST
 
     def set_values(self):
         super().set_values()

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -348,6 +348,21 @@
                                 <field name="module_product_margin"/>
                             </setting>
                         </block>
+                        <field name="is_account_peppol_eligible" invisible="1"/>
+                        <block title="PEPPOL Electronic Document Invoicing" id="peppol" invisible="not is_account_peppol_eligible">
+                            <div class="col-12 col-lg-12 o_setting_box">
+                                <div class="o_setting_left_pane">
+                                    <field name="module_account_peppol" readonly="False"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="module_account_peppol" string="Enable PEPPOL"/>
+                                    <div class="text-muted">
+                                        Allow sending and receiving invoices through the PEPPOL network
+                                    </div>
+                                    <div id="account_peppol"/>
+                                </div>
+                            </div>
+                        </block>
                         <block title="Storno Accounting" id="storno">
                             <setting id="enable_storno_accounting" company_dependent="1" help="Use Storno accounting" title="Allows you to use Storno accounting.">
                                 <field name="account_storno"/>

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -213,11 +213,6 @@ msgid "PEPPOL"
 msgstr ""
 
 #. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
-msgid "PEPPOL Electronic Document Invoicing"
-msgstr ""
-
-#. module: account_peppol
 #: model:ir.model.fields,field_description:account_peppol.field_res_company__is_account_peppol_participant
 msgid "PEPPOL Participant"
 msgstr ""
@@ -226,11 +221,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_peppol.field_res_company__peppol_purchase_journal_id
 #: model:ir.model.fields,field_description:account_peppol.field_res_config_settings__account_peppol_purchase_journal_id
 msgid "PEPPOL Purchase Journal"
-msgstr ""
-
-#. module: account_peppol
-#: model:ir.model.fields,field_description:account_peppol.field_res_config_settings__is_account_peppol_eligible
-msgid "PEPPOL eligible"
 msgstr ""
 
 #. module: account_peppol

--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -6,15 +6,13 @@ from stdnum import get_cc_module, ean
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.addons.account_edi_ubl_cii.models.account_edi_common import EAS_MAPPING
+from odoo.addons.account.models.company import PEPPOL_LIST
 
 try:
     import phonenumbers
 except ImportError:
     phonenumbers = None
 
-# at the moment, only phone numbers in European countries are accepted
-PHONE_ALLOWED_COUNTRIES = set(EAS_MAPPING.keys()) - {'AU', 'SG', 'NZ'}
 
 PEPPOL_ENDPOINT_RULES = {
     '0007': ['se', 'orgnr'],
@@ -95,7 +93,7 @@ class ResCompany(models.Model):
             raise ValidationError(error_message)
 
         country_code = phonenumbers.phonenumberutil.region_code_for_number(phone_nbr)
-        if country_code not in PHONE_ALLOWED_COUNTRIES or not phonenumbers.is_valid_number(phone_nbr):
+        if country_code not in PEPPOL_LIST or not phonenumbers.is_valid_number(phone_nbr):
             raise ValidationError(error_message)
 
     def _check_peppol_endpoint_number(self, warning=False):

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -5,164 +5,164 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <block id="analytic" position="after">
-                <block title="PEPPOL Electronic Document Invoicing">
-                <field name="is_account_peppol_eligible" invisible="1"/>
-                <div invisible="not is_account_peppol_eligible">
-                    <div id='account_peppol'>
-                        <div class="col-12 col-lg-12 o_setting_box">
-                            <field name="account_peppol_proxy_state" invisible="1"/>
-                            <div class="o_setting_left_pane">
-                                <field name="is_account_peppol_participant"
-                                       invisible="account_peppol_proxy_state != 'not_registered'"/>
-                            </div>
-                            <div class="o_setting_right_pane">
-                                <div invisible="account_peppol_proxy_state != 'not_registered'">
-                                    <label for="is_account_peppol_participant" string='Use PEPPOL Invoicing'/>
-                                    <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                                    <div class="text-muted">
-                                        Start sending and receiving documents via Peppol as soon as your registration is complete.
-                                    </div>
-                                    <div class="alert alert-warning mt-3"
-                                         role="alert"
-                                         invisible="not is_account_peppol_participant or not account_peppol_endpoint_warning">
-                                        <field name="account_peppol_endpoint_warning"/>
-                                    </div>
-                                    <div class="pt-3"
-                                         invisible="not is_account_peppol_participant">
-                                        <div class="row">
-                                            <label string="Peppol EAS"
-                                                   for="account_peppol_eas"
-                                                   class="col-lg-3 o_light_label"/>
-                                            <field name="account_peppol_eas"/>
-                                        </div>
-                                        <div class="row">
-                                            <label string="Peppol Endpoint"
-                                                   for="account_peppol_eas"
-                                                   class="col-lg-3 o_light_label"/>
-                                            <field name="account_peppol_endpoint"/>
-                                        </div>
-                                    </div>
+            <div id="account_peppol" position="replace">
+                <field name="has_peppol_participant" invisible="1"/>
+                <div id="account_peppol" class="mt-3">
+                    <div class="col-12 col-lg-12 o_setting_box">
+                        <field name="account_peppol_proxy_state" invisible="1"/>
+                        <div class="o_setting_left_pane">
+                            <field name="is_account_peppol_participant"
+                                   invisible="account_peppol_proxy_state != 'not_registered'"/>
+                        </div>
+                        <div class="o_setting_right_pane border-0">
+                            <div invisible="account_peppol_proxy_state != 'not_registered'">
+                                <label for="is_account_peppol_participant" string="Use PEPPOL Invoicing"/>
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
+                                <div class="text-muted">
+                                    Start sending and receiving documents via Peppol as soon as your registration is complete.
                                 </div>
-                                <div class="row"
-                                     invisible="not is_account_peppol_participant or account_peppol_proxy_state not in ('not_registered', 'not_verified')">
-                                    <label string="Phone Number"
-                                            for="account_peppol_phone_number"
-                                            class="col-lg-3 o_light_label"/>
-                                    <field name="account_peppol_phone_number"
-                                            required="is_account_peppol_participant and account_peppol_proxy_state in ('not_registered', 'not_verified')"/>
+                                <div class="alert alert-warning mt-3"
+                                     role="alert"
+                                     invisible="not is_account_peppol_participant or not account_peppol_endpoint_warning">
+                                    <field name="account_peppol_endpoint_warning"/>
                                 </div>
-                                <div class="row"
-                                     invisible="not is_account_peppol_participant or account_peppol_proxy_state in ('rejected', 'canceled', 'sent_verification')">
-                                    <label string="Primary contact email"
-                                           for="account_peppol_contact_email"
-                                           class="col-lg-3 o_light_label"/>
-                                    <field name="account_peppol_contact_email"
-                                           required="is_account_peppol_participant"/>
-                                </div>
-                                <div class="content-group pt-3"
-                                     invisible="account_peppol_proxy_state != 'not_registered' or not is_account_peppol_participant">
-                                    <span>
-                                        I want to migrate my Peppol connection to Odoo (optional):
-                                    </span>
-                                    <div class="row mt-3">
-                                        <label string="Migration key"
-                                               for="account_peppol_migration_key"
-                                               class="col-lg-3 o_light_label"/>
-                                        <field name="account_peppol_migration_key"/>
-                                    </div>
-                                </div>
-                                <div class="row mb-3"
+                                <div class="pt-3"
                                      invisible="not is_account_peppol_participant">
-                                    <div class="content-group mt-3"
-                                         invisible="account_peppol_proxy_state in ('rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification')">
-                                        <div class="row">
-                                            <label string="Incoming Invoices Journal"
-                                                   for="account_peppol_purchase_journal_id"
-                                                   class="col-lg-3 o_light_label"/>
-                                            <field name="account_peppol_purchase_journal_id"
-                                                   required="is_account_peppol_participant and account_peppol_proxy_state not in ('rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification')"/>
-                                        </div>
+                                    <div class="row">
+                                        <label string="Peppol EAS"
+                                               for="account_peppol_eas"
+                                               class="col-lg-3 o_light_label"/>
+                                        <field name="account_peppol_eas"/>
                                     </div>
-                                    <div class="content-group mt-3"
-                                         invisible="account_peppol_proxy_state != 'sent_verification'">
-                                        <span class="text-muted">
-                                            We sent a verification code to
-                                            <field name="account_peppol_phone_number"
-                                                   nolabel="1"
-                                                   readonly="is_account_peppol_participant and account_peppol_proxy_state == 'sent_verification'"/>.
-                                        </span>
-                                        <div class="row mt-1 ps-3">
-                                            <field name="account_peppol_verification_code" widget="verification_code"/>
-                                        </div>
+                                    <div class="row">
+                                        <label string="Peppol Endpoint"
+                                               for="account_peppol_eas"
+                                               class="col-lg-3 o_light_label"/>
+                                        <field name="account_peppol_endpoint"/>
                                     </div>
-                                    <div class="pt-3 pb-3"
-                                         invisible="account_peppol_proxy_state == 'not_registered'">
-                                        Application status:
-                                        <b>
-                                            <field name="account_peppol_proxy_state"
-                                                   readonly="1"
-                                                   decoration-danger="account_peppol_proxy_state == 'rejected'"
-                                                   decoration-info="account_peppol_proxy_state == 'active'"/>
-                                        </b>
+                                </div>
+                            </div>
+                            <div class="row"
+                                 invisible="not is_account_peppol_participant or account_peppol_proxy_state not in ('not_registered', 'not_verified')">
+                                <label string="Phone Number"
+                                       for="account_peppol_phone_number"
+                                       class="col-lg-3 o_light_label"/>
+                                <field name="account_peppol_phone_number"
+                                       required="is_account_peppol_participant and account_peppol_proxy_state in ('not_registered', 'not_verified')"/>
+                            </div>
+                            <div class="row"
+                                 invisible="not is_account_peppol_participant or account_peppol_proxy_state in ('rejected', 'canceled', 'sent_verification')">
+                                <label string="Primary contact email"
+                                       for="account_peppol_contact_email"
+                                       class="col-lg-3 o_light_label"/>
+                                <field name="account_peppol_contact_email"
+                                       required="is_account_peppol_participant"/>
+                            </div>
+                            <div class="content-group pt-3"
+                                 invisible="account_peppol_proxy_state != 'not_registered' or not is_account_peppol_participant">
+                                <span>
+                                    I want to migrate my Peppol connection to Odoo (optional):
+                                </span>
+                                <div class="row mt-3">
+                                    <label string="Migration key"
+                                           for="account_peppol_migration_key"
+                                           class="col-lg-3 o_light_label"/>
+                                    <field name="account_peppol_migration_key"/>
+                                </div>
+                            </div>
+                            <div class="row mb-3"
+                                 invisible="not is_account_peppol_participant">
+                                <div class="content-group mt-3"
+                                     invisible="account_peppol_proxy_state in ('rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification')">
+                                    <div class="row">
+                                        <label string="Incoming Invoices Journal"
+                                               for="account_peppol_purchase_journal_id"
+                                               class="col-lg-3 o_light_label"/>
+                                        <field name="account_peppol_purchase_journal_id"
+                                               required="is_account_peppol_participant and account_peppol_proxy_state not in ('rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification')"/>
                                     </div>
-                                    <div invisible="account_peppol_proxy_state != 'rejected'">
-                                        <p>
-                                            The rejection reason has been sent to you via email.
-                                        </p>
-                                        <p>
-                                            Please do not hesitate to contact our support if you need further assistance.
-                                        </p>
-                                    </div>
-                                    <div invisible="account_peppol_proxy_state != 'active' or not account_peppol_migration_key">
-                                        Your migration key is:
-                                        <field name="account_peppol_migration_key"
+                                </div>
+                                <div class="content-group mt-3"
+                                     invisible="account_peppol_proxy_state != 'sent_verification'">
+                                    <span class="text-muted">
+                                        We sent a verification code to
+                                        <field name="account_peppol_phone_number"
                                                nolabel="1"
-                                               readonly="account_peppol_proxy_state == 'active' and account_peppol_migration_key"/>
+                                               readonly="is_account_peppol_participant and account_peppol_proxy_state == 'sent_verification'"/>.
+                                    </span>
+                                    <div class="row mt-1 ps-3">
+                                        <field name="account_peppol_verification_code" widget="verification_code"/>
                                     </div>
-                                    <div invisible="account_peppol_proxy_state != 'active'">
-                                        Your Peppol identification is:
-                                        <field name="account_peppol_edi_identification"
-                                               nolabel="1"/>
+                                </div>
+                                <div class="pt-3 pb-3"
+                                     invisible="account_peppol_proxy_state == 'not_registered'">
+                                    Application status:
+                                    <b>
+                                        <field name="account_peppol_proxy_state"
+                                               readonly="1"
+                                               decoration-danger="account_peppol_proxy_state == 'rejected'"
+                                               decoration-info="account_peppol_proxy_state == 'active'"/>
+                                    </b>
+                                </div>
+                                <div invisible="account_peppol_proxy_state != 'rejected'">
+                                    <p>
+                                        The rejection reason has been sent to you via email.
+                                    </p>
+                                    <p>
+                                        Please do not hesitate to contact our support if you need further assistance.
+                                    </p>
+                                </div>
+                                <div invisible="account_peppol_proxy_state != 'active' or not account_peppol_migration_key">
+                                    Your migration key is:
+                                    <field name="account_peppol_migration_key"
+                                           nolabel="1"
+                                           readonly="account_peppol_proxy_state == 'active' and account_peppol_migration_key"/>
+                                </div>
+                                <div invisible="account_peppol_proxy_state != 'active'">
+                                    Your Peppol identification is:
+                                    <field name="account_peppol_edi_identification"
+                                           nolabel="1"/>
+                                </div>
+                                <div class="mt-5"
+                                     invisible="account_peppol_proxy_state != 'not_registered'">
+                                    <div class="mb-3">
+                                        I accept that Odoo may process my e-invoices.
                                     </div>
-                                    <div class="mt-5"
-                                         invisible="account_peppol_proxy_state != 'not_registered'">
-                                        <div class="mb-3">
-                                            I accept that Odoo may process my e-invoices.
-                                        </div>
+                                </div>
+                                <div class="d-flex gap-1 action_buttons" colspan="3">
+                                    <div class="mt-3"
+                                         invisible="account_peppol_proxy_state != 'not_verified'">
+                                        <button name="button_send_peppol_verification_code"
+                                                type="object"
+                                                string="Verify phone number"
+                                                class="btn btn-primary"/>
                                     </div>
-                                    <div class="d-flex gap-1 action_buttons" colspan="3">
-                                        <div class="mt-3"
-                                            invisible="account_peppol_proxy_state != 'not_verified'">
-                                            <button name="button_send_peppol_verification_code"
-                                                    type="object"
-                                                    string="Verify phone number"
-                                                    class="btn btn-primary"/>
-                                        </div>
-                                        <widget name="peppol_settings_buttons"
-                                                invisible="account_peppol_proxy_state not in ('not_registered', 'sent_verification', 'pending', 'manually_approved', 'active')"/>
-                                        <div class="mt-3"
-                                            invisible="account_peppol_proxy_state in ('not_registered', 'active', 'rejected', 'canceled')">
-                                            <button name="button_cancel_peppol_registration"
-                                                    type="object"
-                                                    string="Cancel registration"
-                                                    class="btn btn-secondary"/>
-                                        </div>
-                                        <div class="mt-3"
-                                            invisible="account_peppol_proxy_state != 'canceled' or account_peppol_migration_key">
-                                            <button name="button_reopen_peppol_registration"
-                                                    type="object"
-                                                    string="Retry registration"
-                                                    class="btn btn-secondary"/>
-                                        </div>
+                                    <widget name="peppol_settings_buttons"
+                                            invisible="account_peppol_proxy_state not in ('not_registered', 'sent_verification', 'pending', 'manually_approved', 'active')"/>
+                                    <div class="mt-3"
+                                         invisible="account_peppol_proxy_state in ('not_registered', 'active', 'rejected', 'canceled')">
+                                        <button name="button_cancel_peppol_registration"
+                                                type="object"
+                                                string="Cancel registration"
+                                                class="btn btn-secondary"/>
+                                    </div>
+                                    <div class="mt-3"
+                                         invisible="account_peppol_proxy_state != 'canceled' or account_peppol_migration_key">
+                                        <button name="button_reopen_peppol_registration"
+                                                type="object"
+                                                string="Retry registration"
+                                                class="btn btn-secondary"/>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                </block>
-            </block>
+            </div>
+            <field name="module_account_peppol" position="attributes">
+                <!-- When any company has Peppol enabled, we prevent users from accidentally uninstalling the module -->
+                <attribute name="readonly">has_peppol_participant</attribute>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Currently it is not easily discoverable that users can install the PEPPOL module. They have to go to the Apps list and search for PEPPOL there.

In order to make the installation easy and discoverable, we added a checkbox to the Invoicing/Accounting settings to install the module and afterwards show the checkbox to enable PEPPOL per company.

The install checkbox is only shown when editing the settings of a company that is eligible for PEPPOL to avoid confusion. In order to do that, we created a `PEPPOL_LIST` variable in `account` containing all countries currently allowed to use PEPPOL. The code in `account_peppol` formerly using the `EAS_MAPPING` variable of the `account_edi_ubl_cii` module is now also using this new list.

[task-3519564](https://www.odoo.com/web#id=3519564&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
