### PR TITLE
[14.0][FIX] mail: suggested recipients without email and name

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1530,8 +1530,10 @@ class MailThread(models.AbstractModel):
             return result
         if partner and partner.email:  # complete profile: id, name <email>
             result[self.ids[0]].append((partner.id, partner.email_formatted, reason))
-        elif partner:  # incomplete profile: id, name
-            result[self.ids[0]].append((partner.id, partner.name or '', reason))
+        elif partner and partner.name: # incomplete profile (missing email): id, name
+            result[self.ids[0]].append((partner.id, partner.name, reason))
+        elif partner:  # incomplete profile (missing email and name) -> skip
+            return result
         else:  # unknown partner, we are probably managing an email address
             result[self.ids[0]].append((False, partner_info.get('full_name') or email, reason))
         return result

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -263,3 +263,12 @@ class TestPartner(MailCommon):
         all_msg = p2_msg_ids_init + p1_msg_ids_init + p1_msg1
         self.assertEqual(len(p2.message_ids), len(all_msg) + 1, 'Should have original messages + a log')
         self.assertTrue(all(msg in p2.message_ids for msg in all_msg))
+
+    def test_partner_no_name_suggested_recipient(self):
+        # Partner without name and email is not considered for suggested recipient
+        Partner = self.env['res.partner']
+
+        parent = Partner.create({'name': 'Customer1', 'email': 'test1@test.example.com'})
+        delivery_address = Partner.create({'parent_id': parent.id, 'name': '', 'email': ''})
+        res = delivery_address._message_add_suggested_recipient({delivery_address.id: []}, partner=delivery_address)
+        self.assertFalse(res[delivery_address.id])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
For addresses that don't have an email and don't have a name, an error is raised in the UI when accessing it due to the wrong value passed in the method _message_add_suggested_recipient which assumes that a partner always have one of the two (an email or a name).

![image](https://github.com/odoo/odoo/assets/71635103/b78975b4-f98e-4868-a203-0a4d7fb4496d)

Current behavior before PR:
The current behaviour assumes that we always have an email and a name for a contact. However, partners are not always guaranteed to have a name if their type is not 'contact'. In those cases the suggested recipient information causes an error in the view of the partner.

Desired behavior after PR is merged:
After the fix, the addresses missing email and name are ignored in the suggested recipient logic, preventing the error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
