### PR TITLE
[FIX] website: resolving traceback Issue when creating Tasks/Tickets

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -71,7 +71,7 @@ const FormEditor = options.Class.extend({
                 display_name: el[1],
             }));
         } else if (field.relation && field.relation !== 'ir.attachment') {
-            field.records = await this.orm.searchRead(field.relation, field.domain, ["display_name"]);
+            field.records = await this.orm.searchRead(field.relation, field.domain || [], ["display_name"]);
         }
         return field.records;
     },


### PR DESCRIPTION
Issue:
A traceback error was observed when attempting to create a task or ticket using
the website form.

Cause:
This issue arise as a result of converting RPC  to ORM  readSearch. The problem lay in the domain being passed to the ORM. Not all fields had a defined domain, causing 'undefined' to be passed to the ORM, leading to the traceback error.

Related PR: https://github.com/odoo/odoo/pull/136271

Fix:
To address this, we have introduced an 'or' condition within the domain. Now, if a field has a domain, it will be passed accordingly; otherwise, an empty array is set as the domain. This modification resolves the traceback issue.

Task-3526887