### PR TITLE
[FIX] stock: prevent warehouse stock location to be scrap location

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -9430,6 +9430,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock/models/stock_location.py:0
 #, python-format
+msgid "You cannot set a Warehouse Location Stock as a scrap location."
+msgstr ""
+
+#. module: stock
+#. odoo-python
+#: code:addons/stock/models/stock_location.py:0
+#, python-format
 msgid ""
 "You cannot set a location as a scrap location when it assigned as a "
 "destination location for a manufacturing type operation."

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -190,6 +190,8 @@ class Location(models.Model):
     @api.constrains('scrap_location')
     def _check_scrap_location(self):
         for record in self:
+            if record.scrap_location and record.id == record.warehouse_id.lot_stock_id.id:
+                raise ValidationError(_("You cannot set a Warehouse Location Stock as a scrap location."))
             if record.scrap_location and self.env['stock.picking.type'].search([('code', '=', 'mrp_operation'), ('default_location_dest_id', '=', record.id)]):
                 raise ValidationError(_("You cannot set a location as a scrap location when it assigned as a destination location for a manufacturing type operation."))
 


### PR DESCRIPTION
If a user using inventory sets an internal location which is Location Stock of the Warehouse as Scrap Location and then activattes module mrp would face ParseError.

Steps to produce:
- Install `stock`.
- Inventory > Configuration > Settings > Under Warehouse check Storage Locations.
- Inventory > Configuration > Warehouse Management > Locations > Choose `WH/Stock` as location and check Is a Scrap Location.
(A user can check it as scrap location only when when there are 0 delivery orders to process so unreserve all the products associated to that location).
- Install `mrp`.

Error: 
```ParseError: while parsing /home/odoo/src/odoo/saas-16.4/addons/mrp_subcontracting/data/mrp_subcontracting_data.xml:10
Bạn không thể đặt một vị trí phế phẩm làm vị trí đích cho một hoạt động thuộc loại sản xuất.

View error context:
'-no context-'

  File "odoo/modules/registry.py", line 105, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 561, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
```

This commit won't allow users to  scrape Warehouse Location Stock as a Scrap Location.

Sentry-4247161969

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
