### PR TITLE
[IMP] hr_work_entry: remove current-month filter

### DIFF
--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -15,7 +15,6 @@
         <field name="res_model">hr.work.entry</field>
         <field name="view_mode">calendar,tree,form,pivot</field>
         <field name="context">{
-            'search_default_current_month': True,
             'search_default_work_entries_error': True
         }</field>
     </record>


### PR DESCRIPTION
[IMP] hr_work_entry: remove current-month filter
The current-month filter is not needed anymore since
when we arrive on the work entries view, the current month
is already selected by default.

task-3510499

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
