### PR TITLE
[IMP] pos_self_order: global improvements following review

### DIFF
--- a/addons/point_of_sale/tests/test_res_config_settings.py
+++ b/addons/point_of_sale/tests/test_res_config_settings.py
@@ -27,8 +27,8 @@ class TestConfigureShops(TestPoSCommon):
         """
         self._remove_on_payment_taxes()
 
-        pos_config1 = self.env['pos.config'].create({'name': 'Shop 1'})
-        pos_config2 = self.env['pos.config'].create({'name': 'Shop 2'})
+        pos_config1 = self.env['pos.config'].create({'name': 'Shop 1', 'module_pos_restaurant': False})
+        pos_config2 = self.env['pos.config'].create({'name': 'Shop 2', 'module_pos_restaurant': False})
         self.assertEqual(pos_config1.receipt_header, False)
         self.assertEqual(pos_config2.receipt_header, False)
 
@@ -56,6 +56,7 @@ class TestConfigureShops(TestPoSCommon):
         pos_config = self.env['pos.config'].create({
             'name': 'Shop',
             'is_header_or_footer': True,
+            'module_pos_restaurant': False,
             'receipt_header': 'header val',
             'receipt_footer': 'footer val',
         })

--- a/addons/pos_online_payment_self_order/static/src/components/order_widget/order_widget.js
+++ b/addons/pos_online_payment_self_order/static/src/components/order_widget/order_widget.js
@@ -5,6 +5,7 @@ import { OrderWidget } from "@pos_self_order/app/components/order_widget/order_w
 
 patch(OrderWidget.prototype, {
     get buttonToShow() {
+        const buttonName = this.router.activeSlot === "product_list" ? _t("Order") : _t("Pay");
         const type = this.selfOrder.config.self_ordering_mode;
         const mode = this.selfOrder.config.self_ordering_pay_after;
         const isOnlinePayment = this.selfOrder.pos_payment_methods.find((p) => p.is_online_payment);
@@ -14,7 +15,7 @@ patch(OrderWidget.prototype, {
         }
 
         if (mode === "each") {
-            return { label: _t("Pay"), disabled: false };
+            return { label: buttonName, disabled: false };
         } else if (mode === "meal") {
             const order = this.selfOrder.currentOrder;
 
@@ -26,9 +27,12 @@ patch(OrderWidget.prototype, {
                 return { label: _t("Order"), disabled: false };
             } else {
                 if (isOnlinePayment) {
-                    return { label: _t("Pay"), disabled: false };
+                    return { label: buttonName, disabled: false };
                 } else {
-                    return { label: _t("Pay at cashier"), disabled: true };
+                    return {
+                        label: _t("Pay at cashier"),
+                        disabled: this.router.activeSlot !== "product_list",
+                    };
                 }
             }
         } else {

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -19,6 +19,7 @@
         "views/pos_session_view.xml",
         "views/custom_link_views.xml",
         "data/init_access.xml",
+        "data/custom_link_data.xml",
         "views/res_config_settings_views.xml",
         "views/point_of_sale_dashboard.xml",
         "data/pos_restaurant_data.xml",

--- a/addons/pos_self_order/data/custom_link_data.xml
+++ b/addons/pos_self_order/data/custom_link_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<odoo>
+   <data noupdate="1">
+      <record id="default_custom_link" model="pos_self_order.custom_link">
+         <field name="name">Order Now</field>
+         <field name="pos_config_ids" eval="[(4, ref('pos_restaurant.pos_config_main_restaurant'))]"/>
+         <field name="url" model="pos.config" eval="'/pos-self/' + str(obj().env.ref('pos_restaurant.pos_config_main_restaurant').id) + '/products'" />
+      </record>
+   </data>
+</odoo>

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -49,6 +49,11 @@ class ResConfigSettings(models.TransientModel):
             self.is_kiosk_mode = False
 
     @api.onchange("pos_self_ordering_pay_after", "pos_self_ordering_mode")
+    def _onchange_service_and_ordering(self):
+        if self.pos_self_ordering_pay_after == "meal" and self.pos_self_ordering_mode == 'mobile':
+            self.pos_self_ordering_service_mode = 'table'
+
+    @api.onchange("pos_self_ordering_pay_after", "pos_self_ordering_mode")
     def _onchange_pos_self_order_pay_after(self):
         if self.pos_self_ordering_pay_after == "meal" and self.pos_self_ordering_mode == 'kiosk':
             raise UserError(_("Only pay after each is available with kiosk mode."))
@@ -58,7 +63,7 @@ class ResConfigSettings(models.TransientModel):
 
     @api.onchange("pos_self_ordering_service_mode")
     def _onchange_pos_self_ordering_service_mode(self):
-        table_ids = self.pos_config_id.floor_ids.table_ids
+        table_ids = self.pos_floor_ids.table_ids
         if self.pos_self_ordering_service_mode == 'table' and self.pos_self_ordering_mode == 'mobile' and not table_ids:
             raise UserError(_("In Self-Order mode, you must have at least one table to use the table service mode"))
 

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
@@ -7,16 +7,14 @@
                     Cancel Order
                 </button>
                 <div class="col-6 p-2 m-0">
-                    <span>To Order</span>
+                    <span t-if="!this.selfOrder.currentOrder.isSavedOnServer">To Order</span>
+                    <span t-else="">To Pay</span>
                     <div class="m-2">
                         <span class="p-2 bg-300 rounded" t-esc="lineNotSend.count" />
                         <span class="mx-2" t-if="selfOrder.currentOrder.lines.length" t-esc="selfOrder.formatMonetary(lineNotSend.price)" />
                     </div>
                 </div>
-                <button t-attf-class="col-3 cart btn btn-primary col-3 p-0 m-0 text-uppercase {{ buttonToShow.disabled ? 'disabled' : '' }}" t-on-click="props.action">
-                    <span t-esc="buttonToShow.label"/>
-                    <span class="px-2" t-if="lineNotSend.count === 0" t-esc="selfOrder.formatMonetary(this.selfOrder.currentOrder.amount_total)"/>
-                </button>
+                <button t-attf-class="col-3 cart btn btn-primary col-3 p-0 m-0 text-uppercase {{ buttonToShow.disabled ? 'disabled' : '' }}" t-on-click="props.action" t-esc="buttonToShow.label" />
             </div>
         </div>
     </t>

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -59,7 +59,15 @@ export class LandingPage extends Component {
         return "";
     }
 
-    start() {
+    clickCustomLink(link) {
+        const arrayLink = link.url.split("/");
+        const routeName = arrayLink[arrayLink.length - 1];
+
+        if (routeName !== "products") {
+            this.router.customLink(link);
+            return;
+        }
+
         if (
             this.selfOrder.config.self_ordering_takeaway &&
             this.selfOrder.currentOrder.take_away === null

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
@@ -18,13 +18,6 @@
             </div>
         </div>
         <div class="position-absolute bottom-0 end-0 w-100 py-3 px-3">
-            <t t-foreach="selfOrder.custom_links" t-as="link" t-key="link.id">
-                <a type="button"
-                    t-on-click="(event) => this.router.customLink(link)"
-                    t-attf-class="btn btn-{{link.style}} h-100 w-100 p-0 m-0 fs-1 text-uppercase mb-2">
-                    <t t-esc="link.name"/>
-                </a>
-            </t>
             <t t-if="showMyOrderBtn()">
                 <hr class="bg-500"/>
                 <a
@@ -34,7 +27,13 @@
                     My Orders
                 </a>
             </t>
-            <button class="btn btn-primary h-100 w-100 p-0 m-0 fs-1 text-uppercase" t-on-click="start">TOUCH TO START</button>
+            <t t-foreach="selfOrder.custom_links" t-as="link" t-key="link.id">
+                <a type="button"
+                    t-on-click="() => this.clickCustomLink(link)"
+                    t-attf-class="btn btn-{{link.style}} h-100 w-100 p-0 m-0 fs-1 text-uppercase mb-2">
+                    <t t-esc="link.name"/>
+                </a>
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -46,7 +46,7 @@
                     <setting string="Options" help="All options for your Self devices" invisible="pos_self_ordering_mode in ['nothing', 'consultation']">
                         <div class="content-group row" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
                             <label for="pos_self_ordering_service_mode" class="col-lg-4" string="Service at" />
-                            <field name="pos_self_ordering_service_mode" />
+                            <field name="pos_self_ordering_service_mode" readonly="pos_self_ordering_pay_after == 'meal' and pos_self_ordering_mode == 'mobile'" />
                         </div>
                         <div class="content-group row" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
                             <label for="pos_self_ordering_default_user_id" class="col-lg-4" string="Default User"/>


### PR DESCRIPTION
List of improvements:
- Product list button is now configurable and not hardcoded. Demo data
is updated accordingly. When a new `pos_config` is created the button is
created with the default value "Order Now".
- Fix error 403 error when `pos_session` is not in opened state.
- The `order_widget` display now the number of items to order when all
items are not ordered yet and the total amount to pay and the count when
all items are ordered.
- The `order_widget` button no longer displays the order price.

Mobile mode:
State of order_widget button on `product_list_page`...
..when configured in meal mode, no online payment:
- With new orderlines: "Order"
- Witout new orderlines: "Order"

..when configured in meal mode with online payment:
- With new orderlines: "Order"
- Without new orderlines: "Order"

..when configured in each mode with online payment:
- With new orderlines: "Order"
- Without new orderlines: "Order"

State of order_widget button on `cart_page`...
..when configured in meal mode, no online payment:
- With new orderlines: "Order"
- Witout new orderlines: "Pay at Cashier"

..when configured in meal mode with online payment:
- With new orderlines: "Order"
- Without new orderlines: "Pay"

..when configured in each mode with online payment:
- With new orderlines: "Pay"
- Without new orderlines: "Pay"

Kiosk mode:
State of order_widget button on `product_list_page`...
..when no payment methode:
- Without new orderline: "Pay at Cashier" (disabled)
- With new orderline: "Pay at Cashier" (active)

..when payment methode:
- Without new orderline: "Order" (disabled)
- With new orderline: "Order" (active)

State of order_widget button on `cart_page`...
..when no payment methode:
- Without new orderline: "Pay at Cashier" (disabled)
- With new orderline: "Pay at Cashier" (active)

..when payment methode:
- Without new orderline: "Pay" (disabled)
- With new orderline: "Pay" (active)