### PR TITLE
[FIX] web: correct `archParseBoolean`

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -67,7 +67,7 @@ export function addFieldDependencies(activeFields, fields, dependencies = {}) {
  * @returns {boolean}
  */
 export function archParseBoolean(str, trueIfEmpty = false) {
-    return str ? !/^false|0$/i.test(str) : trueIfEmpty;
+    return str ? !/^(false|0)$/i.test(str) : trueIfEmpty;
 }
 
 /**

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
@@ -95,6 +95,7 @@ QUnit.test("hasQuickCreate", (assert) => {
     check(assert, "quick_add", "false", "hasQuickCreate", false);
     check(assert, "quick_add", "False", "hasQuickCreate", false);
     check(assert, "quick_add", "0", "hasQuickCreate", false);
+    check(assert, "quick_add", "390", "hasQuickCreate", true);
 });
 
 QUnit.test("isDateHidden", (assert) => {


### PR DESCRIPTION
Issue:
------
Depending on the order of installation, we may end up with actions that have a `0` at the end.

For example, for the calendar module, if the value of `quick_create` is `390`,
we will have `hasQuickCreate` which is `false`.

```js
hasQuickCreate = archParseBoolean(node.getAttribute("quick_add"), true);
```

Solution:
---------
Correct the regex to detect a `false` or a `0`
on the entire character string.

opw-3488262