### PR TITLE
[FIX] mail: raise UserError for missing external id on reset email template

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -3546,6 +3546,13 @@ msgid "Extended Filters..."
 msgstr ""
 
 #. module: mail
+#. odoo-python
+#: code:addons/mail/models/template_reset_mixin.py:0
+#, python-format
+msgid "External ID not found for template: %s"
+msgstr ""
+
+#. module: mail
 #. odoo-javascript
 #: code:addons/mail/static/src/models_data/emoji_data.js:0
 #, python-format

--- a/addons/mail/models/template_reset_mixin.py
+++ b/addons/mail/models/template_reset_mixin.py
@@ -93,6 +93,8 @@ class TemplateResetMixin(models.AbstractModel):
         lang_false = {code: False for code, _ in self.env['res.lang'].get_installed() if code != 'en_US'}
         for template in self.filtered('template_fs'):
             external_id = template.get_external_id().get(template.id)
+            if not external_id:
+                raise UserError(_("External ID not found for template: %s", template.name))
             module, xml_id = external_id.split('.')
             fullpath = get_resource_path(*template.template_fs.split('/'))
             if fullpath:


### PR DESCRIPTION
This issue arises when a user deletes the external ID associated with an email template, and attempts to reset the email template, resulting in an error.

Steps to produce :
- Install `mail` module.
- Now go to `External identifiers` and delete an external ID linked to an email template.
- Go to Settings > Technical > Email > Email Templates.
- Open an email template for which the external ID was previously deleted
- Click on `Reset template` button > Error will generated.

See traceback:
```
ValueError: not enough values to unpack (expected 2, got 1)
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/mail/wizard/mail_template_reset.py", line 16, in reset_template
    self.template_ids.reset_template()
  File "addons/mail/models/template_reset_mixin.py", line 95, in reset_template
    module, xml_id = external_id.split('.') 
```

This error occurs because it will not get external id here https://github.com/odoo/odoo/blob/1e3e6d30a8f8ce3d490899113cab31fa465f3a8b/addons/mail/models/template_reset_mixin.py#L95 After this commit, it will raise user error if it does not find the external id.

Sentry-4510563659

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
