### PR TITLE
[FIX] stock: prevent creating negative move line

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -139,18 +139,18 @@ class StockMoveLine(models.Model):
         for record in self:
             if not record.qty_done:
                 if (record.move_id.product_qty - record.move_id.quantity_done):
-                    record.qty_done = min(record.quant_id.available_quantity, max(record.move_id.product_qty - record.move_id.quantity_done, 0))
+                    record.qty_done = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - record.move_id.quantity_done))
                 else:
-                    record.qty_done = record.quant_id.available_quantity
+                    record.qty_done = max(0, record.quant_id.available_quantity)
 
     @api.depends('quant_id')
     def _compute_qty_reserved(self):
         for record in self:
             if not record.reserved_uom_qty:
                 if (record.move_id.product_qty - record.move_id.quantity_done):
-                    record.reserved_uom_qty = min(record.quant_id.available_quantity, max(record.move_id.product_qty - record.move_id.quantity_done, 0))
+                    record.reserved_uom_qty = max(0, min(record.quant_id.available_quantity, record.move_id.product_qty - record.move_id.quantity_done))
                 else:
-                    record.reserved_uom_qty = record.quant_id.available_quantity
+                    record.reserved_uom_qty = max(0, record.quant_id.available_quantity)
 
 
     @api.constrains('lot_id', 'product_id')

--- a/addons/stock/tests/test_move_lines.py
+++ b/addons/stock/tests/test_move_lines.py
@@ -93,3 +93,20 @@ class StockMoveLine(TestStockCommon):
         move = move_form.save()
         self.assertEqual(move.move_line_ids.qty_done, 5)
         self.assertEqual(move.move_line_ids.reserved_qty, 5)
+
+    def test_pick_from_4(self):
+        """ check the quantity done is not negative if the quant has negative quantity"""
+        self.env['stock.quant']._update_available_quantity(self.product, self.shelf1, -20, self.lot, package_id=self.pack, owner_id=self.partner)
+        self.assertEqual(self.quant.quantity, -10)
+        move = self.env['stock.move'].create({
+            'name': 'Test move',
+            'product_id': self.product.id,
+            'product_uom': self.product.uom_id.id,
+            'location_id': self.stock_location,
+            'location_dest_id': self.stock_location,
+        })
+        move_form = Form(move, view='stock.view_stock_move_operations')
+        with move_form.move_line_nosuggest_ids.new() as ml:
+            ml.quant_id = self.quant
+
+        self.assertEqual(move.move_line_ids.qty_done, 0)


### PR DESCRIPTION
Choosing a negative quant to create a new move line in the detailled operation should not take the negative quantity.
This commit set 0 instead.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
