### PR TITLE
[FIX] pos_self_order: pay after each setting require enterprise

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -145,11 +145,11 @@ class PosConfig(models.Model):
                 record.self_ordering_mode = 'nothing'
 
     def _compute_selection_pay_after(self):
-        selection = [("meal", "Meal"), ("each", "Each Order")]
+        selection_each_label = _("Each Order")
         version_info = service.common.exp_version()['server_version_info']
         if version_info[-1] == '':
-            selection[0] = (selection[0][0], selection[0][1] + ' (require Odoo Enterprise)')
-        return selection
+            selection_each_label = f"{selection_each_label} {_('(require Odoo Enterprise)')}"
+        return [("meal", _("Meal")), ("each", selection_each_label)]
 
     @api.constrains('self_ordering_default_user_id')
     def _check_default_user(self):


### PR DESCRIPTION
After merging of the mobile and kiosk app for self order (https://github.com/odoo/odoo/pull/136051), the pay after selection that requires the "upgrade to enterprise" label was misplace. This fix restores the misplaced label.

**Before:**

<img width="446" alt="Screenshot 2023-10-03 at 14 14 25" src="https://github.com/odoo/odoo/assets/3245568/9220c0df-9ba2-4296-b819-860f78f6d348">

**After:**

<img width="469" alt="Screenshot 2023-10-03 at 14 12 34" src="https://github.com/odoo/odoo/assets/3245568/4af2e1cb-c18a-472c-8ae2-302fe09fc39f">

