### PR TITLE
[IMP] web: Adds dynamicProps to Widget

### DIFF
--- a/addons/web/static/src/views/widgets/widget.js
+++ b/addons/web/static/src/views/widgets/widget.js
@@ -47,7 +47,12 @@ export class Widget extends Component {
                 widgetInfo.attrs.readonly,
                 record.evalContextWithVirtualIds
             );
-            propsFromNode = this.widget.extractProps ? this.widget.extractProps(widgetInfo) : {};
+            const dynamicInfo = {
+                readonly: readonlyFromModifiers,
+            };
+            propsFromNode = this.widget.extractProps
+                ? this.widget.extractProps(widgetInfo, dynamicInfo)
+                : {};
         }
 
         return {

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -10654,6 +10654,37 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(target, ".o_widget.my_classname");
     });
 
+    QUnit.test("widget with readonly attribute", async function (assert) {
+        class MyComponent extends owl.Component {
+            static template = owl.xml`<span t-esc="value"/>`;
+            get value() {
+                return this.props.readonly ? "readonly" : "not readonly";
+            }
+        }
+        const myComponent = {
+            component: MyComponent,
+            extractProps(widgetInfo, dynamicInfo) {
+                return { readonly: dynamicInfo.readonly };
+            },
+        };
+        widgetRegistry.add("test_widget", myComponent);
+
+        await makeView({
+            type: "form",
+            serverData,
+            resModel: "partner",
+            arch: `
+                <form>
+                    <field name="bar"/>
+                    <widget name="test_widget" readonly="bar"/>
+                </form>`,
+        });
+
+        assert.strictEqual(target.querySelector(".o_widget").textContent, "not readonly");
+        await click(target.querySelector(".o_field_widget[name=bar] input"));
+        assert.strictEqual(target.querySelector(".o_widget").textContent, "readonly");
+    });
+
     QUnit.test("support header button as widgets on form statusbar", async function (assert) {
         serviceRegistry.add("http", {
             start: () => ({}),


### PR DESCRIPTION
As with fields, dynamicProps will be accessible to widgets from extractProps. This commit will make readonly accessible as the first dynamicProps. We'll be able to add more when we need them.

DynamicInfo.readonly is true if the field is readonly independently of the record.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
