### PR TITLE
[IMP] sales: add discount on SOL in kanban

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -635,6 +635,14 @@
                                                                 <strong class="float-end text-end" t-out="line_price" />
                                                             </div>
                                                         </div>
+                                                        <t t-if="record.discount?.raw_value">
+                                                            <div class="row">
+                                                                <div class="col-12 text-muted">
+                                                                    Discount:
+                                                                    <t t-out="record.discount.value"/>%
+                                                                </div>
+                                                            </div>
+                                                        </t>
                                                     </div>
                                                 </div>
                                             </t>


### PR DESCRIPTION
Before this commit, the discount was not displayed on SOL in mobile view.
This commit adds the discount when it exists.

task-3111127