### PR TITLE
[FIX] mail: fix author browse in web push payload computation

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4340,7 +4340,7 @@ class MailThread(models.AbstractModel):
             if not model and body:
                 model, res_id = self._extract_model_and_id(msg_vals)
         else:
-            author_id = [message.author_id.ids]
+            author_id = message.author_id.ids
             author_name = self.env['res.partner'].browse(author_id).name
             model = message.model
             title = message.record_name or message.subject


### PR DESCRIPTION
There is a double list encoding, probably not required. Coming from mail enterprise code move.
