### PR TITLE
[15.0][FIX] stock: forecasted report fails to unreserve and reserve chained moves

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2045,6 +2045,16 @@ class StockMove(models.Model):
                 dst._rollup_move_dests(seen)
         return seen
 
+    def _rollup_move_origs(self, seen=False):
+        if not seen:
+            seen = OrderedSet()
+        if self.id in seen:
+            return seen
+        seen.add(self.id)
+        for org in self.move_orig_ids:
+            org._rollup_move_origs(seen)
+        return seen
+
     def _get_forecast_availability_outgoing(self, warehouse):
         """ Get forcasted information (sum_qty_expected, max_date_expected) of self for in_locations_ids as the in locations.
         It differ from _get_report_lines because it computes only the necessary information and return a

--- a/addons/stock/report/report_stock_forecasted.xml
+++ b/addons/stock/report/report_stock_forecasted.xml
@@ -113,18 +113,18 @@
                                     Reserved from stock
                                     <button t-if="line['move_out'] and line['move_out'].picking_id"
                                         class="btn btn-sm btn-primary o_report_replenish_unreserve"
-                                        t-attf-model="stock.picking"
-                                        t-att-model-id="line['move_out'].picking_id.id"
+                                        t-attf-model="report.stock.report_product_product_replenishment"
+                                        t-att-move_id="line['move_out'].id"
                                         name="unreserve_link">
                                         Unreserve
                                     </button>
                                 </t>
                                 <t t-elif="line['replenishment_filled']">
                                     <t t-if="line['document_out']">Inventory On Hand
-                                        <button t-if="line['move_out'] and line['move_out'].state in ('confirmed', 'partially_available') and line['move_out'].picking_id"
+                                        <button t-if="line['move_out']"
                                             class="btn btn-sm btn-primary o_report_replenish_reserve"
-                                            t-attf-model="stock.picking"
-                                            t-att-model-id="line['move_out'].picking_id.id"
+                                            t-attf-model="report.stock.report_product_product_replenishment"
+                                            t-att-move_id="line['move_out'].id"
                                             name="reserve_link">
                                             Reserve
                                         </button>

--- a/addons/stock/static/src/js/report_stock_forecasted.js
+++ b/addons/stock/static/src/js/report_stock_forecasted.js
@@ -234,7 +234,7 @@ const ReplenishReport = clientAction.extend({
 
     /**
      * Bind additional action handlers (<button>, <a>)
-     * 
+     *
      * @returns {Promise}
      */
     _bindAdditionalActionHandlers: function () {
@@ -332,11 +332,11 @@ const ReplenishReport = clientAction.extend({
      */
     _onClickUnreserve: function(ev) {
         const model = ev.target.getAttribute('model');
-        const modelId = parseInt(ev.target.getAttribute('model-id'));
+        const move_id = parseInt(ev.target.getAttribute('move_id'));
         return this._rpc( {
             model,
-            args: [[modelId]],
-            method: 'do_unreserve'
+            args: [[move_id]],
+            method: 'action_unreserve_linked_picks'
         }).then(() => this._reloadReport());
     },
 
@@ -347,11 +347,11 @@ const ReplenishReport = clientAction.extend({
      */
     _onClickReserve: function(ev) {
         const model = ev.target.getAttribute('model');
-        const modelId = parseInt(ev.target.getAttribute('model-id'));
+        const move_id = parseInt(ev.target.getAttribute('move_id'));
         return this._rpc( {
             model,
-            args: [[modelId]],
-            method: 'action_assign'
+            args: [[move_id]],
+            method: 'action_reserve_linked_picks'
         }).then(() => this._reloadReport());
     }
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

When user try reserve or unreserve moves in forecasted report with a multi-routes warehouse setting Odoo does not reserve or unreserve.

**Current behavior before PR**:

* Enable multi-steps routes (pick / pack / out)
* Sell some product to customer in stock
* go to forecasted report and try to unreserve the move
* Odoo does not unreserve the quantities
* The same for reserve method

![Peek 03-10-2023 16-44](https://github.com/odoo/odoo/assets/7689807/de21db54-7596-4dc4-a323-9a63dc3794f0)

**Desired behavior after PR is merged:**

* Enable multi-steps routes (pick / pack / out)
* Sell some product to customer in stock
* go to forecasted report and try to unreserve the move
* Odoo does unreserve the quantities
* The same for reserve method

![Peek 03-10-2023 16-47](https://github.com/odoo/odoo/assets/7689807/9a37ff81-6397-4820-8198-caa8f4a2d307)

cc @Tecnativa TT45315
ping @CarlosRoca13 @pedrobaeza

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
