### PR TITLE
[FIX] [16.0] sale_timesheet: Delete timesheets before deleting the sales order

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -122,6 +122,10 @@ class SaleOrder(models.Model):
         moves._link_timesheets_to_invoice(self.env.context.get("timesheet_start_date"), self.env.context.get("timesheet_end_date"))
         return moves
 
+    def unlink(self):
+        self.timesheet_ids.sudo().unlink()
+        return super(SaleOrder, self).unlink()
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"


### PR DESCRIPTION
Delete timesheets before deleting the sales order. Avoid the error of not being able to flush

**Problem:** Error when deleting sales order (link to Project and timesheets)

**Step**:
1. Set up the Product: service type, Create on Order is `Project & Task`.
2. Create a quotation: Choose a product line, which is the product above
3. Confirm sales order
=> SO will link to projects and tasks
4. Create Timesheets for  task or project above
=> SO has recorded timesheets
6. Cancel SO
7. Delete SO
=> Error(See log below)

**Expect:** Successfully deleted, SO, Project, Task, Timesheets

**Solution:**
A simple solution: Delete timesheets before deleting the sales order

or need to fix the `_flush` function (not sure)
https://github.com/odoo/odoo/blob/16.0/odoo/models.py#L5655-L5663


**Image:**
![image](https://github.com/odoo/odoo/assets/65994959/013f3337-5d3f-49c9-9232-035a9cc893e0)

**Log:**
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/http.py", line 1584, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/http.py", line 1611, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/http.py", line 1815, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/vietphuong10/odoo/16.0/16_odoo/addons/web/controllers/dataset.py", line 42, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/vietphuong10/odoo/16.0/16_odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/vietphuong10/odoo/16.0/16_odoo/addons/sale_timesheet/models/sale_order.py", line 127, in unlink
    return super(SaleOrder, self).unlink()
  File "/home/vietphuong10/odoo/16.0/16_odoo/addons/mail/models/mail_thread.py", line 330, in unlink
    res = super(MailThread, self).unlink()
  File "/home/vietphuong10/odoo/16.0/16_odoo/addons/mail/models/mail_activity_mixin.py", line 246, in unlink
    result = super(MailActivityMixin, self).unlink()
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/models.py", line 3621, in unlink
    self.env.flush_all()
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/api.py", line 734, in flush_all
    self[model_name].flush_model()
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/models.py", line 5598, in flush_model
    self._flush(fnames)
  File "/home/vietphuong10/odoo/16.0/16_odoo/odoo/models.py", line 5660, in _flush
    assert len(values) == len(records), \
AssertionError: Could not find all values of sale.order.line.order_partner_id to flush them
    Context: {'lang': 'en_US', 'tz': 'Asia/Saigon', 'uid': 2, 'allowed_company_ids': [1], 'search_default_my_quotation': 1}
    Cache: {account.analytic.line.account_id: {11: 7}, account.analytic.line.amount: {11: 0.0}, account.analytic.line.ancestor_task_id: {11: None}, account.analytic.line.category: {11: 'other'}, account.analytic.line.code: {11: None}, account.analytic.line.company_id: {11: 1}, account.analytic.line.create_date: {11: datetime.datetime(2023, 10, 4, 7, 43, 20, 753551)}, account.analytic.line.create_uid: {11: 2}, account.analytic.line.currency_id: {11: 23}, account.analytic.line.date: {11: datetime.date(2023, 10, 4)}, account.analytic.line.department_id: {11: 1}, account.analytic.line.employee_id: {11: 1}, account.analytic.line.general_account_id: {11: None}, account.analytic.line.is_so_line_edited: {11: False}, account.analytic.line.journal_id: {11: None}, account.analytic.line.manager_id: {11: None}, account.analytic.line.move_line_id: {11: None}, account.analytic.line.name: {11: '/'}, account.analytic.line.order_id: {11: None}, account.analytic.line.partner_id: {11: 9}, account.analytic.line.plan_id: {11: 1}, account.analytic.line.product_id: {11: None}, account.analytic.line.product_uom_id: {11: 4}, account.analytic.line.project_id: {11: 7}, account.analytic.line.ref: {11: None}, account.analytic.line.so_line: {11: None}, account.analytic.line.task_id: {11: 9}, account.analytic.line.timesheet_invoice_id: {11: None}, account.analytic.line.timesheet_invoice_type: {11*: 'non_billable'}, account.analytic.line.unit_amount: {11: 1.0}, account.analytic.line.user_id: {11: 2}, account.analytic.line.write_date: {11: datetime.datetime(2023, 10, 4, 7, 43, 20, 753551)}, account.analytic.line.write_uid: {11: 2}, project.project.access_token: {7: None}, project.project.active: {7: True}, project.project.alias_id: {7: 9}, project.project.allocated_hours: {7: 1.0}, project.project.allow_billable: {7: True}, project.project.allow_milestones: {7: True}, project.project.allow_recurring_tasks: {7: True}, project.project.allow_subtasks: {7: True}, project.project.allow_task_dependencies: {7: True}, project.project.allow_timesheets: {7: True}, project.project.analytic_account_id: {7: 7}, project.project.color: {7: None}, project.project.company_id: {7: 1}, project.project.create_date: {7: datetime.datetime(2023, 10, 4, 7, 43, 1, 447676)}, project.project.create_uid: {7: 2}, project.project.date: {7: None}, project.project.date_start: {7: None}, project.project.description: {7: None}, project.project.label_tasks: {7: {'en_US': 'Tasks'}}, project.project.last_update_id: {7: None}, project.project.last_update_status: {7: 'to_define'}, project.project.message_main_attachment_id: {7: None}, project.project.name: {7: {'en_US': 'S00006 - dịch vụ tùy biến'}}, project.project.partner_email: {7: 'sfsdf@gmail.com'}, project.project.partner_id: {7: 9}, project.project.partner_phone: {7: None}, project.project.privacy_visibility: {7: 'portal'}, project.project.rating_active: {7: True}, project.project.rating_request_deadline: {7: datetime.datetime(2023, 11, 3, 7, 43, 1, 670853)}, project.project.rating_status: {7: 'stage'}, project.project.rating_status_period: {7: 'monthly'}, project.project.sale_line_id: {7: None}, project.project.sale_order_id: {7: None}, project.project.sequence: {7: 10}, project.project.stage_id: {7: 1}, project.project.task_properties_definition: {7: None}, project.project.timesheet_product_id: {7: 2}, project.project.user_id: {7: 2}, project.project.write_date: {7: datetime.datetime(2023, 10, 4, 7, 43, 1, 447676)}, project.project.write_uid: {7: 2}, project.task.access_token: {9: 'f9496a2a-7ec8-4bc4-be40-86aceff46b11'}, project.task.active: {9: True}, project.task.allow_billable: {9: True}, project.task.analytic_account_id: {9: 7}, project.task.ancestor_id: {9: None}, project.task.color: {9: None}, project.task.commercial_partner_id: {9: 9}, project.task.company_id: {9: 1}, project.task.create_date: {9: datetime.datetime(2023, 10, 4, 7, 43, 1, 447676)}, project.task.create_uid: {9: 2}, project.task.date_assign: {9: None}, project.task.date_deadline: {9: None}, project.task.date_end: {9: None}, project.task.date_last_stage_update: {9: datetime.datetime(2023, 10, 4, 7, 43, 1)}, project.task.description: {9: ''}, project.task.display_project_id: {9: 7}, project.task.displayed_image_id: {9: None}, project.task.effective_hours: {9: 1.0}, project.task.email_cc: {9: None}, project.task.email_from: {9: 'sfsdf@gmail.com'}, project.task.is_analytic_account_id_changed: {9: False}, project.task.is_blocked: {9: False}, project.task.is_closed: {9: False}, project.task.kanban_state: {9: 'normal'}, project.task.message_main_attachment_id: {9: None}, project.task.milestone_id: {9: None}, project.task.name: {9: 'dịch vụ tùy biến'}, project.task.overtime: {9: 0.0}, project.task.parent_id: {9: None}, project.task.partner_email: {9: 'sfsdf@gmail.com'}, project.task.partner_id: {9: 9}, project.task.partner_phone: {9: None}, project.task.planned_hours: {9: 1.0}, project.task.priority: {9: '0'}, project.task.progress: {9: 100.0}, project.task.project_id: {9: 7}, project.task.rating_last_value: {9: 0.0}, project.task.recurrence_id: {9: None}, project.task.recurring_task: {9: None}, project.task.remaining_hours: {9: 0.0}, project.task.sale_line_id: {9: None}, project.task.sale_order_id: {9: None}, project.task.sequence: {9: 10}, project.task.stage_id: {9: 14}, project.task.subtask_effective_hours: {9: 0.0}, project.task.total_hours_spent: {9: 1.0}, project.task.working_days_close: {9: 0.0}, project.task.working_days_open: {9: 0.0}, project.task.working_hours_close: {9: 0.0}, project.task.working_hours_open: {9: 0.0}, project.task.write_date: {9: datetime.datetime(2023, 10, 4, 7, 43, 20, 753551)}, project.task.write_uid: {9: 2}, res.partner.active: {9: True}, res.partner.additional_info: {9: None}, res.partner.city: {9: None}, res.partner.color: {9: 0}, res.partner.comment: {9: None}, res.partner.commercial_company_name: {9: None}, res.partner.commercial_partner_id: {9: 9}, res.partner.company_id: {9: None}, res.partner.company_name: {9: None}, res.partner.company_registry: {9: None}, res.partner.country_id: {9: None}, res.partner.create_date: {9: datetime.datetime(2023, 10, 4, 4, 55, 42, 360314)}, res.partner.create_uid: {9: 2}, res.partner.customer_rank: {9: 4}, res.partner.date: {9: None}, res.partner.debit_limit: {9: None}, res.partner.display_name: {9: 'KH 01'}, res.partner.email: {9: 'sfsdf@gmail.com'}, res.partner.email_normalized: {9: 'sfsdf@gmail.com'}, res.partner.employee: {9: None}, res.partner.function: {9: None}, res.partner.industry_id: {9: None}, res.partner.invoice_warn: {9: 'no-message'}, res.partner.invoice_warn_msg: {9: None}, res.partner.is_company: {9: False}, res.partner.lang: {9: 'en_US'}, res.partner.last_time_entries_checked: {9: None}, res.partner.message_bounce: {9: 0}, res.partner.message_main_attachment_id: {9: None}, res.partner.mobile: {9: None}, res.partner.name: {9: 'KH 01'}, res.partner.parent_id: {9: None}, res.partner.partner_gid: {9: 0}, res.partner.partner_latitude: {9: None}, res.partner.partner_longitude: {9: None}, res.partner.partner_share: {9: True}, res.partner.phone: {9: None}, res.partner.phone_sanitized: {9: None}, res.partner.ref: {9: None}, res.partner.sale_warn: {9: 'no-message'}, res.partner.sale_warn_msg: {9: None}, res.partner.signup_expiration: {9: None}, res.partner.signup_token: {9: None}, res.partner.signup_type: {9: None}, res.partner.state_id: {9: None}, res.partner.street: {9: None}, res.partner.street2: {9: None}, res.partner.supplier_rank: {9: 0}, res.partner.team_id: {9: None}, res.partner.title: {9: None}, res.partner.type: {9: 'contact'}, res.partner.tz: {9: 'Asia/Saigon'}, res.partner.user_id: {9: None}, res.partner.vat: {9: None}, res.partner.website: {9: None}, res.partner.write_date: {9: datetime.datetime(2023, 10, 4, 6, 41, 22, 651680)}, res.partner.write_uid: {9: 2}, res.partner.zip: {9: None}}

The above server error caused the following client error:
null
```





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
