### PR TITLE
[REF] *: remove owl from linter's accepted global variables

### DIFF
--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -9,8 +9,7 @@ import { parseDate, formatDate } from "@web/core/l10n/dates";
 
 import { formatMonetary } from "@web/views/fields/formatters";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class AccountPaymentPopOver extends Component {}
 AccountPaymentPopOver.props = {

--- a/addons/account/static/src/components/account_resequence/account_resequence_field.js
+++ b/addons/account/static/src/components/account_resequence/account_resequence_field.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class ChangeLine extends Component {}
 ChangeLine.template = "account.ResequenceChangeLine";

--- a/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.js
+++ b/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class ListItem extends Component {}
 ListItem.template = "account.GroupedItemTemplate";

--- a/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.js
+++ b/addons/account/static/src/components/journal_dashboard_activity/journal_dashboard_activity.js
@@ -4,8 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class JournalDashboardActivity extends Component {
     static props = { ...standardFieldProps };

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.js
@@ -4,9 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { FileInput } from "@web/core/file_input/file_input";
-
-const { Component, onWillUnmount } = owl;
-
+import { Component, onWillUnmount } from "@odoo/owl";
 
 export class MailAttachments extends Component {
     static template = "account.mail_attachments";

--- a/addons/account/static/src/components/open_move_widget/open_move_widget.js
+++ b/addons/account/static/src/components/open_move_widget/open_move_widget.js
@@ -3,8 +3,7 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class OpenMoveWidget extends Component {
     static props = { ...standardFieldProps };

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -6,8 +6,7 @@ import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field"
 import { TextField, ListTextField } from "@web/views/fields/text/text_field";
 import { CharField } from "@web/views/fields/char/char_field";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-const { Component, useEffect } = owl;
+import { Component, useEffect } from "@odoo/owl";
 
 export class SectionAndNoteListRenderer extends ListRenderer {
     /**

--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -6,8 +6,15 @@ import { parseFloat } from "@web/views/fields/parsers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { registry } from "@web/core/registry";
 import { getCurrency } from "@web/core/currency";
-
-const { Component, onPatched, onWillUpdateProps, onWillRender, toRaw, useRef, useState } = owl;
+import {
+    Component,
+    onPatched,
+    onWillUpdateProps,
+    onWillRender,
+    toRaw,
+    useRef,
+    useState,
+} from "@odoo/owl";
 
 /**
  A line of some TaxTotalsComponent, giving the values of a tax group.

--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -17,8 +17,14 @@ import { useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import { parseFloat as oParseFloat } from "@web/views/fields/parsers";
 import { formatPercentage } from "@web/views/fields/formatters";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
-
-const { Component, useState, useRef, useExternalListener, onWillStart, onPatched } = owl;
+import {
+    Component,
+    useState,
+    useRef,
+    useExternalListener,
+    onWillStart,
+    onPatched,
+} from "@odoo/owl";
 
 const PLAN_APPLICABILITY = {
     mandatory: _t("Mandatory"),

--- a/addons/auth_password_policy/static/src/password_field.js
+++ b/addons/auth_password_policy/static/src/password_field.js
@@ -8,8 +8,7 @@ import { useInputField } from "@web/views/fields/input_field_hook";
 
 import { recommendations, ConcretePolicy } from "./password_policy";
 import { Meter } from "./password_meter";
-
-const { Component, onWillStart, useState } = owl;
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class PasswordField extends Component {
     setup() {

--- a/addons/auth_password_policy/static/src/password_meter.js
+++ b/addons/auth_password_policy/static/src/password_meter.js
@@ -2,8 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { computeScore } from "./password_policy";
-
-const { Component, xml } = owl;
+import { Component, xml } from "@odoo/owl";
 
 export class Meter extends Component {
     get title() {

--- a/addons/barcodes/static/src/barcode_handler_field.js
+++ b/addons/barcodes/static/src/barcode_handler_field.js
@@ -3,8 +3,7 @@
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useBus, useService } from "@web/core/utils/hooks";
-
-const { Component, xml } = owl;
+import { Component, xml } from "@odoo/owl";
 
 export class BarcodeHandlerField extends Component {
     setup() {

--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -3,8 +3,7 @@
 import { isBrowserChrome, isMobileOS } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { session } from "@web/session";
-
-const { EventBus, whenReady } = owl;
+import { EventBus, whenReady } from "@odoo/owl";
 
 function isEditable(element) {
     return element.matches('input,textarea,[contenteditable="true"]');

--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -17,8 +17,7 @@ import { registry } from "@web/core/registry";
 import { uiService } from "@web/core/ui/ui_service";
 import { getFixture, mount, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { BaseAutomationErrorDialog } from "@base_automation/base_automation_error_dialog";
-
-const { toRaw } = owl;
+import { toRaw } from "@odoo/owl";
 
 const serviceRegistry = registry.category("services");
 

--- a/addons/base_iban/static/src/components/iban_widget/iban_widget.js
+++ b/addons/base_iban/static/src/components/iban_widget/iban_widget.js
@@ -4,8 +4,8 @@ import { registry } from "@web/core/registry";
 import { CharField, charField } from "@web/views/fields/char/char_field";
 import { useDebounced } from "@web/core/utils/timing";
 import { useService } from "@web/core/utils/hooks";
+import { useState } from "@odoo/owl";
 
-const { useState } = owl;
 export const DELAY = 400;
 
 export class IbanWidget extends CharField {

--- a/addons/board/static/src/add_to_board/add_to_board.js
+++ b/addons/board/static/src/add_to_board/add_to_board.js
@@ -4,8 +4,8 @@ import { _t } from "@web/core/l10n/translation";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { registry } from "@web/core/registry";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { Component, useState } from "@odoo/owl";
 
-const { Component, useState } = owl;
 const cogMenuRegistry = registry.category("cogMenu");
 
 /**

--- a/addons/board/static/src/board_action.js
+++ b/addons/board/static/src/board_action.js
@@ -3,8 +3,7 @@
 import { useService } from "@web/core/utils/hooks";
 import { View } from "@web/views/view";
 import { makeContext } from "@web/core/context";
-
-const { Component, onWillStart } = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 export class BoardAction extends Component {
     setup() {

--- a/addons/board/static/src/board_controller.js
+++ b/addons/board/static/src/board_controller.js
@@ -10,8 +10,7 @@ import { renderToString } from "@web/core/utils/render";
 import { useSortable } from "@web/core/utils/sortable";
 import { standardViewProps } from "@web/views/standard_view_props";
 import { BoardAction } from "./board_action";
-
-const { blockDom, Component, useState, useRef } = owl;
+import { blockDom, Component, useState, useRef } from "@odoo/owl";
 
 export class BoardController extends Component {
     setup() {

--- a/addons/bus/static/src/multi_tab_service.js
+++ b/addons/bus/static/src/multi_tab_service.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { browser } from "@web/core/browser/browser";
-
-const { EventBus } = owl;
+import { EventBus } from "@odoo/owl";
 
 let multiTabId = 0;
 /**

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -6,8 +6,7 @@ import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { isIosApp } from "@web/core/browser/feature_detection";
 import { WORKER_VERSION } from "@bus/workers/websocket_worker";
-
-const { EventBus } = owl;
+import { EventBus } from "@odoo/owl";
 
 /**
  * Communicate with a SharedWorker in order to provide a single websocket

--- a/addons/calendar/static/src/components/calendar_provider_config/calendar_connect_provider.js
+++ b/addons/calendar/static/src/components/calendar_provider_config/calendar_connect_provider.js
@@ -1,28 +1,27 @@
 /** @odoo-module **/
 
-import { registry } from '@web/core/registry';
+import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 import { useService } from "@web/core/utils/hooks";
+import { Component } from "@odoo/owl";
 
-const { Component } = owl;
 const providerData = {
-    'google': {
-        'restart_sync_method': 'restart_google_synchronization',
-        'sync_route': '/google_calendar/sync_data'
+    google: {
+        restart_sync_method: "restart_google_synchronization",
+        sync_route: "/google_calendar/sync_data",
     },
-    'microsoft': {
-        'restart_sync_method': 'restart_microsoft_synchronization',
-        'sync_route': '/microsoft_calendar/sync_data'
-    }
-}
-
+    microsoft: {
+        restart_sync_method: "restart_microsoft_synchronization",
+        sync_route: "/microsoft_calendar/sync_data",
+    },
+};
 
 export class CalendarConnectProvider extends Component {
     setup() {
         super.setup();
-        this.orm = useService('orm');
-        this.rpc = useService('rpc');
+        this.orm = useService("orm");
+        this.rpc = useService("rpc");
     }
 
     /**
@@ -34,27 +33,22 @@ export class CalendarConnectProvider extends Component {
     async onConnect(ev) {
         ev.preventDefault();
         ev.stopImmediatePropagation();
-        if (!await this.props.record.save()) {
-            return;  // handled by view
+        if (!(await this.props.record.save())) {
+            return; // handled by view
         }
         await this.orm.call(
             this.props.record.resModel,
-            'action_calendar_prepare_external_provider_sync',
+            "action_calendar_prepare_external_provider_sync",
             [this.props.record.resId]
-        )
+        );
         // See google/microsoft_calendar for the origin of this shortened version
-        const { restart_sync_method, sync_route } = providerData[this.props.record.data.external_calendar_provider];
-        await this.orm.call(
-            'res.users',
-            restart_sync_method,
-            [[session.uid]]
-        );
-        const response = await this.rpc(
-            sync_route, {
-                model: 'calendar.event',
-                fromurl: window.location.href,
-            }
-        );
+        const { restart_sync_method, sync_route } =
+            providerData[this.props.record.data.external_calendar_provider];
+        await this.orm.call("res.users", restart_sync_method, [[session.uid]]);
+        const response = await this.rpc(sync_route, {
+            model: "calendar.event",
+            fromurl: window.location.href,
+        });
         await this._beforeLeaveContext();
         if (response.status === "need_auth") {
             window.location.assign(response.url);
@@ -74,7 +68,7 @@ export class CalendarConnectProvider extends Component {
 CalendarConnectProvider.props = {
     ...standardWidgetProps,
 };
-CalendarConnectProvider.template = 'calendar.CalendarConnectProvider';
+CalendarConnectProvider.template = "calendar.CalendarConnectProvider";
 
 const calendarConnectProvider = {
     component: CalendarConnectProvider,

--- a/addons/calendar/static/src/views/ask_recurrence_update_policy_dialog.js
+++ b/addons/calendar/static/src/views/ask_recurrence_update_policy_dialog.js
@@ -2,8 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { Dialog } from "@web/core/dialog/dialog";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class AskRecurrenceUpdatePolicyDialog extends Component {
     setup() {
@@ -24,7 +23,7 @@ export class AskRecurrenceUpdatePolicyDialog extends Component {
     }
 
     get selected() {
-        return Object.entries(this.possibleValues).find(state => state[1].checked)[0];
+        return Object.entries(this.possibleValues).find((state) => state[1].checked)[0];
     }
 
     set selected(val) {

--- a/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_controller.js
@@ -2,8 +2,7 @@
 
 import { FormController } from "@web/views/form/form_controller";
 import { useService } from "@web/core/utils/hooks";
-
-const { onWillStart } = owl;
+import { onWillStart } from "@odoo/owl";
 
 export class CalendarFormController extends FormController {
     setup() {
@@ -13,24 +12,24 @@ export class CalendarFormController extends FormController {
         onWillStart(async () => {
             this.discussVideocallLocation = await ormService.call(
                 "calendar.event",
-                "get_discuss_videocall_location",
+                "get_discuss_videocall_location"
             );
         });
     }
-    
+
     /**
      * @override
      */
     async beforeExecuteActionButton(clickParams) {
         const action = clickParams.name;
-        if (action == 'clear_videocall_location' || action === 'set_discuss_videocall_location') {
+        if (action == "clear_videocall_location" || action === "set_discuss_videocall_location") {
             let newVal = false;
-            let videoCallSource = 'custom'
+            let videoCallSource = "custom";
             let changes = {};
-            if (action === 'set_discuss_videocall_location') {
+            if (action === "set_discuss_videocall_location") {
                 newVal = this.discussVideocallLocation;
-                videoCallSource = 'discuss';
-                changes.access_token = this.discussVideocallLocation.split('/').pop();
+                videoCallSource = "discuss";
+                changes.access_token = this.discussVideocallLocation.split("/").pop();
             }
             changes = Object.assign(changes, {
                 videocall_location: newVal,

--- a/addons/delivery_mondialrelay/static/src/components/mondialrelay_field.js
+++ b/addons/delivery_mondialrelay/static/src/components/mondialrelay_field.js
@@ -6,8 +6,7 @@ import { loadJS } from "@web/core/assets";
 // temporary for OnNoResultReturned bug
 import { UncaughtCorsError } from "@web/core/errors/error_service";
 const errorHandlerRegistry = registry.category("error_handlers");
-
-const { Component, onWillRender, useEffect, useRef, useState, xml } = owl;
+import { Component, onWillRender, useEffect, useRef, useState, xml } from "@odoo/owl";
 
 const MONDIALRELAY_SCRIPT_URL = "https://widget.mondialrelay.com/parcelshop-picker/jquery.plugin.mondialrelay.parcelshoppicker.min.js"
 

--- a/addons/event/static/src/icon_selection_field/icon_selection_field.js
+++ b/addons/event/static/src/icon_selection_field/icon_selection_field.js
@@ -3,8 +3,7 @@
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class IconSelectionField extends Component {
     get icon() {

--- a/addons/hr/static/src/components/department_chart/department_chart.js
+++ b/addons/hr/static/src/components/department_chart/department_chart.js
@@ -1,20 +1,19 @@
 /** @odoo-module */
 
-import { registry } from '@web/core/registry';
+import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
-
-const { onWillStart, useState, onWillUpdateProps, Component } = owl;
+import { onWillStart, useState, onWillUpdateProps, Component } from "@odoo/owl";
 
 export class DepartmentChart extends Component {
     setup() {
         super.setup();
 
-        this.action = useService('action');
-        this.orm = useService('orm');
+        this.action = useService("action");
+        this.orm = useService("orm");
         this.state = useState({
-            hierarchy: {}
+            hierarchy: {},
         });
         onWillStart(async () => await this.fetchHierarchy(this.props.record.resId));
 
@@ -24,18 +23,20 @@ export class DepartmentChart extends Component {
     }
 
     async fetchHierarchy(departmentId) {
-        this.state.hierarchy = await this.orm.call('hr.department', 'get_department_hierarchy', [departmentId]);
+        this.state.hierarchy = await this.orm.call("hr.department", "get_department_hierarchy", [
+            departmentId,
+        ]);
     }
 
     openDepartmentEmployees(departmentId) {
-        this.action.doAction('hr.act_employee_from_department', {
+        this.action.doAction("hr.act_employee_from_department", {
             additionalContext: {
-                'active_id': departmentId,
-            }
+                active_id: departmentId,
+            },
         });
     }
 }
-DepartmentChart.template = 'hr.DepartmentChart';
+DepartmentChart.template = "hr.DepartmentChart";
 DepartmentChart.props = {
     ...standardWidgetProps,
 };

--- a/addons/hr/static/src/components/employee_chat/employee_chat.js
+++ b/addons/hr/static/src/components/employee_chat/employee_chat.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 import { useOpenChat } from "@mail/core/web/open_chat_hook";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class HrEmployeeChat extends Component {
     setup() {

--- a/addons/hr/static/src/views/archive_employee_hook.js
+++ b/addons/hr/static/src/views/archive_employee_hook.js
@@ -2,28 +2,30 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-
-const { useComponent } = owl;
+import { useComponent } from "@odoo/owl";
 
 export function useArchiveEmployee() {
     const component = useComponent();
     const action = useService("action");
     return (id) => {
-        action.doAction({
-            type: 'ir.actions.act_window',
-            name: _t('Employee Termination'),
-            res_model: 'hr.departure.wizard',
-            views: [[false, 'form']],
-            view_mode: 'form',
-            target: 'new',
-            context: {
-                'active_id': id,
-                'toggle_active': true,
-            }
-        }, {
-            onClose: async () => {
-                await component.model.load();
+        action.doAction(
+            {
+                type: "ir.actions.act_window",
+                name: _t("Employee Termination"),
+                res_model: "hr.departure.wizard",
+                views: [[false, "form"]],
+                view_mode: "form",
+                target: "new",
+                context: {
+                    active_id: id,
+                    toggle_active: true,
+                },
             },
-        });
-    }
+            {
+                onClose: async () => {
+                    await component.model.load();
+                },
+            }
+        );
+    };
 }

--- a/addons/hr_attendance/static/src/js/attendance_report_views.js
+++ b/addons/hr_attendance/static/src/js/attendance_report_views.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { graphView } from "@web/views/graph/graph_view";
 import { pivotView } from "@web/views/pivot/pivot_view";
-
-const { useComponent } = owl;
+import { useComponent } from "@odoo/owl";
 
 const viewRegistry = registry.category("views");
 

--- a/addons/hr_contract/static/src/widgets/tooltip_warning_widget.js
+++ b/addons/hr_contract/static/src/widgets/tooltip_warning_widget.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ContractWarningTooltip extends Component {
     get tooltipInfo() {

--- a/addons/hr_expense/static/src/components/expense_dashboard.js
+++ b/addons/hr_expense/static/src/components/expense_dashboard.js
@@ -2,8 +2,7 @@
 
 import { useService } from '@web/core/utils/hooks';
 import { getCurrency } from '@web/core/currency';
-
-const { Component, onWillStart, useState } = owl;
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class ExpenseDashboard extends Component {
 

--- a/addons/hr_expense/static/src/mixins/document_upload.js
+++ b/addons/hr_expense/static/src/mixins/document_upload.js
@@ -2,8 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useBus, useService } from '@web/core/utils/hooks';
-
-const { useRef, useEffect, useState } = owl;
+import { useRef, useEffect, useState } from "@odoo/owl";
 
 export const ExpenseDocumentDropZone = (T) => class ExpenseDocumentDropZone extends T {
     setup() {

--- a/addons/hr_expense/static/src/mixins/qrcode.js
+++ b/addons/hr_expense/static/src/mixins/qrcode.js
@@ -2,8 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-
-const { onMounted, onPatched, useRef } = owl;
+import { onMounted, onPatched, useRef } from "@odoo/owl";
 
 export const ExpenseMobileQRCode = (T) => class ExpenseMobileQRCode extends T {
     setup() {

--- a/addons/hr_expense/static/src/views/list.js
+++ b/addons/hr_expense/static/src/views/list.js
@@ -10,8 +10,7 @@ import { listView } from "@web/views/list/list_view";
 
 import { ListController } from "@web/views/list/list_controller";
 import { ListRenderer } from "@web/views/list/list_renderer";
-
-const { onWillStart } = owl;
+import { onWillStart } from "@odoo/owl";
 
 export class ExpenseListController extends ExpenseDocumentUpload(ListController) {
     setup() {

--- a/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.js
+++ b/addons/hr_fleet/static/src/views/hr_fleet_kanban/hr_fleet_kanban_controller.js
@@ -2,8 +2,7 @@
 
 import { KanbanController } from "@web/views/kanban/kanban_controller";
 import { useBus, useService } from "@web/core/utils/hooks";
-
-const { useRef } = owl;
+import { useRef } from "@odoo/owl";
 
 export class HrFleetKanbanController extends KanbanController {
     setup() {

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -1,18 +1,29 @@
 /* @odoo-module */
 
 import { usePopover } from "@web/core/popover/popover_hook";
-import { useNewAllocationRequest } from '@hr_holidays/views/hooks';
-
-const { Component } = owl;
+import { useNewAllocationRequest } from "@hr_holidays/views/hooks";
+import { Component } from "@odoo/owl";
 
 export class TimeOffCardPopover extends Component {}
 
-TimeOffCardPopover.template = 'hr_holidays.TimeOffCardPopover';
-TimeOffCardPopover.props = ['allocated', 'approved', 'planned', 'left', 'employeeId', 'holidayStatusId', 'close?', 'onClickNewAllocationRequest?'];
+TimeOffCardPopover.template = "hr_holidays.TimeOffCardPopover";
+TimeOffCardPopover.props = [
+    "allocated",
+    "approved",
+    "planned",
+    "left",
+    "employeeId",
+    "holidayStatusId",
+    "close?",
+    "onClickNewAllocationRequest?",
+];
 
 export class TimeOffCard extends Component {
     setup() {
-        this.popover = usePopover(TimeOffCardPopover, { position: "right", popoverClass: "bg-view" });
+        this.popover = usePopover(TimeOffCardPopover, {
+            position: "right",
+            popoverClass: "bg-view",
+        });
         this.newAllocationRequest = useNewAllocationRequest();
     }
 
@@ -35,9 +46,9 @@ export class TimeOffCard extends Component {
     }
 }
 
-TimeOffCard.template = 'hr_holidays.TimeOffCard';
-TimeOffCard.props = ['name', 'data', 'requires_allocation', 'employeeId', 'holidayStatusId'];
+TimeOffCard.template = "hr_holidays.TimeOffCard";
+TimeOffCard.props = ["name", "data", "requires_allocation", "employeeId", "holidayStatusId"];
 
 export class TimeOffCardMobile extends TimeOffCard {}
 
-TimeOffCardMobile.template = 'hr_holidays.TimeOffCardMobile';
+TimeOffCardMobile.template = "hr_holidays.TimeOffCardMobile";

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -1,10 +1,9 @@
 /* @odoo-module */
 
-import { TimeOffCard } from './time_off_card';
-import { useNewAllocationRequest } from '@hr_holidays/views/hooks';
+import { TimeOffCard } from "./time_off_card";
+import { useNewAllocationRequest } from "@hr_holidays/views/hooks";
 import { useBus, useService } from "@web/core/utils/hooks";
-
-const { Component, useState, onWillStart } = owl;
+import { Component, useState, onWillStart } from "@odoo/owl";
 
 export class TimeOffDashboard extends Component {
     setup() {
@@ -13,8 +12,8 @@ export class TimeOffDashboard extends Component {
         this.state = useState({
             holidays: [],
         });
-        useBus(this.env.timeOffBus, 'update_dashboard', async () => {
-            await this.loadDashboardData()
+        useBus(this.env.timeOffBus, "update_dashboard", async () => {
+            await this.loadDashboardData();
         });
 
         onWillStart(async () => {
@@ -25,17 +24,12 @@ export class TimeOffDashboard extends Component {
     async loadDashboardData() {
         const context = {};
         if (this.props.employeeId !== null) {
-            context['employee_id'] = this.props.employeeId;
+            context["employee_id"] = this.props.employeeId;
         }
 
-        this.state.holidays = await this.orm.call(
-            'hr.leave.type',
-            'get_days_all_request',
-            [],
-            {
-                context: context
-            }
-        );
+        this.state.holidays = await this.orm.call("hr.leave.type", "get_days_all_request", [], {
+            context: context,
+        });
     }
     async newAllocationRequest() {
         await this.newRequest(this.props.employeeId);
@@ -43,5 +37,5 @@ export class TimeOffDashboard extends Component {
 }
 
 TimeOffDashboard.components = { TimeOffCard };
-TimeOffDashboard.template = 'hr_holidays.TimeOffDashboard';
-TimeOffDashboard.props = ['employeeId'];
+TimeOffDashboard.template = "hr_holidays.TimeOffDashboard";
+TimeOffDashboard.props = ["employeeId"];

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.js
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.js
@@ -5,13 +5,13 @@ import { useService } from "@web/core/utils/hooks";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 
 import { formatDate } from "@web/core/l10n/dates";
+import { Component, useState, onWillStart } from "@odoo/owl";
 
-const { Component, useState, onWillStart } = owl;
 const { DateTime } = luxon;
 
 export class LeaveStatsComponent extends Component {
     setup() {
-        this.orm = useService('orm');
+        this.orm = useService("orm");
 
         this.state = useState({
             leaves: [],
@@ -53,7 +53,7 @@ export class LeaveStatsComponent extends Component {
     }
 
     get thisYear() {
-        return this.date.toFormat('yyyy');
+        return this.date.toFormat("yyyy");
     }
 
     async loadDepartmentLeaves(date, department, employee) {
@@ -62,25 +62,25 @@ export class LeaveStatsComponent extends Component {
             return;
         }
 
-        const dateFrom = date.startOf('month');
-        const dateTo = date.endOf('month');
+        const dateFrom = date.startOf("month");
+        const dateTo = date.endOf("month");
 
         const departmentLeaves = await this.orm.searchRead(
-            'hr.leave',
+            "hr.leave",
             [
-                ['department_id', '=', department[0]],
-                ['state', '=', 'validate'],
-                ['holiday_type', '=', 'employee'],
-                ['date_from', '<=', dateTo],
-                ['date_to', '>=', dateFrom],
+                ["department_id", "=", department[0]],
+                ["state", "=", "validate"],
+                ["holiday_type", "=", "employee"],
+                ["date_from", "<=", dateTo],
+                ["date_to", ">=", dateFrom],
             ],
-            ['employee_id', 'date_from', 'date_to', 'number_of_days'],
+            ["employee_id", "date_from", "date_to", "number_of_days"]
         );
 
         this.state.departmentLeaves = departmentLeaves.map((leave) => {
             return Object.assign({}, leave, {
-                dateFrom: formatDate(DateTime.fromSQL(leave.date_from, { zone: 'utc' }).toLocal()),
-                dateTo: formatDate(DateTime.fromSQL(leave.date_to, { zone: 'utc' }).toLocal()),
+                dateFrom: formatDate(DateTime.fromSQL(leave.date_from, { zone: "utc" }).toLocal()),
+                dateTo: formatDate(DateTime.fromSQL(leave.date_to, { zone: "utc" }).toLocal()),
                 sameEmployee: leave.employee_id[0] === employee[0],
             });
         });
@@ -92,25 +92,25 @@ export class LeaveStatsComponent extends Component {
             return;
         }
 
-        const dateFrom = date.startOf('year');
-        const dateTo = date.endOf('year');
+        const dateFrom = date.startOf("year");
+        const dateTo = date.endOf("year");
         this.state.leaves = await this.orm.readGroup(
-            'hr.leave',
+            "hr.leave",
             [
-                ['employee_id', '=', employee[0]],
-                ['state', '=', 'validate'],
-                ['date_from', '<=', dateTo],
-                ['date_to', '>=', dateFrom]
+                ["employee_id", "=", employee[0]],
+                ["state", "=", "validate"],
+                ["date_from", "<=", dateTo],
+                ["date_to", ">=", dateFrom],
             ],
-            ['holiday_status_id', 'number_of_days:sum'],
-            ['holiday_status_id'],
+            ["holiday_status_id", "number_of_days:sum"],
+            ["holiday_status_id"]
         );
     }
 }
 
-LeaveStatsComponent.template = 'hr_holidays.LeaveStatsComponent';
+LeaveStatsComponent.template = "hr_holidays.LeaveStatsComponent";
 
 export const leaveStatsComponent = {
     component: LeaveStatsComponent,
 };
-registry.category('view_widgets').add('hr_leave_stats', leaveStatsComponent);
+registry.category("view_widgets").add("hr_leave_stats", leaveStatsComponent);

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -2,17 +2,16 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { CalendarController } from '@web/views/calendar/calendar_controller';
-import { FormViewDialog } from '@web/views/view_dialogs/form_view_dialog';
+import { CalendarController } from "@web/views/calendar/calendar_controller";
+import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { Dropdown, DropdownItem } from "@web/core/dropdown/dropdown";
 
 import { serializeDate } from "@web/core/l10n/dates";
 
-import { TimeOffCalendarFilterPanel } from './filter_panel/calendar_filter_panel';
-import { TimeOffFormViewDialog } from '../view_dialog/form_view_dialog';
-import { useLeaveCancelWizard } from '../hooks';
-
-const { EventBus, useSubEnv } = owl;
+import { TimeOffCalendarFilterPanel } from "./filter_panel/calendar_filter_panel";
+import { TimeOffFormViewDialog } from "../view_dialog/form_view_dialog";
+import { useLeaveCancelWizard } from "../hooks";
+import { EventBus, useSubEnv } from "@odoo/owl";
 
 export class TimeOffCalendarController extends CalendarController {
     setup() {
@@ -37,24 +36,26 @@ export class TimeOffCalendarController extends CalendarController {
     newTimeOffRequest() {
         const context = {};
         if (this.employeeId) {
-            context['default_employee_id'] = this.employeeId;
+            context["default_employee_id"] = this.employeeId;
         }
-        if (this.model.meta.scale == 'day') {
-            context['default_date_from'] = serializeDate(
-                this.model.data.range.start.set({ hours: 7 }), "datetime"
+        if (this.model.meta.scale == "day") {
+            context["default_date_from"] = serializeDate(
+                this.model.data.range.start.set({ hours: 7 }),
+                "datetime"
             );
-            context['default_date_to'] = serializeDate(
-                this.model.data.range.end.set({ hours: 19 }), "datetime"
+            context["default_date_to"] = serializeDate(
+                this.model.data.range.end.set({ hours: 19 }),
+                "datetime"
             );
         }
 
         this.displayDialog(FormViewDialog, {
-            resModel: 'hr.leave',
-            title: _t('New Time Off'),
+            resModel: "hr.leave",
+            title: _t("New Time Off"),
             viewId: this.model.formViewId,
             onRecordSaved: () => {
                 this.model.load();
-                this.env.timeOffBus.trigger('update_dashboard');
+                this.env.timeOffBus.trigger("update_dashboard");
             },
             context: context,
         });
@@ -67,14 +68,14 @@ export class TimeOffCalendarController extends CalendarController {
                 body: _t("Are you sure you want to delete this record?"),
                 confirm: async () => {
                     await this.model.unlinkRecord(record.resId);
-                    this.env.timeOffBus.trigger('update_dashboard');
+                    this.env.timeOffBus.trigger("update_dashboard");
                 },
                 cancel: () => {},
             });
         } else {
             this.leaveCancelWizard(record.resId, () => {
                 this.model.load();
-                this.env.timeOffBus.trigger('update_dashboard');
+                this.env.timeOffBus.trigger("update_dashboard");
             });
         }
     }
@@ -82,12 +83,13 @@ export class TimeOffCalendarController extends CalendarController {
     async editRecord(record, context = {}, shouldFetchFormViewId = true) {
         const onDialogClosed = () => {
             this.model.load();
-            this.env.timeOffBus.trigger('update_dashboard');
+            this.env.timeOffBus.trigger("update_dashboard");
         };
 
         return new Promise((resolve) => {
             this.displayDialog(
-                TimeOffFormViewDialog, {
+                TimeOffFormViewDialog,
+                {
                     resModel: this.model.resModel,
                     resId: record.id || false,
                     context,
@@ -96,7 +98,7 @@ export class TimeOffCalendarController extends CalendarController {
                     onRecordSaved: onDialogClosed,
                     onRecordDeleted: (record) => this.deleteRecord(record),
                     onLeaveCancelled: onDialogClosed,
-                    size: 'md',
+                    size: "md",
                 },
                 { onClose: () => resolve() }
             );

--- a/addons/hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/hr_holidays/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -2,18 +2,17 @@
 
 import { CalendarFilterPanel } from "@web/views/calendar/filter_panel/calendar_filter_panel";
 import { TimeOffCardMobile } from "../../../dashboard/time_off_card";
-import { getFormattedDateSpan } from '@web/views/calendar/utils';
+import { getFormattedDateSpan } from "@web/views/calendar/utils";
 
 import { useService } from "@web/core/utils/hooks";
 import { serializeDate } from "@web/core/l10n/dates";
-
-const { useState, onWillStart, onWillUpdateProps } = owl;
+import { useState, onWillStart, onWillUpdateProps } from "@odoo/owl";
 
 export class TimeOffCalendarFilterPanel extends CalendarFilterPanel {
     setup() {
         super.setup();
 
-        this.orm = useService('orm');
+        this.orm = useService("orm");
         this.getFormattedDateSpan = getFormattedDateSpan;
         this.leaveState = useState({
             holidays: [],
@@ -30,38 +29,38 @@ export class TimeOffCalendarFilterPanel extends CalendarFilterPanel {
 
     async updateSpecialDays() {
         const context = {
-            'employee_id': this.props.employee_id,
-        }
+            employee_id: this.props.employee_id,
+        };
         const specialDays = await this.orm.call(
-            'hr.employee', 'get_special_days_data', [
+            "hr.employee",
+            "get_special_days_data",
+            [
                 serializeDate(this.props.model.rangeStart, "datetime"),
                 serializeDate(this.props.model.rangeEnd, "datetime"),
             ],
             {
-                'context': context,
-            },
+                context: context,
+            }
         );
-        specialDays['bankHolidays'].forEach(bankHoliday => {
-            bankHoliday.start = luxon.DateTime.fromISO(bankHoliday.start)
-            bankHoliday.end = luxon.DateTime.fromISO(bankHoliday.end)
+        specialDays["bankHolidays"].forEach((bankHoliday) => {
+            bankHoliday.start = luxon.DateTime.fromISO(bankHoliday.start);
+            bankHoliday.end = luxon.DateTime.fromISO(bankHoliday.end);
         });
-        specialDays['mandatoryDays'].forEach(mandatoryDay => {
-            mandatoryDay.start = luxon.DateTime.fromISO(mandatoryDay.start)
-            mandatoryDay.end = luxon.DateTime.fromISO(mandatoryDay.end)
+        specialDays["mandatoryDays"].forEach((mandatoryDay) => {
+            mandatoryDay.start = luxon.DateTime.fromISO(mandatoryDay.start);
+            mandatoryDay.end = luxon.DateTime.fromISO(mandatoryDay.end);
         });
-        this.leaveState.bankHolidays = specialDays['bankHolidays'];
-        this.leaveState.mandatoryDays = specialDays['mandatoryDays'];
+        this.leaveState.bankHolidays = specialDays["bankHolidays"];
+        this.leaveState.mandatoryDays = specialDays["mandatoryDays"];
     }
 
     async loadFilterData() {
-        if(!this.env.isSmall) {
+        if (!this.env.isSmall) {
             return;
         }
 
         const filterData = {};
-        const data = await this.orm.call(
-            'hr.leave.type', 'get_days_all_request', [],
-        );
+        const data = await this.orm.call("hr.leave.type", "get_days_all_request", []);
 
         data.forEach((leave) => {
             filterData[leave[3]] = leave;
@@ -69,11 +68,11 @@ export class TimeOffCalendarFilterPanel extends CalendarFilterPanel {
         this.leaveState.holidays = filterData;
     }
 }
-TimeOffCalendarFilterPanel.template = 'hr_holidays.CalendarFilterPanel';
+TimeOffCalendarFilterPanel.template = "hr_holidays.CalendarFilterPanel";
 TimeOffCalendarFilterPanel.components = {
     ...TimeOffCalendarFilterPanel.components,
     TimeOffCardMobile,
-}
+};
 TimeOffCalendarFilterPanel.subTemplates = {
     filter: "hr_holidays.CalendarFilterPanel.filter",
-}
+};

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -1,14 +1,13 @@
 /** @odoo-module **/
 
 import { _t } from "@web/core/l10n/translation";
-import { CalendarYearRenderer } from '@web/views/calendar/calendar_year/calendar_year_renderer';
+import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar_year_renderer";
 
 import { useService } from "@web/core/utils/hooks";
-import { useMandatoryDays } from '../../hooks';
-import { useCalendarPopover } from '@web/views/calendar/hooks';
-import { TimeOffCalendarYearPopover } from './calendar_year_popover';
-
-const { useEffect } = owl;
+import { useMandatoryDays } from "../../hooks";
+import { useCalendarPopover } from "@web/views/calendar/hooks";
+import { TimeOffCalendarYearPopover } from "./calendar_year_popover";
+import { useEffect } from "@odoo/owl";
 
 export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
     setup() {
@@ -18,49 +17,64 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
         this.mandatoryDaysList = [];
         this.mandatoryDayPopover = useCalendarPopover(TimeOffCalendarYearPopover);
 
-        useEffect((el) => {
-            for (const week of el) {
-                const row = week.parentElement;
+        useEffect(
+            (el) => {
+                for (const week of el) {
+                    const row = week.parentElement;
 
-                // Remove the week number if the week is empty.
-                // FullCalendar always displays 6 weeks even when empty.
-                if (!row.children[1].classList.length &&
-                    !row.children[row.children.length - 1].classList.length) {
-                    row.remove();
+                    // Remove the week number if the week is empty.
+                    // FullCalendar always displays 6 weeks even when empty.
+                    if (
+                        !row.children[1].classList.length &&
+                        !row.children[row.children.length - 1].classList.length
+                    ) {
+                        row.remove();
+                    }
                 }
-            }
-        }, () => [this.rootRef.el && this.rootRef.el.querySelectorAll('.fc-content-skeleton td.fc-week-number')]);
+            },
+            () => [
+                this.rootRef.el &&
+                    this.rootRef.el.querySelectorAll(".fc-content-skeleton td.fc-week-number"),
+            ]
+        );
     }
 
     get options() {
         return Object.assign(super.options, {
             weekNumbers: true,
             weekNumbersWithinDays: false,
-            weekLabel: _t('Week'),
+            weekLabel: _t("Week"),
         });
     }
 
     /** @override **/
     async onDateClick(info) {
-        const is_mandatory_day = [...info.dayEl.classList].some(elClass => elClass.startsWith('hr_mandatory_day_'))
+        const is_mandatory_day = [...info.dayEl.classList].some((elClass) =>
+            elClass.startsWith("hr_mandatory_day_")
+        );
         this.mandatoryDayPopover.close();
         if (is_mandatory_day && !this.env.isSmall) {
             this.popover.close();
             const date = luxon.DateTime.fromISO(info.dateStr);
             const target = info.dayEl;
-            const mandatory_days_data = await this.orm.call("hr.employee", "get_mandatory_days_data", [date, date]);
-            mandatory_days_data.forEach(mandatory_day_data => {
-                mandatory_day_data['start'] = luxon.DateTime.fromISO(mandatory_day_data['start'])
-                mandatory_day_data['end'] = luxon.DateTime.fromISO(mandatory_day_data['end'])
+            const mandatory_days_data = await this.orm.call(
+                "hr.employee",
+                "get_mandatory_days_data",
+                [date, date]
+            );
+            mandatory_days_data.forEach((mandatory_day_data) => {
+                mandatory_day_data["start"] = luxon.DateTime.fromISO(mandatory_day_data["start"]);
+                mandatory_day_data["end"] = luxon.DateTime.fromISO(mandatory_day_data["end"]);
             });
             const records = Object.values(this.props.model.records).filter((r) =>
-            luxon.Interval.fromDateTimes(r.start.startOf("day"), r.end.endOf("day")).contains(date)
+                luxon.Interval.fromDateTimes(r.start.startOf("day"), r.end.endOf("day")).contains(
+                    date
+                )
             );
-            const props = this.getPopoverProps(date, records)
-            props['records'] = mandatory_days_data.concat(props['records'])
+            const props = this.getPopoverProps(date, records);
+            props["records"] = mandatory_days_data.concat(props["records"]);
             this.mandatoryDayPopover.open(target, props, "o_cw_popover");
-        }
-        else {
+        } else {
             super.onDateClick(info);
         }
     }

--- a/addons/hr_org_chart/static/src/fields/hr_org_chart.js
+++ b/addons/hr_org_chart/static/src/fields/hr_org_chart.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { onEmployeeSubRedirect } from './hooks';
-
-const { Component, onWillStart, onWillRender, useState } = owl;
+import { Component, onWillStart, onWillRender, useState } from "@odoo/owl";
 
 class HrOrgChartPopover extends Component {
     async setup() {

--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
-
-const { markup } = owl;
+import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('hr_recruitment_tour',{
     url: "/web",

--- a/addons/iap/static/src/action_buttons_widget/action_buttons_widget.js
+++ b/addons/iap/static/src/action_buttons_widget/action_buttons_widget.js
@@ -3,8 +3,7 @@
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class IAPActionButtonsWidget extends Component {
     setup() {

--- a/addons/iap/static/src/js/insufficient_credit_error_handler.js
+++ b/addons/iap/static/src/js/insufficient_credit_error_handler.js
@@ -3,8 +3,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
-
-const { Component, onWillStart } = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 class InsufficientCreditDialog extends Component {
     setup() {

--- a/addons/im_livechat/static/src/js/colors_reset_button/colors_reset_button.js
+++ b/addons/im_livechat/static/src/js/colors_reset_button/colors_reset_button.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ColorsResetButton extends Component {
     onColorsResetButtonClick() {

--- a/addons/loyalty/static/src/js/loyalty_list_view.js
+++ b/addons/loyalty/static/src/js/loyalty_list_view.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { listView } from "@web/views/list/list_view";
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { useService } from "@web/core/utils/hooks";
-
-const { Component, onWillStart } = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 export class LoyaltyActionHelper extends Component {
     setup() {

--- a/addons/lunch/static/src/components/lunch_dashboard.js
+++ b/addons/lunch/static/src/components/lunch_dashboard.js
@@ -2,8 +2,7 @@
 
 import { useBus, useService } from "@web/core/utils/hooks";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
-
-const { Component, useState, onWillStart, markup, xml } = owl;
+import { Component, useState, onWillStart, markup, xml } from "@odoo/owl";
 
 export class LunchCurrency extends Component {
     get amount() {

--- a/addons/lunch/static/src/views/search_model.js
+++ b/addons/lunch/static/src/views/search_model.js
@@ -4,9 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 
 import { Domain } from '@web/core/domain';
 import { SearchModel } from '@web/search/search_model';
-
-const { useState, onWillStart } = owl;
-
+import { useState, onWillStart } from "@odoo/owl";
 
 export class LunchSearchModel extends SearchModel {
     setup() {

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -1,7 +1,7 @@
 /* @odoo-module */
 
 import { useSequential } from "@mail/utils/common/hooks";
-import { useComponent, useEffect, useState } from "@odoo/owl";
+import { status, useComponent, useEffect, useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 
@@ -171,7 +171,7 @@ export function useSuggestion() {
                 await suggestionService.fetchSuggestions(self.search, {
                     thread: self.thread,
                 });
-                if (owl.status(comp) === "destroyed") {
+                if (status(comp) === "destroyed") {
                     return;
                 }
                 self.update();

--- a/addons/mail/static/src/discuss/voice_message/common/voice_player.js
+++ b/addons/mail/static/src/discuss/voice_message/common/voice_player.js
@@ -1,5 +1,13 @@
 /* @odoo-module */
-import { Component, useState, onMounted, onWillUnmount, useEffect, useRef } from "@odoo/owl";
+import {
+    Component,
+    useState,
+    onMounted,
+    onWillUnmount,
+    useEffect,
+    useRef,
+    status,
+} from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
@@ -282,7 +290,7 @@ export class VoicePlayer extends Component {
     }
 
     addOnAudioProcess() {
-        if (owl.status(this) === "destroyed") {
+        if (status(this) === "destroyed") {
             return;
         }
         const time = this.getCurrentTime();

--- a/addons/mail/static/src/js/onchange_on_keydown.js
+++ b/addons/mail/static/src/js/onchange_on_keydown.js
@@ -5,8 +5,7 @@ import { useDebounced } from "@web/core/utils/timing";
 import { charField, CharField } from "@web/views/fields/char/char_field";
 import { textField, TextField } from "@web/views/fields/text/text_field";
 import { archParseBoolean } from "@web/views/utils";
-
-const { useEffect } = owl;
+import { useEffect } from "@odoo/owl";
 
 /**
  * Support a key-based onchange in text fields.

--- a/addons/mail/static/tests/helpers/patch_ui_size.js
+++ b/addons/mail/static/tests/helpers/patch_ui_size.js
@@ -3,6 +3,7 @@
 import { browser } from "@web/core/browser/browser";
 import { MEDIAS_BREAKPOINTS, SIZES, utils } from "@web/core/ui/ui_service";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { Component } from "@odoo/owl";
 
 /**
  * Return the width corresponding to the given size. If an upper and lower bound
@@ -45,7 +46,7 @@ function getSizeFromWidth(width) {
  * @param {number} width
  */
 function legacyPatchUiSize(height, width) {
-    const legacyEnv = owl.Component.env;
+    const legacyEnv = Component.env;
     patchWithCleanup(legacyEnv, {
         browser: {
             ...legacyEnv.browser,

--- a/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
+++ b/addons/mass_mailing/static/src/js/mailing_m2o_filter.js
@@ -6,8 +6,7 @@ import { registry } from '@web/core/registry';
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { useService } from "@web/core/utils/hooks";
 import { Many2OneField, many2OneField } from '@web/views/fields/many2one/many2one_field';
-
-const { useState, useEffect } = owl;
+import { useState, useEffect } from "@odoo/owl";
 
 export class MailingFilterDropdown extends Dropdown {
     setup() {

--- a/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
+++ b/addons/mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js
@@ -3,12 +3,7 @@
 import { registry } from "@web/core/registry";
 import { formView } from "@web/views/form/form_view";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
-
-const {
-    useSubEnv,
-    onMounted,
-    onWillUnmount,
-} = owl;
+import { useSubEnv, onMounted, onWillUnmount } from "@odoo/owl";
 
 export class MassMailingFullWidthViewController extends formView.Controller {
     setup() {

--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -14,8 +14,7 @@ import { MassMailingMobilePreviewDialog } from "./mass_mailing_mobile_preview";
 import { getRangePosition } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 import { MassMailingWysiwyg } from '@mass_mailing/js/mass_mailing_wysiwyg';
 import { utils as uiUtils } from "@web/core/ui/ui_service";
-
-const { useSubEnv, status } = owl;
+import { useSubEnv, status } from "@odoo/owl";
 
 export class MassMailingHtmlField extends HtmlField {
     static props = {

--- a/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
@@ -2,9 +2,7 @@
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { getBundle } from "@web/core/assets";
-
-const { useEffect, onWillStart } = owl;
-
+import { useEffect, onWillStart } from "@odoo/owl";
 
 export class MassMailingMobilePreviewDialog extends Dialog {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { BomOverviewControlPanel } from "../bom_overview_control_panel/mrp_bom_overview_control_panel";
 import { BomOverviewTable } from "../bom_overview_table/mrp_bom_overview_table";
-
-const { Component, EventBus, onWillStart, useSubEnv, useState } = owl;
+import { Component, EventBus, onWillStart, useSubEnv, useState } from "@odoo/owl";
 
 export class BomOverviewComponent extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.js
+++ b/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.js
@@ -3,8 +3,7 @@
 import { useBus } from "@web/core/utils/hooks";
 import { BomOverviewLine } from "../bom_overview_line/mrp_bom_overview_line";
 import { BomOverviewExtraBlock } from "../bom_overview_extra_block/mrp_bom_overview_extra_block";
-
-const { Component, onWillUnmount, onWillUpdateProps, useState } = owl;
+import { Component, onWillUnmount, onWillUpdateProps, useState } from "@odoo/owl";
 
 export class BomOverviewComponentsBlock extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -5,8 +5,7 @@ import { BomOverviewDisplayFilter } from "../bom_overview_display_filter/mrp_bom
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class BomOverviewControlPanel extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_display_filter/mrp_bom_overview_display_filter.js
+++ b/addons/mrp/static/src/components/bom_overview_display_filter/mrp_bom_overview_display_filter.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class BomOverviewDisplayFilter extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_extra_block/mrp_bom_overview_extra_block.js
+++ b/addons/mrp/static/src/components/bom_overview_extra_block/mrp_bom_overview_extra_block.js
@@ -3,8 +3,7 @@
 import { useBus } from "@web/core/utils/hooks";
 import { BomOverviewLine } from "../bom_overview_line/mrp_bom_overview_line";
 import { BomOverviewSpecialLine } from "../bom_overview_special_line/mrp_bom_overview_special_line";
-
-const { Component, onWillUnmount, onWillUpdateProps, useState } = owl;
+import { Component, onWillUnmount, onWillUpdateProps, useState } from "@odoo/owl";
 
 export class BomOverviewExtraBlock extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
@@ -4,8 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
 import { formatFloat } from "@web/core/utils/numbers";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class BomOverviewLine extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
@@ -2,8 +2,7 @@
 
 import { formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
 import { formatFloat } from "@web/core/utils/numbers";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class BomOverviewSpecialLine extends Component {
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.js
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.js
@@ -5,8 +5,7 @@ import { formatFloat } from "@web/core/utils/numbers";
 import { useService } from "@web/core/utils/hooks";
 import { BomOverviewLine } from "../bom_overview_line/mrp_bom_overview_line";
 import { BomOverviewComponentsBlock } from "../bom_overview_components_block/mrp_bom_overview_components_block";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class BomOverviewTable extends Component {
     setup() {

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 import { ForecastedButtons } from "@stock/stock_forecasted/forecasted_buttons";
 import { patch } from "@web/core/utils/patch";
-
-const { onWillStart } = owl;
+import { onWillStart } from "@odoo/owl";
 
 patch(ForecastedButtons.prototype, {
     setup() {

--- a/addons/mrp/static/src/views/fields/google_slides_viewer.js
+++ b/addons/mrp/static/src/views/fields/google_slides_viewer.js
@@ -4,8 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { CharField, charField } from "@web/views/fields/char/char_field";
-
-const { useState } = owl;
+import { useState } from "@odoo/owl";
 
 export function getGoogleSlideUrl(value, page) {
     let url = false;

--- a/addons/mrp/static/src/views/mrp_documents_kanban/mrp_documents_kanban_controller.js
+++ b/addons/mrp/static/src/views/mrp_documents_kanban/mrp_documents_kanban_controller.js
@@ -2,8 +2,7 @@
 
 import { KanbanController } from "@web/views/kanban/kanban_controller";
 import { useBus, useService } from "@web/core/utils/hooks";
-
-const { useRef } = owl;
+import { useRef } from "@odoo/owl";
 
 export class MrpDocumentsKanbanController extends KanbanController {
     setup() {

--- a/addons/mrp/static/src/widgets/mrp_consumed.js
+++ b/addons/mrp/static/src/widgets/mrp_consumed.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { FloatField, floatField } from '@web/views/fields/float/float_field';
-
-const { useRef, useEffect } = owl;
+import { useRef, useEffect } from "@odoo/owl";
 
 export class MrpConsumed extends FloatField {
     setup() {

--- a/addons/mrp/static/src/widgets/mrp_should_consume.js
+++ b/addons/mrp/static/src/widgets/mrp_should_consume.js
@@ -2,7 +2,8 @@
 
 import { FloatField, floatField } from "@web/views/fields/float/float_field";
 import { registry } from "@web/core/registry";
-import { formatFloat } from "@web/core/utils/numbers";;
+import { formatFloat } from "@web/core/utils/numbers";
+import { useRef, onPatched, onMounted, useState } from "@odoo/owl";
 
 /**
  * This widget is used to display alongside the total quantity to consume of a production order,
@@ -12,7 +13,6 @@ import { formatFloat } from "@web/core/utils/numbers";;
  * The widget will be '3.000 / 5.000'.
  */
 
-const { useRef, onPatched, onMounted, useState } = owl;
 export class MrpShouldConsumeOwl extends FloatField {
     setup() {
         super.setup();

--- a/addons/mrp/static/src/widgets/timer.js
+++ b/addons/mrp/static/src/widgets/timer.js
@@ -5,8 +5,7 @@ import { useService } from "@web/core/utils/hooks";
 import { parseFloatTime } from "@web/views/fields/parsers";
 import { useInputField } from "@web/views/fields/input_field_hook";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-
-const { Component, useState, onWillUpdateProps, onWillStart, onWillDestroy } = owl;
+import { Component, useState, onWillUpdateProps, onWillStart, onWillDestroy } from "@odoo/owl";
 
 function formatMinutes(value) {
     if (value === false) {

--- a/addons/mrp_subcontracting/static/src/subcontracting_portal/subcontracting_portal.js
+++ b/addons/mrp_subcontracting/static/src/subcontracting_portal/subcontracting_portal.js
@@ -5,8 +5,7 @@ import { ActionContainer } from '@web/webclient/actions/action_container';
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
 import { session } from '@web/session';
-
-const { Component, useEffect, useExternalListener } = owl;
+import { Component, useEffect, useExternalListener } from "@odoo/owl";
 
 export class SubcontractingPortalWebClient extends Component {
     setup() {

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 import { AbstractAwaitablePopup } from "@point_of_sale/app/popup/abstract_awaitable_popup";
-import { Component, useRef, useState, useSubEnv } from "@odoo/owl";
+import { Component, onMounted, useRef, useState, useSubEnv } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 export class BaseProductAttribute extends Component {
@@ -46,7 +46,7 @@ export class RadioProductAttribute extends BaseProductAttribute {
     setup() {
         super.setup();
         this.root = useRef("root");
-        owl.onMounted(this.onMounted);
+        onMounted(this.onMounted);
     }
     onMounted() {
         // With radio buttons `t-model` selects the default input by searching for inputs with

--- a/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.js
+++ b/addons/product/static/src/js/product_document_kanban/product_document_kanban_controller.js
@@ -2,8 +2,7 @@
 
 import { KanbanController } from "@web/views/kanban/kanban_controller";
 import { useBus, useService } from "@web/core/utils/hooks";
-
-const { useRef } = owl;
+import { useRef } from "@odoo/owl";
 
 export class ProductDocumentKanbanController extends KanbanController {
     setup() {

--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -4,8 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Dialog } from '@web/core/dialog/dialog';
 import { formatMonetary } from "@web/views/fields/formatters";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-const { Component, onMounted, markup, useRef } = owl;
-
+import { Component, onMounted, markup, useRef } from "@odoo/owl";
 
 export class ProductMatrixDialog extends Component {
     setup() {

--- a/addons/project/static/src/components/project_control_panel/project_control_panel.js
+++ b/addons/project/static/src/components/project_control_panel/project_control_panel.js
@@ -2,8 +2,7 @@
 
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { useService } from "@web/core/utils/hooks";
-
-const { onWillStart } = owl;
+import { onWillStart } from "@odoo/owl";
 
 export class ProjectControlPanel extends ControlPanel {
     setup() {

--- a/addons/project/static/src/components/project_right_side_panel/components/project_milestone.js
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_milestone.js
@@ -4,8 +4,8 @@ import { formatDate } from "@web/core/l10n/dates";
 import { useService } from '@web/core/utils/hooks';
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
+import { Component, useState, onWillUpdateProps, status } from "@odoo/owl";
 
-const { Component, useState, onWillUpdateProps, status } = owl;
 const { DateTime } = luxon;
 
 export class ProjectMilestone extends Component {

--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ProjectProfitability extends Component {
     get revenues() {

--- a/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.js
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_right_side_panel_section.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ProjectRightSidePanelSection extends Component { }
 

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -10,8 +10,7 @@ import { ProjectRightSidePanelSection } from './components/project_right_side_pa
 import { ProjectMilestone } from './components/project_milestone';
 import { ProjectProfitability } from './components/project_profitability';
 import { getCurrency } from '@web/core/currency';
-
-const { Component, onWillStart, useState } = owl;
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class ProjectRightSidePanel extends Component {
     setup() {

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -9,8 +9,7 @@ import { useCommand } from "@web/core/commands/command_hook";
 import { formatSelection } from "@web/views/fields/formatters";
 
 import { registry } from "@web/core/registry";
-
-const { useState } = owl;
+import { useState } from "@odoo/owl";
 
 export class ProjectTaskStateSelection extends StateSelectionField {
     setup() {

--- a/addons/project/static/src/project_sharing/components/chatter/chatter_attachments_viewer.js
+++ b/addons/project/static/src/project_sharing/components/chatter/chatter_attachments_viewer.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ChatterAttachmentsViewer extends Component {}
 

--- a/addons/project/static/src/project_sharing/components/chatter/chatter_container.js
+++ b/addons/project/static/src/project_sharing/components/chatter/chatter_container.js
@@ -5,8 +5,7 @@ import { ChatterComposer } from "./chatter_composer";
 import { ChatterMessageCounter } from "./chatter_message_counter";
 import { ChatterMessages } from "./chatter_messages";
 import { ChatterPager } from "./chatter_pager";
-
-const { Component, markup, onWillStart, useState, onWillUpdateProps } = owl;
+import { Component, markup, onWillStart, useState, onWillUpdateProps } from "@odoo/owl";
 
 export class ChatterContainer extends Component {
     setup() {

--- a/addons/project/static/src/project_sharing/components/chatter/chatter_message_counter.js
+++ b/addons/project/static/src/project_sharing/components/chatter/chatter_message_counter.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ChatterMessageCounter extends Component { }
 

--- a/addons/project/static/src/project_sharing/components/chatter/chatter_messages.js
+++ b/addons/project/static/src/project_sharing/components/chatter/chatter_messages.js
@@ -3,8 +3,7 @@
 import { useService } from "@web/core/utils/hooks";
 
 import { ChatterAttachmentsViewer } from "./chatter_attachments_viewer";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ChatterMessages extends Component {
     setup() {

--- a/addons/project/static/src/project_sharing/components/chatter/chatter_pager.js
+++ b/addons/project/static/src/project_sharing/components/chatter/chatter_pager.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-const { Component, useState, onWillUpdateProps } = owl;
+import { Component, useState, onWillUpdateProps } from "@odoo/owl";
 
 export class ChatterPager extends Component {
     setup() {

--- a/addons/project/static/src/project_sharing/components/portal_attach_document/portal_attach_document.js
+++ b/addons/project/static/src/project_sharing/components/portal_attach_document/portal_attach_document.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 
 import { PortalFileInput } from '../portal_file_input/portal_file_input';
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class PortalAttachDocument extends Component {}
 

--- a/addons/project/static/src/project_sharing/project_sharing.js
+++ b/addons/project/static/src/project_sharing/project_sharing.js
@@ -5,8 +5,7 @@ import { ActionContainer } from '@web/webclient/actions/action_container';
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
 import { session } from '@web/session';
-
-const { Component, useEffect, useExternalListener, useState } = owl;
+import { Component, useEffect, useExternalListener, useState } from "@odoo/owl";
 
 export class ProjectSharingWebClient extends Component {
     setup() {

--- a/addons/project/static/src/project_sharing/views/list/list_renderer.js
+++ b/addons/project/static/src/project_sharing/views/list/list_renderer.js
@@ -2,8 +2,7 @@
 
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { ListRenderer } from "@web/views/list/list_renderer";
-
-const { onWillUpdateProps } = owl;
+import { onWillUpdateProps } from "@odoo/owl";
 
 export class ProjectSharingListRenderer extends ListRenderer {
     setup() {

--- a/addons/project/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
+++ b/addons/project/static/src/views/form_with_html_expander/form_renderer_with_html_expander.js
@@ -2,8 +2,7 @@
 
 import { useService } from '@web/core/utils/hooks';
 import { FormRenderer } from '@web/views/form/form_renderer';
-
-const { useRef, useEffect } = owl;
+import { useRef, useEffect } from "@odoo/owl";
 
 export class FormRendererWithHtmlExpander extends FormRenderer {
     setup() {

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
@@ -3,8 +3,8 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { renderToMarkup } from '@web/core/utils/render';
+import { markup } from "@odoo/owl";
 
-const { markup } = owl;
 const greenBullet = markup(`<span class="o_status d-inline-block o_status_green"></span>`);
 const orangeBullet = markup(`<span class="o_status d-inline-block text-warning"></span>`);
 const star = markup(`<a style="color: gold;" class="fa fa-star"></a>`);

--- a/addons/purchase/static/src/toaster_button/toaster_button_widget.js
+++ b/addons/purchase/static/src/toaster_button/toaster_button_widget.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class ButtonWithNotification extends Component {
     setup() {

--- a/addons/purchase/static/src/views/purchase_dashboard.js
+++ b/addons/purchase/static/src/views/purchase_dashboard.js
@@ -1,7 +1,6 @@
 /** @odoo-module */
 import { useService } from "@web/core/utils/hooks";
-
-const { Component, onWillStart } = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 export class PurchaseDashBoard extends Component {
     setup() {
@@ -9,10 +8,7 @@ export class PurchaseDashBoard extends Component {
         this.action = useService("action");
 
         onWillStart(async () => {
-            this.purchaseData = await this.orm.call(
-                "purchase.order",
-                "retrieve_dashboard",
-            );
+            this.purchaseData = await this.orm.call("purchase.order", "retrieve_dashboard");
         });
     }
 
@@ -21,14 +17,16 @@ export class PurchaseDashBoard extends Component {
      * the filters found in `filter_name` attibute from button pressed
      */
     setSearchContext(ev) {
-        let filter_name = ev.currentTarget.getAttribute("filter_name");
-        let filters = filter_name.split(',');
-        let searchItems = this.env.searchModel.getSearchItems((item) => filters.includes(item.name));
+        const filter_name = ev.currentTarget.getAttribute("filter_name");
+        const filters = filter_name.split(",");
+        const searchItems = this.env.searchModel.getSearchItems((item) =>
+            filters.includes(item.name)
+        );
         this.env.searchModel.query = [];
-        for (const item of searchItems){
+        for (const item of searchItems) {
             this.env.searchModel.toggleSearchItem(item.id);
         }
     }
 }
 
-PurchaseDashBoard.template = 'purchase.PurchaseDashboard'
+PurchaseDashBoard.template = "purchase.PurchaseDashboard";

--- a/addons/purchase_requisition/static/src/views/list/purchase_order_line_compare_list_renderer.js
+++ b/addons/purchase_requisition/static/src/views/list/purchase_order_line_compare_list_renderer.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 
 import { ListRenderer } from "@web/views/list/list_renderer";
-
-const { onWillStart, useState, useSubEnv } = owl;
+import { onWillStart, useState, useSubEnv } from "@odoo/owl";
 
 export class PurchaseOrderLineCompareListRenderer extends ListRenderer {
     setup() {

--- a/addons/resource/static/src/section_list_renderer.js
+++ b/addons/resource/static/src/section_list_renderer.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 
 import { ListRenderer } from "@web/views/list/list_renderer";
-
-const { useEffect } = owl;
+import { useEffect } from "@odoo/owl";
 
 export class SectionListRenderer extends ListRenderer {
     setup() {

--- a/addons/sale/static/src/js/sale_progressbar_field.js
+++ b/addons/sale/static/src/js/sale_progressbar_field.js
@@ -6,8 +6,7 @@ import {
     KanbanProgressBarField,
     kanbanProgressBarField,
 } from "@web/views/fields/progress_bar/kanban_progress_bar_field";
-
-const { useEffect } = owl;
+import { useEffect } from "@odoo/owl";
 
 /**
  * A custom Component for the view of sales teams on the kanban view in the CRM app.

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
-
-const { markup } = owl;
+import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add("sale_tour", {
     url: "/web",

--- a/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
+++ b/addons/sale_stock/static/src/widgets/qty_at_date_widget.js
@@ -5,8 +5,7 @@ import { localization } from "@web/core/l10n/localization";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
-
-const { Component, onWillRender } = owl;
+import { Component, onWillRender } from "@odoo/owl";
 
 export class QtyAtDatePopover extends Component {
     setup() {

--- a/addons/sms/static/src/components/sms_button/sms_button.js
+++ b/addons/sms/static/src/components/sms_button/sms_button.js
@@ -2,8 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class SendSMSButton extends Component {
     setup() {
@@ -16,25 +15,28 @@ export class SendSMSButton extends Component {
     }
     async onClick() {
         await this.props.record.save();
-        this.action.doAction({
-            type: "ir.actions.act_window",
-            target: "new",
-            name: this.title,
-            res_model: "sms.composer",
-            views: [[false, "form"]],
-            context: {
-                ...this.user.context,
-                default_res_model: this.props.record.resModel,
-                default_res_id: this.props.record.resId,
-                default_number_field_name: this.props.name,
-                default_composition_mode: 'comment',
-            }
-        }, {
-            onClose: () => {
-                this.props.record.load();
+        this.action.doAction(
+            {
+                type: "ir.actions.act_window",
+                target: "new",
+                name: this.title,
+                res_model: "sms.composer",
+                views: [[false, "form"]],
+                context: {
+                    ...this.user.context,
+                    default_res_model: this.props.record.resModel,
+                    default_res_id: this.props.record.resId,
+                    default_number_field_name: this.props.name,
+                    default_composition_mode: "comment",
+                },
             },
-        });
+            {
+                onClose: () => {
+                    this.props.record.load();
+                },
+            }
+        );
     }
-};
+}
 SendSMSButton.template = "sms.SendSMSButton";
 SendSMSButton.props = ["*"];

--- a/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.js
+++ b/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 import { useService } from "@web/core/utils/hooks";
 import { formatFloat } from "@web/core/utils/numbers";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ReceptionReportLine extends Component {
     setup() {

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.js
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.js
@@ -4,8 +4,7 @@ import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { ReceptionReportTable } from "../reception_report_table/stock_reception_report_table";
-
-const { Component, onWillStart, useState } = owl;
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class ReceptionReportMain extends Component {
     setup() {

--- a/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.js
+++ b/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.js
@@ -2,8 +2,7 @@
 
 import { useService } from "@web/core/utils/hooks";
 import { ReceptionReportLine } from "../reception_report_line/stock_reception_report_line";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ReceptionReportTable extends Component {
     setup() {

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-const { Component} = owl;
+import { Component } from "@odoo/owl";
 
 export class ForecastedButtons extends Component {
 

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 import { formatFloat } from "@web/core/utils/numbers";
 import { useService } from "@web/core/utils/hooks";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class ForecastedDetails extends Component {
     setup() {

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -1,10 +1,9 @@
 /** @odoo-module **/
 import { useService } from "@web/core/utils/hooks";
 import { formatFloat } from "@web/core/utils/numbers";
+import { Component } from "@odoo/owl";
 
-const { Component } = owl;
-
-export class ForecastedHeader extends Component{
+export class ForecastedHeader extends Component {
     setup(){
         this.orm = useService("orm");
         this.action = useService("action");

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.js
@@ -2,7 +2,7 @@
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService } from "@web/core/utils/hooks";
-const { Component, onWillStart} = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 export class ForecastedWarehouseFilter extends Component {
 

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -10,8 +10,7 @@ import { ForecastedButtons } from "./forecasted_buttons";
 import { ForecastedDetails } from "./forecasted_details";
 import { ForecastedHeader } from "./forecasted_header";
 import { ForecastedWarehouseFilter } from "./forecasted_warehouse_filter";
-
-const { Component, onWillStart, useState } = owl;
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 export class StockForecasted extends Component {
     setup() {

--- a/addons/stock/static/src/widgets/counted_quantity_widget.js
+++ b/addons/stock/static/src/widgets/counted_quantity_widget.js
@@ -3,8 +3,7 @@
 import { FloatField, floatField } from "@web/views/fields/float/float_field";
 import { registry } from "@web/core/registry";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
-
-const { useEffect, useRef } = owl;
+import { useEffect, useRef } from "@odoo/owl";
 
 export class CountedQuantityWidgetField extends FloatField {
     setup() {

--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -7,7 +7,7 @@ import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { parseInteger  } from "@web/views/fields/parsers";
 import { getId } from "@web/model/relational_model/utils";
-const { Component, useRef, xml, onMounted } = owl;
+import { Component, useRef, xml, onMounted } from "@odoo/owl";
 
 export class GenerateDialog extends Component {
     setup() {

--- a/addons/stock/static/src/widgets/json_widget.js
+++ b/addons/stock/static/src/widgets/json_widget.js
@@ -3,8 +3,7 @@
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-
-const { Component, onWillStart } = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 export class JsonPopOver extends Component {
     get jsonValue() {

--- a/addons/stock/static/src/widgets/popover_widget.js
+++ b/addons/stock/static/src/widgets/popover_widget.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 import { registry } from "@web/core/registry";
 import { usePopover } from "@web/core/popover/popover_hook";
-const { Component } = owl;
-
+import { Component } from "@odoo/owl";
 
 /**
  * Extend this to add functionality to Popover (custom methods etc.)

--- a/addons/survey/static/src/question_page/description_page_field.js
+++ b/addons/survey/static/src/question_page/description_page_field.js
@@ -2,8 +2,7 @@
 
 import { CharField, charField } from "@web/views/fields/char/char_field";
 import { registry } from "@web/core/registry";
-
-const { useEffect, useRef } = owl;
+import { useEffect, useRef } from "@odoo/owl";
 
 class DescriptionPageField extends CharField {
     setup() {

--- a/addons/survey/static/src/question_page/question_page_list_renderer.js
+++ b/addons/survey/static/src/question_page/question_page_list_renderer.js
@@ -2,8 +2,7 @@
 
 import { makeContext } from "@web/core/context";
 import { ListRenderer } from "@web/views/list/list_renderer";
-
-const { useEffect } = owl;
+import { useEffect } from "@odoo/owl";
 
 export class QuestionPageListRenderer extends ListRenderer {
     setup() {

--- a/addons/survey/static/src/question_page/question_page_one2many_field.js
+++ b/addons/survey/static/src/question_page/question_page_one2many_field.js
@@ -6,8 +6,7 @@ import { registry } from "@web/core/registry";
 import { useOpenX2ManyRecord, useX2ManyCrud, X2ManyFieldDialog } from "@web/views/fields/relational_utils";
 import { patch } from '@web/core/utils/patch';
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
-
-const { useSubEnv } = owl;
+import { useSubEnv } from "@odoo/owl";
 
 patch(X2ManyFieldDialog.prototype, {
     /**

--- a/addons/survey/static/src/views/survey_views.js
+++ b/addons/survey/static/src/views/survey_views.js
@@ -6,8 +6,7 @@ import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { listView } from '@web/views/list/list_view';
 import { kanbanView } from '@web/views/kanban/kanban_view';
 import { useService } from "@web/core/utils/hooks";
-
-const { useEffect, useRef } = owl;
+import { useEffect, useRef } from "@odoo/owl";
 
 export function useSurveyLoadSampleHook(selector) {
     const rootRef = useRef("root");

--- a/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
+++ b/addons/survey/static/src/views/widgets/survey_question_trigger/survey_question_trigger.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
-
-const { Component, useEffect, useRef, useState } = owl;
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
 
 export class SurveyQuestionTriggerWidget extends Component {
     static template = "survey.surveyQuestionTrigger";

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -13,6 +13,7 @@ import { editInput, patchWithCleanup, click, patchDate } from "@web/../tests/hel
 import { toggleSearchBarMenu } from "@web/../tests/search/helpers";
 import { contains } from "@web/../tests/utils";
 import { doAction } from "@web/../tests/webclient/helpers";
+import { onMounted, onWillUnmount } from "@odoo/owl";
 const { DateTime } = luxon;
 
 let serverData;
@@ -225,7 +226,7 @@ QUnit.module("test_mail", {}, function () {
 
             for (let i = 0; i < 101; i++) {
                 activityToCreate.push({
-                    display_name: "An activity " + (i * 2),
+                    display_name: "An activity " + i * 2,
                     date_deadline: serializeDate(DateTime.now().plus({ days: 3 })),
                     can_write: true,
                     state: "planned",
@@ -241,7 +242,10 @@ QUnit.module("test_mail", {}, function () {
             }
             const createdActivity = pyEnv["mail.activity"].create(activityToCreate);
             for (let i = 0; i < 101; i++) {
-                recordsToCreate.push({ name: "pagerTestRecord" + i, activity_ids: [createdActivity[i * 2], createdActivity[i * 2 + 1]] });
+                recordsToCreate.push({
+                    name: "pagerTestRecord" + i,
+                    activity_ids: [createdActivity[i * 2], createdActivity[i * 2 + 1]],
+                });
             }
             pyEnv["mail.test.activity"].create(recordsToCreate);
 
@@ -251,7 +255,7 @@ QUnit.module("test_mail", {}, function () {
             await openView({
                 res_model: "mail.test.activity",
                 views: [[false, "activity"]],
-                domain: [['name', 'like', 'pagerTestRecord']],
+                domain: [["name", "like", "pagerTestRecord"]],
             });
             assert.containsN(
                 document.body,
@@ -753,10 +757,10 @@ QUnit.module("test_mail", {}, function () {
         patchWithCleanup(ActivityRenderer.prototype, {
             setup() {
                 super.setup();
-                owl.onMounted(() => {
+                onMounted(() => {
                     assert.step("mounted");
                 });
-                owl.onWillUnmount(() => {
+                onWillUnmount(() => {
                     assert.step("willUnmount");
                 });
             },

--- a/addons/test_website/static/tests/field_html_file_upload.js
+++ b/addons/test_website/static/tests/field_html_file_upload.js
@@ -10,8 +10,7 @@ import { unsplashService } from '@web_unsplash/services/unsplash_service';
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
 import weTestUtils from '@web_editor/../tests/test_utils';
 import {Wysiwyg} from '@web_editor/js/wysiwyg/wysiwyg';
-
-const { useEffect } = owl;
+import { useEffect } from "@odoo/owl";
 
 QUnit.module('field html file upload', {
     beforeEach: function () {

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -5,7 +5,7 @@ import { useAutofocus, useForwardRefToParent, useService } from "@web/core/utils
 import { useDebounced } from "@web/core/utils/timing";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { usePosition } from "@web/core/position_hook";
-import { Component, useExternalListener, useRef, useState } from "@odoo/owl";
+import { Component, onWillUpdateProps, useExternalListener, useRef, useState } from "@odoo/owl";
 
 export class AutoComplete extends Component {
     setup() {
@@ -51,7 +51,7 @@ export class AutoComplete extends Component {
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
 
-        owl.onWillUpdateProps((nextProps) => {
+        onWillUpdateProps((nextProps) => {
             if (this.props.value !== nextProps.value || this.forceValFromProp) {
                 this.forceValFromProp = false;
                 if (!this.inEdition) {

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -3,7 +3,7 @@
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { useActiveElement } from "../ui/ui_service";
 import { useForwardRefToParent } from "@web/core/utils/hooks";
-import { Component, useChildSubEnv, useExternalListener, useState } from "@odoo/owl";
+import { Component, onWillDestroy, useChildSubEnv, useExternalListener, useState } from "@odoo/owl";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { makeDraggableHook } from "../utils/draggable_hook_builder";
 
@@ -69,7 +69,7 @@ export class Dialog extends Component {
         });
         const throttledResize = throttleForAnimation(this.onResize.bind(this));
         useExternalListener(window, "resize", throttledResize);
-        owl.onWillDestroy(() => {
+        onWillDestroy(() => {
             if (this.env.isSmall) {
                 this.data.scrollToOrigin();
             }

--- a/addons/web/static/src/legacy/js/core/service_mixins.js
+++ b/addons/web/static/src/legacy/js/core/service_mixins.js
@@ -6,6 +6,7 @@ import {
     ConnectionLostError,
     RPCError,
 } from "@web/core/network/rpc_service";
+import { Component } from "@odoo/owl";
 
 function protectMethod(widget, fn) {
     return function (...args) {
@@ -35,7 +36,7 @@ function protectMethod(widget, fn) {
 
 var ServicesMixin = {
     bindService: function (serviceName) {
-        const { services } = owl.Component.env;
+        const { services } = Component.env;
         const service = services[serviceName];
         if (!service) {
             throw new Error(`Service ${serviceName} is not available`);

--- a/addons/web/static/src/legacy/js/public/public_root.js
+++ b/addons/web/static/src/legacy/js/public/public_root.js
@@ -20,7 +20,7 @@ import { MainComponentsContainer } from "@web/core/main_components_container";
 import { browser } from '@web/core/browser/browser';
 import { renderToString } from "@web/core/utils/render";
 import { _t } from "@web/core/l10n/translation";
-import { App, whenReady } from "@odoo/owl";
+import { App, Component, whenReady } from "@odoo/owl";
 
 const { Settings } = luxon;
 
@@ -314,7 +314,7 @@ export const PublicRoot = publicWidget.RootWidget.extend({
 /**
  * Configure Owl with the public env
  */
-owl.Component.env = legacyEnv;
+Component.env = legacyEnv;
 
 /**
  * This widget is important, because the tour manager needs a root widget in

--- a/addons/web/static/src/libs/owl.js
+++ b/addons/web/static/src/libs/owl.js
@@ -1,1 +1,2 @@
+/* eslint-disable no-undef */
 owl.App.validateTarget = () => {};

--- a/addons/web/static/src/views/form/form_group/form_group.js
+++ b/addons/web/static/src/views/form/form_group/form_group.js
@@ -1,7 +1,8 @@
 /** @odoo-module */
+import { Component } from "@odoo/owl";
 import { sortBy } from "@web/core/utils/arrays";
 
-class Group extends owl.Component {
+class Group extends Component {
     _getItems() {
         const items = Object.entries(this.props.slots || {}).filter(([k, v]) => v.type === "item");
         return sortBy(items, (i) => i[1].sequence);

--- a/addons/web/static/src/views/view_button/view_button_hook.js
+++ b/addons/web/static/src/views/view_button/view_button_hook.js
@@ -4,7 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 import { evaluateExpr } from "@web/core/py_js/py";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-import { status, useEnv, useSubEnv } from "@odoo/owl";
+import { status, useComponent, useEnv, useSubEnv } from "@odoo/owl";
 
 function disableButtons(el) {
     const btns = [...el.querySelectorAll("button:not([disabled])")];
@@ -28,7 +28,7 @@ function undefinedAsTrue(val) {
 export function useViewButtons(model, ref, options = {}) {
     const action = useService("action");
     const dialog = useService("dialog");
-    const comp = owl.useComponent();
+    const comp = useComponent();
     const env = useEnv();
     const beforeExecuteAction =
         options.beforeExecuteAction ||

--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -7,7 +7,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { escape, sprintf } from "@web/core/utils/strings";
 
-import { Component, onMounted, xml } from "@odoo/owl";
+import { Component, markup, onMounted, xml } from "@odoo/owl";
 
 export function displayNotificationAction(env, action) {
     const params = action.params || {};
@@ -20,7 +20,7 @@ export function displayNotificationAction(env, action) {
     const links = (params.links || []).map((link) => {
         return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
     });
-    const message = owl.markup(sprintf(escape(params.message), ...links));
+    const message = markup(sprintf(escape(params.message), ...links));
     env.services.notification.add(message, options);
     return params.next;
 }

--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -21,7 +21,7 @@
     const STUDIO_SYSTRAY_ICON_SELECTOR = ".o_web_studio_navbar_item:not(.o_disabled) i";
 
     const { isEnterprise } = odoo.info;
-    const { onWillStart } = owl;
+    const { onWillStart } = odoo.loader.modules.get("@odoo/owl");
     let appsMenusOnly = false;
     const isStudioInstalled = odoo.loader.modules.has("@web_studio/studio_service");
     let actionCount = 0;
@@ -125,9 +125,11 @@
         let timeLimit = tl;
         while (!stopCondition()) {
             if (timeLimit <= 0) {
-                throw new Error(`Timeout, the clicked element took more than ${tl / 1000} seconds to load`)
+                throw new Error(
+                    `Timeout, the clicked element took more than ${tl / 1000} seconds to load`
+                );
             }
-            await new Promise(resolve => setTimeout(resolve, interval));
+            await new Promise((resolve) => setTimeout(resolve, interval));
             timeLimit -= interval;
         }
     }

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -1229,8 +1229,8 @@ QUnit.module("Components", ({ beforeEach }) => {
     QUnit.test("Dropdown with a tooltip", async (assert) => {
         assert.expect(2);
 
-        class MyComponent extends owl.Component {}
-        MyComponent.template = owl.xml`
+        class MyComponent extends Component {}
+        MyComponent.template = xml`
             <Dropdown tooltip="'My tooltip'">
                 <DropdownItem/>
             </Dropdown>`;
@@ -1246,8 +1246,8 @@ QUnit.module("Components", ({ beforeEach }) => {
         "Dropdown with a date picker inside do not close when a click occurs in date picker",
         async (assert) => {
             registry.category("services").add("datetime_picker", datetimePickerService);
-            class MyComponent extends owl.Component {}
-            MyComponent.template = owl.xml`
+            class MyComponent extends Component {}
+            MyComponent.template = xml`
                 <Dropdown>
                     <t t-set-slot="toggler">
                         Dropdown toggler

--- a/addons/web/static/tests/helpers/mock_env.js
+++ b/addons/web/static/tests/helpers/mock_env.js
@@ -7,6 +7,7 @@ import { registerCleanup } from "./cleanup";
 import { makeMockServer } from "./mock_server";
 import { mocks } from "./mock_services";
 import { patchWithCleanup } from "./utils";
+import { Component } from "@odoo/owl";
 
 function prepareRegistry(registry, keepContent = false) {
     const _addEventListener = registry.addEventListener.bind(registry);
@@ -124,7 +125,7 @@ export async function makeTestEnv(config = {}) {
 
     let env = makeEnv();
     await startServices(env);
-    owl.Component.env = env;
+    Component.env = env;
     if ("config" in config) {
         env = Object.assign(Object.create(env), { config: config.config });
     }

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -10,7 +10,20 @@ import { isVisible } from "@web/core/utils/ui";
 import { _t } from "@web/core/l10n/translation";
 import { registerCleanup } from "./cleanup";
 
-import { App, onMounted, onPatched, useComponent } from "@odoo/owl";
+import {
+    App,
+    onError,
+    onMounted,
+    onPatched,
+    onRendered,
+    onWillDestroy,
+    onWillPatch,
+    onWillRender,
+    onWillStart,
+    onWillUnmount,
+    onWillUpdateProps,
+    useComponent,
+} from "@odoo/owl";
 
 /**
  * @typedef {keyof HTMLElementEventMap | keyof WindowEventMap} EventType
@@ -775,29 +788,42 @@ export function useChild() {
     onPatched(setChild);
 }
 
-const lifeCycleHooks = [
-    "onError",
-    "onMounted",
-    "onPatched",
-    "onRendered",
-    "onWillDestroy",
-    "onWillPatch",
-    "onWillRender",
-    "onWillStart",
-    "onWillUnmount",
-    "onWillUpdateProps",
-];
 export function useLogLifeCycle(logFn, name = "") {
-    const component = owl.useComponent();
+    const component = useComponent();
     let loggedName = `${component.constructor.name}`;
     if (name) {
         loggedName = `${component.constructor.name} ${name}`;
     }
-    for (const hook of lifeCycleHooks) {
-        owl[hook](() => {
-            logFn(`${hook} ${loggedName}`);
-        });
-    }
+    onError(() => {
+        logFn(`onError ${loggedName}`);
+    });
+    onMounted(() => {
+        logFn(`onMounted ${loggedName}`);
+    });
+    onPatched(() => {
+        logFn(`onPatched ${loggedName}`);
+    });
+    onRendered(() => {
+        logFn(`onRendered ${loggedName}`);
+    });
+    onWillDestroy(() => {
+        logFn(`onWillDestroy ${loggedName}`);
+    });
+    onWillPatch(() => {
+        logFn(`onWillPatch ${loggedName}`);
+    });
+    onWillRender(() => {
+        logFn(`onWillRender ${loggedName}`);
+    });
+    onWillStart(() => {
+        logFn(`onWillStart ${loggedName}`);
+    });
+    onWillUnmount(() => {
+        logFn(`onWillUnmount ${loggedName}`);
+    });
+    onWillUpdateProps(() => {
+        logFn(`onWillUpdateProps ${loggedName}`);
+    });
 }
 
 /**

--- a/addons/web/static/tests/legacy/core/widget_tests.js
+++ b/addons/web/static/tests/legacy/core/widget_tests.js
@@ -6,6 +6,7 @@ import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { renderToString } from "@web/core/utils/render";
 import makeTestEnvironment from "../helpers/test_env";
 import { SERVICES_METADATA } from "@web/env";
+import { Component } from "@odoo/owl";
 
 QUnit.module('core', {}, function () {
 
@@ -404,7 +405,7 @@ QUnit.module('core', {}, function () {
 
         SERVICES_METADATA.rpc = true;
         var def;
-        owl.Component.env = await makeTestEnvironment({}, () => {
+        Component.env = await makeTestEnvironment({}, () => {
             def = testUtils.makeTestPromise();
             return def;
         });

--- a/addons/web/static/tests/legacy/helpers/test_env.js
+++ b/addons/web/static/tests/legacy/helpers/test_env.js
@@ -3,7 +3,7 @@
     import Bus from "@web/legacy/js/core/bus";
     import { templates } from "@web/core/assets";
     import { renderToString } from "@web/core/utils/render";
-    const { App, Component } = owl;
+    import { App, Component } from "@odoo/owl";
 
     let app;
 

--- a/addons/web/static/tests/legacy/widgets/name_and_signature_tests.js
+++ b/addons/web/static/tests/legacy/widgets/name_and_signature_tests.js
@@ -3,6 +3,7 @@
     import { NameAndSignature } from "@web/legacy/js/widgets/name_and_signature";
     import makeTestEnvironment from "../helpers/test_env";
     import { patchWithCleanup } from "@web/../tests/helpers/utils";
+    import { Component } from "@odoo/owl";
 
     const MockedNameAndSignature = NameAndSignature.extend({
         events: {
@@ -15,7 +16,7 @@
 
     async function MockedNameAndSignatureGenerator (options) {
         const parent = $("#qunit-fixture");
-        patchWithCleanup(owl.Component, {
+        patchWithCleanup(Component, {
             env: await makeTestEnvironment({}, (route) => {
                 if (route === "/web/sign/get_fonts/") {
                     return Promise.resolve();

--- a/addons/web/static/tests/qunit.js
+++ b/addons/web/static/tests/qunit.js
@@ -4,11 +4,12 @@ import { isVisible as isElemVisible } from "@web/core/utils/ui";
 import { fullTraceback, fullAnnotatedTraceback } from "@web/core/errors/error_utils";
 import { registry } from "@web/core/registry";
 import { escape } from "@web/core/utils/strings";
+import { Component, whenReady } from "@odoo/owl";
 
 const consoleError = console.error;
 
 function setQUnitDebugMode() {
-    owl.whenReady(() => document.body.classList.add("debug")); // make the test visible to the naked eye
+    whenReady(() => document.body.classList.add("debug")); // make the test visible to the naked eye
     QUnit.config.debug = true; // allows for helper functions to behave differently (logging, the HTML element in which the test occurs etc...)
     QUnit.config.testTimeout = 60 * 60 * 1000;
     // Allows for interacting with the test when it is over
@@ -32,8 +33,6 @@ QUnit.debug = (name, cb) => {
 QUnit.config.autostart = false;
 
 export function setupQUnit() {
-    const { Component } = owl;
-
     // -----------------------------------------------------------------------------
     // QUnit config
     // -----------------------------------------------------------------------------

--- a/addons/web/static/tests/search/search_panel_tests.js
+++ b/addons/web/static/tests/search/search_panel_tests.js
@@ -15,12 +15,17 @@ import {
     toggleSearchBarMenu,
     toggleMenuItem,
 } from "@web/../tests/search/helpers";
-import { createWebClient, doAction }  from "@web/../tests/webclient/helpers";
+import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
 import { registry } from "@web/core/registry";
 import { SearchBarMenu } from "@web/search/search_bar_menu/search_bar_menu";
 import { SearchPanel } from "@web/search/search_panel/search_panel";
 
-import { Component, xml } from "@odoo/owl";
+import {
+    Component,
+    xml,
+    onWillStart as onWillStartOWL,
+    onWillUpdateProps as onWillUpdatePropsOWL,
+} from "@odoo/owl";
 
 const serviceRegistry = registry.category("services");
 
@@ -106,13 +111,13 @@ function makeTestComponent({ onWillStart, onWillUpdateProps } = {}) {
     let domain;
     class TestComponent extends Component {
         setup() {
-            owl.onWillStart(async () => {
+            onWillStartOWL(async () => {
                 if (onWillStart) {
                     await onWillStart();
                 }
                 domain = this.props.domain;
             });
-            owl.onWillUpdateProps(async (nextProps) => {
+            onWillUpdatePropsOWL(async (nextProps) => {
                 if (onWillUpdateProps) {
                     await onWillUpdateProps();
                 }
@@ -3454,19 +3459,22 @@ QUnit.module("Search", (hooks) => {
         );
     });
 
-    QUnit.test("Don't display empty state message when some filters are availible", async (assert) => {
-        const { TestComponent } = makeTestComponent();
-        await makeWithSearch({
-            serverData,
-            Component: TestComponent,
-            resModel: "partner",
-            searchViewId: false,
-        });
+    QUnit.test(
+        "Don't display empty state message when some filters are availible",
+        async (assert) => {
+            const { TestComponent } = makeTestComponent();
+            await makeWithSearch({
+                serverData,
+                Component: TestComponent,
+                resModel: "partner",
+                searchViewId: false,
+            });
 
-        assert.containsNone(
-            target,
-            ".o_search_panel_empty_state",
-            "Search panel does not have the empty state container"
-        );
-    });
+            assert.containsNone(
+                target,
+                ".o_search_panel_empty_state",
+                "Search panel does not have the empty state container"
+            );
+        }
+    );
 });

--- a/addons/web/static/tests/search/with_search_tests.js
+++ b/addons/web/static/tests/search/with_search_tests.js
@@ -13,7 +13,7 @@ import {
     toggleMenuItem,
 } from "./helpers";
 
-import { Component, onWillUpdateProps, onWillStart, useState, xml } from "@odoo/owl";
+import { Component, onWillUpdateProps, onWillStart, useState, xml, useSubEnv } from "@odoo/owl";
 
 let target;
 let serverData;
@@ -266,10 +266,10 @@ QUnit.module("Search", (hooks) => {
 
             class TestComponent extends Component {
                 setup() {
-                    owl.onWillStart(() => {
+                    onWillStart(() => {
                         assert.deepEqual(this.props.domain, []);
                     });
-                    owl.onWillUpdateProps((nextProps) => {
+                    onWillUpdateProps((nextProps) => {
                         assert.deepEqual(nextProps.domain, [[1, "=", 1]]);
                     });
                 }
@@ -312,7 +312,7 @@ QUnit.module("Search", (hooks) => {
 
         class Parent extends Component {
             setup() {
-                owl.useSubEnv({ config: {} });
+                useSubEnv({ config: {} });
                 this.searchState = useState({
                     resModel: "animal",
                     domain: [["type", "=", "carnivorous"]],

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -47,7 +47,7 @@ import { actionService } from "@web/webclient/actions/action_service";
 import { getTimePickers } from "../../core/datetime/datetime_test_helpers";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
 import { calendarView } from "@web/views/calendar/calendar_view";
-import { onWillRender } from "@odoo/owl";
+import { Component, onWillRender, onWillStart, xml } from "@odoo/owl";
 
 const fieldRegistry = registry.category("fields");
 const serviceRegistry = registry.category("services");
@@ -4547,12 +4547,12 @@ QUnit.module("Views", ({ beforeEach }) => {
 
     QUnit.test(`fields are added in the right order in popover`, async (assert) => {
         const def = makeDeferred();
-        class DeferredWidget extends owl.Component {
+        class DeferredWidget extends Component {
             setup() {
-                owl.onWillStart(() => def);
+                onWillStart(() => def);
             }
         }
-        DeferredWidget.template = owl.xml``;
+        DeferredWidget.template = xml``;
         fieldRegistry.add("deferred_widget", { component: DeferredWidget });
         registerCleanup(() => fieldRegistry.remove("deferred_widget"));
 

--- a/addons/web/static/tests/views/fields/float_field_tests.js
+++ b/addons/web/static/tests/views/fields/float_field_tests.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { Component, xml } from "@odoo/owl";
 import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
 import { click, clickSave, editInput, getFixture, triggerEvent } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
@@ -66,7 +67,7 @@ QUnit.module("Fields", (hooks) => {
             "The value should be rendered in human readable format (k, M, G, T)."
         );
     });
-    
+
     QUnit.test("human readable format 3", async function (assert) {
         await makeView({
             type: "form",
@@ -548,8 +549,8 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("float field can be updated by another field/widget", async function (assert) {
-        class MyWidget extends owl.Component {
-            static template = owl.xml`<button t-on-click="onClick">do it</button>`;
+        class MyWidget extends Component {
+            static template = xml`<button t-on-click="onClick">do it</button>`;
             onClick() {
                 const val = this.props.record.data.float_field;
                 this.props.record.update({ float_field: val + 1 });

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { Component, xml } from "@odoo/owl";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { makeServerError } from "@web/../tests/helpers/mock_server";
 import {
@@ -1585,7 +1586,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("standalone many2one field", async function (assert) {
-        class Comp extends owl.Component {
+        class Comp extends Component {
             setup() {
                 this.fields = {
                     partner_id: {
@@ -1600,7 +1601,7 @@ QUnit.module("Fields", (hooks) => {
             }
         }
         Comp.components = { Record, Field };
-        Comp.template = owl.xml`
+        Comp.template = xml`
             <Record resModel="'coucou'" fields="fields" fieldNames="['partner_id']" values="values" mode="'edit'" t-slot-scope="scope">
                 <Field name="'partner_id'" record="scope.record" canOpen="false" />
             </Record>

--- a/addons/web/static/tests/views/fields/numeric_fields_tests.js
+++ b/addons/web/static/tests/views/fields/numeric_fields_tests.js
@@ -7,8 +7,7 @@ import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { localization } from "@web/core/l10n/localization";
 import { useNumpadDecimal } from "@web/views/fields/numpad_decimal_hook";
 import { makeTestEnv } from "../../helpers/mock_env";
-
-const { Component, mount, useState, xml } = owl;
+import { Component, mount, useState, xml } from "@odoo/owl";
 
 let serverData;
 let target;

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -34,6 +34,7 @@ import { Record } from "@web/model/relational_model/record";
 import { getPickerCell } from "../../core/datetime/datetime_test_helpers";
 import { makeServerError } from "@web/../tests/helpers/mock_server";
 import { errorService } from "../../../src/core/errors/error_service";
+import { onWillDestroy, onWillStart } from "@odoo/owl";
 
 const serviceRegistry = registry.category("services");
 
@@ -5196,10 +5197,10 @@ QUnit.module("Fields", (hooks) => {
             class DeltaField extends field.component {
                 setup() {
                     super.setup();
-                    owl.onWillStart(() => {
+                    onWillStart(() => {
                         delta++;
                     });
-                    owl.onWillDestroy(() => {
+                    onWillDestroy(() => {
                         delta--;
                     });
                 }

--- a/addons/web/static/tests/views/form/form_compiler_tests.js
+++ b/addons/web/static/tests/views/form/form_compiler_tests.js
@@ -6,6 +6,7 @@ import { registry } from "@web/core/registry";
 import { getFixture, patchWithCleanup } from "../../helpers/utils";
 import { createElement } from "@web/core/utils/xml";
 import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
+import { Component, xml } from "@odoo/owl";
 
 function compileTemplate(arch) {
     const parser = new DOMParser();
@@ -418,8 +419,8 @@ QUnit.module("Form Renderer", (hooks) => {
         assert.expect(1);
 
         const charField = {
-            component: class CharField extends owl.Component {
-                static template = owl.xml`<div/>`;
+            component: class CharField extends Component {
+                static template = xml`<div/>`;
                 setup() {
                     assert.strictEqual(
                         this.props.placeholder,

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -1,6 +1,16 @@
 /** @odoo-module **/
 
-import { Component, EventBus, xml } from "@odoo/owl";
+import {
+    Component,
+    EventBus,
+    onMounted,
+    onPatched,
+    onWillStart,
+    onWillUpdateProps,
+    useEffect,
+    useState,
+    xml,
+} from "@odoo/owl";
 import { makeServerError } from "@web/../tests/helpers/mock_server";
 import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 import {
@@ -3451,10 +3461,10 @@ QUnit.module("Views", (hooks) => {
         let rpcCount = 0;
         class AsyncField extends CharField {
             setup() {
-                owl.onWillStart(async () => {
+                onWillStart(async () => {
                     assert.step("willStart");
                 });
-                owl.onWillUpdateProps(async () => {
+                onWillUpdateProps(async () => {
                     assert.step("willUpdateProps");
                     if (rpcCount === 1) {
                         return new Promise(() => {});
@@ -3891,12 +3901,12 @@ QUnit.module("Views", (hooks) => {
     QUnit.test("evaluate in python field options", async function (assert) {
         assert.expect(3);
 
-        class MyField extends owl.Component {
+        class MyField extends Component {
             setup() {
                 assert.strictEqual(this.props.horizontal, true);
             }
         }
-        MyField.template = owl.xml`<div>ok</div>`;
+        MyField.template = xml`<div>ok</div>`;
         fieldRegistry.add("my_field", {
             component: MyField,
             extractProps: function ({ options }) {
@@ -10572,8 +10582,8 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("basic support for widgets", async function (assert) {
-        class MyComponent extends owl.Component {
-            static template = owl.xml`<div t-esc="value"/>`;
+        class MyComponent extends Component {
+            static template = xml`<div t-esc="value"/>`;
             get value() {
                 return JSON.stringify(this.props.record.data);
             }
@@ -10602,8 +10612,8 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("widget with class attribute", async function (assert) {
-        class MyComponent extends owl.Component {
-            static template = owl.xml`<span>Hello</span>`;
+        class MyComponent extends Component {
+            static template = xml`<span>Hello</span>`;
         }
         const myComponent = {
             component: MyComponent,
@@ -10624,8 +10634,8 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("widget with readonly attribute", async function (assert) {
-        class MyComponent extends owl.Component {
-            static template = owl.xml`<span t-esc="value"/>`;
+        class MyComponent extends Component {
+            static template = xml`<span t-esc="value"/>`;
             get value() {
                 return this.props.readonly ? "readonly" : "not readonly";
             }
@@ -10674,13 +10684,13 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("basic support for widgets: onchange update", async function (assert) {
-        class MyWidget extends owl.Component {
-            static template = owl.xml`<t t-esc="state.dataToDisplay" />`;
+        class MyWidget extends Component {
+            static template = xml`<t t-esc="state.dataToDisplay" />`;
             setup() {
-                this.state = owl.useState({
+                this.state = useState({
                     dataToDisplay: this.props.record.data.foo,
                 });
-                owl.useEffect(() => {
+                useEffect(() => {
                     this.state.dataToDisplay = this.props.record.data.foo + "!";
                 });
             }
@@ -13698,10 +13708,10 @@ QUnit.module("Views", (hooks) => {
                 setup() {
                     super.setup(...arguments);
                     const prefix = `${this.constructor.name} ${this.props.name}`;
-                    owl.onMounted(() => assert.step(`[${prefix}] onMounted`));
-                    owl.onPatched(() => assert.step(`[${prefix}] onPatched`));
-                    owl.onWillStart(() => assert.step(`[${prefix}] onWillStart`));
-                    owl.onWillUpdateProps(() => assert.step(`[${prefix}] onWillUpdateProps`));
+                    onMounted(() => assert.step(`[${prefix}] onMounted`));
+                    onPatched(() => assert.step(`[${prefix}] onPatched`));
+                    onWillStart(() => assert.step(`[${prefix}] onWillStart`));
+                    onWillUpdateProps(() => assert.step(`[${prefix}] onWillUpdateProps`));
                 },
             });
         }
@@ -13755,10 +13765,10 @@ QUnit.module("Views", (hooks) => {
                     setup() {
                         super.setup(...arguments);
                         const prefix = `${this.constructor.name} ${this.props.name}`;
-                        owl.onMounted(() => assert.step(`[${prefix}] onMounted`));
-                        owl.onPatched(() => assert.step(`[${prefix}] onPatched`));
-                        owl.onWillStart(() => assert.step(`[${prefix}] onWillStart`));
-                        owl.onWillUpdateProps(() => assert.step(`[${prefix}] onWillUpdateProps`));
+                        onMounted(() => assert.step(`[${prefix}] onMounted`));
+                        onPatched(() => assert.step(`[${prefix}] onPatched`));
+                        onWillStart(() => assert.step(`[${prefix}] onWillStart`));
+                        onWillUpdateProps(() => assert.step(`[${prefix}] onWillUpdateProps`));
                     },
                 });
             }

--- a/addons/web/static/tests/views/helpers.js
+++ b/addons/web/static/tests/views/helpers.js
@@ -144,6 +144,6 @@ export async function prepareWowlFormViewDialogs(serverData, mockRPC) {
     const wowlEnv = await makeTestEnv({ serverData, mockRPC });
     const legacyEnv = makeTestEnvironment();
     mapLegacyEnvToWowlEnv(legacyEnv, wowlEnv);
-    owl.Component.env = legacyEnv;
+    Component.env = legacyEnv;
     await mount(MainComponentsContainer, getFixture(), { env: wowlEnv });
 }

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -9254,7 +9254,7 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("basic support for widgets (being Owl Components)", async (assert) => {
         class MyComponent extends Component {
-            static template = owl.xml`<div t-att-class="props.class" t-esc="value"/>`;
+            static template = xml`<div t-att-class="props.class" t-esc="value"/>`;
             get value() {
                 return JSON.stringify(this.props.record.data);
             }
@@ -9287,7 +9287,7 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("kanban card: record value should be update", async (assert) => {
         class MyComponent extends Component {
-            static template = owl.xml`<div><button t-on-click="onClick">CLick</button></div>`;
+            static template = xml`<div><button t-on-click="onClick">CLick</button></div>`;
             onClick() {
                 this.props.record.update({ foo: "yolo" });
             }
@@ -13512,7 +13512,7 @@ QUnit.module("Views", (hooks) => {
         let def;
         class MyField extends Component {
             setup() {
-                owl.onWillRender(() => {
+                onWillRender(() => {
                     renderCount++;
                 });
             }

--- a/addons/web/static/tests/views/record_tests.js
+++ b/addons/web/static/tests/views/record_tests.js
@@ -512,7 +512,7 @@ QUnit.module("Record Component", (hooks) => {
                             type: "boolean",
                         },
                     };
-                    this.values = owl.useState({
+                    this.values = useState({
                         foo: "abc",
                         bar: true,
                     });

--- a/addons/web/static/tests/webclient/actions/client_action_tests.js
+++ b/addons/web/static/tests/webclient/actions/client_action_tests.js
@@ -6,7 +6,7 @@ import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { click, getFixture, nextTick, patchWithCleanup } from "../../helpers/utils";
 import { createWebClient, doAction, getActionManagerServerData } from "./../helpers";
 
-import { Component, xml } from "@odoo/owl";
+import { Component, onMounted, xml } from "@odoo/owl";
 
 let serverData;
 let target;
@@ -166,7 +166,7 @@ QUnit.module("ActionManager", (hooks) => {
                 const { breadcrumbs } = this.env.config;
                 assert.strictEqual(breadcrumbs.length, 2);
                 assert.strictEqual(breadcrumbs[0].name, "Favorite Ponies");
-                owl.onMounted(() => {
+                onMounted(() => {
                     this.env.config.setDisplayName(this.breadcrumbTitle);
                 });
             }

--- a/addons/web/static/tests/webclient/actions/concurrency_tests.js
+++ b/addons/web/static/tests/webclient/actions/concurrency_tests.js
@@ -24,7 +24,7 @@ import {
     loadState,
 } from "@web/../tests/webclient/helpers";
 
-import { Component, xml } from "@odoo/owl";
+import { Component, onWillStart, xml } from "@odoo/owl";
 const actionRegistry = registry.category("actions");
 
 function getBreadCrumbTexts(target) {
@@ -411,7 +411,7 @@ QUnit.module("ActionManager", (hooks) => {
             const slowWillStartDef = makeDeferred();
             class ClientAction extends Component {
                 setup() {
-                    owl.onWillStart(() => slowWillStartDef);
+                    onWillStart(() => slowWillStartDef);
                 }
             }
             ClientAction.template = xml`<div class="client_action">ClientAction</div>`;
@@ -620,7 +620,7 @@ QUnit.module("ActionManager", (hooks) => {
                         return { fromId: this.id };
                     },
                 });
-                owl.onWillStart(() => def);
+                onWillStart(() => def);
             }
         }
         ToyController.template = xml`

--- a/addons/web/static/tests/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/webclient/actions/load_state_tests.js
@@ -30,7 +30,7 @@ import {
 } from "./../helpers";
 import { errorService } from "@web/core/errors/error_service";
 
-import { Component, xml } from "@odoo/owl";
+import { Component, onMounted, xml } from "@odoo/owl";
 
 function getBreadCrumbTexts(target) {
     return getNodesTextContent(target.querySelectorAll(".breadcrumb-item, .o_breadcrumb .active"));
@@ -776,7 +776,7 @@ QUnit.module("ActionManager", (hooks) => {
         const hashchangeDef = makeDeferred();
         class MyAction extends Component {
             setup() {
-                owl.onMounted(() => {
+                onMounted(() => {
                     assert.step("myAction mounted");
                     browser.addEventListener("hashchange", () => {
                         hashchangeDef.resolve();
@@ -818,7 +818,7 @@ QUnit.module("ActionManager", (hooks) => {
 
         class MyAction extends Component {
             setup() {
-                owl.onMounted(() => {
+                onMounted(() => {
                     assert.step("myAction mounted");
                     const newURL = baseURL + "#action=__test__client__action__&menu_id=1";
                     // immediate triggering

--- a/addons/web/tooling/_eslintrc.json
+++ b/addons/web/tooling/_eslintrc.json
@@ -37,7 +37,6 @@
     }]
   },
   "globals": {
-    "owl": "readonly",
     "odoo": "readonly",
     "$": "readonly",
     "jQuery": "readonly",
@@ -48,7 +47,6 @@
     "StackTrace": "readonly",
     "QUnit": "readonly",
     "luxon": "readonly",
-    "moment": "readonly",
     "py": "readonly",
     "FullCalendar": "readonly",
     "ClipboardJS": "readonly",

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -28,6 +28,7 @@ import {
     onWillUpdateProps,
     useEffect,
     onWillUnmount,
+    status,
 } from "@odoo/owl";
 import { uniqueId } from '@web/core/utils/functions';
 import { Wysiwyg, stripHistoryIds } from '../wysiwyg/wysiwyg';
@@ -387,7 +388,7 @@ export class HtmlField extends Component {
                 }
                 this.wysiwyg.odooEditor.observerActive('commitChanges');
             }
-            if (owl.status(this) !== 'destroyed') {
+            if (status(this) !== 'destroyed') {
                 await this.updateValue();
             }
         }

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -8,8 +8,17 @@ import {svgToPNG} from '@website/js/utils';
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { mixCssColors } from '@web/core/utils/colors';
-
-const { Component, onMounted, reactive, useEnv, useRef, useState, useSubEnv, onWillStart, useExternalListener } = owl;
+import {
+    Component,
+    onMounted,
+    reactive,
+    useEnv,
+    useRef,
+    useState,
+    useSubEnv,
+    onWillStart,
+    useExternalListener,
+} from "@odoo/owl";
 
 const ROUTES = {
     descriptionScreen: 2,

--- a/addons/website/static/src/client_actions/website_preview/website_preview.js
+++ b/addons/website/static/src/client_actions/website_preview/website_preview.js
@@ -15,8 +15,16 @@ import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import wUtils from '@website/js/utils';
 import { renderToElement } from "@web/core/utils/render";
 import { SIZES, utils as uiUtils } from "@web/core/ui/ui_service";
-
-const { Component, onWillStart, onMounted, onWillUnmount, useRef, useEffect, useState, useExternalListener } = owl;
+import {
+    Component,
+    onWillStart,
+    onMounted,
+    onWillUnmount,
+    useRef,
+    useEffect,
+    useState,
+    useExternalListener,
+} from "@odoo/owl";
 
 class BlockPreview extends Component {}
 BlockPreview.template = 'website.BlockPreview';

--- a/addons/website/static/src/components/dialog/dialog.js
+++ b/addons/website/static/src/components/dialog/dialog.js
@@ -5,8 +5,7 @@ import { Dialog } from '@web/core/dialog/dialog';
 import { _t } from "@web/core/l10n/translation";
 import { Switch } from '@website/components/switch/switch';
 import {unslugHtmlDataObject} from '../../services/website_service';
-
-const { xml, useState, Component, onWillStart } = owl;
+import { xml, useState, Component, onWillStart } from "@odoo/owl";
 
 const NO_OP = () => {};
 

--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -8,8 +8,7 @@ import {useWowlService} from '@web/legacy/utils';
 import {WebsiteDialog} from './dialog';
 import {FormViewDialog} from "@web/views/view_dialogs/form_view_dialog";
 import { renderToElement } from "@web/core/utils/render";
-
-const { Component, useEffect, useState, xml, useRef } = owl;
+import { Component, useEffect, useState, xml, useRef } from "@odoo/owl";
 
 export class PageDependencies extends Component {
     setup() {

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -4,8 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService, useAutofocus } from '@web/core/utils/hooks';
 import { MediaDialog } from '@web_editor/components/media_dialog/media_dialog';
 import { WebsiteDialog } from './dialog';
-
-const { Component, useState, reactive, onMounted, onWillStart, useEffect } = owl;
+import { Component, useState, reactive, onMounted, onWillStart, useEffect } from "@odoo/owl";
 
 // This replaces \b, because accents(e.g. à, é) are not seen as word boundaries.
 // Javascript \b is not unicode aware, and words beginning or ending by accents won't match \b

--- a/addons/website/static/src/components/editor/editor.js
+++ b/addons/website/static/src/components/editor/editor.js
@@ -4,8 +4,15 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from '@web/core/utils/hooks';
 import { WysiwygAdapterComponent } from '../wysiwyg_adapter/wysiwyg_adapter';
 import { useActiveElement } from '@web/core/ui/ui_service';
-
-const { markup, Component, useState, useEffect, onWillStart, onMounted, onWillUnmount } = owl;
+import {
+    markup,
+    Component,
+    useState,
+    useEffect,
+    onWillStart,
+    onMounted,
+    onWillUnmount,
+} from "@odoo/owl";
 
 export class WebsiteEditorComponent extends Component {
     /**

--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -7,8 +7,7 @@ import {useService} from '@web/core/utils/hooks';
 import {Switch} from '@website/components/switch/switch';
 import {registry} from '@web/core/registry';
 import { _t } from '@web/core/l10n/translation';
-
-const {Component, useState} = owl;
+import { Component, useState } from "@odoo/owl";
 
 /**
  * Displays website page dependencies and URL redirect options when the page URL

--- a/addons/website/static/src/components/fields/publish_button.js
+++ b/addons/website/static/src/components/fields/publish_button.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class PublishField extends Component {}
 PublishField.template = "website.PublishField";

--- a/addons/website/static/src/components/fields/redirect_field.js
+++ b/addons/website/static/src/components/fields/redirect_field.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { pick } from "@web/core/utils/objects";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 class RedirectField extends Component {
     get info() {

--- a/addons/website/static/src/components/fields/widget_iframe.js
+++ b/addons/website/static/src/components/fields/widget_iframe.js
@@ -2,8 +2,7 @@
 
 import { registry } from '@web/core/registry';
 import { useBus } from "@web/core/utils/hooks";
-
-const { Component, useState } = owl;
+import { Component, useState } from "@odoo/owl";
 
 class FieldIframePreview extends Component {
     setup() {

--- a/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
+++ b/addons/website/static/src/components/fullscreen_indication/fullscreen_indication.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 
 import { useBus } from "@web/core/utils/hooks";
-
-const { EventBus, Component, xml, useState } = owl;
+import { EventBus, Component, xml, useState } from "@odoo/owl";
 
 export class FullscreenIndication extends Component {
     setup() {

--- a/addons/website/static/src/components/navbar/navbar.js
+++ b/addons/website/static/src/components/navbar/navbar.js
@@ -4,9 +4,9 @@ import { NavBar } from '@web/webclient/navbar/navbar';
 import { useService, useBus } from '@web/core/utils/hooks';
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
+import { useEffect } from "@odoo/owl";
 
 const websiteSystrayRegistry = registry.category('website_systray');
-const { useEffect } = owl;
 
 patch(NavBar.prototype, {
     setup() {

--- a/addons/website/static/src/components/switch/switch.js
+++ b/addons/website/static/src/components/switch/switch.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-const { Component, xml } = owl;
+import { Component, xml } from "@odoo/owl";
 
 const NO_OP = () => {};
 

--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -5,8 +5,8 @@ import { useService } from '@web/core/utils/hooks';
 import { WebsiteEditorComponent } from '../editor/editor';
 import { WebsiteDialog } from '../dialog/dialog';
 import { browser } from "@web/core/browser/browser";
+import { useEffect, useRef, Component, xml } from "@odoo/owl";
 
-const { useEffect, useRef, Component, xml } = owl;
 const localStorageNoDialogKey = 'website_translator_nodialog';
 
 export class AttributeTranslateDialog extends Component {

--- a/addons/website/static/src/components/views/page_views_mixin.js
+++ b/addons/website/static/src/components/views/page_views_mixin.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import {AddPageDialog} from "../dialog/dialog";
 import {useService} from "@web/core/utils/hooks";
-
-const {onWillStart, useState} = owl;
+import { onWillStart, useState } from "@odoo/owl";
 
 /**
  * Used to share code and keep the same behaviour on different types of 'website

--- a/addons/website/static/src/components/views/theme_preview_form.js
+++ b/addons/website/static/src/components/views/theme_preview_form.js
@@ -6,8 +6,8 @@ import { formView } from "@web/views/form/form_view";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ViewButton } from "@web/views/view_button/view_button";
+import { useSubEnv, useEnv } from "@odoo/owl";
 
-const { useSubEnv, useEnv } = owl;
 /*
 * Common code for theme installation/update handler.
 * It overrides the onClickViewButton function that's present in the env.

--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -3,7 +3,7 @@
 import { useBus, useService } from "@web/core/utils/hooks";
 import { sprintf } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
-const { EventBus, Component, markup, useEffect, useState } = owl;
+import { EventBus, Component, markup, useEffect, useState } from "@odoo/owl";
 
 export class WebsiteLoader extends Component {
     setup() {

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -13,8 +13,7 @@ import { isMediaElement } from '@web_editor/js/editor/odoo-editor/src/utils/util
 import { EditMenuDialog, MenuDialog } from "../dialog/edit_menu";
 import { WebsiteDialog } from '../dialog/dialog';
 import { PageOption } from "./page_options";
-
-const { onWillStart, useEffect, onWillUnmount } = owl;
+import { onWillStart, useEffect, onWillUnmount } from "@odoo/owl";
 
 /**
  * Show/hide the dropdowns associated to the given toggles and allows to wait

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -6,8 +6,7 @@ import { getBundle, loadBundle } from "@web/core/assets";
 
 import { FullscreenIndication } from '../components/fullscreen_indication/fullscreen_indication';
 import { WebsiteLoader } from '../components/website_loader/website_loader';
-
-const { reactive, EventBus } = owl;
+import { reactive, EventBus } from "@odoo/owl";
 
 const websiteSystrayRegistry = registry.category('website_systray');
 

--- a/addons/website/static/src/systray_items/edit_in_backend.js
+++ b/addons/website/static/src/systray_items/edit_in_backend.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { useService, useBus } from "@web/core/utils/hooks";
-
-const { Component, onWillStart, useState } = owl;
+import { Component, onWillStart, useState } from "@odoo/owl";
 
 const websiteSystrayRegistry = registry.category('website_systray');
 

--- a/addons/website/static/src/systray_items/edit_website.js
+++ b/addons/website/static/src/systray_items/edit_website.js
@@ -3,8 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { useService } from '@web/core/utils/hooks';
-
-const { Component, useState, useEffect } = owl;
+import { Component, useState, useEffect } from "@odoo/owl";
 
 class EditWebsiteSystray extends Component {
     setup() {

--- a/addons/website/static/src/systray_items/mobile_preview.js
+++ b/addons/website/static/src/systray_items/mobile_preview.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-
-const { Component, useState } = owl;
+import { Component, useState } from "@odoo/owl";
 
 class MobilePreviewSystray extends Component {
     setup() {

--- a/addons/website/static/src/systray_items/new_content.js
+++ b/addons/website/static/src/systray_items/new_content.js
@@ -6,8 +6,7 @@ import { useService } from '@web/core/utils/hooks';
 import { WebsiteDialog, AddPageDialog } from "@website/components/dialog/dialog";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { sprintf } from '@web/core/utils/strings';
-
-const { Component, xml, useState, onWillStart } = owl;
+import { Component, xml, useState, onWillStart } from "@odoo/owl";
 
 export const MODULE_STATUS = {
     NOT_INSTALLED: 'NOT_INSTALLED',

--- a/addons/website/static/src/systray_items/publish.js
+++ b/addons/website/static/src/systray_items/publish.js
@@ -4,8 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { Switch } from '@website/components/switch/switch';
 import { useService, useBus } from '@web/core/utils/hooks';
-
-const { Component, xml, useState } = owl;
+import { Component, xml, useState } from "@odoo/owl";
 
 const websiteSystrayRegistry = registry.category('website_systray');
 

--- a/addons/website/static/src/systray_items/translate_website.js
+++ b/addons/website/static/src/systray_items/translate_website.js
@@ -2,8 +2,7 @@
 
 import { registry } from "@web/core/registry";
 import { useService } from '@web/core/utils/hooks';
-
-const { Component, useState } = owl;
+import { Component, useState } from "@odoo/owl";
 
 class TranslateWebsiteSystray extends Component {
     setup() {

--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -7,8 +7,7 @@ import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import wUtils from '@website/js/utils';
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class WebsiteSwitcherSystray extends Component {
     setup() {

--- a/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
+++ b/addons/website_sale/static/src/js/components/website_sale_image_viewer.js
@@ -2,8 +2,7 @@
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
-
-const { onRendered, useRef, useEffect, useState } = owl;
+import { onRendered, useRef, useEffect, useState } from "@odoo/owl";
 
 const ZOOM_STEP = 0.1;
 

--- a/addons/website_sale/static/src/js/website_sale_reorder.js
+++ b/addons/website_sale/static/src/js/website_sale_reorder.js
@@ -30,8 +30,7 @@ publicWidget.registry.SaleOrderPortalReorderWidget = publicWidget.Widget.extend(
 
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
-
-const { Component, onWillStart } = owl;
+import { Component, onWillStart } from "@odoo/owl";
 
 // Reorder Dialog
 

--- a/addons/website_sale/static/src/js/website_sale_video_field_preview.js
+++ b/addons/website_sale/static/src/js/website_sale_video_field_preview.js
@@ -1,8 +1,7 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-
-const { Component }  = owl;
+import { Component } from "@odoo/owl";
 
 export class FieldVideoPreview extends Component {}
 FieldVideoPreview.template = 'website_sale.FieldVideoPreview';

--- a/addons/website_slides/static/src/slide_category_list_renderer.js
+++ b/addons/website_slides/static/src/slide_category_list_renderer.js
@@ -2,8 +2,7 @@
 
 import { makeContext } from "@web/core/context";
 import { ListRenderer } from "@web/views/list/list_renderer";
-
-const { useEffect } = owl;
+import { useEffect } from "@odoo/owl";
 
 export class SlideCategoryListRenderer extends ListRenderer {
     setup() {

--- a/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.js
+++ b/odoo/addons/test_assetsbundle/static/tests/lazy_test_component/lazy_test_component.js
@@ -1,8 +1,7 @@
 /** @odoo-module */
 
 import { registry } from "@web/core/registry";
-
-const { Component } = owl;
+import { Component } from "@odoo/owl";
 
 export class LazyTestComponent extends Component {
     setup() {

--- a/odoo/addons/test_assetsbundle/static/tests/lazyloading_test.js
+++ b/odoo/addons/test_assetsbundle/static/tests/lazyloading_test.js
@@ -4,8 +4,7 @@ import { loadBundle, LazyComponent } from "@web/core/assets";
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { getFixture, patchWithCleanup } from "@web/../tests/helpers/utils";
-
-const { Component, App, xml } = owl;
+import { Component, App, xml } from "@odoo/owl";
 
 QUnit.module("utils", () => {
     QUnit.module("Assets");

--- a/odoo/addons/test_lint/tests/eslintrc
+++ b/odoo/addons/test_lint/tests/eslintrc
@@ -23,7 +23,6 @@
         "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all" }]
     },
     "globals": {
-        "owl": "readonly",
         "odoo": "readonly",
         "$": "readonly",
         "jQuery": "readonly",
@@ -33,7 +32,6 @@
         "StackTrace": "readonly",
         "QUnit": "readonly",
         "luxon": "readonly",
-        "moment": "readonly",
         "py": "readonly",
         "FullCalendar": "readonly",
         "ClipboardJS": "readonly",


### PR DESCRIPTION
Before this commit, owl was in the linter's accepted global variables.
This allowed  direct access to owl global object.

For instance, to use xml from owl, you could do :
`const { xml } = owl;`
or you could use it directly:
`owl.xml`

Now, owl is not accepted on linter's global variables anymore, so to
import xml, now you need to use a proper import:

`import { xml } from "@odoo/owl";`

task-id 3498859
