### PR TITLE
[FIX] im_livechat: clean session even if leave fails

### DIFF
--- a/addons/im_livechat/static/src/embed/core/messaging_service_patch.js
+++ b/addons/im_livechat/static/src/embed/core/messaging_service_patch.js
@@ -1,4 +1,5 @@
 /* @odoo-module */
+import { SESSION_STATE } from "@im_livechat/embed/core/livechat_service";
 
 import { Messaging } from "@mail/core/common/messaging_service";
 
@@ -7,7 +8,7 @@ import { session } from "@web/session";
 
 patch(Messaging.prototype, {
     initialize() {
-        if (this.env.services["im_livechat.livechat"].guestToken) {
+        if (this.env.services["im_livechat.livechat"].state === SESSION_STATE.PERSISTED) {
             return super.initialize();
         }
         if (session.livechatData?.options.current_partner_id) {


### PR DESCRIPTION
Before this PR, if an error occurred when leaving the session, the state of the livechat was not properly reset. This is an issue since this could lead to a visitor being stuck with an outdated session. This commit ensures the session state is reset even if an error occurs during the session leave rpc.

