### PR TITLE
[IMP] point_of_sale: mix bill changes

### DIFF
--- a/addons/l10n_in_pos/data/product_demo.xml
+++ b/addons/l10n_in_pos/data/product_demo.xml
@@ -53,5 +53,9 @@
             <field name="l10n_in_hsn_description">Ball point pens; felt tipped and other porous-tipped pens and markers; fountain pens, stylograph pens and other pens; duplicating stylos; propelling or sliding pencils; pen-holders, pencilholders and similar holders; parts (including caps and clips) of the foregoing articles, othe than those of heading 9609
             </field>
         </record>
+        <record model="pos.bill" id="500_00" forcecreate="0">
+            <field name="name">500.00</field>
+            <field name="value">500.00</field>
+        </record>
     </data>
 </odoo>

--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -57,91 +57,76 @@
         <record model="pos.bill" id="0_01" forcecreate="0">
             <field name="name">0.01</field>
             <field name="value">0.01</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="0_02" forcecreate="0">
             <field name="name">0.02</field>
             <field name="value">0.02</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="0_05" forcecreate="0">
             <field name="name">0.05</field>
             <field name="value">0.05</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="0_10" forcecreate="0">
             <field name="name">0.10</field>
             <field name="value">0.10</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="0_20" forcecreate="0">
             <field name="name">0.20</field>
             <field name="value">0.20</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="0_25" forcecreate="0">
             <field name="name">0.25</field>
             <field name="value">0.25</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="0_50" forcecreate="0">
             <field name="name">0.50</field>
             <field name="value">0.50</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="1_00" forcecreate="0">
             <field name="name">1.00</field>
             <field name="value">1.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="2_00" forcecreate="0">
             <field name="name">2.00</field>
             <field name="value">2.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="5_00" forcecreate="0">
             <field name="name">5.00</field>
             <field name="value">5.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="10_00" forcecreate="0">
             <field name="name">10.00</field>
             <field name="value">10.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="20_00" forcecreate="0">
             <field name="name">20.00</field>
             <field name="value">20.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="50_00" forcecreate="0">
             <field name="name">50.00</field>
             <field name="value">50.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="100_00" forcecreate="0">
             <field name="name">100.00</field>
             <field name="value">100.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <record model="pos.bill" id="200_00" forcecreate="0">
             <field name="name">200.00</field>
             <field name="value">200.00</field>
-            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
 
         <function model="pos.config" name="post_install_pos_localisation" />

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1845,7 +1845,7 @@ class PosSession(models.Model):
         return config
 
     def _loader_params_pos_bill(self):
-        return {'search_params': {'domain': [('id', 'in', self.config_id.default_bill_ids.ids)], 'fields': ['name', 'value']}}
+        return {'search_params': {'domain': ['|', ('id', 'in', self.config_id.default_bill_ids.ids), ('pos_config_ids', '=', False)], 'fields': ['name', 'value']}}
 
     def _get_pos_ui_pos_bill(self, params):
         return self.env['pos.bill'].search_read(**params['search_params'])

--- a/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/cash_opening_popup/cash_opening_popup.xml
@@ -24,13 +24,11 @@
                 </div>
             </main>
             <footer class="footer modal-footer">
-                <button class="button btn btn-lg btn-primary" 
+                <button class="button btn btn-lg btn-primary"
                     t-on-click="confirm"
                     t-att-disabled="!env.utils.isValidFloat(state.openingCash)"
                     >
-                    Open session 
-                    <span t-if="env.utils.isValidFloat(state.openingCash)"
-                        t-esc="env.utils.formatStrCurrency(state.openingCash)"/>
+                    Open session
                 </button>
             </footer>
         </div>

--- a/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.xml
@@ -6,14 +6,12 @@
                 <h4 class="modal-title">Coins/Bills</h4>
             </div>
             <main class="modal-body">
-                <t t-set="bills" t-value="Object.keys(state.moneyDetails).sort((a, b) => a - b)"/>
+                <t t-set="bills" t-value="Object.keys(state.moneyDetails).sort((a, b) => b - a)"/>
                 <div t-attf-style="display: grid; grid-template-rows: repeat(calc({{bills.length}}/2) ,auto); grid-auto-flow: column;">
                     <div t-foreach="bills" t-as="moneyValue" t-key="moneyValue" class="d-flex align-items-center justify-content-center my-1 ">
                         <input class="pos-input form-control w-50 text-end" t-att-id="moneyValue" type="number" t-model.number="state.moneyDetails[moneyValue]" t-on-focus="ev=>ev.target.select()"/>
                         <label class="oe_link_icon w-25 text-end" t-att-for="moneyValue">
-                            <t t-if="currency.position === 'before'" t-esc="currency.symbol"/>
-                            <span class="mx-1" t-esc="moneyValue"/>
-                            <t t-if="currency.position === 'after'" t-esc="currency.symbol"/>
+                            <span class="mx-1" t-esc="env.utils.formatStrCurrency(moneyValue)"/>
                         </label>
                     </div>
                 </div>

--- a/addons/point_of_sale/views/pos_bill_view.xml
+++ b/addons/point_of_sale/views/pos_bill_view.xml
@@ -20,10 +20,10 @@
         <field name="name">pos.bill.tree</field>
         <field name="model">pos.bill</field>
         <field name="arch" type="xml">
-            <tree string="Bills" create="1" delete="1">
+            <tree string="Bills" create="1" delete="1" editable="bottom">
                 <field name="name" />
                 <field name="value" />
-                <field name="pos_config_ids" widget="many2many_tags" />
+                <field name="pos_config_ids" widget="many2many_tags" placeholder="ALL POS" />
             </tree>
         </field>
     </record>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -86,9 +86,6 @@
                                     <field name="pos_amount_authorized_diff"/>
                                 </div>
                             </setting>
-                            <setting invisible="not pos_cash_control" string="Coins/Bills" help="Set of coins/bills that will be used in opening and closing control">
-                                <field name="pos_default_bill_ids" colspan="4" widget="many2many_tags" options="{'no_create_edit': True}" context="{'default_pos_config_ids':[(6, False, [pos_config_id])]}"/>
-                            </setting>
                             <setting id="iface_tipproduct" title="This product is used as reference on customer receipts." string="Tips" help="Accept customer tips or convert their change to a tip">
                                 <field name="pos_iface_tipproduct" readonly="pos_has_active_session"/>
                                 <div class="content-group" invisible="not pos_iface_tipproduct">


### PR DESCRIPTION

This commit:
- Changes the order of bills and how the values are displayed in the
pos_bill_view.
- Adds a 500 bill for India localisation.
- Changes the tree view of pos bill to be editable and set the bill
to all the pos_configs if no config is linked to the bill.
- To prevent inconsitancy, 'pos_default_bill_ids' field is removed from
the res.config.settings view since if no pos config is linked to the bill, the
bill is accessible to all the pos configs.
- Removes the amount in the open session button in opening cash control popup.

Task-3537655