### PR TITLE
[FIX] mail: mention same user multiple times in message

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -175,7 +175,7 @@ function generateMentionsLinks(body, { partners = [], threads = [] }) {
             placeholder,
             text,
         });
-        body = body.replace(text, placeholder);
+        body = body.replaceAll(text, placeholder);
     }
     for (const thread of threads) {
         const placeholder = `#-mention-channel-${thread.id}`;
@@ -187,7 +187,7 @@ function generateMentionsLinks(body, { partners = [], threads = [] }) {
             placeholder,
             text,
         });
-        body = body.replace(text, placeholder);
+        body = body.replaceAll(text, placeholder);
     }
     const baseHREF = url("/web");
     for (const mention of mentions) {
@@ -197,7 +197,7 @@ function generateMentionsLinks(body, { partners = [], threads = [] }) {
         const dataOeModel = `data-oe-model='${mention.model}'`;
         const target = "target='_blank'";
         const link = `<a ${href} ${attClass} ${dataOeId} ${dataOeModel} ${target}>${mention.text}</a>`;
-        body = body.replace(mention.placeholder, link);
+        body = body.replaceAll(mention.placeholder, link);
     }
     return body;
 }

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -340,6 +340,34 @@ QUnit.test("add an emoji after a partner mention", async () => {
     await contains(".o-mail-Composer-input", { value: "@TestPartner 😊" });
 });
 
+QUnit.test("mention same user twice in a message", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({
+        email: "testpartner@odoo.com",
+        name: "TestPartner",
+    });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "Mario Party",
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await contains(".o-mail-Composer-input", { value: "" });
+    await insertText(".o-mail-Composer-input", "@Te");
+    await click(".o-mail-Composer-suggestion");
+    await contains(".o-mail-Composer-input", { value: "@TestPartner " });
+    await insertText(".o-mail-Composer-input", "@Te");
+    await click(".o-mail-Composer-suggestion");
+    await click("button", { text: "Send" });
+    await contains(
+        `.o-mail-Message-body .o_mail_redirect[data-oe-id="${partnerId}"][data-oe-model="res.partner"]`,
+        { text: "@TestPartner", count: 2 }
+    );
+});
+
 QUnit.test("mention a channel after some text", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
Before this commit, when mentioning a same user in a message twice, only the 1st `@` text was highlighted as a mention.

This commit fixes the issue by highlighting all matching mentions of user and channel.

Task-3531939
