### PR TITLE
[FIX] web: invisible fields are not fetched

### DIFF
--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -365,7 +365,14 @@ export function getFieldsSpec(
         const { related, limit, defaultOrderBy, invisible } = activeFields[fieldName];
         fieldsSpec[fieldName] = {};
         // X2M
-        if (related && ((invisible !== "True" && invisible !== "1") || withInvisible)) {
+        if (
+            related &&
+            ((invisible !== "True" && invisible !== "1") ||
+                Object.values(related.activeFields).find(
+                    (rf) => rf.invisble !== "True" || rf.invisible !== 1
+                ) ||
+                withInvisible)
+        ) {
             fieldsSpec[fieldName].fields = getFieldsSpec(
                 related.activeFields,
                 related.fields,


### PR DESCRIPTION
Rare use case that used to work in Odoo:
Journal Items (account.move.line list view) display the related moves attachments on the right. In order to do this, the attachments mime type needs to be available in the record's data. This was done by adding a sub tree to the list view 
```xml
<field name="move_attachment_ids" column_invisible="True">
  <tree>
    <field name="mimetype"/>
  </tree>
</field>
```
Since unity_read and the new relational model, invisible fields are no longer fetched.

This solution proposes ignoring the invisible value if there are visible related fields

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
