### PR TITLE
[FIX] mail: make call invitation work from recent discuss model REF

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -191,6 +191,8 @@ export const storeService = {
                                     const r2 = res.store.get(l1);
                                     if (r2) {
                                         r2.__invs__.delete(r1.localId, name);
+                                        const { onDelete } = r1.Model.__rels__.get(name);
+                                        onDelete?.call(r1, r2);
                                     }
                                     r1.__rels__.set(name, undefined);
                                 }
@@ -239,12 +241,7 @@ export const storeService = {
                                     if ([null, false, undefined].includes(val)) {
                                         return true;
                                     }
-                                    for (const v of collection) {
-                                        preinsert(v, r1, name, (r3) => {
-                                            l1.__list__.push(r3.localId);
-                                            r3.__invs__.add(r1.localId, name);
-                                        });
-                                    }
+                                    l1.push(...collection);
                                 } else {
                                     // [Record.one] =
                                     const r1 = receiver;
@@ -252,6 +249,8 @@ export const storeService = {
                                     const r2 = res.store.get(l1);
                                     if (r2) {
                                         r2.__invs__.delete(r1.localId, name);
+                                        const { onDelete } = r1.Model.__rels__.get(name);
+                                        onDelete?.call(r1, r2);
                                     }
                                     if (Record.isCommand(val)) {
                                         const [cmd, cmdData] = val.at(-1);
@@ -261,9 +260,11 @@ export const storeService = {
                                         delete receiver[name];
                                         return true;
                                     }
-                                    preinsert(val, r1, name, (r3) => {
+                                    const r = preinsert(val, r1, name, (r3) => {
                                         r1.__rels__.set(name, r3?.localId);
                                     });
+                                    const { onAdd } = r1.Model.__rels__.get(name);
+                                    onAdd?.call(r1, r);
                                 }
                                 return true;
                             },

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -190,7 +190,17 @@ export class Thread extends Record {
             this._store.env.services["discuss.rtc"].deleteSession(r.id);
         },
     });
-    rtcInvitingSession = Record.one("RtcSession");
+    rtcInvitingSession = Record.one("RtcSession", {
+        /** @this {import("models").Thread} */
+        onAdd(r) {
+            this.rtcSessions.add(r);
+            this._store.discuss.ringingThreads.add(this);
+        },
+        /** @this {import("models").Thread} */
+        onDelete(r) {
+            this._store.discuss.ringingThreads.delete(this);
+        },
+    });
     invitedMembers = Record.many("ChannelMember");
     chatPartner = Record.one("Persona");
     composer = Record.one("Composer");

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -8,23 +8,12 @@ patch(Thread.prototype, {
     update(data) {
         super.update(data);
         if ("rtc_inviting_session" in data) {
-            this.rtcSessions.add(data.rtc_inviting_session);
-            this._store.discuss.ringingThreads.add(this);
+            this.rtcInvitingSession = data.rtc_inviting_session;
         }
-        let rtcContinue = true;
         if ("rtcInvitingSession" in data) {
-            if (Array.isArray(data.rtcInvitingSession)) {
-                if (data.rtcInvitingSession[0][0] === "DELETE") {
-                    this.rtcInvitingSession = undefined;
-                    this._store.discuss.ringingThreads.delete(this);
-                }
-                rtcContinue = false;
-            } else {
-                this.rtcSessions.add(data.rtcInvitingSession);
-                this._store.discuss.ringingThreads.add(this);
-            }
+            this.rtcInvitingSession = data.rtcInvitingSession;
         }
-        if (rtcContinue && "rtcSessions" in data) {
+        if ("rtcSessions" in data) {
             this.rtcSessions = data.rtcSessions;
         }
     },

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -141,7 +141,7 @@ QUnit.test("should display invitations", async (assert) => {
         Thread: {
             id: channelId,
             model: "discuss.channel",
-            rtcInvitingSession: [["DELETE"]],
+            rtcInvitingSession: false,
         },
     });
     await contains(".o-discuss-CallInvitation", { count: 0 });


### PR DESCRIPTION
Discuss model data that had commands have been simplified by [1]. Notably some `unlink` were replaced by `False` and or `DELETE`.

Some code in Discuss calls was still expecting receiving command data in of `DELETE` while data received has become `false`. As a result, the state of ringing threads and showing call invitation card was not working.

This commit fixes the issue by relying on recent improvements that commands can be passed immediately as data to relational fields [2].

Code in Discuss call still have some coupling between fields whenever some records are either added to or removed from a field. Hooks `onAdd` and `onDelete` on relational fields are added to support these cases.

[1]: https://github.com/odoo/odoo/pull/136308
[2]: https://github.com/odoo/odoo/pull/137341
