### PR TITLE
[IMP] website: enable to translate static page url

### DIFF
--- a/addons/web/static/src/views/fields/translation_button.js
+++ b/addons/web/static/src/views/fields/translation_button.js
@@ -16,7 +16,7 @@ import { Component } from "@odoo/owl";
 export function useTranslationDialog() {
     const addDialog = useOwnedDialogs();
 
-    async function openTranslationDialog({ record, fieldName }) {
+    async function openTranslationDialog({ record, fieldName, updateTranslations }) {
         const saved = await record.save();
         if (!saved) {
             return;
@@ -32,6 +32,7 @@ export function useTranslationDialog() {
             onSave: async () => {
                 await record.load();
             },
+            updateTranslations: updateTranslations,
         });
     }
 
@@ -43,6 +44,7 @@ export class TranslationButton extends Component {
     static props = {
         fieldName: { type: String },
         record: { type: Object },
+        updateTranslations: { type: Function, optional: true },
     };
 
     setup() {
@@ -57,7 +59,7 @@ export class TranslationButton extends Component {
     }
 
     onClick() {
-        const { fieldName, record } = this.props;
-        this.translationDialog({ fieldName, record });
+        const { fieldName, record, updateTranslations } = this.props;
+        this.translationDialog({ fieldName, record, updateTranslations });
     }
 }

--- a/addons/web/static/src/views/fields/translation_dialog.js
+++ b/addons/web/static/src/views/fields/translation_dialog.js
@@ -18,6 +18,7 @@ export class TranslationDialog extends Component {
         close: Function,
         isText: { type: Boolean, optional: true },
         showSource: { type: Boolean, optional: true },
+        updateTranslations: { type: Function, optional: true },
     };
     setup() {
         super.setup();
@@ -104,6 +105,16 @@ export class TranslationDialog extends Component {
             this.props.fieldName,
             translations,
         ]);
+
+        if (this.props.updateTranslations) {
+            // Get the translations (possibly modified due to backend rules)
+            const [fieldTranslations] = await this.orm.call(this.props.resModel, "get_field_translations", [
+                this.props.resId,
+                this.props.fieldName,
+            ]);
+            // Provide the new translations to parent components if needed
+            this.props.updateTranslations(fieldTranslations);
+        }
 
         await this.props.onSave();
         this.props.close();

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -634,6 +634,7 @@
             text-align: right;
             border: none;  // usefull for textarea
             visibility: hidden;
+            white-space: nowrap;
     }
 
     div {

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -30,6 +30,7 @@ class IrQWeb(models.AbstractModel):
         'link': 'href',
         'script': 'src',
         'img': 'src',
+        'iframe': 'src',
     }
 
     # assume cache will be invalidated by third party on write to ir.ui.view
@@ -106,11 +107,19 @@ class IrQWeb(models.AbstractModel):
 
         return irQweb
 
+    def _is_static_node(self, el, compile_context):
+        if el.tag in self.URL_ATTRS and not el.attrib.get('data-no-post-process'):
+            return False
+        return super()._is_static_node(el, compile_context)
+
     def _post_processing_att(self, tagName, atts):
         if atts.get('data-no-post-process'):
             return atts
 
         atts = super()._post_processing_att(tagName, atts)
+
+        if tagName not in self.URL_ATTRS:
+            return atts
 
         website = ir_http.get_request_website()
         if not website and self.env.context.get('website_id'):

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -40,7 +40,7 @@ class Menu(models.Model):
                 menu.mega_menu_classes = False
 
     name = fields.Char('Menu', required=True, translate=True)
-    url = fields.Char('Url', default='')
+    url = fields.Char('Url', default='', translate=True)
     page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade')
     controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade')
     new_window = fields.Boolean('New Window')

--- a/addons/website/static/src/components/fields/fields.js
+++ b/addons/website/static/src/components/fields/fields.js
@@ -6,6 +6,7 @@ import {useInputField} from '@web/views/fields/input_field_hook';
 import {useService} from '@web/core/utils/hooks';
 import {Switch} from '@website/components/switch/switch';
 import {registry} from '@web/core/registry';
+import {TranslationButton} from "@web/views/fields/translation_button";
 import { _t } from '@web/core/l10n/translation';
 import { Component, useState } from "@odoo/owl";
 
@@ -14,7 +15,7 @@ import { Component, useState } from "@odoo/owl";
  * is updated.
  */
 class PageUrlField extends Component {
-    static components = { Switch, PageDependencies };
+    static components = { Switch, PageDependencies, TranslationButton };
     static template = "website.PageUrlField";
     static props = {
         ...standardFieldProps,
@@ -47,6 +48,10 @@ class PageUrlField extends Component {
     get fieldURL() {
         const value = this.props.record.data[this.props.name];
         return (value.url !== undefined ? value.url : value).replace(/^\//g, '');
+    }
+
+    get isTranslatable() {
+        return this.props.record.fields[this.props.name].translate;
     }
 
     updateValues() {

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -21,6 +21,12 @@
                 t-model="state.url"
                 t-ref="input"
             />
+            <t t-if="isTranslatable">
+                <TranslationButton
+                    fieldName="props.name"
+                    record="props.record"
+                />
+            </t>
         </div>
         <div t-if="enableRedirect">
             <div class="mt-4">

--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -25,6 +25,7 @@
                 <TranslationButton
                     fieldName="props.name"
                     record="props.record"
+                    updateTranslations="this.updateTranslations.bind(this)"
                 />
             </t>
         </div>

--- a/addons/website/static/tests/tours/translate_url.js
+++ b/addons/website/static/tests/tours/translate_url.js
@@ -2,7 +2,19 @@
 
 import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-const translateUrl = function (newUrl) {
+const translateUrl = function (newUrl, checkRedirect = false) {
+    let activateRedirectIfNeeded = [];
+    if (checkRedirect) {
+        activateRedirectIfNeeded = [{
+            content: "Click on the redirect toggle on the 'Page Properties'",
+            trigger: ".modal-content:contains('Page Properties') label:contains('Redirect Old URL') span:first-of-type",
+            run: "click",
+        }, {
+            content: "Ensure that the option is toggled",
+            trigger: ".modal-content:contains('Page Properties') #redirect_type",
+        },
+    ];
+    }
     return [{
         content: "Click on the 'Site' button",
         trigger: "button:contains('Site')",
@@ -28,7 +40,8 @@ const translateUrl = function (newUrl) {
         content: "Click on 'Save'",
         trigger: ".modal-content:contains('Translate: url') footer button:contains('Save')",
         run: "click",
-    }, {
+    },
+    ... activateRedirectIfNeeded, {
         content: "Click on 'Save and Close'",
         trigger: ".modal-content:contains('Page Properties') footer button:contains('Save & Close')",
         run: "click",
@@ -62,3 +75,9 @@ registerWebsitePreviewTour("update_homepage_url", {
     ...translateUrl("/contactus-fr"),
 ]);
 
+registerWebsitePreviewTour("update_default_lang_website_url", {
+    test: true,
+    url: "/contactus",
+}, () => [
+    ...translateUrl("/contactus-fr", true),
+]);

--- a/addons/website/static/tests/tours/translate_url.js
+++ b/addons/website/static/tests/tours/translate_url.js
@@ -1,0 +1,64 @@
+/** @odoo-module */
+
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+const translateUrl = function (newUrl) {
+    return [{
+        content: "Click on the 'Site' button",
+        trigger: "button:contains('Site')",
+        run: "click",
+    }, {
+        content: "Click on the 'Properties' button",
+        trigger: "a:contains('Properties')",
+        run: "click",
+    }, {
+        content: "Click on the input url",
+        trigger: "[name=url] input.o_input",
+        run: "click",
+    }, {
+        content: "Click on the translate button",
+        trigger: "span.o_field_translate:contains('EN')",
+        run: "click",
+    }, {
+        content: "Change the french translation of the contactus page url",
+        trigger: `div.row:contains('French') input[type='text']`,
+        // TODO: remove && click
+        run: `edit ${newUrl} && click body`,
+    }, {
+        content: "Click on 'Save'",
+        trigger: ".modal-content:contains('Translate: url') footer button:contains('Save')",
+        run: "click",
+    }, {
+        content: "Click on 'Save and Close'",
+        trigger: ".modal-content:contains('Page Properties') footer button:contains('Save & Close')",
+        run: "click",
+    }, {
+        content: "Wait for the load operation to finish",
+        trigger: "body.o_web_client:not(.modal-open)",
+    }, {
+        trigger: ":iframe .s_website_form",
+    },
+];
+};
+
+registerWebsitePreviewTour("translate_url_exists_in_other_language", {
+    test: true,
+    url: "/contactus",
+}, () => [
+    ...translateUrl("/page-en"),
+]);
+
+registerWebsitePreviewTour("translate_url_exists_in_same_language", {
+    test: true,
+    url: "/contactus",
+}, () => [
+    ...translateUrl("/page-fr"),
+]);
+
+registerWebsitePreviewTour("update_homepage_url", {
+    test: true,
+    url: "/contactus",
+}, () => [
+    ...translateUrl("/contactus-fr"),
+]);
+

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -246,3 +246,11 @@ class TestTranslateUrl(TestLangUrl):
         self.assertEqual(self.website.homepage_url, self.name_page_fr)
         self.page.is_homepage = False
         self.assertEqual(self.website.homepage_url, '')
+
+    def test_redirect_on_new_url(self):
+        # If the user modifies a url in the website default language, it should
+        # have the possibility to create a url redirection.
+        self.website.default_lang_id = self.lang_fr
+        self.start_tour('/contactus', 'update_default_lang_website_url', login='admin')
+        website_rewrite = self.env['website.rewrite'].search([('url_from', '=', '/contactus'), ('url_to', '=', '/contactus-fr')])
+        self.assertEqual(len(website_rewrite), 1, "A rewrite route should have been created")

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -129,7 +129,7 @@ class TestQwebWebsite(HttpCase):
             'type': 'qweb',
             'arch': '''
                 <section>
-                    <div>content <a href="/view-en">test</a> and <a href="/view-en">test</a></div>
+                    <div>content <a href="/view-en">test</a> and <a href="/view-fr">test</a></div>
                 </section>''',
             'key': 'test.view_1',
         })
@@ -149,11 +149,12 @@ class TestQwebWebsite(HttpCase):
                 </section>''',
             'key': 'test.view_data',
         })
-        Page.create({
+        page_data = Page.create({
             'view_id': view_data.id,
             'url': '/view-en',
             'is_published': True,
         })
+        page_data.with_context(lang='fr_FR').write({'url': '/view-fr'})
 
         with MockRequest(self.env, website=self.website, context={'lang': 'fr_FR'}):
             self.authenticate('admin', 'admin')
@@ -170,6 +171,7 @@ class TestQwebWebsite(HttpCase):
             r = self.url_open(f'/fr{page_home_1.url}')
             # because debug => no post-processing
             self.assertIn('href="/view-en"', r.text)
+            self.assertIn('href="/view-fr"', r.text)
 
             # read with t-cache
             self.session.debug = ''
@@ -177,5 +179,6 @@ class TestQwebWebsite(HttpCase):
 
             # use french static node cache
             r = self.url_open(f'/fr{page_home_1.url}')
-            self.assertIn('href="/fr/view-en"', r.text)
+            self.assertIn('href="/fr/view-fr"', r.text)
+            self.assertNotIn('/view-en"', r.text)
             self.assertNotIn('href="/view-fr"', r.text)

--- a/addons/website/wizard/base_language_install.py
+++ b/addons/website/wizard/base_language_install.py
@@ -27,5 +27,9 @@ class BaseLanguageInstall(models.TransientModel):
         params = self._context.get('params', {})
         if 'url_return' in params:
             url = params['url_return'].replace('[lang]', self.first_lang_id.code)
-            return self.env['website'].get_client_action(url)
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'reload',
+                'params': {'action_id': self.env['website'].get_client_action_url(url)},
+            }
         return action

--- a/odoo/addons/base/wizard/base_language_install.py
+++ b/odoo/addons/base/wizard/base_language_install.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 
 
 class BaseLanguageInstall(models.TransientModel):
@@ -39,28 +39,14 @@ class BaseLanguageInstall(models.TransientModel):
         self.lang_ids.active = True
         mods._update_translations(self.lang_ids.mapped('code'), self.overwrite)
 
-        if len(self.lang_ids) == 1:
-            return {
-                'type': 'ir.actions.act_window',
-                'res_model': 'base.language.install',
-                'res_id': self.id,
-                'view_mode': 'form',
-                'target': 'new',
-                'views': [[self.env.ref('base.language_install_view_form_lang_switch').id, 'form']],
-            }
-
+        template = 'base.language_install_view_form_lang_switch' if len(self.lang_ids) == 1 else 'base.languages_install'
         return {
-            'type': 'ir.actions.client',
-            'tag': 'display_notification',
-            'context': dict(self._context, active_ids=self.ids),
+            'type': 'ir.actions.act_window',
+            'res_model': 'base.language.install',
+            'res_id': self.id,
+            'view_mode': 'form',
             'target': 'new',
-            'params': {
-                'message': _("The languages that you selected have been successfully installed.\
-                            Users can choose their favorite language in their preferences."),
-                'type': 'success',
-                'sticky': False,
-                'next': {'type': 'ir.actions.act_window_close'},
-            }
+            'views': [[self.env.ref(template).id, 'form']],
         }
 
     def reload(self):

--- a/odoo/addons/base/wizard/base_language_install_views.xml
+++ b/odoo/addons/base/wizard/base_language_install_views.xml
@@ -25,6 +25,23 @@
            </field>
         </record>
 
+        <record id="base.languages_install" model="ir.ui.view">
+            <field name="name">Languages installed</field>
+            <field name="model">base.language.install</field>
+            <field name="priority">100</field>
+            <field name="arch" type="xml">
+                <form string="Languages installed">
+                    <div>
+                        The languages that you selected have been successfully installed.
+                            Users can choose their favorite language in their preferences.
+                    </div>
+                    <footer>
+                        <button name="reload" string="Close" type="object" class="btn-primary" data-hotkey="q"/>
+                    </footer>
+                </form>
+           </field>
+        </record>
+
         <record id="view_base_language_install" model="ir.ui.view">
             <field name="name">Load a Translation</field>
             <field name="model">base.language.install</field>


### PR DESCRIPTION
[FIX] website: add test for wrong cache from translation + edition

Method _post_processing_att changes the value but the result is put in a
static string. When the user go to an other page with other
post-processing information, the result can be wrong.

-----------------------------------------------------------------------------------------------------------------------------------------------------------

[IMP]  website: enable to translate static page url

The goal of this commit is to add the possibility to translate page url.
Here is an example to illustrate the case: A website page has the url
`/page-en`. If the user adds "French (BE)" as a language on its website,
he can now translate the `page-en` website url into `page-fr`. If the
language of the website and its default language is English, the url of
the page will be `/page-en` but if the language of the website is
French, the url of the page will be `/fr_BE/page-fr`. If the language of
the website is in English and the user is searching for `/page-fr`, the
system detects that the requested page exists but redirects the user to
the English version of the page as the language of the website is in
English. However, if the user is searching for `/fr_BE/page-fr`, it will
be redirected to the French version of the page and the language of the
website will switch to French whatever the original language of the
website was.

When a user translates a url, it is slugified and made unique. The
related menus url are then updated. Concerning the website homepage url,
if it is a page url, it has to be the one of the default website
language. When a user modifies a page url, the website homepage url is
updated if the modification of the url is done in the website default
language and if the original url was the default website url.

task-3355343

---------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] web, website: show redirect button at url change

Context: let's imagine that the user default language is English and the
website default language is French. When the user opens the "Page
Properties" modal, it has the possibility to modify the url in its
default language (English) or to translate it in other languages. If it
translates it in French, it should have the possibility to redirect the
old url to the new translated one as the translation is done in the
website default language.

The goal of this commit is to show the redirect button in the "Page
Properties" modal if the user modifies a page url in the website default
language (that can be different from the user default language).

To do so, the translations related to a page url are retrieved in the
`PageUrlField` component. The redirect button is shown if the original
url is different from:
- The one of the input if the website default language is the same than
the one of the user.
- The one of the translations otherwise.

In case of a redirection, the system chooses between those two urls
depending on the website default language and the user default language
to create the correct redirection. Note that the part on the redirection
creation has been moved outside of the `if page.url != url` check to
handle the case of a redirection when the website default language is
different of the user default language. In this case, the redirection is
done thanks to a translation and the code do not enter in the
`if page.url != url` condition.

task-3355343

---------------------------------------------------------------------------------------------------------------------------------------------------

[IMP] http_routing, *: translate page url of links on the page
* website

Thanks to the previous commits, it is possible to translate page url.
The goal of this commit is to translate the links to those urls that are
present on a page. To do so, the website module has been adapted to
correctly translate urls during the post processing process of the
template rendering. This commit also modifies the method
(`_url_localized()`) that adapts a given url for a given language in
order to take page url translation into account.

task-3355343


---------------------------------------------------------------------------------------------------------------------------------------------------

[FIX] base: save modification when installing languages

Steps to reproduce:
- On a new db with website installed, go on the website settings and
click on "Install languages".
- On the "Languages" part, add "French (BE)" and "French (CA)".
- Add "My Website" in the "Websites to translate".
- Click on "Add".
- Go on the website (do not reload the page).
- Go on "Site" -> "This page" -> "Properties".
- Try to translate the url.

-> Problem: It is not possible to translate the url.

The problem is that if multiple languages are added, a notification
appears indicating that the languages have been successfully installed
but the page is not reloaded. Due to it, `TranslationButton` has a wrong
version of `localization`. When the page property appears, the
translation button does not appear as `isMultiLang` is considered false.

To solve the problem, the notification is displayed in a new window. The
system is reloaded when it is closed.

This commit also fix a similar problem:
- On a new db with website installed, enter in edit mode.
- Click on the "Theme" tab.
- Click on "Add a Language".
- On the "Confirmation" modal, click on "Ok".
- Install a new language "French(BE)"
- Go on "Site" -> "This page" -> "Properties".
- Try to translate the url.

-> Problem: It is not possible to translate the url.

The problem here is also that, after installing the language, the system
does the `website.website_preview` action without a reloading. As for
the previous bug, the translation button does not appear as
`isMultiLang` is considered false. To solve this bug, the system is
reloaded before doing the `website.website_preview` action.

task-3355343


-------------------------------------------------------------------------------------------------------------------------------------------------------

[FIX] web: handle line break of the translate button

Steps to reproduce:
- Have a really long domain name.
- Have at least two different languages installed on the website.
- On the website, go on "Site" -> "This page" -> "Properties".

-> The translate button is displayed with a line break.

The goal of this commit is to avoid this unexpected line break in the
translation button.

task-3355343