### PR TITLE
[IMP] account_edi_ubl_cii: EDI format for customer list view improvement

### DIFF
--- a/addons/account_edi_ubl_cii/views/res_partner_views.xml
+++ b/addons/account_edi_ubl_cii/views/res_partner_views.xml
@@ -15,4 +15,26 @@
             </xpath>
         </field>
     </record>
+
+    <record id="res_partner_view_search" model="ir.ui.view">
+        <field name="name">res.partner.search.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_by']" position="after">
+                <filter name="ubl_cii_format" string="EDI Format" context="{'group_by':'ubl_cii_format'}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="res_partner_view_tree" model="ir.ui.view">
+        <field name="name">res.partner.tree.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="ubl_cii_format" string="EDI Format" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -29,4 +29,29 @@
             </data>
         </field>
     </record>
+
+    <record id="res_partner_view_tree" model="ir.ui.view">
+        <field name="name">res.partner.tree.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ubl_cii_format']" position="after">
+                <field name="peppol_eas" string="Peppol EAS" optional="hide"/>
+                <field name="peppol_endpoint" string="Peppol Endpoint" optional="hide"/>
+                <field name="account_peppol_is_endpoint_valid" string="Peppol Validity" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="partner_action_verify_peppol" model="ir.actions.server">
+        <field name="name">Verify Peppol</field>
+        <field name="model_id" ref="account_peppol.model_res_partner"/>
+        <field name="binding_model_id" ref="base.model_res_partner"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            for record in records:
+                action = record.button_account_peppol_check_partner_endpoint()
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Problem
---------
Currently, the tree view for customers does not include information about the EDI format. Only a custom `group_by format` is present which is not user friendly.

Objective
---------
As we have more and more EDI format following each type of customer, we should add an easy way to manage that directly in the customer list.

Solution
---------
1. Extend the `res_partner` search view to add a group_by option on the
format.
2. Extend the `res_partner` tree view to add an optional hidden column on
the format, and one for the PEPPOL eas, endpoint and endpoint validity.
3. Create a server action that executes
`button_account_peppol_check_partner_endpoint` on the selected records
in the list view.

task-3531419

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
