### PR TITLE
[FIX] website, web_editor: dropzone transparency and read-only handles

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.variables.scss
+++ b/addons/web_editor/static/src/scss/web_editor.variables.scss
@@ -46,6 +46,8 @@ $o-we-handle-inside-line-width: 3px !default;
 $o-we-dropzone-size: 30px !default; // $grid-gutter-width (todo: allow to use the variable)
 $o-we-dropzone-border-width: 2px !default;
 $o-we-dropzone-border: $o-we-dropzone-border-width dashed $o-brand-odoo !default;
+$o-we-dropzone-accent-color: $o-we-accent !default;
+$o-we-dropzone-bg-color: rgba($o-we-dropzone-accent-color, .5) !default;
 
 // Translations
 $o-we-content-to-translate-color: rgba(255, 255, 90, 0.5) !default;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2130,12 +2130,12 @@ we-select.o_we_border_preview_aligned_select {
                     width: $o-we-handle-edge-size;
                 }
                 &.w {
-                    inset: $o-we-handles-offset-to-hide auto $o-we-handles-offset-to-hide * -1 0;
+                    inset: $o-we-handles-offset-to-hide auto $o-we-handles-offset-to-hide * -1 $o-we-handle-border-width * 0.5;
                     transform: translateX(-50%);
                     cursor: ew-resize;
                 }
                 &.e {
-                    inset: $o-we-handles-offset-to-hide 0 $o-we-handles-offset-to-hide * -1 auto;
+                    inset: $o-we-handles-offset-to-hide $o-we-handle-border-width * 0.5 $o-we-handles-offset-to-hide * -1 auto;
                     transform: translateX(50%);
                     cursor: ew-resize;
                 }
@@ -2145,6 +2145,10 @@ we-select.o_we_border_preview_aligned_select {
 
                     &.o_grid_handle {
                         transform: translateY(-50%);
+
+                        &:before {
+                            transform: translateY($o-we-handle-border-width * 0.5);
+                        }
                     }
                 }
                 &.s {
@@ -2153,25 +2157,29 @@ we-select.o_we_border_preview_aligned_select {
 
                     &.o_grid_handle {
                         transform: translateY(50%);
+
+                        &:before {
+                            transform: translateY($o-we-handle-border-width * -0.5);
+                        }
                     }
                 }
                 &.ne {
-                    inset: $o-we-handles-offset-to-hide 0 auto auto;
+                    inset: ($o-we-handles-offset-to-hide + $o-we-handle-border-width * 0.5) $o-we-handle-border-width * 0.5 auto auto;
                     transform: translate(50%, -50%);
                     cursor: nesw-resize;
                 }
                 &.se {
-                    inset: auto 0 $o-we-handles-offset-to-hide * -1 auto;
+                    inset: auto $o-we-handle-border-width * 0.5 ($o-we-handles-offset-to-hide * -1 + $o-we-handle-border-width * 0.5) auto;
                     transform: translate(50%, 50%);
                     cursor: nwse-resize;
                 }
                 &.sw {
-                    inset: auto auto $o-we-handles-offset-to-hide * -1 0;
+                    inset: auto auto ($o-we-handles-offset-to-hide * -1 + $o-we-handle-border-width * 0.5) $o-we-handle-border-width * 0.5;
                     transform: translate(-50%, 50%);
                     cursor: nesw-resize;
                 }
                 &.nw {
-                    inset: $o-we-handles-offset-to-hide auto auto 0;
+                    inset: ($o-we-handles-offset-to-hide + $o-we-handle-border-width * 0.5) auto auto $o-we-handle-border-width * 0.5;
                     transform: translate(-50%, -50%);
                     cursor: nwse-resize;
                 }
@@ -2246,24 +2254,27 @@ we-select.o_we_border_preview_aligned_select {
                     }
                     &.o_column_handle {
 
-                        &::before {
-                            inset: 0 $o-we-handle-border-width * -0.5;
-                        }
-
                         &.n::before {
                             margin: 0 auto auto;
-                            transform: translateY(-50%);
                         }
 
                         &.s::before {
                             margin: auto auto 0;
-                            transform: translateY(50%);
                         }
                     }
                 }
 
                 &.readonly {
-                    display: none;
+                    cursor: default;
+
+                    &.o_column_handle.o_side_y {
+                        border: none;
+                        background: none;
+                    }
+
+                    &::after, .o_handle_indicator {
+                        display: none;
+                    }
                 }
             }
 

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2050,21 +2050,20 @@ we-select.o_we_border_preview_aligned_select {
 // DROPZONES
 @keyframes dropZoneInsert {
     to {
-        box-shadow: inset 0 0 $o-we-dropzone-size 0 rgba($o-we-handles-accent-color, .5);
+        box-shadow: inset 0 0 $o-we-dropzone-size 0 scale-color($o-we-dropzone-accent-color, $alpha: -50%);
     }
 }
 
 .oe_drop_zone {
-    background: rgba(lighten($o-we-handles-accent-color, 50%), .95);
+    background: $o-we-dropzone-bg-color;
     animation: dropZoneInsert 1s linear 0s infinite alternate;
 
     &.oe_insert {
         position: relative;
         width: 100%;
         border-radius: $border-radius-lg;
-        outline: $o-we-dropzone-border-width dashed $o-we-handles-accent-color;
+        outline: $o-we-dropzone-border-width dashed $o-we-dropzone-accent-color;
         outline-offset: -$o-we-dropzone-border-width;
-        backdrop-filter: blur(2px);
         z-index: $o-we-overlay-zindex;
     }
 }

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -1,11 +1,10 @@
 $-editor-messages-margin-x: 2%;
 %o-editor-messages {
-    background: rgba(lighten($o-we-handles-accent-color, 50%), .95);
+    background: $o-we-dropzone-bg-color;
     text-align: center;
-    color: $o-we-handles-accent-color;
-    outline: $o-we-dropzone-border-width dashed $o-we-handles-accent-color;
+    color: #fff;
+    outline: $o-we-dropzone-border-width dashed $o-we-dropzone-accent-color;
     outline-offset: -$o-we-dropzone-border-width;
-    backdrop-filter: blur(2px);
 
     &:before {
         content: attr(data-editor-message);


### PR DESCRIPTION
=== ISSUE 1 ===
Since the introduction of the new dropzone design, the dropzones weren't
transparent enough and the inline content behind them wasn't readable.

This PR adapts the layout of dropzones to make the content behind
them more readable.

=== ISSUE 2 ===
Prior to this PR, read-only handles were hidden, which created a
layout issue (eg. the header was no longer highlighted when we clicked
on it).

This PR adapts read-only handles to make them visible by using a
border around the selected element.

task-3537616

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
