### PR TITLE
[IMP] base: cache currency convertion rate per transaction

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2,7 +2,6 @@ import ast
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import date, timedelta
-from functools import lru_cache
 
 from odoo import api, fields, models, Command, _
 from odoo.exceptions import ValidationError, UserError
@@ -634,17 +633,9 @@ class AccountMoveLine(models.Model):
 
     @api.depends('currency_id', 'company_id', 'move_id.date')
     def _compute_currency_rate(self):
-        @lru_cache()
-        def get_rate(from_currency, to_currency, company, date):
-            return self.env['res.currency']._get_conversion_rate(
-                from_currency=from_currency,
-                to_currency=to_currency,
-                company=company,
-                date=date,
-            )
         for line in self:
             if line.currency_id:
-                line.currency_rate = get_rate(
+                line.currency_rate = self.env['res.currency']._get_conversion_rate(
                     from_currency=line.company_currency_id,
                     to_currency=line.currency_id,
                     company=line.company_id,

--- a/addons/project_mrp/models/project_project.py
+++ b/addons/project_mrp/models/project_project.py
@@ -73,16 +73,8 @@ class Project(models.Model):
         if mrp_aal_read_group:
             can_see_manufactoring_order = with_action and len(self) == 1 and self.user_has_groups('mrp.group_mrp_user')
             total_amount = 0
-            currency_ids = {currency.id for currency, amount in mrp_aal_read_group}
-            currency_ids.add(self.currency_id.id)
-            rate_per_currency_id = self.env['res.currency'].browse(currency_ids)._get_rates(self.company_id or self.env.company, fields.Date.context_today(self))
-            project_currency_rate = rate_per_currency_id[self.currency_id.id]
             for currency, amount_summed in mrp_aal_read_group:
-                if currency != self.currency_id:
-                    rate = project_currency_rate / rate_per_currency_id[currency.id]
-                    total_amount += self.currency_id.round(amount_summed * rate)
-                else:
-                    total_amount += amount_summed
+                total_amount += currency._convert(amount_summed, self.currency_id, self.company_id)
 
             mrp_costs = {
                 'id': mrp_category,

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -401,24 +401,13 @@ class SaleOrder(models.Model):
 
     @api.depends('currency_id', 'date_order', 'company_id')
     def _compute_currency_rate(self):
-        cache = {}
         for order in self:
-            order_date = order.date_order.date()
-            if not order.company_id:
-                order.currency_rate = order.currency_id.with_context(date=order_date).rate or 1.0
-                continue
-            elif not order.currency_id:
-                order.currency_rate = 1.0
-            else:
-                key = (order.company_id.id, order_date, order.currency_id.id)
-                if key not in cache:
-                    cache[key] = self.env['res.currency']._get_conversion_rate(
-                        from_currency=order.company_id.currency_id,
-                        to_currency=order.currency_id,
-                        company=order.company_id,
-                        date=order_date,
-                    )
-                order.currency_rate = cache[key]
+            order.currency_rate = self.env['res.currency']._get_conversion_rate(
+                from_currency=order.company_id.currency_id,
+                to_currency=order.currency_id,
+                company=order.company_id,
+                date=order.date_order.date(),
+            )
 
     @api.depends('company_id')
     def _compute_has_active_pricelist(self):

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -410,16 +410,9 @@ class Project(models.Model):
         costs_dict = {}
         total_revenues = {'invoiced': 0.0, 'to_invoice': 0.0}
         total_costs = {'billed': 0.0, 'to_bill': 0.0}
-        dict_rate_per_currency = {}
-        today = fields.Date.context_today(self)
         convert_company = self.company_id or self.env.company
         for timesheet_invoice_type, dummy, currency, amount, ids in aa_line_read_group:
-            if currency != self.currency_id:
-                rate = dict_rate_per_currency.get(currency.id, False)
-                if not rate:
-                    rate = currency._get_conversion_rate(currency, self.currency_id, convert_company, today)
-                    dict_rate_per_currency[currency.id] = rate
-                amount = self.currency_id.round(amount * rate)
+            amount = currency._convert(amount, self.currency_id, convert_company)
             invoice_type = timesheet_invoice_type
             cost = costs_dict.setdefault(invoice_type, {'billed': 0.0, 'to_bill': 0.0})
             revenue = revenues_dict.setdefault(invoice_type, {'invoiced': 0.0, 'to_invoice': 0.0})

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -285,19 +285,6 @@ class Currency(models.Model):
         # apply rounding
         return to_currency.round(to_amount) if round else to_amount
 
-    @api.model
-    def _compute(self, from_currency, to_currency, from_amount, round=True):
-        _logger.warning('The `_compute` method is deprecated. Use `_convert` instead')
-        date = self._context.get('date') or fields.Date.today()
-        company = self.env['res.company'].browse(self._context.get('company_id')) or self.env.company
-        return from_currency._convert(from_amount, to_currency, company, date)
-
-    def compute(self, from_amount, to_currency, round=True):
-        _logger.warning('The `compute` method is deprecated. Use `_convert` instead')
-        date = self._context.get('date') or fields.Date.today()
-        company = self.env['res.company'].browse(self._context.get('company_id')) or self.env.company
-        return self._convert(from_amount, to_currency, company, date)
-
     def _select_companies_rates(self):
         return """
             SELECT

--- a/odoo/addons/base/tests/test_res_currency.py
+++ b/odoo/addons/base/tests/test_res_currency.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from lxml import etree
+from odoo import Command
 from odoo.tests.common import TransactionCase
 
 
-class TestResConfig(TransactionCase):
+class TestResCurrency(TransactionCase):
     def test_view_company_rate_label(self):
         """Tests the label of the company_rate and inverse_company_rate fields
         are well set according to the company currency in the currency form view and the currency rate list view.
@@ -21,3 +22,48 @@ class TestResConfig(TransactionCase):
                 node_inverse_company_rate = tree.xpath('//field[@name="inverse_company_rate"]')[0]
                 self.assertEqual(node_company_rate.get('string'), f'Unit per {expected_currency}')
                 self.assertEqual(node_inverse_company_rate.get('string'), f'{expected_currency} per Unit')
+
+    def test_currency_cache(self):
+        currencyA, currencyB = self.env['res.currency'].create([{
+            'name': 'AAA',
+            'symbol': 'AAA',
+            'rate_ids': [Command.create({'name': '2010-10-10', 'rate': 1})]
+        }, {
+            'name': 'BBB',
+            'symbol': 'BBB',
+            'rate_ids': [
+                Command.create({'name': '2010-10-10', 'rate': 1}),
+                Command.create({'name': '2011-11-11', 'rate': 2}),
+            ],
+        }])
+
+        self.assertEqual(currencyA._convert(
+            from_amount=100,
+            to_currency=currencyB,
+            company=self.env.company,
+            date='2010-10-10',
+        ), 100)
+
+        # only one query is done when changing the convert params
+        with self.assertQueryCount(1):
+            self.assertEqual(currencyA._convert(
+                from_amount=100,
+                to_currency=currencyB,
+                company=self.env.company,
+                date='2011-11-11',
+            ), 200)
+
+        # cache holds multiple values
+        with self.assertQueryCount(0):
+            self.assertEqual(currencyA._convert(
+                from_amount=100,
+                to_currency=currencyB,
+                company=self.env.company,
+                date='2010-10-10',
+            ), 100)
+            self.assertEqual(currencyA._convert(
+                from_amount=100,
+                to_currency=currencyB,
+                company=self.env.company,
+                date='2011-11-11',
+            ), 200)


### PR DESCRIPTION
Most of the time, rates are computed in a loop by using `<res.currency>._convert`. This leads to a lot of round trips with the database.

This PR is caching the value for a whole transaction.
In order to do that, the non stored field `rate` has new (missing)
contextual dependencies: the arguments of `_get_conversion_rate`.
This allows to move the actual computation of the rate to the computed
field, and `_get_conversion_rate` is now only a proxy to avoid playing
with the context manually; also kept for backward compatibility.

Other solutions were considered:
* `ormcache`, but we want to avoid creating multiple caches and reduce the possibility to have inter dependent caches.
* managing a local cache everywhere, which is cumbersome and error prone
* a helper for the previous option by using a converter factory, but it is still an issue when the convert function is called from multiple call functions because the cache isn't shared then.
