### PR TITLE
[FIX] base_import: one product imported twice

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -103,7 +103,10 @@ export class ImportAction extends Component {
 
     async onOptionChanged(name, value, fieldName = null) {
         this.model.block();
-        await this.model.setOption(name, value, fieldName);
+        const res = await this.model.setOption(name, value, fieldName);
+        if (res && res.file_length) {
+            this.state.fileLength = res.file_length;
+        }
         this.model.unblock();
     }
 

--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -314,7 +314,7 @@ export class BaseImportModel {
         }
         this.importOptionsValues[optionName].value = value;
         if (this.importOptionsValues[optionName].reloadParse) {
-            await this.updateData();
+            return (await this.updateData()).res;
         }
     }
 


### PR DESCRIPTION
Steps to reproduce:
---
1. Install stock
2. Go to Inventory > Products
3. Cog wheel > Import records
4. Make a xlsx document where:
5. the first sheet has at least 2400 records (with header)
6. the second sheet only one record (with header)
7. Upload the document
8. Select the second sheet
9. Set batch limit at 2000
10. Click on import
11. 2 records successfully imported

Cause of the issue:
---
When initially uploaded, this.state.fileLength
is set to the length of the first sheet
And isn't refreshed when changing sheet

opw-3507544

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
