### PR TITLE
[FIX] hr_contract: display form with current target

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -110,7 +110,6 @@ class Employee(models.Model):
             action['context'] = {
                 'default_employee_id': self.id,
             }
-            action['target'] = 'new'
             return action
 
         target_contract = self.contract_id


### PR DESCRIPTION
Issue:
------
When we use the smart button to create a contract
for an employee who doesn't have one,
we get a shrunk contract form.

Solution:
---------
Remove target specification to have `current` value by default. The result is a normal form view (i.e. like an existing record).

opw-3515861