### PR TITLE
[IMP] sale_timesheet: make allowed_so_line field column invisible

### DIFF
--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -42,7 +42,7 @@
                 <field name="commercial_partner_id" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="is_so_line_edited" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="allow_billable" column_invisible="True" groups="sales_team.group_sale_salesman"/>
-                <field name="allowed_so_line_ids" invisible="1"/>
+                <field name="allowed_so_line_ids" column_invisible="1"/>
                 <field name="so_line" widget="so_line_field" optional="show" options="{'no_create': True, 'no_open': True}" context="{'create': False, 'edit': False, 'delete': False}" invisible="not allow_billable" readonly="readonly_timesheet" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>


### PR DESCRIPTION
In this commit we made the allowed_so_line field column invisible in list view.

Related Enterprise PR : https://github.com/odoo/enterprise/pull/48362

Related Upgrade PR : https://github.com/odoo/upgrade/pull/5221

task-3478920
