### PR TITLE
[FIX] pos_self_order: show take away price

### DIFF
--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -14,7 +14,7 @@
                 <div class="product-infos d-flex flex-column justify-content-between text-start flex-grow-1 px-2 mt-3 mb-1">
                     <span t-esc="props.product.name" class="fs-3 fw-bolder flex-grow-1 lh-sm" />
                     <div class="d-flex justify-content-between align-items-end gap-3">
-                        <span t-esc="selfOrder.formatMonetary(props.product.prices)" class="fs-4 text-muted flex-grow-1" />
+                        <span t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(props.product))" class="fs-4 text-muted flex-grow-1" />
                         <div class="text-center ms-2 fs-lighter">
                             <div t-if="!props.product.self_order_available" class="fs-lighter bg-secondary rounded">Out of stock</div>
                         </div>

--- a/addons/pos_self_order/static/src/app/models/product.js
+++ b/addons/pos_self_order/static/src/app/models/product.js
@@ -40,10 +40,6 @@ export class Product extends Reactive {
         this.showPriceTaxIncluded = showPriceTaxIncluded;
     }
 
-    get prices() {
-        return this.price_info.display_price;
-    }
-
     get isCombo() {
         return this.pos_combo_ids;
     }

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -16,7 +16,7 @@
                         class="o_self_order_main_desc flex-grow-1 pb-3 mb-3 bg-view text-muted "
                         t-esc="product.description_sale"
                     />
-                    <span class="fs-3 fw-bolder" t-esc="selfOrder.formatMonetary(product.prices)"/>
+                    <span class="fs-3 fw-bolder" t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(product))"/>
                 </div>
             </div>
 

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -434,6 +434,14 @@ export class SelfOrder extends Reactive {
 
         return result;
     }
+
+    getProductDisplayPrice(product) {
+        if (this.currentOrder.take_away) {
+            return product.price_info.display_price_alternative;
+        } else {
+            return product.price_info.display_price_default;
+        }
+    }
 }
 
 export const selfOrderService = {


### PR DESCRIPTION
Steps to reproduce:

- Activate "Eat in / Take away" (`pos_self_ordering_takeaway`) setting.
- Set the alternative fiscal position.
- ISSUE: When selecting take away in the app, the take away price is not shown.

FIX: The issue is because during the loading of the products, only the default price is computed. In this PR, we are now computing the take away price as well. And in the ui, depending on the choice, we are showing the correct price.
