### PR TITLE
[FIX] web: fix color property in calendar status

### DIFF
--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -88,7 +88,6 @@
             >
                 <span
                     class="o_cw_filter_input_bg d-flex flex-shrink-0 justify-content-center position-relative me-1 o_beside_avatar"
-                    t-att-style="filter.colorIndex and typeof filter.colorIndex !== 'number' ? `border-color: ${filter.colorIndex}; background-color: ${filter.colorIndex};` : ''"
                 >
                     <i class="fa fa-check position-relative" />
                 </span>


### PR DESCRIPTION
Problem : From the sales order, if we go to the calendar view, it shows
status like "sales order", "quotation",... when we check the style in
the console, span style has nonsensical values for
background-color and border-color.
Ex : style="background-color:state; border-color:state;"

Correction : The styles are already applied by
t-att-class="getFilterColor(filter)"
used on the div.o_calendar_filter_item.
Then the utilisation of t-att-style is no more useful.

taskId : 3512867
