### PR TITLE
[REF] web: remove use of internal variable

### DIFF
--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -4,6 +4,7 @@ import { memoize } from "./utils/functions";
 import { browser } from "./browser/browser";
 import { registry } from "./registry";
 import { session } from "@web/session";
+import { Component, xml, onWillStart, App } from "@odoo/owl";
 
 /**
  * This export is done only in order to modify the behavior of the exported
@@ -236,15 +237,12 @@ registry.category("xml_templates").addEventListener("UPDATE", (ev) => {
         for (const element of doc.querySelectorAll("templates > [t-name]")) {
             templates.documentElement.appendChild(element);
         }
-        // eslint-disable-next-line no-undef
-        const apps = __OWL_DEVTOOLS__.apps;
-        for (const app of apps) {
+        for (const app of App.apps) {
             app.addTemplates(templates, app);
         }
     }
 });
 
-import { Component, xml, onWillStart } from "@odoo/owl";
 /**
  * Utility component that loads an asset bundle before instanciating a component
  */


### PR DESCRIPTION
In a previous commit, we temporarily used the `__OWL__DEVTOOLS__` global variable to access the list of all apps. This was obviously not something that we want to do, so we introduced a proper hook in Owl.

This commit changes the code to use the static apps object from the App class.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
