### PR TITLE
[IMP] web: domain field: Add condition in folded domain field

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -11,7 +11,10 @@ import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog
 import { standardFieldProps } from "../standard_field_props";
 import { useBus, useService, useOwnedDialogs } from "@web/core/utils/hooks";
 import { toTree } from "@web/core/domain_tree";
-import { useGetDomainTreeDescription } from "@web/core/domain_selector/utils";
+import {
+    useGetDomainTreeDescription,
+    useGetDefaultLeafDomain,
+} from "@web/core/domain_selector/utils";
 
 export class DomainField extends Component {
     static template = "web.DomainField";
@@ -34,6 +37,7 @@ export class DomainField extends Component {
         this.rpc = useService("rpc");
         this.orm = useService("orm");
         this.getDomainTreeDescription = useGetDomainTreeDescription();
+        this.getDefaultLeafDomain = useGetDefaultLeafDomain();
         this.addDialog = useOwnedDialogs();
 
         this.state = useState({
@@ -109,6 +113,12 @@ export class DomainField extends Component {
             resModel = props.record.data[resModel];
         }
         return resModel;
+    }
+
+    async addCondition() {
+        const defaultDomain = await this.getDefaultLeafDomain(this.getResModel());
+        this.update(defaultDomain);
+        this.state.folded = false;
     }
 
     async loadFacets(props = this.props) {

--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -11,6 +11,11 @@
                         <div class="d-print-contents">
                             <t t-if="!state.facets.length">
                                 <span>Match <strong>all records</strong></span>
+                                <t t-if="!props.readonly">
+                                    <button class="btn btn-sm btn-primary o_domain_add_first_node_button mx-2" t-on-click.stop="() => this.addCondition()">
+                                        <i class="fa fa-plus"/> Add condition
+                                    </button>
+                                </t>
                             </t>
                             <t t-foreach="state.facets" t-as="facet" t-key="facet_index">
                                 <div class="d-inline-flex align-items-stretch text-nowrap px-1 position-relative"


### PR DESCRIPTION
This commit adds the recently removed add condition button to the folded domain field so the user can unfold the domain and add a new rule in one click.

Task-3525269