### PR TITLE
[FIX] web: debug menu: can get view

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -27,26 +27,21 @@ debugRegistry.category("view").add("viewSeparator", viewSeparator);
 class GetViewDialog extends Component {}
 GetViewDialog.template = xml`
 <Dialog title="this.constructor.title">
-    <pre t-esc="props.arch"/>
+    <pre t-esc="props.arch.outerHTML"/>
 </Dialog>`;
 GetViewDialog.components = { Dialog };
 GetViewDialog.props = {
-    arch: { type: String },
+    arch: { type: Element },
     close: { type: Function },
 };
 GetViewDialog.title = _t("Get View");
 
 export function getView({ component, env }) {
-    let { arch } = component.props;
-    if ("viewInfo" in component.props) {
-        //legacy
-        arch = component.props.viewInfo.arch;
-    }
     return {
         type: "item",
         description: _t("Get View"),
         callback: () => {
-            env.services.dialog.add(GetViewDialog, { arch });
+            env.services.dialog.add(GetViewDialog, { arch: component.props.arch });
         },
         sequence: 340,
     };


### PR DESCRIPTION
Since commit [1], there was a crash when the user clicked on the "Get View" item in the debug menu (in any views). This was because the arch now received by the views in props is an XmlDocument, whereas before it was a string.

[1] odoo/odoo@cc3a3a328db913da76573404967e1190f40bcc98

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
