### PR TITLE
[FIX] pos_self_order: correct fiscal position in self order

### DIFF
--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -40,20 +40,19 @@ export class OrderWidget extends Component {
         const currentPage = this.router.activeSlot;
         const payAfter = this.selfOrder.config.self_ordering_pay_after;
         const kioskPayment = this.selfOrder.pos_payment_methods.find((p) => !p.is_online_payment); // cannot be online payment in kiosk for instance
-        const isLine = this.selfOrder.currentOrder.lines.length === 0;
+        const isLine = this.selfOrder.currentOrder.lines.length !== 0;
 
         let label = "";
-        let disabled = "";
+        let disabled = !isLine;
 
         if (currentPage === "product_list") {
             label = _t("Order");
-            disabled = isLine;
         } else if (payAfter === "meal" && !this.selfOrder.currentOrder.isSavedOnServer) {
             label = _t("Order");
-            disabled = isLine || !kioskPayment;
+            disabled = disabled || !kioskPayment;
         } else {
             label = kioskPayment ? _t("Pay") : _t("Pay at cashier");
-            disabled = isLine || !kioskPayment;
+            disabled = disabled || kioskPayment;
         }
 
         return { label, disabled };

--- a/addons/pos_self_order/tests/test_frontend.py
+++ b/addons/pos_self_order/tests/test_frontend.py
@@ -1,10 +1,72 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+from uuid import uuid4
+
 import odoo.tests
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+from odoo import Command
 
 
 @odoo.tests.tagged("post_install", "-at_install")
 class TestFrontendMobile(SelfOrderCommonTest):
-    pass
+    def test_order_fiscal_position(self):
+        """ Orders made in take away should have the alternative fiscal position. """
+
+        tax30 = self.env['account.tax'].create({
+            'name': '30%',
+            'amount': 30,
+            'amount_type': 'percent',
+        })
+
+        alternative_fp = self.env['account.fiscal.position'].create({
+            'name': "Test",
+            'auto_apply': True,
+            'tax_ids': [
+                Command.create({
+                    'tax_src_id': self.default_tax15.id,
+                    'tax_dest_id': tax30.id,
+                }),
+            ]
+        })
+
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_takeaway': True,
+            'self_ordering_alternative_fp_id': alternative_fp.id,
+        })
+
+        self.pos_config.open_ui()
+
+        response = self.url_open(
+            "/pos-self-order/process-new-order/kiosk",
+            data=json.dumps({
+                "jsonrpc": "2.0",
+                "method": "call",
+                "id": str(uuid4()),
+                "params": {
+                    "access_token": self.pos_config.access_token,
+                    "order": {
+                        "id": None,
+                        "pos_config_id": self.pos_config.id,
+                        "access_token": None,
+                        "pos_reference": None,
+                        "state": "draft",
+                        "date": None,
+                        "amount_total": 0,
+                        "amount_tax": 0,
+                        "lines": [],
+                        "tracking_number": None,
+                        "take_away": True,
+                        "lastChangesSent": {},
+                    },
+                    "table_identifier": None,
+                }
+            }),
+            headers={"Content-Type": "application/json"},
+        )
+
+        result = response.json()
+        order_id = result['result']['id']
+        self.assertEqual(self.env['pos.order'].browse(order_id).fiscal_position_id.id, alternative_fp.id)


### PR DESCRIPTION
**Steps to reproduce:**

- Create a fiscal position that maps to a different tax.
- Use that fiscal position as alternative fiscal position for the "Eat in / Take away" setting.
- Create a "Take Away" order from the self-ordering app (kiosk or mobile).
- ISSUE: Send the order to the database (by "Pay at Cashier" or "Pay").
  - Check the order and it doesn't have correct fiscal position resulting to wrong amounts in the lines.

**FIX:** When creating the order, we make sure the correct fiscal position is set. Also, we precompute `is_take_away` variable which is used in many places of processing the order.
