### PR TITLE
[FIX] point_of_sale: avoid duplicate order validation

### DIFF
--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -21,7 +21,13 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
             useListener('send-payment-cancel', this._sendPaymentCancel);
             useListener('send-payment-reverse', this._sendPaymentReverse);
             useListener('send-force-done', this._sendForceDone);
-            useListener('validate-order', () => this.validateOrder(false));
+            useListener('validate-order', () => {
+                if (this.currentOrder.isSent) {
+                    this.showScreen(this.nextScreen);
+                } else {
+                    this.validateOrder(false);
+                }
+            });
             this.payment_methods_from_config = this.env.pos.payment_methods.filter(method => this.env.pos.config.payment_method_ids.includes(method.id));
             NumberBuffer.use(this._getNumberBufferConfig);
             useErrorHandlers();
@@ -256,6 +262,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                     }
                 }
             } finally {
+                this.currentOrder.isSent = true;
                 // Always show the next screen regardless of error since pos has to
                 // continue working even offline.
                 this.showScreen(this.nextScreen);

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -1322,6 +1322,13 @@ td {
     cursor: pointer;
     transition: all 150ms linear;
 }
+.screen .top-content .button.disabled{
+    cursor: not-allowed;
+    background: #C9CCD2;
+    color: #626774;
+    opacity: .3;
+    pointer-events: none;
+}
 .screen .top-content .button:hover {
     background: $gray-200;
 }

--- a/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/PaymentScreen/PaymentScreen.xml
@@ -7,6 +7,7 @@
                 <t t-if="!env.isMobile">
                     <div class="top-content">
                         <div class="button back"
+                              t-att-class="{'disabled': this.currentOrder.finalized}"
                               t-on-click="() => this.showScreen('ProductScreen')">
                             <i class="fa fa-angle-double-left fa-fw"></i>
                             <span class="back_text">Back</span>


### PR DESCRIPTION
Previously, users could inadvertently validate an order twice by quickly pressing the back button right after validating an order. This has been addressed by disabling the back button once the order is finalized.

Furthermore, users could bypass this by clicking on the "Orders" to view ongoing orders immediately after order validation. To counter this, an 'isSent' flag is set post sending the order to the server, ensuring the validate order function isn't invoked redundantly.

opw-3539115

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
