### PR TITLE
[FIX] spreadshet: wrong date format for week in pivot

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -123,7 +123,7 @@ const weekAdapter = {
         return `${nextWeek.weekNumber}/${nextWeek.weekYear}`;
     },
     format(normalizedValue, locale) {
-        const [year, week] = normalizedValue.split("/");
+        const [week, year] = normalizedValue.split("/");
         return sprintf(_t("W%(week)s %(year)s"), { week, year });
     },
 };

--- a/addons/spreadsheet/static/tests/pivots/pivot_helpers_test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_helpers_test.js
@@ -2,6 +2,9 @@
 import { getFirstPivotFunction, getNumberOfPivotFormulas } from "@spreadsheet/pivot/pivot_helpers";
 import { getFirstListFunction, getNumberOfListFormulas } from "@spreadsheet/list/list_helpers";
 import { toNormalizedPivotValue } from "@spreadsheet/pivot/pivot_model";
+import { pivotTimeAdapter } from "@spreadsheet/pivot/pivot_time_adapters";
+import { constants } from "@odoo/o-spreadsheet";
+const { DEFAULT_LOCALE } = constants;
 
 function stringArg(value) {
     return { type: "STRING", value: `${value}` };
@@ -170,5 +173,38 @@ QUnit.module("spreadsheet > toNormalizedPivotValue", {}, () => {
             assert.throws(() => toNormalizedPivotValue(field, 1));
             assert.throws(() => toNormalizedPivotValue(field, "won"));
         }
+    });
+});
+
+QUnit.module("spreadsheet > pivot time adapters formatted value", {}, () => {
+    QUnit.test("Day adapter", (assert) => {
+        const adapter = pivotTimeAdapter("day");
+        assert.strictEqual(adapter.format("11/12/2020", DEFAULT_LOCALE), "11/12/2020");
+        assert.strictEqual(adapter.format("01/11/2020", DEFAULT_LOCALE), "1/11/2020");
+        assert.strictEqual(adapter.format("12/05/2020", DEFAULT_LOCALE), "12/5/2020");
+    });
+
+    QUnit.test("Week adapter", (assert) => {
+        const adapter = pivotTimeAdapter("week");
+        assert.strictEqual(adapter.format("5/2024", DEFAULT_LOCALE), "W5 2024");
+        assert.strictEqual(adapter.format("51/2020", DEFAULT_LOCALE), "W51 2020");
+    });
+
+    QUnit.test("Month adapter", (assert) => {
+        const adapter = pivotTimeAdapter("month");
+        assert.strictEqual(adapter.format("12/2020", DEFAULT_LOCALE), "December 2020");
+        assert.strictEqual(adapter.format("02/2020", DEFAULT_LOCALE), "February 2020");
+    });
+
+    QUnit.test("Quarter adapter", (assert) => {
+        const adapter = pivotTimeAdapter("quarter");
+        assert.strictEqual(adapter.format("1/2022", DEFAULT_LOCALE), "Q1 2022");
+        assert.strictEqual(adapter.format("3/1998", DEFAULT_LOCALE), "Q3 1998");
+    });
+
+    QUnit.test("Year adapter", (assert) => {
+        const adapter = pivotTimeAdapter("year");
+        assert.strictEqual(adapter.format("2020", DEFAULT_LOCALE), "2020");
+        assert.strictEqual(adapter.format("1997", DEFAULT_LOCALE), "1997");
     });
 });


### PR DESCRIPTION
When importing a pivot with a date field in week format, the date was formatted as "W2023 40" instead of "W40 2023".

Task: [3539629](https://www.odoo.com/web#id=3539629&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
