### PR TITLE
[FIX] mail: hide author name of notifications on firefox

### DIFF
--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -32,9 +32,3 @@
 .o-mail-NotificationMessage p {
     margin-bottom: 0;
 }
-
-.o-mail-NotificationMessage:has(.o_hide_author) {
-    & .o-mail-NotificationMessage-author {
-        display: none!important;
-    }
-}

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -114,7 +114,7 @@
         'mt-2': prevMsg and !prevMsg.isNotification,
     }" t-ref="root">
         <i t-if="msg.notificationIcon" t-attf-class="{{ msg.notificationIcon }} me-1"/>
-        <span class="o-mail-NotificationMessage-author d-inline mx-1" t-if="msg.author and !msg.body.includes(escape(msg.author.name))" t-esc="msg.author.name"/> <t t-out="msg.body"/>
+        <span class="o-mail-NotificationMessage-author d-inline" t-if="msg.author and !msg.body.includes(escape(msg.author.name)) and !msg.body.includes('o_hide_author')" t-esc="msg.author.name"/> <t t-out="msg.body"/>
     </div>
 </t>
 


### PR DESCRIPTION
The author name of every notification is displayed when the
`o_hide_author` class is not set. In order to do so, the css
rule uses the `:has` pseudo-class. This is an issue since firefox
does not support it. This PR removes the usage of this pseudo-class.