### PR TITLE
[FIX] account, purchase, sale: ensure document access consistency on send

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1020,6 +1020,7 @@ Reason(s) of this behavior could be:
         in sale. Customer and portal group have probably no right to see
         the document so they don't have the access button. """
         groups = super(SaleOrder, self)._notify_get_groups(msg_vals=msg_vals)
+        recipient_group = None
 
         self.ensure_one()
         if self.state not in ('draft', 'cancel'):
@@ -1027,7 +1028,16 @@ Reason(s) of this behavior could be:
                 if group_name not in ('customer', 'portal'):
                     group_data['has_button_access'] = True
 
-        return groups
+            recipient_group = (
+                'additional_intended_recipient',
+                lambda pdata: pdata['id'] in msg_vals['partner_ids'] and pdata['id'] != self.partner_id.id,
+                {
+                    'has_button_access': True,
+                    'notification_is_customer': True,
+                }
+            )
+
+        return [recipient_group] + groups if recipient_group else groups
 
     def _create_payment_transaction(self, vals):
         '''Similar to self.env['payment.transaction'].create(vals) but the values are filled with the

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -747,3 +747,40 @@ class TestSaleOrder(TestSaleCommon):
         })
         so_no_analytic_account.action_confirm()
         self.assertFalse(sol_no_analytic_account.analytic_tag_ids.id, "The compute should not overwrite what the user has set.")
+
+
+    def test_sale_order_sent_to_additional_partner(self):
+        """
+        Make sure that when a SO is deliberately sent to a partner who is not
+        the invoiced customer, they receive a link containing an access token,
+        allowing them to view the SO without needing to log in.
+        """
+        self.partner_b.email = "partner_b@example.com"
+        self.sale_order.message_subscribe(self.partner_b.ids)
+
+        additional_partner = self.env['res.partner'].create({
+            'name': "Additional Partner",
+            'email': "additional@example.com",
+        })
+
+        email_ctx = self.sale_order.action_quotation_send().get('context', {})
+        composer = self.env['mail.compose.message'].with_context(email_ctx).create({})
+        composer.partner_ids |= additional_partner
+        composer.template_id.auto_delete = False
+
+        composer.send_mail()
+
+        additional_partner_mail = self.env['mail.mail'].search([
+            ('res_id', '=', self.sale_order.id),
+            ('recipient_ids', '=', additional_partner.id)
+        ])
+
+        self.assertIn('access_token=', additional_partner_mail.body_html,
+                        "The additional partner should be sent the link including the token")
+
+        additional_partner_mail = self.env['mail.mail'].search([
+            ('res_id', '=', self.sale_order.id),
+            ('recipient_ids', '=', self.partner_b.id)
+        ])
+        self.assertNotIn('access_token=', additional_partner_mail.body_html,
+                        "The followers should not bet sent the access token by default")


### PR DESCRIPTION
# Commit 1
### Summary

Currently, when you send an invoice, every recipient receives the link
including the access token. Only the invoice's customer and manually
added recipients should receive the token.

### Steps to reproduce

* Create and validate an invoice
* Add a follower `F `to the invoice
* Click on the Send & Print button, then add a recipient `R` who is not
  the customer associated with the invoice
* Proceed to send the invoice.
* Access the emails that were sent
* Using an incognito or private browsing window, open the `View Invoice`
  link for each of the 3 recipients.

You should see that all the links give access to the invoice.
What should happen is that only partner `R` and the invoice's customer
should haveaccess to the invoice.
`F` should be asked to login.

### Cause

Issue was introduced by https://github.com/odoo/odoo/commit/95c585f67bd37e1202c57b3e9eed09b0a964472c

### Fix

Add a new notification group for partners that were manually added as
recipients, and give that group access to the invoice.

opw-3385302



# Commit 2
### Summary

When sending an PO/SO to a recipient who is not the customer, they are
unable to view the invoice in the customer portal and are prompted to
log in. They should be able to access it if they've been manually added
as recipients.

### Steps to reproduce
* Create and validate a SO/PO
* Click on the Send By Email button, then add a recipient R who is not
  the customer associated with the invoice
* Proceed to send the SO/PO.
* Access the email that was sent to the added recipient
* Using an incognito or private browsing window, open the link on the
  email

=> you should see that you are asked to log in, instead of being
directed to the customer portal.

opw-3385302
opw-3114579