### PR TITLE
[FIX] l10n_br: Make sure credit notes use same sequence as invoices

### DIFF
--- a/addons/l10n_br/__init__.py
+++ b/addons/l10n_br/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import demo
 from . import models
 from . import wizard

--- a/addons/l10n_br/demo/__init__.py
+++ b/addons/l10n_br/demo/__init__.py
@@ -1,0 +1,1 @@
+from . import account_demo

--- a/addons/l10n_br/demo/account_demo.py
+++ b/addons/l10n_br/demo/account_demo.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, api
+
+
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = 'account.chart.template'
+
+    @api.model
+    def _get_demo_data_move(self, company=False):
+        """ Set the l10n_latam_document_number on demo invoices """
+        move_data = super()._get_demo_data_move(company)
+        if company.account_fiscal_country_id.code == 'BR':
+            number = 0
+            for move in move_data.values():
+                # vendor bills must be manually numbered (l10n_br uses the standard AccountMove._is_manual_document_number())
+                if move['move_type'] == 'in_invoice':
+                    move['l10n_latam_document_number'] = f'{number:08d}'
+                    number += 1
+
+        return move_data

--- a/addons/l10n_br/models/template_br.py
+++ b/addons/l10n_br/models/template_br.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, api
+from odoo import models
 from odoo.addons.account.models.chart_template import template
 
 
@@ -39,18 +39,8 @@ class AccountChartTemplate(models.AbstractModel):
     @template('br', 'account.journal')
     def _get_br_account_journal(self):
         return {
-            'sale': {'l10n_br_invoice_serial': '1'},
+            'sale': {
+                'l10n_br_invoice_serial': '1',
+                'refund_sequence': False,
+            },
         }
-
-    @api.model
-    def _get_demo_data_move(self, company=False):
-        move_data = super()._get_demo_data_move(company)
-        if company.account_fiscal_country_id.code == 'BR':
-            number = 0
-            for move in move_data.values():
-                # vendor bills must be manually numbered (l10n_br uses the standard AccountMove._is_manual_document_number())
-                if move['move_type'] == 'in_invoice':
-                    move['l10n_latam_document_number'] = f'{number:08d}'
-                    number += 1
-
-        return move_data

--- a/addons/l10n_br/views/account_journal_views.xml
+++ b/addons/l10n_br/views/account_journal_views.xml
@@ -6,7 +6,7 @@
             <field name="name">account.journal.form</field>
             <field name="inherit_id" ref="l10n_latam_invoice_document.view_account_journal_form"/>
             <field name="arch" type="xml">
-                 <field name="type" position="after">
+                <field name="type" position="after">
                     <field name="l10n_br_invoice_serial" invisible="not l10n_latam_use_documents or country_code != 'BR'"/>
                 </field>
             </field>


### PR DESCRIPTION
#### Steps to reproduce
1. Create a fresh DB with the Brazilian localization.
2. Create a new Credit Note (directly from the menu, not from an invoice). Confirm.
3. Observe that you get a ValidationError: "Another entry with the same name already exists." because the name of the Credit Note is NFe 00000001, and an invoice called NFe 00000001 already exists.

#### Analysis
- The credit note should be called NFe 00000002, because in Brazil the same sequences should be used both for invoices and for credit notes of a given document type.
- However, because the `refund_sequence` field is set to True on the 'Customer Invoices' journal, the sequence mixin doesn't consider invoices and credit notes as using the same sequence, and therefore doesn't consider the existing invoice when finding a new name for the credit note.

#### Solution
- Set the field `refund_sequence` to False on the journal created by the l10n_br template.
- We also take the opportunity to move the code that provides a default name to the demo invoices to a separate file demo/account_demo.py, for consistency with other localizations.
