### PR TITLE
[FIX] web: correct the tiktok font url

### DIFF
--- a/addons/web/static/src/scss/fontawesome_overridden.scss
+++ b/addons/web/static/src/scss/fontawesome_overridden.scss
@@ -1,7 +1,7 @@
 // This is a patch of the font awesome library to add the TikTok icon.
 @font-face {
     font-family: 'FontAwesome-tiktok-only';
-    src: url('../../../fonts/tiktok_only.woff');
+    src: url('../../fonts/tiktok_only.woff');
     font-weight: normal;
     font-style: normal;
     font-display: block;


### PR DESCRIPTION
This updates the relative url of the 'woff' font that was
one parent too far. Bug introduced in [1]

[1] : https://github.com/odoo/odoo/commit/47c5a092196054359d82edbc79dea0caf213dd9f

task-3477965