### PR TITLE
[FIX] web: fix file upload in post

### DIFF
--- a/addons/web/static/src/core/network/http_service.js
+++ b/addons/web/static/src/core/network/http_service.js
@@ -18,7 +18,14 @@ export async function get(route, readMethod = "json") {
 export async function post(route, params = {}, readMethod = "json") {
     const formData = new FormData();
     for (const key in params) {
-        formData.append(key, params[key]);
+        const value = params[key];
+        if (Array.isArray(value) && value.length) {
+            for (const val of value) {
+                formData.append(key, val);
+            }
+        } else {
+            formData.append(key, value);
+        }
     }
     const response = await browser.fetch(route, {
         body: formData,


### PR DESCRIPTION
In a recent commit odoo/enterprise/pull/47775 the post function was modified so that it directly adds the values in params to the FormData object. Before, a check was done to see if the value was an array and handle it accordingly. This change resulted in not being able to upload attachments in the expense app and probably in other places, as the files were sent in an array to the post method. This commit fixes the issue by adding the check for arrays again.

task-3527686