### PR TITLE
[FIX] website_event_track: prevent error if event track duration exceeds 2 days

### DIFF
--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -162,4 +162,30 @@ tour.register('wevent_register', {
     )
 );
 
+/**
+ * Agenda STEPS
+ */
+
+var discoverAgendaSteps = function (AgendaTitle) {
+    return [{
+        content: `Go on ${AgendaTitle} Event page`,
+        trigger: `span:contains(${AgendaTitle})`,
+    }];
+};
+
+var browseAgendaSteps = [{
+    content: 'Browse Agenda',
+    trigger: 'a:contains("Agenda")',
+}];
+
+tour.register('event_track', {
+    test: true,
+    },[].concat(
+            browseAgendaSteps,
+            discoverAgendaSteps('Live Testimonial'),
+            discoverAgendaSteps('What This Event Is All About'),
+            discoverAgendaSteps('Our Last Day Together !'),
+        )
+    );
+
 });

--- a/addons/test_event_full/tests/__init__.py
+++ b/addons/test_event_full/tests/__init__.py
@@ -4,3 +4,4 @@
 from . import common
 from . import test_event_crm
 from . import test_wevent_register
+from . import test_event_track

--- a/addons/test_event_full/tests/test_event_track.py
+++ b/addons/test_event_full/tests/test_event_track.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.test_event_full.tests.common import TestWEventCommon
+from odoo.addons.http_routing.models.ir_http import slug
+from odoo.tests import tagged
+
+@tagged('post_install', '-at_install')
+class TestEventTrack(TestWEventCommon):
+
+    def test_event_track(self):
+        self.track_0['duration'] = 200
+        self.start_tour('/event/%s' % slug(self.event), 'event_track')

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -287,12 +287,11 @@ class EventTrackController(http.Controller):
         time_slots_by_day_start_time = {start_datetime: 0}
         for i in range(0, time_slots_count):
             # If the new time slot is still on the current day
-            next_day = (start_datetime + timedelta(days=1)).date()
-            if (start_datetime + timedelta(minutes=15*i)).date() <= next_day:
+            next_day = (start_datetime + timedelta(days=1))
+            if (start_datetime + timedelta(minutes=15*i)).date() <= next_day.date():
                 time_slots_by_day_start_time[start_datetime] += 1
             else:
-                start_datetime = next_day.datetime()
-                time_slots_by_day_start_time[start_datetime] = 0
+                time_slots_by_day_start_time[next_day] = 0
 
         return time_slots_by_day_start_time
 


### PR DESCRIPTION
Currently, the error occurs if the event track duration is more than  two days or 48:00 hour

Steps to reproduce

- Install a 'website_event_track' module.
- Go to Events / Configuration / Event Templates and create a new 'Event Templates', Make a boolean true of 'Showcase Tracks', 'Website Submenu', 'Allow Track Proposals', and 'Extra Register Button'. Add name and timezone.
- Open 'Events' and create new events, Add an event name, 'Date', 'Timezone', and 'Template' which we created.
- Click on the 'Tracks' button, Create an Event Tracks, Add a Title, Track Date, and location, and Give a value to a duration field more than 48:00.
- Make this Event Tracks state to 'Published'.
- Click on the 'Go to Website' Button, go into 'Agenda'

Traceback on sentry:

```
AttributeError: 'datetime.date' object has no attribute 'datetime'
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1851, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_event_track/controllers/event_track.py", line 185, in event_agenda
    vals.update(self._prepare_calendar_values(event))
  File "addons/website_event_track/controllers/event_track.py", line 210, in _prepare_calendar_values
    time_slots_by_tracks = {track: self._split_track_by_days(track, local_tz) for track in tracks_sudo}
  File "addons/website_event_track/controllers/event_track.py", line 210, in <dictcomp>
    time_slots_by_tracks = {track: self._split_track_by_days(track, local_tz) for track in tracks_sudo}
  File "addons/website_event_track/controllers/event_track.py", line 315, in _split_track_by_days
    start_datetime = next_day.datetime()
```

When the event track duration is more than 48:00 hours, The error occurs because the system is trying to access the datetime on a datetime.date object, which is not possible[1].

Line 1:https://github.com/odoo/odoo/blob/422625615b2f6708667fa44d2a9e83ad3e66e5af/addons/website_event_track/controllers/event_track.py#L294

This commit solves the issue by preventing the conversion of 'next_day' into a date format, as 'next_day' is already in datetime format.

sentry-4516712041 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr