### PR TITLE
[FIX] base: changed the name field when adding a new sub contact to mandatory

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -307,7 +307,7 @@
                                         <hr/>
                                         <group>
                                             <group>
-                                                <field name="name" string="Contact Name" attrs="{'required' : [('type', '=', 'contact')]}"/>
+                                                <field name="name" string="Contact Name" required="1"/>
                                                 <field name="title" options="{'no_open': True}" placeholder="e.g. Mr."
                                                     attrs="{'invisible': [('type','!=', 'contact')]}"/>
                                                 <field name="function" placeholder="e.g. Sales Director"


### PR DESCRIPTION
Steps to reproduce:
1. Install Contact
2. Go to Contact, open a partner form
3. In the Contacts / Addresses tab, click on Add
4. Click on save without entering a name
5. Go to the Contacts page and open the form for the contact you just added

Current behavior before PR:
When you try to add a partner in Contact app the name field is mandatory, but when you try to add a sub contact under a partner the name field is mandatory just when the type is 'contact' if it is any type of the addresses it will not be mandatory this leads that when you try to open the form of this sub contact it will give you an error because the name is not set

Desired behavior after PR is merged:
Change the name field to be mandatory on all types. So, you will never be able to add a sub contact without specifying a name for it.

opw-3514803