### PR TITLE
[FIX] point_of_sale: backport limited pricelist items loading

### DIFF
--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -196,3 +196,27 @@ odoo.define('point_of_sale.tour.ShowTaxExcludedTour', function (require) {
 
     Tour.register('ShowTaxExcludedTour', { test: true, url: '/pos/ui' }, getSteps());
 });
+
+
+odoo.define('point_of_sale.tour.limitedProductPricelistLoading', function (require) {
+    'use strict';
+
+    const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
+    const { getSteps, startSteps } = require('point_of_sale.tour.utils');
+    var Tour = require('web_tour.tour');
+
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+
+    ProductScreen.do.scan_barcode("0100100");
+    ProductScreen.check.selectedOrderlineHas('Test Product 1', '1.0', '80.0');
+
+    ProductScreen.do.scan_barcode("0100200");
+    ProductScreen.check.selectedOrderlineHas('Test Product 2', '1.0', '100.0');
+
+    ProductScreen.do.scan_barcode("0100300");
+    ProductScreen.check.selectedOrderlineHas('Test Product 3', '1.0', '50.0');
+
+    Tour.register('limitedProductPricelistLoading', { test: true, url: '/pos/ui' }, getSteps());
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -788,6 +788,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'FiscalPositionNoTaxRefund', login="accountman")
+
     def test_lot_refund(self):
 
         self.product1 = self.env['product.product'].create({
@@ -800,3 +801,50 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_session_cb(check_coa=False)
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'LotRefundTour', login="accountman")
+
+    def test_limited_product_pricelist_loading(self):
+        self.main_pos_config.write({
+            'limited_products_loading': True,
+            'limited_products_amount': 1
+        })
+
+        product_1 = self.env['product.product'].create({
+            'name': 'Test Product 1',
+            'list_price': 100,
+            'barcode': '0100100',
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        product_2 = self.env['product.product'].create({
+            'name': 'Test Product 2',
+            'list_price': 200,
+            'barcode': '0100200',
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        self.env['product.product'].create({
+            'name': 'Test Product 3',
+            'list_price': 300,
+            'barcode': '0100300',
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        pricelist_item = self.env['product.pricelist.item'].create([{
+            'applied_on': '3_global',
+            'fixed_price': 50,
+        }, {
+            'applied_on': '1_product',
+            'product_tmpl_id': product_2.product_tmpl_id.id,
+            'fixed_price': 100,
+        }, {
+            'applied_on': '0_product_variant',
+            'product_id': product_1.id,
+            'fixed_price': 80,
+        }])
+        self.main_pos_config.pricelist_id.write({'item_ids': [(6, 0, pricelist_item.ids)]})
+
+        self.main_pos_config.open_session_cb()
+        self.start_tour("/pos/ui?debug=1&config_id=%d" % self.main_pos_config.id, 'limitedProductPricelistLoading', login="accountman")


### PR DESCRIPTION
v15 backport of PR: odoo/odoo#135219

Also add load=False when doing search_read on product.pricelist.item to avoid recomputing many2ones' display_name. Since the call to get_pos_ui_product_pricelist_item_by_product is blocking UI-wise, computing product.product's display_name can make the POS ui seems less responsive when there are lots of pricelist items and the limitedProductLoading is activated.

opw-3251048

Should be v15 only. No FP branches needed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
