### PR TITLE
[IMP] product: add system parameter to control maximum product limit

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -728,9 +728,10 @@ class ProductTemplate(models.Model):
                         current_variants_to_activate += existing_variants[combination]
                     else:
                         current_variants_to_create.append(tmpl_id._prepare_variant_values(combination))
-                        if len(current_variants_to_create) > 1000:
+                        variant_limit = self.env['ir.config_parameter'].sudo().get_param('product.dynamic_variant_limit', 1000)
+                        if len(current_variants_to_create) > int(variant_limit):
                             raise UserError(_(
-                                'The number of variants to generate is too high. '
+                                'The number of variants to generate is above allowed limit. '
                                 'You should either not generate variants for each combination or generate them on demand from the sales order. '
                                 'To do so, open the form view of attributes and change the mode of *Create Variants*.'))
                 variants_to_create += current_variants_to_create


### PR DESCRIPTION
before this commit, if the entered attribute combination in template is creating more than 1000 product, the operation is prevented by raising UserError.

as of now, there is no option to increase or decrease the limit if user need to do so.

system parameter:  product.dynamic_variant_limit

after this commit, if user needs to increase or decrease the limit, it can be done by adding a system parameter and set the needed value


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
