### PR TITLE
[FIX] hr_recruitment: create a application with invalid email_from

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -431,6 +431,8 @@ class Applicant(models.Model):
                 applicant._message_add_suggested_recipient(recipients, partner=applicant.partner_id.sudo(), reason=_('Contact'))
             elif applicant.email_from:
                 email_from = tools.email_normalize(applicant.email_from)
+                if not email_from:
+                    continue
                 if applicant.partner_name:
                     email_from = tools.formataddr((applicant.partner_name, email_from))
                 applicant._message_add_suggested_recipient(recipients, email=email_from, reason=_('Contact Email'))


### PR DESCRIPTION
This error occurs because we are receiving a boolean value in the `email_from` and when the `formataddr` function is called with this boolean value, it results in an error.

Steps to produce :
- Install the 'hr_recruitment' module.
- Go to Applications > All Applications > Create a new Application
- Give value to Subject, Applicant's Name > Give any value in email (e.g. abc)
- save the record > Error will be generated.

See traceback :
```
AttributeError: 'bool' object has no attribute 'rpartition'
  File "odoo/http.py", line 2138, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1714, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1741, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1942, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/mail/controllers/thread.py", line 15, in mail_thread_data
    return thread._get_mail_thread_data(request_list)
  File "addons/mail/models/mail_thread_main_attachment.py", line 38, in _get_mail_thread_data
    res = super()._get_mail_thread_data(request_list)
  File "addons/mail/models/mail_thread.py", line 4213, in _get_mail_thread_data
    res['suggestedRecipients'] = self._message_get_suggested_recipients()[self.id]
  File "addons/hr_recruitment/models/hr_applicant.py", line 505, in _message_get_suggested_recipients
    email_from = tools.formataddr((applicant.partner_name, email_from))
  File "odoo/tools/mail.py", line 688, in formataddr
    local, _, domain = address.rpartition('@')
```


This issue is coming because here https://github.com/odoo/odoo/blob/4abb4ac387cc48759f8f3bacc184188128baadb3/addons/hr_recruitment/models/hr_recruitment.py#L433 it will get false value from the `email_normalize` function, in that it will get the empty list from the `email_split` function, that empty list gets from here https://github.com/odoo/odoo/blob/4abb4ac387cc48759f8f3bacc184188128baadb3/odoo/tools/mail.py#L507 this false value of `email_from` passes to the `formataddr` it generates error

after this commit error will not occur and the record will be saved.

sentry-4500026247

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
