### PR TITLE
[FIX] project: fix change personal task stage by drag and drop to another stage

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -42,8 +42,11 @@ export class ProjectTaskKanbanDynamicGroupList extends RelationalModel.DynamicGr
 
 export class ProjectTaskRecord extends RelationalModel.Record {
     _update(changes, options) {
-        const value = changes.personal_stage_type_ids;
-        if (Array.isArray(value)) {
+        let value = changes.personal_stage_type_ids;
+        if(value){
+            if (!Array.isArray(value)) {
+                value = [value, false];
+            }
             delete changes.personal_stage_type_ids;
             changes.personal_stage_type_id = value;
         }


### PR DESCRIPTION
**Steps to reproduce:**
---
-  Project -> Tasks -> My Tasks
-  try changing task stage by dragging and dropping task to another stage.

**Issue:**
---
The expected behavior was to change the stage when changing task
stage by dragging and dropping to another stage. but The stage is not
being changed.

**Cause:**
---
The for loop inside function `_preprocessX2manyChanges`
was expecting an Array from the `value`  but It wasn't getting
an Array. The reason was the `_update` function in the project.
Where one edge case was missing. and it was producing traceback.

**Fix:**
---
The condition for handling the edge case is added. It will check
whether the `value` is an Array.

**PPR Note**-i think this commit effected- https://github.com/odoo/odoo/commit/4bf77b9ef18f49e409af904334f4dfab88db3cf0
task:3519453