### PR TITLE
[IMP] mail: sort attachments on basis of type in discuss and chatter.

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -139,6 +139,10 @@ export class Attachment extends Record {
         return videoMimeTypes.includes(this.mimetype);
     }
 
+    get isMedia() {
+        return this.isImage || this.isVideo || this.isVoice;
+    }
+
     get isViewable() {
         return (
             (this.isText || this.isImage || this.isVideo || this.isPdf || this.isUrlYoutube) &&

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { Record } from "@mail/core/common/record";
+import { deserializeDateTime } from "@web/core/l10n/dates";
 
 export class LinkPreview extends Record {
     static id = "id";
@@ -55,6 +56,16 @@ export class LinkPreview extends Record {
 
     get isCard() {
         return !this.isImage && !this.isVideo;
+    }
+
+
+    get monthYear() {
+        const message = this.message ?? this._store.Message.get(this.message_id);
+        if (!message) {
+            return undefined;
+        }
+        const datetime = deserializeDateTime(message.create_date);
+        return `${datetime.monthLong}, ${datetime.year}`;
     }
 }
 

--- a/addons/mail/static/src/core/web/chatter.scss
+++ b/addons/mail/static/src/core/web/chatter.scss
@@ -54,3 +54,20 @@
 .o-mail-Chatter button.o-active {
     color: $o-action !important;
 }
+
+.o-mail-Chatter-Attachment-title {
+    text-align: center;
+    width: 100%;
+    cursor: pointer;
+}
+
+.o-mail-Chatter-Attachment-title.active{
+    border-bottom: 4px solid #714B67 ;
+}
+
+.o-mail-ChatterAttachement-Panel-link{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -97,20 +97,42 @@
                 <t t-if="props.hasActivities and activities.length and !state.isSearchOpen">
                     <t t-call="mail.ActivityList"/>
                 </t>
-                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative" t-ref="attachment-box">
+                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative py-1 px-3" t-ref="attachment-box">
                     <div class="d-flex align-items-center">
                         <hr class="flex-grow-1"/>
                         <span class="p-3 fw-bold">
-                            Files
+                            Attachments
                         </span>
                         <hr class="flex-grow-1"/>
                     </div>
+                    <div class="flex-grow-1">
+                    </div>
+                    <div class="o-mail-Chatter-Attachment d-flex flex-column">
+                        <div class="o-mail-AttachmentpanelCatgory mb-2" t-on-click="(ev) => this.handleTabSelection(ev)">
+                            <div class="o-mail-AttachmentPanelCategory-title " t-att-class="state.current === 'media' ? 'active' : ''" data-tab="media" title="Media">
+                                Media
+                            </div>
+                            <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'link' ? 'active' : ''" data-tab="link" title="Links">
+                                Links
+                            </div>
+                            <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'file' ? 'active' : ''" data-tab="file" title="Files">
+                                Files
+                            </div>
+                        </div>
+                        <div class="o-mail-ChatterAttachement-Panel-media" t-if="this.state.current === 'media'">
+                            <p t-if="this.state.media === 0" class="text-center fst-italic text-500 mt-4">This conversation doesn't have any media attachments.</p>
+                            <AttachmentList imagesHeight="100" attachments="getAttachment('media')"  unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                        <div class="o-mail-ChatterAttachement-Panel-link" t-elif="this.state.current === 'link'">
+                            <p t-if="this.state.link === 0" class="text-center fst-italic text-500 mt-4">This conversation doesn't have any link attachments.</p>
+                            <LinkAttachment links="getAttachment('link')"/>
+                        </div>
+                        <div class="o-mail-ChatterAttachement-Panel-file" t-elif="this.state.current === 'file'">
+                            <p t-if="this.state.file === 0" class="text-center fst-italic text-500 mt-4">This conversation doesn't have any file attachments.</p>
+                            <AttachmentList imagesHeight="100" attachments="getAttachment('file')"  unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                    </div>
                     <div class="d-flex flex-column">
-                        <AttachmentList
-                            attachments="attachments"
-                            unlinkAttachment.bind="unlinkAttachment"
-                            imagesHeight="100"
-                        />
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                             <t t-set-slot="toggler">
                                 <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -7,7 +7,7 @@
                 <button t-if="env.closeActionPanel" class="o-mail-ActionPanel-backButton btn opacity-75 opacity-100-hover ps-0 py-0 fs-5" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left"/>
                 </button>
-                <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-700 flex-grow-1" t-esc="props.title"/>
+                <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-700 flex-grow-1 text-center" t-esc="props.title"/>
             </div>
             <t t-slot="default"/>
         </div>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.scss
@@ -1,0 +1,15 @@
+.o-mail-AttachmentpanelCatgory {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+}
+
+.o-mail-AttachmentPanelCategory-title {
+    text-align: center;
+    width: 100%;
+    cursor: pointer;
+}
+
+.o-mail-AttachmentPanelCategory-title.active{
+    border-bottom: 2px solid #714B67 ;
+}

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -11,16 +11,49 @@
                     <t t-else="">File upload is disabled for external users</t>
                 </label>
             </div>
-            <div class="flex-grow-1" t-att-class="{
-                'd-flex justify-content-center align-items-center': props.thread.attachments.length === 0,
-            }">
-                <p t-if="props.thread.attachments.length === 0" class="text-center fst-italic text-500">
-                    <t t-if="props.thread.type === 'channel'">This channel doesn't have any attachments.</t>
-                    <t t-else="">This conversation doesn't have any attachments.</t>
-                </p>
-                <div t-else="" t-foreach="attachmentsByDate" t-as="dateDay" t-key="dateDay" class="d-flex flex-column">
-                    <DateSection date="dateDay" className="'my-1'"/>
-                    <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+            <div class="flex-grow-1">
+                <div class="d-flex flex-column">
+                    <div class="o-mail-AttachmentpanelCatgory" t-on-click="(ev) => this.handleTabSelection(ev)">
+                        <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'media' ? 'active' : ''" data-tab="media">
+                            Media
+                        </div>
+                        <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'links' ? 'active' : ''" data-tab="links">
+                            Links
+                        </div>
+                        <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'files' ? 'active' : ''" data-tab="files" title="Files">
+                            Files
+                        </div>
+                    </div>
+                    <div t-if="state.current === 'media'">
+                        <p t-if="state.media === 0" class="text-center fst-italic text-500 mt-4">
+                            <t t-if="props.thread.type === 'channel'">This channel doesn't have any media attachments.</t>
+                            <t t-else="" >This conversation doesn't have any media attachments.</t>
+                        </p>
+                        <div t-foreach="this.categorizedAttachments('media')" t-as="dateDay" t-key="dateDay">
+                            <DateSection date="dateDay" className="'my-1'"/>
+                            <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                    </div>
+                    <div t-elif="state.current === 'links'">
+                        <p t-if="state.linkPreviews === 0" class="text-center fst-italic text-500 mt-4">
+                            <t t-if="props.thread.type === 'channel'">This channel doesn't have any links.</t>
+                            <t t-else="">This conversation doesn't have any links.</t>
+                        </p>
+                        <div t-foreach="this.categorizedAttachments('link')" t-as="links" t-key="link">
+                            <DateSection date="links" className="'my-1'"/>
+                            <LinkAttachment links="links_value"/>
+                        </div>
+                    </div>
+                    <div t-elif="state.current === 'files'">
+                        <p t-if="state.files === 0" class="text-center fst-italic text-500 mt-4">
+                            <t t-if="props.thread.type === 'channel'">This channel doesn't have any file attachments.</t>
+                            <t t-else="">This conversation doesn't have any file attachments.</t>
+                        </p>
+                        <div t-foreach="this.categorizedAttachments('file')" t-as="dateDay" t-key="dateDay">
+                            <DateSection date="dateDay" className="'my-1'"/>
+                            <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                    </div>
                 </div>
             </div>
             <span t-ref="load-older"/>

--- a/addons/mail/static/src/discuss/core/common/link_attachment.js
+++ b/addons/mail/static/src/discuss/core/common/link_attachment.js
@@ -1,0 +1,15 @@
+/* @odoo-module */
+
+import { LinkPreview } from "@mail/core/common/link_preview";
+import { Component, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * @typedef {Object} Props
+ * @property {import("models").Thread} thread
+ */
+export class LinkAttachment extends Component {
+    static components = { LinkPreview };
+    static props = ["links"];
+    static template = "mail.LinkAttachment";
+}

--- a/addons/mail/static/src/discuss/core/common/link_attachment.scss
+++ b/addons/mail/static/src/discuss/core/common/link_attachment.scss
@@ -1,0 +1,28 @@
+.o-mail-LinkAttachment{
+    margin-top: 8px;
+    padding-top: 0 !important;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 8px;
+    > .o-mail-LinkPreviewList{
+        margin-top: 0px !important;
+    }
+    
+    > .o-mail-LinkPreviewCard{
+        margin-bottom: 0px !important;
+    }
+
+    >.o-mail-LinkPreviewCard.card{
+        border-radius: 0.25rem 0.25rem 0rem 0rem !important;
+        border: 0px !important;
+        border-bottom: 1px solid rgba(255,255,255,0.125) !important;
+        box-shadow: 0 0 0 0 transparent !important; 
+    }
+}
+
+.o-mail-LinkAttachment-Content{
+    margin-left: 5px;
+    margin-right: 5px;
+    display: flex;
+    justify-content: space-between;
+}

--- a/addons/mail/static/src/discuss/core/common/link_attachment.xml
+++ b/addons/mail/static/src/discuss/core/common/link_attachment.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.LinkAttachment">
+        <t t-foreach="this.props.links" t-as="links" t-key="links.id">
+            <div class="o-mail-LinkAttachment card rounded shadow-sm" >
+                <LinkPreview linkPreview="links" deletable="true" />
+                <div class="o-mail-LinkAttachment-Content">
+                    <a href="links.source_url" t-esc="links.source_url"></a>
+                </div>
+            </div>
+        </t>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/core/common/thread_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_service_patch.js
@@ -37,6 +37,7 @@ patch(ThreadService.prototype, {
             const rawAttachments = await this.rpc("/discuss/channel/attachments", {
                 before: Math.min(...thread.attachments.map(({ id }) => id)),
                 channel_id: thread.id,
+                model: thread.model,
                 limit,
             });
             const attachments = rawAttachments.map((a) => this.store.Attachment.insert(a));

--- a/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
@@ -15,7 +15,7 @@ QUnit.test("Empty attachment panel", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
     await contains(".o-mail-Discuss-inspector", {
-        text: "This channel doesn't have any attachments.",
+        text: "This channel doesn't have any media attachments.",
     });
 });
 
@@ -39,6 +39,7 @@ QUnit.test("Attachment panel sort by date", async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
+    await click(".o-mail-AttachmentPanelCategory-title[title='Files']")
     await contains(".o-mail-AttachmentList", {
         text: "file2.pdf",
         after: [".o-mail-DateSection", { text: "September, 2023" }],

--- a/addons/mail/static/tests/web/attachment_box_tests.js
+++ b/addons/mail/static/tests/web/attachment_box_tests.js
@@ -5,7 +5,7 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 import { patchUiSize, SIZES } from "@mail/../tests/helpers/patch_ui_size";
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { click, contains, scroll } from "@web/../tests/utils";
+import { click, contains } from "@web/../tests/utils";
 
 QUnit.module("attachment box");
 
@@ -73,6 +73,7 @@ QUnit.test("remove attachment should ask for confirmation", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
+    await click(".o-mail-AttachmentPanelCategory-title[title='Files']")
     await contains(".o-mail-AttachmentCard");
     await contains("button[title='Remove']");
 
@@ -115,6 +116,7 @@ QUnit.test("view attachments", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
+    await click(".o-mail-AttachmentPanelCategory-title[title='Files']")
     await click('.o-mail-AttachmentCard[aria-label="Blah.txt"] .o-mail-AttachmentCard-image');
     await contains(".o-FileViewer");
     await contains(".o-FileViewer-header", { text: "Blah.txt" });
@@ -126,37 +128,6 @@ QUnit.test("view attachments", async () => {
 
     await click(".o-FileViewer div[aria-label='Next']");
     await contains(".o-FileViewer-header", { text: "Blah.txt" });
-});
-
-QUnit.test("scroll to attachment box when toggling on", async () => {
-    patchUiSize({ size: SIZES.XXL });
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({});
-    for (let i = 0; i < 30; i++) {
-        pyEnv["mail.message"].create({
-            body: "not empty".repeat(50),
-            model: "res.partner",
-            res_id: partnerId,
-        });
-    }
-    pyEnv["ir.attachment"].create({
-        mimetype: "text/plain",
-        name: "Blah.txt",
-        res_id: partnerId,
-        res_model: "res.partner",
-    });
-    const { openView } = await start();
-    openView({
-        res_id: partnerId,
-        res_model: "res.partner",
-        views: [[false, "form"]],
-    });
-    await contains(".o-mail-Message", { count: 30 });
-    await scroll(".o-mail-Chatter", "bottom");
-    await click("button[aria-label='Attach files']");
-    await contains(".o-mail-AttachmentBox");
-    await contains(".o-mail-Chatter", { scroll: 0 });
-    await contains(".o-mail-AttachmentBox", { visible: true });
 });
 
 QUnit.test("do not auto-scroll to attachment box when initially open", async () => {
@@ -208,6 +179,7 @@ QUnit.test("attachment box should order attachments from newest to oldest", asyn
     });
     await contains(".o-mail-Chatter [aria-label='Attach files']", { text: "3" });
     await click(".o-mail-Chatter [aria-label='Attach files']"); // open attachment box
+    await click(".o-mail-AttachmentPanelCategory-title[title='Files']")
     await contains(":nth-child(1 of .o-mail-AttachmentCard)", { text: "C.txt" });
     await contains(":nth-child(2 of .o-mail-AttachmentCard)", { text: "B.txt" });
     await contains(":nth-child(3 of .o-mail-AttachmentCard)", { text: "A.txt" });

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -213,6 +213,7 @@ QUnit.test("chatter: drop attachments", async () => {
     await contains(".o-mail-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
     await dropFiles(".o-mail-Dropzone", files);
+    await click(".o-mail-AttachmentPanelCategory-title[title='Files']");
     await contains(".o-mail-AttachmentCard", { count: 2 });
     const extraFiles = [
         await createFile({


### PR DESCRIPTION
Before this commit:
The attachements that we displayed in the attachmentPanel were not sorted on the basis of type, there were displayed just in the order in which they were inserted.

After  this commit:
1. The attachments in the attachment panel are now sorted in three different tab, namely 'Media', 'Links', 'Files'. Each attachment gets stored in its respective tab.
2. Consider linkPreviews as attachement and store all the linkPreviews in the tab 'Links'

task-3485793
