### PR TITLE
[FIX] tools: wrong translation in default language

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1643,7 +1643,7 @@ def _get_translation_upgrade_queries(cr, field):
             if "en_US" not in new_values:
                 new_values["en_US"] = field.translate(lambda v: None, src_value)
             if extra and extra[0] not in new_values:
-                new_values[extra[0]] = new_values["en_US"]
+                new_values[extra[0]] = field.translate(lambda v: None, src_value)
             elif not extra:
                 missing_languages = languages - set(translations)
                 if missing_languages:


### PR DESCRIPTION
[Here](https://github.com/odoo/odoo/blob/a277faa2ffab7559fcbad95fcc1e8fd6a26d756b/odoo/tools/translate.py#L1645) If 'en_US' is exist in new_values then as a default language 'en_US' translations are loading due to that translation of default language gone lost

Description of the issue/feature this PR addresses:

Current behavior before PR:
original translation look like this 
![translate](https://github.com/odoo/odoo/assets/127722128/5c788ace-fcec-4783-b036-c6b77bea3083)

 if default language is dutch for example then instead of dutch language english's translations are there 
```
en_US : <t t-name="website.test">
  <t t-call="website.layout">
          <p class="o_default_snippet_text">I transalted to english</p>
  </t>
</t>
fr_BE : <t t-name="website.test">
  <t t-call="website.layout">
          <p class="o_default_snippet_text">this french</p>
  </t>
</t>
nl_NL : <t t-name="website.test">
  <t t-call="website.layout">
          <p class="o_default_snippet_text">I transalted to english</p>
  </t>
</t>
```

Desired behavior after PR is merged: arch_db look like this 
```
en_US : <t t-name="website.test">
  <t t-call="website.layout">
          <p class="o_default_snippet_text">I transalted to english</p>
  </t>
</t>
fr_BE : <t t-name="website.test">
  <t t-call="website.layout">
          <p class="o_default_snippet_text">this french</p>
  </t>
</t>
nl_NL : <t t-name="website.test">
  <t t-call="website.layout">
          <p class="o_default_snippet_text">this dutch</p>
  </t>
</t>
```
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
