### PR TITLE
[IMP] point_of_sale: add documentation link for stripe terminal

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -286,7 +286,7 @@
                                      documentation="/applications/sales/point_of_sale/payment_methods/terminals/adyen.html">
                                 <field name="module_pos_adyen"/>
                             </setting>
-                            <setting id="stripe_payment_terminal_setting" title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method." string="Stripe" help="Accept payments with a Stripe payment terminal">
+                            <setting id="stripe_payment_terminal_setting" title="The transactions are processed by Stripe. Set your Stripe credentials on the related payment method." string="Stripe" documentation="/applications/sales/point_of_sale/payment_methods/terminals/stripe.html" help="Accept payments with a Stripe payment terminal">
                                 <field name="module_pos_stripe"/>
                             </setting>
                             <setting id="vantiv_payment_terminal_setting" title="The transactions are processed by Vantiv. Set your Vantiv credentials on the related payment method." string="Vantiv (US &amp; Canada)" documentation="/applications/sales/point_of_sale/payment_methods/terminals/vantiv.html" help="Accept payments with a Vantiv payment terminal">


### PR DESCRIPTION
before this commit, the documentation link for stripe terminal was not added.

after this commit, the documentation link for stripe terminal is added in settings

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
