### PR TITLE
[FIX] pos_self_order,*: modifying the splash screen images

### DIFF
--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -150,7 +150,7 @@ class ResConfigSettings(models.TransientModel):
         # STEP: Finally, we write the value of 'pos' fields to 'pos_config_id'.
         for pos_config_id, pos_fields_vals in pos_config_id_to_fields_vals_map.items():
             pos_config = self.env['pos.config'].browse(pos_config_id)
-            pos_config.write(pos_fields_vals)
+            pos_config.with_context(from_settings_view=True).write(pos_fields_vals)
 
         return result
 

--- a/addons/pos_self_order/tests/test_frontend.py
+++ b/addons/pos_self_order/tests/test_frontend.py
@@ -70,3 +70,27 @@ class TestFrontendMobile(SelfOrderCommonTest):
         result = response.json()
         order_id = result['result']['id']
         self.assertEqual(self.env['pos.order'].browse(order_id).fiscal_position_id.id, alternative_fp.id)
+
+    def test_properly_delete_splash_screen_images(self):
+        """ Simulate what is done from the res.config.settings view when removing an image. """
+
+        self.pos_config.write({
+            'self_ordering_image_home_ids': [
+                Command.clear(),
+                Command.create({'name': 'a1', 'datas': b'blob1234', 'mimetype': 'image/png'}),
+                Command.create({'name': 'a2', 'datas': b'blob2345', 'mimetype': 'image/png'}),
+                Command.create({'name': 'a3', 'datas': b'blob3456', 'mimetype': 'image/png'}),
+            ]
+        })
+
+        linked_ids = self.pos_config.self_ordering_image_home_ids.ids
+        second_id = linked_ids[1]
+
+        # We'll unlink the second image and then save the settings.
+        # It will be a set of link commands for the images except the one we want to delete.
+        commands = [Command.link(id) for id in linked_ids if id != second_id]
+        self.pos_config.with_context(from_settings_view=True).write({
+            'self_ordering_image_home_ids': commands
+        })
+
+        self.assertTrue(second_id not in self.pos_config.self_ordering_image_home_ids.ids)


### PR DESCRIPTION
**Steps to reproduce**

- Open general settings of pos.
- Select/Create a Point of Sale that is kiosk to see the `Splash screens` field.
  - The field is pre-filled with 3 images.
- ISSUE: Try removing the images and save, they won't be removed.

**FIX**

- This is because of the `write` operation made from the `res.config.settings` model to the `pos.config`.
  - When removing an image, the field will be given `link` commands, linking the remaining images. This is wrong because it won't unlink the images that are deleted.

- To ensure the deletion, we reinterpret the command to the splash screen images field if the command comes from the res.config.settings.
  - We introduce a context called 'from_settings_view' such that it's set to true when the write is from the `res.config.settings` view.
  - And specific to the pos_self_order, we compute the items that should be unlinked and we append the unlink commands to the original set of commands for the splash screen field.

