### PR TITLE
[FIX] website_hr_recruitment: fix legacy rpc call

### DIFF
--- a/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
+++ b/addons/website_hr_recruitment/static/src/js/website_hr_applicant_form.js
@@ -13,6 +13,7 @@ publicWidget.registry.hrRecruitment = publicWidget.Widget.extend({
 
     init: function () {
         this._super.apply(this, arguments);
+        this.rpc = this.bindService("rpc");
     },
 
     willStart() {
@@ -60,13 +61,11 @@ publicWidget.registry.hrRecruitment = publicWidget.Widget.extend({
             return;
         }
         const job_id = $('#recruitment7').val();
-        const data = await this._rpc({
-            route: '/website_hr_recruitment/check_recent_application',
-            params: {
+        const data = await this.rpc('/website_hr_recruitment/check_recent_application',
+            {
                 email: email,
                 job_id: job_id,
-            }
-        });
+            });
         if (data.applied_same_job)  {
             $('#email-message').removeClass('alert-warning').hide();
             $(ev.currentTarget).addClass('border-warning');


### PR DESCRIPTION
[FIX] website_hr_recruitment: fix legacy _rpc
Behavior before this commit:
When you try to apply for a job on focusout of the mail field, you get
an error raised in website stating that this._rpc is not a function.

Explanation:
The task 3446696 (PR: 131308) has been merged in master
at almost the same time as the task 3439226 (PR: 136271)
that was removing the legacy rpc call (this._rpc({...})).

Behavior after this commit:
The rpc call is working again and so no error is raised.

Fix:
This commit fix it by using the current
rpc call.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
