### PR TITLE
[FIX] im_livechat: error when loading a page with outdated guest

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -91,7 +91,6 @@ export class LivechatService {
                 (this.sessionCookie && visitorUid !== userId)
             ) {
                 this.leaveSession();
-                this.state = SESSION_STATE.NONE;
             }
             browser.localStorage.setItem(ODOO_VERSION_KEY, currOdooVersion);
         }
@@ -132,7 +131,7 @@ export class LivechatService {
     async leaveSession({ notifyServer = true } = {}) {
         const session = JSON.parse(cookie.get(this.SESSION_COOKIE) ?? "{}");
         try {
-            if (this.state === SESSION_STATE.PERSISTED && notifyServer) {
+            if (session?.uuid && notifyServer) {
                 this.busService.deleteChannel(session.uuid);
                 await this.rpc("/im_livechat/visitor_leave_session", { uuid: session.uuid });
             }

--- a/addons/website_livechat/models/website.py
+++ b/addons/website_livechat/models/website.py
@@ -54,7 +54,7 @@ class Website(models.Model):
                         # linked to another guest in the meantime. We need to
                         # update the channel to link it to the current guest.
                         channel_guest_member = chat_request_channel.channel_member_ids.filtered(lambda m: m.guest_id == current_guest)
-                        chat_request_channel.write({'channel_member_ids': [Command.unlink(channel_guest_member), Command.link(current_guest)]})
+                        chat_request_channel.write({'channel_member_ids': [Command.unlink(channel_guest_member), Command.create({'guest_id': current_guest.id})]})
                     if not current_guest:
                         channel_guest._set_auth_cookie()
                 return {

--- a/addons/website_livechat/models/website.py
+++ b/addons/website_livechat/models/website.py
@@ -48,15 +48,14 @@ class Website(models.Model):
             if chat_request_channel:
                 if not visitor.partner_id:
                     current_guest = self.env['mail.guest']._get_guest_from_context()
-                    channel_guest = chat_request_channel.channel_member_ids.filtered(lambda m: m.guest_id).guest_id
-                    if current_guest and current_guest != channel_guest:
+                    channel_guest_member = chat_request_channel.channel_member_ids.filtered(lambda m: m.guest_id)
+                    if current_guest and current_guest != channel_guest_member.guest_id:
                         # Channel was created with a guest but the visitor was
                         # linked to another guest in the meantime. We need to
                         # update the channel to link it to the current guest.
-                        channel_guest_member = chat_request_channel.channel_member_ids.filtered(lambda m: m.guest_id == current_guest)
-                        chat_request_channel.write({'channel_member_ids': [Command.unlink(channel_guest_member), Command.create({'guest_id': current_guest.id})]})
+                        chat_request_channel.write({'channel_member_ids': [Command.unlink(channel_guest_member.id), Command.create({'guest_id': current_guest.id})]})
                     if not current_guest:
-                        channel_guest._set_auth_cookie()
+                        channel_guest_member.guest_id._set_auth_cookie()
                 return {
                     "folded": False,
                     "id": chat_request_channel.id,

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -78,3 +78,12 @@ class TestLivechatRequestHttpCase(tests.HttpCase, TestLivechatCommon):
         active_channels = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)])
         for active_channel in active_channels:
             active_channel._close_livechat_session()
+
+    def test_update_guest_of_chat_request_if_outdated(self):
+        self.visitor.with_user(self.operator).sudo().action_send_chat_request()
+        chat_request = self.env['discuss.channel'].search([('livechat_visitor_id', '=', self.visitor.id), ('livechat_active', '=', True)])
+        chat_request.message_post(body="Hello", author_id=self.operator.partner_id.id)
+        guest = self.env["mail.guest"].create({"name": "Guest"})
+        self.assertNotEqual(chat_request.channel_member_ids.guest_id, guest)
+        self.env.ref('website.default_website').with_context(guest=guest)._get_livechat_request_session()
+        self.assertEqual(chat_request.channel_member_ids.guest_id, guest)


### PR DESCRIPTION
This PR fixes two issues:
- Incorrect write on `channel_member_ids` (trying to link guest instead
of channel member)
- Incorrect condition in  `livechatService.leaveSession` that relies on
the live chat to be initialized while it can acutally be called before
if the current session is outdated.

This could result in server errors in the following scenario:
- Open a live chat
- Log in
- Open a live chat from the website app
- Log out