### PR TITLE
[IMP] account_peppol: Add actions on dashboard for peppol operations

### DIFF
--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -16,6 +16,7 @@
     ],
     'data': [
         'data/cron.xml',
+        'views/account_journal_dashboard_views.xml',
         'views/account_move_views.xml',
         'views/res_partner_views.xml',
         'views/res_config_settings_views.xml',

--- a/addons/account_peppol/models/__init__.py
+++ b/addons/account_peppol/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_edi_proxy_user
+from . import account_journal
 from . import account_move
 from . import res_company
 from . import res_config_settings

--- a/addons/account_peppol/models/account_journal.py
+++ b/addons/account_peppol/models/account_journal.py
@@ -1,0 +1,24 @@
+# -*- coding:utf-8 -*-
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state')
+    is_peppol_journal = fields.Boolean(string="Account used for Peppol", default=False)
+
+    def peppol_get_new_documents(self):
+        edi_users = self.env['account_edi_proxy_client.user'].search([
+            ('company_id.account_peppol_proxy_state', '=', 'active'),
+            ('company_id', 'in', self.company_id.ids),
+        ])
+        edi_users._peppol_get_new_documents()
+
+    def peppol_get_message_status(self):
+        edi_users = self.env['account_edi_proxy_client.user'].search([
+            ('company_id.account_peppol_proxy_state', '=', 'active'),
+            ('company_id', 'in', self.company_id.ids),
+        ])
+        edi_users._peppol_get_message_status()

--- a/addons/account_peppol/views/account_journal_dashboard_views.xml
+++ b/addons/account_peppol/views/account_journal_dashboard_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_journal_dashboard_kanban_view" model="ir.ui.view">
+        <field name="name">account.journal.dashboard.kanban</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.account_journal_dashboard_kanban_view" />
+        <field name="arch" type="xml">
+            <data>
+                <xpath expr="//kanban" position="inside">
+                    <field name="is_peppol_journal" invisible="1"/>
+                    <field name="account_peppol_proxy_state" invisible="1"/>
+                </xpath>
+
+                <xpath expr="//t[@id='account.JournalBodySalePurchase']//div" position="inside">
+                    <t t-if="record.account_peppol_proxy_state.raw_value == 'active'">
+                        <t t-if="journal_type == 'sale'">
+                            <a type="object" name="peppol_get_message_status" groups="account.group_account_invoice">Fetch Peppol invoice status</a>
+                        </t>
+                        <t t-elif="journal_type == 'purchase'">
+                            <t t-if="record.is_peppol_journal.raw_value">
+                                <a type="object" name="peppol_get_new_documents" groups="account.group_account_invoice">Fetch from Peppol</a>
+                            </t>
+                        </t>
+                    </t>
+                </xpath>
+            </data>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Problem
---------
User want to verify (when he want) if he has bills on Peppol and the
status of his customer invoices. Currently, the only option is wait for
a cron that runs twice a day.

Objective
---------
- Add a button in the Kanban card of the customer invoices that updates
the status of invoice send by Peppol. 
- Add a button in the Kanban card of the incoming journal that fetches
received bills on the Peppol network.

Solution
---------
This commits does several things in order to achieve the objective:
- Seperate the peppol cron functions into business action and cron
function
- Add an interface on the journals so that they can call the peppol
business functions
- Add an inverse function that resets the journal `is_peppol_journal` to
False and sets that field to True on the relevant journal.
- Add a related field that checks whether the company has peppol active
- Add the buttons on the Kandan Dashboard view that call the relevant
business function thanks to the interface. It filters the edi users on the target
companies so that only the target companies are updated when a button is
pressed and not all companies.

task-3531222
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
