### PR TITLE
[FIX] website_sale: fix cart issues

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -885,6 +885,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if not display:
             return values
 
+        values['cart_ready'] = order._is_cart_ready()
         values['website_sale.cart_lines'] = request.env['ir.ui.view']._render_template(
             "website_sale.cart_lines", {
                 'website_sale_order': order,

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -108,6 +108,11 @@ function updateCartNavBar(data) {
 
     $(".js_cart_lines").first().before(data['website_sale.cart_lines']).end().remove();
     $("#cart_total").replaceWith(data['website_sale.total']);
+    if (data.cart_ready) {
+        document.querySelector("a[name='website_sale_main_button']")?.classList.remove('disabled');
+    } else {
+        document.querySelector("a[name='website_sale_main_button']")?.classList.add('disabled');
+    }
 }
 
 function showCartNotification(callService, props, options = {}) {

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -765,4 +765,8 @@ a.no-decoration {
     .o_cta_navigation_placeholder {
         height: o-to-rem(111px) + map-get($spacers, 4) + 2rem;
     }
+
+    a.disabled {
+        pointer-events: none;
+    }
 }

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1709,8 +1709,8 @@
                     <t t-else="" t-call="payment.submit_button"/>
                 </t>
                 <t t-else="">
-                    <a role="button"
-                        t-attf-class="#{_cta_classes} btn btn-primary #{_form_send_navigation and 'order-lg-3 w-100 w-lg-auto ms-lg-auto' or 'w-100'}"
+                    <a role="button" name="website_sale_main_button"
+                        t-attf-class="#{_cta_classes} btn btn-primary #{not website_sale_order._is_cart_ready() and 'disabled'} #{_form_send_navigation and 'order-lg-3 w-100 w-lg-auto ms-lg-auto' or 'w-100'}"
                         t-att-href="step_specific_values['main_button_href']">
                         <t t-out="step_specific_values['main_button']"/>
                         <i class="fa fa-angle-right ms-2 fw-light"/>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1446,7 +1446,7 @@
             Your cart is empty!
         </div>
         <t t-if='website_sale_order'>
-            <div t-if='website_sale_order._get_shop_warning(clear=False)' class="alert alert-warning" role="alert">
+            <div t-if='website_sale_order._get_shop_warning(clear=False)' class="alert alert-warning js_cart_lines" role="alert">
                 <strong>Warning!</strong> <t t-esc='website_sale_order._get_shop_warning()'/>
             </div>
         </t>


### PR DESCRIPTION
Before this commit, the warning message on the cart could be duplicated when editing the cart, as it was not reloaded by the js. This commit makes sure that the warning message is re-rendered, and removed if needed.

The checkout button is always active as soon as the cart is not empty. However, there are many cases where we want to prevent the customer to move on, as the cart is not ready to go on. This PR adds a class to the button that disables it when the method `_is_cart_ready` returns `False`.

task-3537684

See also: https://github.com/odoo/enterprise/pull/48533