### PR TITLE
[FIX] web_editor: node insertion from different document

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -165,10 +165,10 @@ export const editorCommands = {
         const containerFirstChild = document.createElement('fake-element-fc');
         const containerLastChild = document.createElement('fake-element-lc');
 
-        if (content instanceof editor.document.defaultView.Node) {
-            container.replaceChildren(content);
-        } else {
+        if (typeof content === 'string') {
             container.textContent = content;
+        } else {
+            container.replaceChildren(content);
         }
 
         // In case the html inserted starts with a list and will be inserted within


### PR DESCRIPTION
Steps:
- on website or mass_mailing, insert an image via the "/image" command,
- a text node containing "[object HTMLImageElement]" is pasted instead of the expected content.

Since [1], when inserting a node, the instanceof operator is used to compare that node to the Editor's document global `Node` object. While it fixed cases where there was as mismatch of `Node` objects (nodes created by the top document x nodes created via the iframe's document), it revealed errors elsewhere. Notably, the MediaDialog inserts an image node created by the top document, regardless if the editor is mounted in an iframe.

This commit makes the "insert" command more permissive when resolving if `content` is a Node or a string.

task-3543003

[1]: https://github.com/odoo/odoo/commit/bfe0c5fedf172f4c77002a4f54803b376ada43ce

