### PR TITLE
[FIX] maintenance: handle type error without effective_date

### DIFF
--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -176,7 +176,7 @@ class MaintenanceEquipment(models.Model):
                 if next_date < date_now:
                     next_date = date_now
             else:
-                next_date = equipment.effective_date + timedelta(days=equipment.period)
+                next_date = (equipment.effective_date or date_now) + timedelta(days=equipment.period)
             equipment.next_action_date = next_date
         (self - equipments).next_action_date = False
 


### PR DESCRIPTION
When the user creates the new equipment record and sets the "Preventive Maintenance Frequency" as 1, the "Effective Date" is set to empty, and a traceback will be generated.

Steps to reproduce:
- Install the "maintenance" module.
- Maintenance > Equipments
- Try to create a new record, set the "Preventive Maintenance Frequency" to 1, and set the "Effective Date" to empty.
- After that, a traceback will be generated. 

Traceback:
```
TypeError: unsupported operand type(s) for +: 'bool' and 'datetime.timedelta'
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6781, in onchange
    todo = [
  File "odoo/models.py", line 6784, in <listcomp>
    if name not in done and snapshot0.has_changed(name)
  File "odoo/models.py", line 6584, in has_changed
    return self[name] != record[name]
  File "odoo/models.py", line 6211, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1157, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1367, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1340, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4553, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/maintenance/models/maintenance.py", line 178, in _compute_next_maintenance
    next_date = equipment.effective_date + timedelta(days=equipment.period)
```

When the user creates the new equipment record and sets the "Preventive Maintenance Frequency" as 1, the "Effective Date" is set to empty, and a traceback will be generated. So, check the "Effective Date" value in the '_compute_next_maintenance()' function of the maintenance.equipment object; if it is true, pass it; otherwise, it is false.

code reference:
https://github.com/odoo/odoo/blob/a6777c22c84976bc9cb77f9c95566881cf46d5c6/addons/maintenance/models/maintenance.py#L179

sentry-4508012402