### PR TITLE
[FIX] website: check menu.url datatype is sting or not

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -110,6 +110,8 @@ class Website(Home):
 
         # Fallback on first accessible menu
         def is_reachable(menu):
+            if not isinstance(menu.url, str):
+                return False
             return menu.is_visible and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
 
         reachable_menus = top_menu.child_id.filtered(is_reachable)


### PR DESCRIPTION
When a user changes homepage url and adds a menu with no url and then tries to go to homepage then the traceback is generated.

Steps to reproduce:
- Install Website module.
- Go to Configuration > Menus > Create a new menu without URL, website as My Website and parent menu as Top Menu for Website 1 [My Website]
- Go to Site > Properties > Page URL.
- Change its route by adding 'test' to url and activate redirect old url button.
- Repeat above two steps.
- Now go to Site > Homepages, the traceback will occur.

Error: 
```
  File "odoo/http.py", line 2138, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1714, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1741, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1855, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/main.py", line 118, in index
    reachable_menus = top_menu.child_id.filtered(is_reachable)
  File "odoo/models.py", line 5723, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
  File "odoo/models.py", line 5723, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
  File "addons/website/controllers/main.py", line 116, in is_reachable
    return menu.is_visible and menu.url not in ('/', '', '#') and not menu.url.startswith(('/?', '/#', ' '))
AttributeError: 'bool' object has no attribute 'startswith'
```

The issue is occurring because value of menu.url is False over here - https://github.com/odoo/odoo/blob/7e2e2e0b257d44ce051a3ee8f60e9e03f5d14739/addons/website/controllers/main.py#L113

To solve this issue the datatype of menu.url is checked whether it is string or not.

sentry-4527212121

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
