### PR TITLE
[FIX] website_forum: resolve traceback issue for 'View all' tags

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -160,7 +160,7 @@
                 <t t-if="question_count or tags" t-call="website.website_search_box_input">
                     <t t-if="_page_name == 'tags'">
                         <t t-set="search_type" t-value="'forum_tags_only'"/>
-                        <t t-set="action" t-valuef="'/forum/%s/tag' % (_forum_slug)"/>
+                        <t t-set="action" t-value="'/forum/%s/tag' % (_forum_slug)"/>
                     </t>
                     <t t-else="">
                         <t t-set="search_type" t-value="'forums'"/>


### PR DESCRIPTION
**Before the PR**:
A traceback was generated when clicking on 'View all' tags.

**Reason**:
Issue from PR:- https://github.com/odoo/odoo/pull/129123. In the search box
template, the action value for 'View all' tags was incorrectly formatted,
't-valuef' was used with python expression instead of 't-value' resulting in an
erroneous URI path and causing errors.

**After the PR**:
The traceback has been resolved by using correct string formatting ensuring the
correct generation of the string.

**Task**-3525236
