### PR TITLE
[FIX] web: update properties field

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -17,7 +17,6 @@ import { Record } from "./record";
 import { StaticList } from "./static_list";
 import {
     FetchRecordError,
-    applyProperties,
     extractInfoFromGroupData,
     getBasicEvalContext,
     getFieldsSpec,
@@ -511,9 +510,7 @@ export class RelationalModel extends Model {
      * @returns Promise<Object>
      */
     async _loadNewRecord(config, params = {}) {
-        const record = await this._onchange(config, params);
-        applyProperties([record], config.activeFields, config.fields);
-        return record;
+        return this._onchange(config, params);
     }
 
     /**
@@ -538,7 +535,6 @@ export class RelationalModel extends Model {
                 throw new FetchRecordError(resIds);
             }
 
-            applyProperties(records, config.activeFields, config.fields);
             return records;
         } else {
             return resIds.map((resId) => {
@@ -564,10 +560,7 @@ export class RelationalModel extends Model {
             count_limit:
                 config.countLimit !== Number.MAX_SAFE_INTEGER ? config.countLimit + 1 : undefined,
         };
-        const response = await this.orm.webSearchRead(config.resModel, config.domain, kwargs);
-
-        applyProperties(response.records, config.activeFields, config.fields);
-        return response;
+        return this.orm.webSearchRead(config.resModel, config.domain, kwargs);
     }
 
     /**

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -76,39 +76,6 @@ export function addFieldDependencies(activeFields, fields, fieldDependencies = [
     }
 }
 
-export function applyProperties(records, activeFields, fields) {
-    for (const record of records) {
-        for (const fieldName in record) {
-            const field = fields[fieldName];
-            if (fieldName !== "id" && field.type === "properties" && record[fieldName]) {
-                const parent = record[field.definition_record];
-                const relatedPropertyField = {
-                    fieldName,
-                };
-                if (parent) {
-                    relatedPropertyField.id = parent.id;
-                    relatedPropertyField.displayName = parent.display_name;
-                }
-                for (const property of record[fieldName]) {
-                    const propertyFieldName = `${fieldName}.${property.name}`;
-                    if (!fields[propertyFieldName]) {
-                        fields[propertyFieldName] = {
-                            ...property,
-                            name: propertyFieldName,
-                            relatedPropertyField,
-                            propertyName: property.name,
-                            relation: property.comodel,
-                        };
-                    }
-                    if (!activeFields[propertyFieldName]) {
-                        activeFields[propertyFieldName] = createPropertyActiveField(property);
-                    }
-                }
-            }
-        }
-    }
-}
-
 function completeActiveField(activeField, extra) {
     if (extra.related) {
         for (const fieldName in extra.related.activeFields) {

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -11,7 +11,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { Model } from "@web/model/model";
-import { applyProperties, extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
+import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 
 export class CalendarModel extends Model {
     setup(params, services) {
@@ -484,7 +484,6 @@ export class CalendarModel extends Model {
      */
     async loadRecords(data) {
         const rawRecords = await this.fetchRecords(data);
-        applyProperties(rawRecords, this.meta.activeFields, this.meta.fields);
         const records = {};
         for (const rawRecord of rawRecords) {
             records[rawRecord.id] = this.normalizeRecord(rawRecord);

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -12,8 +12,6 @@ import {
     deserializeDateTime,
     formatDate,
     formatDateTime,
-    serializeDate,
-    serializeDateTime,
 } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { TagsList } from "@web/core/tags_list/tags_list";
@@ -204,11 +202,7 @@ export class PropertyValue extends Component {
      * @param {object} newValue
      */
     async onValueChange(newValue) {
-        if (this.props.type === "datetime") {
-            newValue = newValue && serializeDateTime(newValue);
-        } else if (this.props.type === "date") {
-            newValue = newValue && serializeDate(newValue);
-        } else if (this.props.type === "integer") {
+        if (this.props.type === "integer") {
             try {
                 newValue = parseInteger(newValue) || 0;
             } catch {

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -18627,8 +18627,12 @@ QUnit.module("Views", (hooks) => {
 
         await click(target.querySelector(".o_field_cell.o_char_cell"));
         await editInput(target, ".o_field_cell.o_char_cell input", "TEST");
-        await clickSave(target);
+        assert.strictEqual(target.querySelector(".o_field_cell.o_char_cell input").value, "TEST");
 
+        await click(target.querySelector("[name='m2o']"));
+        assert.strictEqual(target.querySelector(".o_field_cell.o_char_cell input").value, "TEST");
+
+        await clickSave(target);
         assert.strictEqual(target.querySelector(".o_field_cell.o_char_cell").textContent, "TEST");
     });
 


### PR DESCRIPTION
The purpose of this commit is to resolve two issues relating to the properties field:

Issue 1:
========
In a list view, when you edit a property and then select another field
in the same record, the edition disappears.

How to resolve:
--------------
Do not delete the changes linked to the property in record.update.

How to reproduce:
----------------
- Go to a list view with a properties field containing a property char
- Insert a value in the char property
- Click on another field in the same record

Before this commit:
    The inserted value disappears

After this commit:
    The inserted value is still present

Issue 2:
========
The fields/activeFields only take into account properties received
during the initial web_read and not those added by an update or an onChange.

How to resolve:
--------------
Generate property fields and activeFields during parseServerValue
(web_read and onChange) and during an update.

How to reproduce:
----------------
- Go to a form view with a properties field
- Editing a field with an onChange
- The onChange returns a new property for the properties field

Before this commit:
    A crash is displayed

After this commit:
    The new property is displayed correctly