### PR TITLE
[FIX] mail: allow empty message edition

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -72,7 +72,7 @@
                         >
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
-                                    <t t-if="message.type !== 'notification' and !message.isTransient and (message.hasTextContent or message.subtypeDescription)">
+                                    <t t-if="message.type !== 'notification' and !message.isTransient and (message.hasTextContent or message.subtypeDescription or state.isEditing)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -1594,3 +1594,28 @@ QUnit.test("Message should display attachments in order", async () => {
     await contains(":nth-child(2 of .o-mail-AttachmentCard)", { text: "B.txt" });
     await contains(":nth-child(3 of .o-mail-AttachmentCard)", { text: "C.txt" });
 });
+
+QUnit.test("Can edit a message only containing an attachment", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    const attachmentId = pyEnv["ir.attachment"].create({
+        name: "Blah.jpg",
+        mimetype: "image/jpeg",
+    });
+    pyEnv["mail.message"].create({
+        attachment_ids: [attachmentId],
+        author_id: pyEnv.currentPartnerId,
+        body: "",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message-editable .o-mail-Composer-input");
+});


### PR DESCRIPTION
Before this PR, it was not possible to edit a message that has an empty body.

Task-3387170
