### PR TITLE
[IMP] core: more stuff with the SQL wrapper

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -686,7 +686,8 @@ class AccountMoveLine(models.Model):
 
         # get the where clause
         query = self._where_calc(list(self.env.context.get('domain_cumulated_balance') or []))
-        order_string = ", ".join(self._generate_order_by_inner(self._table, self.env.context.get('order_cumulated_balance'), query, reverse_direction=True))
+        sql_order = self._order_to_sql(self.env.context.get('order_cumulated_balance'), query, reverse=True)
+        order_string = self.env.cr.mogrify(sql_order).decode()
         from_clause, where_clause, where_clause_params = query.get_sql()
         sql = """
             SELECT account_move_line.id, SUM(account_move_line.balance) OVER (

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -8,6 +8,7 @@ import pytz
 
 from odoo import api, fields, models
 from odoo.osv import expression
+from odoo.tools import SQL
 
 _logger = logging.getLogger(__name__)
 
@@ -258,26 +259,30 @@ class MailActivityMixin(models.AbstractModel):
         self.env['res.partner'].flush_model(['tz'])
 
         tz = 'UTC'
-        if 'tz' in self.env.context and self.env.context.get('tz') in pytz.all_timezones_set:
+        if self.env.context.get('tz') in pytz.all_timezones_set:
             tz = self.env.context['tz']
 
-        join_query = f"""
-        (SELECT res_id,
-            CASE
-                WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, '{tz}'))::date) > 0 THEN 'planned'
-                WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, '{tz}'))::date) < 0 THEN 'overdue'
-                WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, '{tz}'))::date) = 0 THEN 'today'
-                ELSE null
-            END AS activity_state
-        FROM mail_activity
-        JOIN res_users ON (res_users.id = mail_activity.user_id)
-        JOIN res_partner ON (res_partner.id = res_users.partner_id)
-        WHERE res_model = '{self._name}'
-        GROUP BY res_id)
-        """
-        alias = query.join(self._table, "id", join_query, "res_id", "last_activity_state")
+        sql_join = SQL(
+            """
+            (SELECT res_id,
+                CASE
+                    WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, %(tz)s))::date) > 0 THEN 'planned'
+                    WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, %(tz)s))::date) < 0 THEN 'overdue'
+                    WHEN min(date_deadline - (now() AT TIME ZONE COALESCE(res_partner.tz, %(tz)s))::date) = 0 THEN 'today'
+                    ELSE null
+                END AS activity_state
+            FROM mail_activity
+            JOIN res_users ON (res_users.id = mail_activity.user_id)
+            JOIN res_partner ON (res_partner.id = res_users.partner_id)
+            WHERE res_model = %(res_model)s
+            GROUP BY res_id)
+            """,
+            res_model=self._name,
+            tz=tz,
+        )
+        alias = query.join(self._table, "id", sql_join, "res_id", "last_activity_state")
 
-        return f'"{alias}"."activity_state"', ['activity_state']
+        return SQL.identifier(alias, 'activity_state'), ['activity_state']
 
     def toggle_active(self):
         """ Before archiving the record we should also remove its ongoing

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -657,7 +657,13 @@ class MailThread(models.AbstractModel):
         # leading to a traceback in case the related message_id
         # doesn't exist
         cleaned_self = self.with_context(clean_context(self._context))._fallback_lang()
-        templates = self._track_template(changes)
+        try:
+            templates = self._track_template(changes)
+        except MissingError:
+            if not self.exists():
+                return
+            raise
+
         default_composition_mode = 'mass_mail' if len(self) != 1 else 'comment'
         for _field_name, (template, post_kwargs) in templates.items():
             if not template:

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -81,6 +81,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
 
         simple_date_groupby_sql, __ = self._read_group_groupby(f"date:{interval}", main_query)
         # Removing unexistant table name from the expression
+        simple_date_groupby_sql = self.env.cr.mogrify(simple_date_groupby_sql).decode()
         simple_date_groupby_sql = simple_date_groupby_sql.replace('"project_task_burndown_chart_report".', '')
 
         burndown_chart_query = """
@@ -232,7 +233,7 @@ class ReportProjectTaskBurndownChart(models.AbstractModel):
 
     def _read_group_select(self, aggregate_spec, query):
         if aggregate_spec == '__count':
-            return f'SUM("{self._table}"."__count")', []
+            return SQL("SUM(%s)", SQL.identifier(self._table, '__count')), []
         return super()._read_group_select(aggregate_spec, query)
 
     def _read_group(self, domain, groupby=(), aggregates=(), having=(), offset=0, limit=None, order=None):

--- a/addons/purchase_stock/report/vendor_delay_report.py
+++ b/addons/purchase_stock/report/vendor_delay_report.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, tools
-from odoo.exceptions import UserError
-from odoo.osv.expression import expression
+from odoo import fields, models, tools
+from odoo.tools import SQL
 
 
 class VendorDelayReport(models.Model):
@@ -57,6 +56,6 @@ GROUP  BY m.id
     def _read_group_select(self, aggregate_spec, query):
         if aggregate_spec == 'on_time_rate:sum':
             # Make a weigthed average instead of simple average for these fields
-            sql_expression = 'SUM(qty_on_time) / SUM(qty_total) * 100'
-            return sql_expression, ['on_time_rate', 'qty_on_time', 'qty_total']
+            sql_expr = SQL('SUM(qty_on_time) / SUM(qty_total) * 100')
+            return sql_expr, ['on_time_rate', 'qty_on_time', 'qty_total']
         return super()._read_group_select(aggregate_spec, query)

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -123,7 +123,7 @@ class WebsiteForum(WebsiteProfile):
             # retro-compatibility for V8 and google links
             try:
                 sorting = werkzeug.urls.url_unquote_plus(sorting)
-                Post._generate_order_by(sorting, None)
+                Post._order_to_sql(sorting, None)
             except (UserError, ValueError):
                 sorting = False
 

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1281,7 +1281,7 @@ class TestQueries(TransactionCase):
             SELECT "res_partner_title"."id"
             FROM "res_partner_title"
             WHERE (COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>'en_US') like %s)
-            ORDER BY COALESCE("res_partner_title"."name"->>'fr_FR', "res_partner_title"."name"->>'en_US')
+            ORDER BY COALESCE("res_partner_title"."name"->>%s, "res_partner_title"."name"->>'en_US')
         ''']):
             Model.search([('name', 'like', 'foo')])
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4766,7 +4766,7 @@ class Many2many(_RelationalMulti):
         comodel._flush_search(domain, order=comodel._order)
         query = comodel._where_calc(domain)
         comodel._apply_ir_rules(query, 'read')
-        query.order = comodel._generate_order_by(comodel._order, query).replace(' ORDER BY ', '')
+        query.order = comodel._order_to_sql(comodel._order, query)
 
         # join with many2many relation table
         sql_id1 = SQL.identifier(self.relation, self.column1)

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1824,3 +1824,27 @@ def get_flag(country_code: str) -> str:
 def format_frame(frame):
     code = frame.f_code
     return f'{code.co_name} {code.co_filename}:{frame.f_lineno}'
+
+
+def named_to_positional_printf(string: str, args: Mapping) -> tuple[str, tuple]:
+    """ Convert a named printf-style format string with its arguments to an
+    equivalent positional format string with its arguments. This implementation
+    does not support escaped ``%`` characters (``"%%"``).
+    """
+    if '%%' in string:
+        raise ValueError(f"Unsupported escaped '%' in format string {string!r}")
+    args = _PrintfArgs(args)
+    return string % args, tuple(args.values)
+
+
+class _PrintfArgs:
+    """ Helper object to turn a named printf-style format string into a positional one. """
+    __slots__ = ('mapping', 'values')
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+        self.values = []
+
+    def __getitem__(self, key):
+        self.values.append(self.mapping[key])
+        return "%s"

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -73,7 +73,7 @@ class Query(object):
         self._where_clauses = []
 
         # order, limit, offset
-        self.order = None
+        self._order = None
         self.limit = None
         self.offset = None
 
@@ -141,6 +141,14 @@ class Query(object):
         return rhs_alias
 
     @property
+    def order(self) -> SQL | None:
+        return self._order
+
+    @order.setter
+    def order(self, value: SQL | str | None):
+        self._order = SQL(value) if value is not None else None
+
+    @property
     def table(self) -> str:
         """ Return the query's main table, i.e., the first one in the FROM clause. """
         return next(iter(self._tables))
@@ -176,7 +184,7 @@ class Query(object):
             SQL("SELECT %s", SQL(", ").join(sql_args)),
             SQL(" FROM %s", self.from_clause),
             SQL(" WHERE %s", self.where_clause) if self._where_clauses else SQL(),
-            SQL(" ORDER BY %s", SQL(self.order)) if self.order else SQL(),
+            SQL(" ORDER BY %s", self._order) if self._order else SQL(),
             SQL(" LIMIT %s", self.limit) if self.limit else SQL(),
             SQL(" OFFSET %s", self.offset) if self.offset else SQL(),
         )

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 # pylint: disable=sql-injection
+from __future__ import annotations
 
 import enum
 import json
@@ -8,7 +9,7 @@ import logging
 import re
 from binascii import crc32
 from collections import defaultdict
-from typing import Iterable, Optional, Union
+from typing import Iterable, Union
 
 import psycopg2
 
@@ -56,7 +57,7 @@ class SQL:
     __slots__ = ('__code', '__args')
 
     # pylint: disable=keyword-arg-before-vararg
-    def __new__(cls, code: Union[str, "SQL"] = "", /, *args):
+    def __new__(cls, code: (str | SQL) = "", /, *args):
         if isinstance(code, SQL):
             return code
         # validate the format of code
@@ -105,7 +106,7 @@ class SQL:
         yield self.code
         yield self.params
 
-    def join(self, args: Iterable) -> "SQL":
+    def join(self, args: Iterable) -> SQL:
         """ Join SQL objects or parameters with ``self`` as a separator. """
         args = list(args)
         # optimizations for special cases
@@ -122,7 +123,7 @@ class SQL:
         return SQL("%s" * len(items), *items)
 
     @classmethod
-    def identifier(cls, name: str, subname: Optional[str] = None) -> "SQL":
+    def identifier(cls, name: str, subname: (str | None) = None) -> SQL:
         """ Return an SQL object that represents an identifier. """
         assert IDENT_RE.match(name), f"{name!r} invalid for SQL.identifier()"
         if subname is None:


### PR DESCRIPTION
Here we move further on with the `SQL` wrapper:
- extend it to support named parameters (more convenient for large queries);
- adapt more methods to rely on `SQL` objects instead of strings and lists of parameters;
- adapt fields and `expression` to rely on `SQL` objects.

Enterprise https://github.com/odoo/enterprise/pull/48916.