### PR TITLE
[IMP] website_sale: address updates

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -419,7 +419,6 @@ class Website(models.Model):
         self.ensure_one()
         addr = partner_sudo.address_get(['delivery', 'invoice'])
         if not request.website.is_public_user():
-            # FIXME VFE why not use last_website_so_id field ?
             last_sale_order = self.env['sale.order'].sudo().search(
                 [('partner_id', '=', partner_sudo.id)],
                 limit=1,

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -827,6 +827,7 @@ publicWidget.registry.websiteSaleCart = publicWidget.Widget.extend({
         $new.removeClass(cardClass);
         $new.addClass('bg-primary border border-primary');
 
+        // TODO this should not be a form, but a clean rpc to /shop/cart/update_address
         var $form = $(ev.currentTarget).parent('div.one_kanban').find('form.d-none');
         $.post($form.attr('action'), $form.serialize()+'&xhr=1');
     },
@@ -835,8 +836,9 @@ publicWidget.registry.websiteSaleCart = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onClickEditAddress: function (ev) {
-        ev.preventDefault();
-        $(ev.currentTarget).closest('div.one_kanban').find('form.d-none').attr('action', '/shop/address').submit();
+        // Do not trigger _onClickChangeBilling or _onClickChangeShipping when customer
+        // clicks on the pencil to update the address
+        ev.stopPropagation();
     },
     /**
      * @private

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -239,7 +239,7 @@
     },
     {
         content: "Add new shipping address",
-        trigger: '.all_shipping .one_kanban form[action^="/shop/address"] a:contains("Add address")',
+        trigger: '.all_shipping a[href^="/shop/address"]:contains("Add address")',
     },
     {
         content: "Fulfill shipping address form",

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -147,6 +147,7 @@ class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo, HttpCaseWithUs
         self.default_address_values = {
             'name': 'a res.partner address', 'email': 'email@email.email', 'street': 'ooo',
             'city': 'ooo', 'zip': '1200', 'country_id': self.country_id, 'submitted': 1,
+            'phone': '+333333333333333'
         }
         self.default_billing_address_values = self.default_address_values | {'mode': 'billing'}
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1964,7 +1964,7 @@
                                     <input type="hidden" name="callback" t-att-value="callback" />
 
                                     <!-- Example -->
-                                    <input type="hidden" name="field_required" t-att-value="'phone,name'" />
+                                    <input type="hidden" name="field_required" t-att-value="'name,street'" />
 
                                     <div class="d-flex flex-column flex-md-row align-items-center justify-content-between mt32 mb32">
                                         <a role="button" t-att-href="mode == ('new', 'billing') and '/shop/cart' or '/shop/checkout'" class="btn btn-outline-secondary w-100 w-md-auto order-md-1 order-3">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1743,8 +1743,9 @@
             </div>
             <t t-call="website_sale.row_addresses">
                 <t t-set="order" t-value="order"/>
-                <t t-set="is_invoice" t-value="1"/>
+                <t t-set="is_invoice" t-value="True"/>
                 <t t-set="addresses" t-value="billings"/>
+                <t t-set="selected_address" t-value="order.partner_invoice_id"/>
             </t>
             <t t-if="not only_services" groups="account.group_delivery_invoice_address">
                 <div class="row">
@@ -1754,8 +1755,9 @@
                 </div>
                 <t t-call="website_sale.row_addresses">
                     <t t-set="order" t-value="order"/>
-                    <t t-set="is_invoice" t-value="0"/>
+                    <t t-set="is_invoice" t-value="False"/>
                     <t t-set="addresses" t-value="shippings"/>
+                    <t t-set="selected_address" t-value="order.partner_shipping_id"/>
                 </t>
             </t>
         </t>
@@ -1766,50 +1768,53 @@
             <div t-foreach="addresses" t-as="addr"
                     class="one_kanban col-md">
                 <t t-call="website_sale.address_kanban">
-                    <t t-set="is_invoice" t-value="is_invoice"/>
                     <t t-set="contact" t-value="addr"/>
-                    <t t-set="order" t-value="order"/>
-                    <t t-if="not is_invoice" t-set="selected" t-value="order.partner_shipping_id==addr or len(addresses)==1"/>
-                    <t t-if="is_invoice" t-set="selected" t-value="order.partner_invoice_id==addr or len(addresses)==1"/>
-                    <t t-set="readonly" t-value="bool(len(addresses)==1)"/>
-                    <t t-set="allow_edit"
-                       t-value="(website.is_public_user() or order.partner_id.id == addr.id or (addr.id in order.partner_id.commercial_partner_id.child_ids.ids))
-                            and is_invoice or addr.type=='delivery'"
-                    />
+                    <t t-set="selected" t-value="len(addresses) == 1 or addr == selected_address"/>
                 </t>
             </div>
-            <div class="one_kanban col-md">
-                <form action="/shop/address" method="post" class="h-100">
-                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
-                    <t t-if="is_invoice">
-                        <input type="hidden" name="is_invoice" t-att-value="is_invoice" />
-                        <input type="hidden" name="callback" value="/shop/checkout" />
-                    </t>
-                    <a role="button" href="#" class="o_wsale_add_address a-submit d-flex align-items-center justify-content-center h-100 px-4 border rounded mx-auto no-decoration">
-                        <i class="fa fa-plus me-md-2"/><span class="d-none d-md-inline">Add address</span>
-                    </a>
-                </form>
+            <div t-if="not is_invoice or not order.website_id.is_public_user()" class="one_kanban col-md">
+                <!-- We do not allow public users to have multiple billing addresses -->
+                <t t-if="is_invoice">
+                    <t t-set="new_address_href" t-valuef="/shop/address?mode=billing"/>
+                </t>
+                <t t-else="">
+                    <t t-set="new_address_href" t-valuef="/shop/address?mode=shipping"/>
+                </t>
+                <a role="button" t-att-href="new_address_href" class="o_wsale_add_address d-flex align-items-center justify-content-center h-100 px-4 border rounded mx-auto no-decoration">
+                    <i class="fa fa-plus me-md-2"/><span class="d-none d-md-inline">Add address</span>
+                </a>
             </div>
         </div>
     </template>
 
     <!-- Card view of addresses. Called in `website_sale.checkout`. -->
     <template id="address_kanban" name="Kanban address">
-            <form action="/shop/checkout" method="POST" class="d-none">
-                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
-                <input type="hidden" name="partner_id" t-att-value="contact.id" />
-                <t t-if="is_invoice">
-                    <input type="hidden" name="is_invoice" t-att-value="is_invoice"/>
-                    <input type="hidden" name="callback" value="/shop/checkout"/>
+        <t t-set="mode" t-value="is_invoice and 'billing' or 'shipping'"/>
+        <form action="/shop/cart/update_address" method="POST" class="d-none">
+            <input type="hidden"
+                   name="csrf_token"
+                   t-att-value="request.csrf_token()"
+                   t-nocache="The csrf token must always be up to date."/>
+            <input type="hidden" name="partner_id" t-att-value="contact.id"/>
+            <input type="hidden" name="mode" t-att-value="mode"/>
+            <input type="submit"/>
+        </form>
+        <div t-attf-class="card position-relative h-100 #{selected and 'bg-primary border border-primary' or is_invoice and 'js_change_billing' or 'js_change_shipping'}">
+            <div class="card-body d-flex flex-column align-items-start">
+                <t t-esc="contact" t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"/>
+                <t t-if="contact._can_be_edited_by_current_customer(website_sale_order, mode)">
+                    <t t-set="new_address_href" t-value="'/shop/address?mode=' + mode"/>
+                    <a
+                        t-att-href="new_address_href + '&amp;partner_id=' + str(contact.id)"
+                        class="js_edit_address btn btn-link p-0 mt-auto"
+                        role="button"
+                        title="Edit this address"
+                        aria-label="Edit this address">
+                        <i class="fa fa-pencil me-1"/>Edit
+                    </a>
                 </t>
-                <input type="submit"/>
-            </form>
-            <div t-attf-class="card position-relative h-100 #{selected and 'bg-primary border border-primary' or is_invoice and 'js_change_billing' or 'js_change_shipping'}">
-                <div class='card-body d-flex flex-column align-items-start'>
-                    <t t-esc="contact" t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"/>
-                    <a t-if="allow_edit" href="#" class="js_edit_address btn btn-link p-0 mt-auto" role="button" title="Edit this address" aria-label="Edit this address"><i class="fa fa-pencil me-1"/>Edit</a>
-                </div>
             </div>
+        </div>
     </template>
 
     <!-- /shop/address route -->
@@ -1955,10 +1960,9 @@
                                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
                                     <input type="hidden" name="submitted" value="1" />
                                     <input type="hidden" name="partner_id" t-att-value="partner_id or '0'" />
+                                    <input type="hidden" name="mode" t-att-value="mode[1]"/>
                                     <input type="hidden" name="callback" t-att-value="callback" />
-                                    <t t-if="mode[1] == 'billing'">
-                                        <input type="hidden" name="is_invoice" value="1" />
-                                    </t>
+
                                     <!-- Example -->
                                     <input type="hidden" name="field_required" t-att-value="'phone,name'" />
 

--- a/addons/website_sale_mondialrelay/models/__init__.py
+++ b/addons/website_sale_mondialrelay/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from . import res_partner
 from . import sale_order
 from . import website

--- a/addons/website_sale_mondialrelay/models/res_partner.py
+++ b/addons/website_sale_mondialrelay/models/res_partner.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def _can_be_edited_by_current_customer(self, sale_order, mode):
+        return super()._can_be_edited_by_current_customer(sale_order, mode) and not self.is_mondialrelay

--- a/addons/website_sale_mondialrelay/views/templates.xml
+++ b/addons/website_sale_mondialrelay/views/templates.xml
@@ -1,25 +1,19 @@
 <odoo>
-    <data>
-        <template id="website_sale_mondialrelay_address_on_payment" inherit_id="website_sale.address_on_payment">
-            <xpath expr="//span[@t-esc='order.partner_shipping_id']" position="before">
-                <t t-if="order.partner_shipping_id.is_mondialrelay" >
-                    <img src="/website_sale_mondialrelay/static/src/img/logo.png" title="Mondial Relay" height="20px" />
-                </t>
-            </xpath>
-        </template>
 
-        <template id="website_sale_mondialrelay_checkout" inherit_id="website_sale.row_addresses">
-            <xpath expr="//t[@t-set='allow_edit']" position="after">
-                <t t-set="allow_edit" t-value="allow_edit and not contact.is_mondialrelay"/>
-            </xpath>
-        </template>
+    <template id="website_sale_mondialrelay_address_on_payment" inherit_id="website_sale.address_on_payment">
+        <xpath expr="//span[@t-esc='order.partner_shipping_id']" position="before">
+            <t t-if="order.partner_shipping_id.is_mondialrelay" >
+                <img src="/website_sale_mondialrelay/static/src/img/logo.png" title="Mondial Relay" height="20px" />
+            </t>
+        </xpath>
+    </template>
 
-        <template id="website_sale_mondialrelay_address_kanban" inherit_id="website_sale.address_kanban">
-            <xpath expr="//t[@t-esc='contact']" position="before">
-                <t t-if="contact.is_mondialrelay">
-                    <img class="float-end" title="Mondial Relay" height="20px" src="/website_sale_mondialrelay/static/src/img/logo.png" />
-                </t>
-            </xpath>
-        </template>
-    </data>
+    <template id="website_sale_mondialrelay_address_kanban" inherit_id="website_sale.address_kanban">
+        <xpath expr="//t[@t-esc='contact']" position="before">
+            <t t-if="contact.is_mondialrelay">
+                <img class="float-end" title="Mondial Relay" height="20px" src="/website_sale_mondialrelay/static/src/img/logo.png" />
+            </t>
+        </xpath>
+    </template>
+
 </odoo>


### PR DESCRIPTION
* Avoid posting crappy forms when a redirection does the job
* use a dedicated route /shop/cart/update_address for address changes
  * stop updating the SO on /shop/checkout route (cf checkout_values method update)
* clean code from recent PR on invoicing address
* Public user shouldn't be able to create billing addresses
* Logged customer should always see his own partner as billing/shipping address choices.

Task-3258835



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
