### PR TITLE
[FIX] web, base: editable fields now correctly computed

### DIFF
--- a/addons/hr_contract/report/hr_contract_history_report_views.xml
+++ b/addons/hr_contract/report/hr_contract_history_report_views.xml
@@ -92,6 +92,7 @@
                                     <field name="date_start"/>
                                     <field name="date_end"/>
                                     <field name="resource_calendar_id"/>
+                                    <field name="company_id" invisible="1"/>
                                     <field name="currency_id" invisible="1"/>
                                     <field name="wage" string="Monthly Wage"/>
                                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'close'" decoration-success="state == 'open'"/>

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -473,14 +473,19 @@ export class MockServer {
             case "field": {
                 const fname = node.getAttribute("name");
                 const field = this.models[modelName].fields[fname];
+                const isFieldEditable = !field.readonly ||
+                    (field.states &&
+                        Object.values(field.states).some((item) =>
+                            item.includes("readonly")
+                        ));
+                const hasDynamicReadonly = "readonly" in evaluateExpr(node.getAttribute("attrs") || "{}")
+                const archReadonly = node.getAttribute("readonly")
+                const archIsReadonly = ["1", "True"].includes(archReadonly)
+                const archIsEditable = archReadonly && !archIsReadonly;
                 return (
-                    (!field.readonly ||
-                        (field.states &&
-                            Object.values(field.states).some((item) =>
-                                item.includes("readonly")
-                            ))) &&
-                    (!["1", "True"].includes(node.getAttribute("readonly")) ||
-                        !_.isEmpty(evaluateExpr(node.getAttribute("attrs") || "{}")))
+                    isFieldEditable && !archIsReadonly ||
+                    archIsEditable ||
+                    hasDynamicReadonly
                 );
             }
             default:

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1362,9 +1362,15 @@ actual arch.
 
     def _editable_tag_field(self, node, name_manager):
         field = name_manager.model._fields.get(node.get('name'))
-        return field is None or field.is_editable() and (
-            node.get('readonly') not in ('1', 'True')
-            or get_dict_asts(node.get('attrs') or "{}")
+        has_dynamic_readonly = 'readonly' in get_dict_asts(node.get('attrs') or "{}")
+        arch_readonly = node.get('readonly')
+        arch_is_readonly = arch_readonly in ('1', 'True')
+        arch_is_editable = arch_readonly and not arch_is_readonly
+        return (
+            field is None or
+            field.is_editable() and not arch_is_readonly or
+            arch_is_editable or
+            has_dynamic_readonly
         )
 
     def _onchange_able_view(self, node):


### PR DESCRIPTION
Steps to reproduce
==================

- Install purchase_product_matrix,web_studio
- Go to purchase
- Click on a record
- Open studio
- Click on the "Products" tab > Edit List view
- Edit the product field
- Widget: Many2one
- Disable creation: enabled
- Close studio
- Create a new record
- Add a new line
- Type some random text in the product field

-> The option create is available

Cause of the issue
==================

With the studio manipulation, we end up with the following node:

```xml
<field
    name="product_template_id"
    string="Product"
    context="{'partner_id': parent.partner_id}"
    widget="many2one"
    options="{'no_create':true}"
    attrs="{
      'readonly': [['state', 'in', ['purchase', 'to approve', 'done', 'cancel']]],
      'required': [['display_type', '=', false]]
    }"
/>
```

The field is the following:

```py
product_template_id = fields.Many2one(
    'product.template',
    string='Product Template',
    related="product_id.product_tmpl_id",
    domain=[('purchase_ok', '=', True)]
)
```

The `no_create` option is not applied because the attribute `can_create` is missing from the field node (canCreate is undefined). [0]

The `can_create` attribute is added to editable fields of type `many2one` or `many2many`. [1] [2]

In this case, `_editable_tag_field` should return True but returns None. The field is readonly in python because it is a related field, but the readonly modifiers should override that.

There are many ways to define if a field is readonly:

1) On the field declaration. (`... = fields.?(readonly=True)`). 
2) In the states. (`... = fields.?(states={'draft': [('readonly', False)], 'model': [('readonly', False)]})`). 
3) As an attribute on the arch (eg: `<field ... readonly="0"/>`). 
4) As a property of the attrs attribute (eg: `<field ... attrs="{'readonly': [['state', '!=', 'draft']]}"/>`).

- Attributes on the view should override what's defined on the field declaration.
- The options 2 and 4 means that the field should always be considered as editable, as the domain can always be evaluated to something different.

---

[0]: https://github.com/odoo/odoo/blob/e97ec328e8c6ec2b083c854b19cefe5c19db3991/addons/web/static/src/views/fields/many2one/many2one_field.js#L309
[1]: https://github.com/odoo/odoo/blob/fa6da3d63a3a4cce4e8ca788a49772925d318764/odoo/addons/base/models/ir_ui_view.py#L1296-L1297
[2]: https://github.com/odoo/odoo/blob/fa6da3d63a3a4cce4e8ca788a49772925d318764/odoo/addons/base/models/ir_ui_view.py#L1080-L1086

opw-3432903