### PR TITLE
[REF] web,calendar: split calendar quick_add attr

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -359,7 +359,6 @@
             <calendar js_class="attendee_calendar" string="Meetings" date_start="start" date_stop="stop" date_delay="duration" all_day="allday"
                 event_open_popup="true"
                 event_limit="5"
-                quick_add="1"
                 quick_create_view_id="%(calendar.view_calendar_event_form_quick_create)d"
                 color="partner_ids">
                 <field name="location" invisible="not location" options="{'icon': 'fa fa-map-marker'}"/>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -359,7 +359,8 @@
             <calendar js_class="attendee_calendar" string="Meetings" date_start="start" date_stop="stop" date_delay="duration" all_day="allday"
                 event_open_popup="true"
                 event_limit="5"
-                quick_add="%(calendar.view_calendar_event_form_quick_create)d"
+                quick_add="1"
+                quick_create_view_id="%(calendar.view_calendar_event_form_quick_create)d"
                 color="partner_ids">
                 <field name="location" invisible="not location" options="{'icon': 'fa fa-map-marker'}"/>
                 <field name="attendees_count" invisible="1"/>

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -9,7 +9,7 @@
                 date_start="start_datetime"
                 date_stop="stop_datetime"
                 mode="month"
-                quick_add="False"
+                quick_create="0"
                 color="employee_id"
                 event_open_popup="True"
                 js_class="time_off_calendar"

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -370,7 +370,7 @@
                     event_open_popup="true"
                     date_start="date_from"
                     date_stop="date_to"
-                    quick_add="False"
+                    quick_create="0"
                     show_unusual_days="True"
                     color="color"
                     hide_time="True"
@@ -396,7 +396,7 @@
                     date_start="date_from"
                     date_stop="date_to"
                     mode="year"
-                    quick_add="False"
+                    quick_create="0"
                     show_unusual_days="True"
                     color="color"
                     hide_time="True">
@@ -454,7 +454,7 @@
                     date_stop="date_to"
                     mode="month"
                     show_unusual_days="True"
-                    quick_add="False"
+                    quick_create="0"
                     color="color">
                 <field name="display_name"/>
                 <field name="holiday_status_id" color="color" filters="1" invisible="1"/>

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -28,7 +28,7 @@
                 date_start="date_start"
                 date_stop="date_stop"
                 mode="month"
-                quick_add="False"
+                quick_create="0"
                 color="color"
                 event_limit="5">
                 <!-- Sidebar favorites filters -->

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -569,7 +569,7 @@
             <field name="name">mailing.mailing.view.calendar</field>
             <field name="model">mailing.mailing</field>
             <field name="arch" type="xml">
-                <calendar date_start="calendar_date" string="Mailings" hide_time="true" mode="month" color="state" quick_add="False">
+                <calendar date_start="calendar_date" string="Mailings" hide_time="true" mode="month" color="state" quick_create="0">
                     <field name="mailing_model_id" string="Recipient" options="{'no_open': True}"/>
                     <field name="user_id" filters="1" invisible="1"/>
                     <field name="state" filters="1" invisible="1"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -527,7 +527,7 @@
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <calendar date_start="date_start" date_stop="date_finished"
-                          string="Manufacturing Orders" event_limit="5" quick_add="False">
+                          string="Manufacturing Orders" event_limit="5" quick_create="0">
                     <field name="user_id" avatar_field="avatar_128"/>
                     <field name="product_id"/>
                     <field name="product_qty"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -551,7 +551,7 @@
                     mode="month"
                     scales="month,year"
                     event_open_popup="true"
-                    quick_add="false"
+                    quick_create="0"
                     color="color"
                     js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -748,7 +748,7 @@
             <field name="arch" type="xml">
                 <calendar date_start="date_deadline" string="Tasks" mode="month"
                           color="stage_id" event_limit="5" hide_time="true"
-                          event_open_popup="true" quick_add="false" show_unusual_days="True"
+                          event_open_popup="true" quick_create="0" show_unusual_days="True"
                           js_class="project_task_calendar"
                           scales="month,year">
                     <field name="allow_milestones" invisible="1" />

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -24,7 +24,7 @@
         <field name="name">sale.order.calendar</field>
         <field name="model">sale.order</field>
         <field name="arch" type="xml">
-            <calendar string="Sales Orders" create="0" mode="month" date_start="activity_date_deadline" color="state" event_limit="5" quick_add="False">
+            <calendar string="Sales Orders" create="0" mode="month" date_start="activity_date_deadline" color="state" event_limit="5" quick_create="0">
                 <field name="currency_id" invisible="1"/>
                 <field name="state" filters="1" invisible="1"/>
                 <field name="activity_ids" options="{'icon': 'fa fa-clock-o'}"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -5,7 +5,7 @@
             <field name="model">stock.picking</field>
             <field name="priority" eval="2"/>
             <field name="arch" type="xml">
-                <calendar string="Calendar View" date_start="scheduled_date" color="partner_id" event_limit="5" quick_add="False">
+                <calendar string="Calendar View" date_start="scheduled_date" color="partner_id" event_limit="5" quick_create="0">
                     <field name="partner_id" filters="1"/>
                     <field name="origin"/>
                     <field name="picking_type_id"/>

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -84,8 +84,8 @@ export class CalendarArchParser {
                     if (node.hasAttribute("delete")) {
                         canDelete = archParseBoolean(node.getAttribute("delete"), true);
                     }
-                    if (node.hasAttribute("quick_add")) {
-                        quickCreate = archParseBoolean(node.getAttribute("quick_add"), true);
+                    if (node.hasAttribute("quick_create")) {
+                        quickCreate = archParseBoolean(node.getAttribute("quick_create"), true);
                         if (quickCreate && node.hasAttribute("quick_create_view_id")) {
                             quickCreateViewId = parseInt(
                                 node.getAttribute("quick_create_view_id"),

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -30,6 +30,7 @@ export class CalendarArchParser {
         let canCreate = true;
         let canDelete = true;
         let quickCreate = true;
+        let quickCreateViewId = null;
         let hasEditDialog = false;
         let showUnusualDays = false;
         let isDateHidden = false;
@@ -85,12 +86,11 @@ export class CalendarArchParser {
                     }
                     if (node.hasAttribute("quick_add")) {
                         quickCreate = archParseBoolean(node.getAttribute("quick_add"), true);
-                        // quick_add could contain either false, true or an id for a form view
-                        if (quickCreate) {
-                            const viewId = parseInt(node.getAttribute("quick_add"), 10);
-                            if (viewId > 1) {
-                                quickCreate = viewId;
-                            }
+                        if (quickCreate && node.hasAttribute("quick_create_view_id")) {
+                            quickCreateViewId = parseInt(
+                                node.getAttribute("quick_create_view_id"),
+                                10
+                            );
                         }
                     }
                     if (node.hasAttribute("event_open_popup")) {
@@ -191,6 +191,7 @@ export class CalendarArchParser {
             formViewId,
             hasEditDialog,
             quickCreate,
+            quickCreateViewId,
             isDateHidden,
             isTimeHidden,
             popoverFieldNodes,

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -107,7 +107,7 @@ export class CalendarModel extends Model {
         return this.meta.hasEditDialog;
     }
     get hasQuickCreate() {
-        return Boolean(this.meta.quickCreate);
+        return this.meta.quickCreate;
     }
     get isDateHidden() {
         return this.meta.isDateHidden;
@@ -144,8 +144,7 @@ export class CalendarModel extends Model {
     }
 
     get quickCreateFormViewId() {
-        const quickCreate = parseInt(this.meta.quickCreate);
-        return quickCreate ? quickCreate : false;
+        return this.meta.quickCreateViewId;
     }
 
     get defaultFilterLabel() {

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
@@ -35,6 +35,7 @@ QUnit.test("defaults", (assert) => {
         formViewId: false,
         hasEditDialog: false,
         quickCreate: true,
+        quickCreateViewId: null,
         isDateHidden: false,
         isTimeHidden: false,
         popoverFieldNodes: {},
@@ -95,7 +96,25 @@ QUnit.test("quickCreate", (assert) => {
     check(assert, "quick_add", "false", "quickCreate", false);
     check(assert, "quick_add", "False", "quickCreate", false);
     check(assert, "quick_add", "0", "quickCreate", false);
-    check(assert, "quick_add", "12", "quickCreate", 12);
+    check(assert, "quick_add", "12", "quickCreate", true);
+});
+
+QUnit.test("quickCreateViewId", (assert) => {
+    let arch = parseArch(
+        `<calendar date_start="start_date" quick_add="0" quick_create_view_id="12" />`
+    );
+    assert.strictEqual(arch.quickCreate, false);
+    assert.strictEqual(arch.quickCreateViewId, null);
+
+    arch = parseArch(
+        `<calendar date_start="start_date" quick_add="1" quick_create_view_id="12" />`
+    );
+    assert.strictEqual(arch.quickCreate, true);
+    assert.strictEqual(arch.quickCreateViewId, 12);
+
+    arch = parseArch(`<calendar date_start="start_date" quick_add="1"/>`);
+    assert.strictEqual(arch.quickCreate, true);
+    assert.strictEqual(arch.quickCreateViewId, null);
 });
 
 QUnit.test("isDateHidden", (assert) => {

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
@@ -89,30 +89,30 @@ QUnit.test("hasEditDialog", (assert) => {
 });
 
 QUnit.test("quickCreate", (assert) => {
-    check(assert, "quick_add", "", "quickCreate", true);
-    check(assert, "quick_add", "true", "quickCreate", true);
-    check(assert, "quick_add", "True", "quickCreate", true);
-    check(assert, "quick_add", "1", "quickCreate", true);
-    check(assert, "quick_add", "false", "quickCreate", false);
-    check(assert, "quick_add", "False", "quickCreate", false);
-    check(assert, "quick_add", "0", "quickCreate", false);
-    check(assert, "quick_add", "12", "quickCreate", true);
+    check(assert, "quick_create", "", "quickCreate", true);
+    check(assert, "quick_create", "true", "quickCreate", true);
+    check(assert, "quick_create", "True", "quickCreate", true);
+    check(assert, "quick_create", "1", "quickCreate", true);
+    check(assert, "quick_create", "false", "quickCreate", false);
+    check(assert, "quick_create", "False", "quickCreate", false);
+    check(assert, "quick_create", "0", "quickCreate", false);
+    check(assert, "quick_create", "12", "quickCreate", true);
 });
 
 QUnit.test("quickCreateViewId", (assert) => {
     let arch = parseArch(
-        `<calendar date_start="start_date" quick_add="0" quick_create_view_id="12" />`
+        `<calendar date_start="start_date" quick_create="0" quick_create_view_id="12" />`
     );
     assert.strictEqual(arch.quickCreate, false);
     assert.strictEqual(arch.quickCreateViewId, null);
 
     arch = parseArch(
-        `<calendar date_start="start_date" quick_add="1" quick_create_view_id="12" />`
+        `<calendar date_start="start_date" quick_create="1" quick_create_view_id="12" />`
     );
     assert.strictEqual(arch.quickCreate, true);
     assert.strictEqual(arch.quickCreateViewId, 12);
 
-    arch = parseArch(`<calendar date_start="start_date" quick_add="1"/>`);
+    arch = parseArch(`<calendar date_start="start_date" quick_create="1"/>`);
     assert.strictEqual(arch.quickCreate, true);
     assert.strictEqual(arch.quickCreateViewId, null);
 });

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -1087,7 +1087,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month" event_open_popup="1" quick_add="0">
+                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month" event_open_popup="1" quick_create="0">
                     <field name="name" />
                 </calendar>
             `,
@@ -1990,7 +1990,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" mode="week" all_day="allday" quick_add="0" />
+                <calendar date_start="start" date_stop="stop" mode="week" all_day="allday" quick_create="0" />
             `,
             context: {
                 default_name: "New",
@@ -2062,7 +2062,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" all_day="allday" mode="week" quick_add="0" />
+                <calendar date_start="start" date_stop="stop" all_day="allday" mode="week" quick_create="0" />
             `,
         });
 
@@ -3714,7 +3714,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" mode="month" event_open_popup="1" quick_add="0">
+                <calendar date_start="start" date_stop="stop" mode="month" event_open_popup="1" quick_create="0">
                     <field name="name" />
                     <field name="partner_id" />
                 </calendar>
@@ -3751,7 +3751,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" mode="month" event_open_popup="1" quick_add="0" all_day="allday">
+                <calendar date_start="start" date_stop="stop" mode="month" event_open_popup="1" quick_create="0" all_day="allday">
                     <field name="name" />
                     <field name="partner_id" />
                 </calendar>
@@ -3889,7 +3889,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" mode="month" open_event_popup="1" quick_add="0" form_view_id="1">
+                <calendar date_start="start" date_stop="stop" mode="month" open_event_popup="1" quick_create="0" form_view_id="1">
                     <field name="name" />
                 </calendar>
             `,
@@ -4267,7 +4267,7 @@ QUnit.module("Views", ({ beforeEach }) => {
                 resModel: "event",
                 serverData,
                 arch: `
-                    <calendar create="0" event_open_popup="1" quick_add="0" date_start="start" date_stop="stop" mode="month" />
+                    <calendar create="0" event_open_popup="1" quick_create="0" date_start="start" date_stop="stop" mode="month" />
                 `,
             });
 
@@ -4343,7 +4343,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar event_open_popup="1" quick_add="0" date_start="start" date_stop="stop" all_day="allday" mode="week" />
+                <calendar event_open_popup="1" quick_create="0" date_start="start" date_stop="stop" all_day="allday" mode="week" />
             `,
             mockRPC(route, { args, method }) {
                 if (method === "create") {
@@ -4529,7 +4529,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar create="0" event_open_popup="1" quick_add="0" date_start="start" date_stop="stop" all_day="allday" mode="month" />
+                <calendar create="0" event_open_popup="1" quick_create="0" date_start="start" date_stop="stop" all_day="allday" mode="month" />
             `,
         });
 
@@ -4717,7 +4717,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month" quick_add="1" quick_create_view_id="2">
+                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month" quick_create="1" quick_create_view_id="2">
                     <field name="name"/>
                 </calendar>
             `,
@@ -4776,7 +4776,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar js_class="test_calendar_view" date_start="start" date_stop="stop" all_day="allday" mode="month" quick_add="0" event_open_popup="1" />
+                <calendar js_class="test_calendar_view" date_start="start" date_stop="stop" all_day="allday" mode="month" quick_create="0" event_open_popup="1" />
             `,
         });
 
@@ -4831,7 +4831,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar quick_add="false" event_open_popup="1" date_start="start">
+                <calendar quick_create="0" event_open_popup="1" date_start="start">
                     <field name="event_type_id" />
                     <field name="properties" />
                 </calendar>
@@ -4880,7 +4880,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar quick_add="False" event_open_popup="1" date_start="start">
+                <calendar quick_create="0" event_open_popup="1" date_start="start">
                     <field name="event_type_id" />
                     <field name="properties" />
                 </calendar>

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -4703,7 +4703,7 @@ QUnit.module("Views", ({ beforeEach }) => {
         assert.containsOnce(target, ".fc-dayGridMonth-view");
     });
 
-    QUnit.test("calendar rendering with form view id being passed in quick_add", async (assert) => {
+    QUnit.test("calendar with custom quick create view", async (assert) => {
         serviceRegistry.add(
             "dialog",
             makeFakeDialogService((className, props) => {
@@ -4717,7 +4717,7 @@ QUnit.module("Views", ({ beforeEach }) => {
             resModel: "event",
             serverData,
             arch: `
-                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month" quick_add="2">
+                <calendar date_start="start" date_stop="stop" all_day="allday" mode="month" quick_add="1" quick_create_view_id="2">
                     <field name="name"/>
                 </calendar>
             `,

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -16,7 +16,7 @@
             <rng:optional><rng:attribute name="form_view_id" /></rng:optional>
             <rng:optional><rng:attribute name="event_limit" /></rng:optional>
             <rng:optional><rng:attribute name="create_name_field" /></rng:optional>
-            <rng:optional><rng:attribute name="quick_add" /></rng:optional>
+            <rng:optional><rng:attribute name="quick_create" /></rng:optional>
             <rng:optional><rng:attribute name="quick_create_view_id" /></rng:optional>
             <rng:optional><rng:attribute name="color" /></rng:optional>
             <rng:optional><rng:attribute name="event_open_popup" /></rng:optional>

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -17,7 +17,7 @@
             <rng:optional><rng:attribute name="event_limit" /></rng:optional>
             <rng:optional><rng:attribute name="create_name_field" /></rng:optional>
             <rng:optional><rng:attribute name="quick_add" /></rng:optional>
-            <rng:optional><rng:attribute name="quick_create_form_view_id" /></rng:optional>
+            <rng:optional><rng:attribute name="quick_create_view_id" /></rng:optional>
             <rng:optional><rng:attribute name="color" /></rng:optional>
             <rng:optional><rng:attribute name="event_open_popup" /></rng:optional>
             <rng:optional><rng:attribute name="show_unusual_days" /></rng:optional>


### PR DESCRIPTION
Since the PR [1], quick_add can be both a boolean and an id: 0 = without quick create
1 = with quick create and simple dialog
other number = with quick create and custom form view dialog

This is not great to have both behavior in a same attribute so this commit split them back in two attributes as it was before [1]. It's easier to understand when we want a quick create and which view to use in the dialog.

[1]: https://github.com/odoo/odoo/pull/122923
