### PR TITLE
[FIX] website: fix autocompleteWithPages option

### DIFF
--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -112,7 +112,7 @@ function autocompleteWithPages(rpc, $input, options) {
             // choose url in dropdown with arrow change ev.target.value without trigger_up
             // so cannot check here if value has been updated
             ev.target.value = ui.item.value;
-            options?.urlChosen();
+            options.urlChosen?.();
             ev.preventDefault();
         },
     });


### PR DESCRIPTION
Since the PR [1], the function autocompleteWithPages does not receive a widget anymore and does not trigger an event on it when an url is selected. Instead it is replaced by an optional function property "urlChosen" which is called if given.
The error is that the optional check is wrong. The check is done on the "options" parameter, not on its optional property "urlChosen". This commit simply fixes this check.

[1]: https://github.com/odoo/odoo/pull/136271
