### PR TITLE
[FIX] l10n_ke_edi_tremol: Make KE specific fields visible only in KE companies

### DIFF
--- a/addons/l10n_ke_edi_tremol/models/product.py
+++ b/addons/l10n_ke_edi_tremol/models/product.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductTemplate(models.Model):
@@ -14,6 +14,12 @@ class ProductTemplate(models.Model):
         string='KRA Item Description',
         help='Product code description needed when not 16% VAT rated. ',
     )
+    current_country_code = fields.Char(compute='_compute_current_country_code')
+
+    @api.depends_context('uid')
+    def _compute_current_country_code(self):
+        for product in self:
+            product.current_country_code = self.env.company.country_id.code
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
@@ -30,3 +36,9 @@ class ProductProduct(models.Model):
         help="Product code description needed in case of not 16%. ",
         readonly=False,
     )
+    current_country_code = fields.Char(compute='_compute_current_country_code')
+
+    @api.depends_context('uid')
+    def _compute_current_country_code(self):
+        for product in self:
+            product.current_country_code = self.env.company.country_id.code

--- a/addons/l10n_ke_edi_tremol/views/product_view.xml
+++ b/addons/l10n_ke_edi_tremol/views/product_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.product_template_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@name='invoicing']//group[@name='accounting']" position="inside">
-                <group name="HS Code" string="HS Code" attrs="{'invisible': [('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}">
+                <group name="HS Code" string="HS Code" attrs="{'invisible': ['|', '|', ('current_country_code', '!=', 'KE'), ('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}">
                     <field name="l10n_ke_hsn_code"/>
                     <field name="l10n_ke_hsn_name"/>
                 </group>
@@ -21,11 +21,10 @@
         <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
-                <group>
-                    <group name="KRA Item Code" string="KRA Item Code">
-                        <field name="l10n_ke_hsn_code"/>
-                        <field name="l10n_ke_hsn_name"/>
-                    </group>
+                <field name="current_country_code" invisible="1"/>
+                <group name="KRA Item Code" string="KRA Item Code" attrs="{'invisible': [('current_country_code', '!=', 'KE')]}">
+                    <field name="l10n_ke_hsn_code"/>
+                    <field name="l10n_ke_hsn_name"/>
                 </group>
             </xpath>
         </field>

--- a/addons/l10n_ke_edi_tremol/views/res_partner_views.xml
+++ b/addons/l10n_ke_edi_tremol/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <group name="accounting_entries" position="after">
-                <group string="Kenya Accounting Details" name="l10n_ke_details">
+                <group string="Kenya Accounting Details" name="l10n_ke_details" attrs="{'invisible': [('country_code', '!=', 'KE')]}">
                     <field name="l10n_ke_exemption_number"/>
                 </group>
             </group>


### PR DESCRIPTION
Ensures that fields specific to Kenya are only displayed when a Kenyan company is selected.

Task-3525517



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
