### PR TITLE
[REF] website, mass_mailing: remove getBundle usages

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -40,6 +40,7 @@
         'report/mailing_trace_report_views.xml',
         'views/mail_blacklist_views.xml',
         'views/mailing_filter_views.xml',
+        'views/mailing_mobile_preview_content.xml',
         'views/mailing_trace_views.xml',
         'views/link_tracker_views.xml',
         'views/mailing_contact_views.xml',
@@ -131,6 +132,7 @@
             'mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js',
             'mass_mailing/static/src/xml/mailing_filter_widget.xml',
             'mass_mailing/static/src/xml/mass_mailing.xml',
+            'mass_mailing/static/src/xml/mass_mailing_mobile_preview.xml',
             'mass_mailing/static/src/js/tours/**/*',
         ],
         'mass_mailing.assets_mail_themes': [

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -481,3 +481,11 @@ class MassMailController(http.Controller):
                 f'<a href="#" data-oe-model="{escape(mailing.mailing_model_real)}" data-oe-id="{int(document_id)}">{escape(mailing_model_name)}</a>'
             ) if document_id else '',
         }
+
+    # ------------------------------------------------------------
+    # PREVIEW
+    # ------------------------------------------------------------
+
+    @http.route('/mailing/mobile/preview', methods=['GET'], type='http', auth='user', website=True)
+    def mass_mailing_preview_mobile_content(self):
+        return request.render("mass_mailing.preview_content_mobile", {})

--- a/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_mobile_preview.js
@@ -1,51 +1,43 @@
 /** @odoo-module **/
 
+import { Component, markup, useEffect, useRef } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
-import { getBundle } from "@web/core/assets";
-import { useEffect, onWillStart } from "@odoo/owl";
+import { escape } from "@web/core/utils/strings";
+export class MassMailingMobilePreviewDialog extends Component {
+    static components = {
+        Dialog,
+    };
+    static template = "mass_mailing.MobilePreviewDialog";
+    static props = {
+        title: { type: String },
+        preview: { type: Function },
+        close: Function,
+    };
 
-export class MassMailingMobilePreviewDialog extends Dialog {
-    setup() {
-        super.setup();
-        onWillStart(async () => {
-            this.bundle = await getBundle("mass_mailing.iframe_css_assets_edit");
-        });
-        useEffect((modalEl) => {
-            if (modalEl) {
-                const modalBody = modalEl.querySelector('.modal-body');
-                const invertIcon = document.createElement("span");
-                invertIcon.className = "fa fa-refresh";
-                const iframe = document.createElement("iframe");
-                iframe.srcdoc = this._getSourceDocument();
-
-                modalEl.classList.add('o_mailing_mobile_preview');
-                modalEl.querySelector('.modal-title').append(invertIcon);
-                modalEl.querySelector('.modal-header').addEventListener('click', () => modalBody.classList.toggle('o_invert_orientation'));
-                modalBody.append(iframe);
-            }
-        }, () => [document.querySelector(':not(.o_inactive_modal).o_dialog')]);
+    appendPreview() {
+        const iframe = this.iframeRef.el.contentDocument;
+        const body = iframe.querySelector("body");
+        const isMarkup = this.props.preview instanceof markup().constructor;
+        const safePreview = isMarkup ? this.props.preview : escape(this.props.preview);
+        body.innerHTML = safePreview;
     }
 
-    _getSourceDocument() {
-        const links = this.bundle.cssLibs.map((src) => {
-            const link = document.createElement("link");
-            link.setAttribute("type", "text/css");
-            link.setAttribute("rel", "stylesheet");
-            link.setAttribute("href", src);
-            return link.outerHTML;
-        });
-        return `
-            <!DOCTYPE html><html>
-                <head> ${links.join("")} </head>
-                <body> ${this.props.preview} </body>
-            </html>
-        `;
+    setup() {
+        this.iframeRef = useRef("iframeRef");
+        useEffect(
+            (modalEl) => {
+                if (modalEl) {
+                    this.modalBody = modalEl.querySelector(".modal-body");
+                    modalEl.classList.add("o_mailing_mobile_preview");
+                }
+            },
+            () => [document.querySelector(":not(.o_inactive_modal).o_dialog")]
+        );
+    }
+
+    toggle() {
+        this.modalBody.classList.toggle("o_invert_orientation");
     }
 }
 
-MassMailingMobilePreviewDialog.props = {
-    ...Dialog.props,
-    preview: { type: String },
-    close: Function,
-};
 delete MassMailingMobilePreviewDialog.props.slots;

--- a/addons/mass_mailing/static/src/xml/mass_mailing_mobile_preview.xml
+++ b/addons/mass_mailing/static/src/xml/mass_mailing_mobile_preview.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <t t-name="mass_mailing.MobilePreviewDialog">
+        <Dialog bodyClass="'o_mailing_mobile_preview'">
+            <t t-set-slot="header" t-on-click="toggle">
+                <div class="d-flex align-items-center justify-content-between flex w-100">
+                    <h4 class="d-flex align-items-center justify-content-start">
+                        <span class="modal-title text-break" t-esc="props.title"></span>
+                        <span class="fa fa-refresh ms-3"></span>
+                    </h4>
+                    <div type="button" class="btn-close" aria-label="Close" t-on-click="props.close"/>
+                </div>
+            </t>
+            <iframe t-ref="iframeRef" src="/mailing/mobile/preview" t-on-load="appendPreview"></iframe>
+        </Dialog>
+    </t>
+</odoo>

--- a/addons/mass_mailing/views/mailing_mobile_preview_content.xml
+++ b/addons/mass_mailing/views/mailing_mobile_preview_content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="mass_mailing.preview_content_mobile">
+        <html>
+            <head>
+                <t t-call-assets="mass_mailing.iframe_css_assets_edit" t-js="False"></t>
+            </head>
+            <body></body>
+        </html>
+    </template>
+</odoo>

--- a/addons/website/static/src/js/content/website_root_instance.js
+++ b/addons/website/static/src/js/content/website_root_instance.js
@@ -2,14 +2,13 @@
 
 import { createPublicRoot } from "@web/legacy/js/public/public_root";
 import { WebsiteRoot } from "./website_root";
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 
 export default createPublicRoot(WebsiteRoot).then(async (rootInstance) => {
     // This data attribute is set by the WebsitePreview client action for a
     // restricted editor user.
     if (window.frameElement && window.frameElement.dataset.loadWysiwyg === 'true') {
-        const assets = await getBundle("website.assets_all_wysiwyg");
-        await loadBundle(assets);
+        await loadBundle("website.assets_all_wysiwyg");
         window.dispatchEvent(new CustomEvent('PUBLIC-ROOT-READY', {detail: {rootInstance}}));
     }
     return rootInstance;

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from '@web/core/registry';
-import { getBundle, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 
 import { FullscreenIndication } from '../components/fullscreen_indication/fullscreen_indication';
 import { WebsiteLoader } from '../components/website_loader/website_loader';
@@ -219,8 +219,7 @@ export const websiteService = {
                 websites = [...(await orm.searchRead('website', [], ['domain', 'id', 'name']))];
             },
             async loadWysiwyg() {
-                const assets = await getBundle("website.assets_all_wysiwyg");
-                await loadBundle(assets);
+                await loadBundle("website.assets_all_wysiwyg");
             },
             blockPreview(showLoader, processId) {
                 if (!blockingProcesses.length) {


### PR DESCRIPTION
In this commit, we remove three usages of the getBundle function from @web/core/assets.js. The final goal is to remove it totally to simplify the understanding of assets's API. To replace the use of getBundle in mobile preview dialog, an xml template has been created on the server side and then called by http requests. During the request, we retrieve the list of assets (server side getbundle) to inject these into the xml template.

taskId : 3266441
