### PR TITLE
[FIX] Recompute loop check

### DIFF
--- a/odoo/api.py
+++ b/odoo/api.py
@@ -703,8 +703,13 @@ class Environment(Mapping):
 
     def _recompute_all(self):
         """ Process all pending computations. """
-        for field in list(self.fields_to_compute()):
-            self[field.model_name]._recompute_field(field)
+        for _i in range(3):  # arbitrary number of tries
+            fields = list(self.fields_to_compute())
+            if not fields:
+                return
+            for field in fields:
+                self[field.model_name]._recompute_field(field)
+        _logger.error("Could not recompute_all fields, probably due to an invalidation loop")
 
     def flush_all(self):
         """ Flush all pending computations and updates to the database. """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It is possible through automated action or a module to create an invalidation loop.

Current behavior before PR:
When `flush_all` is called, it calls `_recompute_all` and then flushes model by model. Note that flushing a model, calls `_recompute_model`.
An example of the issue would be a custom stored-computed field depending on sale.order.invoice_status with an automated action that would invalidate a sale order line invoice when the new field is changed. In that example, calling `_recompute_all` terminates the execution, but leaves some invalid fields. If those fields are stored, in an extreme case, they may be invalidated while flushing the model.

Desired behavior after PR is merged:
Log an error so that during debugging we are aware something strange is going on.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
