### PR TITLE
[IMP] website, *: make website visitor read-only cursor friendly

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -333,7 +333,7 @@ class WebsiteEventController(http.Controller):
         a partner (if visitor linked to a user for example). Purpose is to gather
         as much informations as possible, notably to ease future communications.
         Also try to update visitor informations based on registration info. """
-        visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
+        visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create='read-only')
 
         registrations_to_create = []
         for registration_values in registration_data:

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -113,7 +113,7 @@ class Event(models.Model):
           * logged as visitor: check partner or visitor are linked to a
             registration;
         """
-        current_visitor = self.env['website.visitor']._get_visitor_from_request(force_create=False)
+        current_visitor = self.env['website.visitor']._get_visitor_from_request()
         if self.env.user._is_public() and not current_visitor:
             events = self.env['event.event']
         elif self.env.user._is_public():

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -286,7 +286,7 @@ class Track(models.Model):
                  'event_track_visitor_ids.is_blacklisted')
     @api.depends_context('uid')
     def _compute_is_reminder_on(self):
-        current_visitor = self.env['website.visitor']._get_visitor_from_request(force_create=False)
+        current_visitor = self.env['website.visitor']._get_visitor_from_request()
         if self.env.user._is_public() and not current_visitor:
             for track in self:
                 track.is_reminder_on = track.wishlisted_by_default
@@ -531,7 +531,7 @@ class Track(models.Model):
     def _get_event_track_visitors(self, force_create=False):
         self.ensure_one()
 
-        force_visitor_create = self.env.user._is_public()
+        force_visitor_create = self.env.user._is_public() and 'read-write'
         visitor_sudo = self.env['website.visitor']._get_visitor_from_request(force_create=force_visitor_create)
         if visitor_sudo:
             visitor_sudo._update_visitor_last_visit()

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -55,7 +55,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
         return values
 
     def _get_leaderboard(self, event, searched_name=None):
-        current_visitor = request.env['website.visitor']._get_visitor_from_request(force_create=False)
+        current_visitor = request.env['website.visitor']._get_visitor_from_request()
         track_visitor_data = request.env['event.track.visitor'].sudo()._read_group(
             [('track_id', 'in', event.track_ids.ids),
              ('visitor_id', '!=', False),

--- a/addons/website_event_track_quiz/models/event_track.py
+++ b/addons/website_event_track_quiz/models/event_track.py
@@ -33,7 +33,7 @@ class EventTrack(models.Model):
         (self - tracks_quiz).is_quiz_completed = False
         (self - tracks_quiz).quiz_points = 0
         if tracks_quiz:
-            current_visitor = self.env['website.visitor']._get_visitor_from_request(force_create=False)
+            current_visitor = self.env['website.visitor']._get_visitor_from_request()
             if self.env.user._is_public() and not current_visitor:
                 for track in tracks_quiz:
                     track.is_quiz_completed = False

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1815,7 +1815,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     @http.route('/shop/products/recently_viewed_update', type='json', auth='public', website=True)
     def products_recently_viewed_update(self, product_id, **kwargs):
         res = {}
-        visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
+        visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create='read-only')
         visitor_sudo._add_viewed_product(product_id)
         return res
 

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -497,6 +497,12 @@ class Cursor(BaseCursor):
     def closed(self):
         return self._closed or self._cnx.closed
 
+    @property
+    def readonly(self):
+        # TODO: This will be introduced with readonly cursor PR from JUC:
+        #   `return bool(self._cnx.readonly)`
+        return True
+
     def now(self):
         """ Return the transaction's timestamp ``NOW() AT TIME ZONE 'UTC'``. """
         if self._now is None:


### PR DESCRIPTION
* website_event, website_event_track, website_event_track_quiz, website_sale

This is a WIP commit, a better description will be added later.

This commit makes the website visitor code works with a read-only cursor implementation, which is going to be added soon by the framework-py team.

With the incoming RO cursor PR, a request / cursor will have its cursor either in read-only or in read/write.
read/write cursor will behaves as now, but read-only cursor should avoid INSERT queries, otherwise it will fail and make it open a new read/write cursor which defeats the whole purpose of the improvement.

Indeed, read-only cursor will query a replicated (readonly) PSQL database / server, allowing to scale drastically.

The problem with website visitor tracking was that every single page load would go through the `UPSERT` query, meaning that those routes could never really be flagged as readonly routes.

It has been decided that once a DB is configured to support RO cursor through PSQL DB replicated, we won't be tracking page visits and thus won't be creating visitor directly as we do now.

Visitors will still be created for features where the business code can't work without a visitor.
The visitor creation in such a case will be done on demand with the (already existing) `force_create` parameter.
Note that even if a visitor is created following this case, pages will still not be tracked (as the routes are still in readonly).

Note that some business flows are using the visitor tracks, such as the visitor livechat request (requested from the operator, not the visitor). In such a case, there is a `time` icon on top of the conversation (if opened in discuss) which is showing the last visited pages.
But it had low value and the tradeoff (only if you setup RO cursor!) is acceptable:
- There were no link to access the tracks or the visitor record(s)
- There was a very limited number of last pages shown?
- The URL of the pages were not even mentioned, only the page name
- The operator can still type `/history` to get the page history from `im_livechat` app's cookie (which is not using visitor tracks).
