### PR TITLE
[CLN] remove classes only used in tour

### DIFF
--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -21,21 +21,21 @@ registry.category("web_tour.tours").add('survey_tour', {
     content: _t("Let's give it a spin!"),
     position: 'bottom',
 }, {
-    trigger: '.o_survey_start button[type=submit]',
+    trigger: 'button[type=submit]',
     content: _t("Let's get started!"),
     position: 'bottom',
 }, {
-    trigger: '.o_survey_simple_choice button[type=submit]',
+    trigger: 'button[type=submit]',
     extra_trigger: '.js_question-wrapper span:contains("How frequently")',
     content: _t("Whenever you pick an answer, Odoo saves it for you."),
     position: 'bottom',
 }, {
-    trigger: '.o_survey_numerical_box button[type=submit]',
+    trigger: 'button[type=submit]',
     extra_trigger: '.js_question-wrapper span:contains("How many")',
     content: _t("Only a single question left!"),
     position: 'bottom',
 }, {
-    trigger: '.o_survey_matrix button[value=finish]',
+    trigger: 'button[value=finish]',
     extra_trigger: '.js_question-wrapper span:contains("How likely")',
     content: _t("Now that you are done, submit your form."),
     position: 'bottom',

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -225,7 +225,7 @@
         An exception is made for options with images, where we always want to optimize screen space.-->
         <t t-set="minimized_display" t-value="survey.questions_layout == 'page_per_question' and not any(suggestion.value_image for suggestion in question.suggested_answer_ids)" />
         <div t-if="survey.questions_layout == 'page_per_question'"
-            t-attf-class="o_survey_page_per_question o_survey_#{question.question_type} #{'w-lg-50 mx-lg-auto' if question.question_type in ('numerical_box', 'date', 'datetime') else ''}">
+            t-attf-class="o_survey_page_per_question #{'w-lg-50 mx-lg-auto' if question.question_type in ('numerical_box', 'date', 'datetime') else ''}">
             <input type="hidden" name="question_id" t-att-value="question.id" />
             <!-- User has already answered for this session -->
             <t t-if="answer.is_session_answer and (has_answered or answer.question_time_limit_reached)">


### PR DESCRIPTION
We removed CSS styling for these classes in 854083f7, but these were only used in the survey tour, and not
instrumental, so we can remove them.

Task-3525225
