### PR TITLE
[FIX] mail: style mention without `@extend`

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -1,3 +1,7 @@
 .o-discuss-badge {
     --o-discuss-badge-bg: #{$primary}; // sync with --o-navbar-badge-bg
 }
+
+a.o_mail_redirect, a.o_channel_redirect {
+    @include button-variant(rgba($primary, .2), rgba($primary, .2), lighten($link-color, 5%), rgba($primary, .3), rgba($primary, .3), lighten($link-color, 10%));
+}

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -43,12 +43,7 @@
 }
 
 a.o_mail_redirect, a.o_channel_redirect {
-    background: rgba($primary, .2) !important;
-    @extend .btn;
-    @extend .btn-sm;
-    @extend .btn-link;
-    @extend .align-baseline;
-    @extend .fw-normal;
-    @extend .px-1;
-    @extend .py-0;
+    @include button-variant(rgba($primary, .2), rgba($primary, .2), darken($link-color, 5%), rgba($primary, .3), rgba($primary, .3), darken($link-color, 10%));
+    @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
+    padding: map-get($spacers, 1);
 }


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/132701

`@extend` was used to reuse classnames intended for styling, such as `.btn`. However, this has the side-effect to increase specificity on these classnames, which results in breaking style on the website where the specificity on `.btn` must not change.

This commit fixes the issue by using a mixin rather than `@extend`. Since using these mixins are not equivalent, we took the opportunity to slightly  improve the constrast of text color and background.

Before/After (white)

![Screenshot 2023-10-09 at 19 15 45](https://github.com/odoo/odoo/assets/6569390/9803b542-b90d-4156-a940-a994861d41b3)
![Screenshot 2023-10-09 at 19 15 10](https://github.com/odoo/odoo/assets/6569390/352a64e0-8c07-46d6-9a9b-71726821bfbb)

Before/After (dark)

![Screenshot 2023-10-09 at 19 15 57](https://github.com/odoo/odoo/assets/6569390/506bf658-3f52-4e9b-9fba-165c8ade1dd1)
![Screenshot 2023-10-09 at 19 14 58](https://github.com/odoo/odoo/assets/6569390/dc5ea90f-6b21-4f7d-a58d-987b6e2f8a16)
