### PR TITLE
[IMP] hr_holidays: allow negative time off

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -25,6 +25,8 @@
         <field name="allocation_validation_type">officer</field>
         <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
         <field name="icon_id" ref="hr_holidays.icon_26"/>
+        <field name="allows_negative" eval="True"/>
+        <field name="max_allowed_negative" eval="20"/>
     </record>
 
     <!-- Accrual Plan -->

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, date, time
@@ -446,7 +445,12 @@ class HrEmployee(models.Model):
 
         to_recheck_leaves_per_leave_type = defaultdict(lambda:
             defaultdict(lambda: {
-                'excess_days': 0,
+                'excess_days': defaultdict(lambda: {
+                    'amount': 0,
+                    'is_virtual': True,
+                }),
+                'total_virtual_excess': 0,
+                'total_real_excess': 0,
                 'exceeding_duration': 0,
                 'to_recheck_leaves': self.env['hr.leave']
             })
@@ -527,7 +531,10 @@ class HrEmployee(models.Model):
                             if not leave_duration:
                                 break
                         if round(leave_duration, 2) > 0:
-                            to_recheck_leaves_per_leave_type[employee][leave_type]['excess_days'] += leave_duration
+                            to_recheck_leaves_per_leave_type[employee][leave_type]['excess_days'][leave.date_to.date()] = {
+                                'amount': leave_duration,
+                                'is_virtual': leave.state != 'validate',
+                            }
                     else:
                         if leave_unit == 'hour':
                             allocated_time = leave.number_of_hours_display

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -712,9 +712,10 @@ class HolidaysRequest(models.Model):
                 continue
             employee = leave.employee_id
             date_from = leave.date_from.date()
-            leave_data = leave_type.get_allocation_data(employee, date=date_from)
-            if leave_data[employee][0][1]['excess_days']:
-                raise ValidationError(_('The allocation configuration does not allow you to take this leave.'))
+            leave_data = leave_type.get_allocation_data(employee, date_from)
+            max_excess = leave_type.max_allowed_negative if leave_type.allows_negative else 0
+            if leave_data[employee][0][1]['total_virtual_excess'] > max_excess:
+                raise ValidationError(_("You don't have a valid allocation to cover that request."))
 
     ####################################################
     # ORM Overrides methods

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -18,6 +18,8 @@ TimeOffCardPopover.props = [
     "request_unit",
     "exceeding_duration",
     "close?",
+    "allows_negative",
+    "max_allowed_negative",
     "onClickNewAllocationRequest?",
 ];
 
@@ -37,10 +39,14 @@ export class TimeOffCard extends Component {
 
     updateWarning() {
         const { data } = this.props;
+        const excess = Math.max(data.exceeding_duration, -data.virtual_remaining_leaves);
+        const exceeding_duration = data.allows_negative
+            ? excess > data.max_allowed_negative
+            : excess > 0;
         const closeExpire =
             data.closest_allocation_duration &&
             data.closest_allocation_duration < data.virtual_remaining_leaves;
-        this.warning = data.exceeding_duration || closeExpire;
+        this.warning = exceeding_duration || closeExpire;
     }
 
     onClickInfo(ev) {
@@ -55,6 +61,8 @@ export class TimeOffCard extends Component {
             closest: data.closest_allocation_duration,
             request_unit: data.request_unit,
             exceeding_duration: data.exceeding_duration,
+            allows_negative: data.allows_negative,
+            max_allowed_negative: data.max_allowed_negative,
             onClickNewAllocationRequest: this.newAllocationRequestFrom.bind(this),
         });
     }

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_mandatory_days
 from . import test_global_leaves
 from . import test_uninstall
 from . import test_holidays_calendar
+from . import test_negative

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -874,13 +874,13 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
             # The holidays count only takes into account the valid allocations at that date
             self._check_holidays_count(
-                self.holidays_type_2.get_allocation_data(self.employee_emp, date=date(2021, 12, 1))[self.employee_emp][0][1],
+                self.holidays_type_2.get_allocation_data(self.employee_emp, target_date=date(2021, 12, 1))[self.employee_emp][0][1],
                 ml=10, lt=5, rl=5, vrl=5, vlt=5,
             )
 
             # Days remaining before the allocation ends is equal to 1 because there is only one day remaining in the allocation based on its validity
             self.assertEqual(
-                self.holidays_type_2.get_allocation_data(self.employee_emp, date=date(2021, 12, 31))[self.employee_emp][0][1]['closest_allocation_duration'],
+                self.holidays_type_2.get_allocation_data(self.employee_emp, target_date=date(2021, 12, 31))[self.employee_emp][0][1]['closest_allocation_duration'],
                 1,
                 "Only one day should remain before the allocation expires"
             )
@@ -903,7 +903,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
             # The holidays count in 2021 is not affected by the leave taken in 2022
             self._check_holidays_count(
-                self.holidays_type_2.get_allocation_data(self.employee_emp, date=date(2021, 12, 1))[self.employee_emp][0][1],
+                self.holidays_type_2.get_allocation_data(self.employee_emp, target_date=date(2021, 12, 1))[self.employee_emp][0][1],
                 ml=10, lt=5, rl=5, vrl=5, vlt=5,
             )
 
@@ -919,11 +919,11 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                 # If the allocation is archived, the leaves taken are not taken into account anymore
                 # As there is no valid allocation, then there is no upcoming one (closest_allocation_to_expire)
                 self._check_holidays_count(
-                    self.holidays_type_2.get_allocation_data(self.employee_emp, date=date(2021, 12, 1))[self.employee_emp][0][1],
+                    self.holidays_type_2.get_allocation_data(self.employee_emp, target_date=date(2021, 12, 1))[self.employee_emp][0][1],
                     ml=0, lt=0, rl=0, vrl=0, vlt=0,
                 )
                 self.assertEqual(
-                    self.holidays_type_2.get_allocation_data(self.employee_emp, date=date(2021, 12, 1))[self.employee_emp][0][1]['closest_allocation_expire'],
+                    self.holidays_type_2.get_allocation_data(self.employee_emp, target_date=date(2021, 12, 1))[self.employee_emp][0][1]['closest_allocation_expire'],
                     False,
                 )
 
@@ -937,7 +937,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
                 # The holidays count in 2021 is back to what it was when the allocation was active
                 self._check_holidays_count(
-                    self.holidays_type_2.get_allocation_data(self.employee_emp, date=date(2021, 12, 1))[self.employee_emp][0][1],
+                    self.holidays_type_2.get_allocation_data(self.employee_emp, target_date=date(2021, 12, 1))[self.employee_emp][0][1],
                     ml=10, lt=5, rl=5, vrl=5, vlt=5,
                 )
 

--- a/addons/hr_holidays/tests/test_negative.py
+++ b/addons/hr_holidays/tests/test_negative.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from freezegun import freeze_time
+
+from odoo.tests.common import tagged
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+from odoo.models import ValidationError
+
+
+@tagged('negative_time_off')
+class TestNegative(TestHrHolidaysCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Limited with negative',
+            'leave_validation_type': 'no_validation',
+            'requires_allocation': 'yes',
+            'company_id': cls.company.id,
+            'allows_negative': True,
+            'max_allowed_negative': 5,
+        })
+
+        cls.allocation_2022 = cls.env['hr.leave.allocation'].create({
+            'employee_id': cls.employee_emp_id,
+            'holiday_status_id': cls.leave_type.id,
+            'date_from': '2022-01-01',
+            'date_to': '2022-12-31',
+            'number_of_days': 1,
+        })
+
+        cls.allocation_2023 = cls.env['hr.leave.allocation'].create({
+            'employee_id': cls.employee_emp_id,
+            'holiday_status_id': cls.leave_type.id,
+            'date_from': '2023-01-01',
+            'number_of_days': 5,
+        })
+
+    def test_negative_time_off(self):
+        with freeze_time('2022-10-02'):
+            # At the start of 2022, the user receives 1 days, his balance is at 1
+            # The first 2022 leave brings the user balance at -4
+            self.env['hr.leave'].with_user(self.user_employee_id).create({
+                'name': 'first 2022 leave of 5 days',
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': self.employee_emp.id,
+                'request_date_from': datetime(2022, 10, 24),
+                'request_date_to': datetime(2022, 10, 28),
+            })
+
+        with freeze_time('2023-10-02'):
+            # At the start of 2023, the user receives 5 days, his balance is at 1
+            # The first leave of 2023 brings the balance at -4
+            self.env['hr.leave'].with_user(self.user_employee_id).create({
+                'name': 'first 2023 leave of 5 days',
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': self.employee_emp.id,
+                'request_date_from': datetime(2023, 10, 9),
+                'request_date_to': datetime(2023, 10, 13),
+            })
+
+            # The leave should not be possible to take since it would bring the balance at -9
+            with self.assertRaises(ValidationError):
+                self.env['hr.leave'].with_user(self.user_employee_id).create({
+                    'name': 'not takable leaves of 5 days',
+                    'holiday_status_id': self.leave_type.id,
+                    'employee_id': self.employee_emp_id,
+                    'request_date_from': datetime(2023, 10, 16),
+                    'request_date_to': datetime(2023, 10, 20),
+                })
+
+            # The second leave of 2023 brings the balance at -5
+            one_day_leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
+                'name': 'Second 2023 leave of 1 day',
+                'holiday_status_id': self.leave_type.id,
+                'employee_id': self.employee_emp_id,
+                'request_date_from': datetime(2023, 10, 23),
+                'request_date_to': datetime(2023, 10, 23),
+            })
+
+            # The leave should not be possible to edit since it would bring the balance at -6
+            with self.assertRaises(ValidationError):
+                one_day_leave.with_user(self.user_hrmanager_id).write({
+                    'date_to': datetime(2023, 10, 24),
+                })

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -63,6 +63,15 @@
                         <group name="leave_validation" id="time_off_requests" string="Time Off Requests">
                             <field name="active" invisible="1"/>
                             <field name="leave_validation_type" string="Approval" widget="radio"/>
+                        </group>
+                        <group name="allocation_validation" id="allocation_requests" string="Allocation Requests">
+                            <field name="requires_allocation" widget="radio" options="{'horizontal':true}"/>
+                            <field name="employee_requests" widget="radio" invisible="requires_allocation == 'no'"/>
+                            <field name="allocation_validation_type" string="Approval" widget="radio" invisible="requires_allocation == 'no'"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group name="configuration" id="configuration" string="Configuration">
                             <field name="responsible_ids"
                                 widget="many2many_tags"
                                 placeholder="Nobody will be notified"
@@ -72,10 +81,15 @@
                             <field name="time_type" required="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
-                        <group name="allocation_validation" id="allocation_requests" string="Allocation Requests">
-                            <field name="requires_allocation" widget="radio" options="{'horizontal':true}"/>
-                            <field name="employee_requests" widget="radio" invisible="requires_allocation == 'no'"/>
-                            <field name="allocation_validation_type" string="Approval" widget="radio" invisible="requires_allocation == 'no'"/>
+                        <group name="negative_cap" id="negative_cap"
+                            string="Negative Cap"
+                            invisible="requires_allocation == 'no'">
+                            <field name="allows_negative"/>
+                            <field name="max_allowed_negative"
+                                widget="char"
+                                class="o_hr_narrow_field"
+                                invisible="not allows_negative"
+                                required="requires_allocation == 'yes' and allows_negative"/>
                         </group>
                     </group>
                     <group name="visual" id="visual" string="Display Option" class="mw-100 col-lg-12">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -257,8 +257,12 @@
                                         '&amp;',
                                             ('has_valid_allocation', '=', True),
                                             '&amp;',
-                                                ('virtual_remaining_leaves', '&gt;', 0),
-                                                ('max_leaves', '>', '0')
+                                                ('max_leaves', '>', '0'),
+                                                '|',
+                                                    ('allows_negative', '=', True),
+                                                    '&amp;',
+                                                        ('virtual_remaining_leaves', '&gt;', 0),
+                                                        ('allows_negative', '=', False),
                                 ]"
                                 context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
                                 options="{'no_create': True, 'no_open': True, 'request_type': 'leave'}"


### PR DESCRIPTION
This commit introduce the possibility for users
to set time off type allowing negative amounts in the computation of remaining leaves on allocations.
This is for example useful in cases where the user wants to take some leaves in advance with accruals not
having accrued the time off yet.

task-3465561