### PR TITLE
[FIX] web_editor: remove bg from snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/image_processing.js
+++ b/addons/web_editor/static/src/js/editor/image_processing.js
@@ -13,6 +13,8 @@ const modifierFields = [
     'originalSrc',
     'resizeWidth',
     'aspectRatio',
+    "mimetypeBeforeConversion",
+    "bgSrc",
 ];
 
 // webgl color filters

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6283,6 +6283,7 @@ registry.BackgroundImage = SnippetOptionWidget.extend({
         } else {
             delete parts.url;
             this.$target.removeClass('oe_img_bg o_bg_img_center');
+            this.$target[0].classList.remove("o_modified_image_to_save");
         }
         const combined = backgroundImagePartsToCss(parts);
         this.$target.css('background-image', combined);


### PR DESCRIPTION
This fixes an issue occurring in website edit mode.
Steps to reproduce:
- In website edit mode.
- Drag and drop a "Text" snippet onto the page.
- Add a bg image to this "Text" snippet.
- Remove the bg image from the snippet.
- Save the page;
- Bug => impossible to save the page

task-3527558
