### PR TITLE
[IMP] account: journal items match improvements

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -97,18 +97,6 @@
                 Command.create({'value': 'percent', 'value_amount': 100.0, 'nb_days': 30})]"/>
         </record>
 
-        <!--
-        Account Statement Sequences
-        -->
-        <record id="sequence_reconcile_seq" model="ir.sequence">
-            <field name="name">Account reconcile sequence</field>
-            <field name="code">account.reconcile</field>
-            <field name="prefix">A</field>
-            <field eval="1" name="number_next"/>
-            <field eval="1" name="number_increment"/>
-            <field eval="False" name="company_id"/>
-        </record>
-
         <!-- Account-related subtypes for messaging / Chatter -->
         <record id="mt_invoice_validated" model="mail.message.subtype">
             <field name="name">Validated</field>

--- a/addons/account/models/account_full_reconcile.py
+++ b/addons/account/models/account_full_reconcile.py
@@ -6,7 +6,6 @@ class AccountFullReconcile(models.Model):
     _name = "account.full.reconcile"
     _description = "Full Reconcile"
 
-    name = fields.Char(string='Number', required=True, copy=False, default=lambda self: self.env['ir.sequence'].next_by_code('account.reconcile'))
     partial_reconcile_ids = fields.One2many('account.partial.reconcile', 'full_reconcile_id', string='Reconciliation Parts')
     reconciled_line_ids = fields.One2many('account.move.line', 'full_reconcile_id', string='Matched Journal Items')
     exchange_move_id = fields.Many2one('account.move', index="btree_not_null")
@@ -35,3 +34,10 @@ class AccountFullReconcile(models.Model):
             moves_to_reverse._reverse_moves(default_values_list, cancel=True)
 
         return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        fulls = super().create(vals_list)
+        for full in fulls:
+            full.reconciled_line_ids.matching_number = str(full.id)
+        return fulls

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -168,7 +168,7 @@ class AccountPartialReconcile(models.Model):
 
         line_matching_number = dict(self.env.cr.fetchall())
 
-        for line in amls:
+        for line in amls.with_context(skip_invoice_sync=True):
             if line.full_reconcile_id:
                 line.matching_number = str(line.full_reconcile_id.id)
             elif line.matched_debit_ids or line.matched_credit_ids:

--- a/addons/account/views/account_full_reconcile_views.xml
+++ b/addons/account/views/account_full_reconcile_views.xml
@@ -9,7 +9,7 @@
                 <form string="Matching">
                     <group>
                         <div class="oe_title" colspan="4">
-                            <h1><field name="name" readonly="1"/></h1>
+                            <h1><field name="id" readonly="1"/></h1>
                         </div>
                         <separator string="Matched Journal Items" colspan="4"/>
                         <field name="reconciled_line_ids" readonly="1" colspan="4" nolabel="1"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -360,7 +360,7 @@
                         <filter string="Invoice Date" name="groupby_invoice_date" domain="[]" context="{'group_by': 'invoice_date'}"/>
                         <filter string="Taxes" name="group_by_taxes" domain="[]" context="{'group_by': 'tax_ids'}"/>
                         <filter string="Tax Grid" name="group_by_tax_tags" domain="[]" context="{'group_by': 'tax_tag_ids'}"/>
-                        <filter string="Matching #" name="group_by_matching" domain="[]" context="{'group_by': 'full_reconcile_id'}"/>
+                        <filter string="Matching #" name="group_by_matching" domain="[]" context="{'group_by': 'matching_number'}"/>
                     </group>
                     <searchpanel class="account_root">
                         <field name="account_root_id" icon="fa-filter" groupby="account_id" limit="0"/>

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -337,7 +337,7 @@ class AccountFrFec(models.TransientModel):
                 ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g') END AS EcritureLib,
             replace(CASE WHEN aml.debit = 0 THEN '0,00' ELSE to_char(aml.debit, '000000000000000D99') END, '.', ',') AS Debit,
             replace(CASE WHEN aml.credit = 0 THEN '0,00' ELSE to_char(aml.credit, '000000000000000D99') END, '.', ',') AS Credit,
-            CASE WHEN rec.name IS NULL THEN '' ELSE rec.name END AS EcritureLet,
+            CASE WHEN rec.id IS NULL THEN ''::text ELSE rec.id::text END AS EcritureLet,
             CASE WHEN aml.full_reconcile_id IS NULL THEN '' ELSE TO_CHAR(rec.create_date, 'YYYYMMDD') END AS DateLet,
             TO_CHAR(am.date, 'YYYYMMDD') AS ValidDate,
             CASE


### PR DESCRIPTION
This commit contains some misc improvements based on the 16.0 overall improvements regarding navigation and Journal Items

in account.full.reconcile, 'name' field has been removed, and the replacement for matching_number will be the SQL id instead (no more sequences)

For full reconciliations, the matching number now don't have an 'A' prefix
For partial reconciliations, the matching number will have a format of 'P{id}'

community-PR: odoo/odoo#138140
enterprise-PR: odoo/enterprise#48980
task-id: 3530458