### PR TITLE
[FIX] web: recalculate specialData when a props is edited

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.js
@@ -11,7 +11,7 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
     setup() {
         super.setup();
         this.specialData = useSpecialData((orm, props) => {
-            const { context, name, record } = this.props;
+            const { context, name, record } = props;
             return orm.call(
                 "res.partner",
                 "get_attendee_detail",

--- a/addons/web/static/lib/owl/owl.js
+++ b/addons/web/static/lib/owl/owl.js
@@ -2076,7 +2076,7 @@
             set(target, key, value, receiver) {
                 const hadKey = objectHasOwnProperty.call(target, key);
                 const originalValue = Reflect.get(target, key, receiver);
-                const ret = Reflect.set(target, key, value, receiver);
+                const ret = Reflect.set(target, key, toRaw(value), receiver);
                 if (!hadKey && objectHasOwnProperty.call(target, key)) {
                     notifyReactives(target, KEYCHANGES);
                 }

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -643,11 +643,12 @@ export function useRecordObserver(callback) {
     const fct = (props) => {
         const def = new Deferred();
         let firstCall = true;
+        const nextProps = omit(props, ["record"]);
         effect(
             async (record) => {
                 if (firstCall) {
                     firstCall = false;
-                    await callback(record);
+                    await callback(record, nextProps);
                     def.resolve();
                 } else {
                     return batched(
@@ -657,7 +658,7 @@ export function useRecordObserver(callback) {
                                 // We must do it manually.
                                 return;
                             }
-                            await callback(record);
+                            await callback(record, nextProps);
                             def.resolve();
                         },
                         () => new Promise((resolve) => window.requestAnimationFrame(resolve))

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -384,7 +384,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsN(target, ".o_statusbar_status button:disabled", 2);
     });
 
-    QUnit.skip(
+    QUnit.test(
         "clickable statusbar should change m2o fetching domain in edit mode",
         async function (assert) {
             serverData.models.partner.fields.trululu.domain = "[('bar', '=', True)]";
@@ -407,6 +407,7 @@ QUnit.module("Fields", (hooks) => {
                 ".o_statusbar_status button:not(.dropdown-toggle)"
             );
             await click(buttons[buttons.length - 1]);
+            await nextTick();
             assert.containsN(target, ".o_statusbar_status button:not(.dropdown-toggle)", 2);
         }
     );

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -384,7 +384,7 @@ QUnit.module("Fields", (hooks) => {
         assert.containsN(target, ".o_statusbar_status button:disabled", 2);
     });
 
-    QUnit.test(
+    QUnit.skip(
         "clickable statusbar should change m2o fetching domain in edit mode",
         async function (assert) {
             serverData.models.partner.fields.trululu.domain = "[('bar', '=', True)]";


### PR DESCRIPTION
Before this commit, specialData is only recaculted when the props change,
but not if a value inside the props changes. For example, when we update
record, the props do not change but the values inside record do. We want to
recalculate the specialData if it is based on a record value.