### PR TITLE
[FIX] website_sale: btn group rpc issue

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -752,6 +752,11 @@ publicWidget.registry.WebsiteSaleLayout = publicWidget.Widget.extend({
         'change .o_wsale_apply_layout input': '_onApplyShopLayoutChange',
     },
 
+    init() {
+        this._super(...arguments);
+        this.rpc = this.bindService("rpc");
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------


### PR DESCRIPTION
In commit f24e61334ec1de577c6031743199e3b713290d2f the legacy rpc files have been removed.

It was not initialized in this public widget making the btn-group switch unusable.

task-3547424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
