### PR TITLE
[FIX] payment_stripe: handle timeout error when connect with stripe

### DIFF
--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -415,8 +415,8 @@ class PaymentProvider(models.Model):
         try:
             response = requests.post(url=url, json=proxy_payload, timeout=60)
             response.raise_for_status()
-        except requests.exceptions.ConnectionError:
-            _logger.exception("unable to reach endpoint at %s", url)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            _logger.warning("unable to reach endpoint at %s", url)
             raise ValidationError(_("Stripe Proxy: Could not establish the connection."))
         except requests.exceptions.HTTPError:
             _logger.exception("invalid API request at %s with data %s", url, payload)


### PR DESCRIPTION
When the user connect with Stripe in the payment provider and an API request takes longer than 60 seconds then a ReadTimeout error will occur.

Line 1: https://github.com/odoo/odoo/blob/29a40a30f3bf7a4a3a205e54fb84e569691d961f/addons/payment_stripe/models/payment_provider.py#L413-L418

Traceback on sentry:
```
TimeoutError: The read operation timed out
  File "urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
    # Permission is hereby granted, free of charge, to any person obtaining a copy
  File "urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "http/client.py", line 1375, in getresponse
    response.begin()
  File "http/client.py", line 318, in begin
    version, status, reason = self._read_status()
  File "http/client.py", line 279, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "socket.py", line 705, in readinto
    return self._sock.recv_into(b)
  File "ssl.py", line 1274, in recv_into
    return self.read(nbytes, buffer)
  File "ssl.py", line 1130, in read
    return self._sslobj.read(len, buffer)
ReadTimeoutError: HTTPSConnectionPool(host='stripe.api.odoo.com', port=443): Read timed out. (read timeout=60)
  File "requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "urllib3/connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "urllib3/util/retry.py", line 532, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "six.py", line 719, in reraise
    raise value
  File "urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "urllib3/connectionpool.py", line 447, in _make_request
    self._raise_timeout(err=e, url=url, timeout_value=read_timeout)
  File "urllib3/connectionpool.py", line 336, in _raise_timeout
    raise ReadTimeoutError(
ReadTimeout: HTTPSConnectionPool(host='stripe.api.odoo.com', port=443): Read timed out. (read timeout=60)
  File "odoo/http.py", line 2134, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1710, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1737, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1938, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/sale/wizard/payment_provider_onboarding_wizard.py", line 31, in add_payment_methods
    return super().add_payment_methods()
  File "addons/payment/wizards/payment_onboarding_wizard.py", line 141, in add_payment_methods
    return self._start_stripe_onboarding()
  File "addons/sale/wizard/payment_provider_onboarding_wizard.py", line 36, in _start_stripe_onboarding
    return self.env.company._run_payment_onboarding_step(menu_id)
  File "addons/payment/models/res_company.py", line 51, in _run_payment_onboarding_step
    return stripe_provider.action_stripe_connect_account(menu_id=menu_id)
  File "home/odoo/src/custom/trial/saas_payment_stripe/models/payment_provider.py", line 87, in action_stripe_connect_account
    return super().action_stripe_connect_account(menu_id)
  File "addons/payment_stripe/models/payment_provider.py", line 152, in action_stripe_connect_account
    connected_account = self._stripe_fetch_or_create_connected_account()
  File "home/odoo/src/custom/trial/saas_payment_stripe/models/payment_provider.py", line 184, in _stripe_fetch_or_create_connected_account
    connected_account = super()._stripe_fetch_or_create_connected_account()
  File "addons/payment_stripe/models/payment_provider.py", line 326, in _stripe_fetch_or_create_connected_account
    return self._stripe_make_proxy_request(
  File "addons/payment_stripe/models/payment_provider.py", line 414, in _stripe_make_proxy_request
    response = requests.post(url=url, json=proxy_payload, timeout=60)
  File "requests/api.py", line 119, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "requests/sessions.py", line 544, in request
    resp = self.send(prep, **send_kwargs)
  File "requests/sessions.py", line 657, in send
    r = adapter.send(request, **kwargs)
  File "requests/adapters.py", line 529, in send
    raise ReadTimeout(e, request=request)

```

To handle this situation, the code has been updated to ensure that if the system takes more than 60 seconds to connect with Stripe then raises a logger warning.

sentry-4506249274

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
