### PR TITLE
[IMP] account: easier payment registration for bills

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -92,6 +92,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/components/**/*',
             'account/static/src/js/tours/account.js',
             'account/static/src/views/**/*.js',
+            'account/static/src/js/search/search_bar/search_bar.js',
         ],
         'web.assets_frontend': [
             'account/static/src/js/account_portal_sidebar.js',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3835,21 +3835,7 @@ class AccountMove(models.Model):
                 })
 
     def action_register_payment(self):
-        ''' Open the account.payment.register wizard to pay the selected journal entries.
-        :return: An action opening the account.payment.register wizard.
-        '''
-        return {
-            'name': _('Register Payment'),
-            'res_model': 'account.payment.register',
-            'view_mode': 'form',
-            'views': [[False, 'form']],
-            'context': {
-                'active_model': 'account.move',
-                'active_ids': self.ids,
-            },
-            'target': 'new',
-            'type': 'ir.actions.act_window',
-        }
+        return self.line_ids.action_register_payment()
 
     def action_duplicate(self):
         # offer the possibility to duplicate thanks to a button instead of a hidden menu, which is more visible

--- a/addons/account/static/src/js/search/search_bar/search_bar.js
+++ b/addons/account/static/src/js/search/search_bar/search_bar.js
@@ -1,0 +1,15 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { SearchBar } from "@web/search/search_bar/search_bar";
+
+patch(SearchBar.prototype, {
+    getPreposition(searchItem) {
+        let preposition = super.getPreposition(searchItem);
+        if (this.fields[searchItem.fieldName].name == 'payment_date') {
+            preposition = _t("until");
+        }
+        return preposition
+    }
+});

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -33,6 +33,7 @@ from . import test_tax_report
 from . import test_transfer_wizard
 from . import test_account_incoming_supplier_invoice
 from . import test_payment_term
+from . import test_account_payment_items
 from . import test_account_payment_register
 from . import test_tour
 from . import test_early_payment_discount

--- a/addons/account/tests/test_account_payment_items.py
+++ b/addons/account/tests/test_account_payment_items.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from datetime import date, datetime, timedelta
+from freezegun import freeze_time
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+@tagged('post_install', '-at_install')
+class TestAccountPaymentItems(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.bill = cls.create_bill(due_date='2023-03-20')
+        cls.late_bill = cls.create_bill(due_date='2023-03-01')
+        cls.discount_bill = cls.create_bill(due_date='2023-03-20', discount_days=19)
+        cls.late_discount_bill = cls.create_bill(due_date='2023-04-20', discount_days=9)
+
+    @classmethod
+    def create_bill(cls, due_date, discount_days=None):
+        payment_term = cls.create_payment_term(due_date, discount_days)
+        bill = cls.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'journal_id': cls.company_data['default_journal_purchase'].id,
+            'partner_id': cls.partner_a.id,
+            'date': '2023-03-15',
+            'invoice_date': '2023-03-01',
+            'invoice_date_due': due_date,
+            'invoice_payment_term_id': payment_term.id,
+            'invoice_line_ids': [(0, 0, {
+                'product_id': cls.product_a.id,
+                'quantity': 1,
+                'name': 'product_a',
+                'discount': 10.00,
+                'price_unit': 100,
+                'tax_ids': [],
+                'discount_date': date(2023, 3, 1) + timedelta(days=discount_days) if discount_days else False,
+                'date_maturity': due_date,
+            })]
+        })
+        bill.action_post()
+        return bill
+
+    @classmethod
+    def create_payment_term(cls, due_date, discount_days=None):
+        due_days = (datetime.strptime(due_date, '%Y-%m-%d').date() - date(2023, 3, 1)).days
+        payment_term = cls.env['account.payment.term'].create({
+            'name': 'Payment Term For Testing',
+            'early_discount': bool(discount_days),
+            'discount_days': discount_days if discount_days else False,
+            'discount_percentage': 5,
+            'line_ids': [
+                (0, 0, {
+                    'value': 'percent',
+                    'value_amount': 100,
+                    'delay_type': 'days_after',
+                    'nb_days': due_days,
+                }),
+            ],
+        })
+        return payment_term
+
+    @freeze_time("2023-03-15")
+    def test_payment_date(self):
+        self.assertEqual(str(self.bill.line_ids[0].payment_date), '2023-03-20')
+        self.assertEqual(str(self.late_bill.line_ids[0].payment_date), '2023-03-01')
+        self.assertEqual(str(self.discount_bill.line_ids[0].payment_date), '2023-03-20')
+        self.assertEqual(str(self.late_discount_bill.line_ids[0].payment_date), '2023-04-20')
+
+    def test_search_payment_date(self):
+        for today, search, expected in [
+            ('2023-03-05', '2023-03-01', self.late_bill),
+            ('2023-03-05', '2023-03-30', self.bill + self.late_bill + self.discount_bill + self.late_discount_bill),
+            ('2023-03-15', '2023-03-01', self.late_bill),
+            ('2023-03-15', '2023-03-30', self.bill + self.late_bill + self.discount_bill),
+            ('2023-03-25', '2023-03-01', self.late_bill),
+            ('2023-03-25', '2023-03-30', self.bill + self.late_bill + self.discount_bill),
+            ('2023-03-25', '2023-06-30', self.bill + self.late_bill + self.discount_bill + self.late_discount_bill),
+        ]:
+            with freeze_time(today):
+                self.assertEqual(self.env['account.move.line'].search([
+                    ('payment_date', '=', search),
+                    ('partner_id', '=', self.partner_a.id),
+                ]).move_id, expected)

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -334,9 +334,8 @@
                                     context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_sale_pay_link">
                                         <t t-out="dashboard.number_waiting"/> Unpaid Invoices
                                     </a>
-
-                                    <a type="object" t-if="journal_type == 'purchase'" name="open_action"
-                                    context="{'search_default_open':1, 'search_default_posted':1, 'search_default_partial': 1}" id="account_dashboard_purchase_pay_link">
+                                    <a type="object" name="open_action" t-if="journal_type == 'purchase'"
+                                    context="{'action_name': 'action_open_payment_items', 'search_default_purchases': '1'}">
                                         <t t-out="dashboard.number_waiting"/> Bills to Pay
                                     </a>
                                 </div>
@@ -346,9 +345,12 @@
                             </div>
                             <div class="row" t-if="dashboard.number_late">
                                 <div class="col overflow-hidden text-start">
-                                    <a type="object" name="open_action" context="{'search_default_late': '1'}">
-                                        <span t-if="journal_type == 'sale'" title="Late Invoices"><t t-out="dashboard.number_late"/> Late Invoices</span>
-                                        <span t-if="journal_type == 'purchase'" title="Late Bills"><t t-out="dashboard.number_late"/> Late Bills</span>
+                                    <a type="object" name="open_action" t-if="journal_type == 'sale'" context="{'search_default_late': '1'}">
+                                        <span><t t-out="dashboard.number_late"/> Late Invoices</span>
+                                    </a>
+                                    <a type="object" t-if="journal_type == 'purchase'" name="open_action"
+                                    context="{'action_name': 'action_open_payment_items', 'search_default_purchases': '1', 'search_default_late': '1'}">
+                                        <span><t t-out="dashboard.number_late"/> Late Bills</span>
                                     </a>
                                 </div>
                                 <div class="col-auto text-end">

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -19,6 +19,7 @@
             <menuitem id="menu_action_move_in_invoice_type" action="action_move_in_invoice_type" sequence="1"/>
             <menuitem id="menu_action_move_in_refund_type" action="action_move_in_refund_type" sequence="2"/>
             <menuitem id="menu_action_move_in_receipt_type" action="action_move_in_receipt_type" groups="account.group_purchase_receipts" sequence="3"/>
+            <menuitem id="menu_action_open_payment_items" action="action_open_payment_items" sequence="10"/>
             <menuitem id="menu_action_account_payments_payable" name="Payments" action="action_account_payments_payable" sequence="20"/>
             <menuitem id="menu_account_supplier_accounts" name="Bank Accounts" action="action_account_supplier_accounts" sequence="80"/>
             <menuitem id="product_product_menu_purchasable" name="Products" action="product_product_action_purchasable" sequence="100"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -305,6 +305,7 @@
         <record id="view_account_move_line_filter" model="ir.ui.view">
             <field name="name">account.move.line.search</field>
             <field name="model">account.move.line</field>
+            <field eval="16" name="priority"/>
             <field name="arch" type="xml">
                 <search string="Search Journal Items">
                     <field name="name" string="Journal Item" filter_domain="[
@@ -314,6 +315,8 @@
                     <field name="ref"/>
                     <field name="date"/>
                     <field name="invoice_date"/>
+                    <field name="date_maturity" string="Due Date"/>
+                    <field name="discount_date" string="Discount Date"/>
                     <field name="balance" string="Amount" filter_domain="['|', ('credit', '=', self), ('debit', '=', self)]"/>
                     <field name="account_id"/>
                     <field name="account_type"/>
@@ -365,6 +368,86 @@
                     <searchpanel class="account_root">
                         <field name="account_root_id" icon="fa-filter" groupby="account_id" limit="0"/>
                     </searchpanel>
+                </search>
+            </field>
+        </record>
+
+        <!-- account.move.line (Payment Items) -->
+
+        <record id="view_move_line_payment_tree" model="ir.ui.view">
+            <field name="name">account.move.line.payment.tree</field>
+            <field name="model">account.move.line</field>
+            <field eval="200" name="priority"/>
+            <field name="arch" type="xml">
+                <tree string="Payment Items" create="false" edit="true" expand="context.get('expand', False)" multi_edit="1" sample="1" js_class="account_search_bar">
+                    <header>
+                        <button name="action_register_payment" type="object" string="Register Payment"/>
+                    </header>
+                    <field name="move_id" column_invisible="True"/>
+                    <field name="invoice_date" string="Invoice Date"/>
+                    <field name="date" readonly="1" optional="hide"/>
+                    <field name="date_maturity" string="Invoice Due Date" readonly="1" optional="hide"/>
+                    <field name="discount_date" string="Discount Date" optional="hide"/>
+                    <field name="payment_date" string="Due Date" readonly="1"/>
+                    <field name="company_id" column_invisible="True"/>
+                    <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hide"/>
+                    <field name="journal_id" readonly="1" options='{"no_open":True}' optional="hide"/>
+                    <field name="move_name" string="Journal Entry" widget="open_move_widget"/>
+                    <field name="partner_id" optional="show" readonly="move_type != 'entry'"/>
+                    <field name="ref" readonly="False"/>
+                    <field name="display_name" optional="show"/>
+                    <field name="discount_amount_currency" string="Discount Amount" optional="show" invisible="not discount_amount_currency"/>
+                    <field name="amount_residual" sum="Total Residual" string="Residual" readonly="1" invisible="not is_account_reconcile"/>
+                    <field name="amount_residual_currency" string="Residual in Currency" optional="hide" readonly="1" invisible="is_same_currency or not is_account_reconcile"/>
+                    <field name="currency_id" groups="base.group_multi_currency" optional="hide" string="Currency" readonly="1" invisible="is_same_currency"/>
+                    <field name="company_currency_id" column_invisible="True"/>
+                    <field name="move_type" column_invisible="True"/>
+                    <field name="is_same_currency" column_invisible="True"/>
+                    <field name="is_account_reconcile" column_invisible="True"/>
+                    <field name="currency_id" groups="base.group_multi_currency" invisible="1"/>
+                    <groupby name="partner_id">
+                        <button name="edit" type="edit" icon="fa-edit" title="Edit"/>
+                    </groupby>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_account_move_line_payment_filter" model="ir.ui.view">
+            <field name="name">account.move.line.payment.search</field>
+            <field name="model">account.move.line</field>
+            <field eval="200" name="priority"/>
+            <field name="arch" type="xml">
+                <search string="Search Journal Items">
+                    <field name="name" string="Journal Item" filter_domain="[
+                        '|', '|', '|',
+                        ('name', 'ilike', self), ('ref', 'ilike', self), ('account_id', 'ilike', self), ('partner_id', 'ilike', self)]"/>
+                    <field name="name"/>
+                    <field name="ref"/>
+                    <field name="payment_date" string="Due Date"/>
+                    <field name="partner_id"/>
+                    <field name="journal_id"/>
+                    <field name="currency_id" groups="base.group_multi_currency" invisible="1"/>
+                    <field name="company_currency_id" invisible="1"/>
+                    <separator/>
+                    <filter string="Posted" name="posted" domain="[('parent_state', '=', 'posted')]" help="Posted Journal Items" invisible="1"/>
+                    <separator/>
+                    <filter string="Sales" name="sales" domain="[('journal_id.type', '=', 'sale')]" context="{'default_journal_type': 'sale'}"/>
+                    <filter string="Purchases" name="purchases" domain="[('journal_id.type', '=', 'purchase')]" context="{'default_journal_type': 'purchase'}"/>
+                    <separator/>
+                    <filter string="Invoice Date" name="invoice_date" date="invoice_date"/>
+                    <filter string="Due Date" name="date_maturity" date="date"/>
+                    <filter string="Overdue" name="late" domain="[('date_maturity', '&lt;', time.strftime('%Y-%m-%d'))]" help="Overdue payments, due date passed"/>
+                    <separator/>
+                    <filter string="Report Dates" name="date_between" domain="[('date', '&gt;=', context.get('date_from')), ('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
+                    <filter string="Report Dates" name="date_before" domain="[('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
+                    <separator/>
+                    <group expand="0" string="Group By">
+                        <filter string="Currency" name="group_by_currencies" domain="[]" context="{'group_by': 'currency_id'}"/>
+                        <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
+                        <filter string="Journal" name="journal" domain="[]" context="{'group_by': 'journal_id'}"/>
+                        <filter string="Invoice Date" name="groupby_invoice_date" domain="[]" context="{'group_by': 'invoice_date'}"/>
+                        <filter string="Due Date" name="groupby_payment_date" domain="[]" context="{'group_by': 'payment_date'}"/>
+                    </group>
                 </search>
             </field>
         </record>
@@ -1603,6 +1686,23 @@
               </p><p>
                 Note that the easiest way to create a vendor credit note is to do it directly from the vendor bill.
               </p>
+            </field>
+        </record>
+
+        <record id="action_open_payment_items" model="ir.actions.act_window">
+            <field name="name">Amounts to Settle</field>
+            <field name="res_model">account.move.line</field>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_move_line_payment_tree"/>
+            <field name="search_view_id" ref="view_account_move_line_payment_filter"/>
+            <field name="context">{'search_default_group_by_partner':1, 'expand':1}</field>
+            <field name="domain">[('parent_state', '=', 'posted'), ('amount_residual', '!=', 0), ('account_id.reconcile', '=', True)]</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Amounts to settle
+                </p><p>
+                    Cool, it looks like you don't have anything to pay either for vendor bills or for customer credit notes.
+                </p>
             </field>
         </record>
 

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -126,14 +126,10 @@ export class SearchBar extends Component {
         const items = [];
 
         const isFieldProperty = searchItem.type === "field_property";
-
-        const { type } = isFieldProperty
-            ? searchItem.propertyFieldDefinition
-            : this.fields[searchItem.fieldName];
-        const fieldType = type === "reference" ? "char" : type;
+        const fieldType = this.getFieldType(searchItem);
 
         /** @todo do something with respect to localization (rtl) */
-        let preposition = _t(["date", "datetime"].includes(fieldType) ? "at" : "for");
+        let preposition = this.getPreposition(searchItem);
 
         if ((isFieldProperty && FOLDABLE_TYPES.includes(fieldType)) || fieldType === "properties") {
             // Do not chose preposition for foldable properties
@@ -234,6 +230,20 @@ export class SearchBar extends Component {
         }
 
         return items;
+    }
+
+    getPreposition(searchItem) {
+        const fieldType = this.getFieldType(searchItem);
+        return ["date", "datetime"].includes(fieldType) ? _t("at") : _t("for");
+    }
+
+    getFieldType(searchItem) {
+        const { type } = searchItem.type === "field_property"
+            ? searchItem.propertyFieldDefinition
+            : this.fields[searchItem.fieldName];
+        const fieldType = type === "reference" ? "char" : type;
+
+        return fieldType
     }
 
     /**


### PR DESCRIPTION
Description of the issue/feature this commit addresses:

Currently, the payment registration for vendor bills is kinda hard to figure. Noticing which bills are overdue, which require a payment is not made so easy by the interface and could be improved. Also there is no way to register a payment for multiple lines at a time which could improve the UX.

---

Desired behavior after the commit is merged :

On the dashboard, all the buttons in the "Customer Invoices" and "Vendor Bills" have been renamed to remove the "Invoices" and the "Bills" inside them.

The buttons "Bills to Pay" and "Late Bills" which now are "To Pay" and "Late" (see above) redirect to the Journal Items with specific filters to show only the necessary lines.

The order of the columns in the Journal Items has been changed and their visibility has been changed too.

The default filters of the Journal Items when coming from the dashboard buttons has been changed. Payable has been replaced by Purchases.

Filters, Group by and Search by options have been added for the Due Date and the Discount Date fields in the Journal Items.

---

task-3516496

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
