### PR TITLE
[FIX] sale_stock: display right customer address on delivery slip

### DIFF
--- a/addons/sale_stock/report/stock_report_deliveryslip.xml
+++ b/addons/sale_stock/report/stock_report_deliveryslip.xml
@@ -7,5 +7,14 @@
                 <p t-field="o.sudo().sale_id.client_order_ref"/>
             </div>
         </xpath>
+        <xpath expr="//div[@name='div_incoming_address']" position="inside">
+            <div name="customer_address" t-if="o.picking_type_id.code=='outgoing' and o.sale_id.partner_shipping_id and o.sale_id.partner_id.commercial_partner_id != o.sale_id.partner_shipping_id.commercial_partner_id">
+                <span><strong>Customer Address:</strong></span>
+                <div name="partner_header">
+                    <div t-field="o.sale_id.partner_id.commercial_partner_id"
+                         t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"], "no_marker": True, "phone_icons": True}'/>
+                </div>
+            </div>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
### Steps
- Create a sale order with different Customer and Delivery address ``partner_id``.
- Add a product that can be delivered.
- Confirm the sale order and validate the transfer created.
- Print the delivery slip.

### Issue
Only the delivery address is printed, which leads to confusion if completely different from the customer address.

### Reason
The ``stock.report_delivery_document`` doesn't consider that there maybe a sale order linked to the stock picking with a  ``partner_shipping_id`` different from his ``partner_id``.

opw-3461483