### PR TITLE
[FIX] mail: no duplicate content on message of type email

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -52,6 +52,7 @@ import { cookie } from "@web/core/browser/cookie";
 export class Message extends Component {
     // This is the darken version of #71639e
     static SHADOW_LINK_COLOR = "#66598f";
+    static SHADOW_HIGHLIGHT_COLOR = "#e99d00bf";
     static SHADOW_LINK_HOVER_COLOR = "#564b79";
     static components = {
         ActionSwiper,
@@ -155,7 +156,8 @@ export class Message extends Component {
             if (this.shadowBody.el) {
                 this.shadowRoot = this.shadowBody.el.attachShadow({ mode: "open" });
                 const body = document.createElement("span");
-                body.innerHTML = this.message.body;
+                body.innerHTML =
+                    this.props.messageSearch?.highlight(this.message.body) ?? this.message.body;
                 this.insertReadMoreLess($(body));
                 const color = cookie.get("color_scheme") === "dark" ? "white" : "black";
                 this.shadowStyle = document.createElement("style");
@@ -169,6 +171,9 @@ export class Message extends Component {
                     }
                     a:hover, a *:hover {
                         color: ${this.constructor.SHADOW_LINK_HOVER_COLOR} !important;
+                    }
+                    .o-mail-Message-searchHighlight {
+                        background: ${this.constructor.SHADOW_HIGHLIGHT_COLOR} !important;
                     }
                 `;
                 this.shadowRoot.appendChild(this.shadowStyle);

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -93,7 +93,7 @@
                                                         <button t-if="message.type === 'email'" class="o-mail-Message-originalEmailText d-block float-end p-1 mb-1 btn btn-link opacity-75 fst-italic" t-att-class="env.inChatWindow and isAlignedRight ? 'me-3' : 'ms-3'" t-esc="originalEmailText" t-on-click="() => this.state.originalEmail = !this.state.originalEmail"/>
                                                         <em t-if="message.subject and !message.isSubjectSimilarToOriginThreadName and !message.isSubjectDefault" class="mb-1 me-2">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div t-if="message.type === 'email'" t-ref="shadowBody"/>
-                                                        <t t-if="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
+                                                        <t t-elif="message.body" t-out="props.messageSearch?.highlight(message.body) ?? message.body"/>
                                                         <!-- <small t-if="message.editDate" class="o-mail-Message-edited fst-italic text-muted" t-att-class="{ 'ms-2': !message.isBodyEmpty }" t-att-title="message.editDatetimeHuge">(edited)</small> --> <!-- DISABLED because new messages sent by email are wrongly flagged as (edited) -->
                                                         <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtypeDescription) ?? message.subtypeDescription"/>
                                                     </t>


### PR DESCRIPTION
Fix the duplicate message in the discuss and search
when the message type is email. This was caused by a wrong
rebase of https://github.com/odoo/odoo/pull/118794 that
did not take into account the branching on message body
for message of type email by https://github.com/odoo/odoo/pull/131202

The search highlight feature was not working on these email
message, so this commit also fixes that.

before/after:
![image](https://github.com/odoo/odoo/assets/26395662/74a9aa9f-2fcb-48dd-ac80-57339dad8a7d)
![image](https://github.com/odoo/odoo/assets/26395662/63e65f1a-2d63-4acd-9ee4-54b6f5a87dbf)

