### PR TITLE
[FIX] account: fix the deletion of the tax grid when changing the credit/debit or the account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -760,7 +760,7 @@ class AccountMove(models.Model):
         for line in self.line_ids.filtered(lambda line: not line.tax_repartition_line_id):
             # Don't call compute_all if there is no tax.
             if not line.tax_ids:
-                if not recompute_tax_base_amount:
+                if not recompute_tax_base_amount and not line.tax_tag_ids.ids:
                     line.tax_tag_ids = [(5, 0, 0)]
                 continue
 

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -40,3 +40,4 @@ from . import test_payment_term
 from . import test_account_payment_register
 from . import test_tour
 from . import test_ir_actions_report
+from . import test_account_account_tag

--- a/addons/account/tests/test_account_account_tag.py
+++ b/addons/account/tests/test_account_account_tag.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo.exceptions import UserError
+
+
+@tagged('post_install', '-at_install')
+class TestAccountAccountTag(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass(chart_template_ref=None)
+
+    def test_changing_debit_credit(self):
+        '''
+            Ensure that that after adding manually the tax grids and changing the debit or credit,
+            the tax grid persist and not initialized
+        '''
+        tax_tag = self.env['account.account.tag'].create({
+            'name': "test_misc_custom_tags",
+            'applicability': 'taxes',
+            'country_id': self.env.ref('base.us').id,
+        })
+        am = self.env['account.move'].create({
+            'move_type': 'entry',
+            'date': '2023-01-01',
+            'line_ids': [
+                (0, 0, {
+                    'name': 'line_debit',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'tax_tag_ids': tax_tag
+                }),
+                (0, 0, {
+                    'name': 'line_credit',
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'tax_tag_ids': tax_tag
+                }),
+            ],
+        })
+
+        with self.assertRaises(UserError):
+            am.line_ids[0].write({
+                'debit': 100,
+                'account_id': self.company_data['default_account_assets'].id,
+                })
+            am.line_ids[1].write({
+                'credit': 100,
+                'account_id': self.company_data['default_account_expense'].id
+                })
+        self.assertEqual(am.line_ids[0].tax_tag_ids, tax_tag)
+        self.assertEqual(am.line_ids[1].tax_tag_ids, tax_tag)


### PR DESCRIPTION
The issue:
on a fresh database, install the accounting app, then create a journal entry, add a journal item, set the account, debit or credit, and add a tax grid, then go back and change the amount on the credit/debit, the tax grid will be deleted

The fix:
if a set of tax grid is already set, no need to reinitialize it

opw-3514901