### PR TITLE
[IMP] *: use correct indentation in manifest summary

### DIFF
--- a/addons/account_lock/__manifest__.py
+++ b/addons/account_lock/__manifest__.py
@@ -5,11 +5,11 @@
     'version': '1.0',
     'category': 'Accounting/Accounting',
     'description': """
-    Make the lock date irreversible:
+Make the lock date irreversible:
 
-    * You cannot set stricter restrictions on accountants than on users. Therefore, the All Users Lock Date must be anterior (or equal) to the Invoice/Bills Lock Date.
-    * You cannot lock a period that has not yet ended. Therefore, the All Users Lock Date must be anterior (or equal) to the last day of the previous month.
-    * Any new All Users Lock Date must be posterior (or equal) to the previous one.
+* You cannot set stricter restrictions on accountants than on users. Therefore, the All Users Lock Date must be anterior (or equal) to the Invoice/Bills Lock Date.
+* You cannot lock a period that has not yet ended. Therefore, the All Users Lock Date must be anterior (or equal) to the last day of the previous month.
+* Any new All Users Lock Date must be posterior (or equal) to the previous one.
     """,
     'depends': ['account'],
     'license': 'LGPL-3',

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -3,9 +3,7 @@
 
 {
     'name': "Peppol",
-    'summary': """
-        This module is used to send/receive documents with PEPPOL
-        """,
+    'summary': "This module is used to send/receive documents with PEPPOL",
     'description': """
 - Register as a PEPPOL participant
 - Send and receive documents via PEPPOL network in Peppol BIS Billing 3.0 format

--- a/addons/account_qr_code_emv/__manifest__.py
+++ b/addons/account_qr_code_emv/__manifest__.py
@@ -5,7 +5,7 @@
     'category': 'Accounting/Payment',
     'version': '1.0',
     'description': """
-        Bridge module addings support for EMV Merchant-Presented QR-code generation for Payment System.
+Bridge module addings support for EMV Merchant-Presented QR-code generation for Payment System.
     """,
     'author': 'Odoo SA',
     'depends': ['account'],

--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -3,7 +3,7 @@
     'name': "Account SEPA QR Code",
 
     'description': """
-        This module adds support for SEPA Credit Transfer QR-code generation.
+This module adds support for SEPA Credit Transfer QR-code generation.
     """,
 
     'category': 'Accounting/Payment',

--- a/addons/base_sparse_field/__manifest__.py
+++ b/addons/base_sparse_field/__manifest__.py
@@ -3,10 +3,10 @@
     'name': "Sparse Fields",
     'summary': """Implementation of sparse fields.""",
     'description': """
-        The purpose of this module is to implement "sparse" fields, i.e., fields
-        that are mostly null. This implementation circumvents the PostgreSQL
-        limitation on the number of columns in a table. The values of all sparse
-        fields are stored in a "serialized" field in the form of a JSON mapping.
+The purpose of this module is to implement "sparse" fields, i.e., fields
+that are mostly null. This implementation circumvents the PostgreSQL
+limitation on the number of columns in a table. The values of all sparse
+fields are stored in a "serialized" field in the form of a JSON mapping.
     """,
     'category': 'Hidden',
     'version': '1.0',

--- a/addons/delivery_mondialrelay/__manifest__.py
+++ b/addons/delivery_mondialrelay/__manifest__.py
@@ -4,10 +4,10 @@
     'summary': """ Let's choose a Point Relais® as shipping address """,
 
     'description': """
-        This module allow your customer to choose a Point Relais® and use it as shipping address.
-        This module doesn't implement the WebService. It is only the integration of the widget.
+This module allow your customer to choose a Point Relais® and use it as shipping address.
+This module doesn't implement the WebService. It is only the integration of the widget.
 
-        Delivery price pre-configured is an example, you need to adapt the pricing's rules.
+Delivery price pre-configured is an example, you need to adapt the pricing's rules.
     """,
     'category': 'Inventory/Delivery',
     'version': '0.1',

--- a/addons/google_recaptcha/__manifest__.py
+++ b/addons/google_recaptcha/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Hidden',
     'version': '1.0',
     'description': """
-        This module implements reCaptchaV3 so that you can prevent bot spam on your public modules.
+This module implements reCaptchaV3 so that you can prevent bot spam on your public modules.
     """,
     'depends': ['base_setup'],
     'data': [

--- a/addons/hr_livechat/__manifest__.py
+++ b/addons/hr_livechat/__manifest__.py
@@ -3,7 +3,7 @@
     'version': '1.0',
     'category': 'Human Resources',
     'description': """
-        Bridge between HR and Livechat.""",
+Bridge between HR and Livechat.""",
     'depends': ['hr', 'im_livechat'],
     'data': [
         'views/discuss_channel_views.xml',

--- a/addons/hr_maintenance/__manifest__.py
+++ b/addons/hr_maintenance/__manifest__.py
@@ -6,7 +6,7 @@
     'sequence': 125,
     'category': 'Human Resources',
     'description': """
-        Bridge between HR and Maintenance.""",
+Bridge between HR and Maintenance.""",
     'depends': ['hr', 'maintenance'],
     'summary': 'Equipment, Assets, Internal Hardware, Allocation Tracking',
     'data': [

--- a/addons/hr_recruitment_survey/__manifest__.py
+++ b/addons/hr_recruitment_survey/__manifest__.py
@@ -5,9 +5,9 @@
     'category': 'Human Resources',
     'summary': 'Surveys',
     'description': """
-        Use interview forms during recruitment process.
-        This module is integrated with the survey module
-        to allow you to define interviews for different jobs.
+Use interview forms during recruitment process.
+This module is integrated with the survey module
+to allow you to define interviews for different jobs.
     """,
     'depends': ['survey', 'hr_recruitment'],
     'data': [

--- a/addons/l10n_account_edi_ubl_cii_tests/__manifest__.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/__manifest__.py
@@ -4,18 +4,18 @@
     'version': '1.0',
     'category': 'Hidden/Tests',
     'description': """
-    This module tests the module 'account_edi_ubl_cii', it is separated since dependencies to some
-    localizations were required. Its name begins with 'l10n' to not overload runbot.
+This module tests the module 'account_edi_ubl_cii', it is separated since dependencies to some
+localizations were required. Its name begins with 'l10n' to not overload runbot.
 
-    The test files are separated by sources, they were taken from:
+The test files are separated by sources, they were taken from:
 
-    * the factur-x doc (form the FNFE)
-    * the peppol-bis-invoice-3 doc (the github repository: https://github.com/OpenPEPPOL/peppol-bis-invoice-3/tree/master/rules/examples contains examples)
-    * odoo, these files pass all validation tests (using ecosio or the FNFE validator)
+* the factur-x doc (form the FNFE)
+* the peppol-bis-invoice-3 doc (the github repository: https://github.com/OpenPEPPOL/peppol-bis-invoice-3/tree/master/rules/examples contains examples)
+* odoo, these files pass all validation tests (using ecosio or the FNFE validator)
 
-    We test that the external examples are correctly imported (currency, total amount and total tax match).
-    We also test that generating xml from odoo with given parameters gives exactly the same xml as the expected,
-    valid ones.
+We test that the external examples are correctly imported (currency, total amount and total tax match).
+We also test that generating xml from odoo with given parameters gives exactly the same xml as the expected,
+valid ones.
     """,
     'depends': [
         'account_edi_ubl_cii',

--- a/addons/l10n_bg/__manifest__.py
+++ b/addons/l10n_bg/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
-        Chart accounting and taxes for Bulgaria
+Chart accounting and taxes for Bulgaria
     """,
     'depends': [
         'account',

--- a/addons/l10n_dk_oioubl/__manifest__.py
+++ b/addons/l10n_dk_oioubl/__manifest__.py
@@ -4,11 +4,9 @@
     'version': '0.1',
     'category': 'Accounting/Localizations/EDI',
     'description': """
-        E-invoice implementation for the Denmark
+E-invoice implementation for the Denmark
     """,
-    'summary': """
-        E-Invoicing, Offentlig Information Online Universal Business Language
-    """,
+    'summary': "E-Invoicing, Offentlig Information Online Universal Business Language",
     'countries': ['dk'],
     'depends': [
         'account_edi_ubl_cii',

--- a/addons/l10n_eg_edi_eta/__manifest__.py
+++ b/addons/l10n_eg_edi_eta/__manifest__.py
@@ -2,12 +2,10 @@
 {
     'name': "Egyptian E-Invoice Integration",
     'countries': ['eg'],
-    'summary': """
-            Egyptian Tax Authority Invoice Integration
-        """,
+    'summary': "Egyptian Tax Authority Invoice Integration",
     'description': """
-       This module integrate with the ETA Portal to automatically sign and send your invoices to the tax Authority.
-       Special thanks to Plementus <info@plementus.com> for their help in developing this module.
+This module integrate with the ETA Portal to automatically sign and send your invoices to the tax Authority.
+Special thanks to Plementus <info@plementus.com> for their help in developing this module.
     """,
     'website': 'https://www.odoo.com',
     'category': 'account',

--- a/addons/l10n_es_edi_facturae/__manifest__.py
+++ b/addons/l10n_es_edi_facturae/__manifest__.py
@@ -6,11 +6,11 @@
     'category': 'Accounting/Localizations/EDI',
     'website': 'https://www.facturae.gob.es/face/Paginas/FACE.aspx',
     'description': """
-    This module create the Facturae file required to send the invoices information to the General State Administrations.
-    It allows the export and signature of the signing of Facturae files.
-    The current version of Facturae supported is the 3.2.1
-    
-    for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
+This module create the Facturae file required to send the invoices information to the General State Administrations.
+It allows the export and signature of the signing of Facturae files.
+The current version of Facturae supported is the 3.2.1
+
+for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
     """,
     'depends': [
         'l10n_es',

--- a/addons/l10n_es_edi_sii/__manifest__.py
+++ b/addons/l10n_es_edi_sii/__manifest__.py
@@ -10,20 +10,20 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'description': """
-        This module sends the taxes information (mostly VAT) of the
-        vendor bills and customer invoices to the SII.  It is called
-        Procedimiento G417 - IVA. Llevanza de libros registro.  It is
-        required for every company with a turnover of +6M€ and others can
-        already make use of it.  The invoices are automatically
-        sent after validation.
+This module sends the taxes information (mostly VAT) of the
+vendor bills and customer invoices to the SII.  It is called
+Procedimiento G417 - IVA. Llevanza de libros registro.  It is
+required for every company with a turnover of +6M€ and others can
+already make use of it.  The invoices are automatically
+sent after validation.
 
-        How the information is sent to the SII depends on the
-        configuration that is put in the taxes.  The taxes
-        that were in the chart template (l10n_es) are automatically
-        configured to have the right type.  It is possible however
-        that extra taxes need to be created for certain exempt/no sujeta reasons.
+How the information is sent to the SII depends on the
+configuration that is put in the taxes.  The taxes
+that were in the chart template (l10n_es) are automatically
+configured to have the right type.  It is possible however
+that extra taxes need to be created for certain exempt/no sujeta reasons.
 
-        You need to configure your certificate and the tax agency.
+You need to configure your certificate and the tax agency.
     """,
     'depends': [
         'l10n_es',

--- a/addons/l10n_es_edi_tbai/__manifest__.py
+++ b/addons/l10n_es_edi_tbai/__manifest__.py
@@ -9,16 +9,16 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'description': """
-    This module sends invoices and vendor bills to the "Diputaciones
-    Forales" of Araba/Álava, Bizkaia and Gipuzkoa.
+This module sends invoices and vendor bills to the "Diputaciones
+Forales" of Araba/Álava, Bizkaia and Gipuzkoa.
 
-    Invoices and bills get converted to XML and regularly sent to the
-    Basque government servers which provides them with a unique identifier.
-    A hash chain ensures the continuous nature of the invoice/bill
-    sequences. QR codes are added to emitted (sent/printed) invoices,
-    bills and tickets to allow anyone to check they have been declared.
+Invoices and bills get converted to XML and regularly sent to the
+Basque government servers which provides them with a unique identifier.
+A hash chain ensures the continuous nature of the invoice/bill
+sequences. QR codes are added to emitted (sent/printed) invoices,
+bills and tickets to allow anyone to check they have been declared.
 
-    You need to configure your certificate and the tax agency.
+You need to configure your certificate and the tax agency.
     """,
     'depends': [
         'l10n_es_edi_sii',

--- a/addons/l10n_gcc_invoice/__manifest__.py
+++ b/addons/l10n_gcc_invoice/__manifest__.py
@@ -5,7 +5,7 @@
     'version': '1.0.0',
     'category': 'Accounting/Localizations',
     'description': """
-    Arabic/English for GCC
+Arabic/English for GCC
 """,
     'license': 'LGPL-3',
     'depends': ['account'],

--- a/addons/l10n_hr/__manifest__.py
+++ b/addons/l10n_hr/__manifest__.py
@@ -5,12 +5,12 @@
     'icon': '/account/static/description/l10n.png',
     'countries': ['hr'],
     'description': """
-    Croatian Chart of Accounts updated (RRIF ver.2021)
+Croatian Chart of Accounts updated (RRIF ver.2021)
 
-    Sources:
-    https://www.rrif.hr/dok/preuzimanje/Bilanca-2016.pdf
-    https://www.rrif.hr/dok/preuzimanje/RRIF-RP2021.PDF
-    https://www.rrif.hr/dok/preuzimanje/RRIF-RP2021-ENG.PDF
+Sources:
+https://www.rrif.hr/dok/preuzimanje/Bilanca-2016.pdf
+https://www.rrif.hr/dok/preuzimanje/RRIF-RP2021.PDF
+https://www.rrif.hr/dok/preuzimanje/RRIF-RP2021-ENG.PDF
     """,
     'version': '13.0',
     'category': 'Accounting/Localizations/Account Charts',

--- a/addons/l10n_hu/__manifest__.py
+++ b/addons/l10n_hu/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '3.0',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
-        Accounting chart and localization for Hungary
+Accounting chart and localization for Hungary
     """,
     'depends': [
         'account',

--- a/addons/l10n_id_efaktur/__manifest__.py
+++ b/addons/l10n_id_efaktur/__manifest__.py
@@ -7,27 +7,27 @@
     'countries': ['id'],
     'version': '1.0',
     'description': """
-        E-Faktur Menu(Indonesia)
-        Format: 010.000-16.00000001
-        * 2 (dua) digit pertama adalah Kode Transaksi
-        * 1 (satu) digit berikutnya adalah Kode Status
-        * 3 (tiga) digit berikutnya adalah Kode Cabang
-        * 2 (dua) digit pertama adalah Tahun Penerbitan
-        * 8 (delapan) digit berikutnya adalah Nomor Urut
+E-Faktur Menu(Indonesia)
+Format: 010.000-16.00000001
+* 2 (dua) digit pertama adalah Kode Transaksi
+* 1 (satu) digit berikutnya adalah Kode Status
+* 3 (tiga) digit berikutnya adalah Kode Cabang
+* 2 (dua) digit pertama adalah Tahun Penerbitan
+* 8 (delapan) digit berikutnya adalah Nomor Urut
 
-        To be able to export customer invoices as e-Faktur,
-        you need to put the ranges of numbers you were assigned
-        by the government in Accounting > Customers > e-Faktur
+To be able to export customer invoices as e-Faktur,
+you need to put the ranges of numbers you were assigned
+by the government in Accounting > Customers > e-Faktur
 
-        When you validate an invoice, where the partner has the ID PKP
-        field checked, a tax number will be assigned to that invoice.
-        Afterwards, you can filter the invoices still to export in the
-        invoices list and click on Action > Download e-Faktur to download
-        the csv and upload it to the site of the government.
+When you validate an invoice, where the partner has the ID PKP
+field checked, a tax number will be assigned to that invoice.
+Afterwards, you can filter the invoices still to export in the
+invoices list and click on Action > Download e-Faktur to download
+the csv and upload it to the site of the government.
 
-        You can replace an already sent invoice by another by indicating
-        the replaced invoice and the new one and you can reset an invoice
-        you have not already sent to the government to reuse its number.
+You can replace an already sent invoice by another by indicating
+the replaced invoice and the new one and you can reset an invoice
+you have not already sent to the government to reuse its number.
     """,
     'category': 'Accounting/Localizations/EDI',
     'depends': ['l10n_id'],

--- a/addons/l10n_ie/__manifest__.py
+++ b/addons/l10n_ie/__manifest__.py
@@ -6,7 +6,7 @@
     "icon": '/account/static/description/l10n.png',
     "category": "Accounting/Localizations/Account Charts",
     "description": """
-    This is the base module to manage the accounting chart for Republic of Ireland in Odoo. 
+This is the base module to manage the accounting chart for Republic of Ireland in Odoo. 
     """,
     "author": "Odoo SA",
     "depends": [

--- a/addons/l10n_in_purchase_stock/__manifest__.py
+++ b/addons/l10n_in_purchase_stock/__manifest__.py
@@ -5,13 +5,12 @@
     'name': "India Purchase and Warehouse Management",
     'countries': ['in'],
 
-    'summary': """
-        Get warehouse address if the bill is created from Purchase Order""",
+    'summary': "Get warehouse address if the bill is created from Purchase Order",
 
     'description': """
-        Get the warehouse address if the bill is created from the Purchase Order
+Get the warehouse address if the bill is created from the Purchase Order
 
-        So this module is to get the warehouse address if the bill is created from Purchase Order
+So this module is to get the warehouse address if the bill is created from Purchase Order
     """,
 
     'website': "https://www.odoo.com",

--- a/addons/l10n_in_sale_stock/__manifest__.py
+++ b/addons/l10n_in_sale_stock/__manifest__.py
@@ -5,14 +5,13 @@
     'name': "India Sales and Warehouse Management",
     'countries': ['in'],
 
-    'summary': """
-        Get warehouse address if the invoice is created from Sale Order""",
+    'summary': "Get warehouse address if the invoice is created from Sale Order",
 
     'description': """
-        Get the warehouse address if the invoice is created from the Sale Order
-        In Indian EDI we send shipping address details if available
+Get the warehouse address if the invoice is created from the Sale Order
+In Indian EDI we send shipping address details if available
 
-        So this module is to get the warehouse address if the invoice is created from Sale Order
+So this module is to get the warehouse address if the invoice is created from Sale Order
     """,
 
     'website': "https://www.odoo.com",

--- a/addons/l10n_ke_edi_tremol/__manifest__.py
+++ b/addons/l10n_ke_edi_tremol/__manifest__.py
@@ -2,11 +2,9 @@
 {
     'name': "Kenya Tremol Device EDI Integration",
     'countries': ['ke'],
-    'summary': """
-            Kenya Tremol Device EDI Integration
-        """,
+    'summary': "Kenya Tremol Device EDI Integration",
     'description': """
-       This module integrates with the Kenyan G03 Tremol control unit device to the KRA through TIMS.
+This module integrates with the Kenyan G03 Tremol control unit device to the KRA through TIMS.
     """,
     'author': 'Odoo',
     'category': 'Accounting/Localizations/EDI',

--- a/addons/l10n_lt/__manifest__.py
+++ b/addons/l10n_lt/__manifest__.py
@@ -5,15 +5,15 @@
     'countries': ['lt'],
     'version': '1.0.0',
     'description': """
-        Chart of Accounts (COA) Template for Lithuania's Accounting.
+Chart of Accounts (COA) Template for Lithuania's Accounting.
 
-        This module also includes:
+This module also includes:
 
-        * List of available banks in Lithuania.
-        * Tax groups.
-        * Most common Lithuanian Taxes.
-        * Fiscal positions.
-        * Account Tags.
+* List of available banks in Lithuania.
+* Tax groups.
+* Most common Lithuanian Taxes.
+* Fiscal positions.
+* Account Tags.
     """,
     'license': 'LGPL-3',
     'author': 'Focusate',

--- a/addons/l10n_lv/__manifest__.py
+++ b/addons/l10n_lv/__manifest__.py
@@ -2,15 +2,15 @@
     'name': "Latvia - Accounting",
     'version': '1.0.0',
     'description': """
-        Chart of Accounts (COA) Template for Latvia's Accounting.
-        This module also includes:
-        * Tax groups,
-        * Most common Latvian Taxes,
-        * Fiscal positions,
-        * Latvian bank list.
+Chart of Accounts (COA) Template for Latvia's Accounting.
+This module also includes:
+* Tax groups,
+* Most common Latvian Taxes,
+* Fiscal positions,
+* Latvian bank list.
 
-        author is Allegro IT (visit for more information https://www.allegro.lv)
-        co-author is Chick.Farm (visit for more information https://www.myacc.cloud)
+author is Allegro IT (visit for more information https://www.allegro.lv)
+co-author is Chick.Farm (visit for more information https://www.myacc.cloud)
     """,
     'license': 'LGPL-3',
     'author': "Allegro IT, Chick.Farm",

--- a/addons/l10n_mz/__manifest__.py
+++ b/addons/l10n_mz/__manifest__.py
@@ -3,7 +3,7 @@
     'name': 'Mozambique - Accounting',
     'website': 'https://www.odoo.com/documentation/master/applications/finance/fiscal_localizations.html',
     'description': """
-        Mozambican Accounting localization
+Mozambican Accounting localization
     """,
     'version': '1.0',
     'icon': '/account/static/description/l10n.png',

--- a/addons/l10n_ph/__manifest__.py
+++ b/addons/l10n_ph/__manifest__.py
@@ -3,9 +3,7 @@
     'name': 'Philippines - Accounting',
     'icon': '/account/static/description/l10n.png',
     'countries': ['ph'],
-    'summary': """
-        This is the module to manage the accounting chart for The Philippines.
-    """,
+    'summary': "This is the module to manage the accounting chart for The Philippines.",
     'category': 'Accounting/Localizations/Account Charts',
     'version': '1.0',
     'author': 'Odoo PS',

--- a/addons/l10n_ro_edi/__manifest__.py
+++ b/addons/l10n_ro_edi/__manifest__.py
@@ -4,11 +4,9 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
     'description': """
-        E-invoice implementation for Romania
+E-invoice implementation for Romania
     """,
-    'summary': """
-        E-Invoice implementation for Romania
-    """,
+    'summary': "E-Invoice implementation for Romania",
     'countries': ['ro'],
     'depends': [
         'account_edi_ubl_cii',

--- a/addons/l10n_rs/__manifest__.py
+++ b/addons/l10n_rs/__manifest__.py
@@ -7,9 +7,9 @@
     'version': '1.0',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
-        This is the base module of the Serbian localization. It manages chart of accounts and taxes.
-        This module is based on the official document "Pravilnik o kontnom okviru i sadržini računa u kontnom okviru za privredna društva, zadruge i preduzetnike ("Sl. glasnik RS", br. 89/2020)"
-        Source: https://www.paragraf.rs/propisi/pravilnik-o-kontnom-okviru-sadrzini-racuna-za-privredna-drustva-zadruge.html
+This is the base module of the Serbian localization. It manages chart of accounts and taxes.
+This module is based on the official document "Pravilnik o kontnom okviru i sadržini računa u kontnom okviru za privredna društva, zadruge i preduzetnike ("Sl. glasnik RS", br. 89/2020)"
+Source: https://www.paragraf.rs/propisi/pravilnik-o-kontnom-okviru-sadrzini-racuna-za-privredna-drustva-zadruge.html
     """,
     'author': 'Modoolar, Odoo S.A.',
     'depends': [

--- a/addons/l10n_sa_edi/__manifest__.py
+++ b/addons/l10n_sa_edi/__manifest__.py
@@ -13,11 +13,9 @@
         'base_vat'
     ],
     'author': 'Odoo',
-    'summary': """
-        E-Invoicing, Universal Business Language
-    """,
+    'summary': "E-Invoicing, Universal Business Language",
     'description': """
-        E-invoice implementation for the Kingdom of Saudi Arabia
+E-invoice implementation for the Kingdom of Saudi Arabia
     """,
     'category': 'Accounting/Localizations/EDI',
     'license': 'LGPL-3',

--- a/addons/l10n_si/__manifest__.py
+++ b/addons/l10n_si/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '1.1',
     'category': 'Accounting/Localizations/Account Charts',
     'description': """
-        Chart of accounts and taxes for Slovenia.
+Chart of accounts and taxes for Slovenia.
     """,
     'depends': [
         'account',

--- a/addons/mail_group/__manifest__.py
+++ b/addons/mail_group/__manifest__.py
@@ -5,7 +5,7 @@
     'name': "Mail Group",
     'summary': "Manage your mailing lists",
     'description': """
-        Manage your mailing lists from Odoo.
+Manage your mailing lists from Odoo.
     """,
     'version': '1.1',
     'depends': [

--- a/addons/maintenance/__manifest__.py
+++ b/addons/maintenance/__manifest__.py
@@ -6,7 +6,7 @@
     'sequence': 100,
     'category': 'Manufacturing/Maintenance',
     'description': """
-        Track equipment and maintenance requests""",
+Track equipment and maintenance requests""",
     'depends': ['mail'],
     'summary': 'Track equipment and manage maintenance requests',
     'website': 'https://www.odoo.com/app/maintenance',

--- a/addons/mrp_subcontracting_account/__manifest__.py
+++ b/addons/mrp_subcontracting_account/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '0.1',
     'category': 'Hidden',
     'description': """
-        This bridge module allows to manage subcontracting with valuation.
+This bridge module allows to manage subcontracting with valuation.
     """,
     'depends': ['mrp_subcontracting', 'mrp_account'],
     'installable': True,

--- a/addons/mrp_subcontracting_dropshipping/__manifest__.py
+++ b/addons/mrp_subcontracting_dropshipping/__manifest__.py
@@ -7,7 +7,7 @@
     'version': '0.1',
     'category': 'Inventory/Purchase',
     'description': """
-        This bridge module allows to manage subcontracting with the dropshipping module.
+This bridge module allows to manage subcontracting with the dropshipping module.
     """,
     'depends': ['mrp_subcontracting', 'stock_dropshipping'],
     'data': [

--- a/addons/mrp_subcontracting_purchase/__manifest__.py
+++ b/addons/mrp_subcontracting_purchase/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '0.1',
     'category': 'Manufacturing/Purchase',
     'description': """
-        This bridge module adds some smart buttons between Purchase and Subcontracting
+This bridge module adds some smart buttons between Purchase and Subcontracting
     """,
     'depends': ['mrp_subcontracting', 'purchase_mrp'],
     'data': [

--- a/addons/mrp_subcontracting_repair/__manifest__.py
+++ b/addons/mrp_subcontracting_repair/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '1.0',
     'category': 'Manufacturing/Repair',
     'description': """
-        Bridge module between MRP subcontracting and Repair
+Bridge module between MRP subcontracting and Repair
     """,
     'depends': [
         'mrp_subcontracting', 'repair'

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -7,7 +7,7 @@
     'summary': "Auto-complete partner companies' data",
     'version': '1.1',
     'description': """
-       Auto-complete partner companies' data
+Auto-complete partner companies' data
     """,
     'category': 'Hidden/Tools',
     'depends': [

--- a/addons/pos_mrp/__manifest__.py
+++ b/addons/pos_mrp/__manifest__.py
@@ -9,7 +9,7 @@
     'sequence': 6,
     'summary': 'Link module between Point of Sale and Mrp',
     'description': """
-    This is a link module between Point of Sale and Mrp.
+This is a link module between Point of Sale and Mrp.
 """,
     'depends': ['point_of_sale', 'mrp'],
     'installable': True,

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -2,9 +2,7 @@
 {
     "name": "POS Self Order",
     'version': '1.0',
-    "summary": """
-        Addon for the POS App that allows customers to view the menu on their smartphone.
-        """,
+    "summary": "Addon for the POS App that allows customers to view the menu on their smartphone.",
     "category": "Sales/Point Of Sale",
     "depends": ["pos_restaurant", "http_routing"],
     "auto_install": ["pos_restaurant"],

--- a/addons/pos_self_order_adyen/__manifest__.py
+++ b/addons/pos_self_order_adyen/__manifest__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "POS Self Order Adyen",
-    "summary": """
-        Addon for the Self Order App that allows customers to pay by Adyen.
-        """,
+    "summary": "Addon for the Self Order App that allows customers to pay by Adyen.",
     "category": "Sales/Point Of Sale",
     "depends": ["pos_adyen", "pos_self_order"],
     "auto_install": True,

--- a/addons/product_matrix/__manifest__.py
+++ b/addons/product_matrix/__manifest__.py
@@ -2,9 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': "Product Matrix",
-    'summary': """
-       Technical module: Matrix Implementation
-    """,
+    'summary': "Technical module: Matrix Implementation",
     'description': """
 Please refer to Sale Matrix or Purchase Matrix for the use of this module.
     """,

--- a/addons/purchase_product_matrix/__manifest__.py
+++ b/addons/purchase_product_matrix/__manifest__.py
@@ -2,12 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': "Purchase Matrix",
-    'summary': """
-       Add variants to your purchase orders through an Order Grid Entry.
-    """,
+    'summary': "Add variants to your purchase orders through an Order Grid Entry.",
     'description': """
-        This module allows to fill Purchase Orders rapidly
-        by choosing product variants quantity through a Grid Entry.
+This module allows to fill Purchase Orders rapidly
+by choosing product variants quantity through a Grid Entry.
     """,
     'category': 'Inventory/Purchase',
     'version': '1.0',

--- a/addons/sale_product_matrix/__manifest__.py
+++ b/addons/sale_product_matrix/__manifest__.py
@@ -4,8 +4,8 @@
     'name': "Sale Matrix",
     'summary': "Add variants to Sales Order through a grid entry.",
     'description': """
-        This module allows to fill Sales Order rapidly
-        by choosing product variants quantity through a Grid Entry.
+This module allows to fill Sales Order rapidly
+by choosing product variants quantity through a Grid Entry.
     """,
     'category': 'Sales/Sales',
     'version': '1.0',

--- a/addons/website_cf_turnstile/__manifest__.py
+++ b/addons/website_cf_turnstile/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Hidden',
     'version': '1.0',
     'description': """
-        This module implements Cloudflare Turnstile so that you can prevent bot spam on your forms.
+This module implements Cloudflare Turnstile so that you can prevent bot spam on your forms.
     """,
     'depends': ['website'],
     'data': [

--- a/addons/website_sale_mondialrelay/__manifest__.py
+++ b/addons/website_sale_mondialrelay/__manifest__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 {
     'name': "eCommerce Mondialrelay Delivery",
-    'summary': """ Let's choose Point Relais® on your ecommerce """,
+    'summary': "Let's choose Point Relais® on your ecommerce",
 
     'description': """
-        This module allow your customer to choose a Point Relais® and use it as shipping address.
+This module allow your customer to choose a Point Relais® and use it as shipping address.
     """,
     'category': 'Website/Website',
     'version': '0.1',

--- a/addons/website_sale_product_configurator/__manifest__.py
+++ b/addons/website_sale_product_configurator/__manifest__.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 {
     'name': "Website Sale Product Configurator",
-    'summary': """
-        Bridge module for website_sale / sale_product_configurator""",
+    'summary': "Bridge module for website_sale / sale_product_configurator",
     'description': """
-        Bridge module to make the website e-commerce compatible with the product configurator
+Bridge module to make the website e-commerce compatible with the product configurator
     """,
     'category': 'Hidden',
     'depends': ['website_sale', 'sale_product_configurator'],

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -5,6 +5,7 @@ import warnings
 from collections import defaultdict, OrderedDict
 from decorator import decorator
 from operator import attrgetter
+from textwrap import dedent
 import io
 import logging
 import os
@@ -702,7 +703,7 @@ class Module(models.Model):
     @staticmethod
     def get_values_from_terp(terp):
         return {
-            'description': terp.get('description', ''),
+            'description': dedent(terp.get('description', '')),
             'shortdesc': terp.get('name', ''),
             'author': terp.get('author', 'Unknown'),
             'maintainer': terp.get('maintainer', False),

--- a/odoo/cli/templates/default/__manifest__.py.template
+++ b/odoo/cli/templates/default/__manifest__.py.template
@@ -2,12 +2,10 @@
 {
     'name': "{{ name }}",
 
-    'summary': """
-        Short (1 phrase/line) summary of the module's purpose, used as
-        subtitle on modules listing or apps.openerp.com""",
+    'summary': "Short (1 phrase/line) summary of the module's purpose",
 
     'description': """
-        Long description of module's purpose
+Long description of module's purpose
     """,
 
     'author': "My Company",

--- a/odoo/cli/templates/l10n_payroll/__manifest__.py.template
+++ b/odoo/cli/templates/l10n_payroll/__manifest__.py.template
@@ -12,13 +12,13 @@
 ''Country-ish'' Payroll Rules.
 ==============================
 
-    * Employee Details
-    * Employee Contracts
-    * Passport based Contract
-    * Allowances/Deductions
-    * Allow to configure Basic/Gross/Net Salary
-    * Employee Payslip
-    * Integrated with Leaves Management
+* Employee Details
+* Employee Contracts
+* Passport based Contract
+* Allowances/Deductions
+* Allow to configure Basic/Gross/Net Salary
+* Employee Payslip
+* Integrated with Leaves Management
     """,
     'data': [
         'data/hr_salary_rule_category_data.xml',


### PR DESCRIPTION
The summary is a short char field. It should not contain carriage returns.
The description is the longer text field.
Remove unnecessary spaces in both.
